### PR TITLE
Add workflow for issue triage replies

### DIFF
--- a/.github/workflows/triage-replies.yml
+++ b/.github/workflows/triage-replies.yml
@@ -1,0 +1,120 @@
+name: Add issue triage comments.
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-dev-comment:
+    if: "github.event.label.name == 'needs developer feedback'"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add developer feedback comment
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hi @${{ github.event.issue.user.login }},\n\n\
+              Thank you for opening the issue! It requires further feedback from the WooCommerce Core team.\n\n\
+              We are adding the `needs developer feedback` label to this issue so that the Core team could take a look.\n\n\
+              Please note it may take a few days for them to get to this issue. Thank you for your patience.'
+            })              
+  add-reproduction-comment:
+    if: "github.event.label.name == 'status: needs reproduction'"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add needs reproduction comment
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'We are adding the `status: needs reproduction` label to this issue to try reproduce it on the \
+              current released version of WooCommerce.\n\n\
+              Thank you for your patience.'
+            })
+  add-support-comment:
+    if: "github.event.label.name == 'type: support request'"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add support request comment
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hi @${{ github.event.issue.user.login }},\n\n\
+              While our goal is to address all the issues reported in this repository, \
+              GitHub should be treated as a place to report confirmed bugs only.\n\n\
+              The type of issue you submitted looks like a support request which may or may not reveal a bug once proper \
+              troubleshooting is done.  In order to confirm the bug, please follow one of the steps below:\n\n\
+              - Review [WooCommerce Self-Service Guide](https://docs.woocommerce.com/document/woocommerce-self-service-guide/) \
+              to see if the solutions listed there apply to your case;\n\
+              - If you are a paying customer of WooCommerce, contact WooCommerce support by \
+              [opening a ticket or starting a live chat](https://woocommerce.com/contact-us/);\n\
+              - Make a post on [WooCommerce community forum](https://wordpress.org/support/plugin/woocommerce/)\n\n\
+              If you confirm the bug, please provide us with clear steps to reproduce it.\n\n\
+              We are closing this issue for now as it seems to be a support request and not a bug. \
+              If we missed something, please leave a comment and we will take a second look.'
+            })
+      - name: Close support request issue
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          script: |
+            github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  state: 'closed'
+                })
+  add-votes-comment:
+    if: "github.event.label.name == 'votes needed'"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add votes needed comment
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Thanks for the suggestion @${{ github.event.issue.user.login }},\n\n\
+              While we appreciate you sharing your ideas with us, it doesn’t fit in with our current priorities for the project.\n\
+              At some point, we may revisit our priorities and look through the list of suggestions like this one to see if it \
+              warrants a second look.\n\n\
+              In the meantime, we are going to close this issue with the `votes needed` label and evaluate over time if this \
+              issue collects more feedback.\n\n\
+              Don’t be alarmed if you don’t see any activity on this issue for a while. \
+              We'll keep an eye on the popularity of this request.'
+            })
+      - name: Close votes needed issue
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          script: |
+            github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  state: 'closed'
+                })


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add GitHub action workflow `triage-replies.yml` to automate issue replies during issue triage. Upon applying certain labels to an issue a reply will be added by the @woocommercebot account. For some labels (currently support request and votes needed) the issues will also be closed automatically.

**Labels which will trigger replies**
- `needs developer feedback`
- `status: needs reproduction`

**Labels which will trigger replies and closing of issue**
- `type: support request`
- `votes needed`



### How to test the changes in this Pull Request:

I don't believe there is a way to be able to test this PR in this repository before it is merged.

Below is a screenshot of testing I performed in another repository.

![screencapture-github-tammullen-label-comment-issues-14-2021-12-22-13_03_14](https://user-images.githubusercontent.com/24649833/147102346-773c6546-ebc7-42a8-8988-f2f229fa1641.jpg)



Feedback welcome on the labels included in this workflow and the reply snippets used.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
