### PR TITLE
Update smoke test on PR to use pnpm

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: package/woocommerce
+          ref: trunk
 
       - name: Install prerequisites.
         working-directory: package/woocommerce/plugins/woocommerce

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: package/woocommerce
-          ref: trunk
 
       - name: Install prerequisites.
         working-directory: package/woocommerce/plugins/woocommerce
@@ -34,6 +33,7 @@ jobs:
           pnpm install jest
           
       - name: Run smoke test.
+        working-directory: package/woocommerce/plugins/woocommerce
         env:
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
           SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -1,6 +1,8 @@
 name: Run smoke tests against pull request.
 on:
   pull_request:
+    branches:
+      - trunk
     types:
       - labeled
 jobs:
@@ -19,14 +21,16 @@ jobs:
       - name: Checkout code.
         uses: actions/checkout@v2
         with:
-          ref: trunk
+          path: package/woocommerce
 
       - name: Install prerequisites.
+        working-directory: package/woocommerce/plugins/woocommerce
         run: |
-          npm install
+          npm install -g pnpm
+          pnpm install
           composer install --no-dev
-          npm run build:assets
-          npm install jest
+          pnpm run build:assets
+          pnpm install jest
           
       - name: Run smoke test.
         env:
@@ -43,8 +47,8 @@ jobs:
           UPDATE_WC: 1
           DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
-          npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js
-          npx wc-e2e test:e2e
+          pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/smoke-tests/update-woocommerce.js
+          pnpx wc-e2e test:e2e
 
       - name: Remove label from pull request.
         if: "${{ contains(github.event.pull_request.labels.*.name, 'run: smoke tests') }}"


### PR DESCRIPTION
Updates the smoke test on PR to use PNPM. This PR ensures the tests are setup correctly and runs. As seen here https://github.com/woocommerce/woocommerce/runs/4087601329?check_suite_focus=true

Not all tests passes but that's ok as it will be fixed by Solaris soon.