### PR TITLE
remove duplicate gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,16 @@ Thumbs.db
 # IDE files
 .idea
 .vscode/
+project.xml
+project.properties
+.project
+.settings*
+*.sublime-project
+*.sublime-workspace
+.sublimelinterrc
 
 # Environment files
 wp-cli.local.yml
-.wp-env.override.json
 yarn-error.log
 npm-debug.log
 .pnpm-debug.log
@@ -22,6 +28,7 @@ npm-debug.log
 build/
 build-module/
 build-style/
+dist/
 
 # Project files
 node_modules/
@@ -37,5 +44,3 @@ tsconfig.tsbuildinfo
 /tmp
 packages/js/e2e-environment/config/default.json
 packages/js/e2e-environment/docker/wp-cli/initialize.sh
-packages/js/e2e-environment/build/
-packages/js/e2e-environment/build-module/

--- a/packages/js/api-core-tests/.gitignore
+++ b/packages/js/api-core-tests/.gitignore
@@ -1,8 +1,2 @@
-# Node modules
-node_modules/
-
-# Environment
-.env
-
 # Collection output
 collection.json

--- a/packages/js/api/.gitignore
+++ b/packages/js/api/.gitignore
@@ -1,18 +1,2 @@
-
 # Editors
-project.xml
-project.properties
 /nbproject/private/
-.buildpath
-.project
-.settings*
-.idea
-.vscode
-*.sublime-project
-*.sublime-workspace
-.sublimelinterrc
-
-# Build Artifacts
-/node_modules/
-/dist/
-tsconfig.tsbuildinfo

--- a/plugins/woocommerce/.gitignore
+++ b/plugins/woocommerce/.gitignore
@@ -1,20 +1,7 @@
 # Editors
-project.xml
-project.properties
 /nbproject/private/
-.buildpath
-.project
-.settings*
-.idea
-.vscode
-.eslintcache
-*.sublime-project
-*.sublime-workspace
-.sublimelinterrc
-*.swp
 
 # Grunt
-node_modules/
 none
 
 # Sass
@@ -26,12 +13,6 @@ none
 
 # Minified JS
 /assets/js/**/*.min.js
-
-# OS X metadata
-.DS_Store
-
-# Windows junk
-Thumbs.db
 
 # Behat/CLI Tests
 tests/cli/installer
@@ -46,15 +27,9 @@ tests/cli/vendor
 /tests/e2e/config/local-*.json
 /tests/e2e/config/local.json
 /tests/e2e/config/default.json
-/tests/e2e/env/config/default.json
 /tests/e2e/docker
-/tests/e2e/env/docker/wp-cli/initialize.sh
-/tests/e2e/env/build/
-/tests/e2e/env/build-module/
 /tests/e2e/screenshots
 /tests/e2e/plugins
-/tests/e2e/utils/build/
-/tests/e2e/utils/build-module/
 
 # Logs
 /logs
@@ -73,12 +48,5 @@ yarn.lock
 /packages/*
 !/packages/README.md
 
-# Screenshots for e2e tests failures
-/screenshots/
-
 # Language files
 i18n/languages/woocommerce.pot
-
-# Build
-build/
-woocommerce.zip


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the duplicate `.gitignore` entries across
- `./.gitignore`
- `./plugins/woocommerce/.gitignore`
- `./packages/js/api/.gitignore`
- `./packages/js/api-core-tests/.gitignore`

Closes #30655 .

### How to test the changes in this Pull Request:

1. Run `pnpm install` in the `woocommerce/plugins` folder
2. Run `composer install`
3. Run `npm run build:zip`
4. Run `pnpx wc-e2e docker:up`
5. Run `pnpx wc-e2e test:e2e`
6. Run `BASE_URL=http://localhost:8084 USER_KEY=admin USER_SECRET=password pnpx wc-api-tests test api`
7. Run `git status` to check that no files matching the removed entries are listed

