### PR TITLE
fix jest-circus dependency, pnpm e2e-environment build

### DIFF
--- a/packages/js/e2e-environment/bin/wc-e2e.sh
+++ b/packages/js/e2e-environment/bin/wc-e2e.sh
@@ -34,7 +34,7 @@ REALPATH=$(readlink "$0")
 cd "$SCRIPTPATH/$(dirname "$REALPATH")/.."
 
 # Set a flag to distinguish between the development repo and npm package
-DEV_PATH=$(echo $0 | rev | cut -f4 -d/ | rev)
+DEV_PATH=$(pwd | rev | cut -f3 -d/ | rev)
 if [ "$DEV_PATH" != "node_modules" ]; then
 	export WC_E2E_WOOCOMMERCE_DEV='true'
 	export WC_E2E_FOLDER='plugins/woocommerce'

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -30,6 +30,7 @@
     "app-root-path": "^3.0.0",
     "commander": "4.1.1",
     "jest": "^25.1.0",
+	"jest-circus": "25.1.0",
     "jest-each": "25.5.0",
     "jest-puppeteer": "^4.4.0",
     "node-stream-zip": "^1.13.6",
@@ -51,7 +52,6 @@
     "@wordpress/browserslist-config": "^4.1.0",
     "@wordpress/eslint-plugin": "7.3.0",
     "eslint": "^8.1.0",
-    "jest-circus": "25.1.0",
     "ndb": "^1.1.5",
     "semver": "^7.3.2"
   },
@@ -59,7 +59,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "clean": "rm -rf ./build ./build-module",
     "compile": "node ./../bin/build.js",
     "build": "pnpm run clean && pnpm run compile",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,7 @@ importers:
       app-root-path: 3.0.0
       commander: 4.1.1
       jest: 25.5.4
+      jest-circus: 25.1.0
       jest-each: 25.5.0
       jest-puppeteer: 4.4.0
       node-stream-zip: 1.15.0
@@ -173,7 +174,6 @@ importers:
       '@wordpress/browserslist-config': 4.1.0
       '@wordpress/eslint-plugin': 7.3.0_eslint@8.2.0+typescript@4.2.4
       eslint: 8.2.0
-      jest-circus: 25.1.0
       ndb: 1.1.5
       semver: 7.3.5
 
@@ -12410,7 +12410,7 @@ packages:
       throat: 5.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
+    dev: false
 
   /jest-circus/27.3.1:
     resolution: {integrity: sha512-v1dsM9II6gvXokgqq6Yh2jHCpfg7ZqV4jWY66u7npz24JnhP3NHxI0sKT7+ZMQ7IrOWHYAaeEllOySbDbWsiXw==}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses three issues with the `pnpm` build of the e2e-environment package:

- `jest-circus` was a devDependency which allowed retries to work fine in this repo but the dependency was missing from the built package. This is addressed by moving the dependency entry.
- When creating the package `wc-e2e` `.bin` symlink `pnpm` uses `../@woocommerce/environment/bin/wc-e2e.sh` where `npm` used the full path `/path/to/.../woocommerce/node_modules/@woocommerce/environment/bin/wc-e2e.sh`. This is fixed by updating the logic to compare the full path.
- Removes `npx only-allow pnpm` from package.json which prevents `npm` from installing the package in another project

### How to test the changes in this Pull Request:

1. In `packages/js/e2e-environment` run ` rm package-lock.json`
1. In `plugins/woocommerce` run
```
pnpm rebuild --filter @woocommerce/e2e-environment
# get the full path to pnpm
which pnpm
```
3. In `packages/js/e2e-environment` run 
```
# use full path to pnpm
 /Users/ronrennick/.nvm/versions/node/v12.22.1/bin/pnpm pack
cp woocommerce-e2e-environment-0.2.3.tgz /path/to/woocommerce-e2e-boilerplate
 ```
4. In the `woocommerce-e2e-boilerplate` repo:
- change the `@woocommerce/e2e-environment` package location to `file:./woocommerce-e2e-environment-0.2.3.tgz`
- delete `package-lock.json` if there is one
- delete the `node_modules/@woocommerce/e2e-environment` folder if it exists
- delete `node_modules/.bin/wc-e2e` if it exists
- run `npm i`
5. copy `woocommerce/plugins/woocommerce/tests/e2e` to `tests/e2e`
6. Run `npx wc-e2e docker:up`
7. Run `npx wc-e2e test:e2e`


