### PR TITLE
Fix PHP Fatal error in Changelogger Formatter class

### DIFF
--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -140,15 +140,15 @@ class Formatter extends KeepAChangelogParser {
 			}
 
 			$version         = '';
-			$timestamp       = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-			$entry_timestamp = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			$timestamp       = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+			$entry_timestamp = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 
 			if ( count( $heading ) ) {
 				$version   = $heading[1];
 				$timestamp = $heading[2];
 
 				try {
-					$timestamp = new DateTime( $timestamp, new DateTimeZone( 'UTC' ) );
+					$timestamp = new \DateTime( $timestamp, new \DateTimeZone( 'UTC' ) );
 				} catch ( \Exception $ex ) {
 					throw new \InvalidArgumentException( "Heading has an invalid timestamp: $heading", 0, $ex );
 				}

--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -239,7 +239,6 @@ class Formatter extends KeepAChangelogParser {
 			$version      = $entry->getVersion();
 			$is_subentry  = preg_match( $this->subentry_pattern, $version, $subentry );
 			$timestamp    = $entry->getTimestamp();
-			error_log(print_r($version, true));
 			$release_link = $this->getReleaseLink( $version );
 
 			if ( $is_subentry ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I fixed some minor issues with the Formatter class:

1. Removed an [`error_log()`](https://github.com/woocommerce/woocommerce/commit/16b35ae2ab2bd7785d4658b783656ffb1a24e29c) function that seems like some debugging leftover.
2. Fixed the [global namespace of `DateTime` and `DateTimeZone`](https://github.com/woocommerce/woocommerce/commit/a8060e34d35b3fecbf648a16c9525e5a65ad0a82).

This last issue was causing a PHP Fatal error while running the `./vendor/bin/changelogger write` command:

```
PHP Fatal error:  Uncaught Error: Class 'Automattic\WooCommerce\MonorepoTools\Changelogger\DateTime' not found in ...wp-content/plugins/woocommerce/tools/changelogger/Formatter.php:143
```

### How to test the changes in this Pull Request:

1. Make sure all dependencies are available, `cd plugins/woocommerce && composer install`.
2. Add an arbitrary changelog entry `./vendor/bin/changelogger add `.
3. Now validate it `./vendor/bin/changelogger validate `.
4. Make sure the process exits without throwing an error.
5. Create a changelog entry with a fictitious version number `./vendor/bin/changelogger write --use-version 88.0`.
6. Check if returns any PHP fatal error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
