### PR TITLE
E2e/add defaults to config get

### DIFF
--- a/packages/js/e2e-core-tests/CHANGELOG.md
+++ b/packages/js/e2e-core-tests/CHANGELOG.md
@@ -12,6 +12,7 @@
 - A `specs/data` folder to store page element data.
 - Tests to verify that different top-level menu and their associated sub-menus load successfully.
 - Test scaffolding via `npx wc-e2e install @woocommerce/e2e-core-tests`
+- Added default values to all calls to config.get()
 
 ## Changed
 

--- a/packages/js/e2e-core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/packages/js/e2e-core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -19,7 +19,7 @@ const {
 	describe,
 } = require( '@jest/globals' );
 
-const shippingZoneNameUS = config.get( 'addresses.customer.shipping.country' );
+const shippingZoneNameUS = config.get( 'addresses.customer.shipping.country', 'United States (US)' );
 
 const runOnboardingFlowTest = () => {
 	describe('Store owner can go through store Onboarding', () => {

--- a/packages/js/e2e-core-tests/specs/api/coupon.test.js
+++ b/packages/js/e2e-core-tests/specs/api/coupon.test.js
@@ -20,9 +20,16 @@ const runCouponApiTest = () => {
 		let repository;
 
 		beforeAll( async () => {
-			percentageCoupon = config.get( 'coupons.percentage' );
-			const admin = config.get( 'users.admin' );
-			const url = config.get( 'url' );
+			percentageCoupon = config.get( 'coupons.percentage', {
+				"code": "20percent",
+				"discountType": "percent",
+				"amount": "20.00"
+			} );
+			const admin = config.get( 'users.admin', {
+				"username": "admin",
+				"password": "password"
+			} );
+			const url = config.get( 'url', 'http://localhost:8084/' );
 
 			client = HTTPClientFactory.build( url )
 				.withBasicAuth( admin.username, admin.password )

--- a/packages/js/e2e-core-tests/specs/api/external-product.test.js
+++ b/packages/js/e2e-core-tests/specs/api/external-product.test.js
@@ -21,9 +21,17 @@ const runExternalProductAPITest = () => {
 		let repository;
 
 		beforeAll( async () => {
-			defaultExternalProduct = config.get( 'products.external' );
-			const admin = config.get( 'users.admin' );
-			const url = config.get( 'url' );
+			defaultExternalProduct = config.get( 'products.external', {
+				"name": "External product",
+				"regularPrice": "24.99",
+				"buttonText": "Buy now",
+				"externalUrl": "https://wordpress.org/plugins/woocommerce"
+			} );
+			const admin = config.get( 'users.admin', {
+				"username": "admin",
+				"password": "password"
+			} );
+			const url = config.get( 'url', 'http://localhost:8084/' );
 
 			client = HTTPClientFactory.build( url )
 				.withBasicAuth( admin.username, admin.password )

--- a/packages/js/e2e-core-tests/specs/api/grouped-product.test.js
+++ b/packages/js/e2e-core-tests/specs/api/grouped-product.test.js
@@ -27,9 +27,28 @@ const runGroupedProductAPITest = () => {
 		let repository;
 
 		beforeAll( async () => {
-			defaultGroupedProduct = config.get( 'products.grouped' );
-			const admin = config.get( 'users.admin' );
-			const url = config.get( 'url' );
+			defaultGroupedProduct = config.get( 'products.grouped', {
+				"name": "Grouped Product with Three Children",
+				"groupedProducts": [
+					{
+						"name": "Base Unit",
+						"regularPrice": "29.99"
+					},
+					{
+						"name": "Add-on A",
+						"regularPrice": "11.95"
+					},
+					{
+						"name": "Add-on B",
+						"regularPrice": "18.97"
+					}
+				]
+			} );
+			const admin = config.get( 'users.admin', {
+				"username": "admin",
+				"password": "password"
+			} );
+			const url = config.get( 'url', 'http://localhost:8084/' );
 
 			client = HTTPClientFactory.build( url )
 				.withBasicAuth( admin.username, admin.password )

--- a/packages/js/e2e-core-tests/specs/api/order.test.js
+++ b/packages/js/e2e-core-tests/specs/api/order.test.js
@@ -19,9 +19,20 @@ const runOrderApiTest = () => {
 		let repository;
 
 		beforeAll( async () => {
-			order = config.get( 'orders.basicPaidOrder' );
-			const admin = config.get( 'users.admin' );
-			const url = config.get( 'url' );
+			order = config.get( 'orders.basicPaidOrder', {
+				"paymentMethod": "cod",
+				"status": "processing",
+				"billing": {
+					"firstName": "John",
+					"lastName": "Doe",
+					"email": "john.doe@example.com"
+				}
+			} );
+			const admin = config.get( 'users.admin', {
+				"username": "admin",
+				"password": "password"
+			} );
+			const url = config.get( 'url', 'http://localhost:8084/' );
 
 			client = HTTPClientFactory.build( url )
 				.withBasicAuth( admin.username, admin.password )

--- a/packages/js/e2e-core-tests/specs/api/telemetry.test.js
+++ b/packages/js/e2e-core-tests/specs/api/telemetry.test.js
@@ -17,8 +17,11 @@ const runTelemetryAPITest = () => {
 		let client;
 
 		beforeAll( async () => {
-			const admin = config.get( 'users.admin' );
-			const url = config.get( 'url' );
+			const admin = config.get( 'users.admin', {
+				"username": "admin",
+				"password": "password"
+			} );
+			const url = config.get( 'url', 'http://localhost:8084/' );
 
 			client = HTTPClientFactory.build( url )
 				.withBasicAuth( admin.username, admin.password )

--- a/packages/js/e2e-core-tests/specs/api/variable-product.test.js
+++ b/packages/js/e2e-core-tests/specs/api/variable-product.test.js
@@ -29,10 +29,104 @@ const runVariableProductAPITest = () => {
 		let variationRepository;
 
 		beforeAll(async () => {
-			defaultVariableProduct = config.get('products.variable');
-			defaultVariations = config.get('products.variations');
-			const admin = config.get('users.admin');
-			const url = config.get('url');
+			defaultVariableProduct = config.get( 'products.variable', {
+				"name": "Variable Product with Three Attributes",
+				"defaultAttributes": [
+					{
+						"id": 0,
+						"name": "Size",
+						"option": "Medium"
+					},
+					{
+						"id": 0,
+						"name": "Colour",
+						"option": "Blue"
+					}
+				],
+				"attributes": [
+					{
+						"id": 0,
+						"name": "Colour",
+						"isVisibleOnProductPage": true,
+						"isForVariations": true,
+						"options": [
+							"Red",
+							"Green",
+							"Blue"
+						],
+						"sortOrder": 0
+					},
+					{
+						"id": 0,
+						"name": "Size",
+						"isVisibleOnProductPage": true,
+						"isForVariations": true,
+						"options": [
+							"Small",
+							"Medium",
+							"Large"
+						],
+						"sortOrder": 0
+					},
+					{
+						"id": 0,
+						"name": "Logo",
+						"isVisibleOnProductPage": true,
+						"isForVariations": true,
+						"options": [
+							"Woo",
+							"WordPress"
+						],
+						"sortOrder": 0
+					}
+				]
+			} );
+			defaultVariations = config.get( 'products.variations', [
+				{
+					"regularPrice": "19.99",
+					"attributes": [
+						{
+							"name": "Size",
+							"option": "Large"
+						},
+						{
+							"name": "Colour",
+							"option": "Red"
+						}
+					]
+				},
+				{
+					"regularPrice": "18.99",
+					"attributes": [
+						{
+							"name": "Size",
+							"option": "Medium"
+						},
+						{
+							"name": "Colour",
+							"option": "Green"
+						}
+					]
+				},
+				{
+					"regularPrice": "17.99",
+					"attributes": [
+						{
+							"name": "Size",
+							"option": "Small"
+						},
+						{
+							"name": "Colour",
+							"option": "Blue"
+						}
+					]
+				}
+			] );
+			const admin = config.get( 'users.admin', {
+				"username": "admin",
+				"password": "password"
+			} );
+			const url = config.get( 'url', 'http://localhost:8084/' );
 
 			client = HTTPClientFactory.build(url)
 				.withBasicAuth(admin.username, admin.password)

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -10,7 +10,7 @@ const {
 
 // TODO create a function for the logic below getConfigSimpleProduct(), see: https://github.com/woocommerce/woocommerce/issues/29072
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 const simpleProductPrice = config.get( 'products.simple.price', '9.99' );
 
 const runMerchantOrdersCustomerPaymentPage = () => {

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-emails.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-emails.test.js
@@ -10,7 +10,7 @@ const {
 } = require( '@woocommerce/e2e-utils' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const customerEmail = config.get( 'addresses.customer.billing.email' );
+const customerEmail = config.get( 'addresses.customer.billing.email', 'john.doe@example.com' );
 const adminEmail = config.get( 'users.admin.email', 'admin@woocommercecoree2etestsuite.com' );
 const storeName = config.get( 'storeName', 'WooCommerce Core E2E Test Suite' );
 

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-new.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-order-new.test.js
@@ -50,9 +50,9 @@ const taxRates = [
 const taxTotals = ['$10.00', '$40.00', '$240.00'];
 
 const initProducts = async () => {
-	const apiUrl = config.get('url');
-	const adminUsername = config.get('users.admin.username');
-	const adminPassword = config.get('users.admin.password');
+	const apiUrl = config.get( 'url', 'http://localhost:8084/' );
+	const adminUsername = config.get( 'users.admin.username', 'admin' );
+	const adminPassword = config.get( 'users.admin.password', 'password' );
 	const httpClient = HTTPClientFactory.build(apiUrl)
 		.withBasicAuth(adminUsername, adminPassword)
 		.create();
@@ -120,7 +120,23 @@ const initProducts = async () => {
 	};
 	const initGroupedProduct = async () => {
 		const groupedRepo = GroupedProduct.restRepository(httpClient);
-		const defaultGroupedData = config.get('products.grouped');
+		const defaultGroupedData = config.get( 'products.grouped', {
+			"name": "Grouped Product with Three Children",
+			"groupedProducts": [
+				{
+					"name": "Base Unit",
+					"regularPrice": "29.99"
+				},
+				{
+					"name": "Add-on A",
+					"regularPrice": "11.95"
+				},
+				{
+					"name": "Add-on B",
+					"regularPrice": "18.97"
+				}
+			]
+		} );
 		const groupedProductData = {
 			...defaultGroupedData,
 			name: 'Grouped Product 858012'
@@ -130,7 +146,12 @@ const initProducts = async () => {
 	};
 	const initExternalProduct = async () => {
 		const repo = ExternalProduct.restRepository(httpClient);
-		const defaultProps = config.get('products.external');
+		const defaultProps = config.get( 'products.external', {
+			"name": "External product",
+			"regularPrice": "24.99",
+			"buttonText": "Buy now",
+			"externalUrl": "https://wordpress.org/plugins/woocommerce"
+		} );
 		const props = {
 			...defaultProps,
 			name: 'External product 786794',

--- a/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-search.test.js
+++ b/packages/js/e2e-core-tests/specs/merchant/wp-admin-product-search.test.js
@@ -9,7 +9,7 @@ const {
 } = require( '@woocommerce/e2e-utils' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 const simpleProductPrice = config.get( 'products.simple.price', '9.99' );
 
 const runProductSearchTest = () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-cart-redirection.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-cart-redirection.test.js
@@ -22,7 +22,7 @@
 } = require( '@jest/globals' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 
 const runCartRedirectionTest = () => {
 	describe('Cart > Redirect to cart from shop', () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-cart.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-cart.test.js
@@ -18,7 +18,7 @@ const {
 } = require( '@jest/globals' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 const singleProductPrice = config.get( 'products.simple.price', '9.99' );
 const twoProductPrice = singleProductPrice * 2;
 

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-checkout-create-account.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-checkout-create-account.test.js
@@ -22,7 +22,19 @@ const {
 } = require( '@jest/globals' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const customerBilling = config.get( 'addresses.customer.billing' );
+const customerBilling = config.get( 'addresses.customer.billing', {
+	"firstname": "John",
+	"lastname": "Doe",
+	"company": "Automattic",
+	"country": "United States (US)",
+	"addressfirstline": "addr 1",
+	"addresssecondline": "addr 2",
+	"city": "San Francisco",
+	"state": "CA",
+	"postcode": "94107",
+	"phone": "123456789",
+	"email": "john.doe@example.com"
+} );
 
 const runCheckoutCreateAccountTest = () => {
 	describe('Shopper Checkout Create Account', () => {

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-checkout-login-account.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-checkout-login-account.test.js
@@ -52,8 +52,8 @@ const runCheckoutLoginAccountTest = () => {
 			await expect(page).toClick('.woocommerce-info > a.showlogin');
 
 			// Fill shopper's login credentials and proceed further
-			await page.type( '#username', config.get('users.customer.username') );
-			await page.type( '#password', config.get('users.customer.password') );
+			await page.type( '#username', config.get('users.customer.username', 'customer') );
+			await page.type( '#password', config.get('users.customer.password', 'password') );
 
 			await Promise.all([
 				page.waitForNavigation({waitUntil: 'networkidle0'}),

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-checkout.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-checkout.test.js
@@ -10,8 +10,32 @@ const {
 } = require( '@woocommerce/e2e-utils' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 const singleProductPrice = config.get( 'products.simple.price', '9.99' );
+const billingAddress = config.get( 'addresses.customer.billing', {
+	"firstname": "John",
+	"lastname": "Doe",
+	"company": "Automattic",
+	"country": "United States (US)",
+	"addressfirstline": "addr 1",
+	"addresssecondline": "addr 2",
+	"city": "San Francisco",
+	"state": "CA",
+	"postcode": "94107",
+	"phone": "123456789",
+	"email": "john.doe@example.com"
+} );
+const shippingAddress = config.get( 'addresses.customer.shipping', {
+	"firstname": "John",
+	"lastname": "Doe",
+	"company": "Automattic",
+	"country": "United States (US)",
+	"addressfirstline": "addr 1",
+	"addresssecondline": "addr 2",
+	"city": "San Francisco",
+	"state": "CA",
+	"postcode": "94107"
+} );
 const twoProductPrice = singleProductPrice * 2;
 const threeProductPrice = singleProductPrice * 3;
 const fourProductPrice = singleProductPrice * 4;
@@ -76,7 +100,7 @@ const runCheckoutPageTest = () => {
 			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `3`, threeProductPrice, threeProductPrice);
-			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));
+			await shopper.fillBillingDetails(billingAddress);
 		});
 
 		it('allows customer to fill shipping details', async () => {
@@ -91,7 +115,7 @@ const runCheckoutPageTest = () => {
 			});
 			await uiUnblocked();
 
-			await shopper.fillShippingDetails(config.get('addresses.customer.shipping'));
+			await shopper.fillShippingDetails(shippingAddress);
 		});
 
 		it('allows guest customer to place order', async () => {
@@ -99,7 +123,7 @@ const runCheckoutPageTest = () => {
 			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `5`, fiveProductPrice, fiveProductPrice);
-			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));
+			await shopper.fillBillingDetails(billingAddress);
 
 			await uiUnblocked();
 
@@ -122,7 +146,7 @@ const runCheckoutPageTest = () => {
 			await shopper.addToCartFromShopPage( productId );
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `1`, singleProductPrice, singleProductPrice);
-			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));
+			await shopper.fillBillingDetails(billingAddress);
 
 			await uiUnblocked();
 

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-my-account-pay-order.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-my-account-pay-order.test.js
@@ -12,7 +12,7 @@ const {
 let simplePostIdValue;
 let orderNum;
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 
 const runMyAccountPayOrderTest = () => {
 	describe('Customer can pay for their order through My Account', () => {
@@ -22,7 +22,19 @@ const runMyAccountPayOrderTest = () => {
 			await shopper.goToProduct(simplePostIdValue);
 			await shopper.addToCart(simpleProductName);
 			await shopper.goToCheckout();
-			await shopper.fillBillingDetails(config.get('addresses.customer.billing'));
+			await shopper.fillBillingDetails(config.get('addresses.customer.billing', {
+				"firstname": "John",
+				"lastname": "Doe",
+				"company": "Automattic",
+				"country": "United States (US)",
+				"addressfirstline": "addr 1",
+				"addresssecondline": "addr 2",
+				"city": "San Francisco",
+				"state": "CA",
+				"postcode": "94107",
+				"phone": "123456789",
+				"email": "john.doe@example.com"
+			}));
 			await uiUnblocked();
 			await shopper.placeOrder();
 

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -13,8 +13,8 @@
 let simplePostIdValue;
 let orderId;
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
-const customerEmail = config.get( 'addresses.customer.billing.email' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
+const customerEmail = config.get( 'addresses.customer.billing.email', 'john.doe@example.com' );
 const storeName = 'WooCommerce Core E2E Test Suite';
 
 /**

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-product-browse-search-sort.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-product-browse-search-sort.test.js
@@ -18,7 +18,7 @@ const {
 } = require( '@jest/globals' );
 
 const { config } = require( '@woocommerce/e2e-environment' );
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 const singleProductPrice = config.get( 'products.simple.price', '9.99' );
 const singleProductPrice2 = '1' + singleProductPrice;
 const singleProductPrice3 = '2' + singleProductPrice;

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-single-product.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-single-product.test.js
@@ -12,11 +12,62 @@ const {
 const { config } = require( '@woocommerce/e2e-environment' );
 
 // Variables for simple product
-const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductName = config.get( 'products.simple.name', 'Simple product' );
 let simplePostIdValue;
 
 // Variables for variable product
-const defaultVariableProduct = config.get( 'products.variable' );
+const defaultVariableProduct = config.get( 'products.variable', {
+	"name": "Variable Product with Three Attributes",
+	"defaultAttributes": [
+		{
+			"id": 0,
+			"name": "Size",
+			"option": "Medium"
+		},
+		{
+			"id": 0,
+			"name": "Colour",
+			"option": "Blue"
+		}
+	],
+	"attributes": [
+		{
+			"id": 0,
+			"name": "Colour",
+			"isVisibleOnProductPage": true,
+			"isForVariations": true,
+			"options": [
+				"Red",
+				"Green",
+				"Blue"
+			],
+			"sortOrder": 0
+		},
+		{
+			"id": 0,
+			"name": "Size",
+			"isVisibleOnProductPage": true,
+			"isForVariations": true,
+			"options": [
+				"Small",
+				"Medium",
+				"Large"
+			],
+			"sortOrder": 0
+		},
+		{
+			"id": 0,
+			"name": "Logo",
+			"isVisibleOnProductPage": true,
+			"isForVariations": true,
+			"options": [
+				"Woo",
+				"WordPress"
+			],
+			"sortOrder": 0
+		}
+	]
+} );
 let variableProductId;
 
 // Variables for grouped product

--- a/packages/js/e2e-core-tests/specs/shopper/front-end-variable-product-updates.test.js
+++ b/packages/js/e2e-core-tests/specs/shopper/front-end-variable-product-updates.test.js
@@ -11,7 +11,43 @@ const { config } = require( '@woocommerce/e2e-environment' );
 let variablePostIdValue;
 
 const cartDialogMessage = 'Please select some product options before adding this product to your cart.';
-const attributes = config.get( 'products.variable.attributes' )
+const attributes = config.get( 'products.variable.attributes', [
+	{
+		"id": 0,
+		"name": "Colour",
+		"isVisibleOnProductPage": true,
+		"isForVariations": true,
+		"options": [
+			"Red",
+			"Green",
+			"Blue"
+		],
+		"sortOrder": 0
+	},
+	{
+		"id": 0,
+		"name": "Size",
+		"isVisibleOnProductPage": true,
+		"isForVariations": true,
+		"options": [
+			"Small",
+			"Medium",
+			"Large"
+		],
+		"sortOrder": 0
+	},
+	{
+		"id": 0,
+		"name": "Logo",
+		"isVisibleOnProductPage": true,
+		"isForVariations": true,
+		"options": [
+			"Woo",
+			"WordPress"
+		],
+		"sortOrder": 0
+	}
+] )
 
 const runVariableProductUpdateTest = () => {
 	describe('Shopper > Update variable product',() => {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds default values to all calls to `config.get`, so that a default.json file is not required to run `e2e-core-tests`, as per https://github.com/woocommerce/woocommerce/issues/31452

Closes #31452

### How to test the changes in this Pull Request:

1. Run the core tests with an empty `default.json` file
2. It should complete the tests without errors

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
