### PR TITLE
Fixed Broken TSConfig

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,40 +1,32 @@
 {
   "compilerOptions": {
-    // Target the latest version of ECMAScript.
-    "target": "esnext",
-    "module": "esnext",
-
-    // Support incremental project builds in the compiler.
-    "composite": true,
-    "incremental": true,
-
-    // Search under node_modules for non-relative imports.
-    "moduleResolution": "node",
-
-    // Support vanilla JavaScript and type-check it.
     "allowJs": true,
     "checkJs": true,
-
-    // Ensures all modules are compatible with ES6 import syntax.
-    "esModuleInterop": true,
-
-    // Allow JSON files to be imported as objects.
-    "resolveJsonModule": true,
-
-    // Support mapping transpiled files back to source files.
-    "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
+    "jsx": "preserve",
+    "target": "es6",
+    "module": "commonjs",
+    "incremental": true,
+    "declaration": true,
     "declarationMap": true,
+    "composite": true,
+    "emitDeclarationOnly": false,
+    "isolatedModules": true,
 
-    // Enable all of the strict type checks.
+    /* Strict Type-Checking Options */
     "strict": true,
 
-    // Warn developers when they write code incompatible with some build tools.
-    "isolatedModules": true
-  },
-  // Make sure we don't transpile any test files.
-  "exclude": [
-    "**/__test_data__/*",
-		"**/__tests__/*",
-		"**/__mocks__/*",
-	]
+    /* Additional Checks */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",
+
+    /* This needs to be false so our types are possible to consume without setting this */
+    "esModuleInterop": false,
+    "resolveJsonModule": true
+  }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/31207, part of the TSConfig work I was doing slipped into the commits, breaking Nx commands. This PR reverts the change to `tsconfig.base.json` to get everything working again.

### How to test the changes in this Pull Request:

1. Verify that `pnpm nx build @woocommerce/api` works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
