### PR TITLE
add generic container environment variable support for PHP, DB

### DIFF
--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added quotes around `WORDPRESS_TITLE` value in .env file to address issue with docker compose 2 "key cannot contain a space" error.
 - Added `LATEST_WP_VERSION_MINUS` that allows setting a number to subtract from the current WordPress version for the WordPress Docker image.
+- Support for PHP_VERSION, MARIADB_VERSION environment variables for built in container initialization
 
 ## Fixed
 

--- a/packages/js/e2e-environment/bin/docker-compose.sh
+++ b/packages/js/e2e-environment/bin/docker-compose.sh
@@ -17,22 +17,30 @@ if [[ $1 ]]; then
 		export WORDPRESS_VERSION=$(./bin/get-previous-version.js $WORDPRESS_VERSION $LATEST_WP_VERSION_MINUS 2> /dev/null)
 	fi
 
-	if ! [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
-		TRAVIS_PHP_VERSION=$(./bin/get-latest-docker-tag.js php 7 2> /dev/null)
-	fi
-	if [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
-		export DC_PHP_VERSION=$TRAVIS_PHP_VERSION
+	if [[ $PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+		export DC_PHP_VERSION=$PHP_VERSION
 	else
-		export DC_PHP_VERSION="7.4.22"
+		if ! [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+			TRAVIS_PHP_VERSION=$(./bin/get-latest-docker-tag.js php 7 2> /dev/null)
+		fi
+		if [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+			export DC_PHP_VERSION=$TRAVIS_PHP_VERSION
+		else
+			export DC_PHP_VERSION="7.4.25"
+		fi
 	fi
 
-	if ! [[ $TRAVIS_MARIADB_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
-		TRAVIS_MARIADB_VERSION=$(./bin/get-latest-docker-tag.js mariadb 10 2> /dev/null)
-	fi
-	if [[ $TRAVIS_MARIADB_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
-		export DC_MARIADB_VERSION=$TRAVIS_MARIADB_VERSION
+	if [[ $MARIADB_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+		export DC_MARIADB_VERSION=$MARIADB_VERSION
 	else
-		export DC_MARIADB_VERSION="10.6.4"
+		if ! [[ $TRAVIS_MARIADB_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+			TRAVIS_MARIADB_VERSION=$(./bin/get-latest-docker-tag.js mariadb 10 2> /dev/null)
+		fi
+		if [[ $TRAVIS_MARIADB_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
+			export DC_MARIADB_VERSION=$TRAVIS_MARIADB_VERSION
+		else
+			export DC_MARIADB_VERSION="10.6.5"
+		fi
 	fi
 
 	if [[ $1 == 'up' ]]; then

--- a/packages/js/e2e-environment/builtin.md
+++ b/packages/js/e2e-environment/builtin.md
@@ -126,9 +126,17 @@ The built in container defaults to mapping the root folder of the repository to 
 
 Since the introduction of the WooCommerce Monorepo, a `WC_CORE_PATH` environment variable maps to Core WooCommerce at `plugins/woocommerce`. It can also be overriden in a similar fashion.
 
+### Specifying Server Software versions
+
+The built-in container supports these variables for use locally and in CI environments:
+
+- `WP_VERSION` - WordPress (default `latest`)
+- `PHP_VERSION` - PHP (default `latest`)
+- `MARIADB_VERSION` - MariaDB (default `latest`)
+
 ### Travis CI Supported Versions
 
-Travis CI uses environment variables to allow control of some software versions in the testing environment. The built in container supports these variables:
+Travis CI uses environment variables to allow control of some software versions in the testing environment. The built-in container supports these variables:
 
 - `WP_VERSION` - WordPress (default `latest`)
 - `TRAVIS_PHP_VERSION` - PHP (default `latest`)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds `PHP_VERSION` and `MARIADB_VERSION` environment variables to the built-in container in the e2e-environment package.

Closes #29381 .

### How to test the changes in this Pull Request:

1. Run the following
```
cd plugins/woocommerce
pnpm install
WP_VERSION=5.7.2 PHP_VERSION=7.4.15 MARIADB_VERSION=10.6.2 pnpx wc-e2e docker:up
```
2. The following should be logged
```
WordPress 5.7.2
PHP 7.4.15
MariaDB 10.6.2
```
