### PR TITLE
Create and activate product attributes lookup table in data migration

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -169,6 +169,10 @@ class WC_Install {
 			'wc_update_600_migrate_rate_limit_options',
 			'wc_update_600_db_version',
 		),
+		'6.1.0' => array(
+			'wc_create_product_attributes_lookup_table',
+			'wc_update_610_db_version',
+		),
 	);
 
 	/**
@@ -571,22 +575,22 @@ class WC_Install {
 		$pages = apply_filters(
 			'woocommerce_create_pages',
 			array(
-				'shop'          => array(
+				'shop'           => array(
 					'name'    => _x( 'shop', 'Page slug', 'woocommerce' ),
 					'title'   => _x( 'Shop', 'Page title', 'woocommerce' ),
 					'content' => '',
 				),
-				'cart'          => array(
+				'cart'           => array(
 					'name'    => _x( 'cart', 'Page slug', 'woocommerce' ),
 					'title'   => _x( 'Cart', 'Page title', 'woocommerce' ),
 					'content' => '<!-- wp:shortcode -->[' . apply_filters( 'woocommerce_cart_shortcode_tag', 'woocommerce_cart' ) . ']<!-- /wp:shortcode -->',
 				),
-				'checkout'      => array(
+				'checkout'       => array(
 					'name'    => _x( 'checkout', 'Page slug', 'woocommerce' ),
 					'title'   => _x( 'Checkout', 'Page title', 'woocommerce' ),
 					'content' => '<!-- wp:shortcode -->[' . apply_filters( 'woocommerce_checkout_shortcode_tag', 'woocommerce_checkout' ) . ']<!-- /wp:shortcode -->',
 				),
-				'myaccount'     => array(
+				'myaccount'      => array(
 					'name'    => _x( 'my-account', 'Page slug', 'woocommerce' ),
 					'title'   => _x( 'My account', 'Page title', 'woocommerce' ),
 					'content' => '<!-- wp:shortcode -->[' . apply_filters( 'woocommerce_my_account_shortcode_tag', 'woocommerce_my_account' ) . ']<!-- /wp:shortcode -->',

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -169,9 +169,9 @@ class WC_Install {
 			'wc_update_600_migrate_rate_limit_options',
 			'wc_update_600_db_version',
 		),
-		'6.2.0' => array(
-			'wc_create_product_attributes_lookup_table',
-			'wc_update_620_db_version',
+		'6.3.0' => array(
+			'wc_update_630_create_product_attributes_lookup_table',
+			'wc_update_630_db_version',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -169,9 +169,9 @@ class WC_Install {
 			'wc_update_600_migrate_rate_limit_options',
 			'wc_update_600_db_version',
 		),
-		'6.1.0' => array(
+		'6.2.0' => array(
 			'wc_create_product_attributes_lookup_table',
-			'wc_update_610_db_version',
+			'wc_update_620_db_version',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2357,8 +2357,8 @@ function wc_create_product_attributes_lookup_table() {
 
 /**
  *
- * Update DB version to 6.1.0.
+ * Update DB version to 6.2.0.
  */
