### PR TITLE
Combine My Subscriptions and Marketplace back into one Extensions page

### DIFF
--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-extensions-connect-wccom.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-extensions-connect-wccom.test.js
@@ -21,7 +21,13 @@ const runInitiateWccomConnectionTest = () => {
 		});
 
 		it.skip('can initiate WCCOM connection', async () => {
-			await merchant.openHelper();
+			await merchant.openExtensions();
+
+			// Click on a tab to choose WooCommerce Subscriptions extension
+			await Promise.all( [
+				expect( page ).toClick( 'a.nav-tab', { text: "WooCommerce.com Subscriptions" } ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			] );
 
 			// Click on Connect button to initiate a WCCOM connection
 			await Promise.all([

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -90,36 +90,15 @@
 		@media only screen and ( min-width: 768px ) {
 			margin-bottom: 24px;
 		}
+	}
 
-		.current-section-dropdown {
-			position: relative;
-			width: 100%;
+	.current-section-dropdown {
+		position: relative;
+		width: 100%;
 
-			@media only screen and ( min-width: 600px ) {
-				margin-left: 70px;
-				width: 288px;
-			}
-		}
-
-		.current-section-name {
-			cursor: pointer;
-			font-weight: 600;
-			font-size: 14px;
-			line-height: 20px;
-			padding: 20px 16px;
-			position: relative;
-		}
-
-		.current-section-name::after {
-			background-image: url(../images/icons/gridicons-chevron-down.svg);
-			background-size: contain;
-			content: "";
-			display: block;
-			height: 20px;
-			position: absolute;
-			right: 20px;
-			top: 20px;
-			width: 20px;
+		@media only screen and (min-width: 600px) {
+			margin-left: 70px;
+			width: 288px;
 		}
 
 		ul {
@@ -136,11 +115,11 @@
 			width: 100%;
 			z-index: 10;
 
-			@media only screen and ( min-width: 600px ) {
+			@media only screen and (min-width: 600px) {
 				border: 1px solid #1e1e1e;
 			}
 
-			@media only screen and ( min-width: 1100px ) {
+			@media only screen and (min-width: 1100px) {
 				justify-content: center;
 			}
 
@@ -165,7 +144,7 @@
 				position: relative;
 				width: 100%;
 
-				@media only screen and ( min-width: 600px ) {
+				@media only screen and (min-width: 600px) {
 					padding: 10px 18px;
 				}
 			}
@@ -181,16 +160,37 @@
 				width: 20px;
 			}
 		}
+	}
 
-		.current-section-dropdown.is-open {
+	.current-section-name {
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 14px;
+		line-height: 20px;
+		padding: 20px 16px;
+		position: relative;
+	}
 
-			ul {
-				display: flex;
-			}
+	.current-section-name::after {
+		background-image: url(../images/icons/gridicons-chevron-down.svg);
+		background-size: contain;
+		content: "";
+		display: block;
+		height: 20px;
+		position: absolute;
+		right: 20px;
+		top: 20px;
+		width: 20px;
+	}
 
-			.current-section-name::after {
-				transform: rotate(0.5turn);
-			}
+	.current-section-dropdown.is-open {
+
+		ul {
+			display: flex;
+		}
+
+		.current-section-name::after {
+			transform: rotate(0.5turn);
 		}
 	}
 
@@ -418,10 +418,6 @@
 	}
 
 	@media only screen and (max-width: 400px) {
-
-		.addons-featured {
-			margin: -1% -5%;
-		}
 
 		.addons-button {
 			width: 100%;
@@ -734,6 +730,37 @@
 		p {
 			max-width: 750px;
 		}
+	}
+}
+
+.marketplace-header__tabs {
+	display: flex;
+	margin: 0;
+}
+
+.marketplace-header__tab {
+	display: flex;
+	flex: 1;
+	margin: 0;
+}
+
+.marketplace-header__tab-link {
+	align-items: center;
+	border-bottom: 2px solid transparent;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	font-size: 14px;
+	height: 60px;
+	justify-content: center;
+	line-height: 20px;
+	padding: 0 24px;
+	text-decoration: none;
+	width: 100%;
+
+	&.is-current {
+		border-bottom: 2px solid #1e1e1e;
+		color: #1e1e1e;
 	}
 }
 
@@ -7642,5 +7669,16 @@ table.bar_chart {
 				width: 278px;
 			}
 		}
+	}
+
+	.marketplace-header__tab {
+		flex: none;
+	}
+}
+
+@media screen and (min-width: 961px) {
+
+	.marketplace-header__tabs {
+		margin-left: 84px;
 	}
 }

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -93,11 +93,13 @@
 	}
 
 	.current-section-dropdown {
+		background: #fff;
+		border: 1px solid #a7aaad;
+		margin-bottom: 16px;
 		position: relative;
 		width: 100%;
 
 		@media only screen and (min-width: 600px) {
-			margin-left: 70px;
 			width: 288px;
 		}
 
@@ -117,6 +119,8 @@
 
 			@media only screen and (min-width: 600px) {
 				border: 1px solid #1e1e1e;
+				left: -1px;
+				top: 48px;
 			}
 
 			@media only screen and (min-width: 1100px) {
@@ -164,10 +168,9 @@
 
 	.current-section-name {
 		cursor: pointer;
-		font-weight: 600;
 		font-size: 14px;
-		line-height: 20px;
-		padding: 20px 16px;
+		line-height: 24px;
+		padding: 12px 16px;
 		position: relative;
 	}
 
@@ -179,7 +182,7 @@
 		height: 20px;
 		position: absolute;
 		right: 20px;
-		top: 20px;
+		top: 16px;
 		width: 20px;
 	}
 
@@ -7681,4 +7684,9 @@ table.bar_chart {
 	.marketplace-header__tabs {
 		margin-left: 84px;
 	}
+}
+
+@media screen and (min-width: 1280px) {
+
+
 }

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -95,7 +95,7 @@
 	.current-section-dropdown {
 		background: #fff;
 		border: 1px solid #a7aaad;
-		margin-bottom: 24px;
+		margin-bottom: 12px;
 		position: relative;
 		width: 100%;
 
@@ -491,6 +491,7 @@
 			background: #fff;
 			border: 1px solid #dcdcde;
 			border-radius: 2px;
+			box-sizing: border-box;
 			display: flex;
 			flex: 1 0 auto;
 			flex-direction: column;
@@ -7696,7 +7697,7 @@ table.bar_chart {
 		.current-section-dropdown {
 			background: none;
 			border: none;
-			margin-bottom: 32px;
+			margin-bottom: 20px;
 			width: 100%;
 
 			ul {
@@ -7706,6 +7707,7 @@ table.bar_chart {
 				flex-direction: row;
 				flex-wrap: wrap;
 				justify-content: flex-start;
+				margin-top: -12px;
 				padding: 0;
 				position: static;
 
@@ -7713,7 +7715,7 @@ table.bar_chart {
 					border: 1px solid #ccc;
 					font-size: 14px;
 					line-height: 20px;
-					margin: 0 12px 12px 0;
+					margin: 12px 12px 0 0;
 
 					&.current {
 						a {
@@ -7732,7 +7734,7 @@ table.bar_chart {
 				a:hover,
 				a:active {
 					color: #50575e;
-					padding: 10px 14px;
+					padding: 10px 14px !important;
 				}
 			}
 

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -205,7 +205,7 @@
 		font-size: 9px;
 		font-weight: 600;
 		line-height: 17px;
-		margin: 1px 0 0 2px;
+		margin: 1px 0 0 4px;
 		padding: 0 6px;
 		vertical-align: text-top;
 	}
@@ -753,7 +753,6 @@
 	border-bottom: 2px solid transparent;
 	box-sizing: border-box;
 	display: flex;
-	flex-direction: column;
 	font-size: 14px;
 	height: 60px;
 	justify-content: center;

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -788,6 +788,19 @@
 
 .wc-subscriptions-wrap {
 	max-width: 1200px;
+
+	.update-plugins .update-count {
+		background-color: #d54e21;
+		border-radius: 10px;
+		color: #fff;
+		display: inline-block;
+		font-size: 9px;
+		font-weight: 600;
+		line-height: 17px;
+		margin: 1px 0 0 2px;
+		padding: 0 6px;
+		vertical-align: text-top;
+	}
 }
 
 .woocommerce-page-wc-marketplace {

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -7688,5 +7688,68 @@ table.bar_chart {
 
 @media screen and (min-width: 1280px) {
 
+	.current-section-name {
+		display: none;
+	}
 
+	.wc-addons-wrap {
+		.current-section-dropdown {
+			background: none;
+			border: none;
+			width: 100%;
+
+			ul {
+				background: none;
+				border: none;
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+				justify-content: flex-start;
+				padding: 0;
+				position: static;
+
+				a {
+					color: #2271b1;
+					padding: 10px 0 10px 14px;
+
+					&::after {
+						color: #ccc;
+						content: '|';
+						display: inline-block;
+						margin-left: 14px;
+					}
+				}
+
+				a:visited {
+					color: #2271b1;
+				}
+
+				a:hover,
+				a:active {
+					color: #135e96;
+				}
+
+				a.current {
+					color: #1e1e1e;
+
+					&::after {
+						background: none;
+						color: #ccc;
+						content: '|';
+						display: inline-block;
+						height: auto;
+						margin-left: 14px;
+						position: static;
+						width: auto;
+					}
+				}
+			}
+
+			li:last-child {
+				a::after {
+					display: none;
+				}
+			}
+		}
+	}
 }

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -95,7 +95,7 @@
 	.current-section-dropdown {
 		background: #fff;
 		border: 1px solid #a7aaad;
-		margin-bottom: 12px;
+		margin-bottom: 20px;
 		position: relative;
 		width: 100%;
 
@@ -226,7 +226,7 @@
 		font-size: 20px;
 		font-family: $font-sf-pro-display;
 		line-height: 1.2;
-		margin: 48px 0 16px;
+		margin: 48px 0 12px;
 		padding: 0;
 	}
 
@@ -438,9 +438,21 @@
 		width: 100%;
 	}
 
+	.addon-product-group {
+		margin-bottom: 24px;
+	}
+
 	.addon-product-group-title {
 		font-family: $font-sf-pro-display;
-		letter-spacing: 0.38px;
+		font-size: 20px;
+		font-weight: 400;
+		line-height: 24px;
+		margin: 0 0 4px;
+	}
+
+	.current-section-dropdown__title {
+		display: none;
+		font-family: $font-sf-pro-display;
 	}
 
 	.addon-product-group-description-container {
@@ -7706,10 +7718,18 @@ table.bar_chart {
 	}
 
 	.wc-addons-wrap {
+		.current-section-dropdown__title {
+			display: block;
+			font-size: 20px;
+			font-weight: 400;
+			line-height: 24px;
+			margin: 0 0 16px;
+		}
+
 		.current-section-dropdown {
 			background: none;
 			border: none;
-			margin-bottom: 20px;
+			margin-bottom: 32px;
 			width: 100%;
 
 			ul {
@@ -7724,15 +7744,19 @@ table.bar_chart {
 				position: static;
 
 				li {
+					background: #fff;
 					border: 1px solid #ccc;
+					border-radius: 32px;
 					font-size: 14px;
 					line-height: 20px;
 					margin: 12px 12px 0 0;
 
 					&.current {
+						background: #007cba;
+						border: 1px solid #007cba;
+
 						a {
-							background: #fff;
-							color: #1e1e1e;
+							color: #fff;
 						}
 
 						a::after {
@@ -7745,8 +7769,8 @@ table.bar_chart {
 				a:visited,
 				a:hover,
 				a:active {
-					color: #50575e;
-					padding: 10px 14px !important;
+					color: #2c3338;
+					padding: 10px 16px !important;
 				}
 			}
 

--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -95,7 +95,7 @@
 	.current-section-dropdown {
 		background: #fff;
 		border: 1px solid #a7aaad;
-		margin-bottom: 16px;
+		margin-bottom: 24px;
 		position: relative;
 		width: 100%;
 
@@ -131,6 +131,17 @@
 				font-size: 13px;
 				line-height: 16px;
 				margin: 0;
+
+				&.current a::after {
+					background-image: url(../images/icons/gridicons-checkmark.svg);
+					content: "";
+					display: block;
+					height: 20px;
+					position: absolute;
+					right: 20px;
+					top: 7px;
+					width: 20px;
+				}
 			}
 
 			a,
@@ -151,17 +162,6 @@
 				@media only screen and (min-width: 600px) {
 					padding: 10px 18px;
 				}
-			}
-
-			a.current::after {
-				background-image: url(../images/icons/gridicons-checkmark.svg);
-				content: "";
-				display: block;
-				height: 20px;
-				position: absolute;
-				right: 20px;
-				top: 7px;
-				width: 20px;
 			}
 		}
 	}
@@ -7686,7 +7686,7 @@ table.bar_chart {
 	}
 }
 
-@media screen and (min-width: 1280px) {
+@media screen and (min-width: 1024px) {
 
 	.current-section-name {
 		display: none;
@@ -7696,6 +7696,7 @@ table.bar_chart {
 		.current-section-dropdown {
 			background: none;
 			border: none;
+			margin-bottom: 32px;
 			width: 100%;
 
 			ul {
@@ -7708,40 +7709,30 @@ table.bar_chart {
 				padding: 0;
 				position: static;
 
-				a {
-					color: #2271b1;
-					padding: 10px 0 10px 14px;
+				li {
+					border: 1px solid #ccc;
+					font-size: 14px;
+					line-height: 20px;
+					margin: 0 12px 12px 0;
 
-					&::after {
-						color: #ccc;
-						content: '|';
-						display: inline-block;
-						margin-left: 14px;
+					&.current {
+						a {
+							background: #fff;
+							color: #1e1e1e;
+						}
+
+						a::after {
+							background: none;
+						}
 					}
 				}
 
-				a:visited {
-					color: #2271b1;
-				}
-
+				a,
+				a:visited,
 				a:hover,
 				a:active {
-					color: #135e96;
-				}
-
-				a.current {
-					color: #1e1e1e;
-
-					&::after {
-						background: none;
-						color: #ccc;
-						content: '|';
-						display: inline-block;
-						height: auto;
-						margin-left: 14px;
-						position: static;
-						width: auto;
-					}
+					color: #50575e;
+					padding: 10px 14px;
 				}
 			}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -758,7 +758,7 @@ class WC_Admin_Addons {
 		$product_list_classes = 'products addons-products-' . $product_list_classes;
 		?>
 			<section class="addon-product-group">
-				<h1 class="addon-product-group-title"><?php echo esc_html( $block->title ); ?></h1>
+				<h2 class="addon-product-group-title"><?php echo esc_html( $block->title ); ?></h2>
 				<div class="addon-product-group-description-container">
 					<?php if ( ! empty( $block->description ) ) : ?>
 					<div class="addon-product-group-description">

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -151,9 +151,8 @@ class WC_Admin_Menus {
 	public function addons_menu() {
 		$count_html = WC_Helper_Updater::get_updates_count_html();
 		/* translators: %s: extensions count */
-		$menu_title = sprintf( __( 'My Subscriptions %s', 'woocommerce' ), $count_html );
-		add_submenu_page( 'woocommerce', __( 'WooCommerce Marketplace', 'woocommerce' ), __( 'Marketplace', 'woocommerce' ), 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
-		add_submenu_page( 'woocommerce', __( 'My WooCommerce.com Subscriptions', 'woocommerce' ), $menu_title, 'manage_woocommerce', 'wc-addons&section=helper', array( $this, 'addons_page' ) );
+		$menu_title = sprintf( __( 'Extensions %s', 'woocommerce' ), $count_html );
+		add_submenu_page( 'woocommerce', __( 'WooCommerce extensions', 'woocommerce' ), $menu_title, 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
 	}
 
 	/**
@@ -391,38 +390,6 @@ class WC_Admin_Menus {
 		);
 	}
 
-	/**
-	 * Highlight the My Subscriptions menu item when on that page
-	 *
-	 * @param string $submenu_file The submenu file.
-	 * @param string $parent_file  currently opened page.
-	 *
-	 * @return string
-	 */
-	public function update_menu_highlight( $submenu_file, $parent_file ) {
-		if ( 'woocommerce' === $parent_file && isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
-			$submenu_file = 'wc-addons&section=helper';
-		}
-		return $submenu_file;
-	}
-
-	/**
-	 * Update the My Subscriptions document title when on that page.
-	 * We want to maintain existing page URL but add it as a separate page,
-	 * which requires updating it manually.
-	 *
-	 * @param  string $admin_title existing page title.
-	 * @return string
-	 */
-	public function update_my_subscriptions_title( $admin_title ) {
-		if (
-			isset( $_GET['page'] ) && 'wc-addons' === $_GET['page'] &&
-			isset( $_GET['section'] ) && 'helper' === $_GET['section']
-		) {
-			$admin_title = 'My WooCommerce.com Subscriptions';
-		}
-		return $admin_title;
-	}
 }
 
 return new WC_Admin_Menus();

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -36,7 +36,6 @@ class WC_Admin_Menus {
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
-		add_filter( 'submenu_file', array( $this, 'update_menu_highlight' ), 10, 2 );
 		add_filter( 'admin_title', array( $this, 'update_my_subscriptions_title' ) );
 
 		// Add endpoints custom URLs in Appearance > Menus > Pages.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -36,7 +36,6 @@ class WC_Admin_Menus {
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
-		add_filter( 'admin_title', array( $this, 'update_my_subscriptions_title' ) );
 
 		// Add endpoints custom URLs in Appearance > Menus > Pages.
 		add_action( 'admin_head-nav-menus.php', array( $this, 'add_nav_menu_meta_boxes' ) );

--- a/plugins/woocommerce/includes/admin/helper/views/html-main.php
+++ b/plugins/woocommerce/includes/admin/helper/views/html-main.php
@@ -9,7 +9,8 @@
 <?php defined( 'ABSPATH' ) || exit(); ?>
 
 <div class="wrap woocommerce wc-subscriptions-wrap wc-helper">
-	<h1 class="screen-reader-text"><?php esc_html_e( 'My Subscriptions', 'woocommerce' ); ?></h1>
+	<?php require WC_Helper::get_view_filename( 'html-section-nav.php' ); ?>
+	<h1 class="screen-reader-text"><?php esc_html_e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>
 
 	<?php require WC_Helper::get_view_filename( 'html-section-notices.php' ); ?>
 

--- a/plugins/woocommerce/includes/admin/helper/views/html-oauth-start.php
+++ b/plugins/woocommerce/includes/admin/helper/views/html-oauth-start.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit();
 ?>
 
 <div class="wrap woocommerce wc-addons-wrap wc-helper">
+	<?php require WC_Helper::get_view_filename( 'html-section-nav.php' ); ?>
 	<h1 class="screen-reader-text"><?php esc_html_e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>
 	<?php require WC_Helper::get_view_filename( 'html-section-notices.php' ); ?>
 

--- a/plugins/woocommerce/includes/admin/helper/views/html-section-nav.php
+++ b/plugins/woocommerce/includes/admin/helper/views/html-section-nav.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit(); ?>
 	<?php
 		$count_html = WC_Helper_Updater::get_updates_count_html();
 		/* translators: %s: WooCommerce.com Subscriptions tab count HTML. */
-		$menu_title = sprintf( __( 'WooCommerce.com Subscriptions %s', 'woocommerce' ), $count_html );
+		$menu_title = sprintf( __( 'My Subscriptions %s', 'woocommerce' ), $count_html );
 	?>
 	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab nav-tab-active"><?php echo wp_kses_post( $menu_title ); ?></a>
 </nav>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons-category-nav.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons-category-nav.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Admin View: Page - Addons - category navigation
+ *
+ * @package WooCommerce\Admin
+ * @var array $sections
+ * @var string $current_section
+ * @var string $current_section_name
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div id="marketplace-current-section-dropdown" class="current-section-dropdown">
+	<ul>
+		<?php foreach ( $sections as $section ) : ?>
+			<?php
+			if ( $current_section === $section->slug && '_featured' !== $section->slug ) {
+				$current_section_name = $section->label;
+			}
+			?>
+			<li>
+				<a
+					class="<?php echo $current_section === $section->slug ? 'current' : ''; ?>"
+					href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section->slug ) ) ); ?>">
+					<?php echo esc_html( $section->label ); ?>
+				</a>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+	<div id="marketplace-current-section-name" class="current-section-name"><?php echo esc_html( $current_section_name ); ?></div>
+</div>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons-category-nav.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons-category-nav.php
@@ -3,7 +3,7 @@
  * Admin View: Page - Addons - category navigation
  *
  * @package WooCommerce\Admin
- * @var array $sections
+ * @var array  $sections
  * @var string $current_section
  * @var string $current_section_name
  */
@@ -20,12 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$current_section_name = $section->label;
 			}
 			?>
-			<li>
-				<a
-					class="<?php echo $current_section === $section->slug ? 'current' : ''; ?>"
-					href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section->slug ) ) ); ?>">
-					<?php echo esc_html( $section->label ); ?>
-				</a>
+			<?php if ( $current_section === $section->slug ) : ?>
+				<li class="current">
+			<?php else: ?>
+				<li>
+			<?php endif; ?>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section->slug ) ) ); ?>">
+				<?php echo esc_html( $section->label ); ?>
+			</a>
 			</li>
 		<?php endforeach; ?>
 	</ul>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons-category-nav.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons-category-nav.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div id="marketplace-current-section-dropdown" class="current-section-dropdown">
+	<h2 class="current-section-dropdown__title"><?php esc_html_e( 'Browse categories', 'woocommerce' ); ?></h2>
 	<ul>
 		<?php foreach ( $sections as $section ) : ?>
 			<?php

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -41,6 +41,24 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 	</div>
 
 	<div class="top-bar">
+		<ul class="marketplace-header__tabs">
+			<li class="marketplace-header__tab">
+				<a
+					class="marketplace-header__tab-link is-current"
+					href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons' ) ); ?>"
+				>
+					<?php esc_html_e( 'Browse Extensions', 'woocommerce' ); ?>
+				</a>
+			</li>
+			<li class="marketplace-header__tab">
+				<a
+					class="marketplace-header__tab-link"
+					href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>"
+				>
+					<?php esc_html_e( 'My Subscriptions', 'woocommerce' ); ?>
+				</a>
+			</li>
+		</ul>
 	</div>
 
 	<div class="wp-header-end"></div>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -6,6 +6,8 @@
  * @var string $view
  * @var object $addons
  * @var object $promotions
+ * @var array $sections
+ * @var string $current_section
  */
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications as PromotionRuleEngine;
@@ -39,26 +41,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 	</div>
 
 	<div class="top-bar">
-		<div id="marketplace-current-section-dropdown" class="current-section-dropdown">
-			<ul>
-				<?php foreach ( $sections as $section ) : ?>
-					<?php
-					if ( $current_section === $section->slug && '_featured' !== $section->slug ) {
-						$current_section_name = $section->label;
-					}
-					?>
-					<li>
-						<a
-							class="<?php echo $current_section === $section->slug ? 'current' : ''; ?>"
-							href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section->slug ) ) ); ?>">
-							<?php echo esc_html( $section->label ); ?>
-						</a>
-					</li>
-				<?php endforeach; ?>
-			</ul>
-			<div id="marketplace-current-section-name" class="current-section-name"><?php echo esc_html( $current_section_name ); ?></div>
-		</div>
-		</div>
+	</div>
 
 	<div class="wp-header-end"></div>
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -55,7 +55,11 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 					class="marketplace-header__tab-link"
 					href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>"
 				>
-					<?php esc_html_e( 'My Subscriptions', 'woocommerce' ); ?>
+					<?php
+					$count_html = WC_Helper_Updater::get_updates_count_html();
+					/* translators: %s: WooCommerce.com Subscriptions tab count HTML. */
+					echo ( sprintf( __( 'My Subscriptions %s', 'woocommerce' ), $count_html ) );
+					?>
 				</a>
 			</li>
 		</ul>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -65,6 +65,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 
 	<div class="wrap">
 		<div class="marketplace-content-wrapper">
+			<?php require 'html-admin-page-addons-category-nav.php'; ?>
 			<?php if ( ! empty( $search ) && 0 === count( $addons ) ) : ?>
 				<h1 class="search-form-title">
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -69,7 +69,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 
 	<div class="wrap">
 		<div class="marketplace-content-wrapper">
-			<?php require 'html-admin-page-addons-category-nav.php'; ?>
+			<?php require __DIR__ . '/html-admin-page-addons-category-nav.php'; ?>
 			<?php if ( ! empty( $search ) && 0 === count( $addons ) ) : ?>
 				<h1 class="search-form-title">
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#### Closes WCCOM issues

https://github.com/Automattic/woocommerce.com/issues/11663
https://github.com/Automattic/woocommerce.com/issues/11665

#### Changes

Reverts https://github.com/woocommerce/woocommerce/pull/30380, which split out the content of the `WooCommerce.com Subscriptions` tab on the main Extensions page (i.e. `wp-admin/admin.php?page=wc-addons&section=helper`) to a new separate page `My Subscriptions`. This meant that fewer people were seeing the extensions listings.

In this PR, we're restoring the earlier arrangent, with `My Subscriptions` being reach via a tab on the `Extensions` page. We're also making the extensions category list more obvious on desktop – with categories hidden in a dropdown, people were less aware of the different types of extensions available.

#### Related WC Admin PRs which will be included in WC 6.0

https://github.com/woocommerce/woocommerce-admin/pull/7901 – sets the page title at the top of both pages back to "Extensions".
https://github.com/woocommerce/woocommerce-admin/pull/7902 – reverts to the previous menu arrangement in the new style nav.

### How to test the changes in this Pull Request:

1. Check out this branch on your local environment.
2. Go to WP Admin and observe the My Subscriptons and Marketplace items have been replaced with an Extensions menu item. If any of your WooCommerce extensions happen to need updating, the menu item should show an update count bubble – please see the screenshot for example. Otherwise you won't see the bubble.
3. View the Extensions page.  (The My Subscriptions tab will also show an update count bubble, if any extensions are due for an update. But if not, you won't see one.)
4. Make sure you can navigate to the My Subscriptions page and back again.
5. Try the links under `Browse Categories`. They should show different lists of extensions.
6. Try the page on a mobile device. 
  i. It should look like the screenshot at bottom.
  ii. The My Subscriptions link should take you to the subscriptions page.
  iii. The Browse Extensions tab on that page should return you to the WooCommerce Marketplace page.
  iv. The Browse Categories dropdown list should continue to work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Update - Merge Marketplace and My Subscriptions pages back into one Extensions page.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.

### Screenshots

#### Before

<img width="500" src="https://user-images.githubusercontent.com/1647564/141128534-5d7d0190-8f4f-4c15-b862-e8c911f47b02.png">

#### After

<img width="500" src="https://user-images.githubusercontent.com/1647564/141116962-cca0db70-3cc8-49bf-97a3-2e4bcdffeeee.png">

#### Mobile

<img width="350" src="https://user-images.githubusercontent.com/1647564/142998135-9373d354-451b-4647-ab68-312727e373ab.png">