### PR TITLE
Bump WooCommerce Admin version to 2.8.0

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.3.0",
-    "woocommerce/woocommerce-admin": "2.8.0-rc.2",
+    "woocommerce/woocommerce-admin": "2.8.0",
     "woocommerce/woocommerce-blocks": "6.1.0"
   },
   "require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb2d2b34aa7845cd6d39a187b7c53753",
+    "content-hash": "2850714f99d072cbc80188fd4b56630f",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -533,16 +533,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.8.0-rc.2",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "f3974919906d4d2168531025340b4f139ae65f1d"
+                "reference": "63b93a95db4bf788f42587a41f2378128a2adfdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f3974919906d4d2168531025340b4f139ae65f1d",
-                "reference": "f3974919906d4d2168531025340b4f139ae65f1d",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/63b93a95db4bf788f42587a41f2378128a2adfdf",
+                "reference": "63b93a95db4bf788f42587a41f2378128a2adfdf",
                 "shasum": ""
             },
             "require": {
@@ -598,9 +598,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.8.0-rc.2"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.8.0"
             },
-            "time": "2021-10-15T00:51:46+00:00"
+            "time": "2021-11-02T19:28:38+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2459,5 +2459,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is the same pull request as https://github.com/woocommerce/woocommerce/pull/31071, which targeted the `release/5.9` branch, but this time targeting `trunk`.  See the original pull request for the changelog.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
