### PR TITLE
Include product object in 'woocommerce_product_options_external'

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -32,7 +32,7 @@ defined( 'ABSPATH' ) || exit;
 			)
 		);
 
-		do_action( 'woocommerce_product_options_external' );
+		do_action( 'woocommerce_product_options_external', $product_object );
 		?>
 	</div>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Following my [previous PR](https://github.com/woocommerce/woocommerce/pull/30448), I think would be good to include the product object variable `$product_object`, to be used to get product data for the custom inputs.

### How to test the changes in this Pull Request:

Just hook into the new action to add a new input, and using the product variable to fetch the product meta for the value.

```php
add_action( 'woocommerce_product_options_external', function( $product_object ) {
	woocommerce_wp_text_input(
		array(
			'id'          => '_button_rel',
			'value'       => ! empty( $product_object->get_meta( '_button_rel' ) ) ? $product_object->get_meta( '_button_rel' ) : '',
			'label'       => __( 'Button rel', 'woocommerce' ),
			'placeholder' => __( 'nofollow', 'woocommerce' ),
			'description' => __( 'This is the rel attribute that will be added on the button linking to the external product.', 'woocommerce' ),
		)
	);
}, 10, 1 );
```

### Changelog entry:
> Dev - Adds '$product_object' variable to the `woocommerce_product_options_external` hook. #30993
