### PR TITLE
Use trunk version of action-build

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -18,7 +18,7 @@ jobs:
           ref: ${{ matrix.build }}
       - name: Build
         id: build
-        uses: woocommerce/action-build@v2
+        uses: woocommerce/action-build@trunk
       - name: Deploy nightly build
         uses: WebFreak001/deploy-nightly@v1.1.0
         env:


### PR DESCRIPTION
Update to use trunk's version of action-build to coincide with https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/pr-build-and-e2e-tests.yml#L13

But I think in the future it's better to use a proper version release than using trunk.