### PR TITLE
Remove the need to invoke LookupDataStore->show_feature() to use the product attributes lookup table

### DIFF
--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -255,10 +255,6 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 	 * @return array The tools array with the entry added.
 	 */
 	private function add_initiate_regeneration_entry_to_tools_array( array $tools_array ) {
-		if ( ! $this->data_store->is_feature_visible() ) {
-			return $tools_array;
-		}
-
 		$lookup_table_exists       = $this->data_store->check_lookup_table_exists();
 		$generation_is_in_progress = $this->data_store->regeneration_is_in_progress();
 
@@ -375,9 +371,6 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 	 * @throws \Exception Something prevents the regeneration from starting.
 	 */
 	private function check_can_do_lookup_table_regeneration( $product_id = null ) {
-		if ( ! $this->data_store->is_feature_visible() ) {
-			throw new \Exception( "Can't do product attribute lookup data regeneration: feature is not visible" );
-		}
 		if ( $product_id && ! $this->data_store->check_lookup_table_exists() ) {
 			throw new \Exception( "Can't do product attribute lookup data regeneration: lookup table doesn't exist" );
 		}

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -31,20 +31,12 @@ class LookupDataStore {
 	private $lookup_table_name;
 
 	/**
-	 * Is the feature visible?
-	 *
-	 * @var bool
-	 */
-	private $is_feature_visible;
-
-	/**
 	 * LookupDataStore constructor. Makes the feature hidden by default.
 	 */
 	public function __construct() {
 		global $wpdb;
 
 		$this->lookup_table_name  = $wpdb->prefix . 'wc_product_attributes_lookup';
-		$this->is_feature_visible = false;
 
 		$this->init_hooks();
 	}
@@ -65,7 +57,7 @@ class LookupDataStore {
 		add_filter(
 			'woocommerce_get_sections_products',
 			function ( $products ) {
-				if ( $this->is_feature_visible() && $this->check_lookup_table_exists() ) {
+				if ( $this->check_lookup_table_exists() ) {
 					$products['advanced'] = __( 'Advanced', 'woocommerce' );
 				}
 				return $products;
@@ -77,7 +69,7 @@ class LookupDataStore {
 		add_filter(
 			'woocommerce_get_settings_products',
 			function ( $settings, $section_id ) {
-				if ( 'advanced' === $section_id && $this->is_feature_visible() && $this->check_lookup_table_exists() ) {
+				if ( 'advanced' === $section_id && $this->check_lookup_table_exists() ) {
 					$title_item = array(
 						'title' => __( 'Product attributes lookup table', 'woocommerce' ),
 						'type'  => 'title',
@@ -134,29 +126,6 @@ class LookupDataStore {
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return $this->lookup_table_name === $wpdb->get_var( $query );
-	}
-
-	/**
-	 * Checks if the feature is visible (so that dedicated entries will be added to the debug tools page).
-	 *
-	 * @return bool True if the feature is visible.
-	 */
-	public function is_feature_visible() {
-		return $this->is_feature_visible;
-	}
-
-	/**
-	 * Makes the feature visible, so that dedicated entries will be added to the debug tools page.
-	 */
-	public function show_feature() {
-		$this->is_feature_visible = true;
-	}
-
-	/**
-	 * Hides the feature, so that no entries will be added to the debug tools page.
-	 */
-	public function hide_feature() {
-		$this->is_feature_visible = false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The new filtering by attributes via lookup table feature (implemented in https://github.com/woocommerce/woocommerce/pull/29778, https://github.com/woocommerce/woocommerce/pull/29896, https://github.com/woocommerce/woocommerce/pull/30041) required a call to `LookupDataStore->show_feature()` in order to be visible. This pull request removes this method and makes the feature always visible.

Note that visible doesn't mean active. The site admin still needs to go to the tools page and trigger the table creation and filling.

Closes #30563.

### How to test the changes in this Pull Request:

Basically the same testing as in the original PRs implementing the feature, but now the extra snippet to invoke `LookupDataStore->show_feature()` isn't needed anymore:

* The tools page shows the appropriate entries (to either create the table if it doesn't exist, or delete or regenerate it otherwise).
* When the table exists and is completely filled, there's a _Products - Advanced_ settings section that allows to enable and disable the table usage.
* The table is effectively used then the setting is set, it isn't when the setting is unset and when the table doesn't exist.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak - Remove the need to invoke LookupDataStore->show_feature() to use the product attributes lookup table

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
