### PR TITLE
Add inline file delivery to WC_Download_Handler

### DIFF
--- a/plugins/woocommerce/changelog/allow-inline-downloads
+++ b/plugins/woocommerce/changelog/allow-inline-downloads
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add option to serve downloadable files inline.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -422,13 +422,13 @@ class WC_Settings_Products extends WC_Settings_Page {
 				),
 
 				array(
-					'title'         => __( 'Content-Disposition', 'woocommerce' ),
-					'desc'          => __( 'Deliver downloadable files inline', 'woocommerce' ),
-					'id'            => 'woocommerce_downloads_deliver_inline',
-					'type'          => 'checkbox',
-					'default'       => false,
-					'desc_tip'      => __( 'Enable this option to have downloadable files open in browser, instead of being downloaded to customer\'s device.', 'woocommerce' ),
-					'autoload'      => false,
+					'title'    => __( 'Open in browser', 'woocommerce' ),
+					'desc'     => __( 'Open downloadable files in the browser, instead of saving them to the device.', 'woocommerce' ),
+					'id'       => 'woocommerce_downloads_deliver_inline',
+					'type'     => 'checkbox',
+					'default'  => false,
+					'desc_tip' => __( 'Enable this option to have downloadable files open in browser, instead of being downloaded to customer\'s device.', 'woocommerce' ),
+					'autoload' => false,
 				),
 
 				array(

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -427,7 +427,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'id'            => 'woocommerce_downloads_deliver_inline',
 					'type'          => 'checkbox',
 					'default'       => false,
-					'desc_tip'      => __( 'Enable this option to have downloadable files open in browser', 'woocommerce' ),
+					'desc_tip'      => __( 'Enable this option to have downloadable files open in browser, instead of being downloaded to customer\'s device.', 'woocommerce' ),
 					'autoload'      => false,
 				),
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -427,7 +427,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'id'       => 'woocommerce_downloads_deliver_inline',
 					'type'     => 'checkbox',
 					'default'  => false,
-					'desc_tip' => __( 'Customers can still save the file to their device, but by default file will be opened instead of being downloaded. (Does not work with redirects).', 'woocommerce' ),
+					'desc_tip' => __( 'Customers can still save the file to their device, but by default file will be opened instead of being downloaded (does not work with redirects).', 'woocommerce' ),
 					'autoload' => false,
 				),
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -427,7 +427,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'id'       => 'woocommerce_downloads_deliver_inline',
 					'type'     => 'checkbox',
 					'default'  => false,
-					'desc_tip' => __( 'Enable this option to have downloadable files open in browser, instead of being downloaded to customer\'s device.', 'woocommerce' ),
+					'desc_tip' => __( 'Customers can still save the file to their device, but by default file will be opened instead of being downloaded. (Does not work with redirects).', 'woocommerce' ),
 					'autoload' => false,
 				),
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -422,6 +422,16 @@ class WC_Settings_Products extends WC_Settings_Page {
 				),
 
 				array(
+					'title'         => __( 'Content-Disposition', 'woocommerce' ),
+					'desc'          => __( 'Deliver downloadable files inline', 'woocommerce' ),
+					'id'            => 'woocommerce_downloads_deliver_inline',
+					'type'          => 'checkbox',
+					'default'       => false,
+					'desc_tip'      => __( 'Enable this option to have downloadable files open in browser', 'woocommerce' ),
+					'autoload'      => false,
+				),
+
+				array(
 					'title'    => __( 'Filename', 'woocommerce' ),
 					'desc'     => __( 'Append a unique string to filename for security', 'woocommerce' ),
 					'id'       => 'woocommerce_downloads_add_hash_to_filename',

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -584,6 +584,12 @@ class WC_Download_Handler {
 		}
 	}
 
