### PR TITLE
Fix PhotoSwipe lightbox "close" triggering elements covered by it on mobile

### DIFF
--- a/plugins/woocommerce/legacy/js/photoswipe/photoswipe.js
+++ b/plugins/woocommerce/legacy/js/photoswipe/photoswipe.js
@@ -3230,7 +3230,7 @@ _registerModule('Tap', {
 				return;
 			}
 
-			if(!_moved && !_isMultitouch && !_numAnimations) {
+			if(!_moved && !_isMultitouch && !_numAnimations && self.container.contains(e.target)) {
 				var p0 = releasePoint;
 				if(tapTimer) {
 					clearTimeout(tapTimer);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25458.

Applies fix from https://github.com/andi34/PhotoSwipe/commit/55d031631096cc79cd05ceb37d543512659c733c.

### How to test the changes in this Pull Request:

1. Use Storefront or other theme that displays a menu toggle on narrow viewports
1. Use a mobile device or simulator to open a single product page
1. Open the photoswipe lightbox
1. Ensure that the close button overlaps with the menu toggle (you might need to force some CSS margins to accomplish)
1. Verify that tapping close does not trigger the menu toggle

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Prevent PhotoSwipe tap from interacting with elements directly underneath. Props @Edsuns and @andi34.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
