### PR TITLE
Fix/e2e unhandled promise rejection

### DIFF
--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -40,7 +40,7 @@ const runAddNewShippingZoneTest = () => {
 		});
 
 		afterAll( async () => {
-			shopper.logout();
+			await shopper.logout();
 		} );
 
 		it('add shipping zone for San Francisco with free Local pickup', async () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-checkout-login-account.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-checkout-login-account.test.js
@@ -42,6 +42,10 @@ const runCheckoutLoginAccountTest = () => {
 			await shopper.goToCheckout();
 		});
 
+		afterAll( async () => {
+			await shopper.logout();
+		} );
+
 		it('can login to an existing account during checkout', async () => {
 			// Click to login during checkout
 			await page.waitForSelector('.woocommerce-form-login-toggle');
@@ -65,8 +69,11 @@ const runCheckoutLoginAccountTest = () => {
 
 			// Verify the user is logged in on my account page
 			await shopper.gotoMyAccount();
-			await expect(page.url()).toMatch('my-account/');
-			await expect(page).toMatchElement('h1', {text: 'My account'});
+
+			await Promise.all( [
+				await expect(page.url()).toMatch('my-account/'),
+				await expect(page).toMatchElement('h1', {text: 'My account'}),
+			] );
 		});
 	});
 };

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-my-account-create-account.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-my-account-create-account.test.js
@@ -26,7 +26,7 @@ const runMyAccountCreateAccountTest = () => {
 		});
 
 		afterAll( async () => {
-			shopper.logout();
+			await shopper.logout();
 		} );
 
 		it('can create a new account via my account', async () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-my-account-pay-order.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-my-account-pay-order.test.js
@@ -35,7 +35,7 @@ const runMyAccountPayOrderTest = () => {
 		});
 
 		afterAll( async () => {
-			shopper.logout();
+			await shopper.logout();
 		} );
 
 		it('allows customer to pay for their order in My Account', async () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-my-account.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-my-account.test.js
@@ -16,7 +16,7 @@ const pages = [
 const runMyAccountPageTest = () => {
 	describe('My account page', () => {
 		afterAll( async () => {
-			shopper.logout();
+			await shopper.logout();
 		} );
 
 		it('allows customer to login', async () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -37,7 +37,7 @@ const runOrderEmailReceivingTest = () => {
 		});
 
 		afterAll( async () => {
-			shopper.logout();
+			await shopper.logout();
 		} );
 
 		it('should receive order email after purchasing an item', async () => {

--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Added
+
+- Added `await` for every call to `shopper.logout`
+
 ## Fixed
 
 - Updated the browserViewport in `jest.setup.js` to match the `defaultViewport` dimensions defined in `jest-puppeteer.config.js`

--- a/packages/js/e2e-utils/CHANGELOG.md
+++ b/packages/js/e2e-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Changes
+
+- Removed `page.waitForNavigation()` from `shopper.logout()`
+
 ## Added
 
 - `utils.waitForTimeout( delay )` pause processing for `delay` milliseconds

--- a/packages/js/e2e-utils/src/flows/shopper.js
+++ b/packages/js/e2e-utils/src/flows/shopper.js
@@ -240,7 +240,6 @@ const shopper = {
 
 		await expect( page.title() ).resolves.toMatch( 'My account' );
 		await page.click( '.woocommerce-MyAccount-navigation-link--customer-logout a' );
-		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 	},
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses unhandled promise rejections in the E2E test suite by:

 -  adding `await` where the `shopper.logout()` function is used to ensure that the test execution waits until the step is completed before moving on.
 - removing the `page.waitForNavigation()` command from `shopper.logout()` that causes execution to hang.

### How to test the changes in this Pull Request:

```
$ pnpm install
$ cd plugins/woocommerce
$ pnpx wc-e2e docker:up
$ pnpx wc-e2e test:e2e
```
