### PR TITLE
Fix #29673, reduce font size and margin of email + phone on order pag…

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -1241,7 +1241,7 @@ a.reset_variations {
 
 		p {
 			font-family: $headings;
-			font-size: 2rem;
+			font-size: 1.25rem;
 		}
 
 		form {
@@ -2850,7 +2850,7 @@ a.reset_variations {
 	.woocommerce-MyAccount-content {
 
 		p:first-of-type {
-			margin-bottom: 2rem;
+			margin-bottom: 0rem;
 		}
 
 		#add_payment_method {


### PR DESCRIPTION
…e in Twenty-twenty-one theme

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29673 .

### How to test the changes in this Pull Request:

1. Create order and add billing + shipping address
2. Review in frontend using Twenty-twenty-one theme and notice the font-size and vertical misalignment of phone + email fields
3. Font-size and alignment made consistent after this fix with rest of address fields.

![image](https://user-images.githubusercontent.com/37321814/137579728-f2ef70ab-f16c-4b37-a565-99503551c9e5.png)


### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix font-size and margin for phone + email fields in Twenty-twenty-one order detail page.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
