### PR TITLE
Update WooCommerce Blocks to 5.9.1

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -1153,5 +1153,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -411,5 +411,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/bin/composer/phpunit/composer.lock
+++ b/bin/composer/phpunit/composer.lock
@@ -1697,5 +1697,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -624,5 +624,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
     "woocommerce/woocommerce-admin": "2.7.0-rc.1",
-    "woocommerce/woocommerce-blocks": "5.9.0"
+    "woocommerce/woocommerce-blocks": "5.9.1"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab83245c9816437b7120b146014ff686",
+    "content-hash": "304dfc04a658b290cce749ee884db7a1",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -603,16 +603,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.9.0",
+            "version": "v5.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "d4f0040e6c41a2e02ce4dff1cd9fc8efe3113af1"
+                "reference": "edfe8e40307f6f48236a066aade02a580d1b74fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d4f0040e6c41a2e02ce4dff1cd9fc8efe3113af1",
-                "reference": "d4f0040e6c41a2e02ce4dff1cd9fc8efe3113af1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/edfe8e40307f6f48236a066aade02a580d1b74fd",
+                "reference": "edfe8e40307f6f48236a066aade02a580d1b74fd",
                 "shasum": ""
             },
             "require": {
@@ -649,9 +649,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.9.0"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.9.1"
             },
-            "time": "2021-09-14T13:42:34+00:00"
+            "time": "2021-09-24T08:17:10+00:00"
         }
     ],
     "packages-dev": [
@@ -2460,5 +2460,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 5.9.1 and targets the WooCommerce 5.8 release branch.

_Note: Although I only executed `composer update woocommerce/woocommerce-blocks` there were a number of other composer lock files changed in this PR._

## Blocks 5.9.1

This fixes a regression in the _Active Filters Block_ which caused the page to hang.

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4820)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/591.md)

## Changelog entry

#### Bug Fixes

- Fix infinite recursion when removing an attribute filter from the Active filters block. #4816