### PR TITLE
Bump WooCommerce Admin version to 2.7.2

### DIFF
--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -251,16 +251,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -303,7 +303,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
-    "woocommerce/woocommerce-admin": "2.7.1",
+    "woocommerce/woocommerce-admin": "2.7.2",
     "woocommerce/woocommerce-blocks": "5.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8492f997177afd87b57924d3bd79c38d",
+    "content-hash": "1a8d9b536eba5d14612c538b56803186",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -533,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.7.1",
+            "version": "2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "a693b1a1d62880012500bb649b5ed0f0a9f880ef"
+                "reference": "9ce54862556815e74cfe2476fae0eb30fcfd65d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/a693b1a1d62880012500bb649b5ed0f0a9f880ef",
-                "reference": "a693b1a1d62880012500bb649b5ed0f0a9f880ef",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/9ce54862556815e74cfe2476fae0eb30fcfd65d6",
+                "reference": "9ce54862556815e74cfe2476fae0eb30fcfd65d6",
                 "shasum": ""
             },
             "require": {
@@ -597,9 +597,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.7.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.7.2"
             },
-            "time": "2021-10-01T21:50:52+00:00"
+            "time": "2021-10-11T21:11:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps the bundled WooCommerce Admin version to `2.7.2`.  This is a last minute fix for users experiencing analytics issues around daylight savings time.

It was decided in p1633951843309300-slack that this affected enough users to warrant a new release including this fix.

## Changes since 2.7.1

- Fix: Fix analytics crashing on daylight saving #7763

## Testing

### Fix analytics crashing on daylight saving #7763

- Go to Settings > General
- Set the timezone to a city/state that observes daylight saving, ex: `Auckland`
- Manually place a successful order that's dated on the previous day of the daylight saving at a time after it's supposed to start, ex: Sept 25th 2021 03:00:00 for `Auckland`.
- Go to Analytics > Overview
- Set the date range to custom, choose both from and to date range to the day of the order, ex: 25th September 2021
- Observe the performance stats widget successfully loads