### PR TITLE
Fixes #30828

### DIFF
--- a/plugins/woocommerce/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/legacy/js/frontend/checkout.js
@@ -579,7 +579,7 @@ jQuery( function( $ ) {
 			var scrollElement           = $( '.woocommerce-NoticeGroup-updateOrderReview, .woocommerce-NoticeGroup-checkout' );
 
 			if ( ! scrollElement.length ) {
-				scrollElement = $( '.form.checkout' );
+				scrollElement = $( 'form.checkout' );
 			}
 			$.scroll_to_notices( scrollElement );
 		}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes issue #30828 by correcting the selector for the scroll target in checkout scroll_to_notices() function.

### How to test the changes in this Pull Request:

The function `scroll_to_notices` in `checkout.js` attempst to scroll to an element matching the selector: `.woocommerce-NoticeGroup-updateOrderReview, .woocommerce-NoticeGroup-checkout` (which itself is prepended to the checkout form in `submit_error`). If for whatever reason no elements match this selector, the fallback is to scroll to `.form.checkout` before the fix.

You can test this locally by intentionlly changing the class names in either function such that the fallback is attempted, and this will not scroll to any element.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? -- Not applicable
* [ ] Have you successfully run tests with your changes locally? -- Not applicable

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Fix checkout scroll to notices fallback scroll element.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
