### PR TITLE
issue 27828: move deprecated to impact only its real purpose

### DIFF
--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -141,11 +141,13 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
-		wc_deprecated_function( 'WC_Order_Item_Coupon::offsetGet', '4.4.0', '' );
 		if ( 'discount_amount' === $offset ) {
 			$offset = 'discount';
 		} elseif ( 'discount_amount_tax' === $offset ) {
 			$offset = 'discount_tax';
+		}
+		if ( 'discount' === $offset || 'discount_tax' === $offset ) {
+			wc_deprecated_function( 'WC_Order_Item_Coupon::offsetGet', '4.4.0', '' );
 		}
 		return parent::offsetGet( $offset );
 	}
@@ -158,11 +160,13 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @param mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
-		wc_deprecated_function( 'WC_Order_Item_Coupon::offsetSet', '4.4.0', '' );
 		if ( 'discount_amount' === $offset ) {
 			$offset = 'discount';
 		} elseif ( 'discount_amount_tax' === $offset ) {
 			$offset = 'discount_tax';
+		}
+		if ( 'discount' === $offset || 'discount_tax' === $offset ) {
+			wc_deprecated_function( 'WC_Order_Item_Coupon::offsetSet', '4.4.0', '' );
 		}
 		parent::offsetSet( $offset, $value );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix https://github.com/woocommerce/woocommerce/issues/27828
Deprecated: WC_Order_Item_Coupon :: offsetGet is deprecated since version 4.4.0

Prevent using subscription coupon in orders. Raise a warning for each subscription order renewal.

Purpose of deprecated seems to be "good usage" forcing using dedicated methods get_discount() and get_discount_tax() but trigger a warning even for base class WC_Order_Item meta access.

So moved the deprecated to be raised only for local class meta.
No other impact.
Fix in WooCommerce or please force WooCommerce-subscriptions team to be compatible with WooCommerce.

Closes # .

### How to test the changes in this Pull Request:

1. Need WooCommerce-subscriptions
2. Create an order with a "Recurring Product Discount" Coupon in it
3. Let order performs a renewal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix issues/27828 WC_Order_Item_Coupon :: offsetGet

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
