### PR TITLE
Adds the image size to gallery nav (waiting the image load)

### DIFF
--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -242,16 +242,16 @@
               }
 
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
-              if ( slider.vars.controlNav === "thumbnails" ) {
-				  item = $('<img/>', {
-					  load: function (el) {
-						  el.currentTarget.width = el.currentTarget.naturalWidth;
-						  el.currentTarget.height = el.currentTarget.naturalHeight;
-					  },
-					  src: slide.attr('data-thumb'),
-					  alt: slide.attr('alt')
-				  })
-			  }
+              if (slider.vars.controlNav === "thumbnails") {
+                item = $('<img/>', {
+                  load: function (el) {
+                    el.currentTarget.width = el.currentTarget.naturalWidth;
+                    el.currentTarget.height = el.currentTarget.naturalHeight;
+                  },
+                  src: slide.attr('data-thumb'),
+                  alt: slide.attr('alt')
+                })
+              }
 
               if ( '' !== slide.attr( 'data-thumb-alt' ) ) {
                 item.attr( 'alt', slide.attr( 'data-thumb-alt' ) );

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -243,8 +243,15 @@
 
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if ( slider.vars.controlNav === "thumbnails" ) {
-                item = $( '<img/>' ).attr( 'src', slide.attr( 'data-thumb' ) );
-              }
+				  item = $('<img/>', {
+					  load: function (el) {
+						  el.currentTarget.width = el.currentTarget.naturalWidth;
+						  el.currentTarget.height = el.currentTarget.naturalHeight;
+					  },
+					  src: slide.attr('data-thumb'),
+					  alt: slide.attr('alt')
+				  })
+			  }
 
               if ( '' !== slide.attr( 'data-thumb-alt' ) ) {
                 item.attr( 'alt', slide.attr( 'data-thumb-alt' ) );


### PR DESCRIPTION
_(Note: I just cherry picked the correct commits from https://github.com/woocommerce/woocommerce/pull/30701 since the rebase got messy -@jeffstieler)_

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Adds the image size to the thumbnail gallery nav - closes #25461 issue. As far as page optimisation is concerned, this is quite important because will enhance the page cumulative layout shift (a Core Web Vitals metric). Both gtmetrix and lighthouse reports about the missing image size while analysing the page so with the single product and it's almost impossible to achieve the 100% score with the default slider and the default settings. 
Also added alt attribute which is mandatory.

it's different that the PR prosed by @Mte90 here https://github.com/woocommerce/woocommerce/pull/30648 because this waits for the image to load before assign the size (which can be better or worse depending on the case)

Closes https://github.com/woocommerce/woocommerce/issues/25461.

### How to test the changes in this Pull Request:

1. In the single product page with more than one image, inspect the flexbox nav
2. The image thumbnail will be like this: `<img src="t-shirt-100x100.jpg" draggable="false" width="100" height="100" alt="t-shirt">` (before was `<img src="t-shirt-100x100.jpg" draggable="false">`)

### Changelog entry

> Adds the image size to the thumbnail gallery nav
> 2021/11/25 [#30701](https://github.com/erikyo/woocommerce/commit/da77ce7fc676f08bba626a9d7ceb0f228e2b61f1) since the file was moved, I have updated the pull request