### PR TITLE
Fix columns in checkout page for TwentyTwenty theme

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty.scss
@@ -193,6 +193,7 @@ a.button {
 	font-family: $headings;
 	list-style: none;
 	overflow: hidden;
+	width: 100%;
 }
 
 .woocommerce-message,
@@ -1663,6 +1664,7 @@ a.reset_variations {
 
 	form[name="checkout"] {
 		display: table;
+		width: 100%;
 	}
 
 	.blockUI.blockOverlay {
@@ -2547,10 +2549,6 @@ a.reset_variations {
 			max-width: 1600px;
 			padding: 4vw 6vw;
 			margin: 0 auto;
-
-			.site-main {
-
-			}
 		}
 
 		.onsale {


### PR DESCRIPTION
Fix issue #30209 - Columns in checkout page appearing misaligned in Twenty Twenty theme. 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Two lines of changes to SCSS for Twenty Twenty theme CSS, that should fix issue 30209 - misaligned columns on checkout page. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30209 .

### How to test the changes in this Pull Request:

1. Install and activate Twenty Twenty theme
2. Add a few products to cart and get to the checkout page.
3. Click the `Have a coupon?` link to expand the coupon fields below. You will no longer see the checkout fields getting squished 
4. Add a test coupon, and then remove by clicking the `remove` link. Click `Have a coupon?` to reveal the coupon field. the message `Coupon has been removed` will no longer be appearing squished between the coupon field and its submit button like earlier. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Twenty Twenty theme - Fix alignment issues on checkout page.
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
