### PR TITLE
Allow safe HTML tags for My Subscriptions' notice

### DIFF
--- a/includes/admin/helper/views/html-main.php
+++ b/includes/admin/helper/views/html-main.php
@@ -226,7 +226,20 @@
 					<tr class="wp-list-table__row wp-list-table__ext-updates">
 						<td class="wp-list-table__ext-status <?php echo sanitize_html_class( $subscription_action['status'] ); ?>">
 							<p><span class="dashicons <?php echo sanitize_html_class( $subscription_action['icon'] ); ?>"></span>
-								<?php echo esc_html( $subscription_action['message'] ); ?>
+								<?php
+									echo wp_kses(
+										$subscription_action['message'],
+										array(
+											'a'      => array(
+												'href'  => array(),
+												'title' => array(),
+											),
+											'br'     => array(),
+											'em'     => array(),
+											'strong' => array(),
+										)
+									);
+								?>
 							</p>
 						</td>
 						<td class="wp-list-table__ext-actions">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/11365.

<img width="969" alt="Screen Shot 2021-10-01 at 13 46 05" src="https://user-images.githubusercontent.com/15897544/135607850-51c3077b-b404-4f81-b91e-cf27b503f62f.png">

The message about a plugin without an active subscription contains HTML which was escaped rather than being sanitized. To remove the cause of it, the PR filters WC Helper messages (all of them are in this file: `includes/admin/helper/class-wc-helper.php`) to allow the most usable tags that are safe.

### How to test the changes in this Pull Request:
- Use the `trunk` branch first to repeat the error
- Connect your test site to WCCOM
- Find out a product that is on the marketplace but you don't have a subscription to it
- [Download](https://woocommerce.com/my-account/downloads/) this product and install it to your site
- Go to _WooCommerce > My Subscriptions_ and see the error
- Switch to the PR's branch
- The notice should look better after a page refresh:
![image](https://user-images.githubusercontent.com/15897544/135609333-2bcb997e-0a7a-425f-a80a-d02ae965f3e1.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix – Display notices on the My Subscriptions page about extensions without a subscription properly

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
