### PR TITLE
Add filter for is_setting_type_valid to allow REST to return custom registered admin field types.

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
@@ -471,7 +471,7 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 	 * @return bool
 	 */
 	public function is_setting_type_valid( $type ) {
-		return in_array(
+		$is_valid_type = in_array(
 			$type, array(
 				'text',         // Validates with validate_setting_text_field.
 				'email',        // Validates with validate_setting_text_field.
@@ -487,6 +487,8 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 				'thumbnail_cropping', // Validates with validate_setting_text_field.
 			)
 		);
+
+		return apply_filters( 'woocommerce_valid_setting_type', $is_valid_type, $type );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a filter for the `\WC_REST_Setting_Options_V2_Controller::is_setting_type_valid()` method which is not currently available for custom registered admin field types. Therefore disabling the ability to get custom fields from REST settings endpoint.

#### Why?

When hitting `/wp-json/wc/v3/settings/<group_id>` any non-standard setting `type` from the group is not returned and completely omitted from the settings fields. As a developer I should be allowed to filter this list. This is ultimately called from `\WC_REST_Setting_Options_V2_Controller::get_items()` but is also used in in `\WC_REST_Setting_Options_V2_Controller::get_setting()`

Ultimately I'm building a react-based settings tab for my personal project and realized that this was a blocker for me and wanted to dive into some REACT and ran into this.

#### Tests
I ran this through the test suite and all unit tests still pass. PHPCS did pick up some things I didn't touch though, and I didn't want to commit more than I originally wanted ( possibly stepping on someone's toes ).

### How to test the changes in this Pull Request:

Register a custom setting field type:
```
        // Setup the field to return the HTML that you would expect.
	add_action( 'woocommerce_admin_field_dc_servers', 'render_settings_servers' );
```

Register a custom settings tab with your own class:
```
         add_filter( 'woocommerce_get_settings_pages', function( array $settings_classes ) {
		$settings_classes[] = new MySettingsClass();
	} );
```

Ensure the class extends the `WC_Settings_Page` class, and set the `$id` property appropriately. 
```
class MySettingsClass extends \WC_Settings_Page {

	public function __construct() {
		$this->id = 'donorcraft';
		$this->label = __( 'Donorcraft', 'donorcraft' );

		parent::__construct();
	}
        // ... other methods
}
```

Inside the settings class, register the settings for a default section ( doesn't matter the section really ), and use a custom type.
```
// ... Settings class
protected function get_settings_for_default_section() {
                 // ... Add other stuff of course.
		return [
                       [
				'title'   => __( 'Servers', 'donorcraft' ),
				'type'    => 'dc_servers',
				'id'      => $this->id . '_servers',
				'default' => [
					[
						'host'     => '',
						'password' => '',
						'port'     => 0,
						'timeout'  => 5,
					],
				],
			],
                ]
```

Now make an authenticated request to your WooCommerce settings endpoint and note that it is not available. Once you confirm you cannot see the setting default values, add the filter and check again:
```
	add_filter( 'woocommerce_valid_setting_type', function( $is_valid, $type ) {
		return $type == 'dc_servers' ? true : $is_valid;
	}, 10, 2 );
```

You should now see the JSON data for the field, including the `default` values. As a reminder, the path would be ( for this settings class ): `/wp-json/wc/v3/settings/donorcraft`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adds `woocommerce_valid_setting_type` filter to allow REST API to return data for custom setting field types registered by  `woocommerce_admin_field_{$type}`.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
