### PR TITLE
Fix PHPDoc Type

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-attribute.php
+++ b/plugins/woocommerce/includes/class-wc-product-attribute.php
@@ -152,7 +152,7 @@ class WC_Product_Attribute implements ArrayAccess {
 	/**
 	 * Set name (this is the attribute name or taxonomy).
 	 *
-	 * @param int $value Attribute name.
+	 * @param string $value Attribute name.
 	 */
 	public function set_name( $value ) {
 		$this->data['name'] = $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This fixes an incorrect PHPDoc type in `class-wc-product-attribute.php` that came up during static analysis.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
