### PR TITLE
Recommend automated taxes to  'GB'

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php
@@ -111,7 +111,7 @@ class WC_Admin_Setup_Wizard {
 		$country_code = WC()->countries->get_base_country();
 		// https://developers.taxjar.com/api/reference/#countries .
 		$tax_supported_countries = array_merge(
-			array( 'US', 'CA', 'AU' ),
+			array( 'US', 'CA', 'AU', 'GB' ),
 			WC()->countries->get_european_union_countries()
 		);
 


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

GB no longer in EU so it stopped getting automated taxes in the on boarding wizard. This will fix that.

Closes 20-gh-Automattic/woocommerce-shipping-issues
Closes # .

### How to test the changes in this Pull Request:

1. Set country to GB
2. Load onboarding wizard
3. See automated taxes recommended

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull 
Add 'GB' back to countries that are recommended to use automated taxes.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.