### PR TITLE
Add missing run command

### DIFF
--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -74,6 +74,7 @@ jobs:
           path: package/woocommerce
 
       - name: Install PNPM and install dependencies
+        working-directory: package/woocommerce
         run: |
             npm install -g pnpm
             pnpm install

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -73,10 +73,10 @@ jobs:
         with:
           path: package/woocommerce
 
-      - name: Run npm install.
-        working-directory: package/woocommerce/plugins/woocommerce
-          npm install -g pnpm
-          pnpm install
+      - name: Install PNPM and install dependencies
+        run: |
+            npm install -g pnpm
+            pnpm install
 
       - name: Load docker images and start containers.
         working-directory: package/woocommerce/plugins/woocommerce


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Found this issue https://github.com/woocommerce/woocommerce/actions/runs/1490554164 It was missing a `run` command.

### How to test the changes in this Pull Request:

1. We probably need to merge to see if the fix worked.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
