### PR TITLE
release package updates

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+# 0.1.6
+
+## Fixed
+
+- Fatal error in order filter test
+
+# 0.1.5
+
 ## Added
 
 - Support for re-running setup and shopper tests

--- a/tests/e2e/core-tests/package.json
+++ b/tests/e2e/core-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-core-tests",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "End-To-End (E2E) tests for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/core-tests/README.md",
   "repository": {
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@woocommerce/api": "^0.2.0",
-    "@woocommerce/e2e-utils": "^0.1.5"
+    "@woocommerce/e2e-utils": "^0.1.6"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-status-filters.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-status-filters.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
+const config = require( 'config' );
 
 const {
 	merchant,

--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
-- `updateReadyPageStatus` utility to update the status of the ready page.
+# 0.2.3
+
+## Added
+
+- `addConsoleSuppression()`, `removeConsoleSuppression()` utilities to allow suppressing deprecation warnings.
+- `updateReadyPageStatus()` utility to update the status of the ready page.
 - Added plugin upload functionality util that provides a method to pull a plugin zip from a remote location:
   - `getRemotePluginZip( fileUrl )` to get the remote zip. Returns the filepath of the zip location.
 - Added plugin zip utility functions:
@@ -8,6 +13,9 @@
   - `downloadZip( fileUrl, downloadPath )` downloads a plugin zip file from a remote location to the provided path.
 - Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository.
 - Added `DEFAULT_TIMEOUT_OVERRIDE` that allows passing in a time in milliseconds to override the default Jest and Puppeteer timeouts.
+
+## Fixed
+
 - Fix latest version tag search paging logic
 - Update fallback PHP version to 7.4.22
 - Update fallback MariaDB version to 10.6.4

--- a/tests/e2e/env/package.json
+++ b/tests/e2e/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-environment",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "WooCommerce End to End Testing Environment Configuration.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.6
+
 ## Added
 
 - Factories for variable product, variation, and grouped product
@@ -18,9 +20,9 @@
 - Added `deleteAllShippingClasses()` which permanently deletes all shipping classes using the API
 - Added `statuses` optional parameter to `deleteAllRepositoryObjects()` to delete on specific statuses
 - Added `createOrder()` component util that creates an order using the API with the passed in details
-- Updated `addShippingZoneAndMethod` to use the API instead of UI to create shipping zones
-- Added `updateSettingOption` to use the API to update a setting option
-- Added `updatePaymentGateway` to use the API to update a payment gateway
+- Updated `addShippingZoneAndMethod()` to use the API instead of UI to create shipping zones
+- Added `updateSettingOption()` to use the API to update a setting option
+- Added `updatePaymentGateway()` to use the API to update a payment gateway
 - Added `getSystemEnvironment()` that gets the current environment from the WooCommerce API.
 
 # 0.1.5

--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-utils",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "End-To-End (E2E) test utils for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/utils/README.md",
   "repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR 

- bumps the package version of e2e-core-tests, e2e-environment, and e2e-utils
- changes an `import` to a `require` in the tests package as it does not have a build script
- expands the readme docs

**Note** These package versions have already been released on npmjs.com.

### How to test the changes in this Pull Request:

1. Verify CI
2. Review text changes
