### PR TITLE
Allow billing email to be empty

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1140,7 +1140,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 						),
 						'email'      => array(
 							'description' => __( 'Email address.', 'woocommerce' ),
-							'type'        => 'string',
+							'type'        => array( 'string', 'null' ),
 							'format'      => 'email',
 							'context'     => array( 'view', 'edit' ),
 						),


### PR DESCRIPTION
Allows passing `null` for the billing email to clear it. This means the
email must either be a string that is a valid email address or a null
value.

Since it is possible to clear the email address for an order in a
similar way via the admin-ajax endpoints, this is meant to provide
consistency with the wp-admin experience.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Get a recent order ID
2. `POST /wp-json/wc/v3/orders/$id` with `{ "billing": { "email": "test@example.com" } }`
3. Verify that the billing email is `test@example.com`
4. `POST /wp-json/wc/v3/orders/$id` with `{ "billing": { "email": null } }`
5. Verify that the billing email is an empty string

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Allow to pass null as the email for billing addresses in REST API

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
