### PR TITLE
Added support for custom checkbox fields used with 'address-i18n.js'

### DIFF
--- a/plugins/woocommerce/assets/js/frontend/address-i18n.js
+++ b/plugins/woocommerce/assets/js/frontend/address-i18n.js
@@ -96,7 +96,15 @@ jQuery( function( $ ) {
 				// Hidden fields.
 				if ( 'state' !== key ) {
 					if ( typeof fieldLocale.hidden !== 'undefined' && true === fieldLocale.hidden ) {
-						field.hide().find( ':input' ).val( '' );
+
+                        // Support for checkboxes
+                        if( field.find( ':input' ).attr( 'type' ) == 'checkbox' ) {
+                            field.hide().find( ':input' ).prop( 'checked', false );
+                        }
+                        else {
+                            field.hide().find( ':input' ).val( '' );
+                        }
+                        
 					} else {
 						field.show();
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31107


### How to test the changes in this Pull Request:
See steps on #31107 for how to reproduce this bug

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added support for custom checkbox fields used with 'address-i18n.js'

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
