### PR TITLE
Make single page add-to-cart button class filterable

### DIFF
--- a/plugins/woocommerce/templates/single-product/add-to-cart/external.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/external.php
@@ -22,7 +22,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 <form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>
+	<button type="submit" class="<?php echo esc_attr( apply_filters( 'woocommerce_single_add_to_cart_button_class', 'single_add_to_cart_button button alt' ) ); ?>"><?php echo esc_html( $button_text ); ?></button>
 
 	<?php wc_query_string_form_fields( $product_url ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -116,7 +116,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-		<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" class="<?php echo esc_attr( apply_filters( 'woocommerce_single_add_to_cart_button_class', 'single_add_to_cart_button button alt' ) ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -46,7 +46,7 @@ if ( $product->is_in_stock() ) : ?>
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
-		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="<?php echo esc_attr( apply_filters( 'woocommerce_single_add_to_cart_button_class', 'single_add_to_cart_button button alt' ) ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 	</form>

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -28,7 +28,7 @@ global $product;
 	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>
 
-	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+	<button type="submit" class="<?php echo esc_attr( apply_filters( 'woocommerce_single_add_to_cart_button_class', 'single_add_to_cart_button button alt' ) ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Added a new filter `woocommerce_single_add_to_cart_button_class` in order to make the classes applied to the add-to-cart buttons on single product pages filterable.

Closes #31275 .

### How to test the changes in this Pull Request:

1.  Add a filter for `woocommerce_single_add_to_cart_button_class` and return something different from the default
2.  Verify frontend code has been updated on single product page for different product types (external, grouped, etc)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Make single page add-to-cart button class filterable


### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
