### PR TITLE
Fix: wc_get_price_excluding_tax when an order with no customer is passed

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1084,7 +1084,8 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
 		$order          = ArrayUtil::get_value_or_default( $args, 'order' );
-		$customer       = $order ? wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Customer::class, $order->get_customer_id() ) : null;
+		$customer_id    = $order ? $order->get_customer_id() : 0;
+		$customer       = $customer_id ? wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Customer::class, $customer_id ) : null;
 		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class(), $customer );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$remove_taxes   = apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ? WC_Tax::calc_tax( $line_price, $base_tax_rates, true ) : WC_Tax::calc_tax( $line_price, $tax_rates, true );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/30692 introduced a change in the `wc_get_price_excluding_tax` function: if the `woocommerce_adjust_non_base_location_prices` is set to return `false`, the function is supposed to take the location of the customer from the order for the taxes calculation, but wasn't doing so when the order was being created directly from the admin area because no customer was being passed to `WC_Tax::get_rates`; thus, the location from the currently logged in user was being used instead. With the fix from that PR, the order was being passed to `woocommerce_adjust_non_base_location_prices` and its customer location was used for the taxes calculation.

The problem is that a newly created order with no customer whatsowever has actually a "null customer" with a zero customer id. The code was taking that to calculate taxes, which resulted in no taxes being deducted; adding a new line item would result in the full product price being added, with taxes; and pressing "Recalculate" would add the taxes again.

This PR fixes that: if an order is passed to `woocommerce_adjust_non_base_location_prices`, a check is done for the cusomer id, and if it's 0 then the shop base location is used for the tax calculation as a fallback.

Closes #31013.

### How to test the changes in this Pull Request:

**Note:** These instructions are an extended version of the ones for https://github.com/woocommerce/woocommerce/pull/30692.

1. Add the following snippet to your store: `add_filter( 'woocommerce_adjust_non_base_location_prices', '__return_false' );`
2. Make sure that you have the "Prices entered with tax" option set as "Yes, I will enter prices inclusive of tax" (_WooCommerce - Settings - Tax - Tax options_).
3. Let A be the country where your currently logged in user is based, and B the country where the shop is based. Create an user U based on a different country C.
4. Go to _WooCommerce - Settings - Tax - Standard rates_ and set 30% for country A, 20% for country B and 10% for country C.
5. Create a simple product, taxable with standard rates, with a price of 110.
6. Create an order from admin area, don't set any customer for it and save it ("Create" button in "Order actions").
7. Add the product you just created to the order. You should see that the price that will appear in the line item is 91,67 (110 minus 20% of taxes), and if you click "Recalculate", the tax for country B is added and the final order price is 110.
8. Remove the line item from the order
9. Set U as the order customer and save the order ("Update" button in "Order actions").
10. Add the same product to the order again. This time the price that will appear in the line item is 100 (110 minus 10% of taxes), and if you click "Recalculate", the tax for country C is added and the final order price is again 110.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

N/A (it's a fix for https://github.com/woocommerce/woocommerce/pull/30692, which was included in 5.9 beta)

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
