### PR TITLE
Rename Swaziland to Eswatini

### DIFF
--- a/plugins/woocommerce/i18n/countries.php
+++ b/plugins/woocommerce/i18n/countries.php
@@ -225,7 +225,7 @@ return array(
 	'SD' => __( 'Sudan', 'woocommerce' ),
 	'SR' => __( 'Suriname', 'woocommerce' ),
 	'SJ' => __( 'Svalbard and Jan Mayen', 'woocommerce' ),
-	'SZ' => __( 'Swaziland', 'woocommerce' ),
+	'SZ' => __( 'Eswatini', 'woocommerce' ),
 	'SE' => __( 'Sweden', 'woocommerce' ),
 	'CH' => __( 'Switzerland', 'woocommerce' ),
 	'SY' => __( 'Syria', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-geo-ip.php
+++ b/plugins/woocommerce/includes/class-wc-geo-ip.php
@@ -843,7 +843,7 @@ class WC_Geo_IP {
 		'Sao Tome and Principe',
 		'El Salvador',
 		'Syrian Arab Republic',
-		'Swaziland',
+		'Eswatini',
 		'Turks and Caicos Islands',
 		'Chad',
 		'French Southern Territories',


### PR DESCRIPTION
The country of Swaziland was officially renamed to Eswatini in April 2018. Let
us reflect this change.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The country of Swaziland was renamed to Eswatini back in April 2018. Many projects and operating systems are using this new **legal** name for the country, and it would be great if WC would do the same.

https://www.bbc.com/news/world-africa-43821512

Closes #31184

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Update country strings, rename Swaziland to Eswatini (per CLDR R41 update).

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
