### PR TITLE
use consistent defaultViewport

### DIFF
--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Added quotes around `WORDPRESS_TITLE` value in .env file to address issue with docker compose 2 "key cannot contain a space" error.
 - Added `LATEST_WP_VERSION_MINUS` that allows setting a number to subtract from the current WordPress version for the WordPress Docker image.
 
+## Fixed
+
+- Use consistent `defaultViewport` in both headless and non-headless context
+
 # 0.2.3
 
 ## Added

--- a/packages/js/e2e-environment/config/jest-puppeteer.config.js
+++ b/packages/js/e2e-environment/config/jest-puppeteer.config.js
@@ -8,6 +8,10 @@ if ( 'no' == global.process.env.node_config_dev ) {
 		launch: {
 			// Required for the logged out and logged in tests so they don't share app state/token.
 			browserContext: 'incognito',
+			defaultViewport: {
+				width: 1280,
+				height: 800,
+			},
 		},
 	};
 } else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the jest Puppeteer config to use a consistent default viewport in both headless and non-headless mode.

Closes #30137 .

### How to test the changes in this Pull Request:

1. Run the following
```
cd plugins/woocommerce
pnpm install
pnpx wc-e2e docker:up
pnpx wc-e2e test:e2e
```
2. Tests should pass
