### PR TITLE
Style My Account Pages for 2022 Theme.

### DIFF
--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
@@ -30,6 +30,10 @@ class WC_Twenty_Twenty_Two {
 		// Enqueue theme compatibility styles.
 		add_filter( 'woocommerce_enqueue_styles', array( __CLASS__, 'enqueue_styles' ) );
 
+		// Wrap checkout form elements for styling.
+		add_action( 'woocommerce_checkout_before_order_review_heading', array( __CLASS__, 'before_order_review' ) );
+		add_action( 'woocommerce_checkout_after_order_review', array( __CLASS__, 'after_order_review' ) );
+
 		// Register theme features.
 		add_theme_support( 'wc-product-gallery-zoom' );
 		add_theme_support( 'wc-product-gallery-lightbox' );
@@ -63,6 +67,19 @@ class WC_Twenty_Twenty_Two {
 		return apply_filters( 'woocommerce_twenty_twenty_two_styles', $styles );
 	}
 
+	/**
+	 * Wrap checkout order review with a `col2-set` div.
+	 */
+	public static function before_order_review() {
+		echo '<div class="col2-set">';
+	}
+
+	/**
+	 * Close the div wrapper.
+	 */
+	public static function after_order_review() {
+		echo '</div>';
+	}
 }
 
 WC_Twenty_Twenty_Two::init();

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -44,6 +44,17 @@ $tt2-gray: #f7f7f7;
 	}
 }
 
+.woocommerce-page {
+
+	main {
+
+		.woocommerce {
+			@include clearfix();
+			max-width: 1000px;
+		}
+	}
+}
+
 .woocommerce {
 
 	.woocommerce-products-header,
@@ -128,6 +139,7 @@ $tt2-gray: #f7f7f7;
 			border: none;
 			background: #ebe9eb;
 			color: var(--wp--preset--color--black);
+			padding: 0.5rem 1rem;
 
 			&:hover,
 			&:visited {
@@ -167,7 +179,7 @@ $tt2-gray: #f7f7f7;
 		background-color: var( --wp--preset--color--primary );
 		color: #fff;
 		border: 1px solid var(--wp--preset--color--black);
-		padding: 0.5rem 1rem 0.5rem 1rem;
+		padding: 1rem 2rem;
 		margin-top: 1rem;
 		text-decoration: none;
 		font-size: medium;
@@ -567,6 +579,140 @@ $tt2-gray: #f7f7f7;
 			text-decoration: none;
 		}
 	}
