### PR TITLE
Support gift cards in admin order refunds template

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -38,17 +38,6 @@ class WC_Meta_Box_Order_Items {
 		$order = $theorder;
 		$data  = get_post_meta( $post->ID );
 
-		/**
-		 * Allow plugins to determine whether refunds UI should be rendered in the template.
-		 *
-		 * @since 6.3.0
-		 *
-		 * @param $order_id The Order ID.
-		 * @param $order The Order object.
-		 * @return bool
-		 */
-		$should_render_refunds = (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order );
-
 		include __DIR__ . '/views/html-order-items.php';
 	}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -38,8 +38,19 @@ class WC_Meta_Box_Order_Items {
 		$order = $theorder;
 		$data  = get_post_meta( $post->ID );
 
+		/**
+		 * Allow plugins to determine whether refunds UI should be rendered in the template.
+		 *
+		 * @since 6.3.0
+		 *
+		 * @param $order_id The Order ID.
+		 * @param $order The Order object.
+		 * @return bool
+		 */
+		$should_render_refunds = (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order );
+
 		include __DIR__ . '/views/html-order-items.php';
-	}
+	}gi
 
 	/**
 	 * Save meta box data.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -50,7 +50,7 @@ class WC_Meta_Box_Order_Items {
 		$should_render_refunds = (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order );
 
 		include __DIR__ . '/views/html-order-items.php';
-	}gi
+	}
 
 	/**
 	 * Save meta box data.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -282,7 +282,8 @@ if ( wc_tax_enabled() ) {
 		<?php else : ?>
 			<span class="description"><?php echo wc_help_tip( __( 'To edit this order change the status back to "Pending payment"', 'woocommerce' ) ); ?> <?php esc_html_e( 'This order is no longer editable.', 'woocommerce' ); ?></span>
 		<?php endif; ?>
-		<?php if ( 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
+
+		<?php if ( apply_filters( 'woocommerce_admin_order_should_render_refunds', false, $order->get_id(), $order ) || 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
 			<button type="button" class="button refund-items"><?php esc_html_e( 'Refund', 'woocommerce' ); ?></button>
 		<?php endif; ?>
 		<?php
@@ -308,7 +309,7 @@ if ( wc_tax_enabled() ) {
 	<button type="button" class="button cancel-action"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
 	<button type="button" class="button button-primary save-action"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 </div>
-<?php if ( 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
+<?php if ( apply_filters( 'woocommerce_admin_order_should_render_refunds', false, $order->get_id(), $order ) || 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
 <div class="wc-order-data-row wc-order-refund-items wc-order-data-row-toggle" style="display: none;">
 	<table class="wc-order-totals">
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -282,7 +282,7 @@ if ( wc_tax_enabled() ) {
 		<?php else : ?>
 			<span class="description"><?php echo wc_help_tip( __( 'To edit this order change the status back to "Pending payment"', 'woocommerce' ) ); ?> <?php esc_html_e( 'This order is no longer editable.', 'woocommerce' ); ?></span>
 		<?php endif; ?>
-		<?php if ( apply_filters( 'woocommerce_admin_order_should_render_refunds', false, $order->get_id(), $order ) || 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
+		<?php if ( (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order ) ) : ?>
 			<button type="button" class="button refund-items"><?php esc_html_e( 'Refund', 'woocommerce' ); ?></button>
 		<?php endif; ?>
 		<?php
@@ -308,7 +308,7 @@ if ( wc_tax_enabled() ) {
 	<button type="button" class="button cancel-action"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
 	<button type="button" class="button button-primary save-action"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 </div>
-<?php if ( apply_filters( 'woocommerce_admin_order_should_render_refunds', false, $order->get_id(), $order ) || 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
+<?php if ( (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order ) ) : ?>
 <div class="wc-order-data-row wc-order-refund-items wc-order-data-row-toggle" style="display: none;">
 	<table class="wc-order-totals">
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -10,11 +10,11 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Allow plugins to determine whether refunds UI should be rendered in the template.
  *
- * @since 6.3.0
+ * @since 6.4.0
  *
- * @param $order_id The Order ID.
- * @param $order The Order object.
- * @return bool
+ * @param bool     $render_refunds If the refunds UI should be rendered.
+ * @param int      $order_id       The Order ID.
+ * @param WC_Order $order          The Order object.
  */
 $render_refunds = (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order );
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -282,7 +282,6 @@ if ( wc_tax_enabled() ) {
 		<?php else : ?>
 			<span class="description"><?php echo wc_help_tip( __( 'To edit this order change the status back to "Pending payment"', 'woocommerce' ) ); ?> <?php esc_html_e( 'This order is no longer editable.', 'woocommerce' ); ?></span>
 		<?php endif; ?>
-
 		<?php if ( apply_filters( 'woocommerce_admin_order_should_render_refunds', false, $order->get_id(), $order ) || 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ) ) : ?>
 			<button type="button" class="button refund-items"><?php esc_html_e( 'Refund', 'woocommerce' ); ?></button>
 		<?php endif; ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -282,7 +282,7 @@ if ( wc_tax_enabled() ) {
 		<?php else : ?>
 			<span class="description"><?php echo wc_help_tip( __( 'To edit this order change the status back to "Pending payment"', 'woocommerce' ) ); ?> <?php esc_html_e( 'This order is no longer editable.', 'woocommerce' ); ?></span>
 		<?php endif; ?>
-		<?php if ( (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order ) ) : ?>
+		<?php if ( $should_render_refunds ) : ?>
 			<button type="button" class="button refund-items"><?php esc_html_e( 'Refund', 'woocommerce' ); ?></button>
 		<?php endif; ?>
 		<?php
@@ -308,7 +308,7 @@ if ( wc_tax_enabled() ) {
 	<button type="button" class="button cancel-action"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
 	<button type="button" class="button button-primary save-action"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 </div>
-<?php if ( (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order ) ) : ?>
+<?php if ( $should_render_refunds ) : ?>
 <div class="wc-order-data-row wc-order-refund-items wc-order-data-row-toggle" style="display: none;">
 	<table class="wc-order-totals">
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-items.php
@@ -7,6 +7,17 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Allow plugins to determine whether refunds UI should be rendered in the template.
+ *
+ * @since 6.3.0
+ *
+ * @param $order_id The Order ID.
+ * @param $order The Order object.
+ * @return bool
+ */
+$render_refunds = (bool) apply_filters( 'woocommerce_admin_order_should_render_refunds', 0 < $order->get_total() - $order->get_total_refunded() || 0 < absint( $order->get_item_count() - $order->get_item_count_refunded() ), $order->get_id(), $order );
+
 global $wpdb;
 
 $payment_gateway     = wc_get_payment_gateway_by_order( $order );
@@ -282,7 +293,7 @@ if ( wc_tax_enabled() ) {
 		<?php else : ?>
 			<span class="description"><?php echo wc_help_tip( __( 'To edit this order change the status back to "Pending payment"', 'woocommerce' ) ); ?> <?php esc_html_e( 'This order is no longer editable.', 'woocommerce' ); ?></span>
 		<?php endif; ?>
-		<?php if ( $should_render_refunds ) : ?>
+		<?php if ( $render_refunds ) : ?>
 			<button type="button" class="button refund-items"><?php esc_html_e( 'Refund', 'woocommerce' ); ?></button>
 		<?php endif; ?>
 		<?php
@@ -308,7 +319,7 @@ if ( wc_tax_enabled() ) {
 	<button type="button" class="button cancel-action"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
 	<button type="button" class="button button-primary save-action"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 </div>
-<?php if ( $should_render_refunds ) : ?>
+<?php if ( $render_refunds ) : ?>
 <div class="wc-order-data-row wc-order-refund-items wc-order-data-row-toggle" style="display: none;">
 	<table class="wc-order-totals">
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>


### PR DESCRIPTION
Closes #31413 

### Specification
Please check the issue description for additional details.

### Changelog

> Dev - Added `woocommerce_admin_order_should_render_refunds` hook to allow control over the refunds UI within the order editor.