### PR TITLE
Bump woocommerce-admin version to 2.9.2

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "2.9.1",
+		"woocommerce/woocommerce-admin": "2.9.2",
 		"woocommerce/woocommerce-blocks": "6.3.3"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20885acd22c0a58cff8852e7cf4ebf20",
+    "content-hash": "688f13d253b2879a5f0181eb7fbf0e38",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "fdffbfef084c65a3e2141f0aff41cef3bad27553"
+                "reference": "0533358c160f58272d02ae1962e267a546a5c26c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/fdffbfef084c65a3e2141f0aff41cef3bad27553",
-                "reference": "fdffbfef084c65a3e2141f0aff41cef3bad27553",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0533358c160f58272d02ae1962e267a546a5c26c",
+                "reference": "0533358c160f58272d02ae1962e267a546a5c26c",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.2"
             },
-            "time": "2021-12-08T02:59:25+00:00"
+            "time": "2021-12-13T23:49:48+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2926,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.9.2

## Testing Instructions

This release fixes an issue in the Shipping task.

**Task completion**

1. Delete any shipping rates so the shipping task is not marked complete.
2. Delete WCS if active so that the plugins step appears.
2. Navigate to the shipping task.
3. On the plugin installation step, click "No thanks"
4. Note that you are redirected to the homescreen and the task is marked complete.

**Connection step**

1. Delete any shipping rates so the shipping task is not marked complete.
2. Delete WCS if active so that the plugins step appears.
2. Navigate to the shipping task.
3. Continue installing the plugin.
4. Note that you land on the Connect step

**Task abandonment**

1. Delete any shipping rates so the shipping task is not marked complete.
2. Navigate to the shipping task.
3. Complete the rates step.
4. Use the back button next to the page title to navigate back to the homescreen.
5. Note that the task is marked complete since rates are complete.

## Changelog

```
- Fix: Fix shipping task completion status #8031
 ```
