### PR TITLE
Update links to moved e2e READMEs.

### DIFF
--- a/packages/js/e2e-core-tests/README.md
+++ b/packages/js/e2e-core-tests/README.md
@@ -16,7 +16,7 @@ This package contains the automated end-to-end tests for WooCommerce.
 
 ### Setting up the test environment
 
-Follow [E2E setup instructions](https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/README.md).
+Follow [E2E setup instructions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md).
 
 ### Setting up core tests
 

--- a/packages/js/e2e-core-tests/package.json
+++ b/packages/js/e2e-core-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/e2e-core-tests",
   "version": "0.1.6",
   "description": "End-To-End (E2E) tests for WooCommerce",
-  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/core-tests/README.md",
+  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-core-tests/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/woocommerce/woocommerce.git"

--- a/packages/js/e2e-environment/README.md
+++ b/packages/js/e2e-environment/README.md
@@ -104,7 +104,7 @@ For a list of the methods that the above timeout affects, please see the Puppete
 
 ### Test Against Previous WordPress Versions
 
-You can use the `LATEST_WP_VERSION_MINUS` flag to determine how many versions back from the current WordPress version to use in the Docker environment. This is calculated from the current WordPress version minus the set value. For example, if `LATEST_WP_VERSION_MINUS` is set to 1, it will calculate the current WordPress version minus one, and use that for the WordPress Docker container. 
+You can use the `LATEST_WP_VERSION_MINUS` flag to determine how many versions back from the current WordPress version to use in the Docker environment. This is calculated from the current WordPress version minus the set value. For example, if `LATEST_WP_VERSION_MINUS` is set to 1, it will calculate the current WordPress version minus one, and use that for the WordPress Docker container.
 
 For example, you could run the following command:
 
