### PR TITLE
Fix undefined variable notice when adding a product that doesn't exis…

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -932,6 +932,7 @@ class WC_AJAX {
 
 			// Add items to order.
 			$order_notes = array();
+			$added_items = array();
 
 			foreach ( $items_to_add as $item ) {
 				if ( ! isset( $item['id'], $item['qty'] ) || empty( $item['id'] ) ) {


### PR DESCRIPTION
…ts in order

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Declare an empty array to the `$added_items` variable so it is defined. Found this issue while testing other things and thus there is no issue associated with it.

Before this patch, if you go to add an item in the order in admin without typing in a product and clicking `Add`, you will get an PHP undefined variable notice.

### How to test the changes in this Pull Request:

1. Apply this patch, go to orders screen and add new order. `wp-admin/edit.php?post_type=shop_order`
2. Click on `Add items`. Then `Add products`.
3. Don't type anything in the search box and click on `Add`.
4. Ensure there are no PHP notices generated from that process.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Undefined variable notice when trying to add product in orders without specifying a product.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
