### PR TITLE
Add wrapper for `get_formatted_meta_data` to make `$include_all` default to `true`

### DIFF
--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -507,9 +507,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 							$html .= '<div class="wc-order-item-sku">' . esc_html( $product_object->get_sku() ) . '</div>';
 						}
 
-						$include_all = false;
-						$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-						$meta_data   = $item->get_formatted_meta_data( '', $include_all );
+						$meta_data = $item->get_formatted_meta_data( '' );
 
 						if ( $meta_data ) {
 							$html .= '<table cellspacing="0" class="wc-order-item-meta">';

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -507,7 +507,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 							$html .= '<div class="wc-order-item-sku">' . esc_html( $product_object->get_sku() ) . '</div>';
 						}
 
-						$meta_data = $item->get_formatted_meta_data( '' );
+						$meta_data = $item->get_all_formatted_meta_data( '' );
 
 						if ( $meta_data ) {
 							$html .= '<table cellspacing="0" class="wc-order-item-meta">';

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -507,7 +507,10 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 							$html .= '<div class="wc-order-item-sku">' . esc_html( $product_object->get_sku() ) . '</div>';
 						}
 
-						$meta_data = $item->get_formatted_meta_data( '' );
+
+						$include_all = false;
+						$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+						$meta_data   = $item->get_formatted_meta_data( '', $include_all );
 
 						if ( $meta_data ) {
 							$html .= '<table cellspacing="0" class="wc-order-item-meta">';

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -507,7 +507,6 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 							$html .= '<div class="wc-order-item-sku">' . esc_html( $product_object->get_sku() ) . '</div>';
 						}
 
-
 						$include_all = false;
 						$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
 						$meta_data   = $item->get_formatted_meta_data( '', $include_all );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -28,7 +28,10 @@ $hidden_order_itemmeta = apply_filters(
 	)
 );
 ?><div class="view">
-	<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>
+	<?php
+	$meta_data = $item->get_formatted_meta_data( '' );
+	if ( $meta_data ) :
+		?>
 		<table cellspacing="0" class="display_meta">
 			<?php
 			foreach ( $meta_data as $meta_id => $meta ) :
