### PR TITLE
Update WooCommerce Blocks to 6.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
-    "woocommerce/woocommerce-admin": "2.7.2",
+    "woocommerce/woocommerce-admin": "2.8.0-rc.2",
     "woocommerce/woocommerce-blocks": "6.1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
     "woocommerce/woocommerce-admin": "2.7.2",
-    "woocommerce/woocommerce-blocks": "5.9.1"
+    "woocommerce/woocommerce-blocks": "6.1.0"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bde2905c076cec3f12338f9464e83e1",
+    "content-hash": "fb2d2b34aa7845cd6d39a187b7c53753",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -533,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.7.2",
+            "version": "2.8.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "9ce54862556815e74cfe2476fae0eb30fcfd65d6"
+                "reference": "f3974919906d4d2168531025340b4f139ae65f1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/9ce54862556815e74cfe2476fae0eb30fcfd65d6",
-                "reference": "9ce54862556815e74cfe2476fae0eb30fcfd65d6",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f3974919906d4d2168531025340b4f139ae65f1d",
+                "reference": "f3974919906d4d2168531025340b4f139ae65f1d",
                 "shasum": ""
             },
             "require": {
@@ -554,7 +554,8 @@
                 "automattic/jetpack-changelogger": "^1.1",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "suin/phpcs-psr4-sniff": "^2.2",
-                "woocommerce/woocommerce-sniffs": "0.1.0"
+                "woocommerce/woocommerce-sniffs": "0.1.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -597,9 +598,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.7.2"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.8.0-rc.2"
             },
-            "time": "2021-10-11T21:11:02+00:00"
+            "time": "2021-10-15T00:51:46+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a8d9b536eba5d14612c538b56803186",
+    "content-hash": "6bde2905c076cec3f12338f9464e83e1",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -603,16 +603,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.9.1",
+            "version": "v6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "edfe8e40307f6f48236a066aade02a580d1b74fd"
+                "reference": "8556efd69e85c01f5571d39e6581d9b8486b682f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/edfe8e40307f6f48236a066aade02a580d1b74fd",
-                "reference": "edfe8e40307f6f48236a066aade02a580d1b74fd",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/8556efd69e85c01f5571d39e6581d9b8486b682f",
+                "reference": "8556efd69e85c01f5571d39e6581d9b8486b682f",
                 "shasum": ""
             },
             "require": {
@@ -649,9 +649,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.9.1"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v6.1.0"
             },
-            "time": "2021-09-24T08:17:10+00:00"
+            "time": "2021-10-12T13:07:11+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 6.1.0 and targets `trunk` but should land on the WooCommerce 5.9 release branch.

## Blocks 6.1.0

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4924)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/610.md)
- [Release post](https://developer.woocommerce.com/2021/10/12/woocommerce-blocks-6-1-0-release-notes/)

## Blocks 6.0.2
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4874)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/602.md)
- [Release post](https://developer.woocommerce.com/2021/09/30/woocommerce-blocks-6-0-2-release-notes/)

## Blocks 6.0.1
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4868)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/601.md)
- [Release post](https://developer.woocommerce.com/2021/09/29/woocommerce-blocks-6-0-1-release-notes/)

## Blocks 6.0.0
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4850)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/600.md)
- Release post - Covered in 6.0.1 release post

## Changelog entry

#### Enhancements
- Added global styles to All Reviews, Reviews by Category and Reviews by Product blocks. Now it's possible to change the text color and font size of those blocks. ([4323](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4323))

#### Bug Fixes
- Fix infinite recursion when removing an attribute filter from the Active filters block. ([4816](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4816))
- Update All Reviews block so it honors 'ratings enabled' and 'show avatars' preferences. ([4764](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4764))
- Products by Category: Moved renderEmptyResponsePlaceholder to separate method to prevent unnecessary rerender. ([4751](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4751))
- Fix calculation of number of reviews in the Reviews by Category block. ([4729](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4729))
- Fix the dropdown list in Product Category List Block for nested categories ([4920](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4920))
- Fixed string translations within the All Products Block. ([4897](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4897))
- Filter By Price: Update aria values to be more representative of the actual values presented. ([4839](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4839))
- Fixed: Filter button from Filter Products by Attribute block is not aligned with the input field. ([4814](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4814))
- Remove IntersectionObserver shim in favor of dropping IE11 support. ([4808](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4808))
