### PR TITLE
Update WooCommerce Blocks to 6.3.2

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -22,7 +22,7 @@
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.3.0",
 		"woocommerce/woocommerce-admin": "2.8.0",
-		"woocommerce/woocommerce-blocks": "6.1.0"
+		"woocommerce/woocommerce-blocks": "6.3.2"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6fc527d8719df0b0247ee188eb3eee9",
+    "content-hash": "eea2b2004bd5f5a1db46cea0fb4d8e25",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -613,16 +613,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v6.1.0",
+            "version": "v6.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "8556efd69e85c01f5571d39e6581d9b8486b682f"
+                "reference": "5b3aea9adb718a1f78525881e4f0c33c72ba175d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/8556efd69e85c01f5571d39e6581d9b8486b682f",
-                "reference": "8556efd69e85c01f5571d39e6581d9b8486b682f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/5b3aea9adb718a1f78525881e4f0c33c72ba175d",
+                "reference": "5b3aea9adb718a1f78525881e4f0c33c72ba175d",
                 "shasum": ""
             },
             "require": {
@@ -630,6 +630,8 @@
                 "composer/installers": "^1.7.0"
             },
             "require-dev": {
+                "johnbillion/wp-hooks-generator": "0.6.1",
+                "mockery/mockery": "^1.4",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
                 "wp-phpunit/wp-phpunit": "^5.4",
                 "yoast/phpunit-polyfills": "^1.0"
@@ -659,9 +661,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v6.1.0"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v6.3.2"
             },
-            "time": "2021-10-12T13:07:11+00:00"
+            "time": "2021-11-18T03:27:03+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 6.3.2 and targets `trunk` but should land on the WooCommerce 6.0 release branch.

## Blocks 6.3.2
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5178)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/632.md)
- Release post (not live yet)

## Blocks 6.3.1
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5169)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/631.md)
- Release post (not live yet)

## Blocks 6.3.0
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5146)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/630.md)
- Release post (not live yet)

## Blocks 6.2.0
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4990)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/620.md)
- [Release post](https://developer.woocommerce.com/2021/10/28/woocommerce-blocks-6-2-0-release-notes/)

## Changelog entry
#### Enhancements
* Legacy Template Block: allow users to delete the block. ( [5176](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5176) )
* Add placeholder text when modifying product search input in the editor. ( [5122](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5122) )
* FSE: Add basic product archive block template. ( [5049](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5049) )
* FSE: Add basic taxonomy block templates. ( [5063](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5063) )
* FSE: Add single product block template. ( [5054](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5054) )
* FSE: Remove the do_action( ‘woocommerce_sidebar’ ); action from the LegacyTemplate.php block. ( [5097](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5097) )
* Fix duplicate queries in product grids. ( [5002](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5002) )
* FSE: Add abstract block legacy template for core PHP templates. ( [4991](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4991) )
* FSE: Add render logic to BlockTemplateController. ( [4984](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4984) )
* Improve accessibility by using self-explaining edit button titles. ( [5113](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5113) )
* Improve readability of terms and condition text by not displaying the text justified. ( [5120](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5120) )
* Improve rendering performance for Single Product block. ( [5107](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5107) )
* Improve the product images placeholder display by adding a light gray border to it. ( [4950](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4950) )
* Deprecate the __experimental_woocommerce_blocks_checkout_update_order_from_request action in favour of woocommerce_blocks_checkout_update_order_from_request. ( [5015](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5015) )
* Deprecate the __experimental_woocommerce_blocks_checkout_update_order_meta action in favour of woocommerce_blocks_checkout_update_order_meta. ( [5017](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5017) )
* Deprecate the __experimental_woocommerce_blocks_checkout_order_processed action in favour of woocommerce_blocks_checkout_order_processed. ( [5014](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5014) )
* Cart v2: The cart block, like checkout block, now supports inner blocks that allow for greater customizability. ( [4973](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4973) )
* BlockTemplateController: Adds the ability to load and manage block template files. ( [4981](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4981) )
* Improve accessibility for the editor view of the Product search block. ( [4905](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4905) )

#### Bug Fixes
* Removed WooCommerce block templates from appearing in the template dropdown for a page or post. ( [5167](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5167) )
* Fix ‘Country is required’ error on the Cart block when updating shipping address ( [5129](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5129) )
* Fix state validation to compare state codes, and only validate if a country is given ( [5132](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5132) )
* Make order note block removable ( [5139](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5139) )
* Fix label alignment of the product search in the editor. ( [5072](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5072) )
* Fix sale badge alignment on smaller screen. ( [5061](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5061) )
* FSE: Fix missing is_custom property for WooCommerce block template objects. ( [5067](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5067) )
* Replace incorrect with correct text domain. ( [5020](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5020) )
* Scripts using wc-settings or script that depend on it would be enqueued in the footer if they’re enqueued in the header. ( [5059](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5059) )
* Fix custom classname support for inner checkout blocks. ( [4978](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4978) )
* Fix a bug in free orders and trial subscription products. ( [4955](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4955) )
* Remove duplicate attributes in saved block HTML. ( [4941](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4941) )
* Fix render error of Filter by Attribute block when no attribute is selected. ( [4847](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4847) )
* Store API – Ensure returned customer address state is valid. ( [4844](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4844) )


