### PR TITLE
Add archive-product template to taxonomy template hierarchy

### DIFF
--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -59,7 +59,9 @@ class WC_Template_Loader {
 
 	/**
 	 * If a block template has an archive-product.html file, but not a taxonomy-product_cat/taxonomy-product_tag file then we will
-	 * use the archive-product.html file in place of those as they are often then same template.
+	 * use the archive-product.html file in place of those as they are often the same template.
+	 *
+	 * We will add archive-product.php second to last, as taxonomy.php will always be last.
 	 *
 	 * @param array $templates list of templates in order of preference.
 	 *
@@ -67,7 +69,6 @@ class WC_Template_Loader {
 	 */
 	public static function modify_taxonomy_block_template_hierachy( $templates ) {
 		if ( is_product_taxonomy() ) {
-			// Add archive-product.php second last, as archive.php will always be last.
 			array_splice( $templates, count( $templates ) - 1, 0, 'archive-product.php' );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -144,7 +144,7 @@ class WC_Template_Loader {
 			$object = get_queried_object();
 
 			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-				if ( self::has_block_template( 'taxonomy-' . $object->taxonomy ) ) {
+				if ( self::has_block_template( 'taxonomy-' . $object->taxonomy ) || self::has_block_template( 'archive-product' ) ) {
 					$default_file = '';
 				} else {
 					$default_file = 'taxonomy-' . $object->taxonomy . '.php';

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -45,14 +45,33 @@ class WC_Template_Loader {
 			add_filter( 'template_include', array( __CLASS__, 'template_loader' ) );
 			add_filter( 'comments_template', array( __CLASS__, 'comments_template_loader' ) );
 
-			// Loads gallery scripts on Product page for FSE themes.
 			if ( wc_current_theme_is_fse_theme() ) {
+				add_filter( 'taxonomy_template_hierarchy', array( __CLASS__, 'modify_taxonomy_block_template_hierachy' ), 10, 1 );
+
+				// Loads gallery scripts on Product page for FSE themes.
 				self::add_support_for_product_page_gallery();
 			}
 		} else {
 			// Unsupported themes.
 			add_action( 'template_redirect', array( __CLASS__, 'unsupported_theme_init' ) );
 		}
+	}
+
+	/**
+	 * If a block template has an archive-product.html file, but not a taxonomy-product_cat/taxonomy-product_tag file then we will
+	 * use the archive-product.html file in place of those as they are often then same template.
+	 *
+	 * @param array $templates list of templates in order of preference.
+	 *
+	 * @return array
+	 */
+	public static function modify_taxonomy_block_template_hierachy( $templates ) {
+		if ( is_product_taxonomy() ) {
+			// Add archive-product.php second last, as archive.php will always be last.
+			array_splice( $templates, count( $templates ) - 1, 0, 'archive-product.php' );
+		}
+
+		return $templates;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5230

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
