### PR TITLE
Delay handling of hide-notice requests

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -51,7 +51,7 @@ class WC_Admin_Notices {
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
-		add_action( 'wp_loaded', array( __CLASS__, 'hide_notices' ) );
+		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
 		// to avoid.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, `WC_Notes_Run_Db_Update` is instantiated on `admin_init` [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-install.php#L180) and hooks into the `woocommerce_hide_update_notice` [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/admin/notes/class-wc-notes-run-db-update.php#L26) to dismiss the "DB Updated" note.

The callback is never run, though, because [the function that intercepts requests to dismiss notices](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/admin/class-wc-admin-notices.php#L54) is hooked into `wp_loaded` -- so when the `woocommerce_hide_update_notice` action is run, `WC_Notes_Run_Db_Update` has not been instantiated yet.

The PR moves the handling of these requests to a later point, ensuring that `WC_Notes_Run_Db_Update` has been instantiated before it can hook into the `woocommerce_hide_update_notice` action.

Closes #30781

### How to test the changes in this Pull Request:

1. Trigger a WC DB update by manually changing the DB version in the `options` table to an earlier one.
2. You'll notice that, without this fix, when the DB update is complete, the "Thanks" note cannot be dismissed. Sometimes it will eventually go away -- I have not been able to explain why it works when it does work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes an issue that prevented database update notices from being dismissed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
