### PR TITLE
Correct IQD currency symbol.

### DIFF
--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -730,7 +730,7 @@ function get_woocommerce_currency_symbols() {
 			'ILS' => '&#8362;',
 			'IMP' => '&pound;',
 			'INR' => '&#8377;',
-			'IQD' => '&#x639;.&#x62f;',
+			'IQD' => '&#x62f;.&#x639;',
 			'IRR' => '&#xfdfc;',
 			'IRT' => '&#x062A;&#x0648;&#x0645;&#x0627;&#x0646;',
 			'ISK' => 'kr.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Modifies the currency symbol for the Iraqi Dinar (IQD) from `ع.د` to `د.ع`. Formatting rules (`rs_comma_dot_rtl`) have not changed as they were already correct, and matched what we have for most other Dinar-type currencies.

This change corrects things per expectations noted in the linked issue, which also matches the publicly available information I can find on this.

Closes #30653.

### How to test the changes in this Pull Request:

1. Start with an LTR language such as English and switch the store currency to Iraqi Dinar (IQD).
2. Visit the storefront and confirm that the symbol is `د.ع` (including in the cart and checkout).
3. Switch to an RTL language.
4. Confirm that the symbol still renders as `د.ع`.

As a further confidence measure, if you visit **WooCommerce ▸ Settings ▸ General ▸ Currency Options** and search for 'Dinar', you should now see that (with the exception of the Libyan Dinar) the Iraqi Dinar now matches most of the other symbols in terms of having the `.د` component on the right:

<img width="490" alt="Screen Shot 2021-11-02 at 10 59 16" src="https://user-images.githubusercontent.com/3594411/139920390-599d3ea3-cd78-4a03-95d8-418939fe58d4.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? _(No, as essentially this was a typo)_
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Correct the Iraqi Dinar (IQD) symbol.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
