### PR TITLE
Db version option consistency

### DIFF
--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -514,7 +514,7 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Cons
 	<tbody>
 		<tr>
 			<td data-export-label="WC Database Version"><?php esc_html_e( 'WooCommerce database version', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( esc_html__( 'The database version for WooCommerce. Note that it may not match WooCommerce core version and that is normal.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The database version for WooCommerce. This should be the same as your WooCommerce version.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $database['wc_database_version'] ); ?></td>
 		</tr>
 		<tr>

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -180,6 +180,7 @@ class WC_Install {
 		add_action( 'admin_init', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'add_admin_note_after_page_created' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
+		add_action( 'woocommerce_update_db_to_current_version', array( __CLASS__, 'update_db_version' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_action( 'woocommerce_page_created', array( __CLASS__, 'page_created' ), 10, 2 );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
@@ -486,6 +487,20 @@ class WC_Install {
 					$loop++;
 				}
 			}
+		}
+
+		// After the callbacks finish, update the db version to the current WC version.
+		$current_wc_version = WC()->version;
+		if ( version_compare( $current_db_version, $current_wc_version, '<' ) &&
+			! WC()->queue()->get_next( 'woocommerce_update_db_to_current_version' ) ) {
+			WC()->queue()->schedule_single(
+				time() + $loop,
+				'woocommerce_update_db_to_current_version',
+				array(
+					'version' => $current_wc_version,
+				),
+				'woocommerce-db-updates'
+			);
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28459.

Reverts https://github.com/woocommerce/woocommerce/pull/29438.

When updating WC step by step, the update works fine, because the `maybe_update_db_version` [function either updates to current version, or runs callbacks and updates to current version](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-install.php#L439-L449). However, if you jump over multiple versions (with some callbacks in between), the db version update to current WC version never runs, because it's just the callbacks that run (and those finish with the largest number the callbacks are for). Thus, this PR has the ambition to fix this inconsistency.

As a bonus, this means that updates no longer need to explicitly update the db version, the callbacks are just unnecessary.

TODO: Test if this actually works when callbacks schedule more callbacks and loop until done, but I'm guessing it should since the update to the current version is scheduled after all the other callbacks?

### How to test the changes in this Pull Request:

1. Install WC 4.2.2
2. Update to WC 4.7.1.
3. Observer the db version is stuck at 4.5.0.
4. Now try the same, but update version after version, i.e. 4.2.2 -> (you can skip these) -> 4.5.0 -> 4.6.0 -> 4.7.1
5. Observe the db version is at 4.7.1 now <--this is the inconsistency. This would also happen if in step 3, you would deactivate and reactivate WC plugin. So again, inconsistent behavior.
6. Install clean WC 4.2.2 again.
4. Create a zip file for a WC version later than 4.5 with the original code, but the diff from this PR applied. E.g. 4.7 or 5.3, etc. The important part is that there are some db update callbacks between 4.2.2 and the new version you applied the changes from this PR.
3. The db version in System Status should match the WC version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix db version inconsistency during updates spanning multiple versions.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
