### PR TITLE
The woocommerce_webhook_options needs webhook

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/views/html-webhooks-edit.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-webhooks-edit.php
@@ -152,7 +152,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</tbody>
 	</table>
 
-	<?php do_action( 'woocommerce_webhook_options', $webhook ); ?>
+	<?php
+	/**
+	 * Fires within the webhook editor, after the Webhook Data fields have rendered.
+	 *
+	 * @param WC_Webhook $webhook
+	 */
+	do_action( 'woocommerce_webhook_options', $webhook ); 
+	?>
 </div>
 
 <div id="webhook-actions" class="settings-panel">

--- a/plugins/woocommerce/includes/admin/settings/views/html-webhooks-edit.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-webhooks-edit.php
@@ -158,7 +158,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 *
 	 * @param WC_Webhook $webhook
 	 */
-	do_action( 'woocommerce_webhook_options', $webhook ); 
+	do_action( 'woocommerce_webhook_options', $webhook );
 	?>
 </div>
 

--- a/plugins/woocommerce/includes/admin/settings/views/html-webhooks-edit.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-webhooks-edit.php
@@ -152,7 +152,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</tbody>
 	</table>
 
-	<?php do_action( 'woocommerce_webhook_options' ); ?>
+	<?php do_action( 'woocommerce_webhook_options', $webhook ); ?>
 </div>
 
 <div id="webhook-actions" class="settings-panel">


### PR DESCRIPTION
The action for adding extra webhook options should pass in the webhook so that those that are extending the webhooks page can know which webhook is being edited.

This is the very first time that I am contributing to woocommerce, so I'm probably doing something the wrong way. I would appreciate guidance on what is required to get this merged in. Cheers!

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In this pull request I attempt to make the woocommerce_webhook_options action be useful by passing in the $webhook to consumers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Make the `$webhook` object available to consumers of the `woocommerce_webhook_options` action.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
