### PR TITLE
Support dynamic `price_suffix` in in-app marketplace

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -1296,13 +1296,15 @@ class WC_Admin_Addons {
 									);
 									?>
 								</span>
-								<span class="price-suffix"><?php
+								<span class="price-suffix">
+									<?php
 									$price_suffix = __( 'per year', 'woocommerce' );
 									if ( ! empty( $mapped->price_suffix ) ) {
 										$price_suffix = $mapped->price_suffix;
 									}
-									echo esc_html( $price_suffix );;
-									?></span>
+									echo esc_html( $price_suffix );
+									?>
+								</span>
 							<?php endif; ?>
 						</div>
 						<?php if ( ! empty( $mapped->reviews_count ) && ! empty( $mapped->rating ) ) : ?>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -1160,28 +1160,34 @@ class WC_Admin_Addons {
 			// For product-related banners icon is a product's image.
 			$mapped->icon = $data->image ?? null;
 		}
+
 		// URL.
 		$mapped->url = $data->link ?? null;
 		if ( empty( $mapped->url ) ) {
 			$mapped->url = $data->url ?? null;
 		}
+
 		// Title.
 		$mapped->title = $data->title ?? null;
+
 		// Vendor Name.
 		$mapped->vendor_name = $data->vendor_name ?? null;
 		if ( empty( $mapped->vendor_name ) ) {
 			$mapped->vendor_name = $data->vendorName ?? null; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
+
 		// Vendor URL.
 		$mapped->vendor_url = $data->vendor_url ?? null;
 		if ( empty( $mapped->vendor_url ) ) {
 			$mapped->vendor_url = $data->vendorUrl ?? null; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
+
 		// Description.
 		$mapped->description = $data->excerpt ?? null;
 		if ( empty( $mapped->description ) ) {
 			$mapped->description = $data->description ?? null;
 		}
+
 		$has_currency = ! empty( $data->currency ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 		// Is Free.
@@ -1190,17 +1196,23 @@ class WC_Admin_Addons {
 		} else {
 			$mapped->is_free = '&#36;0.00' === $data->price;
 		}
+
 		// Price.
 		if ( $has_currency ) {
 			$mapped->price = wc_price( $data->price, array( 'currency' => $data->currency ) );
 		} else {
 			$mapped->price = $data->price;
 		}
+
+		// Price suffix, e.g. "per month".
+		$mapped->price_suffix = $data->price_suffix ?? null;
+
 		// Rating.
 		$mapped->rating = $data->rating ?? null;
 		if ( null === $mapped->rating ) {
 			$mapped->rating = $data->averageRating ?? null; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
+
 		// Reviews Count.
 		$mapped->reviews_count = $data->reviews_count ?? null;
 		if ( null === $mapped->reviews_count ) {
@@ -1284,7 +1296,13 @@ class WC_Admin_Addons {
 									);
 									?>
 								</span>
-								<span class="price-suffix"><?php esc_html_e( 'per year', 'woocommerce' ); ?></span>
+								<span class="price-suffix"><?php
+									$price_suffix = __( 'per year', 'woocommerce' );
+									if ( ! empty( $mapped->price_suffix ) ) {
+										$price_suffix = $mapped->price_suffix;
+									}
+									echo esc_html( $price_suffix );;
+									?></span>
 							<?php endif; ?>
 						</div>
 						<?php if ( ! empty( $mapped->reviews_count ) && ! empty( $mapped->rating ) ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds support for a `price_suffix` property in each product in the WooCommerce.com search and featured endpoints, which provide the data for the product cards in the in-app marketplace. This will allow us to list products whose fees are per month.

### How to test the changes in this Pull Request:

#### Note for GlobalStep testers

The required data changes for this PR haven't been implemented on WooCommerce.com yet, and the test below requires using the test data in a GitHub gist. For now, it's fine if we simply continue to see "per year" on the prices of products in the Marketplace, for example `$29.00 per year`, where the product is not free.

#### Test using dummy data

1. Check out this branch.
2. Edit `wp-content/plugins/woocommerce/plugins/woocommerce/includes/admin/class-wc-admin-addons.php:143` to point to this gist with test data: `https://gist.githubusercontent.com/andfinally/84015c40afc8dc628f2496c9c4faf0f8/raw/search.json`.

```php
$raw_extensions = wp_safe_remote_get(
	'https://gist.githubusercontent.com/andfinally/84015c40afc8dc628f2496c9c4faf0f8/raw/search.json',
	array( 'headers' => $headers )
);
```

3. Go to `wp-admin/admin.php?page=wc-addons&section=payment-gateways`.
4. Check that Authorize.Net has a price "per month".

<img width="509" alt="image" src="https://user-images.githubusercontent.com/1647564/138705270-9964bcdf-c9ae-447b-85bf-a1a8ef32624f.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add - Support for dynamic price period in in-app marketplace product cards.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
