### PR TITLE
Version bump WooCommerce Admin to 3.0.3

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.0.1",
+		"woocommerce/woocommerce-admin": "3.0.3",
 		"woocommerce/woocommerce-blocks": "6.5.1"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ebdb5708b79cdb94e4b2ff5fbed40d89",
+    "content-hash": "fb68c78e4ab4269155c3c9613af1a22a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "5542e80021a43d24ab9b1d2d67083b608899835d"
+                "reference": "0b1abab35c62717f3121428fe7f378998ef4899c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5542e80021a43d24ab9b1d2d67083b608899835d",
-                "reference": "5542e80021a43d24ab9b1d2d67083b608899835d",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0b1abab35c62717f3121428fe7f378998ef4899c",
+                "reference": "0b1abab35c62717f3121428fe7f378998ef4899c",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.3"
             },
-            "time": "2021-12-30T18:38:11+00:00"
+            "time": "2022-01-06T22:46:17+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2926,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.0.3

## New Feature Tests

**Smoke testing**

- Set up a store where WC Pay is not supported (ex: Brazil).
- Go to **WooCommerce > Settings > Payments** the payment method table should be displayed correctly without any blank rows
- Set your store address to a supported WC Pay country (Canada or USA)
- Go to the payment settings page and see if the promotion shows up now


- Add this filter to your theme or a test plugin `add_filter( 'woocommerce_allow_marketplace_suggestions', '__return_false' );`
- Go to **WooCommerce > Settings > Payments** and notice how the WooCommerce Payment promotion is not displayed.

## Changelog

```
== 3.0.3 01/06/2022 ==

- Fix: Fix blank payment gateway method in table when WooCommerce Payments is not supported. #8122
- Add: Add woocommerce_allow_marketplace_suggestions filter to WooCommerce Payments payment method promotion. #8117

== 3.0.2 01/05/2022 ==

- Render the activity panel when the experimental tasklist is hidden. #8111
 ```
