### PR TITLE
Fix hardcoded email template path

### DIFF
--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -782,7 +782,7 @@ class WC_Email extends WC_Settings_API {
 	protected function save_template( $template_code, $template_path ) {
 		if ( current_user_can( 'edit_themes' ) && ! empty( $template_code ) && ! empty( $template_path ) ) {
 			$saved = false;
-			$file  = get_stylesheet_directory() . '/' . WC()->template_path() . $template_path;
+			$file  = $this->get_theme_template_file( $template_path );
 			$code  = wp_unslash( $template_code );
 
 			if ( is_writeable( $file ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writeable


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Due to the hardcoded template directory saving edited email template from the email settings section does not save the changes. It happens when the template directory is different than `woocommerce`. Example WooCommerce Booking the template directory name is `woocommerce-booking`

Closes #31320 

### How to test the changes in this Pull Request:

1. Install and Activate WooCommerce Booking
2. Go to WooCommerce > Settings > Email,
3. Select any of the booking emails and click Copy file to theme
4. Click View template, make some changes, and save.
5. Observe the template saves correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix hardcoded email template path.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
