### PR TITLE
Bump Woo Admin package to 2.9-rc.3

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.3.0",
-		"woocommerce/woocommerce-admin": "2.9.0-rc.2",
+		"woocommerce/woocommerce-admin": "2.9.0-rc.3",
 		"woocommerce/woocommerce-blocks": "6.3.2"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83379234b653f45a89537a0bb470eb69",
+    "content-hash": "d0cd349b4354a60a0d71cf9e94ee4b57",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -542,16 +542,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.9.0-rc.2",
+            "version": "2.9.0-rc.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "6c81e761d9a19e6ed4484db82d6710331f375a3a"
+                "reference": "eba64a4f38284f982e08433b3b6371823fcef48c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/6c81e761d9a19e6ed4484db82d6710331f375a3a",
-                "reference": "6c81e761d9a19e6ed4484db82d6710331f375a3a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/eba64a4f38284f982e08433b3b6371823fcef48c",
+                "reference": "eba64a4f38284f982e08433b3b6371823fcef48c",
                 "shasum": ""
             },
             "require": {
@@ -607,9 +607,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.0-rc.2"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.0-rc.3"
             },
-            "time": "2021-11-18T08:35:56+00:00"
+            "time": "2021-11-24T03:52:01+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2278,6 +2278,7 @@
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
                 "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
             },
+            "abandoned": true,
             "time": "2015-07-28T20:34:47+00:00"
         },
         {
@@ -2853,16 +2854,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
-                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
                 "shasum": ""
             },
             "require": {
@@ -2910,7 +2911,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-10-03T08:40:26+00:00"
+            "time": "2021-11-23T01:37:03+00:00"
         }
     ],
     "aliases": [],
@@ -2925,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.9.0-rc.3

## Testing Instructions

Note that this release contains an ExPlat Experiment on the Task List. You may randomly be selected to view an updated Task List UI.

## New Feature Tests

### Only load default tasks during REST requests #7904

**Smoke testing**

1. Make sure the task lists and all tasks are returned as expected
2. Go to Products->Help (tab)->Setup Wizard
3. Attempt to Disable/Enable the task lists and make sure these actions work as expected
4. Smoke test the task list, viewing, snoozing, dismissing, and undoing those actions

**Performance testing**

1. Create a site with 1k+ products using WC Smooth Generator
2. Install the Query Monitor plugin - https://wordpress.org/plugins/query-monitor/
3. Sort "Queries" by time to load
4. Navigate to a core WC page (like Orders or Products)
5. Note the highest is not stemming from the order counts query in the task list

### Add Avalara to tax task #7874

**Avalara supported, WooCommerce Tax supported**

1. Select an Avalara and WC Tax supported country (e.g., `US`) for your store's country
2. Visit the tax task.
3. Make sure your shown the "WooCommerce Tax" and "Avalara" options in the task list

**Avalara supported, WooCommerce Tax not supported**

1. Install the TaxJar plugin so that WC Tax is not supported and set your country to an Avalara supported country
2. Visit the task tax.
3. Make sure you are shown only the partner card of Avalara

**Avalara not supported, WooCommerce Tax not supported**

1. Set your store country to one not supported by Avalara or WC Tax (e.g., New Caledonia)
2. Visit the task tax.
3. Make sure you are immediately shown the manual set up flow with the "Configure" button

**Partner actions**
1. Visit the task tax with an Avalara supported country
2. Click Avalara and check that a new tab opens with the WCCOM plugin page
3. Back on the task tax, click on WooCommerce Tax
4. Make sure you are dropped into the old configuration flow (which should be identical to the old flow)

**Events**
1. Enter `localStorage.setItem( 'debug', 'wc-admin:*' );` in your browser's console
2. Set your store's country to an Avalara supported country
3. Note the `wcadmin_tasklist_tax_view_options` event occurs
4. Click on each of the partner action buttons
5. Make sure that `wcadmin_tasklist_tax_select_option` is recorded with the respective `selected_option` partner key.

**Completion**
1. Create a fresh site without ever having set any taxes
2. Note the task is incomplete
3. Install the WC Avalara plugin
4. Check that the task is now marked complete


## Changelog

```
- Dev: Remove task status endpoint #7841
- Fix: Fix ordering and styling issue with WooCommerce Payments payment method promotion. #7943
- Fix: Fix ExPlat PHP client #7926
- Fix: Fix marketing extensions tracks #7908
- Update: Increased number of possible items in Recommended Extensions list from 6 to 9 #7887
- Update: Reverts addition of Marketplace and My Subscriptions pages to the Marketplace menu. #7902
- Update: Add marketing extensions back to onboarding wizard #7831
- Update: Add profile notes. #7861
- Update: Change CTA text for personalize store task after completion #7852
- Update: Refactor data source poller for re-usability. #7671
- Update: Update WC Pay card to include in-person information #7830
- Update: Updating navigation link colors #7833
- Tweak: Use page title Extensions for Marketplace and My Subscriptions pages. #7901
- Tweak: Remove the Spinner component to prevent undesired page flickering. #7886
- Tweak: Add route and layout for unmatched path #7503
- Tweak: Avoid caching extended info #7819
- Tweak: Minor design update for Marketing task. #7732
- Fix: Do not clear `current` class from the entire page when updating wp-admin's menu. #7773
- Fix: Fix calendar not being dismissed when clicking outside. #7714
- Fix: fixed warnings when using AdvancedFilters component. #7704
- Fix: Fix Tasklist UI illustrations styling #7858
- Fix: Revert experiment task titles back to original #7853
- Add: Add Avalara to tax task #7874
- Add: Add 2col expirement. #7872
- Add: Added two column experimental task list #7669
- Add: Add header cards for all tasks in Tasklist UI experiment #7838
- Add: Add onboarding task docs #7762
- Dev: Add method to check for install status #7808
- Dev: Refactor tax task into separate components
- Dev: Update the task list to use the new task list REST API #7736
- Performance: Only load default tasks during REST requests #7904
 ```
