### PR TITLE
Update block theme check to work in WP 5.9 without Gutenberg enabled

### DIFF
--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -484,12 +484,15 @@ function wc_is_file_valid_csv( $file, $check_path = true ) {
 }
 
 /**
- * Check if the current theme is an FSE theme.
+ * Check if the current theme is a block theme.
  *
  * @since x.x.x
  * @return bool
  */
 function wc_current_theme_is_fse_theme() {
+	if ( function_exists( 'wp_is_block_theme' ) ) {
+		return (bool) wp_is_block_theme();
+	}
 	if ( function_exists( 'gutenberg_is_fse_theme' ) ) {
 		return (bool) gutenberg_is_fse_theme();
 	}


### PR DESCRIPTION
The function `gutenberg_is_fse_theme()` from Gutenberg was renamed as `wp_is_block_theme()` in WP core. In order to get WC block templates to work correctly in WP 5.9 with Gutenberg disabled, we need to check whether that function exists or not.

@jonathansadowski would it be possible to get this PR included in WC 6.1?

### How to test the changes in this Pull Request:

1. In `trunk`, update your WordPress to 5.9 and make sure you have Gutenberg disabled.
2. Also, install a block theme (ie: [Twenty Twenty Two](https://github.com/wordpress/twentytwentytwo)).
3. Go to a page of a product and notice contents are duplicated (see screenshot below).
4. Checkout this branch and reload the product page.
5. Verify contents are not duplicated (see screenshot below).
6. Activate Gutenberg and make sure contents are not duplicated either (should be as the _After_ screenshot below).

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/147651575-dc30835a-69f5-4bb9-9b34-d3ca8726a5c1.png) | ![imatge](https://user-images.githubusercontent.com/3616980/147651633-9256829d-25f1-4d5c-a394-9bf20b52dd71.png) |

### Changelog entry

> Update block theme checks to work when Gutenberg is not enabled.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
