### PR TITLE
Fix for missing return in API core tests

### DIFF
--- a/tests/e2e/api-core-tests/endpoints/coupons.js
+++ b/tests/e2e/api-core-tests/endpoints/coupons.js
@@ -31,7 +31,7 @@ const couponsApi = {
 		method: 'GET',
 		path: 'coupons',
 		responseCode: 200,
-		coupons: async () => { getRequest( 'coupons' ) },
+		coupons: async () => getRequest( 'coupons' ),
 	},
 	update: {
 		name: 'Update a coupon',

--- a/tests/e2e/api-core-tests/endpoints/orders.js
+++ b/tests/e2e/api-core-tests/endpoints/orders.js
@@ -31,7 +31,7 @@ const ordersApi = {
 		method: 'GET',
 		path: 'orders',
 		responseCode: 200,
-		orders: async () => { getRequest( 'orders' ) },
+		orders: async () => getRequest( 'orders' ),
 	},
 	update: {
 		name: 'Update an order',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses a missing return for the coupon and order API endpoints.

### How to test the changes in this Pull Request:

1. Create some Orders and Coupons.
2. Write a sample test that uses the list all endpoint, e.g. `ordersApi.listAll.orders()`
2. Verify the API returns the list of orders.
3. Repeat steps 2 and 3 for `couponsApi.listAll.coupons()`.