### PR TITLE
Reduce Storefront banner width & track links

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -753,7 +753,7 @@
 	}
 
 	.storefront {
-		max-width: 992px;
+		max-width: 990px;
 		background: url(../images/storefront-bg.jpg) bottom right #f6f6f6;
 		border: 1px solid #ddd;
 		margin: 1em auto;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -757,16 +757,21 @@
 		background: url(../images/storefront-bg.jpg) bottom right #f6f6f6;
 		border: 1px solid #ddd;
 		margin: 1em auto;
-		padding: 20px;
+		padding: 24px;
 		overflow: hidden;
 		zoom: 1;
 
 		img {
-			width: 278px;
+			display: block;
+			width: 100%;
+			max-width: 400px;
 			height: auto;
-			float: left;
-			margin: 0 20px 0 0;
+			margin: 0 auto 16px;
 			box-shadow: 0 1px 6px rgba(0, 0, 0, 0.1);
+		}
+
+		p:last-of-type {
+			margin-bottom: 0;
 		}
 
 		p {
@@ -7690,6 +7695,19 @@ table.bar_chart {
 
 		.marketplace-header {
 			padding-left: 84px;
+		}
+
+		.storefront {
+
+			h2 {
+				margin-top: 0;
+			}
+
+			img {
+				float: left;
+				margin: 0 16px 0 auto;
+				width: 278px;
+			}
 		}
 	}
 }

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -753,9 +753,10 @@
 	}
 
 	.storefront {
+		max-width: 992px;
 		background: url(../images/storefront-bg.jpg) bottom right #f6f6f6;
 		border: 1px solid #ddd;
-		margin-top: 1em;
+		margin: 1em auto;
 		padding: 20px;
 		overflow: hidden;
 		zoom: 1;

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b331cddb4c7fac0665d11c8633b14aac",
+    "content-hash": "ed397d52c25da204154232b3dd4b529f",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -2460,5 +2460,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -144,15 +144,15 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 
 		<?php if ( 'Storefront' !== $theme['Name'] && '_featured' !== $current_section ) : ?>
 			<?php
-				$storefront_url = 'https://woocommerce.com/storefront/?utm_source=extensionsscreen&utm_medium=product&utm_campaign=wcaddon';
+				$storefront_url = WC_Admin_Addons::add_in_app_purchase_url_params( 'https://woocommerce.com/storefront/?utm_source=extensionsscreen&utm_medium=product&utm_campaign=wcaddon' );
 			?>
 			<div class="storefront">
-				<a href="<?php echo esc_url( WC_Admin_Addons::add_in_app_purchase_url_params( $storefront_url ) ); ?>" target="_blank"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/storefront.png" alt="<?php esc_attr_e( 'Storefront', 'woocommerce' ); ?>" /></a>
+				<a href="<?php echo esc_url( $storefront_url ); ?>" target="_blank"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/storefront.png" alt="<?php esc_attr_e( 'Storefront', 'woocommerce' ); ?>" /></a>
 				<h2><?php esc_html_e( 'Looking for a WooCommerce theme?', 'woocommerce' ); ?></h2>
 				<p><?php echo wp_kses_post( __( 'We recommend Storefront, the <em>official</em> WooCommerce theme.', 'woocommerce' ) ); ?></p>
 				<p><?php echo wp_kses_post( __( 'Storefront is an intuitive, flexible and <strong>free</strong> WordPress theme offering deep integration with WooCommerce and many of the most popular customer-facing extensions.', 'woocommerce' ) ); ?></p>
 				<p>
-					<a href="<?php echo esc_url( WC_Admin_Addons::add_in_app_purchase_url_params( $storefront_url ) ); ?>" target="_blank" class="button"><?php esc_html_e( 'Read all about it', 'woocommerce' ); ?></a>
+					<a href="<?php echo esc_url( $storefront_url ); ?>" target="_blank" class="button"><?php esc_html_e( 'Read all about it', 'woocommerce' ); ?></a>
 					<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Download &amp; install', 'woocommerce' ); ?></a>
 				</p>
 			</div>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -143,13 +143,16 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 		<?php endif; ?>
 
 		<?php if ( 'Storefront' !== $theme['Name'] && '_featured' !== $current_section ) : ?>
+			<?php
+				$storefront_url = 'https://woocommerce.com/storefront/?utm_source=extensionsscreen&utm_medium=product&utm_campaign=wcaddon';
+			?>
 			<div class="storefront">
-				<a href="<?php echo esc_url( 'https://woocommerce.com/storefront/' ); ?>" target="_blank"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/storefront.png" alt="<?php esc_attr_e( 'Storefront', 'woocommerce' ); ?>" /></a>
+				<a href="<?php echo esc_url( WC_Admin_Addons::add_in_app_purchase_url_params( $storefront_url ) ); ?>" target="_blank"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/storefront.png" alt="<?php esc_attr_e( 'Storefront', 'woocommerce' ); ?>" /></a>
 				<h2><?php esc_html_e( 'Looking for a WooCommerce theme?', 'woocommerce' ); ?></h2>
 				<p><?php echo wp_kses_post( __( 'We recommend Storefront, the <em>official</em> WooCommerce theme.', 'woocommerce' ) ); ?></p>
 				<p><?php echo wp_kses_post( __( 'Storefront is an intuitive, flexible and <strong>free</strong> WordPress theme offering deep integration with WooCommerce and many of the most popular customer-facing extensions.', 'woocommerce' ) ); ?></p>
 				<p>
-					<a href="https://woocommerce.com/storefront/" target="_blank" class="button"><?php esc_html_e( 'Read all about it', 'woocommerce' ); ?></a>
+					<a href="<?php echo esc_url( WC_Admin_Addons::add_in_app_purchase_url_params( $storefront_url ) ); ?>" target="_blank" class="button"><?php esc_html_e( 'Read all about it', 'woocommerce' ); ?></a>
 					<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Download &amp; install', 'woocommerce' ); ?></a>
 				</p>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR:

- Reduce the Storefront banner width on the in-app marketplace page so that it doesn't go full width but rather stay inline with the addons 2 columns section
- Adds STorefront links tracker

Closes 11343-gh-Automattic/woocommerce.com.

### Screenshots:

Before:

![](https://d.pr/i/Gr8NOe+)

After:

![](https://d.pr/i/NTpAhX+)

### How to test the changes in this Pull Request:

1. Checkout this PR locally
2. Run `npm run build-watch`
3. Access the marketplace page `/wp-admin/admin.php?page=wc-addons&section=_all`
4. Go to the bottom of the page
5. Confirm the Storefront banner isn't full width anymore and displays nicely
6. Confirm links to Storefront still work
7. Confirm the display is OK on large and small devices

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Update Storefront banner width and track links in the marketplace page

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.