### PR TITLE
Add troubleshooting section to running unit test section

### DIFF
--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -79,8 +79,9 @@ If you run into this problem, simply delete the WordPress test directory and run
 ```
 $ rm -rf /var/folders/qr/3cnz_5_j3j1cljph_246ty1h0000gn/T/wordpress-tests-lib
 $ tests/bin/install.sh woocommerce_tests_1 root root
-# Note that woocommerce_tests changed to woocommerce_tests_1 as the database woocommerce_tests already exists due to the prior command.
 ```
+
+Note that `woocommerce_tests` changed to `woocommerce_tests_1` as the `database woocommerce_tests` already exists due to the prior command.
 
 ### Running tests in PHP 8
 

--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -10,6 +10,7 @@ This document discusses unit tests. See [the e2e README](https://github.com/wooc
     - [MySQL database](#mysql-database)
     - [Setup instructions](#setup-instructions)
   - [Running Tests](#running-tests)
+    - [Troubleshooting](#troubleshooting)
     - [Running tests in PHP 8](#running-tests-in-php-8)
   - [Writing Tests](#writing-tests)
   - [Automated Tests](#automated-tests)
@@ -81,7 +82,7 @@ $ rm -rf /var/folders/qr/3cnz_5_j3j1cljph_246ty1h0000gn/T/wordpress-tests-lib
 $ tests/bin/install.sh woocommerce_tests_1 root root
 ```
 
-Note that `woocommerce_tests` changed to `woocommerce_tests_1` as the `database woocommerce_tests` already exists due to the prior command.
+Note that `woocommerce_tests` changed to `woocommerce_tests_1` as the `woocommerce_tests` database already exists due to the prior command.
 
 ### Running tests in PHP 8
 

--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -66,6 +66,22 @@ A text code coverage summary can be displayed using the `--coverage-text` option
 
     $ vendor/bin/phpunit --coverage-text
 
+### Troubleshooting
+
+In case you're unable to run the unit tests, you might see an error message similar to:
+
+```
+Fatal error: require_once(): Failed opening required '/var/folders/qr/3cnz_5_j3j1cljph_246ty1h0000gn/T/wordpress-tests-lib/includes/functions.php' (include_path='.:/usr/local/Cellar/php@7.4/7.4.23/share/php@7.4/pear') in /Users/nielslange/Plugins/woocommerce/tests/legacy/bootstrap.php on line 59
+```
+
+If you run into this problem, simply delete the WordPress test directory and run the installer again. In this particular case, you'd run the following command:
+
+```
+$ rm -rf /var/folders/qr/3cnz_5_j3j1cljph_246ty1h0000gn/T/wordpress-tests-lib
+$ tests/bin/install.sh woocommerce_tests_1 root root
+# Note that woocommerce_tests changed to woocommerce_tests_1 as the database woocommerce_tests already exists due to the prior command.
+```
+
 ### Running tests in PHP 8
 
 WooCommerce currently supports PHP versions from 7.0 up to 8.0, and this poses an issue with PHPUnit:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following the steps to run unit test, might lead to a problem that was firstly mentioned by Daniel Bachhuber in 2015 in https://github.com/wp-cli/wp-cli/issues/1938#issuecomment-124237542. This PR adds troubleshooting instructions in case a unit test cannot be executed and an error message appears instead.

### How to test the changes in this Pull Request:

1. Check out this PR.
2. Look up the file `tests/README.md`.
3. Check the section `### Troubleshooting`.

---

@Konamiman I added you as a reviewer and noticed that my linting settings changed a few additional parts in the file. Please let me know if I shall update my PR and remove the additional markdown lintings.