### PR TITLE
Update WooCommerce Blocks to 5.7.2

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -1153,5 +1153,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -411,5 +411,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/bin/composer/phpunit/composer.lock
+++ b/bin/composer/phpunit/composer.lock
@@ -1697,5 +1697,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -624,5 +624,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,11 @@
 
 * Fix - Redirect (Insecure) download method to also support absolute file paths when allowed.
 
+**WooCommerce Blocks - 5.7.2**
+
+- Fix - Infinite recursion when removing an attribute filter from the Active filters block. #4816
+- Fix - Fix Product Search block displaying incorrectly. #4740
+
 = 5.7.0 2021-09-21 =
 
 **WooCommerce**

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
     "woocommerce/woocommerce-admin": "2.6.4",
-    "woocommerce/woocommerce-blocks": "5.7.1"
+    "woocommerce/woocommerce-blocks": "5.7.2"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d348d40b2ae96f30d9b59f1d0726de5",
+    "content-hash": "440d6d78d0fc65423e09c8655bd4225b",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -599,16 +599,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.7.1",
+            "version": "v5.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "7dfe482d9b36f05f3d0ee78d74a26b49f3ebe6f1"
+                "reference": "ac5c4219ac1848f1425befe980d25dcf64f064a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/7dfe482d9b36f05f3d0ee78d74a26b49f3ebe6f1",
-                "reference": "7dfe482d9b36f05f3d0ee78d74a26b49f3ebe6f1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/ac5c4219ac1848f1425befe980d25dcf64f064a9",
+                "reference": "ac5c4219ac1848f1425befe980d25dcf64f064a9",
                 "shasum": ""
             },
             "require": {
@@ -642,7 +642,11 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2021-08-30T08:15:59+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.7.2"
+            },
+            "time": "2021-09-23T13:58:57+00:00"
         }
     ],
     "packages-dev": [
@@ -2451,5 +2455,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -166,6 +166,11 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 * Fix - Redirect (Insecure) download method to also support absolute file paths when allowed.
 
+**WooCommerce Blocks - 5.7.2**
+
+- Fix - Infinite recursion when removing an attribute filter from the Active filters block. #4816
+- Fix - Fix Product Search block displaying incorrectly. #4740
+
 = 5.7.0 2021-09-21 =
 
 **WooCommerce**


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 5.7.2 and targets the WooCommerce 5.7 release branch.

_Note: Although I only executed `composer update woocommerce/woocommerce-blocks` there were a number of other composer lock files changed in this PR._

## Blocks 5.7.2

This fixes a regression in the _Active Filters Block_ which caused the page to hang. It also fixes a styling issue in the _Product Search Block_ caused by invalid HTML. There is no release post for this update as we're not relating a feature plugin update.

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4819)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/572.md)

## Changelog entry

#### Bug Fixes

- Fix infinite recursion when removing an attribute filter from the Active filters block. #4816
- Fix Product Search block displaying incorrectly. #4740