### PR TITLE
Fix Puerto Rico State Checkout Error

### DIFF
--- a/plugins/woocommerce/i18n/states.php
+++ b/plugins/woocommerce/i18n/states.php
@@ -1461,7 +1461,6 @@ return array(
 		'SD' => __( 'Sindh', 'woocommerce' ),
 	),
 	'PL' => array(),
-	'PR' => array(),
 	'PT' => array(),
 	'PY' => array( // Paraguay states.
 		'PY-ASU' => __( 'Asunción', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1314,8 +1314,7 @@ class WC_Countries {
 							'label' => __( 'Municipality', 'woocommerce' ),
 						),
 						'state' => array(
-							'required' => false,
-							'hidden'   => true,
+							'required' => true,
 						),
 					),
 					'PT' => array(


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

![error-message](https://user-images.githubusercontent.com/3330/146436462-356a92ad-802d-477f-ba72-a438193a8625.png)

This PR makes the State field required again to fix issues with Puerto Rico billing address validation.

Closes #26643

### How to test the changes in this Pull Request:

1. Choose Puerto Rico as a country
2. Fill out all the fields
3. Place and order

### Changelog entry

> Require the State field for Puerto Rico addresses to fix billing address validation.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
