### PR TITLE
update page.waitFor to waitForTimeout

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -8,6 +8,7 @@ const {
 	evalAndClick,
 	merchant,
 	createOrder,
+	utils,
 } = require( '@woocommerce/e2e-utils' );
 
 const config = require( 'config' );
@@ -64,7 +65,7 @@ const runOrderApplyCouponTest = () => {
 
 			await uiUnblocked();
 
-			await page.waitFor(2000); // to avoid flakyness
+			await utils.waitForTimeout( 2000 ); // to avoid flakyness
 
 			// Verify the coupon pricing has been removed
 			await expect(page).not.toMatchElement('.wc_coupon_list li.code.editable', { text: couponCode.toLowerCase() });

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-edit.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-edit.test.js
@@ -1,11 +1,11 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */
 const {
 	merchant,
 	createSimpleOrder,
-	moveAllItemsToTrash
+	withRestApi,
+	utils,
 } = require( '@woocommerce/e2e-utils' );
 
 let orderId;
@@ -18,11 +18,9 @@ const runEditOrderTest = () => {
 		});
 
 		afterAll( async () => {
-			// Make sure we're on the all orders view and cleanup the orders we created
-			await merchant.openAllOrdersView();
-			await moveAllItemsToTrash();
+			await withRestApi.deleteAllOrders();
 		});
-		
+
 		it('can view single order', async () => {
 			// Go to "orders" page
 			await merchant.openAllOrdersView();
@@ -36,7 +34,7 @@ const runEditOrderTest = () => {
 			// Make sure we're on the order details page
 			await expect(page.title()).resolves.toMatch('Edit order');
         });
-        
+
         it('can update order status', async () => {
 			//Open order we created
 			await merchant.goToOrder(orderId);
@@ -44,7 +42,7 @@ const runEditOrderTest = () => {
 			// Make sure we're still on the order details page
 			await expect(page.title()).resolves.toMatch('Edit order');
 
-			// Update order status to `Completed` 
+			// Update order status to `Completed`
 			await merchant.updateOrderStatus(orderId, 'Completed');
 
 			// Verify order status changed note added
@@ -56,7 +54,7 @@ const runEditOrderTest = () => {
 				}
 			);
         });
-        
+
         it('can update order details', async () => {
 			//Open order we created
 			await merchant.goToOrder(orderId);
@@ -68,7 +66,7 @@ const runEditOrderTest = () => {
 			await expect(page).toFill('input[name=order_date]', '2018-12-14');
 
 			// Wait for auto save
-			await page.waitFor( 2000 );
+			await utils.waitForTimeout( 2000 );
 
 			// Save the order changes
 			await expect( page ).toClick( 'button.save_order' );
@@ -77,7 +75,6 @@ const runEditOrderTest = () => {
 			// Verify
 			await expect( page ).toMatchElement( '#message', { text: 'Order updated.' } );
 			await expect( page ).toMatchElement( 'input[name=order_date]', { value: '2018-12-14' } );
-
 		});
 	});
 }

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-tax.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-tax.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */
@@ -9,7 +8,7 @@ const {
 	settingsPageSaveChanges,
 	uiUnblocked,
 	verifyCheckboxIsSet,
-	verifyValueOfInputField
+	verifyValueOfInputField,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -172,7 +171,6 @@ const runTaxSettingsTest = () => {
 				expect(page).toMatchElement('#message', {text: 'Your settings have been saved.'}),
 				expect(page).not.toMatchElement('ul.subsubsub > li > a', {text: 'Fancy rates'}),
 			]);
-			await page.waitFor(10000);
 		});
 	});
 };

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
@@ -8,6 +8,7 @@
 	setCheckbox,
 	unsetCheckbox,
 	settingsPageSaveChanges,
