### PR TITLE
Add/Remove order coupon actions logged in notes

### DIFF
--- a/plugins/woocommerce/changelog/issue-30104
+++ b/plugins/woocommerce/changelog/issue-30104
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Log to order notes when coupons are removed or applied.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -488,6 +488,13 @@ jQuery( function ( $ ) {
 						if ( response.success ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
+
+							// Update notes.
+							if ( response.data.notes_html ) {
+								$( 'ul.order_notes' ).empty();
+								$( 'ul.order_notes' ).append( $( response.data.notes_html ).find( 'li' ) );
+							}
+
 							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
 						} else {
@@ -524,6 +531,13 @@ jQuery( function ( $ ) {
 				if ( response.success ) {
 					$( '#woocommerce-order-items' ).find( '.inside' ).empty();
 					$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
+
+					// Update notes.
+					if ( response.data.notes_html ) {
+						$( 'ul.order_notes' ).empty();
+						$( 'ul.order_notes' ).append( $( response.data.notes_html ).find( 'li' ) );
+					}
+
 					wc_meta_boxes_order_items.reloaded_items();
 					wc_meta_boxes_order_items.unblock();
 				} else {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1285,9 +1285,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Manual discounts are not affected; those are separate and do not affect
 	 * stored line totals.
 	 *
-	 * @since  3.2.0
+	 * @since 3.2.0
+	 * @since 7.6.0 Returns a boolean indicating success.
+	 *
 	 * @param  string $code Coupon code.
-	 * @return void
+	 * @return bool TRUE if coupon was removed, FALSE otherwise.
 	 */
 	public function remove_coupon( $code ) {
 		$coupons = $this->get_items( 'coupon' );
@@ -1299,9 +1301,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$coupon_object = new WC_Coupon( $code );
 				$coupon_object->decrease_usage_count( $this->get_user_id() );
 				$this->recalculate_coupons();
-				break;
+
+				return true;
 			}
 		}
+
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1258,7 +1258,7 @@ class WC_AJAX {
 			$code = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( $order->remove_coupon( $code ) ) {
 				// translators: %s coupon code.
-				$order->add_order_note( sprintf( __( 'Coupon removed: "%s".', 'woocommerce' ), $code ), 0, true );
+				$order->add_order_note( esc_html( sprintf( __( 'Coupon removed: "%s".', 'woocommerce' ), $code ) ), 0, true );
 			}
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1266,6 +1266,12 @@ class WC_AJAX {
 			ob_start();
 			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
+
+			ob_start();
+			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
+			include __DIR__ . '/admin/meta-boxes/views/html-order-notes.php';
+			$response['notes_html'] = ob_get_clean();
+
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1257,6 +1257,7 @@ class WC_AJAX {
 
 			$code = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			if ( $order->remove_coupon( $code ) ) {
+				// translators: %s coupon code.
 				$order->add_order_note( sprintf( __( 'Coupon removed: "%s".', 'woocommerce' ), $code ), 0, true );
 			}
 			$order->calculate_taxes( $calculate_tax_args );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1255,7 +1255,10 @@ class WC_AJAX {
 				throw new Exception( __( 'Invalid coupon', 'woocommerce' ) );
 			}
 
-			$order->remove_coupon( wc_format_coupon_code( wp_unslash( $coupon ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$code = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( $order->remove_coupon( $code ) ) {
+				$order->add_order_note( sprintf( __( 'Coupon removed: "%s".', 'woocommerce' ), $code ), 0, true );
+			}
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );
 

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -219,39 +219,6 @@ class WC_Order extends WC_Abstract_Order {
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this, $tax_display, $display_refunded );
 	}
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * Log the action to order notes.
-	 *
-	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
-	 * @return true|WP_Error True if applied, error if not.
-	 */
-	public function apply_coupon( $raw_coupon ) {
-		$res = parent::apply_coupon( $raw_coupon );
-
-		if ( ! is_wp_error( $res ) ) {
-			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon, 0, true );
-		}
-
-		return $res;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * Log the action to order notes.
-	 *
-	 * @param string $code Coupon code.
-	 * @return void
-	 */
-	public function remove_coupon( $code ) {
-		if ( wc_get_coupon_id_by_code( $code ) ) {
-			parent::remove_coupon( $code );
-			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $code, 0, true );
-		}
-	}
-
 	/*
 	|--------------------------------------------------------------------------
 	| CRUD methods

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -221,34 +221,34 @@ class WC_Order extends WC_Abstract_Order {
 
 	/**
 	 * {@inheritdoc}
-	 * 
+	 *
 	 * Log the action to order notes.
 	 *
 	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
 	 * @return true|WP_Error True if applied, error if not.
 	 */
 	public function apply_coupon( $raw_coupon ) {
-		$couponResult = parent::apply_coupon( $raw_coupon );
+		$res = parent::apply_coupon( $raw_coupon );
 
-		if ( !is_wp_error( $couponResult ) ) {
+		if ( ! is_wp_error( $res ) ) {
 			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon, 0, true );
 		}
 
-		return $couponResult;
+		return $res;
 	}
 
 	/**
 	 * {@inheritdoc}
-	 * 
+	 *
 	 * Log the action to order notes.
 	 *
 	 * @param string $code Coupon code.
 	 * @return void
 	 */
-	public function remove_coupon( $coupon ) {
-		if ( wc_get_coupon_id_by_code( $coupon ) ) {
-			parent::remove_coupon( $coupon );
-			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $coupon, 0, true );
+	public function remove_coupon( $code ) {
+		if ( wc_get_coupon_id_by_code( $code ) ) {
+			parent::remove_coupon( $code );
+			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $code, 0, true );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -227,13 +227,14 @@ class WC_Order extends WC_Abstract_Order {
 	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
 	 * @return true|WP_Error True if applied, error if not.
 	 */
-	public function apply_coupon( $raw_coupon )
-	{
-		if( !is_wp_error( $result = parent::apply_coupon( $raw_coupon ) ) ) {
+	public function apply_coupon( $raw_coupon ) {
+		$couponResult = parent::apply_coupon( $raw_coupon );
+
+		if ( !is_wp_error( $couponResult ) ) {
 			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon );
 		}
 
-		return $result;
+		return $couponResult;
 	}
 
 	/**
@@ -244,9 +245,8 @@ class WC_Order extends WC_Abstract_Order {
 	 * @param string $code Coupon code.
 	 * @return void
 	 */
-	public function remove_coupon( $coupon )
-	{
-		if( wc_get_coupon_id_by_code( $coupon ) ) {
+	public function remove_coupon( $coupon ) {
+		if ( wc_get_coupon_id_by_code( $coupon ) ) {
 			parent::remove_coupon( $coupon );
 			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $coupon );
 		}

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -219,14 +219,31 @@ class WC_Order extends WC_Abstract_Order {
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this, $tax_display, $display_refunded );
 	}
 
+	/**
+	 * {@inheritdoc}
+	 * 
+	 * Log the action to order notes.
+	 *
+	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
+	 * @return true|WP_Error True if applied, error if not.
+	 */
 	public function apply_coupon( $raw_coupon )
 	{
-		if( !is_wp_error( parent::apply_coupon( $raw_coupon ) ) ) {
+		if( !is_wp_error( $result = parent::apply_coupon( $raw_coupon ) ) ) {
 			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon );
-			return true;
 		}
+
+		return $result;
 	}
 
+	/**
+	 * {@inheritdoc}
+	 * 
+	 * Log the action to order notes.
+	 *
+	 * @param string $code Coupon code.
+	 * @return void
+	 */
 	public function remove_coupon( $coupon )
 	{
 		if( wc_get_coupon_id_by_code( $coupon ) ) {

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -219,6 +219,22 @@ class WC_Order extends WC_Abstract_Order {
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this, $tax_display, $display_refunded );
 	}
 
+	public function apply_coupon( $raw_coupon )
+	{
+		if( !is_wp_error( parent::apply_coupon( $raw_coupon ) ) ) {
+			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon );
+			return true;
+		}
+	}
+
+	public function remove_coupon( $coupon )
+	{
+		if( wc_get_coupon_id_by_code( $coupon ) ) {
+			parent::remove_coupon( $coupon );
+			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $coupon );
+		}
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| CRUD methods

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -231,7 +231,7 @@ class WC_Order extends WC_Abstract_Order {
 		$couponResult = parent::apply_coupon( $raw_coupon );
 
 		if ( !is_wp_error( $couponResult ) ) {
-			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon );
+			$this->add_order_note( __( 'Coupon applied:', 'woocommerce' ) . ' ' . $raw_coupon, 0, true );
 		}
 
 		return $couponResult;
@@ -248,7 +248,7 @@ class WC_Order extends WC_Abstract_Order {
 	public function remove_coupon( $coupon ) {
 		if ( wc_get_coupon_id_by_code( $coupon ) ) {
 			parent::remove_coupon( $coupon );
-			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $coupon );
+			$this->add_order_note( __( 'Coupon removed:', 'woocommerce' ) . ' ' . $coupon, 0, true );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -87,7 +87,7 @@ class CouponsController {
 		}
 
 		// translators: %s coupon code.
-		$order->add_order_note( sprintf( __( 'Coupon applied: "%s".', 'woocommerce' ), $code ), 0, true );
+		$order->add_order_note( esc_html( sprintf( __( 'Coupon applied: "%s".', 'woocommerce' ), $code ) ), 0, true );
 
 		return $order;
 	}

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -79,11 +79,14 @@ class CouponsController {
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
 
-		$result = $order->apply_coupon( wc_format_coupon_code( wp_unslash( $coupon ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$code   = wc_format_coupon_code( wp_unslash( $coupon ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$result = $order->apply_coupon( $code );
 
 		if ( is_wp_error( $result ) ) {
 			throw new Exception( html_entity_decode( wp_strip_all_tags( $result->get_error_message() ) ) );
 		}
+
+		$order->add_order_note( sprintf( __( 'Coupon applied: "%s".', 'woocommerce' ), $code ), 0, true );
 
 		return $order;
 	}

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -86,6 +86,7 @@ class CouponsController {
 			throw new Exception( html_entity_decode( wp_strip_all_tags( $result->get_error_message() ) ) );
 		}
 
+		// translators: %s coupon code.
 		$order->add_order_note( sprintf( __( 'Coupon applied: "%s".', 'woocommerce' ), $code ), 0, true );
 
 		return $order;

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -31,6 +31,11 @@ class CouponsController {
 			ob_start();
 			include __DIR__ . '/../../../includes/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
+
+			ob_start();
+			$notes = wc_get_order_notes( array( 'order_id' => $order->get_id() ) );
+			include __DIR__ . '/../../../includes/admin/meta-boxes/views/html-order-notes.php';
+			$response['notes_html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-coupon.spec.js
@@ -95,7 +95,7 @@ test.describe( 'WooCommerce Orders > Apply Coupon', () => {
 		page.on( 'dialog', ( dialog ) => dialog.accept( couponCode ) );
 		await page.click( 'button.add-coupon' );
 
-		await expect( page.locator( `text=${ couponCode }` ) ).toBeVisible();
+		await expect( page.locator( '.wc_coupon_list li',  { hasText: couponCode } ) ).toBeVisible();
 		await expect(
 			page.locator( '.wc-order-totals td.label >> nth=1' )
 		).toContainText( 'Coupon(s)' );
@@ -113,7 +113,7 @@ test.describe( 'WooCommerce Orders > Apply Coupon', () => {
 	test( 'can remove a coupon', async ( { page } ) => {
 		await page.goto( `/wp-admin/post.php?post=${ orderId }&action=edit` );
 		// assert that there is a coupon on the order
-		await expect( page.locator( `text=${ couponCode }` ) ).toBeVisible();
+		await expect( page.locator( '.wc_coupon_list li',  { hasText: couponCode } ) ).toBeVisible();
 		await expect(
 			page.locator( '.wc-order-totals td.label >> nth=1' )
 		).toContainText( 'Coupon(s)' );
@@ -130,9 +130,7 @@ test.describe( 'WooCommerce Orders > Apply Coupon', () => {
 		await page.dispatchEvent( 'a.remove-coupon', 'click' ); // have to use dispatchEvent because nothing visible to click on
 
 		// make sure the coupon was removed
-		await expect(
-			page.locator( `text=${ couponCode }` )
-		).not.toBeVisible();
+		await expect( page.locator( '.wc_coupon_list li',  { hasText: couponCode } ) ).not.toBeVisible();
 		await expect(
 			page.locator( '.wc-order-totals td.label >> nth=1' )
 		).toContainText( 'Order Total' );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30104 .

### How to test the changes in this Pull Request:

1. Go to WC > Coupons (in the admin) and create a coupon.
2. Go to WC > Orderes (in the admin) and create a manual order, with at least a product.
3. Click "Apply Coupon" to apply the coupon from step 1 to this order.
4. Make sure that the coupon was applied (i.e. amounts update accordingly) and that you see a note in the notes metabox about it.
5. Remove the coupon you just applied by clicking the "x" symbol next to its name.
6. Confirm that amounts are updated accordingly and that a new note appears in the notes metabox indicating that the coupon was removed.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
