### PR TITLE
Allow empty arrays to be cached

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -597,7 +597,7 @@ abstract class WC_Data {
 		// We filter the raw meta data again when loading from cache, in case we cached in an earlier version where filter conditions were different.
 		$raw_meta_data = $cache_loaded ? $this->data_store->filter_raw_meta_data( $this, $cached_meta ) : $this->data_store->read_meta( $this );
 
-		if ( $raw_meta_data ) {
+		if ( is_array( $raw_meta_data ) ) {
 			foreach ( $raw_meta_data as $meta ) {
 				$this->meta_data[] = new WC_Meta_Data(
 					array(

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -590,7 +590,7 @@ abstract class WC_Data {
 		if ( ! $force_read ) {
 			if ( ! empty( $this->cache_group ) ) {
 				$cached_meta  = wp_cache_get( $cache_key, $this->cache_group );
-				$cache_loaded = ! empty( $cached_meta );
+				$cache_loaded = is_array( $cached_meta );
 			}
 		}
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -95,7 +95,7 @@ function wc_get_attribute_taxonomy_ids() {
 	$cache_key   = $prefix . 'ids';
 	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
 
-	if ( $cache_value ) {
+	if ( false !== $cache_value ) {
 		return $cache_value;
 	}
 
@@ -117,7 +117,7 @@ function wc_get_attribute_taxonomy_labels() {
 	$cache_key   = $prefix . 'labels';
 	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
 
-	if ( $cache_value ) {
+	if ( false !== $cache_value ) {
 		return $cache_value;
 	}
 
@@ -722,7 +722,7 @@ function wc_attribute_taxonomy_slug( $attribute_name ) {
 	$cache_key   = $prefix . 'slug-' . $attribute_name;
 	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
 
-	if ( $cache_value ) {
+	if ( false !== $cache_value ) {
 		return $cache_value;
 	}
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-data-test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Class WC_Data file.
+ *
+ * @package WooCommerce\Tests\Abstracts
+ */
+
+/**
+ * Class WC_Data.
+ */
+class WC_Data_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Test that create is called on data store when new object is saved.
+	 */
+	public function test_data_store_called_on_save() {
+		$data_store = $this->getMockBuilder( WC_Object_Data_Store_Interface::class )->getMock();
+		$data_store->expects( $this->once() )
+			->method( 'create' )
+			->with(
+			   $this->isInstanceOf( WC_Data::class )
+			);
+		$data_store->expects( $this->once() )
+			->method( 'update' )
+			->with(
+			   $this->isInstanceOf( WC_Data::class )
+			);
+		$data_store->expects( $this->once() )
+			->method( 'delete' )
+			->with(
+			   $this->isInstanceOf( WC_Data::class )
+			);
+
+		$data_object = new class( $data_store ) extends WC_Data {
+			public function __construct( $data_store ) {
+				$this->data_store = $data_store;
+			}
+		};
+		$data_object->save();
+		$data_object->set_id( 1 );
+		$data_object->save();
+		$data_object->delete();
+	}
+
+	/**
+	 * Test that cache is used when reading meta data.
+	 */
+	public function test_meta_data_cache() {
+		$raw_meta_data = [];
+		$data_store = $this->getMockBuilder( WC_Data_Store_WP::class )->getMock();
+		$data_store->expects( $this->once() )
+		           ->method( 'filter_raw_meta_data' )
+		           ->with(
+			           $this->isInstanceOf( WC_Data::class ),
+			           $raw_meta_data
+		           );
+		$data_store->expects( $this->once() )
+		           ->method( 'read_meta' )
+		           ->with(
+			           $this->isInstanceOf( WC_Data::class )
+		           )
+		->willReturn( $raw_meta_data );
+
+		$data_object = new class( $data_store ) extends WC_Data {
+			protected $cache_group = 'object_name';
+			public function __construct( $data_store ) {
+				$this->id = 1;
+				$this->data_store = $data_store;
+			}
+		};
+		$meta_data = $data_object->get_meta_data();
+		$this->assertEquals( [], $meta_data );
+		$data_object->read_meta_data();
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-data-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-data-test.php
@@ -49,17 +49,17 @@ class WC_Data_Test extends WC_Unit_Test_Case {
 		$raw_meta_data = [];
 		$data_store = $this->getMockBuilder( WC_Data_Store_WP::class )->getMock();
 		$data_store->expects( $this->once() )
-		           ->method( 'filter_raw_meta_data' )
-		           ->with(
-			           $this->isInstanceOf( WC_Data::class ),
-			           $raw_meta_data
-		           );
+			->method( 'filter_raw_meta_data' )
+			->with(
+			   $this->isInstanceOf( WC_Data::class ),
+			   $raw_meta_data
+			);
 		$data_store->expects( $this->once() )
-		           ->method( 'read_meta' )
-		           ->with(
-			           $this->isInstanceOf( WC_Data::class )
-		           )
-		->willReturn( $raw_meta_data );
+			->method( 'read_meta' )
+			->with(
+			   $this->isInstanceOf( WC_Data::class )
+			)
+			->willReturn( $raw_meta_data );
 
 		$data_object = new class( $data_store ) extends WC_Data {
 			protected $cache_group = 'object_name';

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -81,13 +81,15 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 			1,
 			$this->filter_recorder->getInvocationCount(),
 			'Filter `woocommerce_attribute_taxonomies` should have been triggered once after fetching all attribute taxonomies.'
-		);		$labels = wc_get_attribute_taxonomy_labels();
+		);
+		$labels = wc_get_attribute_taxonomy_labels();
 		$this->assertEquals( [], $labels );
 		$this->assertEquals(
 			1,
 			$this->filter_recorder->getInvocationCount(),
 			'Filter `woocommerce_attribute_taxonomies` should not be triggered a second time because the results should be loaded from the cache.'
-		);	}
+		);
+	}
 
 	/**
 	 * Test wc_attribute_taxonomy_slug() function.

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Attribute functions tests
+ *
+ * @package WooCommerce\Tests\Functions.
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class WC_Formatting_Functions_Test
+ */
+class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Mock object to spy on filter.
+	 *
+	 * @var MockObject
+	 */
+	protected $attribute_taxonomies_spy;
+
+	/**
+	 * Mock object to spy on filter.
+	 *
+	 * @var MockObject
+	 */
+	protected $sanitize_taxonomy_spy;
+
+	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->attribute_taxonomies_spy = $this->getMockBuilder( stdClass::class )
+			->setMethods( [ '__invoke' ] )
+			->getMock();
+		$this->sanitize_taxonomy_spy = $this->getMockBuilder( stdClass::class )
+			->setMethods( [ '__invoke' ] )
+			->getMock();
+
+		add_filter( 'woocommerce_attribute_taxonomies', $this->attribute_taxonomies_spy );
+		add_filter( 'sanitize_taxonomy_name', $this->sanitize_taxonomy_spy );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		remove_all_filters( 'woocommerce_attribute_taxonomies' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test wc_get_attribute_taxonomy_ids() function.
+	 * Even empty arrays should be cached.
+	 */
+	public function test_wc_get_attribute_taxonomy_ids() {
+		$this->attribute_taxonomies_spy->expects( $this->once() )
+			->method( '__invoke' )
+			->will( $this->returnArgument( 0 ) );
+
+		$ids = wc_get_attribute_taxonomy_ids();
+		$this->assertEquals( [], $ids );
+		$ids = wc_get_attribute_taxonomy_ids();
+		$this->assertEquals( [], $ids );
+	}
+
+	/**
+	 * Test wc_get_attribute_taxonomy_labels() function.
+	 * Even empty arrays should be cached.
+	 */
+	public function test_wc_get_attribute_taxonomy_labels() {
+		$this->attribute_taxonomies_spy->expects( $this->once() )
+			->method( '__invoke' )
+			->will( $this->returnArgument( 0 ) );
+
+		$labels = wc_get_attribute_taxonomy_labels();
+		$this->assertEquals( [], $labels );
+		$labels = wc_get_attribute_taxonomy_labels();
+		$this->assertEquals( [], $labels );
+	}
+
+	/**
+	 * Test wc_attribute_taxonomy_slug() function.
+	 * Even empty strings should be cached.
+	 *
+	 * @dataProvider get_attribute_names_and_slugs
+	 */
+	public function test_wc_get_attribute_taxonomy_slug( $name, $expected_slug ) {
+		$this->sanitize_taxonomy_spy->expects( $this->once() )
+			->method( '__invoke' )
+			->will( $this->returnArgument( 0 ) );
+
+		$slug = wc_attribute_taxonomy_slug( $name );
+		$this->assertEquals( $expected_slug, $slug );
+		$slug = wc_attribute_taxonomy_slug( $name );
+		$this->assertEquals( $expected_slug, $slug );
+	}
+
+	public function get_attribute_names_and_slugs() {
+		return [
+			[ 'Dash Me', 'dash-me' ],
+			[ '', '' ],
+			[ 'pa_SubStr', 'substr' ],
+			[ 'ĂnîC°Dę', 'anicde' ],
+		];
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
When creating a custom data store for a custom object I noticed that the meta data was always being loaded from the database when it should have been using the cache. This was because I was not using the meta data with my custom object. There was cases when meta data would be used and cases when it would not and I wanted it to be able to use the cache in both cases. Turns out WC_Data::read_meta_data was checking if the cache result was not empty to determine if it was found but it is possible for a valid cache result to be an empty array. `wp_cache_get` will return false if the cache key is not found so we either do a strict comparison with false or check that we have the right type returned to determine if the cache result is valid. 

I added a unit test which should make it more clear.

### How to test the changes in this Pull Request:

1. Run unit tests

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Ensure empty arrays can be cached.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
