### PR TITLE
Add category by ID instead of name when creating a product in e2e tests

### DIFF
--- a/packages/js/e2e-utils/CHANGELOG.md
+++ b/packages/js/e2e-utils/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `utils.waitForTimeout( delay )` pause processing for `delay` milliseconds
 - `AdminEdit` class with utility functions for the respective edit screens
 - Update `shopper.addToCartFromShopPage()` and `.removeFromCart()` to accept product Id or Title
+- Added `withRestApi.createProductCategory()` that creates a product category and returns the ID
 
 # 0.1.6
 

--- a/packages/js/e2e-utils/README.md
+++ b/packages/js/e2e-utils/README.md
@@ -151,7 +151,8 @@ This package provides support for enabling retries in tests:
 | `deleteAllOrders` | | Permanently delete all orders |
 | `updateSettingOption` | `settingsGroup`, `settingID`, `payload` | Update a settings group |
 | `updatePaymentGateway`| `paymentGatewayId`, `payload` | Update a payment gateway |
-| `getSystemEnvironment` | | Get the current environment from the WooCommerce system status API.
+| `getSystemEnvironment` | | Get the current environment from the WooCommerce system status API. |
+| `createProductCategory` | `categoryName` | Create a product category with the provided name. |
 
 ### Classes
 

--- a/packages/js/e2e-utils/src/components.js
+++ b/packages/js/e2e-utils/src/components.js
@@ -208,12 +208,15 @@ const createSimpleProduct = async ( productTitle = simpleProductName, productPri
  * @param categoryName Product's category which can be changed when writing a test
  */
 const createSimpleProductWithCategory = async ( productName, productPrice, categoryName ) => {
+	// Get the category ID so we can add it to the product below
+	const categoryId = await withRestApi.createProductCategory( categoryName );
+
 	const product = await factories.products.simple.create( {
 		name: productName,
 		regularPrice: productPrice,
 		categories: [
 			{
-				name: categoryName,
+				id: categoryId,
 			}
 		],
 		isVirtual: true,

--- a/packages/js/e2e-utils/src/components.js
+++ b/packages/js/e2e-utils/src/components.js
@@ -17,6 +17,7 @@ import {
 } from './page-utils';
 import factories from './factories';
 import { waitForTimeout } from './flows/utils';
+import { withRestApi } from './flows/with-rest-api';
 import { Coupon, Order } from '@woocommerce/api';
 
 const client = factories.api.withDefaultPermalinks;

--- a/packages/js/e2e-utils/src/flows/with-rest-api.js
+++ b/packages/js/e2e-utils/src/flows/with-rest-api.js
@@ -300,5 +300,35 @@ export const withRestApi = {
 		} else {
 			return;
 		}
-	}
+	},
+	/**
+	 * Create a product category and return the ID. If the category already exists, the ID of the existing category is returned.
+	 *
+	 * @param {String} categoryName The name of the category to create
+	 * @returns {Promise<Number>} The ID of the category.
+	 */
+	createProductCategory: async ( categoryName ) => {
+		const payload = { name: categoryName };
+		let categoryId;
+
+		try {
+			const response = await client.post( productCategoriesEndpoint, payload );
+			expect( response.status ).toEqual( 201 );
+			categoryId = response.data.id;
+		} catch ( err ) {
+			if ( err.response.status === 400 && err.response.data.code === 'term_exists' ) {
+				// Get the list of categories and pull ID to return
+				const categoryList = await client.get( productCategoriesEndpoint );
+				expect( categoryList.status ).toEqual( 200 );
+				if ( categoryList.data && categoryList.data.length ) {
+					for ( let c = 0; c < categoryList.data.length; c++ ) {
+						if ( categoryList.data[c].name === categoryName ) {
+							categoryId = categoryList.data[c].id;
+						}
+					}
+				}
+			}
+		}
+		return categoryId;
+	},
 };

--- a/packages/js/e2e-utils/src/flows/with-rest-api.js
+++ b/packages/js/e2e-utils/src/flows/with-rest-api.js
@@ -1,5 +1,5 @@
 import factories from '../factories';
-import getSlug from '/utils';
+import { getSlug } from './utils';
 import {Coupon, Setting, SimpleProduct, Order} from '@woocommerce/api';
 
 const client = factories.api.withDefaultPermalinks;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates creating a simple product with category to use the category ID instead of the category name.

Closes https://github.com/woocommerce/woocommerce/issues/30868.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Create a simple test that creates a product with a category that wasn't previously created:

```javascript
const { createSimpleProductWithCategory } = require( '@woocommerce/e2e-utils' );

const runCreateProductWithCategoryTest = () => {
	describe('Create a product with a category', () => {
		it('should be able to create a product with a category', async () => {
			await createSimpleProductWithCategory('My test product' + '10.00', 'e2e');
		});
	});
};

module.exports = runCreateProductWithCategoryTest;
```

3. Run the test and verify the product is created with the correct category.
4. Repeat the test with the category created initially and verify the same category is applied with no errors.