### PR TITLE
Add filter to allow modification of the label

### DIFF
--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -3477,7 +3477,7 @@ function wc_display_product_attributes( $product ) {
 		}
 
 		$product_attributes[ 'attribute_' . sanitize_title_with_dashes( $attribute->get_name() ) ] = array(
-			'label' => wc_attribute_label( $attribute->get_name() ),
+			'label' => apply_filters( 'woocommerce_attribute_label', wc_attribute_label( $attribute->get_name() ), $attribute ),
 			'value' => apply_filters( 'woocommerce_attribute', wpautop( wptexturize( implode( ', ', $values ) ) ), $attribute, $values ),
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a new filter to allow for simpler modification of the label in the Product Attribute table on the product detail page. My use case is that we add tooltips with information regarding an attribute. An example could be "Memory size", where we want a tooltip that describes what memory sizes fits different use cases.

Before this pull request it's difficult and error prone to find the Attribute object. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add filter `woocommerce_attribute_label` to allow modification of attribute label.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.