-function wc_update_610_db_version() {
-	WC_Install::update_db_version( '6.1.0' );
+function wc_update_620_db_version() {
+	WC_Install::update_db_version( '6.2.0' );
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2344,7 +2344,7 @@ function wc_update_600_db_version() {
  *
  * @return false Always false, since the LookupDataStore class handles all the data filling process.
  */
-function wc_create_product_attributes_lookup_table() {
+function wc_update_630_create_product_attributes_lookup_table() {
 	$data_store = wc_get_container()->get( LookupDataStore::class );
 	if ( $data_store->check_lookup_table_exists() ) {
 		return false;
@@ -2357,8 +2357,8 @@ function wc_create_product_attributes_lookup_table() {
 
 /**
  *
- * Update DB version to 6.2.0.
+ * Update DB version to 6.3.0.
  */
-function wc_update_620_db_version() {
-	WC_Install::update_db_version( '6.2.0' );
+function wc_update_630_db_version() {
+	WC_Install::update_db_version( '6.3.0' );
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -11,6 +11,8 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 
 /**
  * Update file paths for 2.0
@@ -2306,7 +2308,7 @@ function wc_update_560_db_version() {
 function wc_update_600_migrate_rate_limit_options() {
 	global $wpdb;
 
-	$rate_limits = $wpdb->get_results(
+	$rate_limits   = $wpdb->get_results(
 		"
 			SELECT option_name, option_value
 			FROM $wpdb->options
@@ -2334,4 +2336,29 @@ function wc_update_600_migrate_rate_limit_options() {
  */
 function wc_update_600_db_version() {
 	WC_Install::update_db_version( '6.0.0' );
+}
+
+/**
+ * Create the product attributes lookup table and initiate its filling,
+ * unless the table had been already created manually (via the tools page).
+ *
+ * @return false Always false, since the LookupDataStore class handles all the data filling process.
+ */
+function wc_create_product_attributes_lookup_table() {
+	$data_store = wc_get_container()->get( LookupDataStore::class );
+	if ( $data_store->check_lookup_table_exists() ) {
+		return false;
+	}
+
+	$data_regenerator = wc_get_container()->get( DataRegenerator::class );
+	$data_regenerator->initiate_regeneration();
+	return false;
+}
+
+/**
+ *
+ * Update DB version to 6.1.0.
+ */
+function wc_update_610_db_version() {
+	WC_Install::update_db_version( '6.1.0' );
 }

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -678,7 +678,7 @@ class LookupDataStore {
 	 *
 	 * @return bool True if the last lookup table regeneration process was aborted.
 	 */
-	public function regeneration_was_aborted() {
+	public function regeneration_was_aborted(): bool {
 		return 'yes' === get_option( 'woocommerce_attribute_lookup_regeneration_aborted' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -36,7 +36,7 @@ class LookupDataStore {
 	public function __construct() {
 		global $wpdb;
 
-		$this->lookup_table_name  = $wpdb->prefix . 'wc_product_attributes_lookup';
+		$this->lookup_table_name = $wpdb->prefix . 'wc_product_attributes_lookup';
 
 		$this->init_hooks();
 	}
@@ -84,9 +84,18 @@ class LookupDataStore {
 					$settings[] = $title_item;
 
 					if ( ! $regeneration_is_in_progress ) {
+						$regeneration_aborted_warning =
+							$this->regeneration_was_aborted() ?
+							sprintf(
+								"<p><strong style='color: #E00000'>%s</strong></p><p>%s</p>",
+								__( 'WARNING: The product attributes lookup table regeneration process was aborted.', 'woocommerce' ),
+								__( 'This means that the table is probably in an inconsistent state. It\'s recommended to run a new regeneration process (Status - Tools - Regenerate the product attributes lookup table) before enabling the table usage.', 'woocommerce' )
+							) : null;
+
 						$settings[] = array(
 							'title'         => __( 'Enable table usage', 'woocommerce' ),
 							'desc'          => __( 'Use the product attributes lookup table for catalog filtering.', 'woocommerce' ),
+							'desc_tip'      => $regeneration_aborted_warning,
 							'id'            => 'woocommerce_attribute_lookup_enabled',
 							'default'       => 'no',
 							'type'          => 'checkbox',
@@ -647,5 +656,29 @@ class LookupDataStore {
 	 */
 	public function unset_regeneration_in_progress_flag() {
 		delete_option( 'woocommerce_attribute_lookup_regeneration_in_progress' );
+	}
+
+	/**
+	 * Set a flag indicating that the last lookup table regeneration process started was aborted.
+	 */
+	public function set_regeneration_aborted_flag() {
+		update_option( 'woocommerce_attribute_lookup_regeneration_aborted', 'yes' );
+	}
+
+	/**
+	 * Remove the flag indicating that the last lookup table regeneration process started was aborted.
+	 */
+	public function unset_regeneration_aborted_flag() {
+		delete_option( 'woocommerce_attribute_lookup_regeneration_aborted' );
+	}
+
+	/**
+	 * Tells if the last lookup table regeneration process started was aborted
+	 * (via deleting the 'woocommerce_attribute_lookup_regeneration_in_progress' option).
+	 *
+	 * @return bool True if the last lookup table regeneration process was aborted.
+	 */
+	public function regeneration_was_aborted() {
+		return 'yes' === get_option( 'woocommerce_attribute_lookup_regeneration_aborted' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -7,6 +7,8 @@
 
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
 
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
+
 require_once __DIR__ . '/class-wc-settings-unit-test-case.php';
 
 /**
@@ -27,6 +29,11 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 			'inventory',
 			'downloadable',
 		);
+
+		// TODO: Once the lookup table is created in a migration, remove the check and just include 'advanced' in $expected.
+		if ( wc_get_container()->get( LookupDataStore::class )->check_lookup_table_exists() ) {
+			array_push( $expected, 'advanced' );
+		}
 
 		$this->assertEquals( $expected, $section_names );
 	}
@@ -134,12 +141,12 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 		$settings_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
-			'digital_download_options'                         => array( 'title', 'sectionend' ),
-			'woocommerce_file_download_method'                 => 'select',
-			'woocommerce_downloads_redirect_fallback_allowed'  => 'checkbox',
-			'woocommerce_downloads_require_login'              => 'checkbox',
+			'digital_download_options'                   => array( 'title', 'sectionend' ),
+			'woocommerce_file_download_method'           => 'select',
+			'woocommerce_downloads_redirect_fallback_allowed' => 'checkbox',
+			'woocommerce_downloads_require_login'        => 'checkbox',
 			'woocommerce_downloads_grant_access_after_payment' => 'checkbox',
-			'woocommerce_downloads_add_hash_to_filename'       => 'checkbox',
+			'woocommerce_downloads_add_hash_to_filename' => 'checkbox',
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -157,7 +157,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_processed_count' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
+		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 
@@ -279,7 +279,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( $product_ids, $this->lookup_data_store->passed_products );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_processed_count' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
+		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -121,7 +121,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 
 		$this->assertEquals( 100, get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
-		$this->assertEquals( 0, get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
+		$this->assertEquals( 0, get_option( 'woocommerce_attribute_lookup_processed_count' ) );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_enabled' ) );
 
 		$expected_enqueued = array(
@@ -156,8 +156,8 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
-		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_processed_count' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 
@@ -165,15 +165,15 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	 * @testdox `initiate_regeneration` processes one chunk of products IDs and enqueues next step if there are more products available.
 	 */
 	public function test_initiate_regeneration_correctly_processes_ids_and_enqueues_next_step() {
-		$requested_products_pages = array();
+		$requested_products_offsets = array();
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) use ( &$requested_products_pages ) {
+				'wc_get_products' => function( $args ) use ( &$requested_products_offsets ) {
 					if ( 'DESC' === current( $args['orderby'] ) ) {
 						return array( 100 );
 					} else {
-						$requested_products_pages[] = $args['page'];
+						$requested_products_offsets[] = $args['offset'];
 						return array( 1, 2, 3 );
 					}
 				},
@@ -186,13 +186,13 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 		$this->queue->clear_methods_called();
 
-		update_option( 'woocommerce_attribute_lookup_last_products_page_processed', 7 );
+		update_option( 'woocommerce_attribute_lookup_processed_count', 7 );
 
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( array( 1, 2, 3 ), $this->lookup_data_store->passed_products );
-		$this->assertEquals( array( 8 ), $requested_products_pages );
-		$this->assertEquals( 8, get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
+		$this->assertEquals( array( 7 ), $requested_products_offsets );
+		$this->assertEquals( 7 + count( $this->lookup_data_store->passed_products ), get_option( 'woocommerce_attribute_lookup_processed_count' ) );
 
 		$expected_enqueued = array(
 			'method'    => 'schedule_single',
@@ -206,6 +206,50 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Products are processed in groups of whatever the 'woocommerce_attribute_lookup_regeneration_step_size' filter returns, defaulting to PRODUCTS_PER_GENERATION_STEP
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $set_filter Whether to use the filter to change the processing group size or not.
+	 */
+	public function test_regeneration_uses_the_woocommerce_attribute_lookup_regeneration_step_size_filter( bool $set_filter ) {
+		$requested_step_sizes = array();
+
+		if ( $set_filter ) {
+			\add_filter(
+				'woocommerce_attribute_lookup_regeneration_step_size',
+				function( $default_filter_size ) {
+					return 100;
+				}
+			);
+		}
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_get_products' => function( $args ) use ( &$requested_step_sizes ) {
+					if ( 'DESC' === current( $args['orderby'] ) ) {
+						return array( 100 );
+					} else {
+						$requested_step_sizes[] = $args['limit'];
+						return array( 1, 2, 3 );
+					}
+				},
+			)
+		);
+
+		$this->sut->initiate_regeneration();
+		$this->queue->clear_methods_called();
+
+		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
+
+		remove_all_filters( ' woocommerce_attribute_lookup_regeneration_step_size' );
+
+		$expected_limit_value = $set_filter ? 100 : DataRegenerator::PRODUCTS_PER_GENERATION_STEP;
+		$this->assertEquals( array( $expected_limit_value ), $requested_step_sizes );
+	}
+
+	/**
 	 * @testdox `initiate_regeneration` finishes regeneration when the max product id is reached or no more products are returned.
 	 *
 	 * @testWith [[98,99,100]]
@@ -215,15 +259,12 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	 * @param array $product_ids The products ids that wc_get_products will return.
 	 */
 	public function test_initiate_regeneration_finishes_when_no_more_products_available( $product_ids ) {
-		$requested_products_pages = array();
-
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) use ( &$requested_products_pages, $product_ids ) {
+				'wc_get_products' => function( $args ) use ( &$requested_products_offsets, $product_ids ) {
 					if ( 'DESC' === current( $args['orderby'] ) ) {
 						return array( 100 );
 					} else {
-						$requested_products_pages[] = $args['page'];
 						return $product_ids;
 					}
 				},
@@ -237,8 +278,8 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->assertEquals( $product_ids, $this->lookup_data_store->passed_products );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
-		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_processed_count' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -157,7 +157,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
+		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 
@@ -238,7 +238,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->assertEquals( $product_ids, $this->lookup_data_store->passed_products );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
+		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -545,16 +545,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			$this->assertEmpty( $filtered_product_ids );
 		}
 
-		/*
-		 * If a variable product defines an attribute value that isn't used by any variation:
-		 * When using the lookup table: that value is not included in the count.
-		 * When not using the lookup table: the value is included in the count since it is part of the parent product.
-		 */
-		if ( $using_lookup_table && 'or' === $filter_type && array( 'Green' ) === $attributes ) {
-			$expected_to_be_included_in_count = false;
-		} else {
-			$expected_to_be_included_in_count = 'or' === $filter_type || $expected_to_be_visible;
-		}
+		$expected_to_be_included_in_count = 'or' === $filter_type || $expected_to_be_visible;
 
 		$this->assert_counters( 'Color', $expected_to_be_included_in_count ? array( 'Blue', 'Red' ) : array(), $filter_type );
 	}
@@ -822,16 +813,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			$this->assertEmpty( $filtered_product_ids );
 		}
 
-		/*
-		 * If a variable product defines an attribute value that isn't used by any variation:
-		 * When using the lookup table: that value is not included in the count.
-		 * When not using the lookup table: the value is included in the count since it is part of the parent product.
-		 */
-		if ( $using_lookup_table && 'or' === $filter_type && array( 'Elastic' ) === $attributes ) {
-			$expected_to_be_included_in_count = false;
-		} else {
-			$expected_to_be_included_in_count = 'or' === $filter_type || $expected_to_be_visible;
-		}
+		$expected_to_be_included_in_count = 'or' === $filter_type || $expected_to_be_visible;
 		$this->assert_counters( 'Features', $expected_to_be_included_in_count ? array( 'Washable', 'Ironable' ) : array(), $filter_type );
 	}
 
@@ -1075,16 +1057,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			$this->assertEmpty( $filtered_product_ids );
 		}
 
-		/*
-		 * If a variable product defines an attribute value that isn't used by any variation:
-		 * When using the lookup table: that value is not included in the count.
-		 * When not using the lookup table: the value is included in the count since it is part of the parent product.
-		 */
-		if ( $using_lookup_table && 'or' === $filter_type && array( 'Green' ) === $attributes ) {
-			$expected_counted_attributes = array();
-		} else {
-			$expected_counted_attributes = 'or' === $filter_type || $expected_to_be_visible ? array( 'Blue', 'Red' ) : array();
-		}
+		$expected_counted_attributes = 'or' === $filter_type || $expected_to_be_visible ? array( 'Blue', 'Red' ) : array();
 
 		$this->assert_counters( 'Color', $expected_counted_attributes, $filter_type );
 	}
@@ -1208,16 +1181,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			$this->assertEmpty( $filtered_product_ids );
 		}
 
-		/*
-		 * If a variable product defines an attribute value that isn't used by any variation:
-		 * When using the lookup table: that value is not included in the count.
-		 * When not using the lookup table: the value is included in the count since it is part of the parent product.
-		 */
-		if ( $using_lookup_table && 'or' === $filter_type && array( 'White' ) === $attributes ) {
-			$expected_to_be_included_in_count = false;
-		} else {
-			$expected_to_be_included_in_count = 'or' === $filter_type || $expected_to_be_visible;
-		}
+		$expected_to_be_included_in_count = 'or' === $filter_type || $expected_to_be_visible;
 
 		$this->assert_counters( 'Color', $expected_to_be_included_in_count ? array( 'Blue', 'Red', 'Green' ) : array(), $filter_type );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -1356,9 +1356,12 @@ class FiltererTest extends \WC_Unit_Test_Case {
 		wp_set_object_terms( $product_simple_1->get_id(), $terms, 'product_visibility' );
 		wp_set_object_terms( $product_variable_1['id'], $terms, 'product_visibility' );
 
-		$filtered_product_ids = $this->do_product_request( array() );
+		$actual_filtered_product_ids   = $this->do_product_request( array() );
+		$expected_filtered_product_ids = array( $product_simple_2->get_id(), $product_variable_2['id'] );
+		sort( $actual_filtered_product_ids );
+		sort( $expected_filtered_product_ids );
 
-		$this->assertEquals( array( $product_simple_2->get_id(), $product_variable_2['id'] ), $filtered_product_ids );
+		$this->assertEquals( $expected_filtered_product_ids, $actual_filtered_product_ids );
 
 		$this->assert_counters( 'Color', $expected_colors_included_in_counters );
 		$this->assert_counters( 'Features', array( 'Ironable' ) );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Testing\Tools\FakeQueue;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
-use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 
 /**
  * Tests for the LookupDataStore class.
@@ -36,7 +35,6 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 	 */
 	public static function tearDownAfterClass() {
 		parent::tearDownAfterClass();
-		wc_get_container()->get( DataRegenerator::class )->delete_all_attributes_lookup_data();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Until now the product attributes lookup table had to be created and its usage had to be activated manually, via the tools page. This pull request does the following changes:

1. Remove the tools to create and delete the table (but keep the tool to regenerate the table data for one or for all the products).

2. Add a data migration that triggers the table creation and filling (unless the table already existed, in this case nothing happens).

3. After the migration finishes, activate the table usage for product filtering (site admin can still disable it via _Settings - Products - Advanced_); again, if the table already existed, nothing happens (the setting is unchanged). The setting will be left disabled if the regeneration is abored manually (see below).

Additionally, the following has been added in order to help in the migration process:

1. A new filter, `woocommerce_attribute_lookup_regeneration_step_size`, that allows to alter the batch size for the process (the number of products that will be processed each time that Action Scheduler runs one migration step). This filter is run on every step, thus it can be used to alter the batch size even if the regeneration process has been already started.

2. If the regeneration process is aborted manually (by deleting the `woocommerce_attribute_lookup_regeneration_in_progress` option), the _Products - Advanced_ settings section will still allow to enable the lookup table usage, but will display a warning discouraging to do so because the lookup table will be in an inconsistent state. The warning is shown when the `woocommerce_attribute_lookup_regeneration_aborted` option exists, and the option is deleted when the table regeneration is triggered again via the tools page.

![image](https://user-images.githubusercontent.com/937723/149765098-830d9792-e6b1-46e0-b9fa-6158a934c557.png)


Closes #30564.
Closes #30565.

### How to test the changes in this Pull Request:

1. If you had tested the product attributes lookup table mechanism already and the table still exists in your db, delete it from _Status - Tools - Delete the product attributes lookup table_ (you need to do this from `trunk`).

2. Switch to the branch of this pull request and go to _Status - Tools_. You shouldn't see any entry related to the product attributes lookup table.

3. Trigger the WooCommerce db update from the update available warning in the admin area.

3. After the update finishes you'll see that the old tools page entry "Regenerate the product attributes lookup table" is back. If you have a lot of products in your db the "Regenerate" button will be disabled and will show a counter of processed products, this means that the table regeneration is still in progress.

4. Once the table filling is complete the "Regenerate" product should appear as enabled. After that has happened go to _Settings - Products - Advanced_ and verify that "Enable table usage" is set.

5. Verify that the feature still works as expected (enabling and disabling the table usage via settings, regenerating the table from tools page for one product or for all products).

Now, to test the case of a db update when the table already exists:

6. Disable the table usage via settings.

7. Run the following in command line: `wp option set woocommerce_db_version 6.0.0`

8. Trigger the db update from the banner again, this time nothing related to the lookup table happens (the "Regenerate" tool has its button enabled right after the db update finishes).

9. Verify that the table usage is still disabled in settings.

To test the new filter:

10. Add the following somewhere (e.g. at the end of `woocommerce.php`):

```php
add_filter('woocommerce_attribute_lookup_regeneration_step_size', function() {
	return 5;
});
```

Verify that the regeneration happens now in increments of five products (hint: use `wp option get woocommerce_attribute_lookup_processed_count` to easily get the count of products already processed). If you change the value mid-regeneration you should see that the new value is used from the following regeneration step.

To test the new warning message:

11. Abort an already started regeneration by running `wp option delete woocommerce_attribute_lookup_regeneration_in_progress`.

12. Verify that the _Products - Advanced_ settings page now shows the warning (you may need to reload a couple of times to give Action Scheduler a chance to run one last time).

13. Start a new regeneration process, let it finish, and verify that the warning has disappeared.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Data migration to create and activate the product attributes lookup table.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
