### PR TITLE
has_archive if current theme supports woocommerce or is an FSE theme

### DIFF
--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -306,7 +306,7 @@ class WC_Post_Types {
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		$theme_support = wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
+		$theme_support = current_theme_supports( 'woocommerce' ) ? 'yes' : 'no';
 		if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
 			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -299,14 +299,14 @@ class WC_Post_Types {
 
 		$shop_page_id = wc_get_page_id( 'shop' );
 
-		if ( current_theme_supports( 'woocommerce' ) ) {
+		if ( wc_current_theme_supports_woocommerce_or_fse() ) {
 			$has_archive = $shop_page_id && get_post( $shop_page_id ) ? urldecode( get_page_uri( $shop_page_id ) ) : 'shop';
 		} else {
 			$has_archive = false;
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		$theme_support = current_theme_supports( 'woocommerce' ) ? 'yes' : 'no';
+		$theme_support = wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
 		if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
 			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -306,7 +306,7 @@ class WC_Post_Types {
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		$theme_support = current_theme_supports( 'woocommerce' ) ? 'yes' : 'no';
+		$theme_support =  wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
 		if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
 			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -44,6 +44,11 @@ class WC_Template_Loader {
 		if ( self::$theme_support ) {
 			add_filter( 'template_include', array( __CLASS__, 'template_loader' ) );
 			add_filter( 'comments_template', array( __CLASS__, 'comments_template_loader' ) );
+
+			// Loads gallery scripts on Product page for FSE themes.
+			if ( wc_current_theme_is_fse_theme() ) {
+				self::add_support_for_product_page_gallery();
+			}
 		} else {
 			// Unsupported themes.
 			add_action( 'template_redirect', array( __CLASS__, 'unsupported_theme_init' ) );
@@ -292,6 +297,15 @@ class WC_Template_Loader {
 		add_filter( 'woocommerce_product_tabs', array( __CLASS__, 'unsupported_theme_remove_review_tab' ) );
 		remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
 		remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
+		self::add_support_for_product_page_gallery();
+	}
+
+	/**
+	 * Add theme support for Product page gallery.
+	 *
+	 * @since x.x.x
+	 */
+	private static function add_support_for_product_page_gallery() {
 		add_theme_support( 'wc-product-gallery-zoom' );
 		add_theme_support( 'wc-product-gallery-lightbox' );
 		add_theme_support( 'wc-product-gallery-slider' );

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -37,7 +37,7 @@ class WC_Template_Loader {
 	 * Hook in methods.
 	 */
 	public static function init() {
-		self::$theme_support = current_theme_supports( 'woocommerce' );
+		self::$theme_support = wc_current_theme_supports_woocommerce_or_fse();
 		self::$shop_page_id  = wc_get_page_id( 'shop' );
 
 		// Supported themes.

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -496,15 +496,26 @@ function wc_is_file_valid_csv( $file, $check_path = true ) {
 }
 
 /**
+ * Check if the current theme is an FSE theme.
+ *
+ * @since x.x.x
+ * @return bool
+ */
+function wc_current_theme_is_fse_theme() {
+	if ( function_exists( 'gutenberg_is_fse_theme' ) ) {
+		return (bool) gutenberg_is_fse_theme();
+	}
+
+	return false;
+}
+
+/**
  * Check if the current theme has WooCommerce support or is a FSE theme.
  *
  * @since x.x.x
  * @return bool
  */
 function wc_current_theme_supports_woocommerce_or_fse() {
-	if ( function_exists( 'gutenberg_is_fse_theme' ) ) {
-		return (bool) current_theme_supports( 'woocommerce' ) || gutenberg_is_fse_theme();
-	}
-
-	return (bool) current_theme_supports( 'woocommerce' );
+	return (bool) current_theme_supports( 'woocommerce' ) || wc_current_theme_is_fse_theme();
 }
+

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -494,3 +494,17 @@ function wc_is_file_valid_csv( $file, $check_path = true ) {
 
 	return false;
 }
+
+/**
+ * Check if the current theme has WooCommerce support or is a FSE theme.
+ *
+ * @since x.x.x
+ * @return bool
+ */
+function wc_current_theme_supports_woocommerce_or_fse() {
+	if ( function_exists( 'gutenberg_is_fse_theme' ) ) {
+		return (bool) current_theme_supports( 'woocommerce' ) || gutenberg_is_fse_theme();
+	}
+
+	return (bool) current_theme_supports( 'woocommerce' );
+}


### PR DESCRIPTION
### Description

This change means FSE themes won't have to declare explicit support for WooCommerce (`add_theme_support( 'woocommerce' )`) and are able to serve the Product Archive block template directly from Woocommerce Blocks.

For more context on the project Full Store Editing: Templates project see [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4926).

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5071

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

### How to test the changes in this Pull Request:

1. Make sure you're running the latest `trunk` from [Woo Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block/), and **do not checkout this PR yet**. You will apply this change in Step 6.
2. Make make sure you have[ this change](https://github.com/woocommerce/woocommerce/pull/30997/files) applied in your WooCommerce plugin.
3. Install and activate the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/) (not the latest built version of `trunk` from the repo)
4. Install and activate a FSE enabled theme such as [Tove](https://en-gb.wordpress.org/themes/tove/)
5. Go to your shop/products archive page on the frontend. Confirm you see no products.
6. Checkout this PR, **deactivate and reactive your theme** then refresh your shop/products archive page on the frontend. Confirm you see products now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Perform check for has product archive if current theme is an FSE theme, and not just if it has `current_theme_supports( 'woocommerce' );`

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
