### PR TITLE
Fixed: Don't show placeholder on transparent product thumbnails

### DIFF
--- a/plugins/woocommerce/changelog/ui-transparent-product-thumbnails
+++ b/plugins/woocommerce/changelog/ui-transparent-product-thumbnails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove placeholder product icon if a featured product image is available (avoids issues with transparent images).

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -1971,7 +1971,7 @@ ul.wc_coupon_list_block {
 					display: block;
 					text-align: center;
 
-					&::before {
+					&:empty::before {
 
 						@include icon_dashicons("\f128");
 						width: 38px;


### PR DESCRIPTION
Small fix for disabling thumbnail placeholders, when image exists. This is for solving issues with transparent product images.