### PR TITLE
Warn users of shipping rates to test for existence of meta_data correctly.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-shipping-rate.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-rate.php
@@ -65,6 +65,9 @@ class WC_Shipping_Rate {
 	 * @return bool
 	 */
 	public function __isset( $key ) {
+		if ( 'meta_data' === $key ) {
+			wc_doing_it_wrong( __FUNCTION__, __( 'Use `array_key_exists` to check for meta_data on Shipping rates to get the correct result.', 'woocommerce' ), '6.0' );
+		}
 		return isset( $this->data[ $key ] );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-shipping-rate.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-rate.php
@@ -66,7 +66,7 @@ class WC_Shipping_Rate {
 	 */
 	public function __isset( $key ) {
 		if ( 'meta_data' === $key ) {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Use `array_key_exists` to check for meta_data on Shipping rates to get the correct result.', 'woocommerce' ), '6.0' );
+			wc_doing_it_wrong( __FUNCTION__, __( 'Use `array_key_exists` to check for meta_data on WC_Shipping_Rate to get the correct result.', 'woocommerce' ), '6.0' );
 		}
 		return isset( $this->data[ $key ] );
 	}


### PR DESCRIPTION
As per the info in the issue itself, using `isset()` gives incorrect result all the time, so warn developers about the problem.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28072 .

### How to test the changes in this Pull Request:

1. Check that `isset()` produces correct message when used with `meta_data`, but not with other keys, and also that original behaviour is unchanged, e.g. 
```
	$sro = new WC_Shipping_Flat_Rate( 0 );
	$sro->add_rate([
		'id' => 'my-rate',
		'label' => 'my label',
		'cost' => 1.5,
		'meta_data' => [
			'custom-meta-1' => 'some-value'
		]
	]);
	$rate = $sro->rates['my-rate'];
	$r = $rate->meta_data['custom-meta-1'];
	$r1 = isset( $rate->label ); // no warning
	$r2 = isset( $rate->meta_data['custom-meta-1'] ); // warning
```


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add warning to developers to avoid gotcha with shipping rates.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
