### PR TITLE
Update WooCommerce Blocks to 6.3.3

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -22,7 +22,7 @@
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
 		"woocommerce/woocommerce-admin": "2.9.0",
-		"woocommerce/woocommerce-blocks": "6.3.2"
+		"woocommerce/woocommerce-blocks": "6.3.3"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf8d5f87950178b9cb2f7f261f891798",
+    "content-hash": "ec7987721f51ed5c0faf6251128ba110",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -581,16 +581,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v6.3.2",
+            "version": "v6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "5b3aea9adb718a1f78525881e4f0c33c72ba175d"
+                "reference": "38975ad6de9c6a556059c4de6e9ffc586ab82245"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/5b3aea9adb718a1f78525881e4f0c33c72ba175d",
-                "reference": "5b3aea9adb718a1f78525881e4f0c33c72ba175d",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/38975ad6de9c6a556059c4de6e9ffc586ab82245",
+                "reference": "38975ad6de9c6a556059c4de6e9ffc586ab82245",
                 "shasum": ""
             },
             "require": {
@@ -627,7 +627,11 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2021-11-18T03:27:03+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v6.3.3"
+            },
+            "time": "2021-11-25T09:47:27+00:00"
         }
     ],
     "packages-dev": [
@@ -2744,5 +2748,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 6.3.3 and targets `trunk` but should land on the WooCommerce 6.0 release branch. It includes a fix to a fatal error in certan WP 5.9 pre-release versions (see https://github.com/woocommerce/woocommerce/issues/31284 and https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5236).

## Blocks 6.3.3
- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5243)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/633.md)
- Release post: not publicly announced

## Changelog entry

### Bug Fixes
- Fix fatal error in certain WP 5.9 pre-release versions. ([5183](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5183))