+	/**
+	 *
+	 * Get selected content disposition
+	 *
+	 * Defaults to attachment if `woocommerce_downloads_deliver_inline` setting is not selected.
+	 */
 	private static function get_content_disposition() {
 		$disposition = 'attachment';
 		if ( 'yes' === get_option( 'woocommerce_downloads_deliver_inline' ) ) {

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -583,8 +583,10 @@ class WC_Download_Handler {
 	 * Get selected content disposition
 	 *
 	 * Defaults to attachment if `woocommerce_downloads_deliver_inline` setting is not selected.
+	 *
+	 * @return string Content disposition value.
 	 */
-	private static function get_content_disposition() {
+	private static function get_content_disposition() : string {
 		$disposition = 'attachment';
 		if ( 'yes' === get_option( 'woocommerce_downloads_deliver_inline' ) ) {
 			$disposition = 'inline';

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -487,12 +487,6 @@ class WC_Download_Handler {
 	}
 
 	/**
-	 * Inline download - For deliverying the file without downloading
-	 *
-	 * @param string $file_path File path.
-	 * @param string $filename  File name.
-	 */
-	/**
 	 * Get content type of a download.
 	 *
 	 * @param  string $file_path File path.

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -591,7 +591,7 @@ class WC_Download_Handler {
 		header( 'X-Robots-Tag: noindex, nofollow', true );
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
-		header( 'Content-Disposition: inline' );
+		header( "Content-Disposition: inline; filename=$filename" );
 		header( 'Content-Transfer-Encoding: binary' );
 
 		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -590,7 +590,7 @@ class WC_Download_Handler {
 
 		header( 'X-Robots-Tag: noindex, nofollow', true );
 		header( 'Content-Description: File Transfer' );
-		header( 'Content-Type: text/html' );
+		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
 		header( 'Content-Disposition: inline' );
 		header( 'Content-Transfer-Encoding: binary' );
 

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -25,6 +25,7 @@ class WC_Download_Handler {
 		add_action( 'woocommerce_download_file_redirect', array( __CLASS__, 'download_file_redirect' ), 10, 2 );
 		add_action( 'woocommerce_download_file_xsendfile', array( __CLASS__, 'download_file_xsendfile' ), 10, 2 );
 		add_action( 'woocommerce_download_file_force', array( __CLASS__, 'download_file_force' ), 10, 2 );
+		add_action( 'woocommerce_download_file_inline', array( __CLASS__, 'download_file_inline' ), 10, 2 );
 	}
 
 	/**
@@ -487,6 +488,31 @@ class WC_Download_Handler {
 	}
 
 	/**
+	 * Inline download - For deliverying the file without downloading
+	 *
+	 * @param string $file_path File path.
+	 * @param string $filename  File name.
+	 */
+	public static function download_file_inline( $file_path, $filename ) {
+		$parsed_file_path = self::parse_file_path( $file_path );
+		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
+
+		self::inline_download_headers( $parsed_file_path['file_path'], $filename, $download_range );
+
+		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
+		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
+		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
+			if ( $parsed_file_path['remote_file'] ) {
+				self::download_file_redirect( $file_path );
+			} else {
+				self::download_error( __( 'File not found', 'woocommerce' ) );
+			}
+		}
+
+		exit;
+	}
+
+	/**
 	 * Get content type of a download.
 	 *
 	 * @param  string $file_path File path.
@@ -523,6 +549,49 @@ class WC_Download_Handler {
 		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Disposition: attachment; filename="' . $filename . '";' );
+		header( 'Content-Transfer-Encoding: binary' );
+
+		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		if ( ! $file_size ) {
+			return;
+		}
+
+		if ( isset( $download_range['is_range_request'] ) && true === $download_range['is_range_request'] ) {
+			if ( false === $download_range['is_range_valid'] ) {
+				header( 'HTTP/1.1 416 Requested Range Not Satisfiable' );
+				header( 'Content-Range: bytes 0-' . ( $file_size - 1 ) . '/' . $file_size );
+				exit;
+			}
+
+			$start  = $download_range['start'];
+			$end    = $download_range['start'] + $download_range['length'] - 1;
+			$length = $download_range['length'];
+
+			header( 'HTTP/1.1 206 Partial Content' );
+			header( "Accept-Ranges: 0-$file_size" );
+			header( "Content-Range: bytes $start-$end/$file_size" );
+			header( "Content-Length: $length" );
+		} else {
+			header( 'Content-Length: ' . $file_size );
+		}
+	}
+
+	/**
+	 * Set headers for the inline delivery.
+	 *
+	 * @param string $file_path      File path.
+	 * @param string $filename       File name.
+	 * @param array  $download_range Array containing info about range download request (see {@see get_download_range} for structure).
+	 */
+	private static function inline_download_headers( $file_path, $filename, $download_range = array() ) {
+		self::check_server_config();
+		self::clean_buffers();
+		wc_nocache_headers();
+
+		header( 'X-Robots-Tag: noindex, nofollow', true );
+		header( 'Content-Description: File Transfer' );
+		header( 'Content-Type: text/html' );
+		header( 'Content-Disposition: inline' );
 		header( 'Content-Transfer-Encoding: binary' );
 
 		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -141,12 +141,13 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 		$settings_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
-			'digital_download_options'                   => array( 'title', 'sectionend' ),
-			'woocommerce_file_download_method'           => 'select',
-			'woocommerce_downloads_redirect_fallback_allowed' => 'checkbox',
-			'woocommerce_downloads_require_login'        => 'checkbox',
+			'digital_download_options'                         => array( 'title', 'sectionend' ),
+			'woocommerce_file_download_method'                 => 'select',
+			'woocommerce_downloads_redirect_fallback_allowed'  => 'checkbox',
+			'woocommerce_downloads_require_login'              => 'checkbox',
 			'woocommerce_downloads_grant_access_after_payment' => 'checkbox',
-			'woocommerce_downloads_add_hash_to_filename' => 'checkbox',
+			'woocommerce_downloads_add_hash_to_filename'       => 'checkbox',
+			'woocommerce_downloads_deliver_inline'             => 'checkbox',
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );


### PR DESCRIPTION
Rebased PR #28412 from trunk

Original description

> Create a new setting option for inline file delivery for downloadable
> products. In the Download Handler create a new method for the new
> setting as well as a method for returning the proper headers to deliver
> files inline.
> 
> Resolves: #28410
> 
> All Submissions:
>  Have you followed the WooCommerce Contributing guideline?
>  Does your code follow the WordPress' coding standards?
>  Have you checked to ensure there aren't other open Pull Requests for the same update/change?
> Changes proposed in this Pull Request:
> Creates a new setting for allowing downloadable product files to be delivered inline so they would open directly in the browser. This would be useful for stores selling HTML or PDF files so customers can access them directly without the need to download.
> 
> Only other change was aligning => signs in an array to match WordPress indentation coding standards.
> 
> Closes #28410 .
> 
> How to test the changes in this Pull Request:
> Create a downloadable/virtual product.
> From Woocommerce Settings > Products > Downloadable Products select Inline File Delivery
> Create a test purchase of the downloadable product
> Test download delivery
> Other information:
>  Have you added an explanation of what your changes do and why you'd like us to include them?
>  Have you successfully run tests with your changes locally?
> Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

## Changelog

Enhancement - Add setting for inline file delivery.