### PR TITLE
Introduce the 'woocommerce_quantity_input_min/step_admin' filters.

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -66,11 +66,36 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 			}
 			?>
 		</div>
+		<?php
+			$step = apply_filters( 'woocommerce_quantity_input_step', '1', $product );
+
+			/**
+			* Filter to change the product quantity stepping in the order editor of the admin area.
+			*
+			* @since   5.8.0
+			* @param   string      $step    The current step amount to be used in the quantity editor.
+			* @param   WC_Product  $product The product that is being edited.
+			* @param   string      $context The context in which the quantity editor is shown, 'edit' or 'refund'.
+			*/
+			$step_edit   = apply_filters( 'woocommerce_quantity_input_step_admin', $step, $product, 'edit' );
+			$step_refund = apply_filters( 'woocommerce_quantity_input_step_admin', $step, $product, 'refund' );
+
+			/**
+			* Filter to change the product quantity minimum in the order editor of the admin area.
+			*
+			* @since   5.8.0
+			* @param   string      $step    The current minimum amount to be used in the quantity editor.
+			* @param   WC_Product  $product The product that is being edited.
+			* @param   string      $context The context in which the quantity editor is shown, 'edit' or 'refund'.
+			*/
+			$min_edit   = apply_filters( 'woocommerce_quantity_input_min_admin', '0', $product, 'edit' );
+			$min_refund = apply_filters( 'woocommerce_quantity_input_min_admin', '0', $product, 'refund' );
+		?>
 		<div class="edit" style="display: none;">
-			<input type="number" step="<?php echo esc_attr( apply_filters( 'woocommerce_quantity_input_step', '1', $product ) ); ?>" min="0" autocomplete="off" name="order_item_qty[<?php echo absint( $item_id ); ?>]" placeholder="0" value="<?php echo esc_attr( $item->get_quantity() ); ?>" data-qty="<?php echo esc_attr( $item->get_quantity() ); ?>" size="4" class="quantity" />
+			<input type="number" step="<?php echo esc_attr( $step_edit ); ?>" min="<?php echo esc_attr( $min_edit ); ?>" autocomplete="off" name="order_item_qty[<?php echo absint( $item_id ); ?>]" placeholder="0" value="<?php echo esc_attr( $item->get_quantity() ); ?>" data-qty="<?php echo esc_attr( $item->get_quantity() ); ?>" size="4" class="quantity" />
 		</div>
 		<div class="refund" style="display: none;">
-			<input type="number" step="<?php echo esc_attr( apply_filters( 'woocommerce_quantity_input_step', '1', $product ) ); ?>" min="0" max="<?php echo absint( $item->get_quantity() ); ?>" autocomplete="off" name="refund_order_item_qty[<?php echo absint( $item_id ); ?>]" placeholder="0" size="4" class="refund_order_item_qty" />
+			<input type="number" step="<?php echo esc_attr( $step_refund ); ?>" min="<?php echo esc_attr( $min_refund ); ?>" max="<?php echo absint( $item->get_quantity() ); ?>" autocomplete="off" name="refund_order_item_qty[<?php echo absint( $item_id ); ?>]" placeholder="0" size="4" class="refund_order_item_qty" />
 		</div>
 	</td>
 	<td class="line_cost" width="1%" data-sort-value="<?php echo esc_attr( $item->get_total() ); ?>">


### PR DESCRIPTION
These filters allow changing the minimum value and change step for the
quantity editors in the order details page of the admin area,
in the context of order line edition and refund line edition.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Introduce two new filters:

* `woocommerce_quantity_input_min_admin`
* `woocommerce_quantity_input_step_admin`

These filters allow setting values for the "minimum" and "step" in the UI for editing the amount for an order line or a refund line in the admin area:

![image](https://user-images.githubusercontent.com/937723/133070454-e1fc6d7c-3b74-4d44-b2cd-961bfc91aa61.png)
 
![image](https://user-images.githubusercontent.com/937723/133070356-386e0ee6-29e8-4389-903c-8abdadfef708.png)

For compatibility, `woocommerce_quantity_input_step_admin` is fed with the value returned by `woocommerce_quantity_input_step`.

Closes #29963.

### How to test the changes in this Pull Request:

1. Go to the admin area and create an order with an item.
2. Add the following snippet to your store:

```php
add_filter( 'woocommerce_quantity_input_step', function($step, $product) {
	return 5;
}, 10, 2 );
```

3. Verify that when you try to edit the amount of the product in the order line, and when you try to create a refund, the quantity editor works in steps of 5. _This is the backwards compatible part, the behavior should be the same without applying this pull request._

4. Keeping the previous snippet add the following too:

```php
add_filter( 'woocommerce_quantity_input_step_admin', function($step, $product, $context) {
	if($context === 'edit') return 2;
	if($context === 'refund') return 3;
	throw new Exception("What the context??");
}, 10, 3 );

add_filter( 'woocommerce_quantity_input_min_admin', function($step, $product, $context) {
	if($context === 'edit') return 4;
	if($context === 'refund') return 5;
	throw new Exception("What the context??");
}, 10, 3 );
```

5. Verify that if you try to edit an order line the quantity editor has a minimum of 4 and a step of 2; and if you try to edit a refund, the quantity editor has a minimum of 5 and a step of 3.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - woocommerce_quantity_input_min_admin and woocommerce_quantity_input_step_admin filters.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
