### PR TITLE
Send set password link instead of the actual password to new users.

### DIFF
--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -115,7 +115,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 			}
 
 			if ( $this->is_enabled() && $this->get_recipient() ) {
-				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments(), $this->set_password_url );
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 			}
 
 			$this->restore_locale();

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-new-account.php
@@ -52,6 +52,13 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		public $password_generated;
 
 		/**
+		 * Magic link to set initial password.
+		 *
+		 * @var string
+		 */
+		public $set_password_url;
+
+		/**
 		 * Constructor.
 		 */
 		public function __construct() {
@@ -104,10 +111,11 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 				$this->user_email         = stripslashes( $this->object->user_email );
 				$this->recipient          = $this->user_email;
 				$this->password_generated = $password_generated;
+				$this->set_password_url   = $this->generate_set_password_url();
 			}
 
 			if ( $this->is_enabled() && $this->get_recipient() ) {
-				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+				$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments(), $this->set_password_url );
 			}
 
 			$this->restore_locale();
@@ -131,6 +139,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 					'sent_to_admin'      => false,
 					'plain_text'         => false,
 					'email'              => $this,
+					'set_password_url'   => $this->set_password_url,
 				)
 			);
 		}
@@ -153,6 +162,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 					'sent_to_admin'      => false,
 					'plain_text'         => true,
 					'email'              => $this,
+					'set_password_url'   => $this->set_password_url,
 				)
 			);
 		}
@@ -166,6 +176,26 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		public function get_default_additional_content() {
 			return __( 'We look forward to seeing you soon.', 'woocommerce' );
 		}
+
+		/**
+		 * Generate set password URL link for a new user.
+		 * 
+		 * See also Automattic\WooCommerce\Blocks\Domain\Services\Email\CustomerNewAccount and wp_new_user_notification.
+		 * 
+		 * @since 6.0.0
+		 * @return string
+		 */
+		protected function generate_set_password_url() {
+			// Generate a magic link so user can set initial password.
+			$key = get_password_reset_key( $this->object );
+			if ( ! is_wp_error( $key ) ) {
+				$action                 = 'newaccount';
+				return wc_get_account_endpoint_url( 'lost-password' ) . "?action=$action&key=$key&login=" . rawurlencode( $this->object->user_login );
+			} else {
+				// Something went wrong while getting the key for new password URL, send customer to the generic password reset.
+				return wc_get_account_endpoint_url( 'lost-password' );
+			}
+		} 
 	}
 
 endif;

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -23,9 +23,9 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
 <?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
 <p><?php printf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
-<?php if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) : ?>
-	<?php /* translators: %s: Auto generated password */ ?>
-	<p><?php printf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), '<strong>' . esc_html( $user_pass ) . '</strong>' ); ?></p>
+<?php if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated && $set_password_url ) : ?>
+	<?php // If the password has not been set by the user during the sign up process, send them a link to set a new password ?>
+	<p><a href="<?php echo esc_attr( $set_password_url ); ?>"><?php printf( esc_html__( 'Click here to set your new password.', 'woocommerce' ) ); ?></a></p>
 <?php endif; ?>
 
 <?php

--- a/plugins/woocommerce/templates/emails/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 3.7.0
+ * @version 6.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account.php
@@ -26,9 +26,11 @@ echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) .
 /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
 echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), esc_html( $user_login ), esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 
-if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) {
-	/* translators: %s: Auto generated password */
-	echo sprintf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), esc_html( $user_pass ) ) . "\n\n";
+// Only send the set new password link if the user hasn't set their password during sign-up.
+if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated && $set_password_url ) {
+	/* translators: URL follows */
+	echo esc_html__( 'To set your password, visit the following address: ', 'woocommerce' ) . "\n\n";
+	echo esc_html( $set_password_url ) . "\n\n";
 }
 
 echo "\n\n----------------------------------------\n\n";

--- a/plugins/woocommerce/templates/emails/plain/customer-new-account.php
+++ b/plugins/woocommerce/templates/emails/plain/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 3.7.0
+ * @version 6.0.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -96,7 +96,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 			<?php else : ?>
 
-				<p><?php esc_html_e( 'A password will be sent to your email address.', 'woocommerce' ); ?></p>
+				<p><?php esc_html_e( 'A link to set a new password will be sent to your email address.', 'woocommerce' ); ?></p>
 
 			<?php endif; ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31035.

### How to test the changes in this Pull Request:

1. Set up a new WC store, use this PR.
2. Go to Woo > Settings > Accounts & Privacy and enable `Allow customers to create an account during checkout`
and `Allow customers to create an account on the "My account" page` while letting WC generate username and password.
3. Add a product and enable one payment gw.
4. Go through the checkout and enable the checkbox to create a new user account.
5. Verify the email receives a link to set a new password instead of the password itself. 
6. Check that you can set the password and log in with it.
7. Try to register/create the user account from My Account page. 
8. Repeat steps 5 & 6
9. Go to Woo > Settings > Accounts & Privacy and disable creating of the new password automatically.
10. Create a new user account through checkout. 
11. Check that the email doesn't contain the link to set a new password.
12. Create a new user account through My Account page.
13. Check that the email doesn't contain the link to set a new password. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add set password link to emails when creating new user account.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
