### PR TITLE
Check if option exists, before calling `delete_option`

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -141,7 +141,9 @@ class WC_Admin_Notices {
 	 */
 	public static function remove_notice( $name, $force_save = false ) {
 		self::$notices = array_diff( self::get_notices(), array( $name ) );
-		delete_option( 'woocommerce_admin_notice_' . $name );
+		if ( false !== get_option( 'woocommerce_admin_notice_' . $name ) ) {
+			delete_option( 'woocommerce_admin_notice_' . $name );
+		}
 
 		if ( $force_save ) {
 			// Adding early save to prevent more race conditions with notices.


### PR DESCRIPTION
Helps with narrowing down the number of SQL queries triggered on every admin screen.

fixes #30823

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a check to whether an option the code is attempting to delete actually exists, while taking advantage of the persistent cache backend, if available (as implemented in `get_option` check).

Closes #30823 .

### How to test the changes in this Pull Request:

1. Have a persistent cache backend installed 
2. Install a plugin for reviewing the SQL queries run on a screen load (eg.: Query monitor)
3. Go to wp-admin
4. Check if there are any SQL queries originating from `WC_Admin_Notices::remove_notice`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
