### PR TITLE
fix ensure cancelling unpaid orders is always re-scheduled

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -915,8 +915,8 @@ add_action( 'woocommerce_order_status_cancelled', 'wc_update_coupon_usage_counts
 function wc_cancel_unpaid_orders() {
 	$held_duration = get_option( 'woocommerce_hold_stock_minutes' );
 
-	// re-schedule the event before cancelling orders
-	// this way in case of a DB timeout or (plugin) crash the event is always scheduled for retry
+	// Re-schedule the event before cancelling orders
+	// this way in case of a DB timeout or (plugin) crash the event is always scheduled for retry.
 	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
 	wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -915,6 +915,12 @@ add_action( 'woocommerce_order_status_cancelled', 'wc_update_coupon_usage_counts
 function wc_cancel_unpaid_orders() {
 	$held_duration = get_option( 'woocommerce_hold_stock_minutes' );
 
+	// re-schedule the event before cancelling orders
+	// this way in case of a DB timeout or (plugin) crash the event is always scheduled for retry
+	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
+	wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+
 	if ( $held_duration < 1 || 'yes' !== get_option( 'woocommerce_manage_stock' ) ) {
 		return;
 	}
@@ -931,9 +937,6 @@ function wc_cancel_unpaid_orders() {
 			}
 		}
 	}
-	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
-	$cancel_unpaid_interval = apply_filters( 'woocommerce_cancel_unpaid_orders_interval_minutes', absint( $held_duration ) );
-	wp_schedule_single_event( time() + ( absint( $cancel_unpaid_interval ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 }
 add_action( 'woocommerce_cancel_unpaid_orders', 'wc_cancel_unpaid_orders' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/30682

I have moved the `wp_schedule_single_event()`to the beginning of the `wc_cancel_unpaid_orders()`as suggested in my bug report. This ensures that cancelling order does not stop in case of a script timeout or plugin-related crash happening once. Moving it up will ensure it gets scheduled for retry.

### How to test the changes in this Pull Request:

1. add a call to `do_action('woocommerce_cancel_unpaid_orders');` inside a WP init hook to call the new code. Alternatively call `wc_cancel_unpaid_orders();` directly
2. call `exit` in `wc_cancel_unpaid_orders()`to simulate a crash.
3. On next script run: print `$timestamp = wp_next_scheduled ( 'woocommerce_cancel_unpaid_orders' );` to ensure `$timestamp > 0`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Fix - Ensure `woocommerce_cancel_unpaid_orders` event is always re-scheduled.

