### PR TITLE
Fix minor issue in README table

### DIFF
--- a/packages/js/e2e-utils/README.md
+++ b/packages/js/e2e-utils/README.md
@@ -152,7 +152,7 @@ Please note: if you're using a non-SSL environment (such as a Docker container f
 | `deleteAllProductCategories` | | Permanently delete all product categories |
 | `deleteAllProducts` | | Permanently delete all products |
 | `deleteAllProductTags` | | Permanently delete all product tags |
-| `deleteAllShippingClasses` | Permanently delete all shipping classes |
+| `deleteAllShippingClasses` | | Permanently delete all shipping classes |
 | `deleteAllShippingZones` | | Permanently delete all shipping zones except the default |
 | `deleteCoupon` | `couponId` | Permanently delete a coupon |
 | `deleteCustomerByEmail` | `emailAddress` | Delete customer user account. Posts are reassigned to user ID 1 |


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a minor issue in the README for the e2e utils package that showed the `deleteAllShippingClasses()` description in the Parameters column instead:

<img width="1044" alt="Screen Shot 2021-11-10 at 10 53 47" src="https://user-images.githubusercontent.com/71906536/141166800-4d56e003-7631-456e-8878-7b0a062ff0c1.png">

### How to test the changes in this Pull Request:

1. Review changes