### PR TITLE
Add a note about the need of Basic Auth plugin to the docs.

### DIFF
--- a/packages/js/e2e-utils/README.md
+++ b/packages/js/e2e-utils/README.md
@@ -138,9 +138,7 @@ This package provides support for enabling retries in tests:
 
 ### REST API `withRestApi`
 
-To use this API you need to install [the Basic Auth plugin](https://github.com/WP-API/Basic-Auth),
-as the docker container is non-SSL and the REST API only supports basic authentication.
-You can achieve that by adding `wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate` to your `initialize.sh`.
+Please note: if you're using a non-SSL environment (such as a Docker container from [`wc-e2e`](https://www.npmjs.com/package/@woocommerce/e2e-environment)) you will need to use Basic Auth in order to authenticate with the API and use the `withRestApi` methods listed below. To do so, you will need to install the [the Basic Auth plugin](https://github.com/WP-API/Basic-Auth). One way this can be accomplished is by adding `wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate` to your `initialize.sh` script.
 
 | Function | Parameters | Description |
 |----------|------------|-------------|

--- a/packages/js/e2e-utils/README.md
+++ b/packages/js/e2e-utils/README.md
@@ -1,4 +1,4 @@
-# WooCommerce End to End Test Utilities 
+# WooCommerce End to End Test Utilities
 
 This package contains utilities to simplify writing e2e tests specific to WooCommmerce.
 
@@ -46,7 +46,7 @@ This package provides support for enabling retries in tests:
 - `WP_ADMIN_DASHBOARD` - WordPress dashboard
 - `WP_ADMIN_WP_UPDATES` - WordPress updates
 - `WP_ADMIN_PLUGINS` - Plugin list
-- `WP_ADMIN_PERMALINK_SETTINGS` - Permalink settings  
+- `WP_ADMIN_PERMALINK_SETTINGS` - Permalink settings
 - `WP_ADMIN_ALL_USERS_VIEW` - WordPress user list
 - `WP_ADMIN_POST_TYPE` - Post listing
 - `WP_ADMIN_NEW_POST_TYPE` - New post
@@ -69,7 +69,7 @@ This package provides support for enabling retries in tests:
 #### Front end
 
 - `SHOP_PAGE` - Shop page
-- `SHOP_PRODUCT_PAGE` - Single product page 
+- `SHOP_PRODUCT_PAGE` - Single product page
 - `SHOP_CART_PAGE` - Cart page
 - `SHOP_CHECKOUT_PAGE` - Checkout page
 - `SHOP_MY_ACCOUNT_PAGE` - Customer account page
@@ -105,10 +105,10 @@ This package provides support for enabling retries in tests:
 | `openImportProducts` | | Open the Import Products page |
 | `openExtensions` | | Go to WooCommerce -> Extensions |
 | `openWordPressUpdatesPage` | | Go to Dashboard -> Updates |
-| `installAllUpdates` | | Install all pending updates on Dashboard -> Updates| 
-| `updateWordPress` | | Install pending WordPress updates on Dashboard -> Updates| 
-| `updatePlugins` | | Install all pending plugin updates on Dashboard -> Updates| 
-| `updateThemes` | | Install all pending theme updates on Dashboard -> Updates| 
+| `installAllUpdates` | | Install all pending updates on Dashboard -> Updates|
+| `updateWordPress` | | Install pending WordPress updates on Dashboard -> Updates|
+| `updatePlugins` | | Install all pending plugin updates on Dashboard -> Updates|
+| `updateThemes` | | Install all pending theme updates on Dashboard -> Updates|
 | `runDatabaseUpdate` || Runs the database update if needed |
 
 ### Shopper `shopper`
@@ -137,6 +137,10 @@ This package provides support for enabling retries in tests:
 | `emptyCart` | | Removes any products and coupons that are in the cart |
 
 ### REST API `withRestApi`
+
+To use this API you need to install [the Basic Auth plugin](https://github.com/WP-API/Basic-Auth),
+as the docker container is non-SSL and the REST API only supports basic authentication.
+You can achieve that by adding `wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate` to your `initialize.sh`.
 
 | Function | Parameters | Description |
 |----------|------------|-------------|


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a note about the need for the Basic Auth plugin to the docs.
`@woocommerce/e2e-utils.withRestApi` requires Basic Auth plugin to work, which was not explicitly stated in the docs before.

The only place where Basic Auth is mentioned is https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/env/builtin.md#project-initialization.
But **that's a different package**, it's quite deep in its docs, seems to be just an example of "WooCommerce core's script", like an example of project-specific setup, and project's dependencies not `e2e-utils` API dependency, without an emphasis on the need for Basic Auth for any other project.

Related to https://github.com/woocommerce/woocommerce/issues/30687#issuecomment-919989929 and https://github.com/woocommerce/woocommerce/issues/30280

### How to test the changes in this Pull Request:

1. Read the `@woocommerce/e2e-utils` docs/README https://github.com/woocommerce/woocommerce/blob/update/e2e-utils-docs/tests/e2e/utils/README.md
2. Find the information about what's needed to make the `withRestApi` work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [n/a] Have you written new tests for your changes, as applicable?
* [n/a] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Mention the dependency on the Basic Auth plugin in the `withRestApi`'s docs.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
