### PR TITLE
Bump woocommerce-admin version to 3.0.0

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.0.0-rc.1",
+		"woocommerce/woocommerce-admin": "3.0.0",
 		"woocommerce/woocommerce-blocks": "6.5.1"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecce1670d22ae2df07e552adce1cfc29",
+    "content-hash": "5a2f54119468e9324a143d18676fc526",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.0.0-rc.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "7c0cdd01ae98be058d684dd19023b0f40094cb63"
+                "reference": "345a6545c370433230abba6f82acbac40c78d8ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/7c0cdd01ae98be058d684dd19023b0f40094cb63",
-                "reference": "7c0cdd01ae98be058d684dd19023b0f40094cb63",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/345a6545c370433230abba6f82acbac40c78d8ea",
+                "reference": "345a6545c370433230abba6f82acbac40c78d8ea",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.0-rc.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.0"
             },
-            "time": "2021-12-14T23:55:42+00:00"
+            "time": "2021-12-28T15:48:59+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.0.0

## New Feature Tests

**Smoke testing**

1. Make sure the task lists and all tasks are returned as expected
2. Go to Products->Help (tab)->Setup Wizard
3. Attempt to Disable/Enable the task lists and make sure these actions work as expected
4. Smoke test the task list, viewing, snoozing, dismissing, and undoing those actions

### Inbox - Read notes

1. Go to WooCommerce home screen
2. Interact with a note by clicking on its title or action buttons.
3. Return to the WooCommerce home screen
4. See that the note is in a read state, with duller appearance.

### Inbox - Dismiss single note

1. Go to WooCommerce home screen
2. Dismiss a single note using the "Dismiss" button when hovering over a note.
3. See the "Message dismissed" notification.
4. Click "Undo" on the notification.
5. See the note returns to inbox.
6. Dismiss the note again.
7. Re-load the WooCommerce home screen.
8. See that the note no longer appears.

### Inbox - Activity menu

1. Go to WooCommerce products screen
2. On Menu bar, see that "Activity" menu item exists in top right corner.
3. Click "Activity" menu item.
4. See notes appear in panel.

### Inbox - Dismiss all notes

1. Go to WooCommerce home screen
2. On "Inbox" heading panel, click kebab menu (3 dots).
3. Click "Dismiss all".
4. On confirmation dialog, press "Cancel" button.
5. See that notes still remain.
6. Dismall all notes again and press "Yes, dismiss all" on confirmation dialog.
7. See that all notes are removed.

### Onboarding Workflow - Add number of employees field

1. Go to step 4 of the OBW (Business details).
2. Under `Currently selling elsewhere?` select any option other than "No".
3. A drop-down list with the following options should be visible:

```
It's just me
<10
10-50
50-250
+250
I'd rather not say
```

4. Select one of those options and fill out the rest of the options.
5. Open the browser devtools, go to the `Console` and enable the debug messages. You can do this by running `localStorage.setItem( 'debug', 'wc-admin:*' );` in the `Console` and looking for the verbose console messages.
6. Verify that the event `wcadmin_storeprofiler_store_business_details_continue_variant` is recorded with the prop `number_employees` after pressing `Continue`.



## Changelog

```
- Fix: Fix an issue with the code that makes use of an invalid parameter with a PHP function. The use of this invalid parameter causes PHP 8 to throw a Fatal Error. #7855
- Fix: Fix TaskList UI experiment enablement logic. #7930
- Fix: Navigation nudge note and navigation feedback notes will delete themselves if the navigation feature is not available. #7914
- Fix: Replace old task list option calls with data store selectors. #7820
- Fix: Self-delete NavigationFeedbackFollowUp note when navigation feature is not present. #7939
- Fix: Fix PHP Warning on 'Add new product' page. #7989
- Fix: Fix usage of Wordpress DatePicker component. #7982
- Fix: Fix shipping task completion status. #8031
- Add: Add option to dismiss promotional payment gateway. #7965
- Add: OBW - Add number of employees field. #7963
- Update: Ending wcpay promotion experiment and always displaying in payment methods table.
- Update: Hide InboxPanel header when it is rendered in the sidebar. #7952
- Update: Introduce a 320 character limit for inbox note contents. #7958
- Update: Move payments task to extended task list when WC Pay task is shown. #7980
- Update: Rename Inbox to Activity from the activity header. #7879
- Update: Load both actioned and unactioned notes. #7983
- Dev: Explicitly sets the Node version to 14 in .nvmrc to prevent incompatible versions of Node from being used with nvm. #7932
- Dev: Remove unused npm package @woocommerce/settings. #7949
- Dev: Update payment method recommendation to new woocommerce.com endpoint. #7913
- Dev: Use abstraction to add and retrieve task data. #7918
- Tweak: Added dismiss all button for inbox notes.
- Tweak: Implement note read state. #7896
- Tweak: Add inbox_panel_view tracks event. #8002
- Enhancement: Add tests to Subscriptions inclusion. #7804
 ```
