### PR TITLE
Update count param consistently.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -270,7 +270,7 @@ class WC_Download_Handler {
 		);
 
 		$count            = 0;
-		$file_path        = str_replace( array_keys( $replacements ), array_values( $replacements ), $file_path );
+		$file_path        = str_replace( array_keys( $replacements ), array_values( $replacements ), $file_path, $count );
 		$parsed_file_path = wp_parse_url( $file_path );
 		$remote_file      = null === $count || 0 === $count; // Remote file only if there were no replacements.
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class WC_Download_Handler_Tests.
+ */
+class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test for local file path.
+	 */
+	public function test_parse_file_path_for_local_file() {
+		$local_file_path = trailingslashit( wp_upload_dir()['basedir'] ) . 'dummy_file.jpg';
+		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
+		$this->assertFalse( $parsed_file_path['remote_file'] );
+	}
+
+	/**
+	 * Test for local URL without protocol.
+	 */
+	public function test_parse_file_path_for_local_url() {
+		$local_file_path = trailingslashit( wp_upload_dir()['baseurl'] ) . 'dummy_file.jpg';
+		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
+		$this->assertFalse( $parsed_file_path['remote_file'] );
+	}
+
+	/**
+	 * Test for local file with `file` protocol.
+	 */
+	public function test_parse_file_path_for_local_file_protocol() {
+		$local_file_path = 'file:/' . trailingslashit( wp_upload_dir()['basedir'] ) . 'dummy_file.jpg';
+		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
+		$this->assertFalse( $parsed_file_path['remote_file'] );
+	}
+
+	/**
+	 * Test for local file with https protocom.
+	 */
+	public function test_parse_file_path_for_local_file_https_protocol() {
+		$local_file_path = site_url( '/', 'https' ) . 'dummy_file.jpg';
+		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
+		$this->assertFalse( $parsed_file_path['remote_file'] );
+	}
+
+	/**
+	 * Test for remote file.
+	 */
+	public function test_parse_file_path_for_remote_file() {
+		$remote_file_path = 'https://dummy.woocommerce.com/dummy_file.jpg';
+		$parsed_file_path = WC_Download_Handler::parse_file_path( $remote_file_path );
+		$this->assertTrue( $parsed_file_path['remote_file'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As far as I can see, this count param is not really needed, but it will still be good to keep it updated in case its getting used in an edge case that I have not considered.

### How to test the changes in this Pull Request:

This is more of a consistency fix. Make sure all test case pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Update count param consistently to make remote_file param accurate.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
