### PR TITLE
Remove path from "include currency-info.php" in locale-info.php

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -8,7 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$locales = include WC()->plugin_path() . '/i18n/currency-info.php';
+$locales = 'currency-info.php';
 
 return array(
 	'AD' => array(

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -8,7 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$locales = 'currency-info.php';
+$locales = include 'currency-info.php';
 
 return array(
 	'AD' => array(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request is the same as https://github.com/woocommerce/woocommerce/pull/30935, but targeting the `release/5.9` branch for inclusion in WooCommerce 5.9. Same testing instructions and changelog entry.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
