### PR TITLE
Fix retrieving status code for API tests

### DIFF
--- a/packages/js/e2e-core-tests/specs/api/coupon.test.js
+++ b/packages/js/e2e-core-tests/specs/api/coupon.test.js
@@ -7,23 +7,19 @@ const { HTTPClientFactory, Coupon } = require( '@woocommerce/api' );
  * External dependencies
  */
 const config = require( 'config' );
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 /**
  * Create the default coupon and tests interactions with it via the API.
  */
 const runCouponApiTest = () => {
-	describe('REST API > Coupon', () => {
+	describe( 'REST API > Coupon', () => {
 		let client;
 		let percentageCoupon;
 		let coupon;
 		let repository;
 
-		beforeAll(async () => {
+		beforeAll( async () => {
 			percentageCoupon = config.get( 'coupons.percentage' );
 			const admin = config.get( 'users.admin' );
 			const url = config.get( 'url' );
@@ -34,15 +30,17 @@ const runCouponApiTest = () => {
 				.create();
 		} );
 
-		it('can create a coupon', async () => {
+		it( 'can create a coupon', async () => {
 			repository = Coupon.restRepository( client );
 
 			// Check properties of the coupon in the create coupon response.
 			coupon = await repository.create( percentageCoupon );
-			expect( coupon ).toEqual( expect.objectContaining( percentageCoupon ) );
-		});
+			expect( coupon ).toEqual(
+				expect.objectContaining( percentageCoupon )
+			);
+		} );
 
-		it('can retrieve a coupon', async () => {
+		it( 'can retrieve a coupon', async () => {
 			const couponProperties = {
 				id: coupon.id,
 				code: percentageCoupon.code,
@@ -51,12 +49,16 @@ const runCouponApiTest = () => {
 			};
 
 			// Read coupon directly from API to compare.
-			const response = await client.get( `/wc/v3/coupons/${coupon.id}` );
-			expect( response.status ).toBe( 200 );
-			expect( response.data ).toEqual( expect.objectContaining( couponProperties ) );
-		});
+			const response = await client.get(
+				`/wc/v3/coupons/${ coupon.id }`
+			);
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual(
+				expect.objectContaining( couponProperties )
+			);
+		} );
 
-		it('can update a coupon', async () => {
+		it( 'can update a coupon', async () => {
 			const updatedCouponProperties = {
 				amount: '75.00',
 				discount_type: 'fixed_cart',
@@ -66,19 +68,23 @@ const runCouponApiTest = () => {
 			await repository.update( coupon.id, updatedCouponProperties );
 
 			// Check the coupon response for the updated values.
-			const response = await client.get( `/wc/v3/coupons/${coupon.id}` );
-			expect( response.status ).toBe( 200 );
-			expect( response.data ).toEqual( expect.objectContaining( updatedCouponProperties ) );
-		});
+			const response = await client.get(
+				`/wc/v3/coupons/${ coupon.id }`
+			);
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual(
+				expect.objectContaining( updatedCouponProperties )
+			);
+		} );
 
-		it('can delete a coupon', async () => {
+		it( 'can delete a coupon', async () => {
 			// Delete the coupon
 			const status = await repository.delete( coupon.id );
 
 			// If the delete is successful, the response comes back truthy
 			expect( status ).toBeTruthy();
-		});
-	});
+		} );
+	} );
 };
 
 module.exports = runCouponApiTest;

--- a/packages/js/e2e-core-tests/specs/api/external-product.test.js
+++ b/packages/js/e2e-core-tests/specs/api/external-product.test.js
@@ -7,24 +7,20 @@ const { HTTPClientFactory, ExternalProduct } = require( '@woocommerce/api' );
  * External dependencies
  */
 const config = require( 'config' );
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 /**
  * Create an external product and retrieve via the API.
  */
 const runExternalProductAPITest = () => {
 	// @todo: add a call to ensure pretty permalinks are enabled once settings api is in use.
-	describe('REST API > External Product', () => {
+	describe( 'REST API > External Product', () => {
 		let client;
 		let defaultExternalProduct;
 		let product;
 		let repository;
 
-		beforeAll(async () => {
+		beforeAll( async () => {
 			defaultExternalProduct = config.get( 'products.external' );
 			const admin = config.get( 'users.admin' );
 			const url = config.get( 'url' );
@@ -35,15 +31,17 @@ const runExternalProductAPITest = () => {
 				.create();
 		} );
 
-		it('can create an external product', async () => {
+		it( 'can create an external product', async () => {
 			repository = ExternalProduct.restRepository( client );
 
 			// Check properties of product in the create product response.
 			product = await repository.create( defaultExternalProduct );
-			expect( product ).toEqual( expect.objectContaining( defaultExternalProduct ) );
-		});
+			expect( product ).toEqual(
+				expect.objectContaining( defaultExternalProduct )
+			);
+		} );
 
-		it('can retrieve a raw external product', async () => {
+		it( 'can retrieve a raw external product', async () => {
 			const rawProperties = {
 				id: product.id,
 				button_text: defaultExternalProduct.buttonText,
@@ -52,12 +50,16 @@ const runExternalProductAPITest = () => {
 			};
 
 			// Read product directly from api.
-			const response = await client.get( `/wc/v3/products/${product.id}` );
-			expect( response.status ).toBe( 200 );
-			expect( response.data ).toEqual( expect.objectContaining( rawProperties ) );
-		});
+			const response = await client.get(
+				`/wc/v3/products/${ product.id }`
+			);
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual(
+				expect.objectContaining( rawProperties )
+			);
+		} );
 
-		it('can retrieve a transformed external product', async () => {
+		it( 'can retrieve a transformed external product', async () => {
 			const transformedProperties = {
 				...defaultExternalProduct,
 				id: product.id,
@@ -66,14 +68,16 @@ const runExternalProductAPITest = () => {
 
 			// Read product via the repository.
 			const transformed = await repository.read( product.id );
-			expect( transformed ).toEqual( expect.objectContaining( transformedProperties ) );
-		});
+			expect( transformed ).toEqual(
+				expect.objectContaining( transformedProperties )
+			);
+		} );
 
-		it('can delete an external product', async () => {
+		it( 'can delete an external product', async () => {
 			const status = repository.delete( product.id );
 			expect( status ).toBeTruthy();
-		});
-	});
+		} );
+	} );
 };
 
 module.exports = runExternalProductAPITest;

--- a/packages/js/e2e-core-tests/specs/api/grouped-product.test.js
+++ b/packages/js/e2e-core-tests/specs/api/grouped-product.test.js
@@ -1,32 +1,32 @@
 /**
  * Internal dependencies
  */
-const { HTTPClientFactory, GroupedProduct, SimpleProduct } = require( '@woocommerce/api' );
+const {
+	HTTPClientFactory,
+	GroupedProduct,
+	SimpleProduct,
+} = require( '@woocommerce/api' );
 
 /**
  * External dependencies
  */
 const config = require( 'config' );
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 /**
  * Create an external product and retrieve via the API.
  */
 const runGroupedProductAPITest = () => {
 	// @todo: add a call to ensure pretty permalinks are enabled once settings api is in use.
-	describe('REST API > Grouped Product', () => {
+	describe( 'REST API > Grouped Product', () => {
 		let client;
 		let defaultGroupedProduct;
 		let baseGroupedProduct;
 		let product;
-		let groupedProducts = [];
+		const groupedProducts = [];
 		let repository;
 
-		beforeAll(async () => {
+		beforeAll( async () => {
 			defaultGroupedProduct = config.get( 'products.grouped' );
 			const admin = config.get( 'users.admin' );
 			const url = config.get( 'url' );
@@ -38,13 +38,19 @@ const runGroupedProductAPITest = () => {
 
 			// Create the simple products to be grouped first.
 			repository = SimpleProduct.restRepository( client );
-			for ( let c = 0; c < defaultGroupedProduct.groupedProducts.length; c++ ) {
-				product = await repository.create( defaultGroupedProduct.groupedProducts[ c ] );
+			for (
+				let c = 0;
+				c < defaultGroupedProduct.groupedProducts.length;
+				c++
+			) {
+				product = await repository.create(
+					defaultGroupedProduct.groupedProducts[ c ]
+				);
 				groupedProducts.push( product.id );
 			}
-		});
+		} );
 
-		it('can create a grouped product', async () => {
+		it( 'can create a grouped product', async () => {
 			baseGroupedProduct = {
 				...defaultGroupedProduct,
 				groupedProducts,
@@ -53,38 +59,46 @@ const runGroupedProductAPITest = () => {
 
 			// Check properties of product in the create product response.
 			product = await repository.create( baseGroupedProduct );
-			expect( product ).toEqual( expect.objectContaining( baseGroupedProduct ) );
-		});
+			expect( product ).toEqual(
+				expect.objectContaining( baseGroupedProduct )
+			);
+		} );
 
-		it('can retrieve a raw grouped product', async () => {
-			let rawProperties = {
+		it( 'can retrieve a raw grouped product', async () => {
+			const rawProperties = {
 				id: product.id,
 				grouped_products: baseGroupedProduct.groupedProducts,
 				...defaultGroupedProduct,
 			};
-			delete rawProperties['groupedProducts'];
+			delete rawProperties.groupedProducts;
 
 			// Read product directly from api.
-			const response = await client.get( `/wc/v3/products/${product.id}` );
-			expect( response.status ).toBe( 200 );
-			expect( response.data ).toEqual( expect.objectContaining( rawProperties ) );
-		});
+			const response = await client.get(
+				`/wc/v3/products/${ product.id }`
+			);
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual(
+				expect.objectContaining( rawProperties )
+			);
+		} );
 
-		it('can retrieve a transformed grouped product', async () => {
+		it( 'can retrieve a transformed grouped product', async () => {
 			// Read product via the repository.
 			const transformed = await repository.read( product.id );
-			expect( transformed ).toEqual( expect.objectContaining( baseGroupedProduct ) );
-		});
+			expect( transformed ).toEqual(
+				expect.objectContaining( baseGroupedProduct )
+			);
+		} );
 
-		it('can delete a grouped product', async () => {
+		it( 'can delete a grouped product', async () => {
 			const status = repository.delete( product.id );
 			expect( status ).toBeTruthy();
 			// Delete the simple "child" products.
 			groupedProducts.forEach( ( productId ) => {
 				repository.delete( productId );
-			});
-		});
-	});
+			} );
+		} );
+	} );
 };
 
 module.exports = runGroupedProductAPITest;

--- a/packages/js/e2e-core-tests/specs/api/order.test.js
+++ b/packages/js/e2e-core-tests/specs/api/order.test.js
@@ -1,28 +1,24 @@
 /**
  * Internal dependencies
  */
- const { HTTPClientFactory, Order } = require( '@woocommerce/api' );
+const { HTTPClientFactory, Order } = require( '@woocommerce/api' );
 
- /**
-  * External dependencies
-  */
- const config = require( 'config' );
- const {
-	 it,
-	 describe,
-	 beforeAll,
- } = require( '@jest/globals' );
+/**
+ * External dependencies
+ */
+const config = require( 'config' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
- /**
+/**
  * Creates an order and tests interactions with it via the API.
  */
 const runOrderApiTest = () => {
-	describe('REST API > Order', () => {
+	describe( 'REST API > Order', () => {
 		let client;
 		let order;
 		let repository;
 
-		beforeAll(async () => {
+		beforeAll( async () => {
 			order = config.get( 'orders.basicPaidOrder' );
 			const admin = config.get( 'users.admin' );
 			const url = config.get( 'url' );
@@ -33,15 +29,15 @@ const runOrderApiTest = () => {
 				.create();
 		} );
 
-		it('can create an order', async () => {
+		it( 'can create an order', async () => {
 			repository = Order.restRepository( client );
 
 			// Check properties of the order in the create order response.
 			order = await repository.create( order );
 			expect( order ).toEqual( expect.objectContaining( order ) );
-		});
+		} );
 
-		it('can retrieve an order', async () => {
+		it( 'can retrieve an order', async () => {
 			const orderProperties = {
 				id: order.id,
 				payment_method: order.paymentMethod,
@@ -49,12 +45,14 @@ const runOrderApiTest = () => {
 			};
 
 			// Read order directly from API to compare.
-			const response = await client.get( `/wc/v3/orders/${order.id}` );
-			expect( response.status ).toBe( 200 );
-			expect( response.data ).toEqual( expect.objectContaining( orderProperties ) );
-		});
+			const response = await client.get( `/wc/v3/orders/${ order.id }` );
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual(
+				expect.objectContaining( orderProperties )
+			);
+		} );
 
-		it('can update an order', async () => {
+		it( 'can update an order', async () => {
 			const updatedOrderProperties = {
 				payment_method: 'bacs',
 				status: 'completed',
@@ -63,19 +61,21 @@ const runOrderApiTest = () => {
 			await repository.update( order.id, updatedOrderProperties );
 
 			// Check the order response for the updated values.
-			const response = await client.get( `/wc/v3/orders/${order.id}` );
-			expect( response.status ).toBe( 200 );
-			expect( response.data ).toEqual( expect.objectContaining( updatedOrderProperties ) );
-		});
+			const response = await client.get( `/wc/v3/orders/${ order.id }` );
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual(
+				expect.objectContaining( updatedOrderProperties )
+			);
+		} );
 
-		it('can delete an order', async () => {
+		it( 'can delete an order', async () => {
 			// Delete the order
 			const status = await repository.delete( order.id );
 
 			// If the delete is successful, the response comes back truthy
 			expect( status ).toBeTruthy();
-		});
-	});
+		} );
+	} );
 };
 
 module.exports = runOrderApiTest;

--- a/packages/js/e2e-core-tests/specs/api/telemetry.test.js
+++ b/packages/js/e2e-core-tests/specs/api/telemetry.test.js
@@ -7,11 +7,7 @@ const { HTTPClientFactory } = require( '@woocommerce/api' );
  * External dependencies
  */
 const config = require( 'config' );
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 /**
  * Create the default coupon and tests interactions with it via the API.
@@ -20,7 +16,7 @@ const runTelemetryAPITest = () => {
 	describe( 'REST API > Telemetry', () => {
 		let client;
 
-		beforeAll(async () => {
+		beforeAll( async () => {
 			const admin = config.get( 'users.admin' );
 			const url = config.get( 'url' );
 
@@ -30,29 +26,26 @@ const runTelemetryAPITest = () => {
 				.create();
 		} );
 
-		it.each([
-			null,
-			{},
-			{ platform: 'ios' },
-			{ version: '1.1' },
-		])( 'errors for invalid request body - %p', async data => {
-			const response = await client
-				.post( `/wc-telemetry/tracker`, data )
-				.catch( err => {
-					expect( err.response.status ).toBe( 400 );
-				} );
+		it.each( [ null, {}, { platform: 'ios' }, { version: '1.1' } ] )(
+			'errors for invalid request body - %p',
+			async ( data ) => {
+				const response = await client
+					.post( `/wc-telemetry/tracker`, data )
+					.catch( ( err ) => {
+						expect( err.statusCode ).toBe( 400 );
+					} );
 
-			expect( response ).toBeUndefined();
-		} );
+				expect( response ).toBeUndefined();
+			}
+		);
 
 		it( 'returns 200 with correct fields', async () => {
-			const response = await client
-				.post( `/wc-telemetry/tracker`, {
-					platform: 'ios',
-					version: '1.0',
-				})
+			const response = await client.post( `/wc-telemetry/tracker`, {
+				platform: 'ios',
+				version: '1.0',
+			} );
 
-			expect( response.status ).toBe( 200 );
+			expect( response.statusCode ).toBe( 200 );
 		} );
 	} );
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the response statusCode validation in the API tests to work with the updated API package:

```
response.status => response.statusCode
```

```
err.response.status => err.statusCode
```

This also updates the formatting in the test files to match what prettier recommends.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the API tests locally and verify they pass:

```
cd plugins/woocommerce
pnpx i
pnpx wc-e2e test:e2e ./tests/e2e/specs/rest-api/api.test.js
```

