### PR TITLE
Fix jest e2e retries

### DIFF
--- a/packages/js/e2e-core-tests/README.md
+++ b/packages/js/e2e-core-tests/README.md
@@ -104,7 +104,7 @@ The functions to access the core tests are:
 
 ## Contributing a new test
 
-- In your branch create a new `example-test-name.test.js` under the `tests/e2e/core-tests/specs` folder.
+- In your branch create a new `example-test-name.test.js` under the appropriate folder in the [`specs`](specs) directory.
 - Jest does not allow its global functions to be accessed outside the jest environment. To allow the test code to be published in a package import any jest global functions used in your test
 ```js
 const {
@@ -130,7 +130,7 @@ const runExampleTestName = () => {
 
 module.exports = runExampleTestName;
 ```
-- Add your test to `tests/e2e/core-tests/specs/index.js`
+- Add your test to [`specs/index.js`](specs/index.js)
 ```js
 const runExampleTestName = require( './grouping/example-test-name.test' );
 // ...

--- a/packages/js/e2e-environment/README.md
+++ b/packages/js/e2e-environment/README.md
@@ -156,7 +156,7 @@ The test sequencer uses the following default Puppeteer configuration:
 	};
 ```
 
-You can customize the configuration in `tests/e2e/config/jest-puppeteer.config.js`
+You can customize the configuration in [`config/jest-puppeteer.config.js`](config/jest-puppeteer.config.js)
 
 ```js
 const { useE2EJestPuppeteerConfig } = require( '@woocommerce/e2e-environment' );
@@ -172,7 +172,7 @@ module.exports = puppeteerConfig;
 
 ### Jest Setup
 
-Jest provides [setup and teardown functions](https://jestjs.io/docs/setup-teardown) similar to PHPUnit. The default setup and teardown is in [`tests/e2e/env/src/setup/jest.setup.js`](src/setup/jest.setup.js). Additional setup and teardown functions can be added to [`tests/e2e/config/jest.setup.js`](../config/jest.setup.js)
+Jest provides [setup and teardown functions](https://jestjs.io/docs/setup-teardown) similar to PHPUnit. The default setup and teardown is in [`src/setup/jest.setup.js`](src/setup/jest.setup.js). Additional setup and teardown functions can be added to [`tests/e2e/config/jest.setup.js`](../../../plugins/woocommerce/tests/e2e/config/jest.setup.js)
 
 #### Console filtering
 

--- a/packages/js/e2e-environment/config/jest-object.config.js
+++ b/packages/js/e2e-environment/config/jest-object.config.js
@@ -3,7 +3,7 @@
  */
 const { E2E_RETRY_TIMES } = process.env;
 
-const setupJestRetries = ( retries = 2 ) => {
+const setupJestRetries = ( retries = 0 ) => {
 	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : retries;
 
 	jest.retryTimes( retryTimes );

--- a/packages/js/e2e-environment/config/jest-object.config.js
+++ b/packages/js/e2e-environment/config/jest-object.config.js
@@ -6,7 +6,9 @@ const { E2E_RETRY_TIMES } = process.env;
 const setupJestRetries = ( retries = 0 ) => {
 	const retryTimes = E2E_RETRY_TIMES ? E2E_RETRY_TIMES : retries;
 
-	jest.retryTimes( retryTimes );
+	if ( retryTimes > 0 ) {
+		jest.retryTimes( retryTimes );
+	}
 };
 
 // If more methods are added to setupJestObject, it should be include in the readme

--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -40,7 +40,7 @@ async function trashExistingPosts() {
 // each other's side-effects.
 beforeAll(async () => {
 
-	setupJestRetries();
+	setupJestRetries( 2 );
 
 	if ( DEFAULT_TIMEOUT_OVERRIDE ) {
 		page.setDefaultNavigationTimeout( DEFAULT_TIMEOUT_OVERRIDE );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Enabled jest retries when being executed locally
* Disabled jest retries by default for package users

### How to test the changes in this Pull Request:

```
$ pnpm install
$ cd plugins/woocommerce
$ pnpx wc-e2e docker:up
$ E2E_RETRY_TIMES=2 pnpx wc-e2e test:e2e
```
