### PR TITLE
Bump Woo Admin to 2.9.4

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "2.9.3",
+		"woocommerce/woocommerce-admin": "2.9.4",
 		"woocommerce/woocommerce-blocks": "6.3.3"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c4f8b290830d85dce9e69de46ca72ce",
+    "content-hash": "d12a5b11e3d6dc2ac228efa1cd5efadc",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.9.3",
+            "version": "2.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "0c4f1e637ad03178999ff53ae930b8258ca95962"
+                "reference": "0cc85981f2def42e604118c7f5032e2750056763"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0c4f1e637ad03178999ff53ae930b8258ca95962",
-                "reference": "0c4f1e637ad03178999ff53ae930b8258ca95962",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0cc85981f2def42e604118c7f5032e2750056763",
+                "reference": "0cc85981f2def42e604118c7f5032e2750056763",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.3"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.9.4"
             },
-            "time": "2021-12-15T03:02:58+00:00"
+            "time": "2021-12-15T14:33:43+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2926,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.9.4

It fixes an issue in 2.9.3, where the reported version was incorrect in the System Status Report.


## Testing Instructions

1. View WooCommerce System Status Report
2. See that WooCommerce Admin version is 2.9.4 

## Changelog

```
== 2.9.4 12/15/2021 ==
- Fix: Incorrect version reported in system status report.
 ```
