### PR TITLE
Added WP Admin page load tests

### DIFF
--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-woocommerce-page-loads.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-woocommerce-page-loads.test.js
@@ -1,0 +1,25 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/**
+ * Internal dependencies
+ */
+const {
+	merchant,
+	waitForSelectorWithoutThrow,
+} = require( '@woocommerce/e2e-utils' );
+
+/**
+ * External dependencies
+ */
+const {
+	it,
+	describe,
+	beforeAll,
+} = require( '@jest/globals' );
+
+const runWooCommercePageLoadTest = () => {
+	describe( ' WooCommerce > Opening Top Level Pages', () => {
+
+	});
+};
+
+module.exports = runWooCommercePageLoadTest;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the `runAdminWcPageTests` test that clicks links in the sidebar for various top-level menu items and verifies that pages load.

Closes #29319.

### How to test the changes in this Pull Request:
1. Run the following commands.
```
$ cd plugins/woocommerce
$ pnpm install
$ pnpx wc-e2e docker:up
$ pnpx wc-e2e test:e2e
```

2. All tests should pass.
### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