+
+	table.shop_table_responsive {
+			
+		width: 100%;
+		text-align: left;
+		border-collapse: collapse;
+
+		th,
+		td {
+			font-size: var(--wp--preset--font-size--small);
+			font-weight: normal;
+		}
+
+		th {
+			padding-bottom: 1rem;
+		}
+
+		tbody {
+
+			tr {
+				border-top: 1px solid var( --wp--preset--color--black );
+			}
+
+			td {
+				a.button,
+				button {
+					margin-bottom: 1rem;
+					border: none;
+					background: #ebe9eb;
+					color: var(--wp--preset--color--black);
+					padding: 0.5rem 1rem 0.5rem 1rem;
+		
+					&:hover,
+					&:visited {
+						color: var(--wp--preset--color--black);
+					}
+				}
+			}
+		}
+	}
+
+	/*
+	 * Cart / Checkout
+	 */
+	.woocommerce-cart-form {
+
+		#coupon_code {
+			width: auto;
+		}
+
+		table.shop_table_responsive {
+
+			td, th {
+				padding: 1rem 0 0.5rem 1rem;
+			}
+
+			tbody {
+
+				tr:last-of-type {
+					border-top: none;
+				}
+
+				@media only screen and (max-width: 768px) {
+					td {
+						padding-left: 0;
+					}
+
+					.product-remove {
+						width: auto;
+						text-align: left !important;
+					}
+
+					#coupon_code {
+						width: 50%;
+						float: left;
+						margin-bottom: 1rem;
+					}
+				}
+			}
+
+			button[name='apply_coupon'],
+			button[name='update_cart'] {
+				padding: 1rem 2rem;
+				border: 1px solid #ebe9eb;
+				margin: 0;
+			}
+
+			.product-remove {
+				width: 1rem;
+				font-size: var(--wp--preset--font-size--large);
+
+				a {
+					text-decoration: none;
+				}
+			}
+
+			.product-thumbnail {
+				width: 7.5rem;
+	
+				a {
+					img {
+						width: 117px;
+					}
+				}
+			}
+
+			.product-name {
+				a:not(:hover) {
+					text-decoration: none;
+				}
+
+				a:hover {
+					text-decoration: underline;
+					text-decoration-thickness: 1px;
+				}
+
+				.variation {
+					dt {
+						font-style: italic;
+						margin-right: 0.25rem;
+						float: left;
+					}
+
+					dd {
+						font-style: normal;
+
+						a {
+							font-style: normal;
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 .select2-container {
@@ -655,44 +801,6 @@ $tt2-gray: #f7f7f7;
 
 		> p:first-of-type {
 			margin-block-start: 0px;
-		}
-
-		table {
-			
-			width: 100%;
-			text-align: left;
-			border-collapse: collapse;
-
-			th,
-			td {
-				font-size: var(--wp--preset--font-size--small);
-				font-weight: normal;
-			}
-
-			th {
-				padding-bottom: 1rem;
-			}
-
-			tbody {
-
-				tr {
-					border-top: 1px solid var( --wp--preset--color--black );
-				}
-
-				td {
-					a.button {
-						margin-bottom: 1rem;
-						border: none;
-						background: #ebe9eb;
-						color: var(--wp--preset--color--black);
-			
-						&:hover,
-						&:visited {
-							color: var(--wp--preset--color--black);
-						}
-					}
-				}
-			}
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -32,6 +32,18 @@ $tt2-gray: #f7f7f7;
 /**
  * Main layout.
  */
+
+.woocommerce-page {
+
+	h1.wp-block-post-title {
+		font-size: var(--wp--preset--font-size--huge);
+	}
+
+	h2 {
+		font-size: var(--wp--preset--font-size--large);
+	}
+}
+
 .woocommerce {
 
 	.woocommerce-products-header,
@@ -595,7 +607,7 @@ $tt2-gray: #f7f7f7;
 /**
  * Account section
  */
- .woocommerce-account {
+.woocommerce-account {
 
 	main {
 
@@ -690,6 +702,16 @@ $tt2-gray: #f7f7f7;
 			form > h3 {
 				margin-block-start: 0px;
 			}
+		}
+	}
+
+	.woocommerce-form-login {
+		max-width: 516px;
+		margin: 0 auto;
+
+		.show-password-input {
+			top: 1.2rem;
+			right: 1.2rem;
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -1031,7 +1031,7 @@ $tt2-gray: #f7f7f7;
 		margin: 0 auto;
 
 		.show-password-input {
-			top: 1rem;
+			top: .8rem;
 			right: 1.2rem;
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -602,6 +602,41 @@ $tt2-gray: #f7f7f7;
 		abbr.required {
 			text-decoration: none;
 		}
+
+		ul {
+			margin-top: 0;
+			margin-bottom: 0;
+			list-style-type: none;
+			padding-left: 0;
+		}
+
+		input[type="radio"][name='payment_method'],
+		input[type="radio"].shipping_method {
+			display: none;
+	
+			& + label {
+	
+				&::before {
+					content: "";
+					display: inline-block;
+					width: 14px !important;
+					height: 14px;
+					border: 2px solid var(--wp--preset--color--black);
+					background: var(--wp--preset--color--white);
+					margin-left: 4px;
+					margin-right: 1.2rem;
+					border-radius: 100%;
+					transform: translateY(2px);
+				}
+			}
+	
+			&:checked + label {
+	
+				&::before {
+					background: radial-gradient(circle at center, black 45%, white 0);
+				}
+			}
+		}
 	}
 
 	table.shop_table_responsive {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -27,6 +27,8 @@
 
 @import "mixins";
 
+$tt2-gray: #f7f7f7;
+
 /**
  * Main layout.
  */
@@ -88,53 +90,55 @@
 		display: none;
 	}
 
-	.woocommerce-notices-wrapper {
+	.woocommerce-message,
+	.woocommerce-error,
+	.woocommerce-info {
+		background: $tt2-gray;
+		border-top-color: var( --wp--preset--color--primary );
+		border-top-style: solid;
+		padding: 1rem 1.5rem;
+		list-style: none;
+		font-size: var(--wp--preset--font-size--small);
 
-		.woocommerce-message,
-		.woocommerce-error,
-		.woocommerce-info {
-			margin-bottom: 5rem;
-			background: #f7f7f7;
-			border-top-color: var( --wp--preset--color--primary );
-			border-top-style: solid;
-			padding: 1rem;
-			list-style: none;
+		&[role='alert']::before {
+			color: var( --wp--preset--color--background );
+			background: var( --wp--preset--color--primary );
+			border-radius: 5rem;
+			font-size: 1rem;
+			padding-left: 3px;
+			padding-right: 3px;
+			margin-right: 1rem;
+		}
 
-			&[role='alert']::before {
-				color: var( --wp--preset--color--background );
-				background: var( --wp--preset--color--primary );
-				border-radius: 5rem;
-				font-size: 1rem;
-				padding-left: 3px;
-				padding-right: 3px;
-				margin-right: 1rem;
-			}
+		a.button {
+			margin-top: -0.5rem;
+			background: #ebe9eb;
+			color: var(--wp--preset--color--black);
 
-			a.button {
-				margin-top: -0.5rem;
-				background: #ebe9eb;
+			&:hover,
+			&:visited {
 				color: var(--wp--preset--color--black);
 			}
 		}
+	}
 
-		.woocommerce-error[role='alert'] {
-			margin: 0;
+	.woocommerce-error[role='alert'] {
+		margin: 0;
 
-			&::before {
-				content: 'X';
-				padding-right: 4px;
-				padding-left: 4px;
-			}
-
-			li {
-				display: inline-block;
-			}
+		&::before {
+			content: 'X';
+			padding-right: 4px;
+			padding-left: 4px;
 		}
 
-		.woocommerce-message {
-			&[role='alert']::before {
-				content: '\2713';
-			}
+		li {
+			display: inline-block;
+		}
+	}
+
+	.woocommerce-message {
+		&[role='alert']::before {
+			content: '\2713';
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -609,61 +609,61 @@ $tt2-gray: #f7f7f7;
 			list-style-type: none;
 			padding-left: 0;
 		}
+	}
 
-		input[type="radio"][name='payment_method'],
-		input[type="radio"].shipping_method {
-			display: none;
-	
-			& + label {
-	
-				&::before {
-					content: "";
-					display: inline-block;
-					width: 1rem;
-					height: 1rem;
-					border: 2px solid var(--wp--preset--color--black);
-					background: var(--wp--preset--color--white);
-					margin-left: 4px;
-					margin-right: 1.2rem;
-					border-radius: 100%;
-					transform: translateY(.2rem);
-				}
-			}
-	
-			&:checked + label {
-	
-				&::before {
-					background: radial-gradient(circle at center, black 45%, white 0);
-				}
+	input[type="radio"][name='payment_method'],
+	input[type="radio"].shipping_method {
+		display: none;
+
+		& + label {
+
+			&::before {
+				content: "";
+				display: inline-block;
+				width: 1rem;
+				height: 1rem;
+				border: 2px solid var(--wp--preset--color--black);
+				background: var(--wp--preset--color--white);
+				margin-left: 4px;
+				margin-right: 1.2rem;
+				border-radius: 100%;
+				transform: translateY(.2rem);
 			}
 		}
 
-		label.woocommerce-form__label-for-checkbox {
-			font-weight: normal;
-			cursor: pointer;
-	
-			span {
-	
-				&::before {
-					content: "";
-					display: inline-block;
-					height: 1rem;
-					width: 1rem;
-					border: 2px solid var(--wp--preset--color--black);
-					background: var(--wp--preset--color--white);
-					margin-right: .5rem;
-					transform: translateY(.2rem);
-				}
+		&:checked + label {
+
+			&::before {
+				background: radial-gradient(circle at center, black 45%, white 0);
 			}
-	
-			input[type="checkbox"] {
-				display: none;
+		}
+	}
+
+	label.woocommerce-form__label-for-checkbox {
+		font-weight: normal;
+		cursor: pointer;
+
+		span {
+
+			&::before {
+				content: "";
+				display: inline-block;
+				height: 1rem;
+				width: 1rem;
+				border: 2px solid var(--wp--preset--color--black);
+				background: var(--wp--preset--color--white);
+				margin-right: .5rem;
+				transform: translateY(.2rem);
 			}
-	
-			input[type="checkbox"]:checked + span::before {
-				background: var(--wp--preset--color--black);
-				box-shadow: inset .2rem .2rem var(--wp--preset--color--white), inset -.2rem -.2rem var(--wp--preset--color--white);
-			}
+		}
+
+		input[type="checkbox"] {
+			display: none;
+		}
+
+		input[type="checkbox"]:checked + span::before {
+			background: var(--wp--preset--color--black);
+			box-shadow: inset .2rem .2rem var(--wp--preset--color--white), inset -.2rem -.2rem var(--wp--preset--color--white);
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -97,6 +97,7 @@ $tt2-gray: #f7f7f7;
 		border-top-color: var( --wp--preset--color--primary );
 		border-top-style: solid;
 		padding: 1rem 1.5rem;
+		margin-bottom: 2rem;
 		list-style: none;
 		font-size: var(--wp--preset--font-size--small);
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -113,6 +113,7 @@ $tt2-gray: #f7f7f7;
 
 		a.button {
 			margin-top: -0.5rem;
+			border: none;
 			background: #ebe9eb;
 			color: var(--wp--preset--color--black);
 
@@ -153,6 +154,7 @@ $tt2-gray: #f7f7f7;
 		word-break: break-word;
 		background-color: var( --wp--preset--color--primary );
 		color: #fff;
+		border: 1px solid var(--wp--preset--color--black);
 		padding: 0.5rem 1rem 0.5rem 1rem;
 		margin-top: 1rem;
 		text-decoration: none;

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -686,7 +686,7 @@ $tt2-gray: #f7f7f7;
 			button[name='apply_coupon'],
 			button[name='update_cart'] {
 				padding: 1rem 2rem;
-				border: 1px solid #ebe9eb;
+				border: 2px solid #ebe9eb;
 				margin: 0;
 			}
 
@@ -735,6 +735,53 @@ $tt2-gray: #f7f7f7;
 					}
 				}
 			}
+		}
+	}
+
+	.cart-collaterals {
+		margin-top: 1.5rem;
+
+		h2 {
+			text-transform: uppercase;
+			font-family: inherit;
+			font-size: var(--wp--preset--font-size--medium);
+		}
+
+		table.shop_table_responsive {
+
+			tr {
+				border-top: none;
+			}
+
+			th {
+				width: 11rem;
+			}
+
+			td, th {
+				padding: 1rem 0;
+				vertical-align: text-top;
+			}
+		}
+
+		.woocommerce-shipping-totals {
+			ul {
+				margin-top: 0;
+				margin-bottom: 0;
+				list-style-type: none;
+				padding-left: 0;
+			}
+
+			td[data-title='Shipping'] {
+
+			}
+		}
+
+		button[name='calc_shipping'] {
+			padding: 1rem 2rem;
+		}
+
+		.woocommerce-Price-amount {
+			font-weight: normal;
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -924,6 +924,59 @@ $tt2-gray: #f7f7f7;
 			margin-right: .6rem;
 		}
 	}
+
+	.woocommerce-thankyou-order-received {
+		font-family: var(--wp--preset--font-family--source-serif-pro);
+		font-size: var(--wp--preset--font-size--large);
+		font-weight: 300;
+	}
+
+	ul.woocommerce-order-overview {
+		font-size: var(--wp--preset--font-size--small);
+		display: flex;
+		padding-left: 0;
+
+		li {
+			display: inline;
+			flex-grow: 1;
+			margin-bottom: 1rem;
+			text-transform: uppercase;
+
+			strong {
+				text-transform: none;
+				display: block;
+			}
+		}
+
+		@media only screen and (max-width: 768px) {
+			flex-direction: column;
+		}
+	}
+
+	.woocommerce-customer-details {
+		address {
+			padding: 2rem;
+			border: 1px solid var(--wp--preset--color--black);
+		}
+	}
+
+	.woocommerce-table--order-details {
+		border: 1px solid var(--wp--preset--color--black);
+		border-collapse: collapse;
+		width: 70%;
+
+		th, td {
+			text-align: left;
+			padding: 1rem;
+			border-top: 1px solid var(--wp--preset--color--black);
+			border-bottom: 1px solid var(--wp--preset--color--black);
+			font-weight: normal;
+		}
+
+		thead th {
+			text-transform: uppercase;
+		}
+	}
 }
 
 .select2-container {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -784,6 +784,22 @@ $tt2-gray: #f7f7f7;
 			font-weight: normal;
 		}
 	}
+
+	.woocommerce-checkout {
+		.col2-set {
+			width: 48%;
+			float: right;
+		}
+
+		#customer_details {
+			float: left;
+
+			.col-1, .col-2 {
+				width: 100%;
+				float: none;
+			}
+		}
+	}
 }
 
 .select2-container {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -525,3 +525,58 @@ $tt2-gray: #f7f7f7;
 		z-index: 99;
 	}
 }
+
+/**
+ * Account section
+ */
+ .woocommerce-account {
+
+	main {
+
+		.woocommerce {
+			@include clearfix();
+			max-width: 1000px;
+		}
+	}
+
+	.woocommerce-MyAccount-navigation {
+
+		ul {
+			margin: 0;
+			padding: 0;
+		}
+
+		li {
+			list-style: none;
+			padding: 1rem 0;
+
+			&:first-child {
+				padding-top: 0;
+			}
+
+			a {
+				box-shadow: none;
+				text-decoration: none;
+
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+
+			&.is-active {
+
+				a {
+					color: var( --wp--preset--color--primary );
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+
+	.woocommerce-MyAccount-content {
+
+		p:first-of-type {
+			margin-block-start: 0px;
+		}
+	}
+}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -591,7 +591,7 @@ $tt2-gray: #f7f7f7;
 		.input-text {
 			border: 1px solid var(--wp--preset--color--black);
 			border-radius: 0;
-			font-size: var(--wp--preset--font-size--medium);
+			font-size: var(--wp--preset--font-size--small);
 			padding: .9rem 1.1rem;
 		}
 
@@ -763,19 +763,6 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
-		.woocommerce-shipping-totals {
-			ul {
-				margin-top: 0;
-				margin-bottom: 0;
-				list-style-type: none;
-				padding-left: 0;
-			}
-
-			td[data-title='Shipping'] {
-
-			}
-		}
-
 		button[name='calc_shipping'] {
 			padding: 1rem 2rem;
 		}
@@ -786,18 +773,79 @@ $tt2-gray: #f7f7f7;
 	}
 
 	.woocommerce-checkout {
+		h3 {
+			font-family: inherit;
+			font-size: var(--wp--preset--font-size--normal);
+			font-weight: 700;
+		}
+
 		.col2-set {
-			width: 48%;
+			width: 43%;
 			float: right;
 		}
 
 		#customer_details {
+			width: 53%;
 			float: left;
 
 			.col-1, .col-2 {
 				width: 100%;
 				float: none;
 			}
+		}
+
+		.woocommerce-billing-fields__field-wrapper,
+		.woocommerce-checkout-review-order-table,
+		.woocommerce-checkout-payment {
+			margin-top: 4rem;
+		}
+
+		.woocommerce-checkout-review-order-table {
+			border-collapse: collapse;
+			width: 100%;
+
+			thead {
+				display: none;
+			}
+
+			th {
+				text-align: left;
+				font-weight: normal;
+				vertical-align: text-top;
+			}
+
+			th, td {
+				padding: 1rem 1rem 1rem 0;
+			}
+
+			tbody,
+			tr.woocommerce-shipping-totals {
+				border-bottom: 1px solid #d2ced2;
+			}
+
+			.product-quantity {
+				font-weight: normal;
+			}
+
+			.product-total,
+			.cart-subtotal,
+			.order-total {
+				.woocommerce-Price-amount {
+					font-weight: bold;
+				}
+			}
+		}
+	}
+
+	ul.wc_payment_methods,
+	ul.woocommerce-shipping-methods {
+		margin-top: 0;
+		margin-bottom: 0;
+		list-style-type: none;
+		padding-left: 0;
+
+		input[type='radio'] {
+			margin-right: .6rem;
 		}
 	}
 }
@@ -807,7 +855,7 @@ $tt2-gray: #f7f7f7;
 	.select2-selection,
 	.select2-search__field {
 		height: 3.5rem;
-		font-size: var(--wp--preset--font-size--medium);
+		font-size: var(--wp--preset--font-size--small);
 		padding: .9rem 1.1rem;
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -818,7 +818,7 @@ $tt2-gray: #f7f7f7;
 		margin: 0 auto;
 
 		.show-password-input {
-			top: 1.2rem;
+			top: 1rem;
 			right: 1.2rem;
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -969,7 +969,9 @@ $tt2-gray: #f7f7f7;
 
 	.woocommerce-MyAccount-content {
 
-		> p:first-of-type {
+		> p:first-of-type,
+		p.form-row-first,
+		p.form-row-last {
 			margin-block-start: 0px;
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -857,6 +857,14 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
+		@media only screen and (max-width: 768px) {
+			.col2-set,
+			#customer_details {
+				width: 100%;
+				float: none;
+			}
+		}
+
 		.woocommerce-billing-fields__field-wrapper,
 		.woocommerce-checkout-review-order-table,
 		.woocommerce-checkout-payment {
@@ -897,6 +905,11 @@ $tt2-gray: #f7f7f7;
 					font-weight: bold;
 				}
 			}
+		}
+
+		button#place_order {
+			width: 100%;
+			text-transform: uppercase;
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -541,7 +541,6 @@ $tt2-gray: #f7f7f7;
 	form {
 
 		.input-text {
-			height: 3.5rem;
 			border: 1px solid var(--wp--preset--color--black);
 			border-radius: 0;
 			font-size: var(--wp--preset--font-size--medium);

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -192,6 +192,12 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
+	button.woocommerce-form-login__submit,
+	button.single_add_to_cart_button,
+	a.checkout-button {
+		font-size: 18px;
+		padding: 1.5rem 3.5rem;
+	}
 
 	// Shop page
 
@@ -227,6 +233,10 @@ $tt2-gray: #f7f7f7;
 				font-size: 1.2rem;
 				text-decoration: none;
 				margin-bottom: 0;
+			}
+
+			a.add_to_cart_button {
+				padding: 0.8rem 2.7rem;
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -619,14 +619,14 @@ $tt2-gray: #f7f7f7;
 				&::before {
 					content: "";
 					display: inline-block;
-					width: 14px !important;
-					height: 14px;
+					width: 1rem;
+					height: 1rem;
 					border: 2px solid var(--wp--preset--color--black);
 					background: var(--wp--preset--color--white);
 					margin-left: 4px;
 					margin-right: 1.2rem;
 					border-radius: 100%;
-					transform: translateY(2px);
+					transform: translateY(.2rem);
 				}
 			}
 	
@@ -635,6 +635,34 @@ $tt2-gray: #f7f7f7;
 				&::before {
 					background: radial-gradient(circle at center, black 45%, white 0);
 				}
+			}
+		}
+
+		label.woocommerce-form__label-for-checkbox {
+			font-weight: normal;
+			cursor: pointer;
+	
+			span {
+	
+				&::before {
+					content: "";
+					display: inline-block;
+					height: 1rem;
+					width: 1rem;
+					border: 2px solid var(--wp--preset--color--black);
+					background: var(--wp--preset--color--white);
+					margin-right: .5rem;
+					transform: translateY(.2rem);
+				}
+			}
+	
+			input[type="checkbox"] {
+				display: none;
+			}
+	
+			input[type="checkbox"]:checked + span::before {
+				background: var(--wp--preset--color--black);
+				box-shadow: inset .2rem .2rem var(--wp--preset--color--white), inset -.2rem -.2rem var(--wp--preset--color--white);
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -238,6 +238,11 @@ $tt2-gray: #f7f7f7;
 			a.add_to_cart_button {
 				padding: 0.8rem 2.7rem;
 			}
+
+			a.added_to_cart {
+				display: block;
+				margin-top: 1rem;
+			}
 		}
 	}
 
@@ -564,6 +569,15 @@ $tt2-gray: #f7f7f7;
 		top: 1rem;
 		right: 1rem;
 		z-index: 99;
+	}
+
+	.return-to-shop {
+		a.button {
+			background-color: #fff;
+			color: var( --wp--preset--color--primary );
+			border: 2px solid var( --wp--preset--color--primary );
+			padding: 0.7rem 2rem;
+		}
 	}
 }
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -644,6 +644,44 @@ $tt2-gray: #f7f7f7;
 		> p:first-of-type {
 			margin-block-start: 0px;
 		}
+
+		table {
+			
+			width: 100%;
+			text-align: left;
+			border-collapse: collapse;
+
+			th,
+			td {
+				font-size: var(--wp--preset--font-size--small);
+				font-weight: normal;
+			}
+
+			th {
+				padding-bottom: 1rem;
+			}
+
+			tbody {
+
+				tr {
+					border-top: 1px solid var( --wp--preset--color--black );
+				}
+
+				td {
+					a.button {
+						margin-bottom: 1rem;
+						border: none;
+						background: #ebe9eb;
+						color: var(--wp--preset--color--black);
+			
+						&:hover,
+						&:visited {
+							color: var(--wp--preset--color--black);
+						}
+					}
+				}
+			}
+		}
 	}
 
 	&.woocommerce-edit-address {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -142,7 +142,11 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	a.button, button[name='add-to-cart'], input[name='submit'], button.single_add_to_cart_button {
+	a.button,
+	button[name='add-to-cart'],
+	input[name='submit'],
+	button.single_add_to_cart_button,
+	button[type='submit'] {
 		display: inline-block;
 		text-align: center;
 		word-break: break-word;
@@ -527,6 +531,66 @@ $tt2-gray: #f7f7f7;
 }
 
 /**
+ * Form fields
+ */
+.woocommerce-page {
+	
+	form {
+
+		.input-text {
+			height: 3.5rem;
+			border: 1px solid var(--wp--preset--color--black);
+			border-radius: 0;
+			font-size: var(--wp--preset--font-size--medium);
+			padding: .9rem 1.1rem;
+		}
+
+		label {
+			margin-bottom: .7rem;
+		}
+
+		abbr.required {
+			text-decoration: none;
+		}
+	}
+}
+
+.select2-container {
+
+	.select2-selection,
+	.select2-search__field {
+		height: 3.5rem;
+		font-size: var(--wp--preset--font-size--medium);
+		padding: .9rem 1.1rem;
+	}
+
+	.select2-selection,
+	.select2-dropdown {
+		border: 1px solid var(--wp--preset--color--black);
+		border-radius: 0;
+	}
+
+	.select2-dropdown {
+		border-top: 0;
+		padding: .9rem 1.1rem;
+
+		.select2-search__field {
+			border: 1px solid var(--wp--preset--color--black);
+			border-radius: 0;
+			margin-bottom: 1rem;
+		}
+	}
+
+	.select2-selection .select2-selection__arrow {
+		height: 3.5rem;
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 3rem;
+	}
+}
+
+/**
  * Account section
  */
  .woocommerce-account {
@@ -575,8 +639,17 @@ $tt2-gray: #f7f7f7;
 
 	.woocommerce-MyAccount-content {
 
-		p:first-of-type {
+		> p:first-of-type {
 			margin-block-start: 0px;
+		}
+	}
+
+	&.woocommerce-edit-address {
+
+		.woocommerce-MyAccount-content {
+			form > h3 {
+				margin-block-start: 0px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31548.

This PR styles the My Account pages for 2022 theme support.

### How to test the changes in this Pull Request:

1. Switch to WP 5.9 beta.
1. Switch to 2022 theme.
1. View all my account pages (with and without placing orders and having downloads)
1. Log out and view login form

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Add support for 2022 my account pages.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
