### PR TITLE
Update the priority of the email field in shortcode checkout

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1539,7 +1539,7 @@ class WC_Countries {
 				'class'        => array( 'form-row-wide' ),
 				'validate'     => array( 'email' ),
 				'autocomplete' => 'no' === get_option( 'woocommerce_registration_generate_username' ) ? 'email' : 'email username',
-				'priority'     => 10,
+				'priority'     => 5,
 			);
 		}
 

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1539,7 +1539,7 @@ class WC_Countries {
 				'class'        => array( 'form-row-wide' ),
 				'validate'     => array( 'email' ),
 				'autocomplete' => 'no' === get_option( 'woocommerce_registration_generate_username' ) ? 'email' : 'email username',
-				'priority'     => 110,
+				'priority'     => 10,
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the order of the billing address fields in the  shortcode checkout so that the email field is displayed first. 

**Email field now position at the top of billing details**
<img width="1498" alt="Screen Shot 2021-09-21 at 9 45 33 AM" src="https://user-images.githubusercontent.com/4500952/134212823-aac6b07d-67ea-4f4a-8b0b-4a590209a5f1.png">

This pattern is observed in numerous high profile checkouts across the internet. For example, the four checkouts below: Etsy, a Shopify powered checkout, a Big Commerce powered checkout, as well as our own block-based Gutenberg powered checkout. This change is advantageous for a merchant in that it more easily powers features such as abandoned cart recovery, etc.

**Etsy** 
<img width="879" alt="Screen Shot 2021-09-21 at 9 29 32 AM" src="https://user-images.githubusercontent.com/4500952/134212265-6c90ee7d-1231-42ce-90ba-845a2047721f.png">

**Shopify powered checkout**
<img width="1138" alt="Screen Shot 2021-09-21 at 9 34 06 AM" src="https://user-images.githubusercontent.com/4500952/134212499-2786cead-2adb-4e41-8710-05173883a495.png">

**BigCommerce powered checkout**
<img width="1263" alt="Screen Shot 2021-09-21 at 9 35 30 AM" src="https://user-images.githubusercontent.com/4500952/134212527-6f468c50-1e0b-45c5-886f-78bf91042912.png">

**WooCommerce powered block checkout**
<img width="1380" alt="Screen Shot 2021-09-21 at 9 42 15 AM" src="https://user-images.githubusercontent.com/4500952/134212577-ec5e72e6-34f2-4820-8490-37a07c112307.png">

### How to test the changes in this Pull Request:

1. Add a product to you cart, and proceed to checkout.
2. Observe the email field is now the first field presented in the billing address section. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

While this change is rather simple in nature, my primary concern is how it might affect merchants who've made adjustments to their checkout templates already. Looking for feedback and guidance specifically in regards to this concern. 

cc @mikejolley @ObliviousHarmony @thenbrent p7bje6-3ui-p2



<!-- Mark completed items with an [x] -->

### Changelog entry

> Change the priority of the email field in billing address so that it's moved to the top of the billing address fields

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.