### PR TITLE
Fix errant stock adjustment when saving partially refunded orders.

### DIFF
--- a/packages/js/e2e-core-tests/specs/index.js
+++ b/packages/js/e2e-core-tests/specs/index.js
@@ -37,6 +37,7 @@ const runProductSettingsTest = require( './merchant/wp-admin-settings-product.te
 const runTaxSettingsTest = require( './merchant/wp-admin-settings-tax.test' );
 const runOrderStatusFiltersTest = require( './merchant/wp-admin-order-status-filters.test' );
 const runOrderRefundTest = require( './merchant/wp-admin-order-refund.test' );
+const runOrderRefundRestockTest = require( './merchant/wp-admin-order-refund-restock.test' );
 const runOrderApplyCouponTest = require( './merchant/wp-admin-order-apply-coupon.test' );
 const runProductEditDetailsTest = require( './merchant/wp-admin-product-edit-details.test' );
 const runProductSearchTest = require( './merchant/wp-admin-product-search.test' );
@@ -95,6 +96,7 @@ const runMerchantTests = () => {
 	runTaxSettingsTest();
 	runOrderStatusFiltersTest();
 	runOrderRefundTest();
+	runOrderRefundRestockTest();
 	runOrderApplyCouponTest();
 	runProductEditDetailsTest();
 	runProductSearchTest();
@@ -142,6 +144,7 @@ module.exports = {
 	runOrderApiTest,
 	runOrderStatusFiltersTest,
 	runOrderRefundTest,
+	runOrderRefundRestockTest,
 	runOrderApplyCouponTest,
 	runProductEditDetailsTest,
 	runProductSearchTest,

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-refund-restock.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-refund-restock.test.js
@@ -1,0 +1,117 @@
+/**
+ * Internal dependencies
+ */
+const {
+	merchant,
+	createOrder,
+	createSimpleProduct,
+	verifyCheckboxIsSet,
+	uiUnblocked,
+	evalAndClick,
+	clickUpdateOrder,
+} = require( '@woocommerce/e2e-utils' );
+const { waitForSelector } = require( '@woocommerce/e2e-environment' );
+
+/**
+ * Evaluate and click a button selector then wait for a result selector.
+ * This is a work around for what appears to be intermittent delays in handling confirm dialogs.
+ *
+ * @param {string} buttonSelector
+ * @param {string} resultSelector
+ * @returns {Promise<void>}
+ */
+const clickAndWaitForSelector = async ( buttonSelector, resultSelector ) => {
+	await evalAndClick( buttonSelector );
+	await waitForSelector( page, resultSelector, {
+		timeout: 5000,
+	} );
+};
+
+const getRefundQuantityInputSelector = ( productName ) =>
+	`td.name[data-sort-value="${ productName }"] ~ td.quantity input.refund_order_item_qty`;
+
+const runOrderRefundRestockTest = () => {
+	describe( 'WooCommerce Orders > Refund and restock an order item', () => {
+		// See: https://github.com/woocommerce/woocommerce/issues/30618
+		it( 'Can update order after refunding item without automatic stock adjustment', async () => {
+			const noInventoryProductId = await createSimpleProduct();
+			const productToRestockId = await createSimpleProduct(
+				'Product with Stock',
+				'10',
+				{
+					trackInventory: true,
+					remainingStock: 10,
+				}
+			);
+
+			const orderId = await createOrder( {
+				status: 'completed',
+				lineItems: [
+					{
+						product_id: noInventoryProductId,
+					},
+					{
+						product_id: productToRestockId,
+						quantity: 2,
+					},
+				],
+			} );
+
+			await merchant.login();
+			await merchant.goToOrder( orderId );
+
+			// Get the currency symbol for the store's selected currency
+			await page.waitForSelector( '.woocommerce-Price-currencySymbol' );
+
+			// Verify stock reduction system note was added
+			await expect( page ).toMatchElement( '.system-note', {
+				text: `Stock levels reduced: Product with Stock (#${ productToRestockId }) 10→8`,
+			} );
+
+			// Click the Refund button
+			await expect( page ).toClick( 'button.refund-items' );
+
+			// Verify the refund section shows
+			await page.waitForSelector( 'div.wc-order-refund-items', {
+				visible: true,
+			} );
+			await verifyCheckboxIsSet( '#restock_refunded_items' );
+
+			// Initiate a refund
+			await expect( page ).toFill(
+				getRefundQuantityInputSelector( 'Product with Stock' ),
+				'2'
+			);
+			await expect( page ).toFill( '#refund_reason', 'No longer wanted' );
+
+			await clickAndWaitForSelector(
+				'.do-manual-refund',
+				'.quantity .refunded'
+			);
+			await uiUnblocked();
+
+			// Verify restock system note was added
+			await expect( page ).toMatchElement( '.system-note', {
+				text: `Item #${ productToRestockId } stock increased from 8 to 10.`,
+			} );
+
+			// Update the order.
+			await clickUpdateOrder( 'Order updated.' );
+
+			// Verify that inventory wasn't modified.
+			// For some reason using expect().not.toMatchElement() did not work for this case.
+			expect(
+				await page.$$eval( '.note', ( notes ) =>
+					notes.every(
+						( note ) =>
+							! note.textContent.match(
+								/Adjusted stock: Product with Stock \(10→8\)/
+							)
+					)
+				)
+			).toEqual( true );
+		} );
+	} );
+};
+
+module.exports = runOrderRefundRestockTest;

--- a/packages/js/e2e-utils/src/components.js
+++ b/packages/js/e2e-utils/src/components.js
@@ -190,16 +190,23 @@ const completeOnboardingWizard = async () => {
 /**
  * Create simple product.
  *
- * @param productTitle Defaults to Simple Product. Customizable title.
- * @param productPrice Defaults to $9.99. Customizable pricing.
+ * @param {string} productTitle Defaults to Simple Product. Customizable title.
+ * @param {string} productPrice Defaults to $9.99. Customizable pricing.
+ * @param {Object} additionalProps Defaults to nothing. Additional product properties.
  */
-const createSimpleProduct = async ( productTitle = simpleProductName, productPrice = simpleProductPrice ) => {
-	const product = await factories.products.simple.create( {
+const createSimpleProduct = async (
+	productTitle = simpleProductName,
+	productPrice = simpleProductPrice,
+	additionalProps = {}
+) => {
+	const newProduct = {
 		name: productTitle,
 		regularPrice: productPrice,
-	} );
+		...additionalProps,
+	};
+	const product = await factories.products.simple.create( newProduct );
 	return product.id;
-} ;
+};
 
 /**
  * Create simple product with categories
@@ -335,21 +342,29 @@ const createGroupedProduct = async (groupedProduct = defaultGroupedProduct) => {
  */
 const createOrder = async ( orderOptions = {} ) => {
 	const newOrder = {
-		...( orderOptions.status ) && { status: orderOptions.status },
-		...( orderOptions.customerId ) && { customer_id: orderOptions.customerId },
-		...( orderOptions.customerBilling ) && { billing: orderOptions.customerBilling },
-		...( orderOptions.customerShipping ) && { shipping: orderOptions.customerShipping },
-		...( orderOptions.productId ) && { line_items: [
-				{ product_id: orderOptions.productId },
-			]
-		},
+		...( orderOptions.status && { status: orderOptions.status } ),
+		...( orderOptions.customerId && {
+			customer_id: orderOptions.customerId,
+		} ),
+		...( orderOptions.customerBilling && {
+			billing: orderOptions.customerBilling,
+		} ),
+		...( orderOptions.customerShipping && {
+			shipping: orderOptions.customerShipping,
+		} ),
+		...( orderOptions.productId && {
+			line_items: [ { product_id: orderOptions.productId } ],
+		} ),
+		...( orderOptions.lineItems && {
+			line_items: orderOptions.lineItems,
+		} ),
 	};
 
 	const repository = Order.restRepository( client );
 	const order = await repository.create( newOrder );
 
 	return order.id;
-}
+};
 
 /**
  * Create a basic order with the provided order status.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -715,16 +715,11 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		// Update _reduced_stock meta to track changes.
 		$item_stock_reduced = $item_stock_reduced - $qty_to_refund;
 
-		if ( 0 < $item_stock_reduced ) {
-			// Keeps track of total running tally of reduced stock.
-			$item->update_meta_data( '_reduced_stock', $item_stock_reduced );
+		// Keeps track of total running tally of reduced stock.
+		$item->update_meta_data( '_reduced_stock', $item_stock_reduced );
 
-			// Keeps track of only refunded items that needs restock.
-			$item->update_meta_data( '_restock_refunded_items', $qty_to_refund + $restock_refunded_items );
-		} else {
-			$item->delete_meta_data( '_reduced_stock' );
-			$item->delete_meta_data( '_restock_refunded_items' );
-		}
+		// Keeps track of only refunded items that needs restock.
+		$item->update_meta_data( '_restock_refunded_items', $qty_to_refund + $restock_refunded_items );
 
 		/* translators: 1: product ID 2: old stock level 3: new stock level */
 		$order->add_order_note( sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock ) );

--- a/plugins/woocommerce/tests/e2e/specs/wp-admin/order-refund-restock.test.js
+++ b/plugins/woocommerce/tests/e2e/specs/wp-admin/order-refund-restock.test.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runOrderRefundRestockTest } = require( '@woocommerce/e2e-core-tests' );
+
+runOrderRefundRestockTest();

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Order functions tests
+ *
+ * @package WooCommerce\Tests\Order.
+ */
+
+/**
+ * Class WC_Order_Functions_Test
+ */
+class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test that wc_restock_refunded_items() preserves order item stock metadata.
+	 */
+	public function test_wc_restock_refunded_items_stock_metadata() {
+		// Create a product, with stock management enabled.
+		$product = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'manage_stock'   => true,
+				'stock_quantity' => 10,
+			)
+		);
+
+		// Place an order for the product, qty 2.
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+		WC()->cart->calculate_totals();
+
+		$checkout = WC_Checkout::instance();
+		$order    = new WC_Order();
+		$checkout->set_data_from_cart( $order );
+		$order->set_status( 'wc-processing' );
+		$order->save();
+
+		// Get the line item.
+		$items     = $order->get_items();
+		$line_item = reset( $items );
+
+		// Force a restock of one item.
+		$refunded_items = array();
+		$refunded_items[ $line_item->get_id() ] = array(
+			'qty' => 1,
+		);
+		wc_restock_refunded_items( $order, $refunded_items );
+
+		// Verify metadata.
+		$this->assertEquals( 1, (int) $line_item->get_meta( '_reduced_stock', true ) );
+		$this->assertEquals( 1, (int) $line_item->get_meta( '_restock_refunded_items', true ) );
+
+		// Force another restock of one item.
+		wc_restock_refunded_items( $order, $refunded_items );
+
+		// Verify metadata.
+		$this->assertEquals( 0, (int) $line_item->get_meta( '_reduced_stock', true ) );
+		$this->assertEquals( 2, (int) $line_item->get_meta( '_restock_refunded_items', true ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30618.

This PR seeks to resolve the errant stock adjustment on restocked items in partially refunded orders by preserving the `_reduced_stock` and `_restock_refunded_items` order item metadata value so `wc_maybe_adjust_line_item_product_stock()` correctly identifies no `$diff` between the ordered quantity and the amount deducted and restocked.

I've added unit test and E2E test coverage, but I'm still unsure of all of the potential ramifications of keeping the `_reduced_stock` metadata around (perhaps extensions are looking for it?).

### How to test the changes in this Pull Request:

1. Create an order for 2 products with set stock levels (products with manage stock enabled and an inventory quantity)
1. Refund one of the products on the order and select the "restock refunded items" option.
1. Notice the note is added confirming the stock has been restored.
1. Update the order (click "update").
1. Verify there is **not** a new note indicating the stock level has been reduced again.
1. Verify the product inventory levels have not changed (beyond the restocking) by checking the product edit screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix - errant stock adjustment on restocked items when saving partially refunded orders.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
