### PR TITLE
Update wp-background-process.php to use wp_convert_hr_to_bytes()

### DIFF
--- a/plugins/woocommerce/changelog/memory-limits-background-processing
+++ b/plugins/woocommerce/changelog/memory-limits-background-processing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+`WP_Background_Process` updated to work nicely with memory_limits expressed in units other than 'M'.

--- a/plugins/woocommerce/includes/libraries/wp-background-process.php
+++ b/plugins/woocommerce/includes/libraries/wp-background-process.php
@@ -370,7 +370,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			$memory_limit = '32000M';
 		}
 
-		return intval( $memory_limit ) * 1024 * 1024;
+		return wp_convert_hr_to_bytes( $memory_limit );
 	}
 
 	/**


### PR DESCRIPTION
We spent hours looking into why a plugin was not working on our staging environment when reaching the WooCommerce thank you page. It turns out that this plugin was failing due to a background process receiving the incorrect value of the memory limit, as supplied by the WP_Background_Process class.

Currently the code is typecasting the memory limit to an int. This assumes that the memory limit is in MB, so if you set your memory limit to 4G this will return 4194304 bytes (4.19304 MB.) Instead, the native WordPress function `wp_convert_hr_to_bytes` should be used to handle the conversion into bytes correctly.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? - There is a similar issue raised however it did not make it and never included the native WordPress function.

### Changes proposed in this Pull Request:

Use the native WordPress function for handling the memory limit.

### How to test the changes in this Pull Request:

1. Call WP_Background_Process->get_memory_value() and test with different values (i.e. 4G, 4000M)

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fix: WP_Background_Process::get_memory_limit() now reads B, MB or GB.

### FOR PR REVIEWER ONLY:

* [X] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
