### PR TITLE
If applied, this commit will format Line items price in order api

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -169,7 +169,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		// Add SKU and PRICE to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
-			$data['price'] = $item->get_quantity() ? (float) number_format( $item->get_total() / $item->get_quantity(), wc_get_price_decimals(), '.', '' ) : 0;
+			$data['price'] = $item->get_quantity() ? wc_format_decimal( $item->get_total() / $item->get_quantity(), $this->request['dp'] ) : 0;
 		}
 
 		// Add parent_name if the product is a variation.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -169,7 +169,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		// Add SKU and PRICE to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
-			$data['price'] = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['price'] = $item->get_quantity() ? (float) number_format( $item->get_total() / $item->get_quantity(), wc_get_price_decimals(), '.', '' ) : 0;
 		}
 
 		// Add parent_name if the product is a variation.


### PR DESCRIPTION
When buying three products at price is 17.17. request /wp-json/wc/v3/orders api will get line_items prices is 17.169999999999998, this is because floating point numbers have limited precision.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. add a product price is 17.17
2. buy 3 this product
3. get request /wp-json/wc/v3/orders api

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Format price decimal places correctly in the order API.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