@@ -47,7 +50,7 @@ $hidden_order_itemmeta = apply_filters(
 <div class="edit" style="display: none;">
 	<table class="meta" cellspacing="0">
 		<tbody class="meta_items">
-			<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>
+			<?php if ( $meta_data ) : ?>
 				<?php
 				foreach ( $meta_data as $meta_id => $meta ) :
 					if ( in_array( $meta->key, $hidden_order_itemmeta, true ) ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -29,7 +29,7 @@ $hidden_order_itemmeta = apply_filters(
 );
 ?><div class="view">
 	<?php
-	$meta_data = $item->get_formatted_meta_data( '' );
+	$meta_data = $item->get_all_formatted_meta_data( '' );
 	if ( $meta_data ) :
 		?>
 		<table cellspacing="0" class="display_meta">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Shows an order item meta
+ *
+ * @package WooCommerce\Admin
+ * @var object $item The item being displayed
+ * @var int $item_id The id of the item being displayed
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -21,7 +21,12 @@ $hidden_order_itemmeta = apply_filters(
 	)
 );
 ?><div class="view">
-	<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>
+	<?php
+		$include_all = false;
+		$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+		$meta_data = $item->get_formatted_meta_data( '', $include_all );
+	?>
+	<?php if ( $meta_data ) : ?>
 		<table cellspacing="0" class="display_meta">
 			<?php
 			foreach ( $meta_data as $meta_id => $meta ) :
@@ -40,7 +45,7 @@ $hidden_order_itemmeta = apply_filters(
 <div class="edit" style="display: none;">
 	<table class="meta" cellspacing="0">
 		<tbody class="meta_items">
-			<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>
+			<?php if ( $meta_data ) : ?>
 				<?php
 				foreach ( $meta_data as $meta_id => $meta ) :
 					if ( in_array( $meta->key, $hidden_order_itemmeta, true ) ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Shows an order item meta
+ *
+ * @package WooCommerce\Admin
+ * @var object $item The item being displayed
+ * @var int $item_id The id of the item being displayed
+ */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Shows an order item meta
- *
- * @package WooCommerce\Admin
- * @var object $item The item being displayed
- * @var int $item_id The id of the item being displayed
- */
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -29,12 +21,7 @@ $hidden_order_itemmeta = apply_filters(
 	)
 );
 ?><div class="view">
-	<?php
-		$include_all = false;
-		$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-		$meta_data = $item->get_formatted_meta_data( '', $include_all );
-	?>
-	<?php if ( $meta_data ) : ?>
+	<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>
 		<table cellspacing="0" class="display_meta">
 			<?php
 			foreach ( $meta_data as $meta_id => $meta ) :
@@ -53,7 +40,7 @@ $hidden_order_itemmeta = apply_filters(
 <div class="edit" style="display: none;">
 	<table class="meta" cellspacing="0">
 		<tbody class="meta_items">
-			<?php if ( $meta_data ) : ?>
+			<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>
 				<?php
 				foreach ( $meta_data as $meta_id => $meta ) :
 					if ( in_array( $meta->key, $hidden_order_itemmeta, true ) ) {

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -248,6 +248,17 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	*/
 
 	/**
+	 * Wrapper for get_formatted_meta_data that includes all metadata by default. See https://github.com/woocommerce/woocommerce/pull/30948
+	 *
+	 * @param string $hideprefix  Meta data prefix, (default: _).
+	 * @param bool   $include_all Include all meta data, this stop skip items with values already in the product name.
+	 * @return array
+	 */
+	public function get_all_formatted_meta_data( $hideprefix = '_', $include_all = true ) {
+		return $this->get_formatted_meta_data( $hideprefix, $include_all );
+	}
+
+	/**
 	 * Expands things like term slugs before return.
 	 *
 	 * @param string $hideprefix  Meta data prefix, (default: _).

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -279,19 +279,8 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 				}
 			}
 
-			$show_metadata_line = ! $include_all &&
-									$product && $product->is_type( 'variation' ) &&
-									wc_is_attribute_in_product_name( $display_value, $order_item_name );
-			$show_metadata_line = apply_filters(
-				'woocommerce_show_product_variant_metadata_line',
-				$attribute_key,
-				$display_value,
-				$product,
-				$show_metadata_line
-			);
-
 			// Skip items with values already in the product details area of the product name.
-			if ( ! $show_metadata_line ) {
+			if ( ! $include_all && $product && $product->is_type( 'variation' ) && wc_is_attribute_in_product_name( $display_value, $order_item_name ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -279,8 +279,19 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 				}
 			}
 
+			$show_metadata_line = ! $include_all &&
+									$product && $product->is_type( 'variation' ) &&
+									wc_is_attribute_in_product_name( $display_value, $order_item_name );
+			$show_metadata_line = apply_filters(
+				'woocommerce_show_product_variant_metadata_line',
+				$attribute_key,
+				$display_value,
+				$product,
+				$show_metadata_line
+			);
+
 			// Skip items with values already in the product details area of the product name.
-			if ( ! $include_all && $product && $product->is_type( 'variation' ) && wc_is_attribute_in_product_name( $display_value, $order_item_name ) ) {
+			if ( ! $show_metadata_line ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
@@ -213,7 +213,7 @@ class WC_API_Orders extends WC_API_Resource {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product    = $item->get_product();
 			$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-			$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+			$item_meta  = $item->get_all_formatted_meta_data( $hideprefix );
 
 			foreach ( $item_meta as $key => $values ) {
 				$item_meta[ $key ]->label = $values->display_key;
@@ -1525,7 +1525,7 @@ class WC_API_Orders extends WC_API_Resource {
 			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
 				$product    = $item->get_product();
 				$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-				$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+				$item_meta  = $item->get_all_formatted_meta_data( $hideprefix );
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
@@ -213,10 +213,7 @@ class WC_API_Orders extends WC_API_Resource {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product    = $item->get_product();
 			$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-
-			$include_all = false;
-			$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-			$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
+			$item_meta  = $item->get_formatted_meta_data( $hideprefix );
 
 			foreach ( $item_meta as $key => $values ) {
 				$item_meta[ $key ]->label = $values->display_key;
@@ -1528,10 +1525,7 @@ class WC_API_Orders extends WC_API_Resource {
 			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
 				$product    = $item->get_product();
 				$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-
-				$include_all = false;
-				$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-				$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
+				$item_meta  = $item->get_formatted_meta_data( $hideprefix );
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
@@ -213,7 +213,10 @@ class WC_API_Orders extends WC_API_Resource {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product    = $item->get_product();
 			$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-			$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+
+			$include_all = false;
+			$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+			$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
 
 			foreach ( $item_meta as $key => $values ) {
 				$item_meta[ $key ]->label = $values->display_key;
@@ -1525,7 +1528,10 @@ class WC_API_Orders extends WC_API_Resource {
 			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
 				$product    = $item->get_product();
 				$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-				$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+
+				$include_all = false;
+				$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+				$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
@@ -220,7 +220,7 @@ class WC_API_Orders extends WC_API_Resource {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product    = $item->get_product();
 			$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-			$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+			$item_meta  = $item->get_all_formatted_meta_data( $hideprefix );
 
 			foreach ( $item_meta as $key => $values ) {
 				$item_meta[ $key ]->label = $values->display_key;
@@ -1570,7 +1570,7 @@ class WC_API_Orders extends WC_API_Resource {
 			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
 				$product    = $item->get_product();
 				$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-				$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+				$item_meta  = $item->get_all_formatted_meta_data( $hideprefix );
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
@@ -220,10 +220,7 @@ class WC_API_Orders extends WC_API_Resource {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product    = $item->get_product();
 			$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-
-			$include_all = false;
-			$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-			$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
+			$item_meta  = $item->get_formatted_meta_data( $hideprefix );
 
 			foreach ( $item_meta as $key => $values ) {
 				$item_meta[ $key ]->label = $values->display_key;
@@ -1573,10 +1570,7 @@ class WC_API_Orders extends WC_API_Resource {
 			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
 				$product    = $item->get_product();
 				$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-
-				$include_all = false;
-				$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-				$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
+				$item_meta  = $item->get_formatted_meta_data( $hideprefix );
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
@@ -220,7 +220,10 @@ class WC_API_Orders extends WC_API_Resource {
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product    = $item->get_product();
 			$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-			$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+
+			$include_all = false;
+			$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+			$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
 
 			foreach ( $item_meta as $key => $values ) {
 				$item_meta[ $key ]->label = $values->display_key;
@@ -1570,7 +1573,10 @@ class WC_API_Orders extends WC_API_Resource {
 			foreach ( $refund->get_items( 'line_item' ) as $item_id => $item ) {
 				$product    = $item->get_product();
 				$hideprefix = ( isset( $filter['all_item_meta'] ) && 'true' === $filter['all_item_meta'] ) ? null : '_';
-				$item_meta  = $item->get_formatted_meta_data( $hideprefix );
+
+				$include_all = false;
+				$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+				$item_meta   = $item->get_formatted_meta_data( $hideprefix, $include_all );
 
 				foreach ( $item_meta as $key => $values ) {
 					$item_meta[ $key ]->label = $values->display_key;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
@@ -161,7 +161,7 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 
 			$hideprefix = 'true' === $request['all_item_meta'] ? null : '_';
 
-			foreach ( $item->get_formatted_meta_data( $hideprefix, true ) as $meta_key => $formatted_meta ) {
+			foreach ( $item->get_all_formatted_meta_data( $hideprefix ) as $meta_key => $formatted_meta ) {
 				$item_meta[] = array(
 					'key'   => $formatted_meta->key,
 					'label' => $formatted_meta->display_key,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -189,7 +189,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 
 			$hideprefix = 'true' === $request['all_item_meta'] ? null : '_';
 
-			foreach ( $item->get_formatted_meta_data( $hideprefix, true ) as $meta_key => $formatted_meta ) {
+			foreach ( $item->get_all_formatted_meta_data( $hideprefix ) as $meta_key => $formatted_meta ) {
 				$item_meta[] = array(
 					'key'   => $formatted_meta->key,
 					'label' => $formatted_meta->display_key,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -209,7 +209,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		unset( $data['type'] );
 
 		// Expand meta_data to include user-friendly values.
-		$formatted_meta_data = $item->get_formatted_meta_data( null, true );
+		$formatted_meta_data = $item->get_all_formatted_meta_data( null );
 		$data['meta_data'] = array_map(
 			array( $this, 'merge_meta_item_with_formatted_meta_display_attributes' ),
 			$data['meta_data'],
@@ -224,7 +224,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * {@link WC_Meta_Data}. Returns the merged array.
 	 *
 	 * @param WC_Meta_Data $meta_item           An object from {@link WC_Order_Item::get_meta_data()}.
-	 * @param array        $formatted_meta_data An object result from {@link WC_Order_Item::get_formatted_meta_data}.
+	 * @param array        $formatted_meta_data An object result from {@link WC_Order_Item::get_all_formatted_meta_data}.
 	 * The keys are the IDs of {@link WC_Meta_Data}.
 	 *
 	 * @return array

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3336,7 +3336,9 @@ if ( ! function_exists( 'wc_display_item_meta' ) ) {
 			)
 		);
 
-		foreach ( $item->get_formatted_meta_data() as $meta_id => $meta ) {
+		$include_all = false;
+		$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
+		foreach ( $item->get_formatted_meta_data( '_', $include_all ) as $meta_id => $meta ) {
 			$value     = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( $meta->display_value ) ) );
 			$strings[] = $args['label_before'] . wp_kses_post( $meta->display_key ) . $args['label_after'] . $value;
 		}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3336,9 +3336,7 @@ if ( ! function_exists( 'wc_display_item_meta' ) ) {
 			)
 		);
 
-		$include_all = false;
-		$include_all = apply_filters( 'woocommerce_get_formatted_meta_data_include_all_meta_lines', $include_all, $item );
-		foreach ( $item->get_formatted_meta_data( '_', $include_all ) as $meta_id => $meta ) {
+		foreach ( $item->get_formatted_meta_data() as $meta_id => $meta ) {
 			$value     = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( $meta->display_value ) ) );
 			$strings[] = $args['label_before'] . wp_kses_post( $meta->display_key ) . $args['label_after'] . $value;
 		}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3336,7 +3336,7 @@ if ( ! function_exists( 'wc_display_item_meta' ) ) {
 			)
 		);
 
-		foreach ( $item->get_formatted_meta_data() as $meta_id => $meta ) {
+		foreach ( $item->get_all_formatted_meta_data() as $meta_id => $meta ) {
 			$value     = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( $meta->display_value ) ) );
 			$strings[] = $args['label_before'] . wp_kses_post( $meta->display_key ) . $args['label_after'] . $value;
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -213,6 +213,85 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test the get_formatted_meta_data method.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_all_formatted_meta_data() {
+		$parent_product = new WC_Product_Variable();
+		$parent_product->set_name( 'Test Parent' );
+		$parent_product->save();
+
+		$variation_product = new WC_Product_Variation();
+		$variation_product->set_name( 'Test Variation' );
+		$variation_product->set_parent_id( $parent_product->get_id() );
+		$variation_product->set_attributes(
+			array(
+				'color' => 'Green',
+				'size'  => 'Large',
+			)
+		);
+		$variation_product->save();
+
+		$product_item = new WC_Order_Item_Product();
+		$product_item->set_product( $variation_product );
+		$product_item->add_meta_data( 'testkey', 'testval', true );
+		$product_item->save();
+
+		// Test with show_all set to default.
+		$formatted          = $product_item->get_all_formatted_meta_data( '_' );
+		$formatted_as_array = array();
+		foreach ( $formatted as $f ) {
+			$formatted_as_array[] = (array) $f;
+		}
+		$this->assertEquals(
+			array(
+				array(
+					'key'           => 'color',
+					'value'         => 'Green',
+					'display_key'   => 'color',
+					'display_value' => "<p>Green</p>\n",
+				),
+				array(
+					'key'           => 'size',
+					'value'         => 'Large',
+					'display_key'   => 'size',
+					'display_value' => "<p>Large</p>\n",
+				),
+				array(
+					'key'           => 'testkey',
+					'value'         => 'testval',
+					'display_key'   => 'testkey',
+					'display_value' => "<p>testval</p>\n",
+				),
+			),
+			$formatted_as_array
+		);
+
+		// Test with show_all off.
+		$formatted          = $product_item->get_all_formatted_meta_data( '_', false );
+		$formatted_as_array = array();
+		foreach ( $formatted as $f ) {
+			$formatted_as_array[] = (array) $f;
+		}
+		$this->assertEquals(
+			array(
+				array(
+					'key'           => 'testkey',
+					'value'         => 'testval',
+					'display_key'   => 'testkey',
+					'display_value' => "<p>testval</p>\n",
+				),
+			),
+			$formatted_as_array
+		);
+
+		// Test with an exclude prefix. Should exclude everything since they're either in the title or in the exclude prefix.
+		$formatted = $product_item->get_all_formatted_meta_data( 'test', false );
+		$this->assertEmpty( $formatted );
+	}
+
+	/**
 	 * Test the Array Access methods.
 	 *
 	 * @since 3.3.0


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR proposes the introduction of a new method called `get_all_formatted_meta_data` in the `WC_Order_Item` class. The purpose of this is to allow us to call `get_formatted_meta_data` with `$include_all = true` while leaving the existing functionality of `get_formatted_meta_data` intact for back-compatibility with whoever might be using it.

The PR also changes uses of `get_formatted_meta_data` in _this_ repository to use the new method.

The current behaviour _without_ this change is that metadata line items are skipped if the _value_ is the same as one that is previously shown.

In some cases, this is problematic, for example if using WooCommerce Product Addons on a variable product and one of the addons has the same value as the selected attribute.

Without this change, the below image would only show the size, and not the trophy cup inscription.

<img src="https://user-images.githubusercontent.com/5656702/137300211-9f62f6b2-77a7-4186-b7f4-07a774b40431.png" width=400 />

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 645-gh-woocommerce/woocommerce-product-addons.
### How to test the changes in this Pull Request:

1. Create a variable product with attribute Size: Small, Medium, Large, Extra Large
2. Check out the PR in Product Addons: 705-gh-woocommerce/woocommerce-product-addons
3. Create a global add-on that has these 4 options + some extra ones (you can import these as a reference):

```
a:1:{i:0;a:16:{s:4:"name";s:22:"Trophy Cup Inscription";s:12:"title_format";s:5:"label";s:18:"description_enable";i:1;s:11:"description";s:101:"Please select the option that applies to your cup size if you require your trophy cup to be engraved.";s:4:"type";s:15:"multiple_choice";s:7:"display";s:6:"select";s:8:"position";i:0;s:8:"required";i:1;s:12:"restrictions";i:0;s:17:"restrictions_type";s:8:"any_text";s:12:"adjust_price";i:0;s:10:"price_type";s:8:"flat_fee";s:5:"price";s:0:"";s:3:"min";d:0;s:3:"max";d:0;s:7:"options";a:13:{i:0;a:4:{s:5:"label";s:8:"4X Small";s:5:"price";s:5:"20.00";s:5:"image";s:0:"";s:10:"price_type";s:8:"flat_fee";}i:1;a:4:{s:5:"label";s:8:"3X Small";s:5:"price";s:5:"20.00";s:5:"image";s:0:"";s:10:"price_type";s:8:"flat_fee";}i:2;a:4:{s:5:"label";s:8:"2X Small";s:5:"price";s:5:"20.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:3;a:4:{s:5:"label";s:7:"X Small";s:5:"price";s:5:"25.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:4;a:4:{s:5:"label";s:5:"Small";s:5:"price";s:5:"30.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:5;a:4:{s:5:"label";s:6:"Medium";s:5:"price";s:5:"35.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:6;a:4:{s:5:"label";s:5:"Large";s:5:"price";s:5:"40.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:7;a:4:{s:5:"label";s:7:"X Large";s:5:"price";s:5:"45.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:8;a:4:{s:5:"label";s:8:"2X Large";s:5:"price";s:5:"50.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:9;a:4:{s:5:"label";s:8:"3X Large";s:5:"price";s:5:"55.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:10;a:4:{s:5:"label";s:8:"4X large";s:5:"price";s:5:"60.00";s:5:"image";s:0:"";s:10:"price_type";s:8:"flat_fee";}i:11;a:4:{s:5:"label";s:22:"Engraved Plate on Base";s:5:"price";s:5:"15.00";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}i:12;a:4:{s:5:"label";s:12:"No engraving";s:5:"price";s:0:"";s:5:"image";s:0:"";s:10:"price_type";s:14:"quantity_based";}}}}
```
4. Add a simple product to your cart.
5. Add the variable product from step 1 with the variation `Size: Large` and add-on option `Large` (which appears in the attribute list) and complete the order.
6. Go to the order in the WooCommerce dashboard and ensure the attribute Size: Large and the Addon with the value Large are both displaying.
7. Ensure the simple product's addon value is displaying too.
7. Delete the global addon and check out normally with a **variable** product. Go to the order in the WooCommerce dashboard and ensure the variations are shown as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? **I don't think this requires tests, but I can't run tests locally - see p1634213755141500-slack-C8X6Q7XQU** 
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add 'woocommerce_get_formatted_meta_data_include_all_meta_lines' filter hook. This can be used to control whether metadata lines are shown in the order meta box.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.