### PR TITLE
Retry failed E2E tests using Jest

### DIFF
--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Added
+
+- Added `jest-circus` as a test runner to enable retrying failed tests
+- Added `E2E_RETRY_TIMES` environment variable to determine retry count. The default is 3.
+
 ## Fixed
 
 - Updated the browserViewport in `jest.setup.js` to match the `defaultViewport` dimensions defined in `jest-puppeteer.config.js`

--- a/packages/js/e2e-environment/README.md
+++ b/packages/js/e2e-environment/README.md
@@ -71,6 +71,20 @@ module.exports = jestConfig;
 
 **NOTE:** Your project's Jest config file is: `tests/e2e/config/jest.config.js`.
 
+### The Jest Object
+
+The E2E environment has the following methods to let us control Jest's overall behavior.
+
+|  Function |  Parameters | Description  |
+|-----------|-------------|--------------|
+| `setupJestRetries` | `retries` | Sets the amount of retries on failed tests 
+
+**NOTE:** The amount of times failed tests are retried can also be set using the `E2E_RETRY_TIMES` environment variable when executing tests. This can be done using the command below: 
+
+```
+E2E_RETRY_TIMES=2 pnpx wc-e2e test:e2e
+```
+
 #### Test Screenshots
 
 The test sequencer provides a screenshot function for test failures. To enable screenshots on test failure use

--- a/packages/js/e2e-environment/config/index.js
+++ b/packages/js/e2e-environment/config/index.js
@@ -3,7 +3,7 @@
  */
 const jestConfig = require( './jest.config' );
 const jestPuppeteerConfig = require( './jest-puppeteer.config' );
