### PR TITLE
Add Core API tests for Refunds API

### DIFF
--- a/plugins/woocommerce/tests/e2e/api-core-tests/CHANGELOG.md
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Added API tests for the Coupons API.
+- Added API tests for the Refunds API.
 
 # 0.1.0
 

--- a/plugins/woocommerce/tests/e2e/api-core-tests/CHANGELOG.md
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.1.0
 
 - Initial/beta release
-- Added API tests for the Coupons API.
-- Added API tests for the Refunds API.
+
+## Added
+- Coupons API Tests
+- Refunds API Tests

--- a/plugins/woocommerce/tests/e2e/api-core-tests/CHANGELOG.md
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/CHANGELOG.md
@@ -1,8 +1,5 @@
-# Unreleased
-
-- Added API tests for the Coupons API.
-- Added API tests for the Refunds API.
-
 # 0.1.0
 
 - Initial/beta release
+- Added API tests for the Coupons API.
+- Added API tests for the Refunds API.

--- a/plugins/woocommerce/tests/e2e/api-core-tests/data/index.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/data/index.js
@@ -1,5 +1,6 @@
 const { order, getOrderExample } = require('./order');
 const { coupon } = require('./coupon');
+const { refund } = require('./refund');
 const shared = require('./shared');
 
 module.exports = {
@@ -7,4 +8,5 @@ module.exports = {
 	getOrderExample,
 	coupon,
 	shared,
+	refund,
 };

--- a/plugins/woocommerce/tests/e2e/api-core-tests/data/refund.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/data/refund.js
@@ -1,0 +1,18 @@
+/**
+ * A basic refund.
+ *
+ * For more details on the order refund properties, see:
+ *
+ * https://woocommerce.github.io/woocommerce-rest-api-docs/#order-refund-properties
+ *
+ */
+const refund = {
+	api_refund: false,
+	amount: '1.00',
+	reason: 'Late delivery refund.',
+	line_items: [],
+};
+
+module.exports = {
+	refund: refund,
+};

--- a/plugins/woocommerce/tests/e2e/api-core-tests/endpoints/index.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/endpoints/index.js
@@ -1,9 +1,11 @@
 const { ordersApi } = require('./orders');
 const { couponsApi } = require('./coupons');
 const { productsApi } = require('./products');
+const { refundsApi } = require('./refunds');
 
 module.exports = {
 	ordersApi,
 	couponsApi,
 	productsApi,
+	refundsApi,
 };

--- a/plugins/woocommerce/tests/e2e/api-core-tests/endpoints/refunds.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/endpoints/refunds.js
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+const {
+	getRequest,
+	postRequest,
+	putRequest,
+	deleteRequest,
+} = require( '../utils/request' );
+
+/**
+ * WooCommerce Refunds endpoints.
+ *
+ * https://woocommerce.github.io/woocommerce-rest-api-docs/#refunds
+ */
+const refundsApi = {
+	name: 'Refunds',
+	create: {
+		name: 'Create a refund',
+		method: 'POST',
+		path: 'orders/<id>/refunds',
+		responseCode: 201,
+		refund: async ( orderId, refundDetails ) =>
+			postRequest( `orders/${ orderId }/refunds`, refundDetails ),
+	},
+	retrieve: {
+		name: 'Retrieve a refund',
+		method: 'GET',
+		path: 'orders/<id>/refunds/<refund_id>',
+		responseCode: 200,
+		refund: async ( orderId, refundId ) =>
+			getRequest( `orders/${ orderId }/refunds/${ refundId }` ),
+	},
+	listAll: {
+		name: 'List all refunds',
+		method: 'GET',
+		path: 'orders/<id>/refunds',
+		responseCode: 200,
+		refunds: async ( orderId ) =>
+			getRequest( `orders/${ orderId }/refunds` ),
+	},
+	delete: {
+		name: 'Delete a refund',
+		method: 'DELETE',
+		path: 'orders/<id>/refunds/<refund_id>',
+		responseCode: 200,
+		payload: {
+			force: false,
+		},
+		refund: async ( orderId, refundId, deletePermanently ) =>
+			deleteRequest(
+				`orders/${ orderId }/refunds/${ refundId }`,
+				deletePermanently
+			),
+	},
+};
+
+module.exports = {
+	refundsApi: refundsApi,
+};

--- a/plugins/woocommerce/tests/e2e/api-core-tests/tests/refunds/refunds.test.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/tests/refunds/refunds.test.js
@@ -2,7 +2,6 @@ const { refundsApi } = require( '../../endpoints/refunds' );
 const { ordersApi } = require( '../../endpoints/orders' );
 const { productsApi } = require( '../../endpoints/products' );
 const { refund } = require( '../../data' );
-const { expect } = require( '@jest/globals' );
 
 /**
  * Tests for the WooCommerce Refunds API.

--- a/plugins/woocommerce/tests/e2e/api-core-tests/tests/refunds/refunds.test.js
+++ b/plugins/woocommerce/tests/e2e/api-core-tests/tests/refunds/refunds.test.js
@@ -1,0 +1,123 @@
+const { refundsApi } = require( '../../endpoints/refunds' );
+const { ordersApi } = require( '../../endpoints/orders' );
+const { productsApi } = require( '../../endpoints/products' );
+const { refund } = require( '../../data' );
+const { expect } = require( '@jest/globals' );
+
+/**
+ * Tests for the WooCommerce Refunds API.
+ *
+ * @group api
+ * @group refunds
+ *
+ */
+describe( 'Refunds API tests', () => {
+	let expectedRefund;
+	let orderId;
+	let productId;
+
+	beforeAll( async () => {
+		// Create a product and save its product ID
+		const product = {
+			name: 'Simple Product for Refunds API tests',
+			regular_price: '100',
+		};
+		const createProductResponse = await productsApi.create.product(
+			product
+		);
+		productId = createProductResponse.body.id;
+
+		// Create an order with a product line item, and save its Order ID
+		const order = {
+			status: 'pending',
+			line_items: [
+				{
+					product_id: productId,
+				},
+			],
+		};
+		const createOrderResponse = await ordersApi.create.order( order );
+		orderId = createOrderResponse.body.id;
+
+		// Setup the expected refund object
+		expectedRefund = {
+			...refund,
+			line_items: [
+				{
+					product_id: productId,
+				},
+			],
+		};
+	} );
+
+	afterAll( async () => {
+		// Cleanup the created product and order
+		await productsApi.delete.product( productId, true );
+		await ordersApi.delete.order( orderId, true );
+	} );
+
+	it( 'can create a refund', async () => {
+		const { status, body } = await refundsApi.create.refund(
+			orderId,
+			expectedRefund
+		);
+		expect( status ).toEqual( refundsApi.create.responseCode );
+		expect( body.id ).toBeDefined();
+
+		// Save the refund ID
+		expectedRefund.id = body.id;
+
+		// Verify that the order was refunded.
+		const getOrderResponse = await ordersApi.retrieve.order( orderId );
+		expect( getOrderResponse.body.refunds ).toHaveLength( 1 );
+		expect( getOrderResponse.body.refunds[ 0 ].id ).toEqual(
+			expectedRefund.id
+		);
+		expect( getOrderResponse.body.refunds[ 0 ].reason ).toEqual(
+			expectedRefund.reason
+		);
+		expect( getOrderResponse.body.refunds[ 0 ].total ).toEqual(
+			`-${ expectedRefund.amount }`
+		);
+	} );
+
+	it( 'can retrieve a refund', async () => {
+		const { status, body } = await refundsApi.retrieve.refund(
+			orderId,
+			expectedRefund.id
+		);
+
+		expect( status ).toEqual( refundsApi.retrieve.responseCode );
+		expect( body.id ).toEqual( expectedRefund.id );
+	} );
+
+	it( 'can list all refunds', async () => {
+		const { status, body } = await refundsApi.listAll.refunds( orderId );
+
+		expect( status ).toEqual( refundsApi.listAll.responseCode );
+		expect( body ).toHaveLength( 1 );
+		expect( body[ 0 ].id ).toEqual( expectedRefund.id );
+	} );
+
+	it( 'can delete a refund', async () => {
+		const { status, body } = await refundsApi.delete.refund(
+			orderId,
+			expectedRefund.id,
+			true
+		);
+
+		expect( status ).toEqual( refundsApi.delete.responseCode );
+		expect( body.id ).toEqual( expectedRefund.id );
+
+		// Verify that the refund cannot be retrieved
+		const retrieveRefundResponse = await refundsApi.retrieve.refund(
+			orderId,
+			expectedRefund.id
+		);
+		expect( retrieveRefundResponse.status ).toEqual( 404 );
+
+		// Verify that the order no longer has a refund
+		const retrieveOrderResponse = await ordersApi.retrieve.order( orderId );
+		expect( retrieveOrderResponse.body.refunds ).toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/30675.

### How to test the changes in this Pull Request:

1. After cloning this branch, setup the e2e environment in your local.
2. Setup the `.env` file using the following values:
    ```
    BASE_URL="http://localhost:8084"
    USER_KEY="admin"
    USER_SECRET="password"
    VERBOSE=true
    ```
3. Run the tests for the Refunds API in this PR: `npm test -- --group=refunds`
4. All refunds tests should pass:
    <img width="268" alt="Screen Shot 2021-10-19 at 8 34 12 PM 1" src="https://user-images.githubusercontent.com/4509348/137911095-81956fa0-6681-40d3-9a08-044d9d6d2672.png">
5. Login to WP Admin and navigate to WooCommerce > Orders. Verify that there are no orders in the list. This means that the tests correctly cleaned up the order it created.
6. Go to Products page. Verify that there are no products listed. This means that the test had correctly cleaned up the product it created.

### Changelog entry

> Added API tests for the Refunds API.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
