### PR TITLE
Move merchant.login out of beforeAll block

### DIFF
--- a/packages/js/e2e-core-tests/CHANGELOG.md
+++ b/packages/js/e2e-core-tests/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fixed
+- Moved `merchant.login()` out of `beforeAll()` block and into test body for retried runs.
+
 ## Added
 
 - A `specs/data` folder to store page element data.

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -23,7 +23,6 @@ const {
 const {
 	it,
 	describe,
-	beforeAll,
 } = require( '@jest/globals' );
 const config = require( 'config' );
 
@@ -41,10 +40,6 @@ const openNewProductAndVerify = async () => {
 
 const runAddSimpleProductTest = () => {
 	describe('Add New Simple Product Page', () => {
-		beforeAll(async () => {
-			await merchant.login();
-		});
-
 		it('can create simple virtual product and add it to the cart', async () => {
 
 			// @todo: remove this once https://github.com/woocommerce/woocommerce/issues/31337 has been addressed
@@ -53,6 +48,7 @@ const runAddSimpleProductTest = () => {
 				height: 700,
 			} );
 
+			await merchant.login();
 			await openNewProductAndVerify();
 
 			// Set product data and publish the product
@@ -120,11 +116,8 @@ const runAddSimpleProductTest = () => {
 
 const runAddVariableProductTest = () => {
 	describe('Add New Variable Product Page', () => {
-		beforeAll(async () => {
-			await merchant.login();
-		});
-
 		it('can create product with variations', async () => {
+			await merchant.login();
 			await openNewProductAndVerify();
 
 			// Set product data


### PR DESCRIPTION
### All Submissions:

* [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After running the test locally and forcing a failure, it looked like the test was failing after the last step was being run (`await merchant.logout()`).  Because the `merchant.login()` was occurring in the `beforeAll()` block, it wasn't being re-run when the test was retried.

Moving the `merchant.login()` into the body of the test (and eliminating the `beforeAll()` block) ensures that authentication will happen with each retry.

Closes #31468  .

### How to test the changes in this Pull Request:

1. `$ pnpx wc-e2e docker:up`
2. `$ pnpx wc-e2e test:e2e`

It looks like the issue causing the failure was addressed in #31314 -- so if you need to force a failure, you can add `await expect(true).toBe(false);` after line 61.  Also ensure that you've enabled retries locally by running `$ export E2E_RETEST=1`

### Other information:

* [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Moved `merchant.login()` out of `beforeAll()` block and into test body for retried runs.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
