### PR TITLE
Add `wc_supports_explicit_format` method for total price modifications

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -536,6 +536,16 @@ function wc_get_price_decimals() {
 }
 
 /**
+ * Return if the total prices should be shown in explicit formatting or not.
+ *
+ * @since   5.7.1
+ * @return  bool
+ */
+function wc_supports_explicit_format() {
+	return boolval( apply_filters( '__experimental_woocommerce_supports_explicit_format', false ) );
+}
+
+/**
  * Format the price with a currency symbol.
  *
  * @param  float $price Raw price.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

### Changes proposed in this Pull Request:

This PR contains a new formatting method for prices with currencies, whether they should expose their currency code or not. 

This is needed by the plugins which interacts/will interact with WCPay multi currency plugin, if there are more than one currency enabled in the store, the currencies should expose their currency codes via appending them to the end of the price, on prices that indicate any totals. This process is explained here: paJDYF-20W-p2

### How to test the changes in this Pull Request:

1. Check all PHP and E2E tests are all green.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.