### PR TITLE
Bump WCA to 2.7.1 RC 1

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -1153,5 +1153,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -411,5 +411,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/bin/composer/phpunit/composer.lock
+++ b/bin/composer/phpunit/composer.lock
@@ -1697,5 +1697,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -624,5 +624,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@
 * Tweak - Deleted unneeded double spaces in text strings. #30486
 * Tweak - Open Browse all extensions link in a new tab. #30264
 
-**WooCommerce Admin - 2.7.0**
+** WooCommerce Admin - 2.7.1 ** 
 
 * Fix - Allow super admins all capabilities within WooCommerce Admin
 * Fix - Fix end date for last periods
@@ -41,6 +41,7 @@
 * Update - Deleted OnboardingEmailMarketing note class #7595
 * Update - Removes the use of the depreciated woocommerce_shared_settings hook. #7480
 * Update - Updating eway logo in payment suggestions defaults
+* Update - Update marketing task completion logic. #7586
 * Dev - Add email address field to OBW #7552
 * Tweak - Add navigation items for the Marketplace menu. #7529
 * Tweak - Change all analytics strings and labels to sentence case. #6501

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
-    "woocommerce/woocommerce-admin": "2.7.0-rc.1",
+    "woocommerce/woocommerce-admin": "2.7.1-rc.1",
     "woocommerce/woocommerce-blocks": "5.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "304dfc04a658b290cce749ee884db7a1",
+    "content-hash": "b331cddb4c7fac0665d11c8633b14aac",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -533,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.7.0-rc.1",
+            "version": "2.7.1-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "7c5eb86f723353f5a04572414eecdabca77616f6"
+                "reference": "3e873f3a3733ef81fc3352a21dd152840550fffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/7c5eb86f723353f5a04572414eecdabca77616f6",
-                "reference": "7c5eb86f723353f5a04572414eecdabca77616f6",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/3e873f3a3733ef81fc3352a21dd152840550fffe",
+                "reference": "3e873f3a3733ef81fc3352a21dd152840550fffe",
                 "shasum": ""
             },
             "require": {
@@ -597,9 +597,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.7.0-rc.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.7.1-rc.1"
             },
-            "time": "2021-09-21T20:10:27+00:00"
+            "time": "2021-09-23T22:13:54+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2460,5 +2460,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -176,7 +176,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Tweak - Deleted unneeded double spaces in text strings. #30486
 * Tweak - Open Browse all extensions link in a new tab. #30264
 
-**WooCommerce Admin - 2.7.0**
+** WooCommerce Admin - 2.7.1 ** 
 
 * Fix - Allow super admins all capabilities within WooCommerce Admin
 * Fix - Fix end date for last periods
@@ -201,6 +201,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Update - Deleted OnboardingEmailMarketing note class #7595
 * Update - Removes the use of the depreciated woocommerce_shared_settings hook. #7480
 * Update - Updating eway logo in payment suggestions defaults
+* Update - Update marketing task completion logic. #7586
 * Dev - Add email address field to OBW #7552
 * Tweak - Add navigation items for the Marketplace menu. #7529
 * Tweak - Change all analytics strings and labels to sentence case. #6501


### PR DESCRIPTION
- Cherry-pick of https://github.com/woocommerce/woocommerce/pull/30800
- Changelog entries updated appropriately