### PR TITLE
E2E test case for adding downloadable product to existing order under downloadable product permissions section.

### DIFF
--- a/packages/js/e2e-core-tests/specs/index.js
+++ b/packages/js/e2e-core-tests/specs/index.js
@@ -47,6 +47,7 @@ const runOrderSearchingTest = require( './merchant/wp-admin-order-searching.test
 const runAnalyticsPageLoadsTest = require( './merchant/wp-admin-analytics-page-loads.test' );
 const runImportProductsTest = require( './merchant/wp-admin-product-import-csv.test' );
 const runInitiateWccomConnectionTest = require( './merchant/wp-admin-extensions-connect-wccom.test' );
+const runAddDownloadableProductToOrderTest = require( './merchant/wp-admin-add-downloadable-product-to-order.test' );
 
 // REST API tests
 const runExternalProductAPITest = require( './api/external-product.test' );
@@ -103,6 +104,7 @@ const runMerchantTests = () => {
 	runMerchantOrdersCustomerPaymentPage();
 	runAnalyticsPageLoadsTest();
 	runInitiateWccomConnectionTest();
+	runAddDownloadableProductToOrderTest();
 }
 
 const runApiTests = () => {
@@ -166,4 +168,5 @@ module.exports = {
 	runOrderEmailReceivingTest,
 	runInitiateWccomConnectionTest,
 	runTelemetryAPITest,
+	runAddDownloadableProductToOrderTest,
 };

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-add-downloadable-product-to-order.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-add-downloadable-product-to-order.test.js
@@ -1,0 +1,287 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/**
+ * Internal dependencies
+ */
+
+const {
+	merchant,
+	clickTab,
+	verifyAndPublish,
+	backboneUnblocked,
+	utils,
+	withRestApi,
+} = require('@woocommerce/e2e-utils');
+const {
+	getTestConfig,
+} = require('@woocommerce/e2e-environment');
+
+
+const config = require('config');
+const virtualProductName1 = 'Virtual Product Name 1';
+const virtualProductName2 = 'Virtual Product Name 2';
+const virtualProductName3 = 'Virtual Product Name 3';
+const customerBillingAddress = 'customer1@gmail.com'
+const virtualProductPrice = config.has('products.simple.price') ? config.get('products.simple.price') : '9.99';
+const testConfig = getTestConfig();
+const downloadableFileName = 'Downloadable File 1'
+const downloadableFileUrl = testConfig.url + 'wp-content/uploads/2021/11/sample_products_override.csv'
+
+let orderId;
+let newOrderId;
+
+const openNewProductAndVerify = async () => {
+	// Go to "add product" page
+	await merchant.openNewProduct();
+
+	// Make sure we're on the add product page
+	await expect(page.title()).resolves.toMatch('Add new product');
+}
+
+const createNewProductWithoutDownloadableFile = async (productName, virtualProductPrice) => {
+	await openNewProductAndVerify();
+
+	// Set product data and publish the product
+	await expect(page).toFill('#title', productName);
+	await expect(page).toClick('#_virtual');
+	await clickTab('General');
+	await expect(page).toFill('#_regular_price', virtualProductPrice);
+	await expect(page).toClick('#_downloadable');
+	await verifyAndPublish();
+}
+
+const createNewProductWithDownloadableFile = async (productName, virtualProductPrice, downloadableFileName, downloadableFileUrl) => {
+	await openNewProductAndVerify();
+
+	// Set product data and publish the product
+	await expect(page).toFill('#title', productName);
+	await expect(page).toClick('#_virtual');
+	await clickTab('General');
+	await expect(page).toFill('#_regular_price', virtualProductPrice);
+	await expect(page).toClick('#_downloadable');
+	await expect(page).toClick('.downloadable_files>table>tfoot>tr>th>a')
+	await page.waitForSelector('.downloadable_files>table>tfoot>tr>th>a');
+	await expect(page).toFill('.file_name>input', downloadableFileName);
+	await expect(page).toFill('.file_url>input', downloadableFileUrl);
+	await verifyAndPublish();
+}
+
+const createNewOrderWithExistingProduct = async (productName, customerBillingAddress) => {
+
+	// Go to "add order" page
+	await merchant.openNewOrder();
+	// Make sure we're on the add order page
+	await expect(page.title()).resolves.toMatch('Add new order');
+
+	// Set product data and publish the product
+	await expect(page).toSelect('#order_status', 'Processing');
+	await utils.waitForTimeout(2000)
+	await expect(page).toClick('.order_data_column_container > div:nth-child(2) > h3 > a');
+	await page.waitForSelector('#_billing_email');
+	await expect(page).toFill('#_billing_email', customerBillingAddress);
+	await expect(page).toClick('button.add-line-item');
+	await expect(page).toClick('button.add-order-item');
+	await page.waitForSelector('.wc-backbone-modal-header');
+	await expect(page).toClick('.wc-backbone-modal-content .wc-product-search');
+	await expect(page).toFill('#wc-backbone-modal-dialog + .select2-container .select2-search__field', productName);
+	await page.waitForSelector('li[aria-selected="true"]', { timeout: 10000 });
+	await expect(page).toClick('li[aria-selected="true"]');
+	await page.click('.wc-backbone-modal-content #btn-ok');
+	await backboneUnblocked();
+	await expect(page).toClick('button.save_order');
+	await page.waitForSelector('#message');
+	//Verify
+	await expect(page).toMatchElement('#message', { text: 'Order updated.' });
+	const variablePostId = await page.$('#post_ID');
+	let variablePostIdValue = (await (await variablePostId.getProperty('value')).jsonValue());
+	return variablePostIdValue;
+}
+
+const merchantCanAddDownloadableFileToExistingOrder = async (orderId, productName) => {
+	await merchant.openAllOrdersView();
+
+	// Make sure we're on the orders page
+	await expect(page.title()).resolves.toMatch('Orders');
+
+	//Open order we created
+	await merchant.goToOrder(orderId);
+
+	// Make sure we're on the order details page
+	await expect(page.title()).resolves.toMatch('Edit order');
+	await expect(page).toClick('.select2-container .select2-search__field');
+	await expect(page).toFill('.select2-container .select2-search__field', productName);
+	// Wait for options to load
+	await utils.waitForTimeout(2000)
+	await page.waitForSelector('.select2-results__option');
+	await expect(page).toClick('.select2-results__option');
+	await backboneUnblocked();
+	await expect(page).toClick('.button.grant_access');
+	// Wait for auto save
+	await utils.waitForTimeout(2000)
+	// Save the order changes
+	await expect(page).toClick('button.save_order');
+	await page.waitForSelector('#message');
+
+	// Verify
+	await expect(page).toMatchElement('#message', { text: 'Order updated.' });
+}
+
+const merchantCanDeleteDownloadableFileFromExistingOrder = async (orderId) => {
+	await merchant.openAllOrdersView();
+
+	// Make sure we're on the orders page
+	await expect(page.title()).resolves.toMatch('Orders');
+
+	//Open order we created
+	await merchant.goToOrder(orderId);
+	await expect(page).toClick('.button.revoke_access');
+	await page.keyboard.press('Enter');
+	// Wait for auto save
+	await utils.waitForTimeout(2000)
+	// Save the order changes
+	await expect(page).toClick('button.save_order');
+	await page.waitForSelector('#message');
+	// Verify
+	await expect(page).toMatchElement('#message', { text: 'Order updated.' });
+}
+
+
+const runAddDownloadableProductToOrderTest = () => {
+
+	describe('WooCommerce Products > Merchant can add downloadable product to order', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
+
+		afterAll(async () => {
+			// Delete created products and orders
+			await withRestApi.deleteAllProducts();
+			await withRestApi.deleteAllOrders();
+		});
+
+		it('Merchant create a product without downloadable file', async () => {
+			await createNewProductWithoutDownloadableFile(virtualProductName1, virtualProductPrice);
+		});
+
+		it('Merchant creates an order', async () => {
+			orderId = await createNewOrderWithExistingProduct(virtualProductName1, customerBillingAddress);
+		});
+
+		it('Merchant creates a new downloadable product', async () => {
+			await createNewProductWithDownloadableFile(virtualProductName2, virtualProductPrice, downloadableFileName, downloadableFileUrl);
+		});
+
+		it('Merchant can add downloadable product in existing order', async () => {
+			await merchantCanAddDownloadableFileToExistingOrder(orderId, virtualProductName2);
+			newOrderId = parseInt(orderId) + 1;
+			//Verify that user is able to add downloadable file in existing order without any error
+			await expect(page).toMatchElement(
+				'#woocommerce-order-downloads strong',
+				{
+					text: '#' + newOrderId + ' — Virtual Product Name 2 — Downloadable File 1: sample_products_override.csv — Downloaded 0 times',
+				}
+			);
+
+		});
+
+	});
+
+	describe('WooCommerce Products > Merchant can add multiple downloadable product to order', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
+
+		afterAll(async () => {
+			// Delete created products and orders
+			await withRestApi.deleteAllProducts();
+			await withRestApi.deleteAllOrders();
+		});
+		it('Merchant create a product without downloadable file', async () => {
+			await createNewProductWithoutDownloadableFile(virtualProductName1, virtualProductPrice);
+		});
+
+		it('Merchant creates an order', async () => {
+			orderId = await createNewOrderWithExistingProduct(virtualProductName1, customerBillingAddress);
+		});
+
+		it('Merchant creates multiple new downloadable product', async () => {
+			await createNewProductWithDownloadableFile(virtualProductName2, virtualProductPrice, downloadableFileName, downloadableFileUrl);
+			await createNewProductWithDownloadableFile(virtualProductName3, virtualProductPrice, downloadableFileName, downloadableFileUrl);
+
+		});
+
+		it('Merchant can add multiple downloadable product in existing order', async () => {
+
+			await merchantCanAddDownloadableFileToExistingOrder(orderId, virtualProductName2);
+			newOrderId = parseInt(orderId) + 1;
+			//Verify that user is able to add downloadable file in existing order without any error
+			await expect(page).toMatchElement(
+				'#woocommerce-order-downloads strong',
+				{
+					text: '#' + newOrderId + ' — Virtual Product Name 2 — Downloadable File 1: sample_products_override.csv — Downloaded 0 times',
+				}
+			);
+
+			await merchantCanAddDownloadableFileToExistingOrder(orderId, virtualProductName3);
+			newOrderId = parseInt(newOrderId) + 1;
+			//Verify that user is able to add downloadable file in existing order without any error
+			await expect(page).toMatchElement(
+				'#woocommerce-order-downloads strong',
+				{
+					text: '#' + newOrderId + ' — Virtual Product Name 3 — Downloadable File 1: sample_products_override.csv — Downloaded 0 times',
+				}
+			);
+		});
+
+
+	});
+
+
+	describe('WooCommerce Products > Merchant can delete downloadable product from order', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
+		afterAll(async () => {
+			// Delete created products and orders
+			await withRestApi.deleteAllProducts();
+			await withRestApi.deleteAllOrders();
+		});
+
+		it('Merchant create a product without downloadable file', async () => {
+			await createNewProductWithoutDownloadableFile(virtualProductName1, virtualProductPrice);
+		});
+
+		it('Merchant creates an order', async () => {
+			orderId = await createNewOrderWithExistingProduct(virtualProductName1, customerBillingAddress);
+		});
+
+		it('Merchant creates a new downloadable product', async () => {
+			await createNewProductWithDownloadableFile(virtualProductName2, virtualProductPrice, downloadableFileName, downloadableFileUrl);
+		});
+
+		it('Merchant can add downloadable product in existing order', async () => {
+			await merchantCanAddDownloadableFileToExistingOrder(orderId, virtualProductName2);
+			newOrderId = parseInt(orderId) + 1;
+			//Verify that user is able to add the downloadable product and it is listed under Downloadable product permissions section
+			await expect(page).toMatchElement(
+				'#woocommerce-order-downloads strong',
+				{
+					text: '#' + newOrderId + ' — Virtual Product Name 2 — Downloadable File 1: sample_products_override.csv — Downloaded 0 times',
+				}
+			);
+
+		});
+
+		it('Merchant can delete downloadable product from existing order', async () => {
+			await merchantCanDeleteDownloadableFileFromExistingOrder(orderId, virtualProductName2);
+			//Verify that user is able to revoke/delete downloadable product listed under Downloadable product permissions section
+			await page.waitForSelector('#woocommerce-order-downloads strong', { hidden: true });
+		});
+
+
+	});
+
+
+};
+
+
+module.exports = runAddDownloadableProductToOrderTest;

