### PR TITLE
add product id support to addToCartFromShopPage / removeFromCart

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -32,8 +32,10 @@ const shippingZoneNameSF = 'SF with Local pickup';
 
 const runAddNewShippingZoneTest = () => {
 	describe('WooCommerce Shipping Settings - Add new shipping zone', () => {
+		let productId;
+
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			await withRestApi.deleteAllShippingZones();
 			await merchant.login();
 		});
@@ -64,7 +66,7 @@ const runAddNewShippingZoneTest = () => {
 
 			// Add product to cart as a shopper
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCart();
 
 			// Set shipping country to United States (US)
@@ -120,7 +122,7 @@ const runAddNewShippingZoneTest = () => {
 			await expect(page).toMatchElement('.shipping ul#shipping_method > li', {text: 'Local pickup'});
 			await expect(page).toMatchElement('.order-total .amount', {text: `$${simpleProductPrice}`});
 
-			await shopper.removeFromCart(simpleProductName);
+			await shopper.removeFromCart( productId );
 		});
 	});
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -23,7 +23,6 @@ const {
 
 const config = require( 'config' );
 const simpleProductPrice = config.has( 'products.simple.price' ) ? config.get( 'products.simple.price' ) : '9.99';
-const simpleProductName = config.get( 'products.simple.name' );
 const california = 'state:US:CA';
 const sanFranciscoZIP = '94107';
 const shippingZoneNameUS = 'US with Flat rate';

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -35,9 +35,12 @@ const shippingCountryFR = 'country:FR';
 
 const runCartCalculateShippingTest = () => {
 	describe('Cart Calculate Shipping', () => {
+		let firstProductId;
+		let secondProductId;
+
 		beforeAll(async () => {
-			await createSimpleProduct(firstProductName);
-			await createSimpleProduct(secondProductName, secondProductPrice);
+			firstProductId = await createSimpleProduct(firstProductName);
+			secondProductId = await createSimpleProduct(secondProductName, secondProductPrice);
 
 			await withRestApi.resetSettingsGroupToDefault( 'general' );
 
@@ -56,7 +59,7 @@ const runCartCalculateShippingTest = () => {
 
 		it('allows customer to calculate Free Shipping if in Germany', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(firstProductName);
+			await shopper.addToCartFromShopPage( firstProductId );
 			await shopper.goToCart();
 
 			// Set shipping country to Germany
@@ -97,7 +100,7 @@ const runCartCalculateShippingTest = () => {
 
 		it('should show correct total cart price with 2 products and flat rate', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(secondProductName);
+			await shopper.addToCartFromShopPage( secondProductId );
 			await shopper.goToCart();
 
 			await shopper.setCartQuantity(firstProductName, 1);

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
 /**
  * Internal dependencies
  */
@@ -43,15 +42,16 @@ const getCoupon = (couponType) => {
 
 const runCartApplyCouponsTest = () => {
 	describe('Cart applying coupons', () => {
+		let productId;
 
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			couponFixedCart = await createCoupon();
 			couponPercentage = await createCoupon('50', 'Percentage discount');
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await shopper.emptyCart();
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage('Simple product');
+			await shopper.addToCartFromShopPage( productId );
 			await uiUnblocked();
 			await shopper.goToCart();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
 /**
  * Internal dependencies
  */
@@ -50,7 +49,7 @@ const runCartRedirectionTest = () => {
 			await page.waitFor(1000); // to avoid flakiness
 
 			await shopper.productIsInCart(simpleProductName);
-			await shopper.removeFromCart(simpleProductName);
+			await shopper.removeFromCart( simplePostIdValue );
 		});
 
 		it('can redirect user to cart from detail page', async () => {
@@ -61,7 +60,7 @@ const runCartRedirectionTest = () => {
 			await page.waitFor(1000); // to avoid flakiness
 
 			await shopper.productIsInCart(simpleProductName);
-			await shopper.removeFromCart(simpleProductName);
+			await shopper.removeFromCart( simplePostIdValue );
 		});
 
 		afterAll(async () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
@@ -25,6 +25,7 @@ const twoProductPrice = singleProductPrice * 2;
 const runCartPageTest = () => {
 	describe('Cart page', () => {
 		let productId;
+
 		beforeAll(async () => {
 			productId = await createSimpleProduct();
 			await withRestApi.resetSettingsGroupToDefault('general');
@@ -47,7 +48,7 @@ const runCartPageTest = () => {
 
 		it('should increase item qty when "Add to cart" of the same product is clicked', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 
 			await shopper.goToCart();
 			await shopper.productIsInCart(simpleProductName, 2);
@@ -72,7 +73,7 @@ const runCartPageTest = () => {
 
 		it('should update subtotal in cart totals when adding product to the cart', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 
 			await shopper.goToCart();
 			await shopper.productIsInCart(simpleProductName, 1);

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
@@ -24,8 +24,9 @@ const twoProductPrice = singleProductPrice * 2;
 
 const runCartPageTest = () => {
 	describe('Cart page', () => {
+		let productId;
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			await withRestApi.resetSettingsGroupToDefault('general');
 			await withRestApi.resetSettingsGroupToDefault('products');
 			await withRestApi.resetSettingsGroupToDefault('tax');
@@ -38,7 +39,7 @@ const runCartPageTest = () => {
 
 		it('should add the product to the cart from the shop page', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 
 			await shopper.goToCart();
 			await shopper.productIsInCart(simpleProductName);
@@ -63,7 +64,7 @@ const runCartPageTest = () => {
 
 		it('should remove the item from the cart when remove is clicked', async () => {
 			await shopper.goToCart();
-			await shopper.removeFromCart(simpleProductName);
+			await shopper.removeFromCart( productId );
 			await uiUnblocked();
 
 			await expect(page).toMatchElement('.cart-empty', {text: 'Your cart is currently empty.'});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect, jest/no-standalone-expect */
 /**
  * Internal dependencies
  */
@@ -44,15 +43,17 @@ const getCoupon = (couponType) => {
 
 const runCheckoutApplyCouponsTest = () => {
 	describe('Checkout coupons', () => {
+		let productId;
+
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			couponFixedCart = await createCoupon();
 			couponPercentage = await createCoupon('50', 'Percentage discount');
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await shopper.emptyCart();
 			await shopper.goToShop();
 			await waitForSelectorWithoutThrow( '.add_to_cart_button' );
-			await shopper.addToCartFromShopPage('Simple product');
+			await shopper.addToCartFromShopPage( productId );
 			await uiUnblocked();
 			await shopper.goToCheckout();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-create-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-create-account.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
 /**
  * Internal dependencies
  */
@@ -28,8 +27,10 @@ const customerBilling = config.get( 'addresses.customer.billing' );
 
 const runCheckoutCreateAccountTest = () => {
 	describe('Shopper Checkout Create Account', () => {
+		let productId;
+
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			await withRestApi.deleteCustomerByEmail( customerBilling.email );
 
 			// Set checkbox for creating an account during checkout
@@ -45,7 +46,7 @@ const runCheckoutCreateAccountTest = () => {
 
 			// Add simple product to cart and proceed to checkout
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await uiUnblocked();
 			await shopper.goToCheckout();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-create-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-create-account.test.js
@@ -22,7 +22,6 @@ const {
 } = require( '@jest/globals' );
 
 const config = require( 'config' );
-const simpleProductName = config.get( 'products.simple.name' );
 const customerBilling = config.get( 'addresses.customer.billing' );
 
 const runCheckoutCreateAccountTest = () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
@@ -20,7 +20,6 @@ const {
 } = require( '@jest/globals' );
 
 const config = require('config');
-const simpleProductName = config.get('products.simple.name');
 
 const runCheckoutLoginAccountTest = () => {
 	describe('Shopper Checkout Login Account', () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
 /**
  * Internal dependencies
  */
@@ -25,8 +24,10 @@ const simpleProductName = config.get('products.simple.name');
 
 const runCheckoutLoginAccountTest = () => {
 	describe('Shopper Checkout Login Account', () => {
+		let productId;
+
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 
 			// Set checkbox for logging to account during checkout
 			await merchant.login();
@@ -37,7 +38,7 @@ const runCheckoutLoginAccountTest = () => {
 
 			// Add simple product to cart and proceed to checkout
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await uiUnblocked();
 			await shopper.goToCheckout();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -21,9 +21,11 @@ let guestOrderId;
 let customerOrderId;
 
 const runCheckoutPageTest = () => {
+	let productId;
+
 	describe('Checkout page', () => {
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			await withRestApi.resetSettingsGroupToDefault('general');
 			await withRestApi.resetSettingsGroupToDefault('products');
 			await withRestApi.resetSettingsGroupToDefault('tax');
@@ -54,14 +56,14 @@ const runCheckoutPageTest = () => {
 
 		it('should display cart items in order review', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `1`, singleProductPrice, singleProductPrice);
 		});
 
 		it('allows customer to choose available payment methods', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `2`, twoProductPrice, twoProductPrice);
 
@@ -71,7 +73,7 @@ const runCheckoutPageTest = () => {
 
 		it('allows customer to fill billing details', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `3`, threeProductPrice, threeProductPrice);
 			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));
@@ -79,7 +81,7 @@ const runCheckoutPageTest = () => {
 
 		it('allows customer to fill shipping details', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `4`, fourProductPrice, fourProductPrice);
 
@@ -94,7 +96,7 @@ const runCheckoutPageTest = () => {
 
 		it('allows guest customer to place order', async () => {
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `5`, fiveProductPrice, fiveProductPrice);
 			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));
@@ -117,7 +119,7 @@ const runCheckoutPageTest = () => {
 		it('allows existing customer to place order', async () => {
 			await shopper.login();
 			await shopper.goToShop();
-			await shopper.addToCartFromShopPage(simpleProductName);
+			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `1`, singleProductPrice, singleProductPrice);
 			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));

--- a/tests/e2e/core-tests/specs/shopper/front-end-my-account-create-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-my-account-create-account.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */

--- a/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */
@@ -56,7 +55,7 @@ const runSingleProductPageTest = () => {
 
 		it('should be able to remove simple products from the cart', async () => {
 			// Remove items from cart
-			await shopper.removeFromCart(simpleProductName);
+			await shopper.removeFromCart( simplePostIdValue );
 			await uiUnblocked();
 			await expect(page).toMatchElement('.cart-empty', {text: 'Your cart is currently empty.'});
 		});
@@ -89,7 +88,7 @@ const runSingleProductPageTest = () => {
 
 		it('should be able to remove variation products from the cart', async () => {
 			// Remove items from cart
-			await shopper.removeFromCart(defaultVariableProduct.name);
+			await shopper.removeFromCart( variableProductId );
 			await uiUnblocked();
 			await expect(page).toMatchElement('.cart-empty', {text: 'Your cart is currently empty.'});
 		});
@@ -124,7 +123,7 @@ const runSingleProductPageTest = () => {
 
 		it('should be able to remove grouped products from the cart', async () => {
 			// Remove items from cart
-			await shopper.removeFromCart(simpleProductName+' 1');
+			await shopper.removeFromCart( simpleProductName+' 1' );
 			await uiUnblocked();
 			await expect(page).toMatchElement('.woocommerce-message', {text: '“'+simpleProductName+' 1” removed.'});
 			await Promise.all( [

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `utils.waitForTimeout( delay )` pause processing for `delay` milliseconds
 - `AdminEdit` class with utility functions for the respective edit screens
-- Update `shopper.addToCartFromShopPage()` to accept product Id or Title
+- Update `shopper.addToCartFromShopPage()` and `.removeFromCart()` to accept product Id or Title
 
 # 0.1.6
 

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Added
+
+- Update `shopper.addToCartFromShopPage()` to accept product Id or Title
+
 # 0.1.6
 
 ## Added

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -116,7 +116,7 @@ This package provides support for enabling retries in tests:
 | Function | Parameters | Description |
 |----------|------------|-------------|
 | `addToCart` | | Add an item to the cart from a single product page |
-| `addToCartFromShopPage` | `productTitle` | Add an item to the cart from a single product page |
+| `addToCartFromShopPage` | `productIdOrTitle` | Add an item to the cart from the shop page |
 | `fillBillingDetails` | `customerBillingDetails` | Fill billing fields in checkout form using configured address |
 | `fillShippingDetails` | `customerShippingDetails` | Fill shipping fields in checkout form using configured address |
 | `goToAddresses` |  | Go to My Account -> Address Details |
@@ -131,7 +131,7 @@ This package provides support for enabling retries in tests:
 | `login` |  | Log in as the shopper |
 | `placeOrder` |  | Place an order from the checkout page |
 | `productIsInCheckout` | `productTitle, quantity, total, cartSubtotal` | Verify product is in cart on checkout page |
-| `removeFromCart` | `productTitle` | Remove a product from the cart on the cart page |
+| `removeFromCart` | `productIdOrTitle` | Remove a product from the cart on the cart page |
 | `setCartQuantity` | `productTitle, quantityValue` | Change the quantity of a product on the cart page |
 | `searchForProduct` | | Searching for a product name and landing on its detail page |
 | `emptyCart` | | Removes any products and coupons that are in the cart |

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -40,14 +40,21 @@ const shopper = {
 		] );
 	},
 
-	addToCartFromShopPage: async ( productTitle ) => {
-		const addToCartXPath = `//li[contains(@class, "type-product") and a/h2[contains(text(), "${ productTitle }")]]` +
-			'//a[contains(@class, "add_to_cart_button") and contains(@class, "ajax_add_to_cart")';
+	addToCartFromShopPage: async ( productIdOrTitle ) => {
+		if ( Number.isInteger( productIdOrTitle ) ) {
+			const addToCart = `a[data-product_id="${ productIdOrTitle }"]`;
+			await page.click( addToCart );
+			await expect( page ).toMatchElement( addToCart + '.added' );
+		} else {
+			const addToCartXPath = `//li[contains(@class, "type-product") and a/h2[contains(text(), "${ productIdOrTitle }")]]` +
+				'//a[contains(@class, "add_to_cart_button") and contains(@class, "ajax_add_to_cart")';
 
-		const [ addToCartButton ] = await page.$x( addToCartXPath + ']' );
-		addToCartButton.click();
+			const [ addToCartButton ] = await page.$x( addToCartXPath + ']' );
+			await addToCartButton.click();
 
-		await page.waitFor( addToCartXPath + ' and contains(@class, "added")]' );
+			await page.waitFor( addToCartXPath + ' and contains(@class, "added")]' );
+		}
+
 	},
 
 	goToCheckout: async () => {
@@ -121,12 +128,16 @@ const shopper = {
 		await expect( page ).toFill( '#shipping_postcode', customerShippingDetails.postcode );
 	},
 
-	removeFromCart: async ( productTitle ) => {
-		const cartItemXPath = getCartItemExpression(productTitle);
-		const removeItemXPath = cartItemXPath + '//' + getRemoveExpression();
+	removeFromCart: async ( productIdOrTitle ) => {
+		if ( Number.isInteger( productIdOrTitle ) ) {
+			await page.click( `a[data-product_id="${ productIdOrTitle }"]` );
+		} else {
+			const cartItemXPath = getCartItemExpression( productIdOrTitle );
+			const removeItemXPath = cartItemXPath + '//' + getRemoveExpression();
 
-		const [removeButton] = await page.$x(removeItemXPath);
-		await removeButton.click();
+			const [ removeButton ] = await page.$x( removeItemXPath );
+			await removeButton.click();
+		}
 	},
 
 	emptyCart: async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds support for product ID to both `shopper.addToCartFromShopPage` and `shopper.removeFromCart`.

**Note:** In the first commit on this branch I updated one add to cart call and one remove from cart call to demonstrate that both functions continue to support product title. The second commit updates most of the remainder of the calls.

Closes #25963 .

### How to test the changes in this Pull Request:

1. Review CI result on both commits
2. Verify first & second commits are as described


