### PR TITLE
Improve the performance of the product attributes lookup table query

### DIFF
--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
@@ -63,12 +63,16 @@ class Filterer {
 			return $args;
 		}
 
-		$clause_root = " {$wpdb->prefix}posts.ID IN (";
+		// The extra derived table ("SELECT product_or_parent_id FROM") is needed for performance
+		// (causes the filtering subquery to be executed only once).
+		$clause_root = " {$wpdb->prefix}posts.ID IN ( SELECT product_or_parent_id FROM (";
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$in_stock_clause = ' AND in_stock = 1';
 		} else {
 			$in_stock_clause = '';
 		}
+
+		$attribute_ids_for_and_filtering = array();
 
 		foreach ( $attributes_to_filter_by as $taxonomy => $data ) {
 			$all_terms                  = get_terms( $taxonomy, array( 'hide_empty' => false ) );
@@ -79,24 +83,10 @@ class Filterer {
 			$is_and_query               = 'and' === $data['query_type'];
 
 			$count = count( $term_ids_to_filter_by );
+
 			if ( 0 !== $count ) {
-				if ( $is_and_query ) {
-					$clauses[] = "
-						{$clause_root}
-						SELECT product_or_parent_id
-						FROM {$this->lookup_table_name} lt
-						WHERE is_variation_attribute=0
-						{$in_stock_clause}
-						AND term_id in {$term_ids_to_filter_by_list}
-						GROUP BY product_id
-						HAVING COUNT(product_id)={$count}
-						UNION
-						SELECT product_or_parent_id
-						FROM {$this->lookup_table_name} lt
-						WHERE is_variation_attribute=1
-						{$in_stock_clause}
-						AND term_id in {$term_ids_to_filter_by_list}
-					)";
+				if ( $is_and_query && $count > 1 ) {
+					$attribute_ids_for_and_filtering = array_merge( $attribute_ids_for_and_filtering, $term_ids_to_filter_by );
 				} else {
 					$clauses[] = "
 							{$clause_root}
@@ -109,8 +99,30 @@ class Filterer {
 			}
 		}
 
+		if ( ! empty( $attribute_ids_for_and_filtering ) ) {
+			$count                      = count( $attribute_ids_for_and_filtering );
+			$term_ids_to_filter_by_list = '(' . join( ',', $attribute_ids_for_and_filtering ) . ')';
+			$clauses[]                  = "
+				{$clause_root}
+				SELECT product_or_parent_id
+				FROM {$this->lookup_table_name} lt
+				WHERE is_variation_attribute=0
+				{$in_stock_clause}
+				AND term_id in {$term_ids_to_filter_by_list}
+				GROUP BY product_id
+				HAVING COUNT(product_id)={$count}
+				UNION
+				SELECT product_or_parent_id
+				FROM {$this->lookup_table_name} lt
+				WHERE is_variation_attribute=1
+				{$in_stock_clause}
+				AND term_id in {$term_ids_to_filter_by_list}
+			)";
+		}
+
 		if ( ! empty( $clauses ) ) {
-			$args['where'] .= ' AND (' . join( ' AND ', $clauses ) . ')';
+			// "temp" is needed because the extra derived tables require an alias.
+			$args['where'] .= ' AND (' . join( ' temp ) AND ', $clauses ) . ' temp ))';
 		} elseif ( ! empty( $attributes_to_filter_by ) ) {
 			$args['where'] .= ' AND 1=0';
 		}
@@ -228,10 +240,12 @@ class Filterer {
 				}
 
 				if ( ! empty( $and_term_ids ) ) {
-					$terms_count     = count( $and_term_ids );
-					$term_ids_list   = '(' . join( ',', $and_term_ids ) . ')';
+					$terms_count   = count( $and_term_ids );
+					$term_ids_list = '(' . join( ',', $and_term_ids ) . ')';
+					// The extra derived table ("SELECT product_or_parent_id FROM") is needed for performance
+					// (causes the filtering subquery to be executed only once).
 					$query['where'] .= "
-						AND product_or_parent_id IN (
+						AND product_or_parent_id IN ( SELECT product_or_parent_id FROM (
 							SELECT product_or_parent_id
 							FROM {$this->lookup_table_name} lt
 							WHERE is_variation_attribute=0
@@ -245,17 +259,17 @@ class Filterer {
 							WHERE is_variation_attribute=1
 							{$in_stock_clause}
 							AND term_id in {$term_ids_list}
-						)";
+						) temp )";
 				}
 
 				if ( ! empty( $or_term_ids ) ) {
 					$term_ids_list   = '(' . join( ',', $or_term_ids ) . ')';
 					$query['where'] .= "
-						AND product_or_parent_id IN (
+						AND product_or_parent_id IN ( SELECT product_or_parent_id FROM (
 							SELECT product_or_parent_id FROM {$this->lookup_table_name}
 							WHERE term_id in {$term_ids_list}
 							{$in_stock_clause}
-						)";
+						) temp )";
 
 				}
 			} else {

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/Filterer.php
@@ -65,7 +65,7 @@ class Filterer {
 
 		// The extra derived table ("SELECT product_or_parent_id FROM") is needed for performance
 		// (causes the filtering subquery to be executed only once).
-		$clause_root = " {$wpdb->prefix}posts.ID IN ( SELECT product_or_parent_id FROM (";
+		$clause_root = " {$wpdb->posts}.ID IN ( SELECT product_or_parent_id FROM (";
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
 			$in_stock_clause = ' AND in_stock = 1';
 		} else {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Improve (by a lot) the performance of the queries for the product attributes lookup table by doing the following:

1. Fallback the query for the "AND" case to the query for the "OR" case when there's only one term being filtered for the category (the subquery for the "OR" case is much simpler).

2. Collapse all of the "AND" queries (for all the categories) into a single one (this is possible since term ids are unique even across categories).

3. The most important change: introduce an extra derived query, enclosing the subquery that does the actual filtering, so that this subquery is executed only once. Inspired by [this blog post](https://tosska.com/how-to-tune-sql-statement-with-multiple-union-in-subquery-for-mysql/). This one is applied to the query that calculates the counts for the filtering widget too.

That is, the `where` part we introduce to filter the returned product ids:

```
...AND posts.ID in ( 
   SELECT product_id FROM lookup_table WHERE...
)
```

becomes

```
...AND posts.ID in ( 
   SELECT product_id FROM (
       SELECT product_id FROM lookup_table WHERE...
   ) temp
)
```

Testing on an Atomic site having 50 variable products, each having 3 attribute defining variations and each having 5 defined variations, and filtering by 3 different attributes simultaneously (selecting 3 terms for each), the execution time for the main query goes down from 10-12s to 0.02-0.04s after applying these changes.

Closes #31110.

### How to test the changes in this Pull Request:

The testing instructions are the same as in https://github.com/woocommerce/woocommerce/pull/29896. However, in this case emphasis should be put on the following:

* Create a lot of products (at least 50) with multiple attributes (at least 3 per product); variable products should have a few variations defined as well.
* Add a few filter by attribute widgets (at least 3), filtering by at least three terms for each attribute.
* Try the widgets configured as both "AND" and "OR".
* Use the query monitor plugin or a similar tool to verify that the main query execution time is as expected.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enhancement - Improve the performance of the filtering by attributes using the new lookup table.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
