### PR TITLE
migrate e2e puppeteer utils

### DIFF
--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -9,11 +9,11 @@ const {
 	evalAndClick,
 	setCheckbox,
 	verifyAndPublish,
+	waitForSelector,
 	waitForSelectorWithoutThrow
 } = require( '@woocommerce/e2e-utils' );
 const {
 	waitAndClick,
-	waitForSelector,
 } = require( '@woocommerce/e2e-environment' );
 
 /**

--- a/packages/js/e2e-environment/config/jest-puppeteer.config.js
+++ b/packages/js/e2e-environment/config/jest-puppeteer.config.js
@@ -1,32 +1,46 @@
 /** @format */
-const { jestPuppeteerConfig } = require( '@automattic/puppeteer-utils' );
+/**
+ * For a detailed explanation of configuration properties, visit:
+ * https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions
+ */
 
+const { CI, E2E_DEBUG, PUPPETEER_SLOWMO, E2E_EXE_PATH } = process.env;
+let executablePath = '';
+let dumpio = false;
 let puppeteerConfig;
+
+
+if ( ! CI && E2E_EXE_PATH !== '' ) {
+	executablePath = E2E_EXE_PATH;
+}
+
+if ( E2E_DEBUG ) {
+	dumpio = true;
+}
+const jestPuppeteerLaunch = {
+	// Required for the logged out and logged in tests so they don't share app state/token.
+	browserContext: 'incognito',
+	defaultViewport: {
+		width: 1280,
+		height: 800,
+	},
+};
 
 if ( 'no' == global.process.env.node_config_dev ) {
 	puppeteerConfig = {
-		launch: {
-			// Required for the logged out and logged in tests so they don't share app state/token.
-			browserContext: 'incognito',
-			defaultViewport: {
-				width: 1280,
-				height: 800,
-			},
-		},
+		launch: jestPuppeteerLaunch,
 	};
 } else {
 	puppeteerConfig = {
 		launch: {
-			...jestPuppeteerConfig.launch,
-			slowMo: process.env.PUPPETEER_SLOWMO ? process.env.PUPPETEER_SLOWMO : 50,
+			...jestPuppeteerLaunch,
+			executablePath,
+			dumpio,
+			slowMo: PUPPETEER_SLOWMO ? PUPPETEER_SLOWMO : 50,
 			headless: false,
 			ignoreHTTPSErrors: true,
 			args: [ '--window-size=1920,1080', '--user-agent=chrome' ],
 			devtools: true,
-			defaultViewport: {
-				width: 1280,
-				height: 800,
-			},
 		},
 	};
 }

--- a/packages/js/e2e-environment/config/jest.config.js
+++ b/packages/js/e2e-environment/config/jest.config.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-const { jestConfig } = require( '@automattic/puppeteer-utils' );
 const { WC_E2E_SCREENSHOTS } = process.env;
 const path = require( 'path' );
 const fs = require( 'fs' );
@@ -33,7 +32,13 @@ if ( fs.existsSync( localJestSetupFile ) ) {
 }
 
 const combinedConfig = {
-	...jestConfig,
+	preset: 'jest-puppeteer',
+	clearMocks: true,
+	moduleFileExtensions: [ 'js' ],
+	testMatch: [
+		'**/*.(test|spec).js',
+		'*.(test|spec).js'
+	],
 	moduleNameMapper: {
 		'@woocommerce/e2e/tests/(.*)': appPath + 'tests/e2e/$1',
 	},
@@ -49,7 +54,6 @@ const combinedConfig = {
 	testTimeout: parseInt( global.process.env.jest_test_timeout ),
 
 	transformIgnorePatterns: [
-		...jestConfig.transformIgnorePatterns,
 		'node_modules/(?!(woocommerce)/)',
 	],
 	roots: [ appPath + 'tests/e2e/specs' ],

--- a/packages/js/e2e-utils/src/page-utils.js
+++ b/packages/js/e2e-utils/src/page-utils.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { pressKeyWithModifier } from '@wordpress/e2e-test-utils';
-import { waitForSelector } from '@automattic/puppeteer-utils';
 
 /**
  * Internal dependencies
@@ -318,3 +317,21 @@ export const clickAndWaitForSelector = async ( buttonSelector, resultSelector, t
 		}
 	);
 };
+/**
+ * Waits for selector to be present in DOM.
+ * Throws a `TimeoutError` if element was not found after 30 sec.
+ * Behavior can be modified with @param options. Possible keys: `visible`, `hidden`, `timeout`.
+ * More details at: https://pptr.dev/#?product=Puppeteer&show=api-pagewaitforselectorselector-options
+ *
+ * @param {Puppeteer.Page} page Puppeteer representation of the page.
+ * @param {string} selector CSS selector of the element
+ * @param {Object} options Custom options to modify function behavior.
+ */
+export async function waitForSelector( page, selector, options = {} ) {
+	// set up default options
+	const defaultOptions = { timeout: 30000, logHTML: false };
+	options = Object.assign( defaultOptions, options );
+
+	const element = await page.waitForSelector( selector, options );
+	return element;
+}


### PR DESCRIPTION
This PR accidentally has the commit from #31239. We'll hold this until it has been merged.

### Changes proposed in this Pull Request:

This PR merges the Jest and Puppeteer defaults from `@automattic/puppeteer-utils`. We were overriding most of the defaults. We were also using `waitForSelector`. A modified version of the function was added to the page utils.

### How to test the changes in this Pull Request:

1. Run `cd plugins/woocommerce`
2. Run `pnpm install`
3. Run `pnpx wc-e2e docker:up`
4. Run `pnpx wc-e2e test:e2e`
5. All tests should pass