### PR TITLE
Remove project.json from distribution

### DIFF
--- a/plugins/woocommerce/.distignore
+++ b/plugins/woocommerce/.distignore
@@ -16,6 +16,7 @@ docker-compose.yaml
 Dockerfile
 Gruntfile.js
 none
+project.json
 package-lock.json
 package.json
 packages/woocommerce-admin/docs


### PR DESCRIPTION
Just removing `project.json` from being included in production build.