### PR TITLE
Revert #30044

### DIFF
--- a/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
+++ b/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
@@ -21,7 +21,6 @@ class WC_Shop_Customizer {
 		add_action( 'customize_controls_print_styles', array( $this, 'add_styles' ) );
 		add_action( 'customize_controls_print_scripts', array( $this, 'add_scripts' ), 30 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_frontend_scripts' ) );
-		add_action( 'admin_menu', array( $this, 'add_fse_customize_link' ) );
 	}
 
 	/**
@@ -84,19 +83,6 @@ class WC_Shop_Customizer {
 				width: auto;
 				display: inline-block;
 			}
-			<?php
-			// For FSE themes hide the back button so we only surface WooCommerce options.
-			if ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) {
-				?>
-					#sub-accordion-panel-woocommerce .customize-panel-back{
-						display: none;
-					}
-					#customize-controls #sub-accordion-panel-woocommerce .panel-meta.customize-info .accordion-section-title {
-						margin-left: 0;
-					}
-				<?php
-			}
-			?>
 		</style>
 		<?php
 	}
@@ -263,29 +249,6 @@ class WC_Shop_Customizer {
 			} );
 		</script>
 		<?php
-	}
-
-	/**
-	 * For FSE themes add a "Customize WooCommerce" link to the Appearance menu.
-	 *
-	 * FSE themes hide the "Customize" link in the Appearance menu. In WooCommerce we have several options that can currently
-	 * only be edited via the Customizer. For now, we are thus adding a new link for WooCommerce specific Customizer options.
-	 */
-	public function add_fse_customize_link() {
-
-		// Exit early if the FSE theme feature isn't present or the current theme is not a FSE theme.
-		if ( ! function_exists( 'gutenberg_is_fse_theme' ) || function_exists( 'gutenberg_is_fse_theme' ) && ! gutenberg_is_fse_theme() ) {
-			return;
-		}
-
-		// Add a link to the WooCommerce panel in the Customizer.
-		add_submenu_page(
-			'themes.php',
-			__( 'Customize WooCommerce', 'woocommerce' ),
-			__( 'Customize WooCommerce', 'woocommerce' ),
-			'edit_theme_options',
-			admin_url( 'customize.php?autofocus[panel]=woocommerce' )
-		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/30044, the link `Customize WooCommerce` had been added to `Apperance` section and the back button of the `WooCommerce` settings within `Apperance » Customize` had been removed. This change had been applied assuming that when using a block theme, the `Customizer` would no longer be visible.

In https://github.com/WordPress/gutenberg/pull/35877, a switch had been added to Gutenberg, to show the `Customizer` for block themes, when a plugin is adding settings to the Customizer.

### How to test the changes in this Pull Request:

1. Spin up a site using 5.9+.
2. Select a block theme, e.g. TT1.
3. Go to `/wp-admin/themes.php` and verify that the link `Customize WooCommerce` is no longer visible.
4. Go to `/wp-admin/customize.php`, click on the section WooCommerce and verify that the back button is visible again.

### Screenshot

<table>
<tr>
<td valign="top">Before:
<br><br>

![before](https://user-images.githubusercontent.com/3323310/147355709-8ff918c7-00ef-47c3-ab1f-49cef3b77f55.png)
</td>
<td valign="top">After:
<br><br>

![after](https://user-images.githubusercontent.com/3323310/147355713-175a0cc3-4ea7-4647-a4d5-4e9b0d77195d.png)
</td>
</tr>
</table>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Ensure that `WooCommerce` panel within the `Customizer` is showing a back button.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
