### PR TITLE
Fix typo in variable name

### DIFF
--- a/includes/queue/class-wc-queue.php
+++ b/includes/queue/class-wc-queue.php
@@ -31,7 +31,7 @@ class WC_Queue {
 	 *
 	 * @var string
 	 */
-	protected static $default_cass = 'WC_Action_Queue';
+	protected static $default_class = 'WC_Action_Queue';
 
 	/**
 	 * Single instance of WC_Queue_Interface
@@ -60,7 +60,7 @@ class WC_Queue {
 			wc_doing_it_wrong( __FUNCTION__, __( 'This function should not be called before plugins_loaded.', 'woocommerce' ), '3.5.0' );
 		}
 
-		return apply_filters( 'woocommerce_queue_class', self::$default_cass );
+		return apply_filters( 'woocommerce_queue_class', self::$default_class );
 	}
 
 	/**
@@ -71,7 +71,7 @@ class WC_Queue {
 	 */
 	protected static function validate_instance( $instance ) {
 		if ( false === ( $instance instanceof WC_Queue_Interface ) ) {
-			$default_class = self::$default_cass;
+			$default_class = self::$default_class;
 			/* translators: %s: Default class name */
 			wc_doing_it_wrong( __FUNCTION__, sprintf( __( 'The class attached to the "woocommerce_queue_class" does not implement the WC_Queue_Interface interface. The default %s class will be used instead.', 'woocommerce' ), $default_class ), '3.5.0' );
 			$instance = new $default_class();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR renames a fixes a typo in variable name in `WC_Queue` class

### How to test the changes in this Pull Request:

1. Open up `includes/queue/class-wc-queue.php`
2. And ensure variable `$default_cass` is renamed to `$default_class`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Fixes a typo in a variable name

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
