### PR TITLE
2022 theme stylings for product and shop pages.

### DIFF
--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -571,6 +571,9 @@ final class WooCommerce {
 				case 'twentytwentyone':
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-one.php';
 					break;
+				case 'twentytwentytwo':
+					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-two.php';
+					break;
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
@@ -30,9 +30,6 @@ class WC_Twenty_Twenty_Two {
 		// Enqueue theme compatibility styles.
 		add_filter( 'woocommerce_enqueue_styles', array( __CLASS__, 'enqueue_styles' ) );
 
-		// Enqueue wp-admin compatibility styles.
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_styles' ) );
-
 		// Register theme features.
 		add_theme_support( 'wc-product-gallery-zoom' );
 		add_theme_support( 'wc-product-gallery-lightbox' );
@@ -65,20 +62,6 @@ class WC_Twenty_Twenty_Two {
 
 		return apply_filters( 'woocommerce_twenty_twenty_two_styles', $styles );
 	}
-
-	/**
-	 * Enqueue the wp-admin CSS overrides for this theme.
-	 */
-	public static function enqueue_admin_styles() {
-		wp_enqueue_style(
-			'woocommerce-twenty-twenty-one-admin',
-			str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/css/twenty-twenty-two-admin.css',
-			'',
-			Constants::get_constant( 'WC_VERSION' ),
-			'all'
-		);
-	}
-
 
 }
 

--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Twenty Twenty TWO support.
+ *
+ * @since   6.0.0
+ * @package WooCommerce\Classes
+ */
+
+use Automattic\Jetpack\Constants;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Twenty_Twenty_One class.
+ */
+class WC_Twenty_Twenty_Two {
+
+	/**
+	 * Theme init.
+	 */
+	public static function init() {
+
+		// Change WooCommerce wrappers.
+		remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
+		remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
+
+		// This theme doesn't have a traditional sidebar.
+		remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
+
+		// Enqueue theme compatibility styles.
+		add_filter( 'woocommerce_enqueue_styles', array( __CLASS__, 'enqueue_styles' ) );
+
+		// Enqueue wp-admin compatibility styles.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_styles' ) );
+
+		// Register theme features.
+		add_theme_support( 'wc-product-gallery-zoom' );
+		add_theme_support( 'wc-product-gallery-lightbox' );
+		add_theme_support( 'wc-product-gallery-slider' );
+		add_theme_support( 'woocommerce',
+			array(
+				'thumbnail_image_width' => 450,
+				'single_image_width'    => 600,
+			)
+		);
+
+	}
+
+	/**
+	 * Enqueue CSS for this theme.
+	 *
+	 * @param  array $styles Array of registered styles.
+	 * @return array
+	 */
+	public static function enqueue_styles( $styles ) {
+		unset( $styles['woocommerce-general'] );
+
+		$styles['woocommerce-general'] = array(
+			'src'     => str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/css/twenty-twenty-two.css',
+			'deps'    => '',
+			'version' => Constants::get_constant( 'WC_VERSION' ),
+			'media'   => 'all',
+			'has_rtl' => true,
+		);
+
+		return apply_filters( 'woocommerce_twenty_twenty_two_styles', $styles );
+	}
+
+	/**
+	 * Enqueue the wp-admin CSS overrides for this theme.
+	 */
+	public static function enqueue_admin_styles() {
+		wp_enqueue_style(
+			'woocommerce-twenty-twenty-one-admin',
+			str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/css/twenty-twenty-two-admin.css',
+			'',
+			Constants::get_constant( 'WC_VERSION' ),
+			'all'
+		);
+	}
+
+
+}
+
+WC_Twenty_Twenty_Two::init();

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2362,6 +2362,7 @@ function wc_is_active_theme( $theme ) {
 function wc_is_wp_default_theme_active() {
 	return wc_is_active_theme(
 		array(
+			'twentytwentytwo',
 			'twentytwentyone',
 			'twentytwenty',
 			'twentynineteen',

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -289,6 +289,15 @@
 		a.reset_variations {
 			margin-left: 0.5em;
 		}
+
+		table.group_table {
+			td {
+				padding-right: 0.5rem;
+				padding-bottom: 1rem;
+			}
+
+			margin-bottom: var( --wp--style--block-gap );
+		}
 	}
 
 	.woocommerce-tabs {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -126,7 +126,7 @@
 		}
 	}
 
-	a.button, button[name='add-to-cart'], input[name='submit'] {
+	a.button, button[name='add-to-cart'], input[name='submit'], button.single_add_to_cart_button {
 		display: inline-block;
 		text-align: center;
 		word-break: break-word;
@@ -250,11 +250,40 @@
 					font-size: 1em;
 				}
 			}
+		}
 
-			button[name='add-to-cart'] {
-				margin-top: 0.5rem;
+		button[name='add-to-cart'], button.single_add_to_cart_button {
+			margin-top: 0.5rem;
+			margin-bottom: var( --wp--style--block-gap );
+		}
+
+		table.variations {
+			tr {
+				display: block;
 				margin-bottom: var( --wp--style--block-gap );
+
+				th {
+					padding-right: 1rem;
+				}
+
+				td select {
+					padding: 2px;
+				}
 			}
+		}
+
+		ol.flex-control-thumbs {
+			padding-left: 0;
+			float: left;
+
+			li {
+				list-style: none;
+				cursor: pointer;
+				float: left;
+				width: 18%;
+				margin-right: 1rem;
+			}
+
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -227,7 +227,7 @@
 			font-size: 1rem;
 
 			h1.product_title {
-				font-size: 3.5rem;
+				font-size: 2.5rem;
 				margin: 0;
 			}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -285,6 +285,10 @@
 			}
 
 		}
+
+		a.reset_variations {
+			margin-left: 0.5em;
+		}
 	}
 
 	.woocommerce-tabs {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -338,6 +338,8 @@
 
 		.woocommerce-Tabs-panel {
 			padding-top: var( --wp--style--block-gap );
+			font-size: 0.8em;
+			margin-left: 1em;
 
 			h2 {
 				display: none;

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -32,6 +32,21 @@
  */
 .woocommerce {
 
+	.woocommerce-products-header,
+	.woocommerce-notices-wrapper,
+	.woocommerce-result-count,
+	.woocommerce-ordering,
+	.woocommerce-breadcrumb,
+	.products {
+		max-width: 1000px;
+	}
+
+	.wp-site-blocks > .wp-block-group {
+		max-width: 1000px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
 	// Common
 	.woocommerce-products-header {
 		h1.page-title {
@@ -69,7 +84,7 @@
 		}
 	}
 
-	.woocommerce-breadcrumb {
+	&.woocommerce-shop .woocommerce-breadcrumb {
 		display: none;
 	}
 
@@ -146,18 +161,12 @@
 	// Shop page
 
 	.woocommerce-result-count {
-		float: none;
-		width: 100%;
+		margin-top: 0;
 		font-size: 0.9rem;
 	}
 
 	.woocommerce-ordering {
-		//170px is box size, 50% - 170px is to give right alignment
-		width: max( 170px, calc( 50% - 170px ) );
-		// For wide screens
-		max-width: 100%;
-
-		margin-top: 0;
+		margin-top: -0.2rem;
 		margin-bottom: 3rem;
 
 		select {
@@ -167,6 +176,9 @@
 
 	// Products.
 	ul.products {
+
+		padding-inline-start: 0;
+
 		li.product {
 			list-style: none;
 			margin-top: var(--wp--style--block-gap);
@@ -190,12 +202,13 @@
 
 	div.product {
 		position: relative;
+		max-width: 1000px;
 
-		span.onsale {
+		> span.onsale {
 			position: absolute;
 			left: -1rem;
 			top: -1rem;
-			width: 2.4em;
+			width: 1.8rem;
 			z-index: 1;
 		}
 
@@ -225,6 +238,10 @@
 
 		div.summary {
 			font-size: 1rem;
+
+			> *{
+				margin-bottom: var( --wp--style--block-gap );
+			}
 
 			h1.product_title {
 				font-size: 2.5rem;

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -1,0 +1,465 @@
+/**
+* Fonts
+*/
+@font-face {
+	font-family: star;
+	src: url(../fonts/star.eot);
+	src:
+		url(../fonts/star.eot?#iefix) format("embedded-opentype"),
+		url(../fonts/star.woff) format("woff"),
+		url(../fonts/star.ttf) format("truetype"),
+		url(../fonts/star.svg#star) format("svg");
+	font-weight: 400;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: WooCommerce;
+	src: url(../fonts/WooCommerce.eot);
+	src:
+		url(../fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
+		url(../fonts/WooCommerce.woff) format("woff"),
+		url(../fonts/WooCommerce.ttf) format("truetype"),
+		url(../fonts/WooCommerce.svg#WooCommerce) format("svg");
+	font-weight: 400;
+	font-style: normal;
+}
+
+@import "mixins";
+
+/**
+ * Main layout.
+ */
+.woocommerce {
+
+	// Common
+	.woocommerce-products-header {
+		h1.page-title {
+			font-family: var(--wp--preset--font-family--source-serif-pro);
+			font-size: var(--wp--custom--typography--font-size--gigantic);
+			font-weight: 300;
+			line-height: var(--wp--custom--typography--line-height--tiny);
+			margin-bottom: var(--wp--custom--spacing--medium);
+		}
+	}
+
+	span.onsale {
+		top: -1rem;
+		right: -1rem;
+		position: absolute;
+		background: var( --wp--preset--color--secondary );
+		border-radius: 2rem;
+		line-height: 2.6rem;
+		font-size: 0.8rem;
+		padding: 0rem 0.5rem 0rem 0.5rem;
+	}
+
+	.price ins, bdi {
+		text-decoration: none;
+	}
+
+	.quantity {
+		input[type='number'] {
+			width: 3em;
+		}
+
+		input[type='number']::-webkit-inner-spin-button,
+		input[type='number']::-webkit-outer-spin-button{
+			opacity: 1;
+		}
+	}
+
+	.woocommerce-breadcrumb {
+		margin-bottom: var( --wp--style--block-gap );
+		padding-bottom: var( --wp--style--block-gap );
+		font-size: 0.9em;
+		font-weight: 300;
+	}
+
+	.woocommerce-notices-wrapper {
+		margin-bottom: 5rem;
+		background: #f7f7f7;
+		border-top-color: var( --wp--preset--color--primary );
+		border-top-style: solid;
+
+		.woocommerce-message,
+		.woocommerce-error,
+		.woocommerce-info {
+			padding: 1rem;
+			list-style: none;
+
+			&[role='alert']::before {
+				color: var( --wp--preset--color--background );
+				background: var( --wp--preset--color--primary );
+				border-radius: 5rem;
+				font-size: 1rem;
+				padding-left: 3px;
+				padding-right: 3px;
+				margin-right: 1rem;
+			}
+
+			a.button {
+				margin-top: -0.5rem;
+				background: #ebe9eb;
+				color: var(--wp--preset--color--black);
+			}
+		}
+
+		.woocommerce-error[role='alert'] {
+			margin: 0;
+
+			&::before {
+				content: 'X';
+				padding-right: 4px;
+				padding-left: 4px;
+			}
+
+			li {
+				display: inline-block;
+			}
+		}
+
+		.woocommerce-message {
+			&[role='alert']::before {
+				content: '\2713';
+			}
+		}
+	}
+
+	a.button, button[name='add-to-cart'], input[name='submit'] {
+		display: inline-block;
+		text-align: center;
+		word-break: break-word;
+		background-color: var( --wp--preset--color--primary );
+		color: #fff;
+		padding: 0.5rem 1rem 0.5rem 1rem;
+		margin-top: 1rem;
+		text-decoration: none;
+		font-size: medium;
+		cursor: pointer;
+
+		&:hover,
+		&:visited {
+			color: var( --wp--preset--color--white );
+			text-decoration: underline;
+		}
+	}
+
+
+	// Shop page
+
+	.woocommerce-result-count {
+		float: none;
+		width: 100%;
+		font-size: 0.9rem;
+	}
+
+	.woocommerce-ordering {
+		//170px is box size, 50% - 170px is to give right alignment
+		width: max( 170px, calc( 50% - 170px ) );
+		// For wide screens
+		max-width: 100%;
+
+		margin-top: 0;
+		margin-bottom: 3rem;
+
+		select {
+			padding: 0.2rem 0 0.2rem 0.5rem;
+		}
+	}
+
+	// Products.
+	ul.products {
+		li.product {
+			list-style: none;
+			margin-top: var(--wp--style--block-gap);
+
+			a.woocommerce-loop-product__link {
+				text-decoration: none;
+				display: block;
+			}
+
+			h2.woocommerce-loop-product__title {
+				font-size: 1.2rem;
+				text-decoration: none;
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	ul.page-numbers {
+		text-align: center;
+	}
+
+	div.product {
+		position: relative;
+
+		span.onsale {
+			position: absolute;
+			left: -1rem;
+			top: -1rem;
+			width: 2.4em;
+			z-index: 1;
+		}
+
+		div.woocommerce-product-gallery {
+			position: relative;
+
+			a.woocommerce-product-gallery__trigger {
+				position: absolute;
+				top: 1rem;
+				right: 1rem;
+				z-index: 1;
+				text-decoration: none;
+				border-radius: 1rem;
+				border-style: solid;
+				line-height: 1.5rem;
+				padding: 0 0.5rem 0 0.5rem;
+				font-size: 0.6rem;
+				background: var( --wp--preset--color--white );;
+				border-color: var( --wp--preset--color--white );
+			}
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		div.summary {
+			font-size: 1rem;
+
+			h1.product_title {
+				font-size: 3.5rem;
+				margin: 0;
+			}
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+			.woocommerce-product-rating {
+				.star-rating {
+					display: inline-block;
+				}
+				.woocommerce-review-link {
+					display: inline-block;
+					overflow: hidden;
+					position: relative;
+					top: -0.5em;
+					font-size: 1em;
+				}
+			}
+
+			button[name='add-to-cart'] {
+				margin-top: 0.5rem;
+				margin-bottom: var( --wp--style--block-gap );
+			}
+		}
+	}
+
+	.woocommerce-tabs {
+		padding-top: var( --wp--style--block-gap );
+
+		ul.wc-tabs {
+			padding: 0;
+			border-bottom-style: solid;
+			border-bottom-width: 1px;
+			border-bottom-color: #EAE9EB;
+
+			li {
+				background: #EAE9EB;
+				margin: 0;
+				padding: 0.5em 1em 0.5em 1em;
+				border-color: #EAE9EB;
+				border-top-left-radius: 5px;
+				border-top-right-radius: 5px;
+				float: left;
+				border-style: solid;
+				border-width: 1px;
+				border-left-color: var( --wp--preset--color--background );
+				font-weight: 500;
+				font-size: 0.8em;
+
+				&:first-child {
+					border-left-color: #EAE9EB;
+					margin-left: 1em;
+				}
+
+				&.active {
+					background: var( --wp--preset--color--background );
+					border-bottom-color: var( --wp--preset--color--background );
+				}
+
+				a {
+					text-decoration: none;
+				}
+			}
+		}
+
+		.woocommerce-Tabs-panel {
+			padding-top: var( --wp--style--block-gap );
+
+			h2 {
+				display: none;
+			}
+		}
+	}
+
+	.woocommerce-Reviews {
+		ol.commentlist {
+			list-style: none;
+			padding-left: 0;
+
+			img.avatar {
+				float: left;
+			}
+
+			p.meta {
+				font-size: 1rem;
+			}
+
+			.comment-text {
+				display: inline-block;
+				padding-left: var( --wp--style--block-gap );
+
+				.star-rating {
+					margin-top: 0;
+				}
+			}
+		}
+
+		.comment-form-rating {
+			label {
+				display: inline-block;
+				padding-right: var( --wp--style--block-gap );
+				padding-top: var( --wp--style--block-gap );
+			}
+
+			p.stars {
+				display: inline;
+				a::before {
+					color: var( --wp--preset--color--secondary );
+				}
+			}
+		}
+
+		.comment-form-comment {
+			label {
+				float: left;
+				padding-right: var( --wp--style--block-gap );
+			}
+		}
+	}
+
+
+	.star-rating {
+		overflow: hidden;
+		position: relative;
+		height: 1em;
+		line-height: 1;
+		width: 5.4rem;
+		font-family: star;
+		margin-bottom: 0.7rem;
+		color: var( --wp--preset--color--secondary );
+		margin-top: 1rem;
+
+		&::before {
+			content: "\73\73\73\73\73";
+			float: left;
+			top: 0;
+			left: 0;
+			position: absolute;
+			font-size: 1rem;
+		}
+
+		span {
+			overflow: hidden;
+			float: left;
+			top: 0;
+			left: 0;
+			position: absolute;
+			padding-top: 1.5em;
+		}
+
+		span::before {
+			content: "\53\53\53\53\53";
+			top: 0;
+			position: absolute;
+			left: 0;
+			font-size: 1rem;
+		}
+	}
+
+	p.stars {
+		margin-top: 0;
+
+		a {
+			position: relative;
+			height: 1em;
+			width: 1em;
+			text-indent: -999em;
+			display: inline-block;
+			text-decoration: none;
+			box-shadow: none;
+
+			&::before {
+				display: block;
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 1em;
+				height: 1em;
+				line-height: 1;
+				font-family: WooCommerce;
+				content: "\e021";
+				text-indent: 0;
+			}
+
+			&:hover {
+
+				~ a::before {
+					content: "\e021";
+				}
+			}
+		}
+
+		&:hover {
+
+			a {
+
+				&::before {
+					content: "\e020";
+				}
+			}
+		}
+
+		&.selected {
+
+			a.active {
+
+				&::before {
+					content: "\e020";
+				}
+
+				~ a::before {
+					content: "\e021";
+				}
+			}
+
+			a:not(.active) {
+
+				&::before {
+					content: "\e020";
+				}
+			}
+		}
+	}
+
+	.woocommerce-product-gallery__trigger {
+		position: absolute;
+		top: 1rem;
+		right: 1rem;
+		z-index: 99;
+	}
+}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -70,21 +70,18 @@
 	}
 
 	.woocommerce-breadcrumb {
-		margin-bottom: var( --wp--style--block-gap );
-		padding-bottom: var( --wp--style--block-gap );
-		font-size: 0.9em;
-		font-weight: 300;
+		display: none;
 	}
 
 	.woocommerce-notices-wrapper {
-		margin-bottom: 5rem;
-		background: #f7f7f7;
-		border-top-color: var( --wp--preset--color--primary );
-		border-top-style: solid;
 
 		.woocommerce-message,
 		.woocommerce-error,
 		.woocommerce-info {
+			margin-bottom: 5rem;
+			background: #f7f7f7;
+			border-top-color: var( --wp--preset--color--primary );
+			border-top-style: solid;
 			padding: 1rem;
 			list-style: none;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR contains styling support for 2022 theme support for product and shop page.

Closes #31549.

### How to test the changes in this Pull Request:

1. Switch to WP 5.9 beta.
2. Switch to 2022 theme.
3. View shop and individual product page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement -  Add support for 2022 theme shop and product pages.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
