### PR TITLE
Add woocommerce_product_options_shipping_product_data hook to metabox

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-shipping.php
+++ b/includes/admin/meta-boxes/views/html-product-data-shipping.php
@@ -63,4 +63,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 		do_action( 'woocommerce_product_options_shipping' );
 		?>
 	</div>
+	<?php do_action( 'woocommerce_product_options_shipping_product_data' ); ?>
 </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30811 .

### How to test the changes in this Pull Request:

1. apply following snippet
```
/**
 * Shipping field, missing in action.
 */
function test_shipping_options_admin_html() { ?>

	<div class="options_group hide_if_virtual test_options show_if_simple">
		Missing in action.
	</div>

<?php
}
add_action( 'woocommerce_product_options_shipping_product_data', 'test_shipping_options_admin_html', 10000 );
```
Note that the markup will now be:
```
<div class="options_group"></div>
<div class="options_group"></div>
```

instead of 

```
<div class="options_group">
   <div class="options_group"></div>
</div>

```

if adding above snippet to `woocommerce_product_options_shipping` hook.

This makes it easier for multiple plugins to simultaneously add info to the shipping panel by enabling them to add open and closing markup. For example... WooCommerce Subscriptions is getting around this shortfall by adding a closing and opening div tag

```
</div>
<div class="options_group">Subs stuff
```

Which can cause problem with other plugins attempting to also add an options_group div.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add woocommerce_product_options_shipping_product_data hook to product data metabox

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
