### PR TITLE
Enable redirect method to also handle absolute filepaths.

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -241,6 +241,11 @@ class WC_Download_Handler {
 	 * @param string $filename  File name.
 	 */
 	public static function download_file_redirect( $file_path, $filename = '' ) {
+		$parsed_file_path = self::parse_file_path( $file_path );
+		$file_path = $parsed_file_path['file_path'];
+		if ( ! $parsed_file_path['remote_file'] ) {
+			$file_path = trim( preg_replace( '`^' . str_replace( '\\', '/', getcwd() ) . '`', '', $file_path ), '/' );
+		}
 		header( 'Location: ' . $file_path );
 		exit;
 	}

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -172,9 +172,6 @@ class WC_Product_Download implements ArrayAccess {
 			$value = $matches[1];
 		}
 
-		$parsed_file_path = WC_Download_Handler::parse_file_path( $value );
-		$value            = $parsed_file_path['file_path'];
-
 		switch ( $this->get_type_of_file_path( $value ) ) {
 			case 'absolute':
 				$this->data['file'] = esc_url_raw( $value );


### PR DESCRIPTION
Earlier redirect was only able to handle absolute paths.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We changed `get_file` method to already replace the remote file path with an absolute file path if they are going to be replaced eventually. However, the redirect method relies on files to be remote even on the same server.

This also changes `set_file` method to not use parsed_file method for now.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30772.

### How to test the changes in this Pull Request:

1. Change download method to"Redirect (Insecure)" from WooCommerce > Setting > Product > Downloadable
2. Check out a downloadable product and try to download it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Redirect (Insecure) download method to also support absolute file paths when allowed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
