### PR TITLE
Change hardcoded wp-content to dynamic code

### DIFF
--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -306,7 +306,7 @@ class WC_Download_Handler {
 			$remote_file = false;
 			$file_path   = ABSPATH . $file_path;
 
-		} elseif ( '/wp-content' === substr( $file_path, 0, 11 ) ) {
+		} elseif ( '/' . str_replace( ABSPATH, '', WP_CONTENT_DIR ) === substr( $file_path, 0, strlen( str_replace( ABSPATH, '', WP_CONTENT_DIR ) ) + 1 ) ) {
 			$remote_file = false;
 			$file_path   = realpath( WP_CONTENT_DIR . substr( $file_path, 11 ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change hardcoded wp-content to dynamic code

Closes #30898

### How to test the changes in this Pull Request:

change WP_CONTENT_DIR in wp-config to anything that does not include wp-content and update your WP installation accordingly. Then test download with it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? => not applicable, as the code is the same as before, I just copied the logic from WP core
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Fix: downloads for installations where WP_CONTENT_DIR does not start with wp-content

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
