### PR TITLE
Bump WooCommerce Admin version to 2.8.0-rc.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
-    "woocommerce/woocommerce-admin": "2.7.2",
+    "woocommerce/woocommerce-admin": "2.8.0-rc.1",
     "woocommerce/woocommerce-blocks": "5.9.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
-    "woocommerce/woocommerce-admin": "2.8.0-rc.1",
+    "woocommerce/woocommerce-admin": "2.8.0-rc.2",
     "woocommerce/woocommerce-blocks": "5.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "268007b3eb4c3ba76f2fd842cac50145",
+    "content-hash": "f8e8dbfd35519080b366b6f5b50addb9",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -533,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.8.0-rc.1",
+            "version": "2.8.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "48ae15dc851db8ad7c4a13319b017c8926fb0b89"
+                "reference": "f3974919906d4d2168531025340b4f139ae65f1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/48ae15dc851db8ad7c4a13319b017c8926fb0b89",
-                "reference": "48ae15dc851db8ad7c4a13319b017c8926fb0b89",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f3974919906d4d2168531025340b4f139ae65f1d",
+                "reference": "f3974919906d4d2168531025340b4f139ae65f1d",
                 "shasum": ""
             },
             "require": {
@@ -598,9 +598,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.8.0-rc.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.8.0-rc.2"
             },
-            "time": "2021-10-14T15:39:02+00:00"
+            "time": "2021-10-15T00:51:46+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed397d52c25da204154232b3dd4b529f",
+    "content-hash": "268007b3eb4c3ba76f2fd842cac50145",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -533,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.7.2",
+            "version": "2.8.0-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "9ce54862556815e74cfe2476fae0eb30fcfd65d6"
+                "reference": "48ae15dc851db8ad7c4a13319b017c8926fb0b89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/9ce54862556815e74cfe2476fae0eb30fcfd65d6",
-                "reference": "9ce54862556815e74cfe2476fae0eb30fcfd65d6",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/48ae15dc851db8ad7c4a13319b017c8926fb0b89",
+                "reference": "48ae15dc851db8ad7c4a13319b017c8926fb0b89",
                 "shasum": ""
             },
             "require": {
@@ -554,7 +554,8 @@
                 "automattic/jetpack-changelogger": "^1.1",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "suin/phpcs-psr4-sniff": "^2.2",
-                "woocommerce/woocommerce-sniffs": "0.1.0"
+                "woocommerce/woocommerce-sniffs": "0.1.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -597,9 +598,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.7.2"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.8.0-rc.1"
             },
-            "time": "2021-10-11T21:11:02+00:00"
+            "time": "2021-10-14T15:39:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps the bundled WooCommerce Admin version to `2.8.0-rc.2`, in preparation for the upcoming WooCommerce 5.9 release.

## Changes since 2.7.2

