### PR TITLE
Issue/31555 add status field coupons api

### DIFF
--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -28,6 +28,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	protected $data = array(
 		'code'                        => '',
 		'amount'                      => 0,
+		'status'                      => null,
 		'date_created'                => null,
 		'date_modified'               => null,
 		'date_expires'                => null,
@@ -182,6 +183,17 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function get_description( $context = 'view' ) {
 		return $this->get_prop( 'description', $context );
+	}
+
+	/**
+	 * Get coupon status.
+	 *
+	 * @since  6.2.0
+	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
+	 * @return string
+	 */
+	public function get_status( $context = 'view' ) {
+		return $this->get_prop( 'status', $context );
 	}
 
 	/**
@@ -489,6 +501,16 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 */
 	public function set_description( $description ) {
 		$this->set_prop( 'description', $description );
+	}
+
+	/**
+	 * Set coupon status.
+	 *
+	 * @since 3.0.0
+	 * @param string $status Status.
+	 */
+	public function set_status( $status ) {
+		$this->set_prop( 'status', $status );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -123,6 +123,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			array(
 				'code'                        => $post_object->post_title,
 				'description'                 => $post_object->post_excerpt,
+				'status'	                  => $post_object->post_status,
 				'date_created'                => $this->string_to_timestamp( $post_object->post_date_gmt ),
 				'date_modified'               => $this->string_to_timestamp( $post_object->post_modified_gmt ),
 				'date_expires'                => metadata_exists( 'post', $coupon_id, 'date_expires' ) ? get_post_meta( $coupon_id, 'date_expires', true ) : get_post_meta( $coupon_id, 'expiry_date', true ), // @todo: Migrate expiry_date meta to date_expires in upgrade routine.

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -123,7 +123,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			array(
 				'code'                        => $post_object->post_title,
 				'description'                 => $post_object->post_excerpt,
-				'status'	                      => $post_object->post_status,
+				'status'                      => $post_object->post_status,
 				'date_created'                => $this->string_to_timestamp( $post_object->post_date_gmt ),
 				'date_modified'               => $this->string_to_timestamp( $post_object->post_modified_gmt ),
 				'date_expires'                => metadata_exists( 'post', $coupon_id, 'date_expires' ) ? get_post_meta( $coupon_id, 'date_expires', true ) : get_post_meta( $coupon_id, 'expiry_date', true ), // @todo: Migrate expiry_date meta to date_expires in upgrade routine.

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -123,7 +123,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			array(
 				'code'                        => $post_object->post_title,
 				'description'                 => $post_object->post_excerpt,
-				'status'	                  => $post_object->post_status,
+				'status'	                      => $post_object->post_status,
 				'date_created'                => $this->string_to_timestamp( $post_object->post_date_gmt ),
 				'date_modified'               => $this->string_to_timestamp( $post_object->post_modified_gmt ),
 				'date_expires'                => metadata_exists( 'post', $coupon_id, 'date_expires' ) ? get_post_meta( $coupon_id, 'date_expires', true ) : get_post_meta( $coupon_id, 'expiry_date', true ), // @todo: Migrate expiry_date meta to date_expires in upgrade routine.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -166,6 +166,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 			'id'                          => $object->get_id(),
 			'code'                        => $data['code'],
 			'amount'                      => $data['amount'],
+			'status'                      => $data['status'],
 			'date_created'                => $data['date_created'],
 			'date_created_gmt'            => $data['date_created_gmt'],
 			'date_modified'               => $data['date_modified'],
@@ -344,6 +345,11 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 				),
 				'amount'                      => array(
 					'description' => __( 'The amount of discount. Should always be numeric, even if setting a percentage.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'status'                      => array(
+					'description' => __( 'The status of the coupon. Should always be draft, published or pending review', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -349,7 +349,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 					'context'     => array( 'view', 'edit' ),
 				),
 				'status' => array(
-					'description' => __( 'The status of the coupon. Should always be draft, published or pending review', 'woocommerce' ),
+					'description' => __( 'The status of the coupon. Should always be draft, published, or pending review', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -348,7 +348,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'status'                      => array(
+				'status' => array(
 					'description' => __( 'The status of the coupon. Should always be draft, published or pending review', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php
@@ -29,6 +29,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $code, $coupon->get_code() );
 		$this->assertNotEquals( 0, $coupon->get_id() );
+		$this->assertNotEquals( 'publish', $coupon->get_status() );
 	}
 
 	/**
@@ -95,6 +96,7 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 5, $coupon_read->get_usage_count() );
 		$this->assertEquals( $code, $coupon_read->get_code() );
+		$this->assertEquals( 'publish', $coupon_read->get_status() );
 		$this->assertEquals( 0, $coupon->get_amount() );
 		$this->assertEquals( 'This is a test coupon.', $coupon_read->get_description() );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/data.php
@@ -174,6 +174,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 			'description'                => 'hello world',
 			'discount_type'              => 'percent',
 			'amount'                     => 10.50,
+			'status'					 => 'publish',
 			'usage_count'                => 5,
 			'individual_use'             => true,
 			'product_ids'                => array( 5, 10 ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/coupon/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/coupon/data.php
@@ -174,7 +174,7 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 			'description'                => 'hello world',
 			'discount_type'              => 'percent',
 			'amount'                     => 10.50,
-			'status'					 => 'publish',
+			'status'                     => 'publish',
 			'usage_count'                => 5,
 			'individual_use'             => true,
 			'product_ids'                => array( 5, 10 ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/coupons.php
@@ -53,6 +53,7 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 			array(
 				'id'                          => $coupon_1->get_id(),
 				'code'                        => 'dummycoupon-1',
+				'status'                      => $coupon_1->get_status(),
 				'amount'                      => '1.00',
 				'date_created'                => wc_rest_prepare_date_response( $post_1->post_date_gmt, false ),
 				'date_created_gmt'            => wc_rest_prepare_date_response( $post_1->post_date_gmt ),
@@ -121,6 +122,7 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 			array(
 				'id'                          => $coupon->get_id(),
 				'code'                        => 'dummycoupon-1',
+				'status'                      => $coupon->get_status(),
 				'amount'                      => '1.00',
 				'date_created'                => wc_rest_prepare_date_response( $post->post_date_gmt, false ),
 				'date_created_gmt'            => wc_rest_prepare_date_response( $post->post_date_gmt ),
@@ -196,6 +198,7 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 			array(
 				'id'                          => $data['id'],
 				'code'                        => 'test',
+				'status'                      => 'publish',
 				'amount'                      => '5.00',
 				'date_created'                => $data['date_created'],
 				'date_created_gmt'            => $data['date_created_gmt'],
@@ -440,9 +443,10 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 27, count( $properties ) );
+		$this->assertEquals( 28, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'code', $properties );
+		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'date_created_gmt', $properties );
 		$this->assertArrayHasKey( 'date_modified', $properties );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/coupons.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/coupons.php
@@ -67,6 +67,7 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 				'id'                          => $coupon_1->get_id(),
 				'code'                        => 'dummycoupon-1',
 				'amount'                      => '1.00',
+				'status'                      => $coupon_1->get_status(),
 				'date_created'                => wc_rest_prepare_date_response( $post_1->post_date_gmt, false ),
 				'date_created_gmt'            => wc_rest_prepare_date_response( $post_1->post_date_gmt ),
 				'date_modified'               => wc_rest_prepare_date_response( $post_1->post_modified_gmt, false ),
@@ -135,6 +136,7 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 				'id'                          => $coupon->get_id(),
 				'code'                        => 'dummycoupon-1',
 				'amount'                      => '1.00',
+				'status'                      => $coupon->get_status(),
 				'date_created'                => wc_rest_prepare_date_response( $post->post_date_gmt, false ),
 				'date_created_gmt'            => wc_rest_prepare_date_response( $post->post_date_gmt ),
 				'date_modified'               => wc_rest_prepare_date_response( $post->post_modified_gmt, false ),
@@ -210,6 +212,7 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 				'id'                          => $data['id'],
 				'code'                        => 'test',
 				'amount'                      => '5.00',
+				'status'                      => 'publish',
 				'date_created'                => $data['date_created'],
 				'date_created_gmt'            => $data['date_created_gmt'],
 				'date_modified'               => $data['date_modified'],
@@ -453,9 +456,10 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 27, count( $properties ) );
+		$this->assertEquals( 28, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'code', $properties );
+		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'date_created', $properties );
 		$this->assertArrayHasKey( 'date_created_gmt', $properties );
 		$this->assertArrayHasKey( 'date_modified', $properties );


### PR DESCRIPTION
Addresses part 1 of #31555. 

## All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Background

The Woo mobile app is working on adding coupon management to the app. As part of that project, there are a few enhancements in the GET Coupon(s) API endpoint that we would need to make. 
- We would need to display the status of the coupon. It looks like the GET Coupons and GET Coupon endpoints don't provide the status of the field. But this is available in `wp-admin`.
- It looks like only published coupons are available in the API response. It would be nice to list all coupons available for the store, regardless of the status, since Core displays it that way. 
-  Update the status of a coupon from the API.

### Designs
<img width="1541" alt="Screenshot 2022-01-05 at 4 03 09 PM" src="https://user-images.githubusercontent.com/22608780/148203152-e532f716-8538-4ea2-a85a-e8267d6c329b.png">
<img width="292" alt="Screenshot 2022-01-05 at 4 03 52 PM" src="https://user-images.githubusercontent.com/22608780/148203270-9a1112a5-842f-4e3d-9cfb-152bc282da84.png">

## Proposed Changes
This PR addresses the first point from the above list. i.e. add the `status` field to the GET Coupon(s) API response. Using an example JSON, this is how it would look like:

```
{
        "id": 13,
        "code": "test",
        "amount": "100.00",
        "status": "publish",   <-- New property added here
        "date_created": "2022-01-04T07:11:29",
        "date_created_gmt": "2022-01-04T07:11:29",
        "date_modified": "2022-01-05T09:45:28",
        "date_modified_gmt": "2022-01-05T09:45:28",
        "discount_type": "fixed_cart",
       ...
}
```

This change would allow us to reliably show the status of the coupon (as displayed in the designs). The rest of the blockers mentioned above will be taken care of in a separate PR. 

## How to test the changes in this Pull Request:
This is just a suggestion but please feel free to test other scenarios. 🙂

1. Add a new coupon in wp-admin → Coupons → Add New.
2. Publish the coupon (since only published coupons will be available in the API response).
3. In the API, run `GET /wp-json/wc/v3/coupons`.
4. Confirm that the `status` field is available in the API response.

## Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

## Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds `status` field to the `GET /coupons` endpoint. This will display the status of the coupon. 

## Questions
- I have marked this PR as draft for now since I'm not sure how to go about adding unit tests for this PR. I have updated some existing unit tests for coupons. But these tests seem to be part of the legacy package. Should I create a new class for `class-wc-coupon-data-store-cpt.php` or should I continue to use `plugins/woocommerce/tests/legacy/unit-tests/coupon/data-store.php`?
- Since this PR adds changes to the data in the coupons section, I feel like we should also update the related documentation [here](https://github.com/woocommerce/woocommerce/wiki/Coupon-Data). I can do that in this PR, if this is fine?