--- a/plugins/woocommerce/tests/e2e/specs/wp-admin/add-downloadable-product-to-order.test.js
+++ b/plugins/woocommerce/tests/e2e/specs/wp-admin/add-downloadable-product-to-order.test.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runAddDownloadableProductToOrderTest } = require( '@woocommerce/e2e-core-tests' );
+
+runAddDownloadableProductToOrderTest();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This Pull Request adds three new e2e test for adding/removing downloadable product to existing order under downloadable product permissions section. Github Issue #[29884](https://github.com/woocommerce/woocommerce/issues/29884).

**Test Case 1: Verify that the Merchant can manually add a downloadable product to the order.**

1. Merchant can log in.
2. Merchant create a product that doesn’t have any downloadable file.
3. Merchant creates an order of the product created at step 2
4. Merchant creates a new downloadable product
5. Verify merchant can add a newly created downloadable product and can grant access to existing order using Downloadable product permissions section without any error Notice on UI.

**Test Case 2: Verify that the Merchant can manually add multiple downloadable products to order.**

1. Merchant can log in.
2. Merchant create a product that doesn’t have any downloadable file.
3. Merchant creates an order of the product created at step 2
4. Merchant creates two new downloadable product
5. Verify merchant can add all two newly created downloadable products to an existing order and can grant access using Downloadable product permissions section without any error Notice on UI.

**Test Case 3: Verify that the Merchant can manually delete a downloadable product from an order.**

1. Merchant can log in.
2. Merchant create a product that doesn’t have any downloadable file.
3. Merchant creates an order of the product created at step 2
4. Merchant creates a new downloadable product
5. Merchant add the newly created downloadable product to existing order using Downloadable product permissions section.
6. Verify merchant can delete the newly added downloadable product by revoking access from the Downloadable product permissions section without any error Notice on UI.

### How to test the changes in this Pull Request:

1. Run the **runAddDownloadableProductToOrderTest** test both in headful and headless mode and see if it passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
![passed](https://user-images.githubusercontent.com/19307354/143621529-a032bb80-38ba-4f74-af8f-ef03f16ab506.JPG)


<!-- Mark completed items with an [x] -->