+	utils,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -46,7 +47,7 @@ const runCartRedirectionTest = () => {
 			'//a[contains(@class, "add_to_cart_button") and contains(@class, "ajax_add_to_cart")';
 			const [ addToCartButton ] = await page.$x( addToCartXPath + ']' );
 			addToCartButton.click();
-			await page.waitFor(1000); // to avoid flakiness
+			await utils.waitForTimeout( 1000 ); // to avoid flakiness
 
 			await shopper.productIsInCart(simpleProductName);
 			await shopper.removeFromCart( simplePostIdValue );
@@ -57,7 +58,7 @@ const runCartRedirectionTest = () => {
 
 			// Add to cart from detail page
 			await shopper.addToCart();
-			await page.waitFor(1000); // to avoid flakiness
+			await utils.waitForTimeout( 1000 ); // to avoid flakiness
 
 			await shopper.productIsInCart(simpleProductName);
 			await shopper.removeFromCart( simplePostIdValue );

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -16,6 +16,7 @@ import {
 	waitForSelectorWithoutThrow,
 } from './page-utils';
 import factories from './factories';
+import { waitForTimeout } from './flows/utils';
 import { Coupon, Order } from '@woocommerce/api';
 
 const client = factories.api.withDefaultPermalinks;
@@ -32,7 +33,7 @@ const defaultGroupedProduct = config.get('products.grouped');
  */
 const verifyAndPublish = async ( noticeText ) => {
 	// Wait for auto save
-	await page.waitFor( 2000 );
+	await waitForTimeout( 2000 );
 
 	// Publish product
 	await expect( page ).toClick( '#publish' );
@@ -379,7 +380,7 @@ const createSimpleOrder = async ( orderStatus = 'Pending payment' ) => {
 /**
  * Creates a batch of orders from the given `statuses`
  * using the "Batch Create Order" API.
- * 
+ *
  * @param statuses Array of order statuses
  */
 const batchCreateOrders = async (statuses) => {

--- a/tests/e2e/utils/src/flows/merchant.js
+++ b/tests/e2e/utils/src/flows/merchant.js
@@ -31,7 +31,7 @@ const {
 	IS_RETEST_MODE,
 } = require( './constants' );
 
-const { getSlug } = require('./utils');
+const { getSlug, waitForTimeout } = require('./utils');
 
 const baseUrl = config.get( 'url' );
 const WP_ADMIN_SINGLE_CPT_VIEW = ( postId ) => baseUrl + `wp-admin/post.php?post=${ postId }&action=edit`;
@@ -166,7 +166,7 @@ const merchant = {
 			waitUntil: 'networkidle0',
 		} );
 		await expect( page ).toSelect( '#order_status', status );
-		await page.waitFor( 2000 );
+		await waitForTimeout( 2000 );
 		await expect( page ).toClick( 'button.save_order' );
 		await page.waitForSelector( '#message' );
 		await expect( page ).toMatchElement( '#message', { text: 'Order updated.' } );

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -52,6 +52,7 @@ const shopper = {
 			const [ addToCartButton ] = await page.$x( addToCartXPath + ']' );
 			await addToCartButton.click();
 
+			// @todo: Update to waitForXPath when available in Puppeteer api.
 			await page.waitFor( addToCartXPath + ' and contains(@class, "added")]' );
 		}
 

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -7,6 +7,7 @@ import { pressKeyWithModifier } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import { AdminEdit } from './pages/admin-edit';
+import { waitForTimeout } from './flows/utils';
 
 /**
  * Perform a "select all" and then fill a input.
@@ -107,7 +108,7 @@ export const waitForSelectorWithoutThrow = async ( selector, timeoutInSeconds = 
 		if ( selected ) {
 			break;
 		}
-		await page.waitFor( 1000 );
+		await waitForTimeout( 1000 );
 		selected = await page.$( selector );
 	}
 	return Boolean( selected );
@@ -222,7 +223,7 @@ export const selectOptionInSelect2 = async ( value, selector = 'input.select2-se
 	await page.waitForSelector(selector);
 	await page.click(selector);
 	await page.type(selector, value);
-	await page.waitFor(2000); // to avoid flakyness, must wait before pressing Enter
+	await waitForTimeout( 2000 ); // to avoid flakyness, must wait before pressing Enter
 	await page.keyboard.press('Enter');
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates all `page.waitFor()` calls to use our `waitForTimeout` utility function except one. `waitFor()` is deprecated in newer versions of Puppeteer and does not exist in Playwright. There is **todo** note added to the remaining one because the version of Puppeteer we are using predates the introduction of `waitForXPath()`.

There are two other changes included in this PR:
- The order edit test was using the browser to delete all orders at the end of the test. This is updated to delete via the API.
- Removes a 10 second wait at the end of the tax settings test. This was probably added at some point to address a flakiness issue in the subsequent test.

Closes #29818 .

### How to test the changes in this Pull Request:

1. Verify CI
