### PR TITLE
Add some common composer executor commands for woocommerce so it can …

### DIFF
--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -13,6 +13,8 @@
     "wp_org_slug": "woocommerce"
   },
   "scripts": {
+    "composer:install": "composer install",
+    "composer:dump-autoload": "composer dump-autoload",
     "check:subset-installed": "pnpm list --depth 1 install-subset > /dev/null 2>&1",
     "preinstall": "npx only-allow pnpm",
     "install:subset-only": "pnpm install --no-package-lock --no-save install-subset",

--- a/plugins/woocommerce/project.json
+++ b/plugins/woocommerce/project.json
@@ -3,6 +3,18 @@
   "sourceRoot": "plugins/woocommerce",
   "projectType": "application",
   "targets": {
+    "composer-install": {
+      "executor": "@nrwl/workspace:run-script",
+      "options": {
+        "script": "composer:install"
+      }
+	},
+    "composer-dump-autoload": {
+      "executor": "@nrwl/workspace:run-script",
+      "options": {
+        "script": "composer:dump-autoload"
+      }
+	},
     "build": {
       "executor": "@nrwl/workspace:run-script",
       "options": {


### PR DESCRIPTION
…be used in Nx context

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently to get `plugins/woocommerce` ready to work we would have to navigate to that directory to run `composer install`. This PR adds executors so that some common composer commands are available to Nx which can now be used at root level. This is done for completeness so that everything can be done at root level with Nx.

### How to test the changes in this Pull Request:

1. After running `pnpm install`, run `pnpm nx composer-install woocommerce`.
2. Check to make sure packages have been installed in `plugins/woocommerce/vendor`.
3. Also try running `pnpm nx composer-dump-autoload woocommerce`. Ensure that runs correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
