### PR TITLE
Jetpack Changelogger: Validate entries

### DIFF
--- a/packages/js/api-core-tests/composer.json
+++ b/packages/js/api-core-tests/composer.json
@@ -12,15 +12,15 @@
 			"formatter": {
 				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
-			"types": [
-				"Fix",
-				"Add",
-				"Update",
-				"Dev",
-				"Tweak",
-				"Performance",
-				"Enhancement"
-			],
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
 			"changelog": "NEXT_CHANGELOG.md"
 		}
 	}

--- a/packages/js/api/composer.json
+++ b/packages/js/api/composer.json
@@ -12,15 +12,15 @@
 			"formatter": {
 				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
-			"types": [
-				"Fix",
-				"Add",
-				"Update",
-				"Dev",
-				"Tweak",
-				"Performance",
-				"Enhancement"
-			],
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
 			"changelog": "NEXT_CHANGELOG.md"
 		}
 	}

--- a/packages/js/e2e-core-tests/composer.json
+++ b/packages/js/e2e-core-tests/composer.json
@@ -12,15 +12,15 @@
 			"formatter": {
 				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
-			"types": [
-				"Fix",
-				"Add",
-				"Update",
-				"Dev",
-				"Tweak",
-				"Performance",
-				"Enhancement"
-			],
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
 			"changelog": "NEXT_CHANGELOG.md"
 		}
 	}

--- a/packages/js/e2e-environment/composer.json
+++ b/packages/js/e2e-environment/composer.json
@@ -12,15 +12,15 @@
 			"formatter": {
 				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
-			"types": [
-				"Fix",
-				"Add",
-				"Update",
-				"Dev",
-				"Tweak",
-				"Performance",
-				"Enhancement"
-			],
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
 			"changelog": "NEXT_CHANGELOG.md"
 		}
 	}

--- a/packages/js/e2e-utils/composer.json
+++ b/packages/js/e2e-utils/composer.json
@@ -12,15 +12,15 @@
 			"formatter": {
 				"filename": "../../../tools/changelogger/PackageFormatter.php"
 			},
-			"types": [
-				"Fix",
-				"Add",
-				"Update",
-				"Dev",
-				"Tweak",
-				"Performance",
-				"Enhancement"
-			],
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
 			"changelog": "NEXT_CHANGELOG.md"
 		}
 	}

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -39,7 +39,7 @@
 		"sort-packages": true,
 		"platform": {
 			"php": "7.0.33"
-	  	}
+		}
 	},
 	"autoload": {
 		"exclude-from-classmap": [
@@ -122,15 +122,15 @@
 			"formatter": {
 				"filename": "../../tools/changelogger/PluginFormatter.php"
 			},
-			"types": [
-				"Fix",
-				"Add",
-				"Update",
-				"Dev",
-				"Tweak",
-				"Performance",
-				"Enhancement"
-			],
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
 			"versioning": "wordpress",
 			"changelog": "NEXT_CHANGELOG.md"
 		}

--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -256,10 +256,11 @@ class Formatter extends KeepAChangelogParser {
 
 			foreach ( $entry->getChangesBySubheading() as $heading => $changes ) {
 				foreach ( $changes as $change ) {
-					$breaking_change = 'major' === $change->getSignificance() ? ' [ **BREAKING CHANGE** ]' : '';
+					$significance    = $change->getSignificance();
+					$breaking_change = 'major' === $significance ? ' [ **BREAKING CHANGE** ]' : '';
 					$text            = trim( $change->getContent() );
 					if ( '' !== $text ) {
-						$preamble = $is_subentry ? '' : $bullet . $heading . $breaking_change . ' - ';
+						$preamble = $is_subentry ? '' : $bullet . ucfirst( $significance ) . $breaking_change . ' - ';
 						$ret     .= $preamble . str_replace( "\n", "\n$indent", $text ) . "\n";
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure Jetpack Changelogger is able to validate existing changelog entries. This is useful for automating changelog creation

### How to test the changes in this Pull Request:

1. Make sure all dependencies are available, `cd plugins/woocommerce && composer install`.
2. Add an arbitrary changelog entry `./vendor/bin/changelogger add `.
3. Now validate it `./vendor/bin/changelogger validate `.
4. Make sure the process exits without throwing an error.
5. Create a changelog entry with a fictitious version number `./vendor/bin/changelogger write --use-version 88.0`. 
6. See the changelog makes sense in `plugins/woocommerce/NEXT_CHANGELOG.md`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
