### PR TITLE
Updated workflow to remove label after smoke tests are complete

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -96,9 +96,7 @@ jobs:
             await script({github, context})
 
       - name: Remove label from pull request.
-        if: |
-          ${{ contains(github.event.label.name, 'run: smoke tests') }} &&
-          always()
+        if: always()
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run smoke test.
         working-directory: package/woocommerce/plugins/woocommerce
-        if: steps.installation.outcome == 'success'
+        if: always()
         env:
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
           SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run E2E tests.
         working-directory: package/woocommerce/plugins/woocommerce
-        if: steps.installation.outcome == 'success'
+        if: always()
         env:
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
           SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Create dirs.
         run: |
-              mkdir -p code/woocommerce
-              mkdir -p package/woocommerce
-              mkdir -p tmp/woocommerce
-              mkdir -p node_modules
+          mkdir -p code/woocommerce
+          mkdir -p package/woocommerce
+          mkdir -p tmp/woocommerce
+          mkdir -p node_modules
 
       - name: Checkout code.
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
           pnpm nx composer-install-no-dev woocommerce
           pnpm nx build-assets woocommerce
           pnpm install jest
-          
+
       - name: Run smoke test.
         working-directory: package/woocommerce/plugins/woocommerce
         if: steps.installation.outcome == 'success'
@@ -55,7 +55,7 @@ jobs:
       - name: Post Smoke tests results comment on PR
         if: always()
         uses: actions/github-script@v5
-        env: 
+        env:
           TITLE: 'Smoke Test Results'
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
         with:
@@ -86,7 +86,7 @@ jobs:
       - name: Post E2E tests results comment on PR
         if: always()
         uses: actions/github-script@v5
-        env: 
+        env:
           TITLE: 'E2E Test Results'
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
         with:
@@ -96,7 +96,9 @@ jobs:
             await script({github, context})
 
       - name: Remove label from pull request.
-        if: "${{ contains(github.event.pull_request.labels.*.name, 'run: smoke tests') }}"
+        if: |
+          ${{ contains(github.event.label.name, 'run: smoke tests') }} &&
+          always()
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -96,7 +96,7 @@ jobs:
             await script({github, context})
 
       - name: Remove label from pull request.
-        if: always()
+        if: always() && ${{ contains(github.event.label.name, format( 'run{0} smoke tests', ':') ) }}
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the workflow step that removes the `run: smoke tests` label after smoke tests are done on PRs. 
The condition for the **Remove label from pull request.** step has been set to `always` because the workflow can only be executed if the `run: smoke tests` label was already present on the PR.

I also updated the steps to execute steps to be `always()` since we always want them to be executed even when previous steps may fail. This is to ensure that we get accurate test results posted to the associated PR.

Closes #31398.

### How to test the changes in this Pull Request:

1. Create a PR
2. Add `run: smoke tests` label
3. Wait for tests to complete and observe comments on the associated PR