### PR TITLE
Fix E2E Tests

### DIFF
--- a/packages/js/api-core-tests/composer.json
+++ b/packages/js/api-core-tests/composer.json
@@ -10,7 +10,7 @@
 	"extra": {
 		"changelogger": {
 			"formatter": {
-				"class": "PackageFormatter"
+				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
 			"types": [
 				"Fix",
@@ -23,10 +23,5 @@
 			],
 			"changelog": "NEXT_CHANGELOG.md"
 		}
-	},
-	"autoload": {
-		"files": [
-			"../../../tools/changelogger/PackageFormatter.php"
-		]
 	}
 }

--- a/packages/js/api/composer.json
+++ b/packages/js/api/composer.json
@@ -10,7 +10,7 @@
 	"extra": {
 		"changelogger": {
 			"formatter": {
-				"class": "PackageFormatter"
+				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
 			"types": [
 				"Fix",
@@ -23,10 +23,5 @@
 			],
 			"changelog": "NEXT_CHANGELOG.md"
 		}
-	},
-	"autoload": {
-		"files": [
-			"../../../tools/changelogger/PackageFormatter.php"
-		]
 	}
 }

--- a/packages/js/e2e-core-tests/composer.json
+++ b/packages/js/e2e-core-tests/composer.json
@@ -10,7 +10,7 @@
 	"extra": {
 		"changelogger": {
 			"formatter": {
-				"class": "PackageFormatter"
+				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
 			"types": [
 				"Fix",
@@ -23,10 +23,5 @@
 			],
 			"changelog": "NEXT_CHANGELOG.md"
 		}
-	},
-	"autoload": {
-		"files": [
-			"../../../tools/changelogger/PackageFormatter.php"
-		]
 	}
 }

--- a/packages/js/e2e-environment/composer.json
+++ b/packages/js/e2e-environment/composer.json
@@ -10,7 +10,7 @@
 	"extra": {
 		"changelogger": {
 			"formatter": {
-				"class": "PackageFormatter"
+				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
 			"types": [
 				"Fix",
@@ -23,10 +23,5 @@
 			],
 			"changelog": "NEXT_CHANGELOG.md"
 		}
-	},
-	"autoload": {
-		"files": [
-			"../../../tools/changelogger/PackageFormatter.php"
-		]
 	}
 }

--- a/packages/js/e2e-utils/composer.json
+++ b/packages/js/e2e-utils/composer.json
@@ -10,7 +10,7 @@
 	"extra": {
 		"changelogger": {
 			"formatter": {
-				"class": "PackageFormatter"
+				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
 			"types": [
 				"Fix",
@@ -23,10 +23,5 @@
 			],
 			"changelog": "NEXT_CHANGELOG.md"
 		}
-	},
-	"autoload": {
-		"files": [
-			"../../../tools/changelogger/PackageFormatter.php"
-		]
 	}
 }

--- a/plugins/woocommerce/bin/composer/mozart/composer.lock
+++ b/plugins/woocommerce/bin/composer/mozart/composer.lock
@@ -1153,5 +1153,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -411,5 +411,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/plugins/woocommerce/bin/composer/phpunit/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpunit/composer.lock
@@ -1697,5 +1697,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/plugins/woocommerce/bin/composer/wp/composer.lock
+++ b/plugins/woocommerce/bin/composer/wp/composer.lock
@@ -164,16 +164,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.13.8",
+            "version": "v1.13.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "4f0423441ec557f3935b056d10987f2e1c7a3e76"
+                "reference": "5329e997fb50e0b82ca8f6e4164f92941f689b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/4f0423441ec557f3935b056d10987f2e1c7a3e76",
-                "reference": "4f0423441ec557f3935b056d10987f2e1c7a3e76",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/5329e997fb50e0b82ca8f6e4164f92941f689b47",
+                "reference": "5329e997fb50e0b82ca8f6e4164f92941f689b47",
                 "shasum": ""
             },
             "require": {
@@ -185,7 +185,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13.8-dev"
+                    "dev-master": "1.13.9-dev"
                 }
             },
             "autoload": {
@@ -207,9 +207,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.13.8"
+                "source": "https://github.com/mck89/peast/tree/v1.13.9"
             },
