### PR TITLE
Optionally get category enhanced selects to return term IDs

### DIFF
--- a/assets/js/admin/wc-enhanced-select.js
+++ b/assets/js/admin/wc-enhanced-select.js
@@ -264,6 +264,9 @@ jQuery( function( $ ) {
 
 				// Ajax category search boxes
 				$( ':input.wc-category-search' ).filter( ':not(.enhanced)' ).each( function() {
+
+					var return_ids = $( this ).data( 'return_ids' ) ? true : false;
+
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),
@@ -287,7 +290,7 @@ jQuery( function( $ ) {
 								if ( data ) {
 									$.each( data, function( id, term ) {
 										terms.push({
-											id:   term.slug,
+											id:   return_ids ? term.term_id : term.slug,
 											text: term.formatted_name
 										});
 									});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `wc-category-search` inputs return the category _term_. This is much more difficult to translate than a category ID. So for inputs that are categories it would be better to save the term ID. Changing that could be breaky so this PR makes it option. The feature can be enabled by adding `data-return_ID="true"` to the `<select>` element intended to be enhanced.


### How to test the changes in this Pull Request:

Use the following snippet to add an enhanced select to the General panel in a product data metabox. You can search for categories. Upon save you should see a `var_dump()` of an array of IDs.

```
function add_category_enhanced_select() { 
	global $product_object;
	?>

    <p class="form-field cat_field">
        <label for="cat_field"><?php _e( 'Some product categories', 'your-textdomain' ); ?></label>

        <?php

        // Generate some data for the select2 input.
        $selected_cats = $product_object->get_meta( '_some_cat_meta' );

		if ( ! $selected_cats ) {
			$selected_cats = array();
		}

        ?>

        <select id="cat_field"
            class="wc-category-search"
            name="cat_field[]"
            style="width: 400px;"	
            data-return_ids="true"
            data-placeholder="<?php esc_attr_e( 'Search for a category&hellip;', 'your-textdomain' ); ?>"
            data-allow_clear="true"
			data-multiple="true"
        >
        <?php
            foreach ( $selected_cats as $id ) {

                $current_cat      = get_term_by( 'ID', $id, 'product_cat' );

                if ( $current_cat && ! is_wp_error( $current_cat ) ) {
                    echo '<option value="' . esc_attr( $id ) . '"' . selected( true, true, false ) . '>' . wp_kses_post( $current_cat->name ) . '</option>';
                }
            }
        ?>
        </select>
    </p>

	<pre><?php var_dump($selected_cats); ?>
	</pre>

<?php
}
add_action( 'woocommerce_product_options_general_product_data', 'add_category_enhanced_select' );

/**
 * Saves the new meta field.
 *
 * @param  WC_Product  $product
 */
function save_category_id_meta( $product ) {

	if ( isset( $_POST[ 'cat_field' ] ) ) {
		$meta = array_map( 'intval',  $_POST[ 'cat_field' ] );
		$product->update_meta_data( '_some_cat_meta', $meta );
	}
}
add_action( 'woocommerce_admin_process_product_object', 'save_category_id_meta', 20 );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add support for product category enhanced select search inputs by adding `data-return_ids="true"` to your `<select>` element.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
