### PR TITLE
Add individual item remove notices for shipping and fees closes #29890

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -653,7 +653,17 @@ jQuery( function ( $ ) {
 		},
 
 		delete_item: function() {
-			var answer = window.confirm( woocommerce_admin_meta_boxes.remove_item_notice );
+			var notice = woocommerce_admin_meta_boxes.remove_item_notice;
+
+			if ( $( this ).parents( 'tbody#order_fee_line_items' ).length ) {
+				notice = woocommerce_admin_meta_boxes.remove_fee_notice;
+			}
+
+			if ( $( this ).parents( 'tbody#order_shipping_line_items' ).length ) {
+				notice = woocommerce_admin_meta_boxes.remove_shipping_notice;
+			}
+
+			var answer = window.confirm( notice );
 
 			if ( answer ) {
 				var $item         = $( this ).closest( 'tr.item, tr.fee, tr.shipping' );

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -305,9 +305,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				);
 			}
 			if ( in_array( str_replace( 'edit-', '', $screen_id ), array_merge( array( 'shop_coupon', 'product' ), wc_get_order_types( 'order-meta-boxes' ) ) ) ) {
-				$post_id            = isset( $post->ID ) ? $post->ID : '';
-				$currency           = '';
-				$remove_item_notice = __( 'Are you sure you want to remove the selected items?', 'woocommerce' );
+				$post_id                = isset( $post->ID ) ? $post->ID : '';
+				$currency               = '';
+				$remove_item_notice     = __( 'Are you sure you want to remove the selected items?', 'woocommerce' );
+				$remove_fee_notice      = __( 'Are you sure you want to remove the selected fees?', 'woocommerce' );
+				$remove_shipping_notice = __( 'Are you sure you want to remove the selected shipping?', 'woocommerce' );
 
 				if ( $post_id && in_array( get_post_type( $post_id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
 					$order = wc_get_order( $post_id );
@@ -322,6 +324,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				$params = array(
 					'remove_item_notice'            => $remove_item_notice,
+					'remove_fee_notice'             => $remove_fee_notice,
+					'remove_shipping_notice'        => $remove_shipping_notice,
 					'i18n_select_items'             => __( 'Please select some items.', 'woocommerce' ),
 					'i18n_do_refund'                => __( 'Are you sure you wish to process this refund? This action cannot be undone.', 'woocommerce' ),
 					'i18n_delete_refund'            => __( 'Are you sure you wish to delete this refund? This action cannot be undone.', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29890

### How to test the changes in this Pull Request:

1. Create an order with products, fee and shipping line items. See screenshot below.
2. Go to the order and click on the delete icon on each of the line items (product, fee and shipping).
3. For each popup confirmation, ensure the correct text message is shown based on the context of the line item.

![](https://d.pr/i/aOq9UO+)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Add individual item remove notices based on the context of the line item in the order.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
