### PR TITLE
Add an admin notice about the upcoming change in PHP requirements

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -312,8 +312,7 @@ class WC_Admin_Notices {
 	 * @deprecated 4.6.0
 	 */
 	public static function install_notice() {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '4.6.0', __( 'Onboarding is maintained in WooCommerce Admin.', 'woocommerce' ) );
+		_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '4.6.0', esc_html__( 'Onboarding is maintained in WooCommerce Admin.', 'woocommerce' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -136,7 +136,7 @@ class WC_Admin_Notices {
 
 		self::add_custom_notice(
 			'php72_required_in_woo_65',
-			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. An upgrade to at least PHP 7.4 is recommended. <b><a href="">Learn more about this change.</a></b></p>', 'woocommerce' )
+			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. An upgrade to at least PHP 7.4 is recommended. <b><a href="https://developer.woocommerce.com/?p=11584">Learn more about this change.</a></b></p>', 'woocommerce' )
 		);
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -52,6 +52,13 @@ class WC_Admin_Notices {
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
+		add_action(
+			'admin_init',
+			function() {
+				self::maybe_remove_php72_required_notice();
+			},
+			20
+		);
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
 		// to avoid.
@@ -113,6 +120,36 @@ class WC_Admin_Notices {
 		self::add_notice( 'template_files' );
 		self::add_min_version_notice();
 		self::add_maxmind_missing_license_key_notice();
+		self::maybe_add_php72_required_notice();
+	}
+
+	/**
+	 * Add an admin notice about the bump of the required PHP version in WooCommerce 6.5
+	 * if the current PHP version is too old.
+	 *
+	 * TODO: Remove this method in WooCommerce 6.5.
+	 */
+	private static function maybe_add_php72_required_notice() {
+		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
+			return;
+		}
+
+		self::add_custom_notice(
+			'php72_required_in_woo_65',
+			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. An upgrade to at least PHP 7.4 is recommended. <b><a href="">Learn more about this change.</a></b></p>', 'woocommerce' )
+		);
+	}
+
+	/**
+	 * Remove the admin notice about the bump of the required PHP version in WooCommerce 6.5
+	 * if the current PHP version is good.
+	 *
+	 * TODO: Remove this method in WooCommerce 6.5.
+	 */
+	private static function maybe_remove_php72_required_notice() {
+		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
+			self::remove_notice( 'php72_required_in_woo_65' );
+		}
 	}
 
 	/**
@@ -275,6 +312,7 @@ class WC_Admin_Notices {
 	 * @deprecated 4.6.0
 	 */
 	public static function install_notice() {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		_deprecated_function( __CLASS__ . '::' . __FUNCTION__, '4.6.0', __( 'Onboarding is maintained in WooCommerce Admin.', 'woocommerce' ) );
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -136,7 +136,7 @@ class WC_Admin_Notices {
 
 		self::add_custom_notice(
 			'php72_required_in_woo_65',
-			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. An upgrade to at least PHP 7.4 is recommended. <b><a href="https://developer.woocommerce.com/?p=11584">Learn more about this change.</a></b></p>', 'woocommerce' )
+			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 7.4 is recommended. <b><a href="https://developer.woocommerce.com/2022/01/05/new-requirement-for-woocommerce-6-5-php-7-2/">Learn more about this change.</a></b></p>', 'woocommerce' )
 		);
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -147,7 +147,7 @@ class WC_Admin_Notices {
 	 * TODO: Remove this method in WooCommerce 6.5.
 	 */
 	private static function maybe_remove_php72_required_notice() {
-		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
+		if ( version_compare( phpversion(), '7.2', '>=' ) && self::has_notice( 'php72_required_in_woo_65' ) ) {
 			self::remove_notice( 'php72_required_in_woo_65' );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The minimum required PHP version will be 7.2 as of WooCommerce 6.5. This pull request adds a dismissable admin notice visible when PHP 7.0 or 7.1 is used:

![image](https://user-images.githubusercontent.com/937723/148522801-70055bac-9800-4dc5-b8cc-9682f27b8472.png)

The notice is created (if needed) when the theme is switched or a new version of WooCommerce is installed.

**TODO:** Add the url of the announcement post in the link included in the notice.

### How to test the changes in this Pull Request:

1. Run the following in command line to simulate a new WooCommerce version installed, this will also attempt to clear some user meta that doesn't exist yet:

```
wp eval 'WC_Admin_Notices::reset_admin_notices(); delete_user_meta(get_current_user_id(), "dismissed_php72_required_in_woo_65_notice");' --user=<your WP user name or id>
```

2. Switch to PHP 7.2 and load any admin page, e.g. orders. You shouldn't see any notice.

3. Switch to PHP 7.1, repeat step 1, and load the admin page again. You should see the notice.

4. Switch to PHP 7.2, reload the admin page (DON'T repeat step 1 this time), and you should see that the notice has disappeared.

5. Switch to PHP 7.1, repeat step 1, reload the admin page, and click the "Dismiss" button. The notice shouldn't appear anymore unless you repeat step 1.

1+2 simulates a user that was already on PHP 7.2+ at the time of upgrading to the WooCommerce release that includes this pull request, nothing will happen for these users; 3+4 simulates a user that upgrades his PHP without dismissing the notice; and 3+5 simulates a user that dismisses the notice without (or before) upgrading his PHP. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Admin notice warning about the upcoming minimum PHP version bump

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
