### PR TITLE
change string 'automatically generate an account password'

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -93,7 +93,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'      => false,
 			),
 			array(
-				'desc'          => __( 'When creating an account, automatically generate an account password', 'woocommerce' ),
+				'desc'          => __( 'When creating an account, send the new user link to set his password', 'woocommerce' ),
 				'id'            => 'woocommerce_registration_generate_password',
 				'default'       => 'yes',
 				'type'          => 'checkbox',

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -93,7 +93,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'      => false,
 			),
 			array(
-				'desc'          => __( 'When creating an account, send the new user a link to set his password', 'woocommerce' ),
+				'desc'          => __( 'When creating an account, send the new user a link to set their password', 'woocommerce' ),
 				'id'            => 'woocommerce_registration_generate_password',
 				'default'       => 'yes',
 				'type'          => 'checkbox',

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -93,7 +93,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'      => false,
 			),
 			array(
-				'desc'          => __( 'When creating an account, send the new user link to set his password', 'woocommerce' ),
+				'desc'          => __( 'When creating an account, send the new user a link to set his password', 'woocommerce' ),
 				'id'            => 'woocommerce_registration_generate_password',
 				'default'       => 'yes',
 				'type'          => 'checkbox',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Change Text for Checkbox due to reasons listed here #31560
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31560 .

### How to test the changes in this Pull Request:

1. go to woocommerce settings
2. visit account area
3. Check Account Creation Part and last checkbox

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Change Checkbox Text to clarify that the user receives a link to set his password instead to send him the password directly
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
