### PR TITLE
Use update_coupon_usage_counts to avoid double count.

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1166,7 +1166,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$used_by = $this->get_billing_email();
 		}
 
-		$coupon->increase_usage_count( $used_by );
+		$order_data_store = $this->get_data_store();
+		if ( $order_data_store->get_recorded_coupon_usage_counts( $this ) ) {
+			$coupon->increase_usage_count( $used_by );
+		}
+
+		wc_update_coupon_usage_counts( $this->get_id() );
 
 		return true;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously we were increasing coupon usage count on every apply_coupon method. This was causing double usages because we would also increase on order save callback.

We instead now call `wc_update_coupon_usage_counts` in apply_method itself, which would increase the usage and also set the `_recorded_coupon_usage_counts` order meta.

Additionally, we also manually call $couon->increase_usage_count if `_recorded_coupon_usage_counts` is because in this case, we are likely applying more than one coupon to the order. And `_recorded_coupon_usage_counts` meta would have already been set by the first coupon. This is not a good solution, ideally, we should revamp how we store the coupon recorded information to support multiple coupon information from the get-go.

Closes #27686.

### How to test the changes in this Pull Request:

1. Create a new coupon (or note the usage count of an existing coupon).
2. Create a new order from admin view status pending and add the coupon from step 1. Check that coupon usage is increased.
3. Move the order to a different status (other than canceled), for example - processing. Check that coupon usage is not increased again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Duplicate coupon usage count when order is created via admin/API and status is changed.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
