### PR TITLE
add common utilities for cart, checkout coupon tests

### DIFF
--- a/packages/js/e2e-core-tests/specs/utils/coupons.js
+++ b/packages/js/e2e-core-tests/specs/utils/coupons.js
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+const { createCoupon } = require( '@woocommerce/e2e-utils' );
+
+const couponsTable = [
+	[ 'fixed cart', { text: '$5.00' }, { text: '$4.99' } ],
+	[ 'percentage', { text: '$4.99' }, { text: '$5.00' } ],
+	[ 'fixed product', { text: '$5.00' }, { text: '$4.99' } ]
+];
+
+let couponFixedCart;
+let couponPercentage;
+let couponFixedProduct;
+
+/**
+ * Get a test coupon Id. Create the coupon if it does not exist.
+ *
+ * @param {string} couponType Coupon type.
+ * @return {string} Coupon code.
+ */
+const getCouponId = async ( couponType ) => {
+	switch ( couponType ) {
+		case 'fixed cart':
+			if ( ! couponFixedCart ) {
+				couponFixedCart = await createCoupon();
+			}
+			return couponFixedCart;
+		case 'percentage':
+			if ( ! couponPercentage ) {
+				couponPercentage = await createCoupon( '50', 'Percentage discount' );
+			}
+			return couponPercentage;
+		case 'fixed product':
+			if ( ! couponFixedProduct ) {
+				couponFixedProduct = await createCoupon( '5', 'Fixed product discount' );
+			}
+			return couponFixedProduct;
+	}
+};
+
+const getCouponsTable = () => {
+	return couponsTable;
+};
+
+module.exports = {
+	getCouponsTable,
+	getCouponId,
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR moves the common cart and checkout coupon data and functions to a single set of utilities. This was the only remaining instance of function(s) used in multiple places. The others had been addressed in previous PRs.

Closes #29677 .

### How to test the changes in this Pull Request:

1. Verify CI
