### PR TITLE
`int` casting added in `get_percent_complete` method

### DIFF
--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -184,6 +184,6 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @return int
 	 */
 	public function get_percent_complete() {
-		return $this->total_rows ? floor( ( $this->get_total_exported() / $this->total_rows ) * 100 ) : 100;
+		return $this->total_rows ? (int) floor( ( $this->get_total_exported() / $this->total_rows ) * 100 ) : 100;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`int` casting added in `get_percent_complete` method in `WC_CSV_Batch_Exporter `

Closes #31137 .

### How to test the changes in this Pull Request:

To test, You have to create one class by extending `WC_CSV_Batch_Exporter`. For example i added `OrderExporter` class
````
<?php

namespace Your/Namespace;

/**
 * Include dependencies.
 */
if ( ! class_exists( 'WC_CSV_Batch_Exporter', false ) ) {
    include_once WC_ABSPATH . 'includes/export/abstract-wc-csv-batch-exporter.php';
}

class OrderExporter extends \WC_CSV_Batch_Exporter {
    protected $filename = 'order-export.csv';

    public function get_column_names() {
        return $this->column_names;
    }

    public function set_items( $items = [] ) {
        $this->items = $items;
    }

    public function set_total_rows( $total_rows ) {
        $this->total_rows = absint( $total_rows );
    }

    public function prepare_data_to_export() {
        // TODO: Implement prepare_data_to_export() method.
    }
}
````

Now execute following code
````
include_once DIR_To . '/OrderExporter.php';
$exporter = new OrderExporter();
$exporter->set_page( 1 );
$exporter->set_total_rows(2);
var_dump($exporter->get_percent_complete());
die();
````
Now it's giving `int` value as expected but previously it was giving `float` value
<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Ensure the `WC_CSV_Batch_Exporter::get_percent_complete()` method returns an int.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
