### PR TITLE
POC: Add tombstone endpoint

### DIFF
--- a/plugins/woocommerce/includes/class-wc-tombstones.php
+++ b/plugins/woocommerce/includes/class-wc-tombstones.php
@@ -1,0 +1,47 @@
+<?php
+
+class WC_Tombstones {
+	const option = 'woocommerce_deleted_posts';
+
+	public static function init() {
+		add_action( 'deleted_post', array( __CLASS__, 'deleted_post' ), 10, 2 );
+	}
+
+	public static function ids() {
+		return array_keys( self::get() );
+	}
+
+	public static function get() {
+		$tombstones = get_option( self::option, array() );
+		return array_filter(
+			$tombstones,
+			function( $time ) {
+				$threshold = EMPTY_TRASH_DAYS;
+				if ( $threshold < 10 ) {
+					$threshold = 30;
+				}
+
+				return $threshold < ( time() - $time );
+			}
+		);
+	}
+
+	public static function deleted_post( $id, $post ) {
+		$post_types = array(
+			'shop_order',
+			'product',
+		);
+
+		if ( ! in_array( $post->post_type, $post_types, true ) ) {
+			return;
+		}
+
+		// TODO: Only log posts that were manually deleted.
+		$tombstones        = self::get();
+		$tombstones[ $id ] = time();
+
+		update_option( self::option, $tombstones );
+	}
+}
+
+WC_Tombstones::init();

