### PR TITLE
Add action hook to generate a custom field type

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -331,12 +331,18 @@ abstract class WC_Settings_API {
 				$html .= $this->{'generate_' . $type . '_html'}( $k, $v );
 			} elseif ( has_filter( 'woocommerce_generate_' . $type . '_html' ) ) {
 				/**
-				 * Allow the generation of custom field types on the settings screen
+				 * Allow the generation of custom field types on the settings screen.
 				 *
-				 * @param string $field_html The markup of the field being generated (initiated as an empty string)
-				 * @param string $key The key of the field
-				 * @param array  $data The attributes of the field as an associative array
-				 * @param object $wc_settings The current WC_Settings_API object
+				 * The dynamic portion of the hook name refers to the slug of the custom field type.
+				 * For instance, to introduce a new field type `fancy_lazy_dropdown` you would use
+				 * the hook `woocommerce_generate_fancy_lazy_dropdown_html`.
+				 *
+				 * @since 6.5.0
+				 *
+				 * @param string $field_html The markup of the field being generated (initiated as an empty string).
+				 * @param string $key The key of the field.
+				 * @param array  $data The attributes of the field as an associative array.
+				 * @param object $wc_settings The current WC_Settings_API object.
 				 */
 				$html .= apply_filters( 'woocommerce_generate_' . $type . '_html', '', $k, $v, $this );
 			} else {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -329,10 +329,16 @@ abstract class WC_Settings_API {
 
 			if ( method_exists( $this, 'generate_' . $type . '_html' ) ) {
 				$html .= $this->{'generate_' . $type . '_html'}( $k, $v );
-			} elseif ( has_action( 'woocommerce_generate_' . $type . '_html' ) ) {
-				ob_start();
-				do_action( 'woocommerce_generate_' . $type . '_html', $k, $v, $this );
-				$html .= ob_get_clean();
+			} elseif ( has_filter( 'woocommerce_generate_' . $type . '_html' ) ) {
+				/**
+				 * Allow the generation of custom field types on the settings screen
+				 *
+				 * @param string $field_html The markup of the field being generated (initiated as an empty string)
+				 * @param string $key The key of the field
+				 * @param array  $data The attributes of the field as an associative array
+				 * @param object $wc_settings The current WC_Settings_API object
+				 */
+				$html .= apply_filters( 'woocommerce_generate_' . $type . '_html', '', $k, $v, $this );
 			} else {
 				$html .= $this->generate_text_html( $k, $v );
 			}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -329,6 +329,10 @@ abstract class WC_Settings_API {
 
 			if ( method_exists( $this, 'generate_' . $type . '_html' ) ) {
 				$html .= $this->{'generate_' . $type . '_html'}( $k, $v );
+			} elseif ( has_action( 'woocommerce_generate_' . $type . '_html' ) ) {
+				ob_start();
+				do_action( 'woocommerce_generate_' . $type . '_html', $k, $v, $this );
+				$html .= ob_get_clean();
 			} else {
 				$html .= $this->generate_text_html( $k, $v );
 			}


### PR DESCRIPTION
Summary: Adding a `woocommerce_generate_{$type}_html` action hook allows to generate the HTML output of a custom field type for those classes extending the `WC_Settings_API` (e.g. `WC_Email`).

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `generate_settings_html` method of the `WC_Settings_API` abstract class doesn't offer the possibility to add a custom field type. Any field type that doesn't have a corresponding `generate_{$type}_html` method within the class falls back to the `generate_text_html` method, which outputs the HTML markup of a `text` field type.

The proposed change adds a `woocommerce_generate_{$type}_html` action hook that allows developers to freely define the HTML output of custom field types. The call to `has_action` is needed to keep the original fallback to a `text` field type. The `if` clause first checks if the field type corresponds to a factory method of the `WC_Settings_API`. If that is not the case, it then checks if a callback function was hooked to the `woocommerce_generate_{$type}_html` action. Finally, if also the second check fails, the field is output as a regular `text` field type.

This change is necessary if developers want to add more field types to those used by any class extending `WC_Settings_API`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Added a new `woocommerce_generate_{$type}_html` action hook to generate custom field types in `WC_Settings_API` class objects.