### PR TITLE
Fixes #30400 by multiplying refund values by -1

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-fee.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-fee.php
@@ -35,8 +35,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php
 			echo wc_price( $item->get_total(), array( 'currency' => $order->get_currency() ) );
 
-			if ( $refunded = $order->get_total_refunded_for_item( $item_id, 'fee' ) ) {
-				echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>';
+			if ( $refunded = -1 * $order->get_total_refunded_for_item( $item_id, 'fee' ) ) {
+				echo '<small class="refunded">' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>';
 			}
 			?>
 		</div>
@@ -59,8 +59,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php
 					echo ( '' !== $tax_item_total ) ? wc_price( wc_round_tax_total( $tax_item_total ), array( 'currency' => $order->get_currency() ) ) : '&ndash;';
 
-					if ( $refunded = $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'fee' ) ) {
-						echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>';
+					if ( $refunded = -1 * $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'fee' ) ) {
+						echo '<small class="refunded">' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>';
 					}
 					?>
 				</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -59,10 +59,10 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 			<?php
 			echo '<small class="times">&times;</small> ' . esc_html( $item->get_quantity() );
 
-			$refunded_qty = $order->get_qty_refunded_for_item( $item_id );
+			$refunded_qty = -1 * $order->get_qty_refunded_for_item( $item_id );
 
 			if ( $refunded_qty ) {
-				echo '<small class="refunded">-' . esc_html( $refunded_qty * -1 ) . '</small>';
+				echo '<small class="refunded">' . esc_html( $refunded_qty * -1 ) . '</small>';
 			}
 			?>
 		</div>
@@ -108,10 +108,10 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 				echo '<span class="wc-order-item-discount">' . sprintf( esc_html__( '%s discount', 'woocommerce' ), wc_price( wc_format_decimal( $item->get_subtotal() - $item->get_total(), '' ), array( 'currency' => $order->get_currency() ) ) ) . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 
-			$refunded = $order->get_total_refunded_for_item( $item_id );
+			$refunded = -1 * $order->get_total_refunded_for_item( $item_id );
 
 			if ( $refunded ) {
-				echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '<small class="refunded">' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			?>
 		</div>
@@ -156,10 +156,10 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 						echo '&ndash;';
 					}
 
-					$refunded = $order->get_tax_refunded_for_item( $item_id, $tax_item_id );
+					$refunded = -1 * $order->get_tax_refunded_for_item( $item_id, $tax_item_id );
 
 					if ( $refunded ) {
-						echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo '<small class="refunded">' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					}
 					?>
 				</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -64,9 +64,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="view">
 			<?php
 			echo wp_kses_post( wc_price( $item->get_total(), array( 'currency' => $order->get_currency() ) ) );
-			$refunded = $order->get_total_refunded_for_item( $item_id, 'shipping' );
+			$refunded = -1 * $order->get_total_refunded_for_item( $item_id, 'shipping' );
 			if ( $refunded ) {
-				echo wp_kses_post( '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>' );
+				echo wp_kses_post( '<small class="refunded">' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>' );
 			}
 			?>
 		</div>
@@ -89,9 +89,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div class="view">
 					<?php
 					echo wp_kses_post( ( '' !== $tax_item_total ) ? wc_price( $tax_item_total, array( 'currency' => $order->get_currency() ) ) : '&ndash;' );
-					$refunded = $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'shipping' );
+					$refunded = -1 * $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'shipping' );
 					if ( $refunded ) {
-						echo wp_kses_post( '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>' );
+						echo wp_kses_post( '<small class="refunded">' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>' );
 					}
 					?>
 				</div>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #30400.

### How to test the changes in this Pull Request:

1. Go to Products > Add New, and create any type of product but with a negative price, ex: -$10.00
2. Go to Orders > Add Order, and create a new order with the previous negative-priced product
3. Once the Order is generated, go to the Order and attempt to refund it
4. See how the refund appears as $10 (previously would show as "- -$10"

The changes made remove the hardcoded "-" sign from the refund values, and instead multiply the refund value by -1.
For positive values, this results in a negative refund value, eg refund $10 will display as -$10.
For negative values, this results in a positive refund value, eg. refund -$10 will display as $10.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? - N/A
* [ ] Have you successfully run tests with your changes locally? - N/A

### Changelog entry

> Fix - Corrects the display of negative refund values within the order editor screen.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
