### PR TITLE
Update has_block_template function to use apply_filters

### DIFF
--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -107,7 +107,7 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		$has_template = (bool) is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' );
+		$has_template = is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' );
 
 		/**
 		 * Filters the value of the result of the block template check.
@@ -117,7 +117,7 @@ class WC_Template_Loader {
 		 * @param boolean $has_template value to be filtered.
 		 * @param string $template_name The name of the template.
 		 */
-		return apply_filters( 'woocommerce_has_block_template', $has_template, $template_name );
+		return (bool) apply_filters( 'woocommerce_has_block_template', $has_template, $template_name );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -107,7 +107,17 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		return apply_filters( 'wc_has_block_template', is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' ) );
+		$has_template = (bool) is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' );
+
+		/**
+		 * Filters the value of the result of the block template check.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param boolean $has_template value to be filtered.
+		 * @param string $template_name The name of the template.
+		 */
+		return apply_filters( 'woocommerce_has_block_template', $has_template, $template_name );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -107,9 +107,7 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		return is_readable(
-			get_stylesheet_directory() . '/block-templates/' . $template_name . '.html'
-		);
+		return apply_filters( 'wc_has_block_template', is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding an `apply_filters( 'woocommerce_has_block_template ')` will allow us to a step forward to rendering block templates from Woo Blocks in an effort to replace core PHP Templates.

Context found [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4926)

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4970

### How to test the changes in this Pull Request:

This will need some regression testing to confirm we haven't introduced any adverse side effects.

1. Activate a block template enabled theme.
2. Add `single-product.html` in `theme-dir/block-templates` with the following content.

```html
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true} /-->
<!-- wp:paragraph --> <p>You are using the block template now</p> <!-- /wp:paragraph -->
<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true} /-->
```

3. Check on the frontend product page that this template is getting served to the user instead of the core PHP template.
4. Delete the `single-product.html` template file and confirm that the core PHP template is getting rendered
5. Activate a classic theme and confirm core PHP template is getting rendered there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Update has_block_template method: Add apply_filters to the function which will enable third-party plugins to override the return value.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
