### PR TITLE
Update WooCommerce blocks to 5.9.0

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -618,6 +618,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -779,6 +782,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -938,6 +944,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",

--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -71,6 +71,10 @@
                 "stylecheck",
                 "tests"
             ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
@@ -239,6 +243,10 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
             "time": "2021-07-21T11:09:57+00:00"
         },
         {
@@ -335,6 +343,10 @@
                 "woocommerce",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
+                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/0.1.1"
+            },
             "time": "2021-07-29T17:25:16+00:00"
         },
         {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
     "woocommerce/woocommerce-admin": "2.6.2",
-    "woocommerce/woocommerce-blocks": "5.7.1"
+    "woocommerce/woocommerce-blocks": "5.9.0"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5eac31e7455cc69f5e7eaa1869d473c6",
+    "content-hash": "f4e4f1b246c0f4581566253aadf74143",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -595,16 +595,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.7.1",
+            "version": "v5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "7dfe482d9b36f05f3d0ee78d74a26b49f3ebe6f1"
+                "reference": "d4f0040e6c41a2e02ce4dff1cd9fc8efe3113af1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/7dfe482d9b36f05f3d0ee78d74a26b49f3ebe6f1",
-                "reference": "7dfe482d9b36f05f3d0ee78d74a26b49f3ebe6f1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d4f0040e6c41a2e02ce4dff1cd9fc8efe3113af1",
+                "reference": "d4f0040e6c41a2e02ce4dff1cd9fc8efe3113af1",
                 "shasum": ""
             },
             "require": {
@@ -612,8 +612,9 @@
                 "composer/installers": "^1.7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "7.5.20",
-                "woocommerce/woocommerce-sniffs": "0.1.0"
+                "woocommerce/woocommerce-sniffs": "0.1.0",
+                "wp-phpunit/wp-phpunit": "^5.4",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -638,7 +639,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2021-08-30T08:15:59+00:00"
+            "time": "2021-09-14T13:42:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 5.9.0 and targets WooCommerce 5.8 release.

*Note: Although I only executed composer update woocommerce/woocommerce-blocks there were a number of other composer lock files changed in this PR. Not sure if that's expected or not.*

## Blocks 5.8.0
[Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4656)
[Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/580.md)
[Release post](https://developer.woocommerce.com/?p=10265)

## Blocks 5.9.0
[Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4731)
[Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/590.md)
[Release post](https://developer.woocommerce.com/2021/09/14/woocommerce-blocks-5-9-0-release-notes/)

Note: there is another test to carry out that is only testable in WC Core, it will not function in the feature plugin.

### Add inbox notification to surface cart and checkout blocks to select merchants ([4518](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4518))

1. Ensure your store is set to US or UK (or add your country locale to the `ELIGIBLE_COUNTRIES` array in `InboxNotifications.php`
1. Open the WooCommerce Admin dashboard (`/wp-admin/admin.php?page=wc-admin`)
2. Check `wp_options` table and verify an entry has been made for `wc_blocks_surface_cart_checkout_probability` - if the number is above 10, change it to be below 10. (This ensures we only target 10% of users) (If using JN or somewhere without direct db access, use this plugin https://wordpress.org/plugins/options-view/ to modify the options table)
2. If you've got any of the [incompatible plugins](https://gist.github.com/opr/d76f94178ec6154990b4e7607c6db05f) active, then you should not see the notification in your inbox.
3. Disable any incompatible plugins and refresh the admin page, you should see a notification about the Cart and Checkout.
4. To delete the notification, add this code to the top of `create_surface_cart_checkout_blocks_notification` ` Notes::delete_notes_with_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );`
5. Re-test with a store in an ineligible location, or with incompatible plugins active.

## Changelog entry

_The following changelog entries are only those that impact functionality surfaced to users in core:_

#### Enhancements

- Add "Filter Products by Stock" block. ([4145](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4145))
- Add label element to `<BlockTitle>` component. ([4585](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4585))


#### Bug Fixes

- Prevent Product Category List from displaying incorrectly when used on the shop page. ([4587](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4587))
- Fix Product Search block displaying incorrectly ([4740](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4740))



