### PR TITLE
Store WC_Rate_Limit Entries in a Custom Table

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1040,6 +1040,13 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	PRIMARY KEY  (`order_id`, `product_id`)
 ) $collate;
+CREATE TABLE {$wpdb->prefix}woocommerce_rate_limits (
+  rate_limit_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  rate_limit_key varchar(200) NOT NULL,
+  rate_limit_expiry BIGINT UNSIGNED NOT NULL,
+  PRIMARY KEY  (rate_limit_id),
+  UNIQUE KEY rate_limit_key (rate_limit_key($max_index_length))
+) $collate;
 		";
 
 		return $tables;
@@ -1074,6 +1081,7 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 			"{$wpdb->prefix}woocommerce_tax_rate_locations",
 			"{$wpdb->prefix}woocommerce_tax_rates",
 			"{$wpdb->prefix}wc_reserved_stock",
+			"{$wpdb->prefix}woocommerce_rate_limits",
 		);
 
 		/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -165,6 +165,10 @@ class WC_Install {
 			'wc_update_560_create_refund_returns_page',
 			'wc_update_560_db_version',
 		),
+		'6.0.0' => array(
+			'wc_update_600_migrate_rate_limit_options',
+			'wc_update_600_db_version',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -528,6 +528,7 @@ class WC_Install {
 		wp_clear_scheduled_hook( 'woocommerce_cleanup_logs' );
 		wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 		wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
+		wp_clear_scheduled_hook( 'woocommerce_cleanup_rate_limits' );
 
 		$ve = get_option( 'gmt_offset' ) > 0 ? '-' : '+';
 
@@ -549,6 +550,7 @@ class WC_Install {
 		wp_schedule_event( time() + ( 6 * HOUR_IN_SECONDS ), 'twicedaily', 'woocommerce_cleanup_sessions' );
 		wp_schedule_event( time() + MINUTE_IN_SECONDS, 'fifteendays', 'woocommerce_geoip_updater' );
 		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
+		wp_schedule_event( time() + ( 3 * HOUR_IN_SECONDS ), 'daily', 'woocommerce_cleanup_rate_limits' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-rate-limiter.php
+++ b/plugins/woocommerce/includes/class-wc-rate-limiter.php
@@ -37,6 +37,13 @@ class WC_Rate_Limiter {
 	const CACHE_GROUP = 'wc_rate_limit';
 
 	/**
+	 * Hook in methods.
+	 */
+	public static function init() {
+		add_action( 'woocommerce_cleanup_rate_limits', array( __CLASS__, 'cleanup' ) );
+	}
+
+	/**
 	 * Constructs key name from action identifier.
 	 * Left in for backwards compatibility.
 	 *
@@ -162,3 +169,5 @@ class WC_Rate_Limiter {
 		}
 	}
 }
+
+WC_Rate_Limiter::init();

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2548,3 +2548,10 @@ function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
 	}
 	return $values;
 }
+
+/**
+ * Cleans up rate limit data - cron callback.
+ *
+ * @since 6.0.0
+ */
+add_action( 'woocommerce_cleanup_rate_limits', array( 'WC_Rate_Limiter', 'cleanup' ) );

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2548,10 +2548,3 @@ function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
 	}
 	return $values;
 }
-
-/**
- * Cleans up rate limit data - cron callback.
- *
- * @since 6.0.0
- */
-add_action( 'woocommerce_cleanup_rate_limits', array( 'WC_Rate_Limiter', 'cleanup' ) );

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2297,3 +2297,40 @@ function wc_update_560_create_refund_returns_page() {
 function wc_update_560_db_version() {
 	WC_Install::update_db_version( '5.6.0' );
 }
+
+/**
+ * Migrate rate limit options to the new table.
+ *
+ * See @link https://github.com/woocommerce/woocommerce/issues/27103.
+ */
+function wc_update_600_migrate_rate_limit_options() {
+	global $wpdb;
+
+	$rate_limits = $wpdb->get_results(
+		"
+			SELECT option_name, option_value
+			FROM $wpdb->options
+			WHERE option_name LIKE 'woocommerce_rate_limit_add_payment_method_%'
+		",
+		ARRAY_A
+	);
+
+	foreach ( $rate_limits as $rate_limit ) {
+		$new_delay = (int) $rate_limit['option_value'] - time();
+
+		// Migrate the limit if it hasn't expired yet.
+		if ( 0 < $new_delay ) {
+			$action_id = str_replace( 'woocommerce_rate_limit_', '', $rate_limit['option_name'] );
+			WC_Rate_Limiter::set_rate_limit( $action_id, $new_delay );
+		}
+
+		delete_option( $rate_limit['option_name'] );
+	}
+}
+
+/**
+ * Update DB version to 6.0.0.
+ */
+function wc_update_600_db_version() {
+	WC_Install::update_db_version( '6.0.0' );
+}

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2314,13 +2314,14 @@ function wc_update_600_migrate_rate_limit_options() {
 		",
 		ARRAY_A
 	);
+	$prefix_length = strlen( 'woocommerce_rate_limit_' );
 
 	foreach ( $rate_limits as $rate_limit ) {
 		$new_delay = (int) $rate_limit['option_value'] - time();
 
 		// Migrate the limit if it hasn't expired yet.
 		if ( 0 < $new_delay ) {
-			$action_id = str_replace( 'woocommerce_rate_limit_', '', $rate_limit['option_name'] );
+			$action_id = substr( $rate_limit['option_name'], $prefix_length );
 			WC_Rate_Limiter::set_rate_limit( $action_id, $new_delay );
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
@@ -49,4 +49,33 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user after the designated delay.' );
 	}
 
+	/**
+	 * Test setting the limit and running rate limited actions when missing cache.
+	 */
+	public function test_rate_limit_limits_without_cache() {
+		$action_identifier = 'action_1';
+		$user_1_id         = 10;
+		$user_2_id         = 15;
+
+		$rate_limit_id_1 = $action_identifier . $user_1_id;
+		$rate_limit_id_2 = $action_identifier . $user_2_id;
+
+		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 1 );
+		// Clear cached value for user 1.
+		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'rate_limit' . $rate_limit_id_1 ), WC_Rate_Limiter::CACHE_GROUP );
+
+		$this->assertEquals( true, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_1 ), 'retried_too_soon allowed action to run too soon before the delay.' );
+		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user before the delay.' );
+
+		// Clear cached values for both users.
+		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'rate_limit' . $rate_limit_id_1 ), WC_Rate_Limiter::CACHE_GROUP );
+		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'rate_limit' . $rate_limit_id_2 ), WC_Rate_Limiter::CACHE_GROUP );
+
+		// As retired_too_soon bails if current time <= limit, the actual time needs to be at least 1 second after the limit.
+		sleep( 2 );
+
+		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_1 ), 'retried_too_soon did not allow action to run after the designated delay.' );
+		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user after the designated delay.' );
+	}
+
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
@@ -37,13 +37,13 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		$rate_limit_id_1 = $action_identifier . $user_1_id;
 		$rate_limit_id_2 = $action_identifier . $user_2_id;
 
