### PR TITLE
[PHP 8.1] Add ReturnTypeWillChange attribute to classes implementing ArrayAccess

### DIFF
--- a/plugins/woocommerce/includes/class-wc-customer-download.php
+++ b/plugins/woocommerce/includes/class-wc-customer-download.php
@@ -311,14 +311,15 @@ downloads_remaining = IF( downloads_remaining = '', '', GREATEST( 0, downloads_r
 WHERE permission_id = %d",
 			$this->get_id()
 		);
-		$wpdb->query( $query ); // WPCS: unprepared SQL ok.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $query );
 
 		// Re-read this download from the data store to pull updated counts.
 		$this->data_store->read( $this );
 
 		// Track download in download log.
 		$download_log = new WC_Customer_Download_Log();
-		$download_log->set_timestamp( current_time( 'timestamp', true ) );
+		$download_log->set_timestamp( time() );
 		$download_log->set_permission_id( $this->get_id() );
 
 		if ( ! is_null( $user_id ) ) {
@@ -341,9 +342,10 @@ WHERE permission_id = %d",
 	/**
 	 * OffsetGet.
 	 *
-	 * @param string $offset Offset.
+	 * @param mixed $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( is_callable( array( $this, "get_$offset" ) ) ) {
 			return $this->{"get_$offset"}();
@@ -353,9 +355,10 @@ WHERE permission_id = %d",
 	/**
 	 * OffsetSet.
 	 *
-	 * @param string $offset Offset.
-	 * @param mixed  $value  Value.
+	 * @param mixed $offset Offset.
+	 * @param mixed $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		if ( is_callable( array( $this, "set_$offset" ) ) ) {
 			$this->{"set_$offset"}( $value );
@@ -365,8 +368,9 @@ WHERE permission_id = %d",
 	/**
 	 * OffsetUnset
 	 *
-	 * @param string $offset Offset.
+	 * @param mixed $offset Offset.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 		if ( is_callable( array( $this, "set_$offset" ) ) ) {
 			$this->{"set_$offset"}( '' );
@@ -376,9 +380,10 @@ WHERE permission_id = %d",
 	/**
 	 * OffsetExists.
 	 *
-	 * @param string $offset Offset.
+	 * @param mixed $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return in_array( $offset, array_keys( $this->data ), true );
 	}

--- a/plugins/woocommerce/includes/class-wc-order-item-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-coupon.php
@@ -140,6 +140,7 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		wc_deprecated_function( 'WC_Order_Item_Coupon::offsetGet', '4.4.0', '' );
 		if ( 'discount_amount' === $offset ) {
@@ -157,6 +158,7 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		wc_deprecated_function( 'WC_Order_Item_Coupon::offsetSet', '4.4.0', '' );
 		if ( 'discount_amount' === $offset ) {
@@ -173,6 +175,7 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		if ( in_array( $offset, array( 'discount_amount', 'discount_amount_tax' ), true ) ) {
 			return true;

--- a/plugins/woocommerce/includes/class-wc-order-item-fee.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-fee.php
@@ -293,6 +293,7 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( 'line_total' === $offset ) {
 			$offset = 'total';
@@ -311,6 +312,7 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		wc_deprecated_function( 'WC_Order_Item_Fee::offsetSet', '4.4.0', '' );
 		if ( 'line_total' === $offset ) {
@@ -329,6 +331,7 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		if ( in_array( $offset, array( 'line_total', 'line_tax', 'line_tax_data' ), true ) ) {
 			return true;

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -428,6 +428,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( 'line_subtotal' === $offset ) {
 			$offset = 'subtotal';
@@ -452,6 +453,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		wc_deprecated_function( 'WC_Order_Item_Product::offsetSet', '4.4.0', '' );
 		if ( 'line_subtotal' === $offset ) {
@@ -476,6 +478,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		if ( in_array( $offset, array( 'line_subtotal', 'line_subtotal_tax', 'line_total', 'line_tax', 'line_tax_data', 'item_meta_array', 'item_meta', 'qty' ), true ) ) {
 			return true;

--- a/plugins/woocommerce/includes/class-wc-order-item-shipping.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-shipping.php
@@ -279,6 +279,7 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	 * @param string $offset Key.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( 'cost' === $offset ) {
 			$offset = 'total';
@@ -293,6 +294,7 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	 * @param string $offset Key.
 	 * @param mixed  $value Value to set.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetSet', '4.4.0', '' );
 		if ( 'cost' === $offset ) {
@@ -307,6 +309,7 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	 * @param string $offset Key.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		if ( in_array( $offset, array( 'cost' ), true ) ) {
 			return true;

--- a/plugins/woocommerce/includes/class-wc-order-item-tax.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-tax.php
@@ -247,6 +247,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		if ( 'tax_amount' === $offset ) {
 			$offset = 'tax_total';
@@ -263,6 +264,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		wc_deprecated_function( 'WC_Order_Item_Tax::offsetSet', '4.4.0', '' );
 		if ( 'tax_amount' === $offset ) {
@@ -279,6 +281,7 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		if ( in_array( $offset, array( 'tax_amount', 'shipping_tax_amount' ), true ) ) {
 			return true;

--- a/plugins/woocommerce/includes/class-wc-order-item.php
+++ b/plugins/woocommerce/includes/class-wc-order-item.php
@@ -310,6 +310,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		if ( 'item_meta_array' === $offset ) {
 			foreach ( $value as $meta_id => $meta ) {
@@ -334,6 +335,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 *
 	 * @param string $offset Offset.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 		$this->maybe_read_meta_data();
 
@@ -359,6 +361,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		$this->maybe_read_meta_data();
 		if ( 'item_meta_array' === $offset || 'item_meta' === $offset || array_key_exists( $offset, $this->data ) ) {
@@ -373,6 +376,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		$this->maybe_read_meta_data();
 

--- a/plugins/woocommerce/includes/class-wc-product-attribute.php
+++ b/plugins/woocommerce/includes/class-wc-product-attribute.php
@@ -266,6 +266,7 @@ class WC_Product_Attribute implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		switch ( $offset ) {
 			case 'is_variation':
@@ -291,6 +292,7 @@ class WC_Product_Attribute implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		switch ( $offset ) {
 			case 'is_variation':
@@ -304,7 +306,7 @@ class WC_Product_Attribute implements ArrayAccess {
 				break;
 			default:
 				if ( is_callable( array( $this, "set_$offset" ) ) ) {
-					return $this->{"set_$offset"}( $value );
+					$this->{"set_$offset"}( $value );
 				}
 				break;
 		}
@@ -315,6 +317,7 @@ class WC_Product_Attribute implements ArrayAccess {
 	 *
 	 * @param string $offset Offset.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {}
 
 	/**
@@ -323,6 +326,7 @@ class WC_Product_Attribute implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return in_array( $offset, array_merge( array( 'is_variation', 'is_visible', 'is_taxonomy', 'value' ), array_keys( $this->data ) ), true );
 	}

--- a/plugins/woocommerce/includes/class-wc-product-download.php
+++ b/plugins/woocommerce/includes/class-wc-product-download.php
@@ -53,14 +53,14 @@ class WC_Product_Download implements ArrayAccess {
 	 * @return string absolute, relative, or shortcode.
 	 */
 	public function get_type_of_file_path( $file_path = '' ) {
-		$file_path = $file_path ? $file_path : $this->get_file();
-		$parsed_url = parse_url( $file_path );
+		$file_path  = $file_path ? $file_path : $this->get_file();
+		$parsed_url = wp_parse_url( $file_path );
 		if (
 			$parsed_url &&
 			isset( $parsed_url['host'] ) && // Absolute url means that it has a host.
 			( // Theoretically we could permit any scheme (like ftp as well), but that has not been the case before. So we allow none or http(s).
 				! isset( $parsed_url['scheme'] ) ||
-				in_array( $parsed_url['scheme'], array( 'http', 'https' ) )
+				in_array( $parsed_url['scheme'], array( 'http', 'https' ), true )
 			)
 		) {
 			return 'absolute';
@@ -255,6 +255,7 @@ class WC_Product_Download implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		switch ( $offset ) {
 			default:
@@ -272,11 +273,12 @@ class WC_Product_Download implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @param mixed  $value Offset value.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		switch ( $offset ) {
 			default:
 				if ( is_callable( array( $this, "set_$offset" ) ) ) {
-					return $this->{"set_$offset"}( $value );
+					$this->{"set_$offset"}( $value );
 				}
 				break;
 		}
@@ -287,6 +289,7 @@ class WC_Product_Download implements ArrayAccess {
 	 *
 	 * @param string $offset Offset.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {}
 
 	/**
@@ -295,6 +298,7 @@ class WC_Product_Download implements ArrayAccess {
 	 * @param string $offset Offset.
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return in_array( $offset, array_keys( $this->data ), true );
 	}

--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -96,7 +96,7 @@ To workaround this, the testing strategy used by WooCommerce is as follows:
 * We normally use PHPUnit 6.5.14
 * For PHP 8 we use [a custom fork of PHPUnit 7.5.20 with support for PHP 8](https://github.com/woocommerce/phpunit/pull/1). WooCommerce's GitHub Actions CI workflow is configured to use this fork instead of the old version 6 when running in PHP 8.
 
-If you want to run the tests locally under PHP 8 you'll need to temporarily modify `composer.json` to use the custom PHPUnit fork in the same way that the GitHub Actions CI workflow file does. These are the commands that you'll need (run them after a regular `composer install`):
+If you want to run the tests locally under PHP 8 you'll need to temporarily modify `composer.json` to use the custom PHPUnit fork in the same way that the GitHub Actions CI workflow file does. These are the commands that you'll need (run them after a regular `composer install` from within the `plugins/woocommerce` directory):
 
 ```shell
 curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
@@ -104,6 +104,8 @@ unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
 composer bin phpunit config --unset platform
 composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
 composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
+rm -rf ./vendor/phpunit/
+composer dump-autoload
 ```
 
 Just remember that you can't include the modified `composer.json` in any commit!


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

PHP 7.x and 8.1 will throw a fatal error, thus causing the unit tests suite to abruptly end, if a method from an implemented interface doesn't fully match the signature as defined in the interface. In WooCommerce that's the case for the classes that implement `ArrayAccess`: in PHP 8.0+ these signatures have type hints and return types (as in `offsetUnset( mixed $offset ):void` ) but the code in WooCommerce doesn't. We can't just add the missing types to the signatures because then the same error appears in PHP 7.x, in which there aren't types in the method signatures of ArrayAccess.

The fix consists of adding [the `ReturnTypeWillChange` attribute](https://php.watch/versions/8.1/ReturnTypeWillChange), introduced in PHP 8.1, which instructs the runtime to not throw the error. PHP 7.x doesn't support attributes, but in this case the attribute declaration is seen as a comment.

In `class-wc-product-attribute.php` and `class-wc-product-download.php`, additionally, the `offsetSet` method was returning a value; this was causing an error too, since the method signature has return type `void`. In this case the `return` statement has simple been removed, since the returned value wasn't being used anywhere.

These changes are enough for the unit tests to _run_ but not to _pass_, additional work will be required to fix all the existing errors and test failures.

Additionally, fix the README file in the `tests` directory as the instructions for testing in PHP 8.0 were incomplete.

### How to test the changes in this Pull Request:

1. Verify that all the unit tests pass in PHP 7.x.
2. Perform [the steps needed to run unit tests in PHP 8](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/pr-unit-tests.yml#L68-L74).
3. Switch to PHP 8.0 and verify that all the unit tests still pass.
4. Switch to PHP 8.1 and verify that all the unit tests run, even though a lot of error and failures are thrown.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak - Add ReturnTypeWillChange attributes to prevent errors in PHP 8.1.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
