### PR TITLE
fix #28752

### DIFF
--- a/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -153,10 +153,6 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 		if ( in_array( $this->requires, array( 'min_amount', 'either', 'both' ), true ) ) {
 			$total = WC()->cart->get_displayed_subtotal();
 
-			if ( WC()->cart->display_prices_including_tax() ) {
-				$total = $total - WC()->cart->get_discount_tax();
-			}
-
 			if ( 'no' === $this->ignore_discounts ) {
 				$total = $total - WC()->cart->get_discount_total();
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The coupons should not be taken into account at all if the free shipping has ignore_discounts but currently there is a line that deduces coupon taxes regardless even though the next line with the correct check uses the total which already includes the taxes. Effectively the lines that I removed should indeed not be there
Closes #28752 .

### How to test the changes in this Pull Request:

1.    Go to WooCommerce > Settings > Tax
1.    Set Prices entered with tax to Yes, I will enter prices inclusive of tax
1.    Set Display prices during cart and checkout to Including tax
1.    Add a tax rate, e.g. 20%
1.    Add Free shipping with a required minimum order amount, e.g. 50 pesos
1.    Check the _Apply minimum order rule before coupon discount_ option for Free shipping
1.    Add a physical product with a price inclusive of tax is above the minimum order amount, but the pre-tax amount is below the minimum order amount, e.g. 51 pesos
1.    Add 10 pesos coupon that doesn't include free shipping. 
2. Please note that to replicate this bug, the **tax** on the coupon amount when subtracted from product's price must get the price below the free shipping threshold. E.g. Product price 51, the limit for free shipping 50, then if the tax is set to 20%, the coupon value must be at least 6 pesos (so that 20% of 6p = 1.2p, 51 (product price) - 1.2 (coupon tax) < 50 (free shipping limit). Otherwise it will look like as if all is working fine. 
1.    Add the product to the cart
1.    Confirm free shipping is available
1.    Add the coupon
1.    Confirm free shipping is still available


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Removed coupon taxes from free shipping calculation

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
