### PR TITLE
Add Product Reviews filter for `review` comment type.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -47,7 +47,7 @@ class WC_Comments {
 		add_filter( 'get_avatar_comment_types', array( __CLASS__, 'add_avatar_for_review_comment_type' ) );
 
 		// Add Product Reviews filter for `review` comment type.
-		add_filter( 'admin_comment_types_dropdown', array( __CLASS__, 'add_review_comment_fitler' ) );
+		add_filter( 'admin_comment_types_dropdown', array( __CLASS__, 'add_review_comment_filter' ) );
 
 		// Review of verified purchase.
 		add_action( 'comment_post', array( __CLASS__, 'add_comment_purchase_verification' ) );
@@ -299,11 +299,13 @@ class WC_Comments {
 	/**
 	 * Add Product Reviews filter for `review` comment type.
 	 *
-	 * @since  5.9
+	 * @since 6.0.0
+	 *
 	 * @param  array $comment_types Array of comment type labels keyed by their name.
+	 *
 	 * @return array
 	 */
-	public static function add_review_comment_fitler( $comment_types ) {
+	public static function add_review_comment_filter( array $comment_types ): array {
 		$comment_types['review'] = __( 'Product Reviews', 'woocommerce' );
 		return $comment_types;
 	}

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -46,6 +46,9 @@ class WC_Comments {
 		// Support avatars for `review` comment type.
 		add_filter( 'get_avatar_comment_types', array( __CLASS__, 'add_avatar_for_review_comment_type' ) );
 
+		// Add Product Reviews filter for `review` comment type.
+		add_filter( 'admin_comment_types_dropdown', array( __CLASS__, 'add_review_comment_fitler' ) );
+
 		// Review of verified purchase.
 		add_action( 'comment_post', array( __CLASS__, 'add_comment_purchase_verification' ) );
 
@@ -291,6 +294,18 @@ class WC_Comments {
 	 */
 	public static function add_avatar_for_review_comment_type( $comment_types ) {
 		return array_merge( $comment_types, array( 'review' ) );
+	}
+
+	/**
+	 * Add Product Reviews filter for `review` comment type.
+	 *
+	 * @since  5.9
+	 * @param  array $comment_types Array of comment type labels keyed by their name.
+	 * @return array
+	 */
+	public static function add_review_comment_fitler( $comment_types ) {
+		$comment_types['review'] = __( 'Product Reviews', 'woocommerce' );
+		return $comment_types;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-comments.php
+++ b/plugins/woocommerce/includes/class-wc-comments.php
@@ -301,7 +301,7 @@ class WC_Comments {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param  array $comment_types Array of comment type labels keyed by their name.
+	 * @param array $comment_types Array of comment type labels keyed by their name.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
Creates the filter option for the WordPress Comments page to filter to product reviews.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds a new filter for the `admin_comment_types_dropdown` to add the Product Reviews option to be able to filter comments by.

Closes #29920

### How to test the changes in this Pull Request:

1. View the WordPress comments page
2. See filter for Product Reviews
3. Filter to just reviews.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Add Product Reviews filter for `review` comment type to the WordPress comment page.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
