### PR TITLE
Bump WCA version to 2.9.3

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "2.9.2",
+		"woocommerce/woocommerce-admin": "2.9.3",
 		"woocommerce/woocommerce-blocks": "6.3.3"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "688f13d253b2879a5f0181eb7fbf0e38",
+    "content-hash": "8c4f8b290830d85dce9e69de46ca72ce",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.9.2",
+            "version": "2.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "0533358c160f58272d02ae1962e267a546a5c26c"
+                "reference": "0c4f1e637ad03178999ff53ae930b8258ca95962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0533358c160f58272d02ae1962e267a546a5c26c",
-                "reference": "0533358c160f58272d02ae1962e267a546a5c26c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0c4f1e637ad03178999ff53ae930b8258ca95962",
+                "reference": "0c4f1e637ad03178999ff53ae930b8258ca95962",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.2"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.3"
             },
-            "time": "2021-12-13T23:49:48+00:00"
+            "time": "2021-12-15T03:02:58+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.9.3

## Fixes

https://github.com/woocommerce/woocommerce-admin/pull/7994


## Testing Instructions

1. Use fresh site, and ensure you select a country that is WCPay supported (USA)
2. Go through Onboarding wizard don't install any plugins in Business Details step
3. Click the "Setup payments" task (NOT the WCPay specific task)
4. Click "Get Started" button on the WCPay card.
5. Notice how the `Set up` button is now present on step 2
6. Try the same thing for the Paypal or Stripe gateways, step 2 should not be blank.

## Changelog

```
- Fix: Correctly match payment gateways by id #7994
 ```
