### PR TITLE
initialize index permalinks before e2e tests

### DIFF
--- a/tests/e2e/docker/init-wp-beta.sh
+++ b/tests/e2e/docker/init-wp-beta.sh
@@ -12,6 +12,9 @@ wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --acti
 # install the WP Mail Logging plugin to test emails
 wp plugin install wp-mail-logging --activate
 
+# initialize pretty permalinks
+wp rewrite structure /%postname%/
+
 echo "Updating to WordPress Nightly Point Release"
 wp core update https://wordpress.org/nightly-builds/wordpress-latest.zip
 

--- a/tests/e2e/docker/initialize.sh
+++ b/tests/e2e/docker/initialize.sh
@@ -16,3 +16,6 @@ wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --acti
 
 # install the WP Mail Logging plugin to test emails
 wp plugin install wp-mail-logging --activate
+
+# initialize pretty permalinks
+wp rewrite structure /%postname%/


### PR DESCRIPTION
### Changes proposed in this Pull Request:

See https://github.com/woocommerce/woocommerce-e2e-boilerplate/issues/10. This PR adds the permalink initialization to the two core container initialization scripts.

### How to test the changes in this Pull Request:

1. Verify CI
2. Run `npm wc-e2e docker:up` locally
3. Go to Settings -> Permalinks
4. Verify permalinks are set to `/%postname%/`
