### PR TITLE
Show generic error when trying to process a checkout while offline

### DIFF
--- a/plugins/woocommerce/changelog/friendlier-checkout-errors
+++ b/plugins/woocommerce/changelog/friendlier-checkout-errors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Show a generic error when trying to process a checkout while offline.

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -560,7 +560,11 @@ jQuery( function( $ ) {
 						// Detach the unload handler that prevents a reload / redirect
 						wc_checkout_form.detachUnloadEventsOnSubmit();
 
-						wc_checkout_form.submit_error( '<div class="woocommerce-error">' + errorThrown + '</div>' );
+						wc_checkout_form.submit_error(
+							'<div class="woocommerce-error">' +
+							( errorThrown || wc_checkout_params.i18n_checkout_error ) +
+							'</div>'
+						);
 					}
 				});
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
When testing https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2009 we found a problem in core. If a customer when offline then pressed the 'place order' on the checkout page they would see this very unhelpful message:
![image](https://user-images.githubusercontent.com/1534605/135619313-4d6daa2a-1790-49c1-bb54-d81aabe55949.png)

Now with this change they will see the generic message:
![image](https://user-images.githubusercontent.com/1534605/135619368-542121fb-0d3a-4c5e-9cfa-b1fb61951b67.png)


### How to test the changes in this Pull Request:

1. checkout branch and build js
2. At items to cart and proceed to checkout
3. before clicking 'place order' turn your device offline. Unplug the network cable, turn off wifi or select the offline setting in the network tab of the chrome developer tools under throttle options.
4. You should see helpful error instead of blank red notice.

### Changelog entry

> Show friendly errors on checkout when customer is offline.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
