### PR TITLE
add new filter hook to add custom atts in products shortcode

### DIFF
--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-products.php
@@ -111,7 +111,7 @@ class WC_Shortcode_Products {
 		$attributes = $this->parse_legacy_attributes( $attributes );
 
 		$attributes = shortcode_atts(
-			array(
+			apply_filters( 'woocommerce_products_shortcode_atts', array(
 				'limit'          => '-1',      // Results limit.
 				'columns'        => '',        // Number of columns.
 				'rows'           => '',        // Number of rows. If defined, limit will be ignored.
@@ -131,7 +131,7 @@ class WC_Shortcode_Products {
 				'page'           => 1,         // Page for pagination.
 				'paginate'       => false,     // Should results be paginated.
 				'cache'          => true,      // Should shortcode output be cached.
-			),
+			) ),
 			$attributes,
 			$this->type
 		);


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

To show specific products based on product shortcode atts.

Closes # .

### How to test the changes in this Pull Request:

1. Add a new atts in products shortcode
2. Add custom query arguments based on atts in use

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add - Add new filter hook to push custom atts in products shortcode

### FOR PR REVIEWER ONLY:

* [ x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