-const setupJestObject = require('./jest-object.config');
+const jestobjectConfig = require('./jest-object.config');
 const {
 	useE2EBabelConfig,
 	useE2EEsLintConfig,
@@ -13,7 +13,7 @@ const {
 
 module.exports = {
 	jestConfig,
-	setupJestObject,
+	...jestobjectConfig,
 	jestPuppeteerConfig,
 	useE2EBabelConfig,
 	useE2EEsLintConfig,

--- a/packages/js/e2e-environment/config/index.js
+++ b/packages/js/e2e-environment/config/index.js
@@ -3,15 +3,17 @@
  */
 const jestConfig = require( './jest.config' );
 const jestPuppeteerConfig = require( './jest-puppeteer.config' );
+const setupJestObject = require('./jest-object.config');
 const {
 	useE2EBabelConfig,
 	useE2EEsLintConfig,
 	useE2EJestConfig,
-	useE2EJestPuppeteerConfig
+	useE2EJestPuppeteerConfig,
 } = require( './use-config' );
 
 module.exports = {
 	jestConfig,
+	setupJestObject,
 	jestPuppeteerConfig,
 	useE2EBabelConfig,
 	useE2EEsLintConfig,

--- a/packages/js/e2e-environment/config/jest-object.config.js
+++ b/packages/js/e2e-environment/config/jest-object.config.js
@@ -1,0 +1,16 @@
+/**
+ * External Dependencies
+ */
+const { E2E_RETRY_TIMES } = process.env;
+
+const setupJestRetries = () => {
+	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : 3;
+
+	jest.retryTimes( retryTimes );
+};
+
+const setupJestObject = () => {
+	setupJestRetries();
+};
+
+module.exports = setupJestObject;

--- a/packages/js/e2e-environment/config/jest-object.config.js
+++ b/packages/js/e2e-environment/config/jest-object.config.js
@@ -9,6 +9,7 @@ const setupJestRetries = ( retries = 2 ) => {
 	jest.retryTimes( retryTimes );
 };
 
+// If more methods are added to setupJestObject, it should be include in the readme
 const setupJestObject = () => {
 	setupJestRetries();
 };
@@ -17,4 +18,3 @@ module.exports = {
 	setupJestObject,
 	setupJestRetries,
 };
-

--- a/packages/js/e2e-environment/config/jest-object.config.js
+++ b/packages/js/e2e-environment/config/jest-object.config.js
@@ -3,8 +3,8 @@
  */
 const { E2E_RETRY_TIMES } = process.env;
 
-const setupJestRetries = () => {
-	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : 3;
+const setupJestRetries = ( retries = 2 ) => {
+	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : retries;
 
 	jest.retryTimes( retryTimes );
 };
@@ -13,4 +13,8 @@ const setupJestObject = () => {
 	setupJestRetries();
 };
 
-module.exports = setupJestObject;
+module.exports = {
+	setupJestObject,
+	setupJestRetries,
+};
+

--- a/packages/js/e2e-environment/config/jest.config.js
+++ b/packages/js/e2e-environment/config/jest.config.js
@@ -55,6 +55,9 @@ const combinedConfig = {
 	transformIgnorePatterns: [
 		'node_modules/(?!(woocommerce)/)',
 	],
+
+	testRunner: 'jest-circus/runner',
+
 	roots: [ testSpecs ],
 };
 

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -32,8 +32,8 @@
     "jest": "^25.1.0",
     "jest-each": "25.5.0",
     "jest-puppeteer": "^4.4.0",
-    "request": "^2.88.2",
-    "node-stream-zip": "^1.13.6"
+    "node-stream-zip": "^1.13.6",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "@babel/cli": "7.12.8",
@@ -42,6 +42,7 @@
     "@babel/preset-env": "7.12.7",
     "@wordpress/eslint-plugin": "7.3.0",
     "eslint": "^8.1.0",
+    "jest-circus": "25.1.0",
     "ndb": "^1.1.5",
     "semver": "^7.3.2"
   },

--- a/packages/js/e2e-environment/src/setup/jest.setup.js
+++ b/packages/js/e2e-environment/src/setup/jest.setup.js
@@ -176,7 +176,7 @@ beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
 	observeConsoleLogging();
-	setupJestRetries( 2 );
+	setupJestRetries();
 } );
 
 afterEach( async () => {

--- a/packages/js/e2e-environment/src/setup/jest.setup.js
+++ b/packages/js/e2e-environment/src/setup/jest.setup.js
@@ -9,6 +9,7 @@ import {
 	setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
 import { consoleShouldSuppress, addConsoleSuppression } from '../../utils';
+import { setupJestRetries } from '../../config/jest-object.config';
 
 /**
  * Array of page event tuples of [ eventName, handler ].
@@ -175,6 +176,7 @@ beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
 	observeConsoleLogging();
+	setupJestRetries( 2 );
 } );
 
 afterEach( async () => {

--- a/packages/js/e2e-utils/CHANGELOG.md
+++ b/packages/js/e2e-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixed
+
+- Identified the default product category using `slug == 'uncategorized'` in `deleteAllProductCategories`
+
 ## Changes
 
 - Removed `page.waitForNavigation()` from `shopper.logout()`

--- a/packages/js/e2e-utils/src/flows/with-rest-api.js
+++ b/packages/js/e2e-utils/src/flows/with-rest-api.js
@@ -138,7 +138,7 @@ export const withRestApi = {
 		if ( productCategories.data && productCategories.data.length ) {
 			for ( let c = 0; c < productCategories.data.length; c++ ) {
 				// The default `uncategorized` category can't be deleted
-				if ( productCategories.data[c].id == 0 ) {
+				if ( productCategories.data[c].slug == 'uncategorized' ) {
 					continue;
 				}
 				const response = await client.delete( productCategoriesPath + `/${productCategories.data[c].id}?force=true` );

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -186,6 +186,15 @@ For example:
 - `PUPPETEER_SLOWMO=10` - will run tests faster
 - `PUPPETEER_SLOWMO=70` - will run tests slower
 
+### How to retry failed tests
+
+Sometimes tests may fail for different reasons such as network issues, or lost connection. To mitigate against test flakiess, failed tests are rerun up to 3 times before being marked as failed. The amount of retry attempts can be adjusted by passing the `E2E_RETRY_TIMES` variable when running tests. For example:
+
+```
+cd plugins/woocommerce
+E2E_RETRY_TIMES=2 pnpx wc-e2e test:e2e
+```
+
 ### How to run tests in debug mode
 
 Tests run in headless mode by default. While writing tests it may be useful to have the debugger loaded while running a test in non-headless mode. To run tests in debug mode:

--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -7,8 +7,8 @@ import {
 
 const config = require( 'config' );
 const { HTTPClientFactory } = require( '@woocommerce/api' );
-const { addConsoleSuppression, updateReadyPageStatus } = require( '@woocommerce/e2e-environment' );
-const { DEFAULT_TIMEOUT_OVERRIDE, E2E_RETRY_TIMES } = process.env;
+const { addConsoleSuppression, updateReadyPageStatus, setupJestObject } = require( '@woocommerce/e2e-environment' );
+const { DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 // @todo: remove this once https://github.com/woocommerce/woocommerce-admin/issues/6992 has been addressed
 addConsoleSuppression( 'woocommerce_shared_settings', false );
@@ -40,7 +40,7 @@ async function trashExistingPosts() {
 // each other's side-effects.
 beforeAll(async () => {
 
-	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : 3;
+	setupJestObject();
 
 	if ( DEFAULT_TIMEOUT_OVERRIDE ) {
 		page.setDefaultNavigationTimeout( DEFAULT_TIMEOUT_OVERRIDE );
@@ -64,9 +64,6 @@ beforeAll(async () => {
 		width: 1280,
 		height: 800,
 	});
-
-	// Set how many times to retry failed tests.
-	jest.retryTimes( retryTimes );
 });
 
 // Clear browser cookies and cache using DevTools.

--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -40,7 +40,7 @@ async function trashExistingPosts() {
 // each other's side-effects.
 beforeAll(async () => {
 
-	setupJestRetries( 2 );
+	setupJestRetries();
 
 	if ( DEFAULT_TIMEOUT_OVERRIDE ) {
 		page.setDefaultNavigationTimeout( DEFAULT_TIMEOUT_OVERRIDE );

--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -8,7 +8,7 @@ import {
 const config = require( 'config' );
 const { HTTPClientFactory } = require( '@woocommerce/api' );
 const { addConsoleSuppression, updateReadyPageStatus } = require( '@woocommerce/e2e-environment' );
-const { DEFAULT_TIMEOUT_OVERRIDE } = process.env;
+const { DEFAULT_TIMEOUT_OVERRIDE, E2E_RETRY_TIMES } = process.env;
 
 // @todo: remove this once https://github.com/woocommerce/woocommerce-admin/issues/6992 has been addressed
 addConsoleSuppression( 'woocommerce_shared_settings', false );
@@ -40,6 +40,8 @@ async function trashExistingPosts() {
 // each other's side-effects.
 beforeAll(async () => {
 
+	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : 3;
+
 	if ( DEFAULT_TIMEOUT_OVERRIDE ) {
 		page.setDefaultNavigationTimeout( DEFAULT_TIMEOUT_OVERRIDE );
 		page.setDefaultTimeout( DEFAULT_TIMEOUT_OVERRIDE );
@@ -62,6 +64,9 @@ beforeAll(async () => {
 		width: 1280,
 		height: 800,
 	});
+
+	// Set how many times to retry failed tests.
+	jest.retryTimes( retryTimes );
 });
 
 // Clear browser cookies and cache using DevTools.

--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -7,7 +7,7 @@ import {
 
 const config = require( 'config' );
 const { HTTPClientFactory } = require( '@woocommerce/api' );
-const { addConsoleSuppression, updateReadyPageStatus, setupJestObject } = require( '@woocommerce/e2e-environment' );
+const { addConsoleSuppression, updateReadyPageStatus, setupJestRetries } = require( '@woocommerce/e2e-environment' );
 const { DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 // @todo: remove this once https://github.com/woocommerce/woocommerce-admin/issues/6992 has been addressed
@@ -40,7 +40,7 @@ async function trashExistingPosts() {
 // each other's side-effects.
 beforeAll(async () => {
 
-	setupJestObject();
+	setupJestRetries( 2 );
 
 	if ( DEFAULT_TIMEOUT_OVERRIDE ) {
 		page.setDefaultNavigationTimeout( DEFAULT_TIMEOUT_OVERRIDE );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,7 @@ importers:
       commander: 4.1.1
       eslint: ^8.1.0
       jest: ^25.1.0
+      jest-circus: 25.1.0
       jest-each: 25.5.0
       jest-puppeteer: ^4.4.0
       ndb: ^1.1.5
@@ -152,6 +153,7 @@ importers:
       '@babel/preset-env': 7.12.7_@babel+core@7.12.9
       '@wordpress/eslint-plugin': 7.3.0_eslint@8.1.0+typescript@4.2.4
       eslint: 8.1.0
+      jest-circus: 25.1.0
       ndb: 1.1.5
       semver: 7.3.5
 
@@ -13275,6 +13277,30 @@ packages:
       '@jest/types': 27.2.5
       execa: 5.1.1
       throat: 6.0.1
+    dev: true
+
+  /jest-circus/25.1.0:
+    resolution: {integrity: sha512-Axlcr2YMxVarMW4SiZhCFCjNKhdF4xF9AIdltyutQOKyyDT795Kl/fzI95O0l8idE51Npj2wDj5GhrV7uEoEJA==}
+    engines: {node: '>= 8.3'}
+    dependencies:
+      '@babel/traverse': 7.16.3
+      '@jest/environment': 25.5.0
+      '@jest/test-result': 25.5.0
+      '@jest/types': 25.5.0
+      chalk: 3.0.0
+      co: 4.6.0
+      expect: 25.5.0
+      is-generator-fn: 2.1.0
+      jest-each: 25.5.0
+      jest-matcher-utils: 25.5.0
+      jest-message-util: 25.5.0
+      jest-snapshot: 25.5.1
+      jest-util: 25.5.0
+      pretty-format: 25.5.0
+      stack-utils: 1.0.5
+      throat: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-circus/27.3.1:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR added support for retrying failed E2E tests. As a default, it will retry any failed test up to 3 times before marking that test as a failure. The amount of retries can be changed by passing the `E2E_RETRY_TIMES` env variable when running tests.

Closes #28185.

### How to test the changes in this Pull Request:

```
$ pnpm install
$ cd plugins/woocommerce
$ pnpx wc-e2e docker:up
$ E2E_RETRY_TIMES=2 pnpx wc-e2e test:e2e
```
