### PR TITLE
Copy e2e files for smoke testing release

### DIFF
--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -103,7 +103,6 @@ jobs:
             mv ./code/woocommerce/project.json ./package/woocommerce/plugins/woocommerce
             mv ./code/woocommerce/legacy/project.json ./package/woocommerce/plugins/woocommerce/legacy
             mv ./code/woocommerce/tests ./package/woocommerce/plugins/woocommerce
-            ls ./package/woocommerce/plugins/woocommerce/node_modules/.bin/wc-e2e
 
       - name: Run tests command.
         working-directory: package/woocommerce/plugins/woocommerce

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -1,7 +1,5 @@
 name: Smoke test release
-on:
-  release:
-    types: [published]
+on: pull_request
 jobs:
   login-run:
     name: Daily smoke test on release.
@@ -93,10 +91,19 @@ jobs:
         run: |
           ASSET_ID=$(jq ".release.assets[0].id" $GITHUB_EVENT_PATH)
 
-          curl https://api.github.com/repos/woocommerce/woocommerce/releases/assets/${ASSET_ID} -LJOH 'Accept: application/octet-stream'
+          curl https://api.github.com/repos/woocommerce/woocommerce/releases/assets/52302540 -LJOH 'Accept: application/octet-stream'
 
           unzip woocommerce.zip -d woocommerce
           mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+      
+      - name: Copy relevant e2e files for testing purposes
+        run: |
+            mv ./code/woocommerce/node_modules ./package/woocommerce/plugins/woocommerce
+            mv ./code/woocommerce/package.json ./package/woocommerce/plugins/woocommerce
+            mv ./code/woocommerce/project.json ./package/woocommerce/plugins/woocommerce
+            mv ./code/woocommerce/legacy/project.json ./package/woocommerce/plugins/woocommerce/legacy
+            mv ./code/woocommerce/tests ./package/woocommerce/plugins/woocommerce
+            ls ./package/woocommerce/plugins/woocommerce/node_modules/.bin/wc-e2e
 
       - name: Run tests command.
         working-directory: package/woocommerce/plugins/woocommerce

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -1,5 +1,7 @@
 name: Smoke test release
-on: pull_request
+on:
+  release:
+    types: [published]
 jobs:
   login-run:
     name: Daily smoke test on release.
@@ -91,7 +93,7 @@ jobs:
         run: |
           ASSET_ID=$(jq ".release.assets[0].id" $GITHUB_EVENT_PATH)
 
-          curl https://api.github.com/repos/woocommerce/woocommerce/releases/assets/52302540 -LJOH 'Accept: application/octet-stream'
+          curl https://api.github.com/repos/woocommerce/woocommerce/releases/assets/${ASSET_ID} -LJOH 'Accept: application/octet-stream'
 
           unzip woocommerce.zip -d woocommerce
           mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Similarly to e2e tests, certain files are required for testing and running scripts that are not included in a release when a zip is created. In order to ensure those files are present when smoke testing a release's zip, this PR manually moves `node_modules` from the previous step's `pnpm install`.

I preserved the entire `node_modules` folder because packages like `@woocommerce/e2e-environment` and all of its dependencies are required in the `plugins/woocommerce` folder. Previously those dependencies were being used at the root level and our file restructuring require them in `plugins/woocommerce`. So functionally, nothing has changed besides this.

## A note on testing

In order to test these changes without making a release, **I had to make two modifications that will need to be removed before merge.** I'll note them on the lines as well, but they are including Smoke Test Release on pull request and I hard coded the asset id to point to the `release/6.1` asset. You can confirm this by verifying the asset id found at https://api.github.com/repos/woocommerce/woocommerce/releases. I have left these changes so passing tests can be confirmed.

## Test

See the Smoke Test Release Github Action passing with the `release/6.1` asset.

