### PR TITLE
WIP dismiss onboarding wizard on page load tests

### DIFF
--- a/packages/js/e2e-core-tests/specs/data/elements.js
+++ b/packages/js/e2e-core-tests/specs/data/elements.js
@@ -9,7 +9,7 @@ export const MENUS = [
 		[
 			[
 				'Home',
-				'#toplevel_page_woocommerce > ul > li:nth-child(2) > a',
+				'',
 				'Home',
 			],
 			[

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-page-loads.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-page-loads.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-const { merchant } = require( '@woocommerce/e2e-utils' );
+const { merchant, waitForSelectorWithoutThrow } = require( '@woocommerce/e2e-utils' );
 const { MENUS } = require( '../data/elements' );
 
 /**
@@ -28,13 +28,17 @@ const runPageLoadTest = () => {
 					await Promise.all( [
 						page.click( menuElement ),
 						page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+						merchant.dismissOnboardingWizard(),
+						merchant.collapseAdminMenu( false ),
 					] );
 
 					// Click sub-menu item and wait for the page to finish loading
-					await Promise.all( [
-						page.click( subMenuElement ),
-						page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-					] );
+					if ( subMenuElement.length ) {
+						await Promise.all([
+							page.click( subMenuElement ),
+							page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+						] );
+					}
 
 					await expect( page ).toMatchElement( 'h1', {
 						text: subMenuText,

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-page-loads.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-page-loads.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-const { merchant, waitForSelectorWithoutThrow } = require( '@woocommerce/e2e-utils' );
+const { merchant } = require( '@woocommerce/e2e-utils' );
 const { MENUS } = require( '../data/elements' );
 
 /**

--- a/packages/js/e2e-utils/CHANGELOG.md
+++ b/packages/js/e2e-utils/CHANGELOG.md
@@ -23,6 +23,8 @@
 - `clickAndWaitForSelector( buttonSelector, resultSelector, timeout )` to click a button and wait for response
 - Optional parameter `testResponse` to `withRestApi` functions that contain an `expect()`
 - `shopper.logout()` to log out the shopper account
+- `merchant.dismissOnboardingWizard()` to dismiss the onboarding wizard
+- `merchant.collapseAdminMenu()` to expand or collapse the WP admin menu
 
 # 0.1.6
 

--- a/packages/js/e2e-utils/README.md
+++ b/packages/js/e2e-utils/README.md
@@ -84,6 +84,8 @@ This package provides support for enabling retries in tests:
 
 | Function | Parameters | Description |
 |----------|-------------|------------|
+| `collapseAdminMenu` | `collapse` | Collapse or expand the WP admin menu |
+| `dismissOnboardingWizard` |  | Dismiss the onboarding wizard if present |
 | `goToOrder` | `orderId` | Go to view a single order |
 | `goToProduct` | `productId` | Go to view a single product |
 | `login` | | Log in as merchant |

--- a/packages/js/e2e-utils/src/flows/merchant.js
+++ b/packages/js/e2e-utils/src/flows/merchant.js
@@ -440,7 +440,7 @@ const merchant = {
 	 */
 	collapseAdminMenu: async ( collapse = true ) => {
 		const collapseButton = await page.$( '.folded #collapse-button' );
-		if ( ( ! collapseButton ) == collapseButton ) {
+		if ( ( ! collapseButton ) == collapse ) {
 			await collapseButton.click();
 		}
 

--- a/packages/js/e2e-utils/src/flows/merchant.js
+++ b/packages/js/e2e-utils/src/flows/merchant.js
@@ -52,6 +52,7 @@ const merchant = {
 		await Promise.all( [
 			page.click( 'input[type=submit]' ),
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			merchant.dismissOnboardingWizard(),
 		] );
 	},
 
@@ -409,6 +410,41 @@ const merchant = {
 			await merchant.checkDatabaseUpdateComplete();
 		}
    },
+
+	/**
+	 * Dismiss the onboarding wizard if it is open.
+	 */
+	dismissOnboardingWizard: async () => {
+		let waitForNav = false;
+		const skipButton = await page.$( '.woocommerce-profile-wizard__footer-link' );
+		if ( skipButton ) {
+			await skipButton.click();
+			waitForNav = true;
+		}
+
+		// Dismiss usage tracking pop-up window if it appears on a new site
+		const usageTrackingHeader = await page.$( '.woocommerce-usage-modal button.is-secondary' );
+		if ( usageTrackingHeader ) {
+			await usageTrackingHeader.click();
+			waitForNav = true;
+		}
+
+		if ( waitForNav ) {
+			await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+		}
+	},
+
+	/**
+	 * Expand or collapse the WP admin menu.
+	 * @param {boolean} collapse Flag to collapse or expand the menu. Default collapse.
+	 */
+	collapseAdminMenu: async ( collapse = true ) => {
+		const collapseButton = await page.$( '.folded #collapse-button' );
+		if ( ( ! collapseButton ) == collapseButton ) {
+			await collapseButton.click();
+		}
+
+	},
 };
 
 module.exports = merchant;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses two potential issues with the admin page load test. One of those could also cause other tests to fail.

1. Many of the merchant tests can fail if they are the first test to run on a new WP install. The tests rely on the onboarding wizard having been dismissed in a previous test. 
2. In screenshots from the release smoke test, the WP admin menu was collapsed. When collapsed, submenus are accessed via hover flyout and not directly clickable.

This PR adds the following:
- `merchant.dismissOnboardingWizard()` which will dismiss the onboarding wizard if present. It also declines the tracking opt in if present.
- `merchant.collapseAdminMenu()` which collapses the admin menu if expanded. When passed `false` as a parameter, it expands the menu if collapsed.
- Dismisses the onboarding screen on merchant login if auto directed to it.
- Dismisses the onboarding screen and expands the WP admin menu in the page load tests.
- Allows the submenu selector to be empty when the submemu item is the default item for the top level menu item.

Note: no changelog needed for e2e-core-tests as the admin page test hadn't been released yet

### How to test the changes in this Pull Request:

1. Run `pnpm i`
2. Run `pnpx wc-e2e docker:up`
3. Run `pnpx tests/e2e/specs/wp-admin/page-loads.test.js`
4. Tests should pass
