### PR TITLE
Use application installed Grunt instead of requiring global install

### DIFF
--- a/plugins/woocommerce/legacy/project.json
+++ b/plugins/woocommerce/legacy/project.json
@@ -9,7 +9,7 @@
 			"options": {
 				"commands": [
 					{
-						"command": "grunt assets",
+						"command": "pnpx grunt assets",
 						"forwardAllArgs": false
 					}
 				],
@@ -25,11 +25,11 @@
 			"options": {
 				"commands": [
 					{
-						"command": "grunt eslint",
+						"command": "pnpx grunt eslint",
 						"forwardAllArgs": false
 					},
 					{
-						"command": "grunt stylelint",
+						"command": "pnpx grunt stylelint",
 						"forwardAllArgs": false
 					}
 				],

--- a/plugins/woocommerce/project.json
+++ b/plugins/woocommerce/project.json
@@ -53,7 +53,7 @@
 		"build-watch": {
 			"executor": "@nrwl/workspace:run-commands",
 			"options": {
-				"command": "grunt watch",
+				"command": "pnpx grunt watch",
 				"cwd": "plugins/woocommerce/legacy"
 			}
 		},


### PR DESCRIPTION
This PR adds the ability to use the installed Grunt package to do the Grunt work instead of having to globally install Grunt.

Testing:

* Uninstall Grunt from your globals. `npm uninstall grunt --global`.
* Run `pnpm nx build woocommerce-legacy-assets --skip-nx-cache`. Ensure you don't see any errors about Grunt not found and that the build succeeds.
* Run `pnpm nx build woocommerce --skip-nx-cache`. Ensure you don't see any errors about Grunt not found and that the build succeeds.