-            "time": "2021-09-11T10:28:18+00:00"
+            "time": "2021-11-12T13:44:49+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -624,5 +624,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -55,10 +55,7 @@
 		},
 		"psr-0": {
 			"Automattic\\WooCommerce\\Vendor\\": "lib/packages/"
-		},
-		"files": [
-			"../../tools/changelogger/PluginFormatter.php"
-		]
+		}
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -120,7 +120,7 @@
 		},
 		"changelogger": {
 			"formatter": {
-				"class": "PluginFormatter"
+				"filename": "../../tools/changelogger/PluginFormatter.php"
 			},
 			"types": [
 				"Fix",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d115ec1c2d2dab03533d674edb48a44",
+    "content-hash": "f6fc527d8719df0b0247ee188eb3eee9",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -2923,5 +2923,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -1,19 +1,24 @@
 <?php
+
+namespace Automattic\WooCommerce\MonorepoTools\Changelogger;
+
 /**
  * Base Jetpack Changelogger Formatter for WooCommerce
  */
 
 use Automattic\Jetpack\Changelog\Changelog;
 use Automattic\Jetpack\Changelog\KeepAChangelogParser;
-use Automattic\Jetpack\Changelogger\FormatterPlugin;
 use Automattic\Jetpack\Changelogger\PluginTrait;
 
 /**
  * Base Jetpack Changelogger Formatter for WooCommerce
  *
+ * Note: Since the "filename" loading relies on a single class implementing the plugin interface,
+ * we have to implement it in the child class, even though the base class satisfies it.
+ *
  * Class Formatter
  */
-class Formatter extends KeepAChangelogParser implements FormatterPlugin {
+class Formatter extends KeepAChangelogParser {
 	use PluginTrait;
 
 	/**
@@ -61,7 +66,7 @@ class Formatter extends KeepAChangelogParser implements FormatterPlugin {
 	/**
 	 * Get Release link given a version number.
 	 *
-	 * @throws InvalidArgumentException When directory parsing fails.
+	 * @throws \InvalidArgumentException When directory parsing fails.
 	 * @param string $version Release version.
 	 *
 	 * @return string Link to the version's release.
@@ -76,13 +81,13 @@ class Formatter extends KeepAChangelogParser implements FormatterPlugin {
 		preg_match( '/\/woocommerce\/(.+)/', getcwd(), $path );
 
 		if ( ! count( $path ) ) {
-			throw new InvalidArgumentException( 'Invalid directory.' );
+			throw new \InvalidArgumentException( 'Invalid directory.' );
 		}
 
 		$release_url = $path_map[ $path[1] ];
 
 		if ( ! $release_url ) {
-			throw new InvalidArgumentException( 'Release URL not found.' );
+			throw new \InvalidArgumentException( 'Release URL not found.' );
 		}
 
 		return $release_url . $version;
@@ -93,7 +98,7 @@ class Formatter extends KeepAChangelogParser implements FormatterPlugin {
 	 *
 	 * @param string $changelog Changelog contents.
 	 * @return Changelog
-	 * @throws InvalidArgumentException If the changelog data cannot be parsed.
+	 * @throws \InvalidArgumentException If the changelog data cannot be parsed.
 	 */
 	public function parse( $changelog ) {
 		$ret = new Changelog();
@@ -131,7 +136,7 @@ class Formatter extends KeepAChangelogParser implements FormatterPlugin {
 			$is_subentry = count( $subheading ) > 0;
 
 			if ( ! count( $heading ) && ! count( $subheading ) ) {
-				throw new InvalidArgumentException( 'Invalid heading' );
+				throw new \InvalidArgumentException( 'Invalid heading' );
 			}
 
 			$version         = '';
@@ -145,11 +150,11 @@ class Formatter extends KeepAChangelogParser implements FormatterPlugin {
 				try {
 					$timestamp = new DateTime( $timestamp, new DateTimeZone( 'UTC' ) );
 				} catch ( \Exception $ex ) {
-					throw new InvalidArgumentException( "Heading has an invalid timestamp: $heading", 0, $ex );
+					throw new \InvalidArgumentException( "Heading has an invalid timestamp: $heading", 0, $ex );
 				}
 
 				if ( strtotime( $heading[2], 0 ) !== strtotime( $heading[2], 1000000000 ) ) {
-					throw new InvalidArgumentException( "Heading has a relative timestamp: $heading" );
+					throw new \InvalidArgumentException( "Heading has a relative timestamp: $heading" );
 				}
 				$entry_timestamp = $timestamp;
 
@@ -271,4 +276,4 @@ class Formatter extends KeepAChangelogParser implements FormatterPlugin {
 
 		return $ret;
 	}
-} 
+}

--- a/tools/changelogger/PackageFormatter.php
+++ b/tools/changelogger/PackageFormatter.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace Automattic\WooCommerce\MonorepoTools\Changelogger;
+
+use Automattic\Jetpack\Changelogger\FormatterPlugin;
+
 /**
  * Jetpack Changelogger Formatter for WooCommerce packages
  */
@@ -10,7 +15,7 @@ require_once 'Formatter.php';
  *
  * Class Formatter
  */
-class PackageFormatter extends Formatter {
+class PackageFormatter extends Formatter implements FormatterPlugin {
 	/**
 	 * Prologue text.
 	 *

--- a/tools/changelogger/PluginFormatter.php
+++ b/tools/changelogger/PluginFormatter.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace Automattic\WooCommerce\MonorepoTools\Changelogger;
+
+use Automattic\Jetpack\Changelogger\FormatterPlugin;
+
 /**
  * Jetpack Changelogger Formatter for WooCommerce plugins
  */
@@ -10,7 +15,7 @@ require_once 'Formatter.php';
  *
  * Class Formatter
  */
-class PluginFormatter extends Formatter {
+class PluginFormatter extends Formatter implements FormatterPlugin {
 	/**
 	 * Epilogue text.
 	 *
@@ -24,4 +29,4 @@ class PluginFormatter extends Formatter {
 	 * @var string
 	 */
 	public $entry_pattern = '/^##?#\s+([^\n=]+)\s+((?:(?!^##).)+)/ms';
-} 
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In #31136, we added the Jetpack Changelogger to all of the projects in the Monorepo. This included the addition of a new autoload in all of those packages, which in turn attempts to load one of the formatters from `tools/changelogger`. Composer will automatically load any `"files"` autoload definitions when included in a script, since it has no clear indication about whether or not it should be loading it at any other point in the lifecycle. These autoloads are primarily used for function definition files, where the functions should generally be available to all other code loaded after.

Unfortunately, this means that the WooCommerce plugin will attempt to autoload from this directory, which in some cases, won't actually be accessible. If you are mounting the `plugins/woocommerce` directory using a symlink for instance, it won't necessarily be able to find the file, and will fail to load.

This PR changes the plugin loading to use the `"filename"` option, which allows us to load the specific formatter plugin without needing to have Composer autoload it. This means it will only be loaded when used by the Changelogger, and the problem should be resolved.

### How to test the changes in this Pull Request:

1. Make sure E2E tests pass in CI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
