### PR TITLE
add phpdoc block with gist reference to woocommerce_package_rates filter

### DIFF
--- a/plugins/woocommerce/includes/class-wc-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-shipping.php
@@ -358,7 +358,13 @@ class WC_Shipping {
 				}
 			}
 
-			// Filter the calculated rates.
+			/**
+			 * Filter the calculated shipping rates.
+			 *
+			 * @see https://gist.github.com/woogists/271654709e1d27648546e83253c1a813 for cache invalidation methods.
+			 * @param array $package['rates'] Package rates.
+			 * @param array $package Package of cart items.
+			 */
 			$package['rates'] = apply_filters( 'woocommerce_package_rates', $package['rates'], $package );
 
 			// Store in session to avoid recalculation.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a PHPDoc block to the `woocommerce_package_rates` filter. The doc bloc references a [gist](https://gist.github.com/woogists/271654709e1d27648546e83253c1a813) which was originally posted in https://github.com/woocommerce/woocommerce/issues/22100#issuecomment-902197264.

Closes #27793 .

### How to test the changes in this Pull Request:

1. Review doc block & gist