_From [WooCommerce Admin 2.8.0-rc.2 changelog.txt](https://github.com/woocommerce/woocommerce-admin/blob/d65d515906f39bf27dc3552279a3ffe87f8acdbc/changelog.txt)_

- Add: Store Profiler and Product task - include Subscriptions https://github.com/woocommerce/woocommerce-admin/pull/7734
- Fix: Fixed navigation menu text color after Gutenberg 11.6.0 https://github.com/woocommerce/woocommerce-admin/pull/7771
- Fix: Add status param to notes/delete/all REST endpoint, to correctly delete all notes. https://github.com/woocommerce/woocommerce-admin/pull/7743
- Fix: Allow already installed marketing extensions to be activated https://github.com/woocommerce/woocommerce-admin/pull/7740
- Fix: Add missing title text for marketing task. https://github.com/woocommerce/woocommerce-admin/pull/7640
- Fix: Assign parent order status as children order status if refund order https://github.com/woocommerce/woocommerce-admin/pull/7253
- Fix: Fix category lookup logic to update children correctly. https://github.com/woocommerce/woocommerce-admin/pull/7709
- Fix: Fixing an unwanted page refresh when using Woo Navigation. https://github.com/woocommerce/woocommerce-admin/pull/7615
- Fix: Fix naming of event names and properties. https://github.com/woocommerce/woocommerce-admin/pull/7677
- Fix: Fix white screen for variation analytic data without a name. https://github.com/woocommerce/woocommerce-admin/pull/7686
- Update: Update back up copy of free extension for Google Listing & Ads plugin. https://github.com/woocommerce/woocommerce-admin/pull/7798
- Update: Update Eway payment gateway capitalization (was eWAY). https://github.com/woocommerce/woocommerce-admin/pull/7678
- Update: Enable Square in France. https://github.com/woocommerce/woocommerce-admin/pull/7679
- Enhancement: Add experiment for promoting WooCommerce Payments in payment methods table. https://github.com/woocommerce/woocommerce-admin/pull/7666

## Testing

_From [Release Testing Instructions WooCommerce Admin 2.8.0](https://github.com/woocommerce/woocommerce-admin/wiki/Release-Testing-Instructions-WooCommerce-Admin-2.8.0)_

### Store Profiler and Product task - include Subscriptions [#7734](https://github.com/woocommerce/woocommerce-admin/pull/7734)

##### Non US stores

1. Deactivate and delete `WooCommerce Payments` if you have it installed.
2. Go to step one of the store profiler and select `France` (or any country other than the US) as the store `Country / Region`.
3. Go to step three of the store profiler (`Product Types`).
4. Verify `Subscriptions` is shown as a paid extension (with a price chip).
5. Check `Subscriptions` and continue with the OBW.
6. Go back to the `Home` screen by pressing `Skip setup store details` in step one of the store profiler. Check that the task item `Add Subscriptions to my store` is visible in the setup task list.
7. Press `Add my products` in the setup task list.
8. Select `Start with a template`. Verify that the option `Subscription product` is not visible in the popup.

##### US stores

9. Deactivate and delete `WooCommerce Payments`.
10. Go to step one of the store profiler and select `US` as the store `Country / Region`.
11. Go to step three of the store profiler (`Product Types`).
12. Verify `Subscriptions` is shown as free (without a price chip). Also, verify that the text

```
The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature
```

is visible at the bottom when `WooCommerce Payments` is not installed.

![screenshot-one wordpress test-2021 09 30-14_12_58](https://user-images.githubusercontent.com/1314156/135506696-b7812f7e-437f-4d89-956a-b73248f70f6b.png)


13. Check `Subscriptions` and press `Continue` and verify that the `WooCommerce Payments` plugin is installed and activated and it's not shown in the `Free features` list

![screenshot-one wordpress test-2021 09 30-14_32_20](https://user-images.githubusercontent.com/1314156/135506727-d8888f2b-3424-4cf5-a4bf-b67a14a198b6.png)

14. Verify that the `WooCommerce Payments` plugin is being shown in the `Free features` list when the store country is other than the `US`.

15. Go back to the `Home` screen by pressing `Skip setup store details` in step one of the store profiler. Check that the task item `Add Subscriptions to my store` is not visible in the setup task list. It should be visible if the store is from any country other than the `US`.

![screenshot-one wordpress test-2021 09 30-14_39_28](https://user-images.githubusercontent.com/1314156/135506770-91571f8f-2e2e-43a7-b092-b9e5fdf56df8.png)

16. Press `Add my products` in the setup task list.
17. Select `Start with a template`. Verify that the option `Subscription product` is visible in the popup

![screenshot-one wordpress test-2021 09 30-14_35_22](https://user-images.githubusercontent.com/1314156/135506748-0b7bdce5-b006-47f9-9289-03ed26e4950c.png)

18. Select `Subscription product` and press `Ok`. You should have been redirected to `post-new.php?post_type=product&subscription_pointers=true`.

