### PR TITLE
Explicitly add plugins allowed

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -39,6 +39,11 @@
 		"sort-packages": true,
 		"platform": {
 			"php": "7.0.33"
+		},
+		"allow-plugins": {
+			"automattic/jetpack-autoloader": true,
+			"composer/installers": true,
+			"bamarni/composer-bin-plugin": true
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
This PR explicitly states what Composer plugins are whitelisted to execute. Without it, when running `pnpm nx composer-install woocommerce` would generate prompts for you to allow execution. As of Composer 2.2.0, this is now enforced for security reasons. https://getcomposer.org/doc/06-config.md#allow-plugins