### PR TITLE
Use proper location for taxes when adding products via admin

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -10,6 +10,7 @@
  * @package     WooCommerce\Classes
  */
 
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 
@@ -1402,7 +1403,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
-		$item = new WC_Order_Item_Product();
+		$item = wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Order_Item_Product::class );
 		$item->set_props( $args );
 		$item->set_backorder_meta();
 		$item->set_order_id( $this->get_id() );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -10,6 +10,7 @@
  * @package     WooCommerce\Classes
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -1361,14 +1362,23 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function add_product( $product, $qty = 1, $args = array() ) {
 		if ( $product ) {
+			$order = ArrayUtil::get_value_or_default( $args, 'order' );
+			$total = wc_get_price_excluding_tax(
+				$product,
+				array(
+					'qty'   => $qty,
+					'order' => $order,
+				)
+			);
+
 			$default_args = array(
 				'name'         => $product->get_name(),
 				'tax_class'    => $product->get_tax_class(),
 				'product_id'   => $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id(),
 				'variation_id' => $product->is_type( 'variation' ) ? $product->get_id() : 0,
 				'variation'    => $product->is_type( 'variation' ) ? $product->get_attributes() : array(),
-				'subtotal'     => wc_get_price_excluding_tax( $product, array( 'qty' => $qty ) ),
-				'total'        => wc_get_price_excluding_tax( $product, array( 'qty' => $qty ) ),
+				'subtotal'     => $total,
+				'total'        => $total,
 				'quantity'     => $qty,
 			);
 		} else {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -955,7 +955,7 @@ class WC_AJAX {
 					/* translators: %s: error message */
 					throw new Exception( sprintf( __( 'Error: %s', 'woocommerce' ), $validation_error->get_error_message() ) );
 				}
-				$item_id                 = $order->add_product( $product, $qty );
+				$item_id                 = $order->add_product( $product, $qty, array( 'order' => $order ) );
 				$item                    = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id, $order, $product );
 				$added_items[ $item_id ] = $item;
 				$order_notes[ $item_id ] = $product->get_formatted_name();

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -1081,7 +1082,9 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 	$line_price = $price * $qty;
 
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
-		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class() );
+		$order          = ArrayUtil::get_value_or_default( $args, 'order' );
+		$customer       = $order ? new WC_Customer( $order->get_customer_id() ) : null;
+		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class(), $customer );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$remove_taxes   = apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ? WC_Tax::calc_tax( $line_price, $base_tax_rates, true ) : WC_Tax::calc_tax( $line_price, $tax_rates, true );
 		$return_price   = $line_price - array_sum( $remove_taxes ); // Unrounded since we're dealing with tax inclusive prices. Matches logic in cart-totals class. @see adjust_non_base_location_price.

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 
@@ -1083,7 +1084,7 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
 		$order          = ArrayUtil::get_value_or_default( $args, 'order' );
-		$customer       = $order ? new WC_Customer( $order->get_customer_id() ) : null;
+		$customer       = $order ? wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Customer::class, $order->get_customer_id() ) : null;
 		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class(), $customer );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$remove_taxes   = apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ? WC_Tax::calc_tax( $line_price, $base_tax_rates, true ) : WC_Tax::calc_tax( $line_price, $tax_rates, true );

--- a/tests/legacy/mockable-functions.php
+++ b/tests/legacy/mockable-functions.php
@@ -13,5 +13,6 @@ return array(
 	'get_woocommerce_currencies',
 	'get_woocommerce_currency_symbol',
 	'wc_get_shipping_method_count',
+	'wc_prices_include_tax',
 	'wc_site_is_https',
 );

