### PR TITLE
use PR labels for label check on PR smoke test

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -96,7 +96,7 @@ jobs:
             await script({github, context})
 
       - name: Remove label from pull request.
-        if: always() && ${{ contains(github.event.label.name, format( 'run{0} smoke tests', ':') ) }}
+        if: always() && ${{ contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) }}
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the `Run smoke tests against pull request.` Github workflow to search the pull request labels for `run: smoke tests` instead of the event label.

Workflows that run on a schedule or are triggered by comments or labels cannot be tested until they have been merged to the main branch. To that end I implemented this logic in a test repo.

### How to test the changes in this Pull Request:

1. Go to https://github.com/rrennick/rons-test-repo/pull/2
2. Add the `run: smoke tests` label
3. Within a minute or so Github should automatically add a comment to the PR and remove the `run: smoke tests` label
4. Compare the logic in https://github.com/rrennick/rons-test-repo/blob/trunk/.github/workflows/pr-smoke-test.yml#L38 to the change in this PR

