### PR TITLE
Fix refund amount field validation message appears misaligned on Edit…

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1709,6 +1709,7 @@ ul.wc_coupon_list_block {
 			width: 10em;
 			margin: 0 0 0 0.5em;
 			box-sizing: border-box;
+			position: relative;
 
 			input[type="text"] {
 				width: 96%;


### PR DESCRIPTION
… order screen #30527

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30527 .

### How to test the changes in this Pull Request:

1. Create any test site using JN site.
2. Install and activate all the required plugins.
3. Complete the setup wizard.
4. Place order for any product.
5. Go to "WooCommerce -> Orders"
6. Click on "Order".
7. Click on "Refund" button.
8. Enter any text in "Refund amount" field.
9. Observe that validation message appears misaligned.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated admin.scss file, added `position: relative;` to the .total cell element. Now the validation message appears following the .total element.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
