### PR TITLE
Monorepo: Add wp-env to test plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Operating System files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.idea
+.vscode/
+
+# Environment files
+wp-cli.local.yml
+.wp-env.override.json
+yarn-error.log
+npm-debug.log
+.pnpm-debug.log
+
+# Build files
+*.sql
+*.swp
+*.zip
+
+# Built packages
+build/
+build-module/
+build-style/
+
+# Project files
+node_modules/
+vendor/
+
+# TypeScript files
+tsconfig.tsbuildinfo
+
+# wp-env config
+.wp-env.override.json

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,11 @@
+{
+	"phpVersion": "7.4",
+	"core": null,
+	"plugins": [ "./plugins/woocommerce" ],
+	"config": {
+		"JETPACK_AUTOLOAD_DEV": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"ALTERNATE_WP_CRON": true
+	}
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,120 @@
+# WooCommerce Development Setup with WP-ENV
+
+Docker development setup for WooCommerce with WP-ENV.
+
+## Prerequisites
+
+Please install WP-ENV before getting started. You can find more about WP-ENV on [here](https://github.com/WordPress/gutenberg/tree/master/packages/env).
+
+The following command installs WP-ENV globally.
+
+`npm -g i @wordpress/env`
+
+## Starting WP-ENV
+
+1. Navigate to the root of WooCommerce source code.
+2. Start the docker container by running `wp-env start`
+
+You should see the following output
+
+```
+WordPress development site started at http://localhost:8888/
+WordPress test site started at http://localhost:8889/
+MySQL is listening on port 55003
+```
+
+The port # might be different depending on your `.wp-env.override.json` configuration.
+
+## Getting Started with Developing
+
+Once you have WP-ENV container up, we need to run a few commands to start developing.
+
+1. Run `npm install` to install npm modules.
+2. Run `npm run dev`
+3. Run `composer install` to install PHP dependencies.
+
+If you don't have Composer available locally, run the following command. It runs the command in WP-ENV container.
+
+`wp-env run composer composer install`
+
+You might also want to run `npm start` to watch your CSS and JS changes if you are working on the frontend.
+
+You're now ready to develop!
+
+## Using Xdebug
+
+Please refer to [WP-ENV official README](https://github.com/WordPress/gutenberg/tree/master/packages/env#using-xdebug) section for setting up Xdebug.
+
+## Overriding the Default Configuration
+
+The default configuration comes with PHP 7.4, WooCommerce 5.0, and a few WordPress config values.
+
+You can create `.wp-env.override.json` file and override the default configuration values.
+
+You can find more about `.wp-env.override.json` configuration [here](https://github.com/WordPress/gutenberg/tree/master/packages/env#wp-envoverridejson).
+
+**Example: Overriding PHP version to 8.0**
+
+Create `.wp-env.override.json` in the root directory with the following content.
+
+```json
+{
+	"phpVersion": "8.0"
+}
+```
+
+**Exampe: Adding a locally installed plugin**
+
+Method 1 - Adding to the `plugins` array
+
+Open the default `.wp-env.json` and copy `plugins` array and paste it into the `.wp-env.override.json` and add your locally installed plugin. Copying the default `plugins` is needed as WP-ENV does not merge the values of the `plugins`.
+
+```json
+{
+	"plugins": [
+		"./plugins/woocommerce",
+		"https://downloads.wordpress.org/plugin/wp-crontrol.1.10.0.zip"
+	]
+}
+```
+
+Method 2 - Adding to the `mappings`
+
+This method is simpler, but the plugin does not get activated on startup. You need to manually activate it yourself on the first startup.
+
+```json
+{
+	"mappings": {
+		"wp-content/plugins/wp-crontrol": "../woocommerce"
+	}
+}
+```
+
+## Accessing MySQL
+
+The MySQL port can change when you restart your container.
+
+You can get the current MySQL port from the output of `wp-env start` command.
+
+1. Open your choice of MySQL tool.
+2. Use the following values to access the MySQL container.
+3. You can omit the username and password.
+
+| Name     | Value                 |
+| -------- | --------------------- |
+| Host     | 127.0.0.1             |
+| Username |                       |
+| Password |                       |
+| Port     | Port from the command |
+
+## HOWTOs
+
+##### How do I ssh into the container?
+
+Run the following command to ssh into the container
+`wp-env run wordpress /bin/bash`
+
+You can run a command in the container with the following syntax. You can find more about on the `run` command [here](https://github.com/WordPress/gutenberg/tree/master/packages/env#wp-env-run-container-command)
+
+Syntax:
+`wp-env run :container-type :linux-command`

--- a/plugins/woocommerce/.gitignore
+++ b/plugins/woocommerce/.gitignore
@@ -69,6 +69,10 @@ contributors.html
 # Yarn
 yarn.lock
 
+# Packages
+/packages/*
+!/packages/README.md
+
 # Screenshots for e2e tests failures
 /screenshots/
 

--- a/plugins/woocommerce/package-lock.json
+++ b/plugins/woocommerce/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11044,7 +11044,7 @@
               }
             },
             "prettier": {
-              "version": "npm:wp-prettier@1.19.1",
+              "version": "npm:prettier@1.19.1",
               "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
               "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
               "dev": true

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -13,7 +13,6 @@
     "wp_org_slug": "woocommerce"
   },
   "scripts": {
-    "install": " if [ -z \"$SKIP_LERNA_BOOTSTRAP\" ]; then npx lerna bootstrap --hoist; fi",
     "check:subset-installed": "npm list --depth 1 install-subset > /dev/null 2>&1",
     "install:subset-only": "npm install --no-package-lock --no-save install-subset",
     "install:no-e2e": "npm run check:subset-installed --silent || npm run install:subset-only && SKIP_LERNA_BOOTSTRAP=true npx install-subset i no-e2e",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds wp-env to test out WooCommerce Core working as a plugin

### How to test the changes in this Pull Request:

1. `cd plugins/woocommerce` and `npm install`, `composer install`.
1. `npm -g i @wordpress/env`.
2. `wp-env start` from the root of the monorepo.
3. Navigate to `http://localhost:8888/wp-admin` (user: admin, pw: password)
4. See WooCommerce being served from the monorepo.