### PR TITLE
Show fallback message in extensions marketplace when the store can't connect to the WCCOM API

### DIFF
--- a/plugins/woocommerce/assets/css/admin.scss
+++ b/plugins/woocommerce/assets/css/admin.scss
@@ -7733,6 +7733,22 @@ table.bar_chart {
 	font-weight: bold;
 }
 
+.wc-addons__empty {
+	margin: 48px auto;
+	max-width: 640px;
+
+	h2 {
+		font-size: 20px;
+		font-weight: 400;
+		line-height: 1.2;
+	}
+
+	p {
+		font-size: 16px;
+		line-height: 1.5;
+	}
+}
+
 @media screen and (min-width: 600px) {
 
 	.wc-addons-wrap {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -967,14 +967,14 @@ class WC_Admin_Addons {
 	public static function output_empty( $message = '' ) {
 		?>
 		<div class="wc-addons__empty">
-			<h2><?php echo wp_kses_post( __( 'Sorry, we\'re having trouble connecting to the extensions catalog.', 'woocommerce' ) ); ?></h2>
+			<h2><?php echo wp_kses_post( __( 'Oh no! We\'re having trouble connecting to the extensions catalog right now.', 'woocommerce' ) ); ?></h2>
 			<p>
 				<?php
 				/* translators: a url */
 				printf(
 					wp_kses_post(
 						__(
-							'Head over to <a href="%s">WooCommerce.com</a> to start growing your business with the most popular WooCommerce extensions.',
+							'To start growing your business, head over to <a href="%s">WooCommerce.com</a>, where you\'ll find the most popular WooCommerce extensions.',
 							'woocommerce'
 						)
 					),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -94,8 +94,14 @@ class WC_Admin_Addons {
 			}
 
 			$response_code = intval( wp_remote_retrieve_response_code( $raw_featured ) );
+			if ( 200 !== $response_code ) {
+				self::output_empty();
+
+				return;
+			}
+
 			$featured      = json_decode( wp_remote_retrieve_body( $raw_featured ) );
-			if ( empty( $featured ) || ! is_array( $featured ) || 200 !== $response_code ) {
+			if ( empty( $featured ) || ! is_array( $featured ) ) {
 				self::output_empty();
 
 				return;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -88,6 +88,7 @@ class WC_Admin_Addons {
 			);
 
 			if ( is_wp_error( $raw_featured ) ) {
+				do_action( 'woocommerce_page_wc-addons_connection_error', $raw_featured->get_error_message() );
 				self::output_empty();
 
 				return;
@@ -95,6 +96,7 @@ class WC_Admin_Addons {
 
 			$response_code = intval( wp_remote_retrieve_response_code( $raw_featured ) );
 			if ( 200 !== $response_code ) {
+				do_action( 'woocommerce_page_wc-addons_connection_error', $response_code );
 				self::output_empty();
 
 				return;
@@ -102,6 +104,7 @@ class WC_Admin_Addons {
 
 			$featured      = json_decode( wp_remote_retrieve_body( $raw_featured ) );
 			if ( empty( $featured ) || ! is_array( $featured ) ) {
+				do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
 				self::output_empty();
 
 				return;
@@ -160,17 +163,20 @@ class WC_Admin_Addons {
 		);
 
 		if ( is_wp_error( $raw_extensions ) ) {
+			do_action( 'woocommerce_page_wc-addons_connection_error', $raw_extensions->get_error_message() );
 			return $raw_extensions;
 		}
 
 		$response_code = intval( wp_remote_retrieve_response_code( $raw_extensions ) );
 		if ( 200 !== $response_code ) {
+			do_action( 'woocommerce_page_wc-addons_connection_error', $response_code );
 			return new WP_Error( 'error', __( 'API error', 'woocommerce' ) );
 		}
 
 		$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) );
 
 		if ( ! is_object( $addons ) || ! isset( $addons->products ) ) {
+			do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
 			return new WP_Error( 'error', __( 'API error', 'woocommerce' ) );
 		}
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -70,7 +70,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 	<div class="wrap">
 		<div class="marketplace-content-wrapper">
 			<?php require __DIR__ . '/html-admin-page-addons-category-nav.php'; ?>
-			<?php if ( ! empty( $search ) && 0 === count( $addons ) ) : ?>
+			<?php if ( ! empty( $search ) && ! is_wp_error( $addons ) && 0 === count( $addons ) ) : ?>
 				<h1 class="search-form-title">
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>
 				</h1>
@@ -89,7 +89,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 			<?php endif; ?>
 			<?php if ( '_featured' !== $current_section ) : ?>
 				<?php if ( is_wp_error( $addons ) ) : ?>
-					<?php WC_Admin_Addons::output_empty(); ?>
+					<?php WC_Admin_Addons::output_empty( $addons->get_error_message() ); ?>
 				<?php else: ?>
 					<?php
 					if ( ! empty( $promotions ) && WC()->is_wc_admin_active() ) {

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-addons.php
@@ -75,7 +75,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>
 				</h1>
 			<?php endif; ?>
-			<?php if ( ! empty( $search ) && count( $addons ) > 0 ) : ?>
+			<?php if ( ! empty( $search ) && ! is_wp_error( $addons ) && count( $addons ) > 0 ) : ?>
 				<h1 class="search-form-title">
 					<?php // translators: search keyword. ?>
 					<?php printf( esc_html__( 'Search results for "%s"', 'woocommerce' ), esc_html( sanitize_text_field( wp_unslash( $search ) ) ) ); ?>
@@ -87,42 +87,46 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 					<?php WC_Admin_Addons::render_featured(); ?>
 				</div>
 			<?php endif; ?>
-			<?php if ( '_featured' !== $current_section && $addons ) : ?>
-				<?php
-				if ( ! empty( $promotions ) && WC()->is_wc_admin_active() ) {
-					foreach ( $promotions as $promotion ) {
-						WC_Admin_Addons::output_search_promotion_block( $promotion );
-					}
-				}
-				?>
-				<ul class="products">
-					<?php foreach ( $addons as $addon ) : ?>
-						<?php
-						if ( 'shipping_methods' === $current_section ) {
-							// Do not show USPS or Canada Post extensions for US and CA stores, respectively.
-							$country = WC()->countries->get_base_country();
-							if ( 'US' === $country
-								&& false !== strpos(
-									$addon->link,
-									'woocommerce.com/products/usps-shipping-method'
-								)
-							) {
-								continue;
-							}
-							if ( 'CA' === $country
-								&& false !== strpos(
-									$addon->link,
-									'woocommerce.com/products/canada-post-shipping-method'
-								)
-							) {
-								continue;
-							}
+			<?php if ( '_featured' !== $current_section ) : ?>
+				<?php if ( is_wp_error( $addons ) ) : ?>
+					<?php WC_Admin_Addons::output_empty(); ?>
+				<?php else: ?>
+					<?php
+					if ( ! empty( $promotions ) && WC()->is_wc_admin_active() ) {
+						foreach ( $promotions as $promotion ) {
+							WC_Admin_Addons::output_search_promotion_block( $promotion );
 						}
+					}
+					?>
+					<ul class="products">
+						<?php foreach ( $addons as $addon ) : ?>
+							<?php
+							if ( 'shipping_methods' === $current_section ) {
+								// Do not show USPS or Canada Post extensions for US and CA stores, respectively.
+								$country = WC()->countries->get_base_country();
+								if ( 'US' === $country
+									 && false !== strpos(
+										$addon->link,
+										'woocommerce.com/products/usps-shipping-method'
+									)
+								) {
+									continue;
+								}
+								if ( 'CA' === $country
+									 && false !== strpos(
+										$addon->link,
+										'woocommerce.com/products/canada-post-shipping-method'
+									)
+								) {
+									continue;
+								}
+							}
 
-						WC_Admin_Addons::render_product_card( $addon );
-						?>
-					<?php endforeach; ?>
-				</ul>
+							WC_Admin_Addons::render_product_card( $addon );
+							?>
+						<?php endforeach; ?>
+					</ul>
+				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 		<?php else : ?>

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -68,6 +68,7 @@ class WC_Tracks {
 
 	/**
 	 * Record an event in Tracks - this is the preferred way to record events from PHP.
+	 * Note: the event request won't be made if $properties has a member called `error`.
 	 *
 	 * @param string $event_name The name of the event.
 	 * @param array  $properties Custom properties to send with the event.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-extensions-tracking.php
@@ -22,6 +22,7 @@ class WC_Extensions_Tracking {
 		add_action( 'woocommerce_helper_disconnected', array( $this, 'track_helper_disconnected' ) );
 		add_action( 'woocommerce_helper_subscriptions_refresh', array( $this, 'track_helper_subscriptions_refresh' ) );
 		add_action( 'woocommerce_addon_installed', array( $this, 'track_addon_install' ), 10, 2 );
+		add_action( 'woocommerce_page_wc-addons_connection_error', array( $this, 'track_extensions_page_connection_error' ), 10, 1 );
 	}
 
 	/**
@@ -45,6 +46,29 @@ class WC_Extensions_Tracking {
 		// phpcs:enable
 
 		WC_Tracks::record_event( $event, $properties );
+	}
+
+	/**
+	 * Send a Tracks event when the Extensions page gets a bad response or no response
+	 * from the WCCOM extensions API.
+	 *
+	 * @param string $error
+	 */
+	public function track_extensions_page_connection_error( string $error = '' ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$properties = array(
+			'section' => empty( $_REQUEST['section'] ) ? '_featured' : wc_clean( wp_unslash( $_REQUEST['section'] ) ),
+		);
+
+		if ( ! empty( $_REQUEST['search'] ) ) {
+			$properties['search_term'] = wc_clean( wp_unslash( $_REQUEST['search'] ) );
+		}
+		// phpcs:enable
+
+		if ( ! empty( $error ) ) {
+			$properties['error_data'] = $error;
+		}
+		WC_Tracks::record_event( 'extensions_view_connection_error', $properties );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- When a store is unable to connect to the WooCommerce.com API to show extensions in the in-app marketplace, we'd like to show the user a message with a link to WCCOM. 
- This branch modifies `WC_Admin_Addons::render_featured` to check the response from the API's "featured" endpoint more carefully, and call a new `output_empty` method if it doesn't seem correct.
- Likewise, it changes `WC_Admin_Addons::get_extension_data` to return a `WP_Error` if the API's search endpoint doesn't return a good response. If the addons page template finds this error, it also calls `output_empty`.
- `output_empty` renders a simple error message.
- When a connection error happens, it does a `woocommerce_page_wc-addons_connection_error` action. This records a `wcadmin_extensions_view_connection_error` Tracks event.
- When a connection error happens on the featured page, the error message contains an extra line giving more detail about the error.

Closes https://github.com/Automattic/woocommerce.com/issues/11757.

### How to test the changes in this Pull Request:

1. Check out this branch on your local environment.
2. Go to to Extensions page `/wp-admin/admin.php?page=wc-addons`.
3. First, test the good case.
    1. Check that you see a list of extensions on this "featured" page.
    2. Search for a term like "shipping" and see the results.
    3. Search for a term that won't get any results.
    4. Browse to one of the categories and see there are extensions listed.
4. Now break the API request by downloading this [patch](https://github.com/woocommerce/woocommerce/files/7514631/breaking-marketplace-api.txt) and appying it with `git apply ~/Downloads/breaking-marketplace-api.txt`.
5. Repeat the steps from 3. You should see the message in each case. 
    1. On the featured page, the error message will have an extra line with the status code 404.
6. If you have access to the Tracks Live Viewer, note that after a few minutes, a [wcadmin_extensions_view_connection_error](https://mc.a8c.com/tracks/events/event.php?eventname=wcadmin_extensions_view_connection_error) event has been recorded.
7. Revert the changes from the patch.
8. Add this on line 163 of `wp-includes/Requests/Transport/cURL.php` on your test site. This forces the site to connect using an out of date TLS version.

```php
curl_setopt( $this->handle, CURLOPT_SSLVERSION, CURL_SSLVERSION_MAX_TLSv1_1 );
```

9. View the "featured" page `/wp-admin/admin.php?page=wc-addons`.  On this page only, the error message will have an extra line about the SSL error. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Update - Show fallback message when extensions marketplace cannot connect to WCCOM API.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.

### Screenshots

#### Featured page - 404 error message

<img width="500" src="https://user-images.githubusercontent.com/1647564/141810780-b1cc5f6d-ca17-4554-924a-8f6dbacf128c.png">

#### Featured page – SSL error message

<img width="500" src="https://user-images.githubusercontent.com/1647564/141810753-1d6785a2-b635-48ad-83a4-8b8a51ef6d7a.png">

#### Category page

<img width="500" src="https://user-images.githubusercontent.com/1647564/141160799-d788bc36-46f5-43ec-a746-faba98c2874a.png">
