### PR TITLE
Make the setting's name for default customer location more accurately reflect the effect of it.

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -175,7 +175,7 @@ class WC_Settings_General extends WC_Settings_Page {
 					'class'    => 'wc-enhanced-select',
 					'options'  => array(
 						''                 => __( 'No location by default', 'woocommerce' ),
-						'base'             => __( 'Shop base address', 'woocommerce' ),
+						'base'             => __( 'Shop country/region', 'woocommerce' ),
 						'geolocation'      => __( 'Geolocate', 'woocommerce' ),
 						'geolocation_ajax' => __( 'Geolocate (with page caching support)', 'woocommerce' ),
 					),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since this settings only sets country/state for the customer, we shouldn't really call it address, as it can be confusing, especially in context of some extensions, like Distant Rate Shipping.
Ref  p1638561552105500-slack-C7U3Y3VMY

### How to test the changes in this Pull Request:

1. Go to settings and check the new string is present in the Shipping section.
2. Check that there is no change in the tax section, as over there, we set the city and zip code as well.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Update shipping base address settings wording.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
