### PR TITLE
Use calc function to prevent deprecated warnings when building

### DIFF
--- a/plugins/woocommerce/legacy/css/wc-setup.scss
+++ b/plugins/woocommerce/legacy/css/wc-setup.scss
@@ -1498,19 +1498,19 @@ p.jetpack-terms {
 			background-color: #f4a224;
 			max-height: 3em;
 			max-width: 3em;
-			padding: ( 3.5em - 3em ) / 2;
+			padding: calc( ( 3.5em - 3em ) / 2 );
 		}
 
 		&.recommended-item-icon-automated_taxes {
 			background-color: #d0011b;
 			max-height: 1.75em;
-			padding: ( 3.5em - 1.75em ) / 2;
+			padding: calc( ( 3.5em - 1.75em ) / 2 );
 		}
 
 		&.recommended-item-icon-mailchimp {
 			background-color: #ffe01b;
 			height: 2em;
-			padding: ( 3.5em - 2em ) / 2;
+			padding: calc( ( 3.5em - 2em ) / 2 );
 		}
 
 		&.recommended-item-icon-woocommerce_services {


### PR DESCRIPTION
Was seeing a deprecated warning when building the assets on calculation format. This PR fixes that.

Test:
* Run `pnpm nx build woocommerce-legacy-assets` and ensure you no longer see this warning `DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.`

