### PR TITLE
fix/30156: prevent 'Search' field from overflowing container on the 'Downloadable product permissions' widget when in the sidebar on the admin order detail page

### DIFF
--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -2426,6 +2426,14 @@ ul.wc_coupon_list_block {
 	}
 }
 
+#side-sortables #woocommerce-order-downloads {
+
+	.buttons,
+	.select2-container {
+		max-width: 100%;
+	}
+}
+
 #poststuff #woocommerce-order-actions .inside {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
Fixes #30156.