### PR TITLE
Add support for Gutenberg 12.1.0 block template naming convention

### DIFF
--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -102,6 +102,9 @@ class WC_Template_Loader {
 
 	/**
 	 * Checks whether a block template with that name exists.
+	 * 
+	 * **Note: ** This checks both the `templates` and `block-templates` directories
+	 * as both conventions should be supported.
 	 *
 	 * @since  5.5.0
 	 * @param string $template_name Template to check.
@@ -112,7 +115,35 @@ class WC_Template_Loader {
 			return false;
 		}
 
-		$has_template = is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' );
+		$has_template            = false;
+		$template_filename       = $template_name . '.html';
+		// Since Gutenberg 12.1.0, the conventions for block templates directories have changed,
+		// we should check both these possible directories for backwards-compatibility.
+		$possible_templates_dirs = array('templates', 'block-templates');
+
+		// Combine the possible root directory names with either the template directory
+		// or the stylesheet directory for child themes, getting all possible block templates
+		// locations combinations.
+		$possible_paths = array_reduce(
+			$possible_templates_dirs,
+			function( $carry, $item ) use ( $template_filename ) {
+				$filepath = DIRECTORY_SEPARATOR . $item . DIRECTORY_SEPARATOR . $template_filename;
+
+				$carry[] = get_template_directory() . $filepath;
+				$carry[] = get_stylesheet_directory() . $filepath;
+
+				return $carry;
+			},
+			array()
+		);
+
+		// Check the first matching one.
+		foreach ( $possible_paths as $path ) {
+			if ( is_readable( $path ) ) {
+				$has_template = true;
+				continue;
+			}
+		}
 
 		/**
 		 * Filters the value of the result of the block template check.

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -119,22 +119,18 @@ class WC_Template_Loader {
 		$template_filename       = $template_name . '.html';
 		// Since Gutenberg 12.1.0, the conventions for block templates directories have changed,
 		// we should check both these possible directories for backwards-compatibility.
-		$possible_templates_dirs = array('templates', 'block-templates');
+		$possible_templates_dirs = array( 'templates', 'block-templates' );
 
 		// Combine the possible root directory names with either the template directory
 		// or the stylesheet directory for child themes, getting all possible block templates
 		// locations combinations.
-		$possible_paths = array_reduce(
-			$possible_templates_dirs,
-			function( $carry, $item ) use ( $template_filename ) {
-				$filepath = DIRECTORY_SEPARATOR . $item . DIRECTORY_SEPARATOR . $template_filename;
-
-				$carry[] = get_template_directory() . $filepath;
-				$carry[] = get_stylesheet_directory() . $filepath;
-
-				return $carry;
-			},
-			array()
+		$filepath        = DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $template_filename;
+		$legacy_filepath = DIRECTORY_SEPARATOR . 'block-templates' . DIRECTORY_SEPARATOR . $template_filename;
+		$possible_paths  = array(
+			get_stylesheet_directory() . $filepath,
+			get_stylesheet_directory() . $legacy_filepath,
+			get_template_directory() . $filepath,
+			get_template_directory() . $legacy_filepath,
 		);
 
 		// Check the first matching one.

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -102,7 +102,7 @@ class WC_Template_Loader {
 
 	/**
 	 * Checks whether a block template with that name exists.
-	 * 
+	 *
 	 * **Note: ** This checks both the `templates` and `block-templates` directories
 	 * as both conventions should be supported.
 	 *
@@ -137,7 +137,7 @@ class WC_Template_Loader {
 		foreach ( $possible_paths as $path ) {
 			if ( is_readable( $path ) ) {
 				$has_template = true;
-				continue;
+				break;
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Gutenberg 12.1.0 has changed the convention for the directory paths from `block-templates` and `block-template-parts` to `templates` and `parts` respectively.

Previously, WooCommerce was checking whether block templates were available, only in the `block-templates` directory.

This commit adds support for both older and newer naming conventions, as well as parents and child themes.

Closes #31518

### How to test the changes in this Pull Request:

Using WP 5.8

1. Install Gutenberg plugin and a block theme which is using the old template directory names such as TT1 Blocks.
2. Check that the WC block templates render/are available in the Site Editor (under Appearance), and on the frontend.
3. Activate a block theme which is using the new template directory names such as the latest version of [Tove](https://en-gb.wordpress.org/themes/tove/))
4. Check that the WC block templates still render/are available  in the Site Editor (under Appearance), and on the frontend.

Using WP 5.9, replicate the steps above with the Gutenberg plugin deactivated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add support for Gutenberg 12.1.0 block template naming convention in themes

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
