### PR TITLE
Fix #25641: Gallery thumbnails without size

### DIFF
--- a/assets/js/flexslider/jquery.flexslider.js
+++ b/assets/js/flexslider/jquery.flexslider.js
@@ -243,7 +243,11 @@
 
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if ( slider.vars.controlNav === "thumbnails" ) {
-                item = $( '<img/>' ).attr( 'src', slide.attr( 'data-thumb' ) );
+                item = $( '<img/>' )
+                .attr( 'width', parseInt( parseInt( slider.width() ) / slider.pagingCount ) )
+                .attr( 'height', parseInt( parseInt( slider.width() ) / slider.pagingCount ) )
+                .attr( 'alt', slide.attr( 'alt' ) )
+                .attr( 'src', slide.attr( 'data-thumb' ) );
               }
 
               if ( '' !== slide.attr( 'data-thumb-alt' ) ) {


### PR DESCRIPTION
Copy of https://github.com/woocommerce/FlexSlider/pull/1799/

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->


Closes https://github.com/woocommerce/woocommerce/issues/25461

### How to test the changes in this Pull Request:

1. Check the HTML in the browser now includes width/heights
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