--- a/tests/legacy/mockable-functions.php
+++ b/tests/legacy/mockable-functions.php
@@ -12,6 +12,7 @@ return array(
 	'get_bloginfo',
 	'get_woocommerce_currencies',
 	'get_woocommerce_currency_symbol',
+	'wc_get_price_excluding_tax',
 	'wc_get_shipping_method_count',
 	'wc_prices_include_tax',
 	'wc_site_is_https',

--- a/tests/php/includes/wc-product-functions-test.php
+++ b/tests/php/includes/wc-product-functions-test.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Unit tests for wc-product-functions.php.
+ *
+ * @package WooCommerce\Tests\Functions\Stock
+ */
+
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
+
+/**
+ * Class WC_Stock_Functions_Tests.
+ */
+class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox If 'wc_get_price_excluding_tax' gets an order as argument, it passes the order customer to 'WC_Tax::get_rates'.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $pass_order Whether an order is passed to 'wc_get_price_excluding_tax' or not.
+	 */
+	public function test_wc_get_price_excluding_tax_passes_order_customer_to_get_rates_if_order_is_available( $pass_order ) {
+		$customer_passed_to_get_rates                  = false;
+		$customer_id_passed_to_wc_customer_constructor = false;
+
+		FunctionsMockerHack::add_function_mocks(
+			array(
+				'wc_prices_include_tax' => '__return_true',
+			)
+		);
+
+		StaticMockerHack::add_method_mocks(
+			array(
+				'WC_Tax' =>
+				array(
+					'get_rates'          => function( $tax_class, $customer ) use ( &$customer_passed_to_get_rates ) {
+						$customer_passed_to_get_rates = $customer;
+					},
+					'get_base_tax_rates' => function( $tax_class ) {
+						return 0;
+					},
+					'calc_tax'           => function( $price, $rates, $price_includes_tax = false, $deprecated = false ) {
+						return array( 0 );
+					},
+				),
+			)
+		);
+
+		// phpcs:disable Squiz.Commenting.FunctionComment.Missing
+
+		$product = new class() extends WC_Product {
+			public function get_price( $context = 'view' ) {
+				return 0;
+			}
+
+			public function is_taxable() {
+				return true;
+			}
+
+			public function get_tax_class( $context = 'view' ) {
+				return '';
+			}
+		};
+
+		$customer = new stdClass();
+		$this->register_legacy_proxy_class_mocks(
+			array(
+				'WC_Customer' => function( $customer_id ) use ( &$customer_id_passed_to_wc_customer_constructor, $customer ) {
+					$customer_id_passed_to_wc_customer_constructor = $customer_id;
+					return $customer;
+				},
+			)
+		);
+
+		if ( $pass_order ) {
+			$order = new class() {
+				public function get_customer_id() {
+					return 1;
+				}
+			};
+
+			wc_get_price_excluding_tax( $product, array( 'order' => $order ) );
+
+			$this->assertEquals( $order->get_customer_id(), $customer_id_passed_to_wc_customer_constructor );
+			$this->assertSame( $customer, $customer_passed_to_get_rates );
+		} else {
+			wc_get_price_excluding_tax( $product );
+
+			$this->assertFalse( $customer_id_passed_to_wc_customer_constructor );
+			$this->assertNull( $customer_passed_to_get_rates );
+		}
+
+		// phpcs:enable Squiz.Commenting.FunctionComment.Missing
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the `woocommerce_adjust_non_base_location_prices` is set to always use the customer location to calculate taxes, and "I will enter prices inclusive of tax" setting is set, adding a product to an order as an admin via the order editor will calculate the wrong price, because no customer/order data is passed to `wc_get_price_excluding_tax` and thus the location of the currently logged in user (the shop admin) is used instead of the location of the customer.

This PR fixes that by changing `WC_AJAX::maybe_add_order_item` so that it passes the order to `WC_Abstract_Order->add_product`, which in turn passes it to `wc_get_price_excluding_tax` which then obtains the customer from the order and uses his location to calculate the taxes to be substracted from the price.

Closes #30231.

### How to test the changes in this Pull Request:

1. Add the following snippet to your store: `add_filter( 'woocommerce_adjust_non_base_location_prices', '__return_false' );`
2. Make sure that you have the "Prices entered with tax" option set as "Yes, I will enter prices inclusive of tax" (_WooCommerce - Settings - Tax - Tax options_).
3. Let A be the country where your currently logged in user is based. Create an user based on a different country B.
4. Go to _WooCommerce - Settings - Tax - Standard rates_ and set 20% for country A and 10% for country B.
5. Create a simple product, taxable with standard rates, with a price of 110.
6. Create an order from admin area, set U as the customer.
7. Add the product you just created to the order.

Without the fix, the price that will appear in the line item is 91,67 (110 minus 20% of taxes). With the fix, the price will be 100 (10% of taxes substracted this time).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Use proper location for taxes when adding products via admin

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
