### PR TITLE
Issue/31252 Add $loop var to woocommerce_variation_header hook

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -57,8 +57,9 @@ defined( 'ABSPATH' ) || exit;
 		 * @since 3.6.0
 		 *
 		 * @param WP_Post $variation Post data.
+		 * @param int     $loop      Position in the loop.
 		 */
-		do_action( 'woocommerce_variation_header', $variation );
+		do_action( 'woocommerce_variation_header', $variation, $loop );
 		?>
 	</h3>
 	<div class="woocommerce_variable_attributes wc-metabox-content" style="display: none;">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds `$loop` var to `woocommerce_variation_header` action.

Closes #31252.

### Changelog entry

> Tweak - Made the `$loop` position counter available via the 'woocommerce_variation_header' hook.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
