### PR TITLE
prohibit creating of coupons with empty coupon code

### DIFF
--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -273,6 +273,10 @@ class WC_Post_Data {
 		} elseif ( 'shop_coupon' === $data['post_type'] ) {
 			// Coupons should never allow unfiltered HTML.
 			$data['post_title'] = wp_filter_kses( $data['post_title'] );
+
+			if ( empty($data['post_title']) ) {
+				$data['post_status'] = 'draft';
+			}
 		}
 
 		return $data;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After applying this PR a user cannot create a coupon with an empty code

Closes woocommerce#30874.

### How to test the changes in this Pull Request:

1. Go to Marketing >> Coupons
2. Try to add an empty coupon
3. A new coupon with an empty code is assigned a 'draft' status

### Changelog entry

> Prohibited creation of an empty coupon.

### FOR PR REVIEWER ONLY:

* [X] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
