### PR TITLE
fix/30829: Old Woo Purple a36597 & a16696

### DIFF
--- a/plugins/woocommerce/legacy/css/activation.scss
+++ b/plugins/woocommerce/legacy/css/activation.scss
@@ -20,17 +20,17 @@ p.woocommerce-actions,
 
 	.button-primary {
 		background: #bb77ae;
-		border-color: #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+		border-color: #7f54b3;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 		color: #fff;
-		text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+		text-shadow: 0 -1px 1px #7f54b3, 1px 0 1px #7f54b3, 0 1px 1px #7f54b3, -1px 0 1px #7f54b3;
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: #a36597;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			background: #7f54b3;
+			border-color: #7f54b3;
+			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -909,22 +909,22 @@
 	a.button-primary,
 	button.button-primary {
 		background: #bb77ae;
-		border-color: #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+		border-color: #7f54b3;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 		color: #fff;
 		text-shadow:
-			0 -1px 1px #a36597,
-			1px 0 1px #a36597,
-			0 1px 1px #a36597,
-			-1px 0 1px #a36597;
+			0 -1px 1px #7f54b3,
+			1px 0 1px #7f54b3,
+			0 1px 1px #7f54b3,
+			-1px 0 1px #7f54b3;
 		display: inline-block;
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: #a36597;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			background: #7f54b3;
+			border-color: #7f54b3;
+			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 		}
 	}
 }
@@ -7389,21 +7389,21 @@ table.bar_chart {
 		}
 
 		li.active {
-			border-color: #a16696;
-			color: #a16696;
+			border-color: #3c2861;
+			color: #3c2861;
 
 			&::before {
-				border-color: #a16696;
+				border-color: #3c2861;
 			}
 		}
 
 		li.done {
-			border-color: #a16696;
-			color: #a16696;
+			border-color: #3c2861;
+			color: #3c2861;
 
 			&::before {
-				border-color: #a16696;
-				background: #a16696;
+				border-color: #3c2861;
+				background: #3c2861;
 			}
 		}
 	}
@@ -7417,28 +7417,28 @@ table.bar_chart {
 		height: auto !important;
 		border-radius: 4px;
 		background-color: #bb77ae;
-		border-color: #a36597;
+		border-color: #7f54b3;
 		-webkit-box-shadow:
 			inset 0 1px 0 rgba(255, 255, 255, 0.25),
-			0 1px 0 #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			0 1px 0 #7f54b3;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 		text-shadow:
-			0 -1px 1px #a36597,
-			1px 0 1px #a36597,
-			0 1px 1px #a36597,
-			-1px 0 1px #a36597;
+			0 -1px 1px #7f54b3,
+			1px 0 1px #7f54b3,
+			0 1px 1px #7f54b3,
+			-1px 0 1px #7f54b3;
 		margin: 0;
 		opacity: 1;
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: #a36597;
-			border-color: #a36597;
+			background: #7f54b3;
+			border-color: #7f54b3;
 			-webkit-box-shadow:
 				inset 0 1px 0 rgba(255, 255, 255, 0.25),
-				0 1px 0 #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+				0 1px 0 #7f54b3;
+			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 		}
 	}
 
