### PR TITLE
fix internal meta key getter/setter identification

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -305,7 +305,7 @@ abstract class WC_Data {
 			return false;
 		}
 
-		$has_setter_or_getter = is_callable( array( $this, 'set_' . $key ) ) || is_callable( array( $this, 'get_' . $key ) );
+		$has_setter_or_getter = is_callable( array( $this, 'set_' . ltrim( $key, '_' ) ) ) || is_callable( array( $this, 'get_' . ltrim( $key, '_' ) ) );
 
 		if ( ! $has_setter_or_getter ) {
 			return false;
@@ -327,7 +327,7 @@ abstract class WC_Data {
 	 */
 	public function get_meta( $key = '', $single = true, $context = 'view' ) {
 		if ( $this->is_internal_meta_key( $key ) ) {
-			$function = 'get_' . $key;
+			$function = 'get_' . ltrim( $key, '_' );
 
 			if ( is_callable( array( $this, $function ) ) ) {
 				return $this->{$function}();
@@ -403,7 +403,7 @@ abstract class WC_Data {
 	 */
 	public function add_meta_data( $key, $value, $unique = false ) {
 		if ( $this->is_internal_meta_key( $key ) ) {
-			$function = 'set_' . $key;
+			$function = 'set_' . ltrim( $key, '_' );
 
 			if ( is_callable( array( $this, $function ) ) ) {
 				return $this->{$function}( $value );
@@ -433,7 +433,7 @@ abstract class WC_Data {
 	 */
 	public function update_meta_data( $key, $value, $meta_id = 0 ) {
 		if ( $this->is_internal_meta_key( $key ) ) {
-			$function = 'set_' . $key;
+			$function = 'set_' . ltrim( $key, '_' );
 
 			if ( is_callable( array( $this, $function ) ) ) {
 				return $this->{$function}( $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix internal meta key getter/setter identification

Closes #31140 .

### Changelog

> Dev - Ensure "doing it wrong" is triggered when internal meta keys are used directly.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
