### PR TITLE
Update db table name to use the new convention.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1046,7 +1046,7 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	PRIMARY KEY  (`order_id`, `product_id`)
 ) $collate;
-CREATE TABLE {$wpdb->prefix}woocommerce_rate_limits (
+CREATE TABLE {$wpdb->prefix}wc_rate_limits (
   rate_limit_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   rate_limit_key varchar(200) NOT NULL,
   rate_limit_expiry BIGINT UNSIGNED NOT NULL,
@@ -1087,7 +1087,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_rate_limits (
 			"{$wpdb->prefix}woocommerce_tax_rate_locations",
 			"{$wpdb->prefix}woocommerce_tax_rates",
 			"{$wpdb->prefix}wc_reserved_stock",
-			"{$wpdb->prefix}woocommerce_rate_limits",
+			"{$wpdb->prefix}wc_rate_limits",
 		);
 
 		/**

--- a/plugins/woocommerce/includes/class-wc-rate-limiter.php
+++ b/plugins/woocommerce/includes/class-wc-rate-limiter.php
@@ -101,7 +101,7 @@ class WC_Rate_Limiter {
 				$wpdb->prepare(
 					"
 						SELECT rate_limit_expiry
-						FROM {$wpdb->prefix}woocommerce_rate_limits
+						FROM {$wpdb->prefix}wc_rate_limits
 						WHERE rate_limit_key = %s
 					",
 					$action_id
@@ -138,7 +138,7 @@ class WC_Rate_Limiter {
 		$next_try_allowed_at = time() + $delay;
 
 		$result = $wpdb->replace(
-			$wpdb->prefix . 'woocommerce_rate_limits',
+			$wpdb->prefix . 'wc_rate_limits',
 			array(
 				'rate_limit_key'    => $action_id,
 				'rate_limit_expiry' => $next_try_allowed_at,
@@ -159,7 +159,7 @@ class WC_Rate_Limiter {
 
 		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}woocommerce_rate_limits WHERE rate_limit_expiry < %d",
+				"DELETE FROM {$wpdb->prefix}wc_rate_limits WHERE rate_limit_expiry < %d",
 				time()
 			)
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-rate-limiter.php
@@ -93,7 +93,7 @@ class WC_Tests_Rate_Limiter extends WC_Unit_Test_Case {
 		wc_update_600_migrate_rate_limit_options();
 
 		// Ensure that only the _123 limit was migrated.
-		$migrated = $wpdb->get_col( "SELECT rate_limit_key FROM {$wpdb->prefix}woocommerce_rate_limits" );
+		$migrated = $wpdb->get_col( "SELECT rate_limit_key FROM {$wpdb->prefix}wc_rate_limits" );
 
 		$this->assertCount( 1, $migrated );
 		$this->assertEquals( 'add_payment_method_123', $migrated[0] );


### PR DESCRIPTION
Just renaming db table to use `wc_` prefix instead of the older and longer `woocommerce_`.