### PR TITLE
Include Customer VAT Exemption Status in Variable Product Price Cache Key

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -397,7 +397,16 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	protected function get_price_hash( &$product, $for_display = false ) {
 		global $wp_filter;
 
-		$price_hash   = $for_display && wc_tax_enabled() ? array( get_option( 'woocommerce_tax_display_shop', 'excl' ), WC_Tax::get_rates() ) : array( false );
+		$price_hash = array( false );
+
+		if ( $for_display && wc_tax_enabled() ) {
+			$price_hash = array(
+				get_option( 'woocommerce_tax_display_shop', 'excl' ),
+				WC_Tax::get_rates(),
+				empty( WC()->customer ) ? false : WC()->customer->is_vat_exempt(),
+			);
+		}
+
 		$filter_names = array( 'woocommerce_variation_prices_price', 'woocommerce_variation_prices_regular_price', 'woocommerce_variation_prices_sale_price' );
 
 		foreach ( $filter_names as $filter_name ) {

--- a/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
+++ b/tests/php/includes/data-stores/class-wc-product-variable-data-store-cpt-test.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Class WC_Product_Variable_Data_Store_CPT_Test
+ */
+class WC_Product_Variable_Data_Store_CPT_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Helper filter to force prices inclusice of tax.
+	 */
+	public function __return_incl() {
+		return 'incl';
+	}
+
+	/**
+	 * @testdox Variation price cache accounts for Customer VAT exemption.
+	 */
+	public function test_variation_price_cache_vat_exempt() {
+		// Set store to include tax in price display.
+		add_filter( 'wc_tax_enabled', '__return_true' );
+		add_filter( 'woocommerce_prices_include_tax', '__return_true' );
+		add_filter( 'pre_option_woocommerce_tax_display_shop', array( $this, '__return_incl' ) );
+		add_filter( 'pre_option_woocommerce_tax_display_cart', array( $this, '__return_incl' ) );
+
+		// Create tax rate.
+		$tax_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
+
+		// Create our variable product.
+		$product = WC_Helper_Product::create_variation_product();
+
+		// Verify that a VAT exempt customer gets prices with tax removed.
+		WC()->customer->set_is_vat_exempt( true );
+
+		$prices_no_tax    = array( '9.09', '13.64', '14.55', '15.45', '16.36', '17.27' );
+		$variation_prices = $product->get_variation_prices( true );
+
+		$this->assertEquals( $prices_no_tax, array_values( $variation_prices['price'] ) );
+
+		// Verify that a normal customer gets prices with tax included.
+		// This indirectly proves that the customer's VAT exemption influences the cache key.
+		WC()->customer->set_is_vat_exempt( false );
+
+		$prices_with_tax  = array( '10.00', '15.00', '16.00', '17.00', '18.00', '19.00' );
+		$variation_prices = $product->get_variation_prices( true );
+
+		$this->assertEquals( $prices_with_tax, array_values( $variation_prices['price'] ) );
+
+		// Clean up.
+		WC_Tax::_delete_tax_rate( $tax_id );
+
+		remove_filter( 'wc_tax_enabled', '__return_true' );
+		remove_filter( 'woocommerce_prices_include_tax', '__return_true' );
+		remove_filter( 'pre_option_woocommerce_tax_display_shop', array( $this, '__return_incl' ) );
+		remove_filter( 'pre_option_woocommerce_tax_display_cart', array( $this, '__return_incl' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25255.

This PR adds logic to alter the Variable Product price hash (cache key) when the current customer is VAT exempt.

### How to test the changes in this Pull Request:

_(Lovingly plagiarized from the issue)_

1. Setup a variable product with taxes
1. Set prices in the store to show including taxes
1. Set up taxes for the site, it's the easiest to reproduce with just one tax rate for every location
1. Use one logged in user and save a location as well as a matching VAT number in their account
1. View the shop page and you should now see the variable product with **no** tax (user is tax exempt)
1. In an incognito window view the same shop page and verify that the variable product is shown **with** taxes
1. Clear the transients in WooCommerce > Status > Tools
1. Refresh the incognito window and see the variable product including taxes
1. Now refresh the shop page again for the logged in user and verify the variable product still shows without taxes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Variable product price caching bug with VAT exemption.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
