### PR TITLE
Bump woocommerce-admin version to 3.0.1

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.0.0",
+		"woocommerce/woocommerce-admin": "3.0.1",
 		"woocommerce/woocommerce-blocks": "6.5.1"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a2f54119468e9324a143d18676fc526",
+    "content-hash": "ebdb5708b79cdb94e4b2ff5fbed40d89",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "345a6545c370433230abba6f82acbac40c78d8ea"
+                "reference": "5542e80021a43d24ab9b1d2d67083b608899835d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/345a6545c370433230abba6f82acbac40c78d8ea",
-                "reference": "345a6545c370433230abba6f82acbac40c78d8ea",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5542e80021a43d24ab9b1d2d67083b608899835d",
+                "reference": "5542e80021a43d24ab9b1d2d67083b608899835d",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.0"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.1"
             },
-            "time": "2021-12-28T15:48:59+00:00"
+            "time": "2021-12-30T18:38:11+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.0.1

## New Feature Tests

### Settings - Payments

1. Start OBW and choose `CBD and other hemp-derived products` from the Industry tab.
2. Make sure **not** to install any payment plugins.
3. Navigate to `WooCommerce` -> `Settings` -> `Payments`.
4. Make sure no error is shown.

## Changelog

```
- Do not initialize WC Pay promotion if spec is empty #8087
 ```
