### PR TITLE
Add filter for refund restock note

### DIFF
--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -728,11 +728,11 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 
 		/* translators: 1: product ID 2: old stock level 3: new stock level */
 		$restock_note = sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock );
-		
+
 		/**
 		 * Allow the restock note to be modified.
 		 *
-		 * @since 6.2.0
+		 * @since 6.3.0
 		 *
 		 * @param string $restock_note The original note.
 		 * @param int $old_stock The old stock.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -727,7 +727,10 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		}
 
 		/* translators: 1: product ID 2: old stock level 3: new stock level */
-		$order->add_order_note( sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock ) );
+		$restock_note = sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock );
+		$restock_note = apply_filters( 'woocommerce_refund_restock_note', $restock_note, $old_stock, $new_stock, $order, $product );
+
+		$order->add_order_note( $restock_note );
 
 		$item->save();
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -728,6 +728,18 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 
 		/* translators: 1: product ID 2: old stock level 3: new stock level */
 		$restock_note = sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock );
+		
+		/**
+		 * Allow the restock note to be modified.
+		 *
+		 * @since 6.2.0
+		 *
+		 * @param string $restock_note The original note.
+		 * @param int $old_stock The old stock.
+		 * @param bool|int|null $new_stock The new stock.
+		 * @param WC_Order $order The order the refund was done for.
+		 * @param bool|WC_Product $product The product the refund was done for.
+		 */
 		$restock_note = apply_filters( 'woocommerce_refund_restock_note', $restock_note, $old_stock, $new_stock, $order, $product );
 
 		$order->add_order_note( $restock_note );

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -732,7 +732,7 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		/**
 		 * Allow the restock note to be modified.
 		 *
-		 * @since 6.3.0
+		 * @since 6.4.0
 		 *
 		 * @param string $restock_note The original note.
 		 * @param int $old_stock The old stock.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a filter to the restock note inside `wc_restock_refunded_items()` that allows for modifying the note text. This can be useful if for example the SKU needs to be added to the note.

### How to test the changes in this Pull Request:

1. Add a filter using the `woocommerce_refund_restock_note` tag that modifies the note.
2. Refund an item and make sure it increases the stock.
3. Check that the added restock note matches what was configured in the filter in step 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add 'woocommerce_refund_restock_note' filter that allows the modification of the refund restock note.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
