### PR TITLE
Update setBrowserViewport to use default dimensions

### DIFF
--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-page-loads.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-page-loads.test.js
@@ -28,10 +28,6 @@ const runPageLoadTest = () => {
 					await Promise.all( [
 						page.click( menuElement ),
 						page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-						page.setViewport( {
-							width: 1280,
-							height: 800,
-						} ),
 					] );
 
 					// Click sub-menu item and wait for the page to finish loading

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -45,6 +45,12 @@ const runAddSimpleProductTest = () => {
 		});
 
 		it('can create simple virtual product and add it to the cart', async () => {
+
+			await page.setViewport( {
+				width: 970,
+				height: 700,
+			} );
+
 			await openNewProductAndVerify();
 
 			// Set product data and publish the product
@@ -72,6 +78,11 @@ const runAddSimpleProductTest = () => {
 		});
 
 		it('can create simple non-virtual product and add it to the cart', async () => {
+			await page.setViewport( {
+				width: 960,
+				height: 700,
+			} );
+
 			await merchant.login();
 			await openNewProductAndVerify();
 

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -8,6 +8,7 @@ const {
 	uiUnblocked,
 	evalAndClick,
 	setCheckbox,
+	setBrowserViewport,
 	verifyAndPublish,
 	waitForSelector,
 	waitForSelectorWithoutThrow
@@ -46,7 +47,8 @@ const runAddSimpleProductTest = () => {
 
 		it('can create simple virtual product and add it to the cart', async () => {
 
-			await page.setViewport( {
+			// @todo: remove this once https://github.com/woocommerce/woocommerce/issues/31337 has been addressed
+			await setBrowserViewport( {
 				width: 970,
 				height: 700,
 			} );
@@ -78,7 +80,8 @@ const runAddSimpleProductTest = () => {
 		});
 
 		it('can create simple non-virtual product and add it to the cart', async () => {
-			await page.setViewport( {
+			// @todo: remove this once https://github.com/woocommerce/woocommerce/issues/31337 has been addressed
+			await setBrowserViewport( {
 				width: 960,
 				height: 700,
 			} );

--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fixed
+
+- Updated the browserViewport in `jest.setup.js` to match the `defaultViewport` dimensions defined in `jest-puppeteer.config.js`
 ## Added
 
 - Added quotes around `WORDPRESS_TITLE` value in .env file to address issue with docker compose 2 "key cannot contain a space" error.

--- a/packages/js/e2e-environment/src/setup/jest.setup.js
+++ b/packages/js/e2e-environment/src/setup/jest.setup.js
@@ -38,7 +38,10 @@ const OBSERVED_CONSOLE_MESSAGE_TYPES = {
 
 async function setupBrowser() {
 	await clearLocalStorage();
-	await setBrowserViewport( 'large' );
+	await setBrowserViewport( {
+		width: 1280,
+		height: 800,
+	});
 }
 
 /**

--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -58,7 +58,10 @@ beforeAll(async () => {
 
 	await page.goto(WP_ADMIN_LOGIN);
 	await clearLocalStorage();
-	await setBrowserViewport('large');
+	await setBrowserViewport( {
+		width: 1280,
+		height: 800,
+	});
 });
 
 // Clear browser cookies and cache using DevTools.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

updated the setting of the viewport in `packages/js/e2e-environment/src/setup/jest.setup.js` and `plugins/woocommerce/tests/e2e/config/jest.setup.js` to the defaultViewport dimensions defined in `jest-puppeteer.config.js`

Closes #31305 .

### How to test the changes in this Pull Request:
```
$ cd plugins/woocommerce
$ pnpm install
$ pnpx wc-e2e docker:up
$ pnpx wc-e2e test:e2e
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Stopped `jest.setup.js` from overriding the defualtViewport defined in `jest-puppeteer.config.js`

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
