### PR TITLE
Allow auto-draft in API orders

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -545,12 +545,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		// If setting the status, ensure it's set to a valid status.
 		if ( true === $this->object_read ) {
 			// Only allow valid new status.
-			if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses(), true ) && 'trash' !== $new_status ) {
+			if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses(), true ) && 'trash' !== $new_status && 'auto-draft' !== $new_status ) {
 				$new_status = 'pending';
 			}
 
 			// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && 'trash' !== $old_status ) {
+			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && 'trash' !== $old_status && 'auto-draft' !== $new_status ) {
 				$old_status = 'pending';
 			}
 		}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -550,7 +550,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 
 			// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && 'trash' !== $old_status && 'auto-draft' !== $new_status ) {
+			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && 'trash' !== $old_status ) {
 				$old_status = 'pending';
 			}
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -924,7 +924,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function get_order_statuses() {
-		$order_statuses = array();
+		$order_statuses = array( 'auto-draft' );
 
 		foreach ( array_keys( wc_get_order_statuses() ) as $status ) {
 			$order_statuses[] = str_replace( 'wc-', '', $status );


### PR DESCRIPTION
For some operations in the API, like calculating taxes or shipping, it's
helpful to be able to have an order saved in the database. Having an
order object with an ID lets us perform other API actions on that order.
However, we also don't necessarily want these to show up on certain
screens.

Here we adopt the auto-draft status from core WordPress as a way to save
an order as a discrete object while signalling that it's not ready to
action yet.

Suggestions:

* auto-draft might not make sense given that it's used in core. We might
  want to use something like `draft` instead.
* We may want to track this separate set of statuses (trash, auto-draft)
  in a more official way, so we don't have to copy/paste around the
  codebase.