-		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 1 );
+		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 0 );
 
 		$this->assertEquals( true, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_1 ), 'retried_too_soon allowed action to run too soon before the delay.' );
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user before the delay.' );
 
 		// As retired_too_soon bails if current time <= limit, the actual time needs to be at least 1 second after the limit.
-		sleep( 2 );
+		sleep( 1 );
 
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_1 ), 'retried_too_soon did not allow action to run after the designated delay.' );
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user after the designated delay.' );
@@ -60,7 +60,7 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		$rate_limit_id_1 = $action_identifier . $user_1_id;
 		$rate_limit_id_2 = $action_identifier . $user_2_id;
 
-		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 1 );
+		WC_Rate_Limiter::set_rate_limit( $rate_limit_id_1, 0 );
 		// Clear cached value for user 1.
 		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'rate_limit' . $rate_limit_id_1 ), WC_Rate_Limiter::CACHE_GROUP );
 
@@ -72,7 +72,7 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'rate_limit' . $rate_limit_id_2 ), WC_Rate_Limiter::CACHE_GROUP );
 
 		// As retired_too_soon bails if current time <= limit, the actual time needs to be at least 1 second after the limit.
-		sleep( 2 );
+		sleep( 1 );
 
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_1 ), 'retried_too_soon did not allow action to run after the designated delay.' );
 		$this->assertEquals( false, WC_Rate_Limiter::retried_too_soon( $rate_limit_id_2 ), 'retried_too_soon did not allow action to run for another user after the designated delay.' );

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -19,6 +19,7 @@ wp_clear_scheduled_hook( 'woocommerce_cleanup_personal_data' );
 wp_clear_scheduled_hook( 'woocommerce_cleanup_logs' );
 wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
+wp_clear_scheduled_hook( 'woocommerce_cleanup_rate_limits' );
 
 /*
  * Only remove ALL product and page data if WC_REMOVE_ALL_DATA constant is set to true in user's


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27103.

This PR seeks to resolve the performance problems caused by storing rate limit entries in the `wp_options` table (which are by default autoloaded). It introduces a new table, `woocommerce_rate_limits` to accomplish this.

Rate limit lookups are cached upon creation and retrieval, so DB reads should be kept to minimum.

I've included a migration for existing options that haven't expired, though I suspect the scenario to be unlikely unless a 3PD is using `WC_Rate_Limiter` or has filtered the `woocommerce_payment_gateway_add_payment_method_delay` value to be very high.

Additionally, I've included a daily cron job to clean up expired limits.

### How to test the changes in this Pull Request:

1. (On `trunk`) Add a rate limit to a test store with a long delay: `WC_Rate_Limiter::set_rate_limit( 'add_payment_method_1', 99999 );`
2. Check out this branch
3. Run the DB migration
4. Verify that an `add_payment_method_1` row exists in the `woocommerce_rate_limits` table in your database
5. Go to the My Account page
6. Add a payment method
7. Immediately attempt to add another payment method
8. Verify the error that you "tried too soon"

If you're having trouble triggering the rate limit default, use this filter:
```php
add_filter( 'woocommerce_payment_gateway_add_payment_method_delay', function() {
	return 60;
} );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Stop using options table to store rate limits.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
