### PR TITLE
Fix Products Endpoint orderby parameter - slug and include

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -207,10 +207,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$args['post_type'] = $this->post_type;
 		}
 
-		$orderby = $request->get_param( 'orderby' );
-		$order   = $request->get_param( 'order' );
-
-		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
+		$ordering_args   = WC()->query->get_catalog_ordering_args( $args['orderby'], $args['order'] );
 		$args['orderby'] = $ordering_args['orderby'];
 		$args['order']   = $ordering_args['order'];
 		if ( $ordering_args['meta_key'] ) {

--- a/plugins/woocommerce/tests/e2e/api-core-tests/tests/products/products.test.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/tests/products/products.test.js
@@ -568,31 +568,35 @@ const { productsApi } = require('../../endpoints/products');
 				} );
 			} );
 
-			// This case will remain skipped until orderby slug is fixed.
-			// See: https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099.
-			it.skip( 'slug', async () => {
+			it( 'slug', async () => {
+				const productNamesBySlugAsc = [
+					'Polo', // The Polo isn't published so it has an empty slug.
+					...productNamesAsc.filter( p => p !== 'Polo' ),
+				];
+				const productNamesBySlugDesc = [ ...productNamesBySlugAsc ].reverse();
+
 				const result1 = await productsApi.listAll.products( {
 					order: 'asc',
 					orderby: 'slug',
-					per_page: productNamesAsc.length,
+					per_page: productNamesBySlugAsc.length,
 				} );
 				expect( result1.statusCode ).toEqual( 200 );
 
 				// Verify all results are in ascending order.
 				result1.body.forEach( ( { name }, idx ) => {
-					expect( name ).toBe( productNamesAsc[ idx ] );
+					expect( name ).toBe( productNamesBySlugAsc[ idx ] );
 				} );
 
 				const result2 = await productsApi.listAll.products( {
 					order: 'desc',
 					orderby: 'slug',
-					per_page: productNamesDesc.length,
+					per_page: productNamesBySlugDesc.length,
 				} );
 				expect( result2.statusCode ).toEqual( 200 );
 
 				// Verify all results are in descending order.
 				result2.body.forEach( ( { name }, idx ) => {
-					expect( name ).toBe( productNamesDesc[ idx ] );
+					expect( name ).toBe( productNamesBySlugDesc[ idx ] );
 				} );
 			} );
 
@@ -675,7 +679,7 @@ const { productsApi } = require('../../endpoints/products');
 
 			// This case will remain skipped until orderby include is fixed.
 			// See: https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099.
-			it.skip( 'include', async () => {
+			it( 'include', async () => {
 				const includeIds = [
 					sampleData.groupedProducts[ 0 ].id,
 					sampleData.simpleProducts[ 3 ].id,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As discovered in https://github.com/woocommerce/woocommerce/issues/30354#issuecomment-925955099, sorting products by `slug` and `include` was broken.

There is handling for these parameters in [`WC_REST_Posts_Controller::prepare_items_query()`](https://github.com/woocommerce/woocommerce/blob/trunk/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php#L529-L535), but `WC_REST_Products_Controller::prepare_objects_query()` was using the raw values from the `$request`, not the processed output of `WC_REST_CRUD_Controller::prepare_objects_query()`.

### How to test the changes in this Pull Request:

1. Specify the `include` parameter in a request to `/wc/v3/products` with `orderby` set to `include`
2. Verify the products are in the order specified in the `include` parameter
3. In a request to `/wc/v3/products` set `orderby` to `slug` 
4. Verify the products are sorted by the slug properly - check both `asc` and `desc` value for `order`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix products API orderby slug and include.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
