### PR TITLE
Update locale-info.php

### DIFF
--- a/plugins/woocommerce/i18n/locale-info.php
+++ b/plugins/woocommerce/i18n/locale-info.php
@@ -8,7 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$locales = include WC()->plugin_path() . '/i18n/currency-info.php';
+$locales = include 'currency-info.php';
 
 return array(
 	'AD' => array(


### PR DESCRIPTION
Revert changes in https://github.com/woocommerce/woocommerce/commit/9d06c74339c2ae190b40acc7f0aef38a53140e94?branch=9d06c74339c2ae190b40acc7f0aef38a53140e94&diff=unified#diff-122b62121f7a3deb664f05d12fb2af1c40cf819712b5f2db935017ce4a4c45cbR11

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I have reverted the changes made in https://github.com/woocommerce/woocommerce/commit/9d06c74339c2ae190b40acc7f0aef38a53140e94?branch=9d06c74339c2ae190b40acc7f0aef38a53140e94&diff=unified#diff-122b62121f7a3deb664f05d12fb2af1c40cf819712b5f2db935017ce4a4c45cbR11 as it doesn't seem necessary to determine the absolute path to the `currency-info.php` file since it resides in the same directory as the `local-info.php` file. There is some discussion there on that commit about the changes. We are using the `locale-info.php` file in one of our applications, and including it before WooCommerce is loaded, so including that file is throwing a fatal error in our application. It doesn't seem necessary to determine the absolute path of the file since they reside in the same directory.

Closes # .

### How to test the changes in this Pull Request:

There are no major changes here.

1. Pull down these changes.
2. Run through the WooCommerce setup wizard, where the `locale-info.php` is included.
3. Change the store location to somewhere in the world (United Kingdom, Afghanistan, Hebrew etc.) and complete the setup wizard.
4. Check the settings page 'WooCommerce > Settings' > General', scroll down and confirm the 'Currency options' values updated accordingly based on the selected country.

![image](https://user-images.githubusercontent.com/5321364/138312739-4a949a33-3b08-4679-b02d-1cecde45eed8.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove the absolute path to the `currency-info.php` from within `locale-info.php`. Reverts https://github.com/woocommerce/woocommerce/commit/9d06c74339c2ae190b40acc7f0aef38a53140e94?branch=9d06c74339c2ae190b40acc7f0aef38a53140e94&diff=unified#diff-122b62121f7a3deb664f05d12fb2af1c40cf819712b5f2db935017ce4a4c45cbR11

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
