### PR TITLE
Support using category_id and tag_id in wc_get_product()

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1864,6 +1864,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'field'    => 'slug',
 				'terms'    => $query_vars['category'],
 			);
+		} elseif ( ! empty( $query_vars['category_id'] ) ) {
+			$wp_query_args['tax_query'][] = array(
+				'taxonomy' => 'product_cat',
+				'field'    => 'term_id',
+				'terms'    => $query_vars['category_id'],
+			);
+			unset( $wp_query_args[ 'category_id' ] ) ;
 		}
 
 		// Handle product tags.
@@ -1874,6 +1881,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'field'    => 'slug',
 				'terms'    => $query_vars['tag'],
 			);
+		} elseif ( ! empty( $query_vars['tag_id'] ) ) {
+			$wp_query_args['tax_query'][] = array(
+				'taxonomy' => 'product_tag',
+				'field'    => 'term_id',
+				'terms'    => $query_vars['tag_id'],
+			);
+			unset( $wp_query_args[ 'tag_id' ] ) ;
 		}
 
 		// Handle shipping classes.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add support for category_id and tag_id parameters in wc_get_product()

Closes #30778 .

### How to test the changes in this Pull Request:

Use the following snippet and change `cateogry_id` and `tag_id` to a number relevant to your store:

```
function kia_test_cat_ids() {

	$products = wc_get_products( array(
		'category_id' => 41
		)
	);

	if ( $products ) {
		echo '<ul>By category ID:';
			foreach( $products as $_product ) {
				echo '<li>' . $_product->get_title() . '</li>';
			}
		echo '</ul>';
	}

	$products = wc_get_products( array(
		'tag_id' => 120
		)
	);

	if ( $products ) {
		echo '<ul>By tag ID:';
			foreach( $products as $_product ) {
				echo '<li>' . $_product->get_title() . '</li>';
			}
		echo '</ul>';
	}



}
add_action( 'woocommerce_before_single_product', 'kia_test_cat_ids' );
```

Visit any single product page and get an unordered list of products by category and tag specified.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add support for category_id and tag_id parameters in wc_get_product()

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