@@ -7706,7 +7706,7 @@ table.bar_chart {
 			&::before {
 
 				@include icon("\e015");
-				color: #a16696;
+				color: #3c2861;
 				position: static;
 				font-size: 100px;
 				display: block;

--- a/plugins/woocommerce/legacy/css/auth.scss
+++ b/plugins/woocommerce/legacy/css/auth.scss
@@ -43,7 +43,7 @@ body {
 	}
 
 	a {
-		color: #a16696;
+		color: #3c2861;
 		&:hover, &:focus {
 			color: #111;
 		}
@@ -127,7 +127,7 @@ body {
 	}
 	.button-primary {
 		background: #ad6ea1;
-		border-color: #a16696;
+		border-color: #3c2861;
 		box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.2 ), 0 1px 0 rgba( 0, 0, 0, 0.15 );
 		color: #fff;
 		float: right;

--- a/plugins/woocommerce/legacy/css/menu.scss
+++ b/plugins/woocommerce/legacy/css/menu.scss
@@ -187,23 +187,23 @@ span.mce_woocommerce_shortcodes_button {
 		a.button-primary {
 			float: right;
 			background: #bb77ae;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			border-color: #7f54b3;
+			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 			color: #fff;
 			text-shadow:
-				0 -1px 1px #a36597,
-				1px 0 1px #a36597,
-				0 1px 1px #a36597,
-				-1px 0 1px #a36597;
+				0 -1px 1px #7f54b3,
+				1px 0 1px #7f54b3,
+				0 1px 1px #7f54b3,
+				-1px 0 1px #7f54b3;
 
 			&:hover,
 			&:focus,
 			&:active {
-				background: #a36597;
-				border-color: #a36597;
+				background: #7f54b3;
+				border-color: #7f54b3;
 				box-shadow:
 					inset 0 1px 0 rgba(255, 255, 255, 0.25),
-					0 1px 0 #a36597;
+					0 1px 0 #7f54b3;
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/wc-setup.scss
+++ b/plugins/woocommerce/legacy/css/wc-setup.scss
@@ -79,7 +79,7 @@ body {
 	}
 
 	a {
-		color: #a16696;
+		color: #3c2861;
 
 		&:hover,
 		&:focus {
@@ -356,17 +356,17 @@ body {
 				a.button-primary {
 					color: #fff;
 					background-color: #bb77ae;
-					border-color: #a36597;
-					box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-					text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+					border-color: #7f54b3;
+					box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
+					text-shadow: 0 -1px 1px #7f54b3, 1px 0 1px #7f54b3, 0 1px 1px #7f54b3, -1px 0 1px #7f54b3;
 
 					&:hover,
 					&:focus,
 					&:active {
 						color: #fff;
-						background: #a36597;
-						border-color: #a36597;
-						box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+						background: #7f54b3;
+						border-color: #7f54b3;
+						box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 					}
 				}
 			}
@@ -533,7 +533,7 @@ body {
 		line-height: 1.4;
 
 		a {
-			color: #a16696;
+			color: #3c2861;
 			text-decoration: none;
 			padding: 1.5em;
 			margin: -1.5em;
@@ -563,22 +563,22 @@ body {
 	}
 
 	li.active {
-		border-color: #a16696;
-		color: #a16696;
+		border-color: #3c2861;
+		color: #3c2861;
 		font-weight: 700;
 
 		&::before {
-			border-color: #a16696;
+			border-color: #3c2861;
 		}
 	}
 
 	li.done {
-		border-color: #a16696;
-		color: #a16696;
+		border-color: #3c2861;
+		color: #3c2861;
 
 		&::before {
-			border-color: #a16696;
-			background: #a16696;
+			border-color: #3c2861;
+			background: #3c2861;
 		}
 	}
 }
@@ -592,18 +592,18 @@ body {
 .wc-setup .wc-setup-actions .button-primary,
 .woocommerce-tracker .button-primary {
 	background-color: #bb77ae;
-	border-color: #a36597;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-	text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+	border-color: #7f54b3;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
+	text-shadow: 0 -1px 1px #7f54b3, 1px 0 1px #7f54b3, 0 1px 1px #7f54b3, -1px 0 1px #7f54b3;
 	margin: 0;
 	opacity: 1;
 
 	&:hover,
 	&:focus,
 	&:active {
-		background: #a36597;
-		border-color: #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+		background: #7f54b3;
+		border-color: #7f54b3;
+		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #7f54b3;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updated the old hex colours to be in line with brand guidelines

Closes #30829 

### Changelog entry

> Updated WooCommerce purple hex colour codes

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
