### PR TITLE
Fix format of `order_edit_recalc_totals` track props

### DIFF
--- a/plugins/woocommerce/assets/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/assets/js/admin/meta-boxes-order.js
@@ -816,7 +816,7 @@ jQuery( function ( $ ) {
 
 						window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
 							order_id: data.post_id,
-							OK_cancel: 'OK',
+							ok_cancel: 'OK',
 							status: $( '#order_status' ).val()
 						} );
 					}
@@ -824,7 +824,7 @@ jQuery( function ( $ ) {
 			} else {
 				window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
 					order_id: woocommerce_admin_meta_boxes.post_id,
-					OK_cancel: 'cancel',
+					ok_cancel: 'cancel',
 					status: $( '#order_status' ).val()
 				} );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Update the track props of the `order_edit_recalc_totals` event to be lower case, follow `^[a-z_][a-z0-9_]*$` pattern.

Closes #30736

### How to test the changes in this Pull Request:

1. Load this branch and create a WooCommerce store with at-least two products (make sure tracking is enabled, asked on the first step in the onboarding wizard).
2. Go to **WooCommerce > Orders** and click **Add order**
3. Click **Add item(s)** and **Add product(s)** select one of your products and click **Add**
4. Open your developer console
5. Click **Recalculate** and click either ok, or cancel
6. Go to the developer tools network tab, and look for the latest request to `t.gif` make sure the Query String Parameters show `ok_cancel: cancel or OK`
7. In the same request copy the `_ui` value, this starts with `woo:...` and go to the tracks live
8. Use the above value in the `Username, ID, or Email` field (see screenshot):
<img width="529" alt="Screen Shot 2021-10-07 at 12 14 49 PM" src="https://user-images.githubusercontent.com/2240960/136413908-4d460882-c0fb-4e52-9bd1-8bd9566e755c.png">
9. Click 'search' (you might have to wait a couple minutes for the tracks to show)
10. Make sure the `wcadmin_order_edit_recalc_totals` track shows up with the correct values
11. Now enable the **Filter for only rejected events** option and click **Search**
12. No events should show

### Changelog entry

> Update track properties to follow correct format.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
