### PR TITLE
Change '__return_true' to true in apply_filters()

### DIFF
--- a/plugins/woocommerce/includes/wc-term-functions.php
+++ b/plugins/woocommerce/includes/wc-term-functions.php
@@ -401,7 +401,7 @@ function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_
 	 * @since 5.2
 	 * @param bool
 	 */
-	if ( ! apply_filters( 'woocommerce_product_recount_terms', '__return_true' ) ) {
+	if ( ! apply_filters( 'woocommerce_product_recount_terms', true ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Presumably the original author of this code intended to use true here
instead of '__return_true'; '__return_true' is commonly used with
add_filter() but it does not really make sense to use it here.

This was not really a bug because '__return_true' is a "truthy" value,
so the logic was working as intended; I am changing it to true just to
improve code readability.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. I used WP-CLI just to make sure that nothing broke:
```
$ wp wc product_cat create --name=test_product_category --user=1
Success: Created product_cat 17.
$ wp wc product create --name=test_product --user=1
Success: Created product 13.
$ wp wc product update 13 --categories='[{"id":17}]' --user=1
Success: Updated product 13.
$ wp db query "SELECT * FROM wp_termmeta WHERE meta_key = 'product_count_product_cat' AND term_id = 17"
meta_id term_id meta_key        meta_value
7       17      product_count_product_cat       1
$ wp wc product update 13 --categories='[]' --user=1
Success: Updated product 13.
$ wp db query "SELECT * FROM wp_termmeta WHERE meta_key = 'product_count_product_cat' AND term_id = 17"
meta_id term_id meta_key        meta_value
7       17      product_count_product_cat       0
```
2. Check the product_count_product_cat meta_value - if the number is getting updated, that means the terms are successfully being recounted as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Change `'__return_true'` to `true` in the `apply_filters()` call for the `woocommerce_product_recount_terms` filter.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
