### PR TITLE
Bump woocomemrce-admin version to 2.6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
-    "woocommerce/woocommerce-admin": "2.6.4",
+    "woocommerce/woocommerce-admin": "2.6.5",
     "woocommerce/woocommerce-blocks": "5.7.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d348d40b2ae96f30d9b59f1d0726de5",
+    "content-hash": "b8da8a5a281b3f410373184f4e693f9d",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -221,6 +221,10 @@
                 "zend",
                 "zikula"
             ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.12.0"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -529,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.6.4",
+            "version": "2.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "b7fcc71b972ea7af3579fd5ce5f66ed9bfab80f3"
+                "reference": "03d45390fb555d3a649f87c2b3385257c9d7ac02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/b7fcc71b972ea7af3579fd5ce5f66ed9bfab80f3",
-                "reference": "b7fcc71b972ea7af3579fd5ce5f66ed9bfab80f3",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/03d45390fb555d3a649f87c2b3385257c9d7ac02",
+                "reference": "03d45390fb555d3a649f87c2b3385257c9d7ac02",
                 "shasum": ""
             },
             "require": {
@@ -593,9 +597,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.6.4"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.6.5"
             },
-            "time": "2021-09-21T19:35:21+00:00"
+            "time": "2021-09-22T22:45:59+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -642,6 +646,10 @@
                 "gutenberg",
                 "woocommerce"
             ],
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.7.1"
+            },
             "time": "2021-08-30T08:15:59+00:00"
         }
     ],

--- a/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -61,7 +61,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 	 * @param array $options a set of options.
 	 */
 	public function test_widget_does_not_get_rendered( array $options ) {
-		$this->markTestSkipped('Skipping this test for 5.7.1. See https://github.com/woocommerce/woocommerce/pull/30784 for details');		
+		$this->markTestSkipped( 'Skipping this test for 5.7.1. See https://github.com/woocommerce/woocommerce/pull/30784 for details' );
 		global $wp_meta_boxes;
 
 		foreach ( $options as $name => $value ) {

--- a/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -61,6 +61,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 	 * @param array $options a set of options.
 	 */
 	public function test_widget_does_not_get_rendered( array $options ) {
+		$this->markTestSkipped('Skipping this test for 5.7.1. See https://github.com/woocommerce/woocommerce/pull/30784 for details');		
 		global $wp_meta_boxes;
 
 		foreach ( $options as $name => $value ) {


### PR DESCRIPTION
This PR bumps `woocommerce/woocommerce-admin` in Composer to the latest published package, version 2.6.5

The 2.6.5 version includes the following PRs.

- https://github.com/woocommerce/woocommerce-admin/pull/7698

This PR also skips [test_widget_does_not_get_rendered](https://github.com/woocommerce/woocommerce/pull/30784/files#diff-d53b603e2abe0484e812e8974cd034775cb42f9512f67629c77ac9a01738cfc6L63) test. 

Please see slack discussions: p1632331688174500 and p1632427265311000


## Testing Instructions

### Match stock status value in CSV download to table #7284
1. Add some products and set stock value.
2. Place an order and make it completed.
3. Navigate to Analytics -> Stocks
4. Click the Download button.
5. Open the downloaded file and confirm the status values match the table.

##  Changelog

```
- Fix: Add filters to get new hidden options #7698
 ```
