### PR TITLE
Fix typo in in-app marketplace sections conditional

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -370,7 +370,8 @@
 		}
 	}
 
-	.addons-shipping-methods .addons-wcs-banner-block {
+	.addons-shipping-methods .addons-wcs-banner-block,
+	.addons-payment .addons-wcs-banner-block {
 		margin-left: 0;
 		margin-right: 0;
 		margin-top: 1em;

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * Addons Page
@@ -470,7 +471,7 @@ class WC_Admin_Addons {
 		$location  = wc_get_base_location();
 
 		if (
-			! in_array( $location['country'], array( 'US' ), true ) ||
+			! in_array( $location['country'], array( 'AU', 'AT', 'BE', 'CA', 'FR', 'DE', 'HK', 'IE', 'IT', 'NL', 'NZ', 'PL', 'PT', 'SG', 'ES', 'CH', 'UK', 'US' ), true ) ||
 			$is_active ||
 			! current_user_can( 'install_plugins' ) ||
 			! current_user_can( 'activate_plugins' )

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Addons Page

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -77,20 +77,20 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 				</div>
 			<?php endif; ?>
 			<?php if ( '_featured' !== $current_section && $addons ) : ?>
-				<?php if ( 'shipping_methods' === $current_section ) : ?>
+				<?php if ( 'shipping-methods' === $current_section ) : ?>
 					<div class="addons-shipping-methods">
 						<?php WC_Admin_Addons::output_wcs_banner_block(); ?>
 					</div>
 				<?php endif; ?>
 				<?php if ( 'payment-gateways' === $current_section ) : ?>
-					<div class="addons-shipping-methods">
+					<div class="addons-payment">
 						<?php WC_Admin_Addons::output_wcpay_banner_block(); ?>
 					</div>
 				<?php endif; ?>
 				<ul class="products">
 					<?php foreach ( $addons as $addon ) : ?>
 						<?php
-						if ( 'shipping_methods' === $current_section ) {
+						if ( 'shipping-methods' === $current_section ) {
 							// Do not show USPS or Canada Post extensions for US and CA stores, respectively.
 							$country = WC()->countries->get_base_country();
 							if ( 'US' === $country


### PR DESCRIPTION
### All Submissions:

*    Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
*    Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
*    Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On the **WooCommerce > Marketplace > Shipping** page, the conditional statement that checks the current section has a typo and there's no specific class for the gateways section.

Also, the list of countries where WooCommerce Payments is available has been updated.

This PR addresses those issues.

Closes 11246-gh-Automattic/woocommerce.com

### How to test the changes in this Pull Request:

*   Check out this branch on your local environment

#### WC Shipping banner

*   Update the store country / state to any US state from the [settings](https://woocommerce.test/wp-admin/admin.php?page=wc-settings)
*   Visit the in-app marketplace [page](https://woocommerce.test/wp-admin/admin.php?page=wc-addons&section=shipping-methods)
*   Go to the "Shipping" section from the dropdown select
*   Confirm you see the featured "WooCommerce Shipping" large card (see screenshot below)

#### WC Payments banner

* In WooCommerce > Settings, set your store's Country/State to one of the countries WooCommerce Payments supports: 🇦🇺 Australia, 🇦🇹 Austria, 🇧🇪 Belgium, 🇨🇦 Canada, 🇫🇷 France, 🇩🇪 Germany, 🇭🇰 Hong Kong, 🇮🇪 Ireland, 🇮🇹 Italy, 🇳🇱 Netherlands, 🇳🇿 New Zealand, 🇵🇱 Poland, 🇵🇹 Portugal, 🇸🇬 Singapore, 🇪🇸 Spain, 🇨🇭 Switzerland, 🇬🇧 United Kingdom, 🇺🇸 United States.
* Go to the "Payments" section in WooCommerce > Marketplace.
* Confirm you see the feature "WooCommerce Payments" banner (see screenshot below).
* Go to another section, like "Enhancements".
* Confirm you do not see the WooCommerce Payments banner.
* Change your Country/State to some other country.
* Go to the "Payments" section and confirm you do not see the banner.
* Please test around this issue

### Screenshots

#### WC Shipping banner

<img width="500" src="https://camo.githubusercontent.com/febc15933278183540c56e35917eba4f0ed03c97ce5274dcc62acc980b0a2930/68747470733a2f2f642e70722f692f4e455a3979522b">

#### WC Payments banner

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1647564/134514990-7bcf3023-6dbd-4dc0-84ac-5d2fe68d2bae.png">


### Other information:

*    Have you added an explanation of what your changes do and why you'd like us to include them?
*    Have you written new tests for your changes, as applicable?
*    Have you successfully run tests with your changes locally?

### Changelog entry

> fix in-app marketplace conditional statements for WooCommerce Payments and WooCommerce Shipping banners

### FOR PR REVIEWER ONLY:

*    I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.