@@ -163,7 +163,7 @@ Jest provides [setup and teardown functions](https://jestjs.io/docs/setup-teardo
 #### Console filtering
 
 **Added version 0.2.3**
-By default, messages logged to the console are included in the test results. The test runner suppresses 404 not found and proxy connection messages. 
+By default, messages logged to the console are included in the test results. The test runner suppresses 404 not found and proxy connection messages.
 
 Pages that you are testing may contain repetitive console output that you expect. Use `addConsoleSuppression` in your jest setup script to filter these repetitive messages:
 
@@ -182,8 +182,8 @@ removeConsoleSuppression( 'suppress this after the first instance' );
 
 Depending on the project and testing scenario, the built in testing environment container might not be the best solution for testing. This could be local testing where there is already a testing container, a repository that isn't a plugin or theme and there are multiple folders mapped into the container, or similar. The `e2e-environment` test runner supports using either the built in container or an external container. See the appropriate readme for  details:
 
-- [Built In Container](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/env/builtin.md)
-- [External Container](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/env/external.md)
+- [Built In Container](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-environment/builtin.md)
+- [External Container](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-environment/external.md)
 
 ### Slackbot Setup
 
@@ -233,4 +233,4 @@ This will return a string with the latest release URL. Optionally, you can use t
 
 ## Additional information
 
-Refer to [`tests/e2e/core-tests`](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/core-tests) for some test examples, and [`tests/e2e`](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e) for general information on e2e tests.
+Refer to [`@woocommerce/e2e-core-tests`](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-core-tests) for some test examples, and [`plugins/woocommerce/tests/e2e`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e) for general information on e2e tests.

--- a/packages/js/e2e-utils/package.json
+++ b/packages/js/e2e-utils/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/e2e-utils",
   "version": "0.1.6",
   "description": "End-To-End (E2E) test utils for WooCommerce",
-  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/utils/README.md",
+  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-utils/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/woocommerce/woocommerce.git"

--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Tests
 
-This document discusses unit tests. See [the e2e README](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e) to learn how to setup testing environment for running e2e tests and run them.
+This document discusses unit tests. See [the e2e README](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e) to learn how to setup testing environment for running e2e tests and run them.
 
 ## Table of contents
 
@@ -25,7 +25,7 @@ To run the tests, you need to create a test database. You can:
 - Access a database on a server
 - Connect to your local database on your machine
 - Use a solution like VVV - if you are using VVV you might need to `vagrant ssh` first
-- Run a throwaway database in docker with this one-liner: `docker run --rm --name woocommerce_test_db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=woocommerce_test_password -d mysql:5.7.33`. ( Use `tests/bin/install.sh woocommerce_tests root woocommerce_test_password 0.0.0.0` in next step) 
+- Run a throwaway database in docker with this one-liner: `docker run --rm --name woocommerce_test_db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=woocommerce_test_password -d mysql:5.7.33`. ( Use `tests/bin/install.sh woocommerce_tests root woocommerce_test_password 0.0.0.0` in next step)
 
 ### Setup instructions
 
@@ -103,7 +103,7 @@ curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-ph
 unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
 composer bin phpunit config --unset platform
 composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs    
+composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
 ```
 
 Just remember that you can't include the modified `composer.json` in any commit!
@@ -123,7 +123,7 @@ Each test file should correspond to an associated source file and be named accor
         * When testing functions: use one test file per functions group file, for example `wc-formatting-functions-test.php` for code in the `wc-formatting-functions.php` file.
 
 
-See also [the guidelines for writing unit tests for `src` code](https://github.com/woocommerce/woocommerce/tree/trunk/src/README.md#writing-unit-tests) and [the guidelines for `includes` code](https://github.com/woocommerce/woocommerce/tree/trunk/includes/README.md#writing-unit-tests). 
+See also [the guidelines for writing unit tests for `src` code](https://github.com/woocommerce/woocommerce/tree/trunk/src/README.md#writing-unit-tests) and [the guidelines for `includes` code](https://github.com/woocommerce/woocommerce/tree/trunk/includes/README.md#writing-unit-tests).
 
 General guidelines for all the unit tests:
 

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -351,8 +351,8 @@ FAIL ../specs/front-end/front-end-my-account.test.js (9.219s)
 
 In the example above, you can see that `allows customer to see downloads` part of the test failed and can start looking at it right away. Without steps the test goes through being detailed, it is more difficult to debug it. 
 
-## Debugging tests 
+## Debugging tests
 
-The test sequencer (`npx wc-e2e test:e2e`) includes support for saving [screenshots on test errors](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/env#test-screenshots) which can be sent to a Slack channel via a [Slackbot](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/env#slackbot-setup).
+The test sequencer (`npx wc-e2e test:e2e`) includes support for saving [screenshots on test errors](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-environment#test-screenshots) which can be sent to a Slack channel via a [Slackbot](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/e2e-environment#slackbot-setup).
 
-For Puppeteer debugging, follow [Google's documentation](https://developers.google.com/web/tools/puppeteer/debugging).   
+For Puppeteer debugging, follow [Google's documentation](https://developers.google.com/web/tools/puppeteer/debugging).

--- a/plugins/woocommerce/tests/performance/README.md
+++ b/plugins/woocommerce/tests/performance/README.md
@@ -54,7 +54,7 @@ Alternatively the k6 docker image can be used to execute tests.
 
 Before using the tests a test environment is needed to run against.
 
-In the WooCommerce e2e tests there is a Docker Initialization Script [`init-sample-products.sh`](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/docker/init-sample-products.sh) that will set up a shop with sample products imported and the shop settings (payment method, permalinks, address etc) needed for the tests already set. It is recommended using this to just see the tests in action.
+In the WooCommerce e2e tests there is a Docker Initialization Script [`init-sample-products.sh`](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e/docker/init-sample-products.sh) that will set up a shop with sample products imported and the shop settings (payment method, permalinks, address etc) needed for the tests already set. It is recommended using this to just see the tests in action.
 
 `npx wc-e2e docker:up ./tests/e2e/docker/init-sample-products.sh`
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After recent moves, some links to/from e2e-related `README.md`s become outdated and result in 404. This PR updates a bunch of them.

### How to test the changes in this Pull Request:

1. Revisit changed files
2. Ctrl/cmd+click the links
3. Make sure they point to respective pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [n/a] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

no changelog needed - it's just a README link fix.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