--- a/plugins/woocommerce/includes/class-wc-tombstones.php
+++ b/plugins/woocommerce/includes/class-wc-tombstones.php
@@ -33,7 +33,7 @@ class WC_Tombstones {
 	 * @param array $filters Query filters.
 	 * @return array
 	 */
-	public static function get( $filters = null ) {
+	public static function get( array $filters = array() ) {
 		$tombstones = get_option( self::OPTION, array() );
 
 		if ( $filters['modified_before'] ) {

--- a/plugins/woocommerce/includes/class-wc-tombstones.php
+++ b/plugins/woocommerce/includes/class-wc-tombstones.php
@@ -1,7 +1,7 @@
 <?php
 
 class WC_Tombstones {
-	const option = 'woocommerce_deleted_posts';
+	const OPTION = 'woocommerce_deleted_posts';
 
 	public static function init() {
 		add_action( 'deleted_post', array( __CLASS__, 'deleted_post' ), 10, 2 );
@@ -12,7 +12,7 @@ class WC_Tombstones {
 	}
 
 	public static function get( $filters = null ) {
-		$tombstones = get_option( self::option, array() );
+		$tombstones = get_option( self::OPTION, array() );
 
 		if ( $filters['modified_before'] ) {
 			$modified_before = strtotime( $filters['modified_before'] );
@@ -63,7 +63,7 @@ class WC_Tombstones {
 		$tombstones        = self::get();
 		$tombstones[ $id ] = time();
 
-		update_option( self::option, $tombstones );
+		update_option( self::OPTION, $tombstones );
 	}
 }
 

--- a/plugins/woocommerce/includes/class-wc-tombstones.php
+++ b/plugins/woocommerce/includes/class-wc-tombstones.php
@@ -7,12 +7,35 @@ class WC_Tombstones {
 		add_action( 'deleted_post', array( __CLASS__, 'deleted_post' ), 10, 2 );
 	}
 
-	public static function ids() {
-		return array_keys( self::get() );
+	public static function ids( $filters ) {
+		return array_keys( self::get( $filters ) );
 	}
 
-	public static function get() {
+	public static function get( $filters = null ) {
 		$tombstones = get_option( self::option, array() );
+
+		if ( $filters['modified_before'] ) {
+			$modified_before = strtotime( $filters['modified_before'] );
+
+			$tombstones = array_filter(
+				$tombstones,
+				function( $time ) use ( $modified_before ) {
+					return $modified_before > $time;
+				}
+			);
+		}
+
+		if ( $filters['modified_after'] ) {
+			$modified_after = strtotime( $filters['modified_after'] );
+
+			$tombstones = array_filter(
+				$tombstones,
+				function( $time ) use ( $modified_after ) {
+					return $modified_after < $time;
+				}
+			);
+		}
+
 		return array_filter(
 			$tombstones,
 			function( $time ) {

--- a/plugins/woocommerce/includes/class-wc-tombstones.php
+++ b/plugins/woocommerce/includes/class-wc-tombstones.php
@@ -36,7 +36,7 @@ class WC_Tombstones {
 	public static function get( array $filters = array() ) {
 		$tombstones = get_option( self::OPTION, array() );
 
-		if ( $filters['modified_before'] ) {
+		if ( isset( $filters['modified_before'] ) ) {
 			$modified_before = strtotime( $filters['modified_before'] );
 
 			$tombstones = array_filter(
@@ -47,7 +47,7 @@ class WC_Tombstones {
 			);
 		}
 
-		if ( $filters['modified_after'] ) {
+		if ( isset( $filters['modified_after'] ) ) {
 			$modified_after = strtotime( $filters['modified_after'] );
 
 			$tombstones = array_filter(

--- a/plugins/woocommerce/includes/class-wc-tombstones.php
+++ b/plugins/woocommerce/includes/class-wc-tombstones.php
@@ -1,16 +1,38 @@
 <?php
 
+/**
+ * WC Tombstones
+ *
+ * Track WooCommerce objects that have been permanently deleted.
+ */
 class WC_Tombstones {
 	const OPTION = 'woocommerce_deleted_posts';
 
-	public static function init() {
+	/**
+	 *  Initialize actions and hooks.
+	 *
+	 *  @internal
+	 */
+	final public static function init() {
 		add_action( 'deleted_post', array( __CLASS__, 'deleted_post' ), 10, 2 );
 	}
 
+	/**
+	 * Get the tombstone IDs
+	 *
+	 * @param array $filters Query filters.
+	 * @return array
+	 */
 	public static function ids( $filters ) {
 		return array_keys( self::get( $filters ) );
 	}
 
+	/**
+	 * Get the tombstone objects
+	 *
+	 * @param array $filters Query filters.
+	 * @return array
+	 */
 	public static function get( $filters = null ) {
 		$tombstones = get_option( self::OPTION, array() );
 
@@ -49,6 +71,12 @@ class WC_Tombstones {
 		);
 	}
 
+	/**
+	 * Handler to track post objects as they're deleted.
+	 *
+	 * @param int     $id Post ID that has been deleted.
+	 * @param WP_Post $post Post object that has been deleted.
+	 */
 	public static function deleted_post( $id, $post ) {
 		$post_types = array(
 			'shop_order',

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -497,6 +497,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-rest-exception.php';
 		include_once WC_ABSPATH . 'includes/class-wc-auth.php';
 		include_once WC_ABSPATH . 'includes/class-wc-register-wp-admin-settings.php';
+		include_once WC_ABSPATH . 'includes/class-wc-tombstones.php';
 
 		/**
 		 * WCCOM Site.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
@@ -1,0 +1,33 @@
+<?php
+
+class WC_REST_Tombstones_Controller extends WC_REST_CRUD_Controller {
+
+	protected $namespace = 'wc/v3';
+
+	protected $rest_base = 'tombstones';
+
+	protected $request = array();
+
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+			)
+		);
+	}
+
+	function get_items() {
+		return WC_Tombstones::ids();
+	}
+
+	function get_items_permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
@@ -23,11 +23,21 @@ class WC_REST_Tombstones_Controller extends WC_REST_CRUD_Controller {
 		);
 	}
 
-	function get_items() {
-		return WC_Tombstones::ids();
+	function get_items( $request ) {
+		$filters = array();
+
+		if ( $request->get_param( 'modified_before' ) ) {
+			$filters['modified_before'] = $request->get_param( 'modified_before' );
+		}
+
+		if ( $request->get_param( 'modified_after' ) ) {
+			$filters['modified_after'] = $request->get_param( 'modified_after' );
+		}
+
+		return WC_Tombstones::ids( $filters );
 	}
 
-	function get_items_permissions_check() {
+	function get_items_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
@@ -63,7 +63,12 @@ class WC_REST_Tombstones_Controller extends WC_REST_CRUD_Controller {
 			$filters['modified_after'] = $request->get_param( 'modified_after' );
 		}
 
-		return WC_Tombstones::ids( $filters );
+		return array(
+			ids              => WC_Tombstones::instance()::ids( $filters ),
+			first            => WC_Tombstones::instance()::first( $filters ),
+			last             => WC_Tombstones::instance()::last( $filters ),
+			'sync_threshold' => WC_Tombstones::auto_purge_threshold(),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-tombstones-controller.php
@@ -1,13 +1,36 @@
 <?php
 
+/**
+ * WC Tombstone API Controller.
+ *
+ * @extends WC_REST_CRUD_Controller
+ */
 class WC_REST_Tombstones_Controller extends WC_REST_CRUD_Controller {
 
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
 	protected $namespace = 'wc/v3';
 
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
 	protected $rest_base = 'tombstones';
 
+	/**
+	 * The WP_REST_Request object.
+	 *
+	 * @var array
+	 */
 	protected $request = array();
 
+	/**
+	 * Register the routes for tombstones.
+	 */
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
@@ -23,7 +46,13 @@ class WC_REST_Tombstones_Controller extends WC_REST_CRUD_Controller {
 		);
 	}
 
-	function get_items( $request ) {
+	/**
+	 * Get the tombstone IDs.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
 		$filters = array();
 
 		if ( $request->get_param( 'modified_before' ) ) {
@@ -37,7 +66,13 @@ class WC_REST_Tombstones_Controller extends WC_REST_CRUD_Controller {
 		return WC_Tombstones::ids( $filters );
 	}
 
-	function get_items_permissions_check( $request ) {
+	/**
+	 * Check current user can access tombstones.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
 		return current_user_can( 'manage_options' );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Server.php
+++ b/plugins/woocommerce/includes/rest-api/Server.php
@@ -177,6 +177,7 @@ class Server {
 			'data-continents'          => 'WC_REST_Data_Continents_Controller',
 			'data-countries'           => 'WC_REST_Data_Countries_Controller',
 			'data-currencies'          => 'WC_REST_Data_Currencies_Controller',
+			'tombstones'               => 'WC_REST_Tombstones_Controller',
 		);
 	}
 


### PR DESCRIPTION
When objects are permanently deleted (deleted from the database instead
of being moved to the trash) they disappear from the API and it's hard
to tell if they've been removed or they're just on a different page.

The idea here is to keep a list of objects that have been deleted from
the database recently, so apps can purge them from their local caches.

This is a performance optimization. The alternative is to always request
the object from the API before showing it in the app, and remove it from
the local cache if the API returns a 404.

Note: This code is just a proof-of-concept right now. It needs a lot of
clean up.

Adds an API endpoint: `GET /wc/v3/tombstones`, which returns an
array of post IDs.