### PR TITLE
Quote WORDPRESS_TITLE value

### DIFF
--- a/tests/e2e/env/.env
+++ b/tests/e2e/env/.env
@@ -8,4 +8,4 @@ WORDPRESS_DEBUG=1
 
 # WordPress CLI environment
 WORDPRESS_HOST=wordpress-www:80
-WORDPRESS_TITLE=WooCommerce Core E2E Test Suite
+WORDPRESS_TITLE="WooCommerce Core E2E Test Suite"

--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 
+- Added quotes around `WORDPRESS_TITLE` value in .env file to address issue with docker compose 2 "key cannot contain a space" error.
 - Added `LATEST_WP_VERSION_MINUS` that allows setting a number to subtract from the current WordPress version for the WordPress Docker image.
 
 # 0.2.3


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When trying to set up a local development environment, and [setting up to run the e2e tests](https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/README.md#prep-work-for-running-tests), Docker was consistently throwing an error for me when running `npx wc-e2e docker:up`.  I would see:

```
$  npx wc-e2e docker:up
WordPress 5.8.0
PHP 7.4.22
MariaDB 10.6.4
Initializing /Users/lanej0/Code/woocommerce/tests/e2e/docker/initialize.sh
key cannot contain a space
Docker exit code: 15
```

I managed to track the issue down to the unquoted `WORDPRESS_TITLE` key in the `/tests/e2e/env/.env` file.

I believe that this error may only be happening with the latest version of Docker (Mac), however the change made should be non-breaking for other platforms/previous versions:

Version: 4.1.0
Engine: 20.10.8
Compose: 1.29.2

### How to test the changes in this Pull Request:

1. Update Docker.
2. Set up a new development environment, following [the steps in referenced in the documentation](https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/README.md)
2. Run `npx wc-e2e docker:up`.

Previously, this would throw the error referenced above.  Now, the appropriate containers should start as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Quoted WORDPRESS_TITLE value for better compatibility with Docker

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
