### PR TITLE
Allow relevant block templates to be listed in the Edit Product view

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -68,7 +68,7 @@ class WC_Admin_Meta_Boxes {
 		add_action( 'admin_notices', array( $this, 'output_errors' ) );
 		add_action( 'shutdown', array( $this, 'save_errors' ) );
 
-		add_filter( 'theme_product_templates', array( $this, 'filter_product_block_templates' ), 10, 1 );
+		add_filter( 'theme_product_templates', array( $this, 'remove_block_templates' ), 10, 1 );
 	}
 
 	/**
@@ -233,8 +233,8 @@ class WC_Admin_Meta_Boxes {
 	 *
 	 * @return string[] Templates array excluding block-based templates.
 	 */
-	public function filter_product_block_templates( $templates ) {
-		if ( count( $templates ) === 0 || ! wc_current_theme_is_fse_theme() || ! function_exists( 'gutenberg_get_block_template' ) ) {
+	public function remove_block_templates( $templates ) {
+		if ( count( $templates ) === 0 || ! wc_current_theme_is_fse_theme() || ( ! function_exists( 'gutenberg_get_block_template' ) && ! function_exists( 'get_block_template' ) ) ) {
 			return $templates;
 		}
 
@@ -247,10 +247,12 @@ class WC_Admin_Meta_Boxes {
 				continue;
 			}
 
-			$block_template = gutenberg_get_block_template( $theme . '//' . $template_key );
+			$block_template = function_exists( 'gutenberg_get_block_template' ) ?
+				gutenberg_get_block_template( $theme . '//' . $template_key ) :
+				get_block_template( $theme . '//' . $template_key );
 
 			// If the block template has the product post type specified, include it.
-			if ( in_array( 'product', $block_template->post_types ) ) {
+			if ( $block_template && in_array( 'product', $block_template->post_types ) ) {
 				$filtered_templates[ $template_key ] = $template_name;
 			}
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -68,7 +68,7 @@ class WC_Admin_Meta_Boxes {
 		add_action( 'admin_notices', array( $this, 'output_errors' ) );
 		add_action( 'shutdown', array( $this, 'save_errors' ) );
 
-		add_filter( 'theme_product_templates', array( $this, 'remove_block_templates' ), 10, 1 );
+		add_filter( 'theme_product_templates', array( $this, 'filter_product_block_templates' ), 10, 1 );
 	}
 
 	/**
@@ -226,14 +226,15 @@ class WC_Admin_Meta_Boxes {
 	}
 
 	/**
-	 * Remove block-based templates from the list of available templates for products.
+	 * Remove irrelevant block templates from the list of available templates for products.
+	 * This will also remove custom created templates.
 	 *
 	 * @param string[] $templates Array of template header names keyed by the template file name.
 	 *
 	 * @return string[] Templates array excluding block-based templates.
 	 */
-	public function remove_block_templates( $templates ) {
-		if ( count( $templates ) === 0 || ! function_exists( 'gutenberg_get_block_template' ) ) {
+	public function filter_product_block_templates( $templates ) {
+		if ( count( $templates ) === 0 || ! wc_current_theme_is_fse_theme() || ! function_exists( 'gutenberg_get_block_template' ) ) {
 			return $templates;
 		}
 
@@ -241,9 +242,15 @@ class WC_Admin_Meta_Boxes {
 		$filtered_templates = array();
 
 		foreach ( $templates as $template_key => $template_name ) {
-			$gutenberg_template = gutenberg_get_block_template( $theme . '//' . $template_key );
+			// Filter out the single-product.html template as this is a duplicate of "Default Template".
+			if ( 'single-product' === $template_key ) {
+				continue;
+			}
 
-			if ( ! $gutenberg_template ) {
+			$block_template = gutenberg_get_block_template( $theme . '//' . $template_key );
+
+			// If the block template has the product post type specified, include it.
+			if ( in_array( 'product', $block_template->post_types ) ) {
 				$filtered_templates[ $template_key ] = $template_name;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of removing all block templates from selection in the Edit Product view I have:

* Included templates that specified `product` in the theme.json.
* Excluded `single-product` as this is the same as "Default Template".
* Excluded any custom made templates.

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5029

### How to test the changes in this Pull Request:

1. Checkout this pull request and ensure you have a block template such as TT1 blocks enabled.
2. Create a `single-product.html` file in `theme-dir/block-templates` or `theme-dir/templates` depending on your themes convention and enter valid template markup
3. Create a `another-product-template.html` file with valid template markup in the same directory  as above for the purpose of testing
3. Add template both templates to your `theme.json` file and add `product` to their `postTypes`. Find docs [here](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#customtemplates) if needed.
4. Go to the Edit Product view of an existing product in WP Admin and check that `another-product-template.html` file is listed here. Also check that `single-product.html` isn't listed there and that the Default Template option is in fact your `single-product.html` file by checking what gets rendered on the frontend.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> List relevant block templates available for selection in the Edit Product view.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
