### PR TITLE
Fix #31393 to use country from headers only if geolocating current user

### DIFF
--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -149,10 +149,9 @@ class WC_Geolocation {
 		}
 
 		if ( empty( $ip_address ) ) {
-			$ip_address = self::get_ip_address();
+			$ip_address   = self::get_ip_address();
+			$country_code = self::get_country_code_from_headers();
 		}
-
-		$country_code = self::get_country_code_from_headers();
 
 		/**
 		 * Get geolocation filter.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #31393.

This PR changes geolocation to only use country code headers if geolocating the current user, not a specific IP address.

### How to test the changes in this Pull Request:

#31393 includes some code to demonstrate the issue, which should function correctly with these changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog

> Tweak - Geolocating a specific IP address should not be impacted by request headers. #31394

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
