### PR TITLE
In-App Marketplace Category Banners

### DIFF
--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -932,9 +932,9 @@ class WC_Admin_Addons {
 					$url = self::get_action_url( $action );
 
 					$promotion_actions[] = array(
-						'name' => $action->name,
-						'label' => $action_locale->label,
-						'url' => $url,
+						'name'    => $action->name,
+						'label'   => $action_locale->label,
+						'url'     => $url,
 						'primary' => isset( $action->is_primary ) ? $action->is_primary : false,
 					);
 				}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -894,8 +894,8 @@ class WC_Admin_Addons {
 			$formatted_promotions[] = array(
 				'title'       => $locale->title,
 				'description' => $locale->description,
-				'image'       => $locale->image,
-				'image_alt'   => $locale->img_alt,
+				'image'       => ( 'http' === substr( $locale->image, 0, 4 ) ) ? $locale->image : WC()->plugin_url() . $locale->image,
+				'image_alt'   => $locale->image_alt,
 				'actions'     => $promotion_actions,
 			);
 		}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -82,7 +82,7 @@ class WC_Admin_Addons {
 	 * @param  string $term     Search terms.
 	 * @param  string $country  Store country.
 	 *
-	 * @return object of extensions and promotions
+	 * @return object of extensions and promotions.
 	 */
 	public static function get_extension_data( $category, $term, $country ) {
 		$parameters     = self::build_parameter_string( $category, $term, $country );
@@ -524,7 +524,7 @@ class WC_Admin_Addons {
 	}
 
 	/**
-	 * Output the HTML for the promotion block
+	 * Output the HTML for the promotion block.
 	 *
 	 * @param array $promotion Array of promotion block data.
 	 * @return void

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -85,7 +85,7 @@ class WC_Admin_Addons {
 	 * @return object of extensions and promotions.
 	 */
 	public static function get_extension_data( $category, $term, $country ) {
-		$parameters     = self::build_parameter_string( $category, $term, $country );
+		$parameters = self::build_parameter_string( $category, $term, $country );
 
 		$headers = array();
 		$auth    = WC_Helper_Options::get( 'auth' );
@@ -764,12 +764,12 @@ class WC_Admin_Addons {
 		$addons          = array();
 
 		if ( '_featured' !== $current_section ) {
-			$category         = $section ? $section : null;
-			$term             = $search ? $search : null;
-			$country          = WC()->countries->get_base_country();
-			$extension_data   = self::get_extension_data( $category, $term, $country );
-			$addons           = $extension_data->products;
-			$promotions       = ! empty( $extension_data->promotions ) ? $extension_data->promotions : array();
+			$category       = $section ? $section : null;
+			$term           = $search ? $search : null;
+			$country        = WC()->countries->get_base_country();
+			$extension_data = self::get_extension_data( $category, $term, $country );
+			$addons         = $extension_data->products;
+			$promotions     = ! empty( $extension_data->promotions ) ? $extension_data->promotions : array();
 		}
 
 		// We need Automattic\WooCommerce\Admin\RemoteInboxNotifications for the next part, if not remove all promotions.
@@ -780,7 +780,7 @@ class WC_Admin_Addons {
 		if ( ! empty( $promotions ) ) {
 			foreach ( $promotions as $promo_id => $promotion ) {
 				$evaluator = new PromotionRuleEngine\RuleEvaluator();
-				$passed = $evaluator->evaluate( $promotion->rules );
+				$passed    = $evaluator->evaluate( $promotion->rules );
 				if ( ! $passed ) {
 					unset( $promotions[ $promo_id ] );
 				}
@@ -929,7 +929,7 @@ class WC_Admin_Addons {
 			if ( ! empty( $promotion->actions ) ) {
 				foreach ( $promotion->actions as $action ) {
 					$action_locale = PromotionRuleEngine\SpecRunner::get_action_locale( $action->locales );
-					$url = self::get_action_url( $action );
+					$url           = self::get_action_url( $action );
 
 					$promotion_actions[] = array(
 						'name'    => $action->name,

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications as PromotionRuleEngine;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -81,7 +82,7 @@ class WC_Admin_Addons {
 	 * @param  string $term     Search terms.
 	 * @param  string $country  Store country.
 	 *
-	 * @return array of extensions
+	 * @return object of extensions and promotions
 	 */
 	public static function get_extension_data( $category, $term, $country ) {
 		$parameters     = self::build_parameter_string( $category, $term, $country );
@@ -99,7 +100,7 @@ class WC_Admin_Addons {
 		);
 
 		if ( ! is_wp_error( $raw_extensions ) ) {
-			$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) )->products;
+			$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) );
 		}
 		return $addons;
 	}
@@ -710,13 +711,33 @@ class WC_Admin_Addons {
 		$sections        = self::get_sections();
 		$theme           = wp_get_theme();
 		$current_section = isset( $_GET['section'] ) ? $section : '_featured';
+		$promotions      = array();
 		$addons          = array();
 
 		if ( '_featured' !== $current_section ) {
-			$category = $section ? $section : null;
-			$term     = $search ? $search : null;
-			$country  = WC()->countries->get_base_country();
-			$addons   = self::get_extension_data( $category, $term, $country );
+			$category         = $section ? $section : null;
+			$term             = $search ? $search : null;
+			$country          = WC()->countries->get_base_country();
+			$extension_data   = self::get_extension_data( $category, $term, $country );
+			$addons           = $extension_data->products;
+			$promotions       = ! empty( $extension_data->promotions ) ? $extension_data->promotions : array();
+		}
+
+		// We need Automattic\WooCommerce\Admin\RemoteInboxNotifications for the next part, if not remove all promotions.
+		if ( ! WC()->is_wc_admin_active() ) {
+			$promotions = array();
+		}
+		// Check for existance of promotions and evaluate out if we should show them.
+		if ( ! empty( $promotions ) ) {
+			foreach ( $promotions as $promo_id => $promotion ) {
+				$evaluator = new PromotionRuleEngine\RuleEvaluator();
+				$passed = $evaluator->evaluate( $promotion->rules );
+				if ( ! $passed ) {
+					unset( $promotions[ $promo_id ] );
+				}
+			}
+			// Tranform promotions to correct format ready for output.
+			$promotions = self::format_promotions( $promotions );
 		}
 
 		/**
@@ -810,5 +831,74 @@ class WC_Admin_Addons {
 		}
 
 		return " $admin_body_class woocommerce-page-wc-marketplace ";
+	}
+
+	/**
+	 * Take an action object and return the URL based on properties of the action.
+	 *
+	 * @param object $action Action object.
+	 * @return string URL.
+	 */
+	public static function get_action_url( $action ): string {
+		if ( ! isset( $action->url ) ) {
+			return '';
+		}
+
+		if ( isset( $action->url_is_admin_query ) && $action->url_is_admin_query ) {
+			return wc_admin_url( $action->url );
+		}
+
+		if ( isset( $action->url_is_admin_nonce_query ) && $action->url_is_admin_nonce_query ) {
+			if ( empty( $action->nonce ) ) {
+				return '';
+			}
+			return wp_nonce_url(
+				wc_admin_url( $action->url ),
+				$action->nonce
+			);
+		}
+
+		return $action->url;
+	}
+
+	/**
+	 * Format the promotion data ready for display, ie fetch locales and actions.
+	 *
+	 * @param array $promotions Array of promotoin objects.
+	 * @return array Array of formatted promotions ready for output.
+	 */
+	public static function format_promotions( array $promotions ): array {
+		$formatted_promotions = array();
+		foreach ( $promotions as $promotion ) {
+			// Get the matching locale or fall back to en-US.
+			$locale = PromotionRuleEngine\SpecRunner::get_locale( $promotion->locales );
+			if ( null === $locale ) {
+				continue;
+			}
+
+			$promotion_actions = array();
+			if ( ! empty( $promotion->actions ) ) {
+				foreach ( $promotion->actions as $action ) {
+					$action_locale = PromotionRuleEngine\SpecRunner::get_action_locale( $action->locales );
+					$url = self::get_action_url( $action );
+
+					$promotion_actions[] = array(
+						'name' => $action->name,
+						'label' => $action_locale->label,
+						'url' => $url,
+						'primary' => isset( $action->is_primary ) ? $action->is_primary : false,
+					);
+				}
+			}
+
+			$formatted_promotions[] = array(
+				'title'       => $locale->title,
+				'description' => $locale->description,
+				'image'       => $locale->image,
+				'image_alt'   => $locale->img_alt,
+				'actions'     => $promotion_actions,
+			);
+		}
+		return $formatted_promotions;
 	}
 }

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -776,7 +776,7 @@ class WC_Admin_Addons {
 		if ( ! WC()->is_wc_admin_active() ) {
 			$promotions = array();
 		}
-		// Check for existance of promotions and evaluate out if we should show them.
+		// Check for existence of promotions and evaluate out if we should show them.
 		if ( ! empty( $promotions ) ) {
 			foreach ( $promotions as $promo_id => $promotion ) {
 				$evaluator = new PromotionRuleEngine\RuleEvaluator();
@@ -785,7 +785,7 @@ class WC_Admin_Addons {
 					unset( $promotions[ $promo_id ] );
 				}
 			}
-			// Tranform promotions to correct format ready for output.
+			// Transform promotions to the correct format ready for output.
 			$promotions = self::format_promotions( $promotions );
 		}
 

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -524,6 +524,37 @@ class WC_Admin_Addons {
 	}
 
 	/**
+	 * Output the HTML for the promotion block
+	 *
+	 * @param array $promotion Array of promotion block data.
+	 * @return void
+	 */
+	public static function output_search_promotion_block( array $promotion ) {
+		?>
+		<div class="addons-wcs-banner-block">
+			<div class="addons-wcs-banner-block-image">
+				<img
+					class="addons-img"
+					src="<?php echo esc_url( $promotion['image'] ); ?>"
+					alt="<?php echo esc_attr( $promotion['image_alt'] ); ?>"
+				/>
+			</div>
+			<div class="addons-wcs-banner-block-content">
+				<h1><?php echo esc_html( $promotion['title'] ); ?></h1>
+				<p><?php echo esc_html( $promotion['description'] ); ?></p>
+				<?php
+				if ( ! empty( $promotion['actions'] ) ) {
+					foreach ( $promotion['actions'] as $action ) {
+						self::output_promotion_action( $action );
+					}
+				}
+				?>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Handles the output of a full-width block.
 	 *
 	 * @param array $section Section data.
@@ -564,7 +595,6 @@ class WC_Admin_Addons {
 				</div>
 				<div class="addons-promotion-block-buttons">
 					<?php
-
 					if ( $section['button_1'] ) {
 						self::output_button(
 							$section['button_1_href'],
@@ -582,7 +612,6 @@ class WC_Admin_Addons {
 							$section['plugin']
 						);
 					}
-
 					?>
 				</div>
 			</div>
@@ -677,6 +706,26 @@ class WC_Admin_Addons {
 			class="addons-button <?php echo esc_attr( $style ); ?>"
 			href="<?php echo esc_url( $url ); ?>">
 			<?php echo esc_html( $text ); ?>
+		</a>
+		<?php
+	}
+
+	/**
+	 * Output HTML for a promotion action.
+	 *
+	 * @param array $action Array of action properties.
+	 * @return void
+	 */
+	public static function output_promotion_action( array $action ) {
+		if ( empty( $action ) ) {
+			return;
+		}
+		$style = ( ! empty( $action['primary'] ) && $action['primary'] ) ? 'addons-button-solid' : 'addons-button-outline-purple';
+		?>
+		<a
+			class="addons-button <?php echo esc_attr( $style ); ?>"
+			href="<?php echo esc_url( $action['url'] ); ?>">
+			<?php echo esc_html( $action['label'] ); ?>
 		</a>
 		<?php
 	}
@@ -853,7 +902,7 @@ class WC_Admin_Addons {
 				return '';
 			}
 			return wp_nonce_url(
-				wc_admin_url( $action->url ),
+				admin_url( $action->url ),
 				$action->nonce
 			);
 		}

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -81,9 +81,10 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 			<?php endif; ?>
 			<?php if ( '_featured' !== $current_section && $addons ) : ?>
 				<?php
-				print_r( $promotions, true );
 				if ( ! empty( $promotions ) && WC()->is_wc_admin_active() ) {
-
+					foreach ( $promotions as $promotion ) {
+						WC_Admin_Addons::output_search_promotion_block( $promotion );
+					}
 				}
 				?>
 				<ul class="products">

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -5,7 +5,10 @@
  * @package WooCommerce\Admin
  * @var string $view
  * @var object $addons
+ * @var object $promotions
  */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications as PromotionRuleEngine;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -77,16 +80,11 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 				</div>
 			<?php endif; ?>
 			<?php if ( '_featured' !== $current_section && $addons ) : ?>
-				<?php if ( 'shipping_methods' === $current_section ) : ?>
-					<div class="addons-shipping-methods">
-						<?php WC_Admin_Addons::output_wcs_banner_block(); ?>
-					</div>
-				<?php endif; ?>
-				<?php if ( 'payment-gateways' === $current_section ) : ?>
-					<div class="addons-shipping-methods">
-						<?php WC_Admin_Addons::output_wcpay_banner_block(); ?>
-					</div>
-				<?php endif; ?>
+				<?php
+				if ( ! empty( $promotions ) && WC()->is_wc_admin_active() ) {
+
+				}
+				?>
 				<ul class="products">
 					<?php foreach ( $addons as $addon ) : ?>
 						<?php

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -81,6 +81,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 			<?php endif; ?>
 			<?php if ( '_featured' !== $current_section && $addons ) : ?>
 				<?php
+				print_r( $promotions, true );
 				if ( ! empty( $promotions ) && WC()->is_wc_admin_active() ) {
 
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Remove the hardcoded WC Pay and WC Services banners on the Marketplace categories pages and transform the system to use the WCCOM API and the WC Admin Rule Evaluator class for determining if a banner should be displayed on these pages.

Closes 11309-gh-Automattic/woocommerce.com

### How to test the changes in this Pull Request:

1. Check out this branch
2. Ensure your store country is set to US `WooCommerce -> Settings`
3. In WP-Admin visit `WooCommerce -> Marketplace` and verify products are still shown
4. Now navigate to the Payments category in `WooCommerce -> Marketplace` and verify the WC Payments banner is displayed above the products, if you have WC Payments installed it should not show so test with the plugin activated and deactivated.
5. Now navigate to the Shipping category in `WooCommerce -> Marketplace` and verify the WC Services banner is displayed above the products, if you have WC Services installed already it should not show so test with the plugin activated and deactivated.

### Other information:
These changes form part of the In-App Marketplace revamp.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Remove hardcode category banners in Settings > Marketplace and use the WooCommerce.com API instead.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.