### PR TITLE
Add $formatted_destination as an argument to the woocommerce_cart_no_shipping_available_html filter

### DIFF
--- a/plugins/woocommerce/changelog/adjust-no-shipping-hook
+++ b/plugins/woocommerce/changelog/adjust-no-shipping-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make the formatted shipping address available via the `woocommerce_cart_no_shipping_available_html` hook.

--- a/plugins/woocommerce/templates/cart/cart-shipping.php
+++ b/plugins/woocommerce/templates/cart/cart-shipping.php
@@ -67,7 +67,7 @@ $calculator_text          = '';
 			echo wp_kses_post( apply_filters( 'woocommerce_no_shipping_available_html', __( 'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.', 'woocommerce' ) ) );
 		else :
 			// Translators: $s shipping destination.
-			echo wp_kses_post( apply_filters( 'woocommerce_cart_no_shipping_available_html', sprintf( esc_html__( 'No shipping options were found for %s.', 'woocommerce' ) . ' ', '<strong>' . esc_html( $formatted_destination ) . '</strong>' ) ) );
+			echo wp_kses_post( apply_filters( 'woocommerce_cart_no_shipping_available_html', sprintf( esc_html__( 'No shipping options were found for %s.', 'woocommerce' ) . ' ', '<strong>' . esc_html( $formatted_destination ) . '</strong>' ), $formatted_destination ) );
 			$calculator_text = esc_html__( 'Enter a different address', 'woocommerce' );
 		endif;
 		?>

--- a/plugins/woocommerce/templates/cart/cart-shipping.php
+++ b/plugins/woocommerce/templates/cart/cart-shipping.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.6.0
+ * @version 7.3.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/cart/cart-shipping.php
+++ b/plugins/woocommerce/templates/cart/cart-shipping.php
@@ -66,8 +66,22 @@ $calculator_text          = '';
 		elseif ( ! is_cart() ) :
 			echo wp_kses_post( apply_filters( 'woocommerce_no_shipping_available_html', __( 'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.', 'woocommerce' ) ) );
 		else :
-			// Translators: $s shipping destination.
-			echo wp_kses_post( apply_filters( 'woocommerce_cart_no_shipping_available_html', sprintf( esc_html__( 'No shipping options were found for %s.', 'woocommerce' ) . ' ', '<strong>' . esc_html( $formatted_destination ) . '</strong>' ), $formatted_destination ) );
+			echo wp_kses_post(
+				/**
+				 * Provides a means of overriding the default 'no shipping available' HTML string.
+				 *
+				 * @since 3.0.0
+				 *
+				 * @param string $html                  HTML message.
+				 * @param string $formatted_destination The formatted shipping destination.
+				 */
+				apply_filters(
+					'woocommerce_cart_no_shipping_available_html',
+					// Translators: $s shipping destination.
+					sprintf( esc_html__( 'No shipping options were found for %s.', 'woocommerce' ) . ' ', '<strong>' . esc_html( $formatted_destination ) . '</strong>' ),
+					$formatted_destination
+				)
+			);
 			$calculator_text = esc_html__( 'Enter a different address', 'woocommerce' );
 		endif;
 		?>


### PR DESCRIPTION
Developers should be able to access the $formatted_destination variable directly in order to return a new string to the filter including that address.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Developers should be able to access the $formatted_destination variable directly in order to return a new string to the filter including that address.

### Testing instructions

No testing required; nothing functional has changed and no difference in behavior can be observed through manual testing. Code review is sufficient here.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add $formatted_destination as an argument to the woocommerce_cart_no_shipping_available_html filter