### PR TITLE
Use `WC_Order_Query` for the Orders API Endpoint.

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -26,6 +26,24 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	protected $namespace = 'wc/v3';
 
 	/**
+	 * Get Orders.
+	 *
+	 * @param  array $query_args Query args.
+	 *
+	 * @return array Orders.
+	 */
+	protected function get_objects( $query_args ) {
+		$query_args['paginate'] = true;
+		$results                = wc_get_orders( $query_args );
+
+		return array(
+			'objects' => $results->orders,
+			'total'   => $results->total,
+			'pages'   => $results->max_num_pages,
+		);
+	}
+
+	/**
 	 * Calculate coupons.
 	 *
 	 * @throws WC_REST_Exception When fails to set any item.
@@ -255,6 +273,11 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			} else {
 				$args['post_status'][] = $status;
 			}
+		}
+
+		// // Add customer back since WC_Data_Store_WP::get_wp_query_args() will ignore the meta_query.
+		if ( isset( $request['customer'] ) ) {
+			$args['customer'] = $request['customer'];
 		}
 
 		// Put the statuses back for further processing (next/prev links, etc).

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -261,22 +261,17 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	protected function prepare_objects_query( $request ) {
 		// Track if the query is being filtered.
 		$query_has_filter = has_filter( 'woocommerce_rest_orders_prepare_object_query' );
+
 		// This is needed to get around an array to string notice in WC_REST_Orders_V2_Controller::prepare_objects_query.
 		$statuses = $request['status'];
 		unset( $request['status'] );
+
 		$args = parent::prepare_objects_query( $request );
 
-		$args['post_status'] = array();
+		// Format status values for WC_Order_Query.
+		$args['status'] = array();
 		foreach ( $statuses as $status ) {
-			if ( in_array( $status, $this->get_order_statuses(), true ) ) {
-				$args['post_status'][] = 'wc-' . $status;
-			} elseif ( 'any' === $status ) {
-				// Set status to "any" and short-circuit out.
-				$args['post_status'] = 'any';
-				break;
-			} else {
-				$args['post_status'][] = $status;
-			}
+			$args['status'][] = 'wc-' . $status;
 		}
 
 		// Add customer back since WC_Data_Store_WP::get_wp_query_args() will ignore the meta_query.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -279,9 +279,14 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			}
 		}
 
-		// // Add customer back since WC_Data_Store_WP::get_wp_query_args() will ignore the meta_query.
+		// Add customer back since WC_Data_Store_WP::get_wp_query_args() will ignore the meta_query.
 		if ( isset( $request['customer'] ) ) {
 			$args['customer'] = $request['customer'];
+		}
+
+		// Restore the pagination parameter for WC_Order_Query.
+		if ( isset( $request['page'])) {
+			$args['page'] = $request['page'];
 		}
 
 		// See if we need to migrate a meta_query added via filter.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -326,7 +326,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		// If there's still a meta query, we need to preserve it by adding it back in after
 		// WC_Data_Store_WP::get_wp_query_args() has been called, since it will strip it out.
 		if ( ! empty( $meta_query ) ) {
-			$args['_meta_query'] = $meta_query;
+			$args['_rest_api_meta_query'] = $meta_query;
 			add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', array( $this, 'preserve_meta_query' ) );
 		}
 
@@ -342,9 +342,9 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 * @return array Filtered orders query parameters.
 	 */
 	public function preserve_meta_query( $query ) {
-		if ( ! empty( $query['_meta_query'] ) ) {
-			$query['meta_query'] = $query['meta_query'] + $query['_meta_query'];
-			unset( $query['_meta_query'] );
+		if ( ! empty( $query['_rest_api_meta_query'] ) ) {
+			$query['meta_query'] = $query['meta_query'] + $query['_rest_api_meta_query'];
+			unset( $query['_rest_api_meta_query'] );
 			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', array( $this, __FUNCTION__ ) );
 		}
 		return $query;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28745.

This PR restores some changes made in https://github.com/woocommerce/woocommerce/pull/27735 - namely the usage of `WC_Order_Query` by the Orders REST Controller which supplants direct `WP_Query` usage with the WC data stores.


### How to test the changes in this Pull Request:

1. Verify that the Orders Listing E2E tests pass
2. Make REST API requests to `/wc/v3/orders` verifying `before` and `after` parameters (since E2E doesn't cover them)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Tweak - use datastores for Orders listing API endpoint.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
