### PR TITLE
Allow Blocks for Custom Product taxonomies

### DIFF
--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -159,7 +159,7 @@ class WC_Template_Loader {
 	 * @since  3.0.0
 	 * @since  5.5.0 If a block template with the same name exists, return an
 	 * empty string.
-	 * @since  6.1.0 It checks custom product taxonomies
+	 * @since  6.3.0 It checks custom product taxonomies
 	 * @return string
 	 */
 	private static function get_template_loader_default_file() {

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -159,6 +159,7 @@ class WC_Template_Loader {
 	 * @since  3.0.0
 	 * @since  5.5.0 If a block template with the same name exists, return an
 	 * empty string.
+	 * @since  6.1.0 It checks custom product taxonomies
 	 * @return string
 	 */
 	private static function get_template_loader_default_file() {
@@ -170,14 +171,16 @@ class WC_Template_Loader {
 		} elseif ( is_product_taxonomy() ) {
 			$object = get_queried_object();
 
-			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-				if ( self::has_block_template( 'taxonomy-' . $object->taxonomy ) ) {
-					$default_file = '';
-				} else {
+			if ( self::has_block_template( 'taxonomy-' . $object->taxonomy ) ) {
+				$default_file = '';
+			} else {
+				if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 					$default_file = 'taxonomy-' . $object->taxonomy . '.php';
+				} elseif ( ! self::has_block_template( 'archive-product' ) ) {
+					$default_file = 'archive-product.php';
+				} else {
+					$default_file = '';
 				}
-			} elseif ( ! self::has_block_template( 'archive-product' ) ) {
-				$default_file = 'archive-product.php';
 			}
 		} elseif (
 			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -50,10 +50,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->initialize_template_loader();
 
 		// forcing has_block_template to be false
-		add_filter(
-			'woocommerce_has_block_template',
-			'__return_true', 10, 2,
-		);
+		add_filter( 'woocommerce_has_block_template', '__return_true', 10, 2 );
 
 		// Check Single Product
 		$this->load_product_in_query();

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Unit tests for the WC_Template_Loader class.
+ *
+ * @package WooCommerce\Tests\WC_Template_Loader.
+ */
+
+
+/**
+ * Class WC_Template_Loader
+ * @group WC_Template_Loader
+ */
+class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
+
+	public function test_wc_template_loader_loads_default_file_without_blocks() {
+
+		global $wp_taxonomies;
+
+		$this->initialize_template_loader();
+
+		// forcing has_block_template to be false
+		add_filter(
+			'woocommerce_has_block_template',
+			'__return_false', 2, 10,
+		);
+
+		// Check Single Product
+		$this->load_product_in_query();
+		$this->assertDefaultTemplateFileName( 'single-product' );
+
+		// Check Woo Taxonomy Product
+		$this->load_tax_in_query( 'product_cat' );
+		$this->assertDefaultTemplateFileName( 'taxonomy-product-cat' );
+
+		$this->load_tax_in_query( 'product_tag' );
+		$this->assertDefaultTemplateFileName( 'taxonomy-product-tag' );
+
+		// Check Custom Product Taxonomies
+		$wp_taxonomies['product_tax'] = new WP_Taxonomy( 'product_tax', 'product' );
+		$this->load_tax_in_query( 'product_tax' );
+		$this->assertDefaultTemplateFileName( 'archive-product' );
+
+		// Check shop page
+		$this->load_shop_page();
+		$this->assertDefaultTemplateFileName( 'archive-product' );
+
+	}
+
+	public function test_wc_template_loader_loads_template_with_blocks() {
+
+		global $wp_taxonomies;
+
+		$this->initialize_template_loader();
+
+		// forcing has_block_template to be false
+		add_filter(
+			'woocommerce_has_block_template',
+			'__return_true', 2, 10,
+		);
+
+		// Check Single Product
+		$this->load_product_in_query();
+		$this->assertDefaultTemplateFileName();
+
+		// Check Woo Taxonomy Product
+		$this->load_tax_in_query( 'product_cat' );
+		$this->assertDefaultTemplateFileName();
+
+		$this->load_tax_in_query( 'product_tag' );
+		$this->assertDefaultTemplateFileName();
+
+		// Check Custom Product Taxonomies
+		$wp_taxonomies['product_tax'] = new WP_Taxonomy( 'product_tax', 'product' );
+		$this->load_tax_in_query( 'product_tax' );
+		$this->assertDefaultTemplateFileName();
+
+		// Check shop page
+		$this->load_shop_page();
+		$this->assertDefaultTemplateFileName();
+
+	}
+
+
+	private function initialize_template_loader() {
+		// be sure shop is always returning same id doesn't matter the test setup environment
+		add_filter(
+			'woocommerce_get_shop_page_id',
+			function ( $page ) {
+				return 5;
+			},
+			1,
+			10
+		);
+
+		if ( ! function_exists( 'wp_is_block_theme' ) ) {
+			function wp_is_block_theme() {
+				return true;
+			}
+		}
+
+		WC_Template_Loader::init();
+	}
+
+	private function load_product_in_query() {
+		global $wp_query;
+		$wp_query->is_tax         = false;
+		$wp_query->is_singular    = true;
+		$wp_query->is_page        = false;
+		$wp_query->queried_object = (object) array(
+			'post_type' => 'product',
+			'post_name' => 'test',
+		);
+	}
+
+	private function load_shop_page() {
+		global $wp_query;
+		$wp_query->is_tax         = false;
+		$wp_query->is_singular    = false;
+		$wp_query->is_page        = true;
+		$wp_query->queried_object = (object) array(
+			'post_type'  => 'page',
+			'post_name'  => 'shop',
+			'post_title' => 'shop',
+			'ID'         => 5,
+		);
+	}
+
+	private function load_tax_in_query( $taxonomy ) {
+		global $wp_query;
+
+		$wp_query->is_singular    = false;
+		$wp_query->is_tax         = true;
+		$wp_query->is_page        = false;
+		$wp_query->queried_object = (object) array(
+			'taxonomy' => $taxonomy,
+			'slug'     => 'test',
+		);
+	}
+
+	private function assertDefaultTemplateFileName( $expected = '' ) {
+
+		$default_file = WC_Template_Loader::template_loader( 'test' );
+
+		if ( ! $expected ) {
+			$this->assertEquals( 'test', $default_file );
+		} else {
+			$this->assertEquals( WC()->plugin_path() . '/templates/' . $expected . '.php', $default_file );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -19,10 +19,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->initialize_template_loader();
 
 		// forcing has_block_template to be false
-		add_filter(
-			'woocommerce_has_block_template',
-			'__return_false', 2, 10,
-		);
+		add_filter( 'woocommerce_has_block_template', '__return_false', 10, 2 );
 
 		// Check Single Product
 		$this->load_product_in_query();
@@ -55,7 +52,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		// forcing has_block_template to be false
 		add_filter(
 			'woocommerce_has_block_template',
-			'__return_true', 2, 10,
+			'__return_true', 10, 2,
 		);
 
 		// Check Single Product
@@ -83,14 +80,9 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	private function initialize_template_loader() {
 		// be sure shop is always returning same id doesn't matter the test setup environment
-		add_filter(
-			'woocommerce_get_shop_page_id',
-			function ( $page ) {
-				return 5;
-			},
-			1,
-			10
-		);
+		add_filter( 'woocommerce_get_shop_page_id', function ( $page ) {
+			return 5;
+		}, 10, 1 );
 
 		if ( ! function_exists( 'wp_is_block_theme' ) ) {
 			function wp_is_block_theme() {


### PR DESCRIPTION

### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #31607

We added here #30013 some logic for checking Block templates. It works well in most of the cases. However, it doesn't work for custom product taxonomies. 

This PR fixes that. 

### How to test the changes in this Pull Request:

<details>
<summary>
taxonomy-product_brands.html content
</summary>

```
<!-- wp:template-part {"slug":"header"} /-->
<!-- wp:group {"layout":{"inherit":true}} -->
<div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"archive-product"} /--></div>
<!-- /wp:group -->
<!-- wp:template-part {"slug":"footer"} /-->
```
</details>

**Manual test with your own Product Taxonomy** 

1. Clone this PR
2. Create a custom product taxonomy. For example `taxonomy_product_brands` (see alternative testing method for preventing creating manually the taxonomy)
3. Load a block theme FSE like TT2
4. Load the file `taxonomy-product_brands.html` provided at the top in the theme `templates` folder
5. Navigate to the taxonomy archive in the frontend. 
6. You won't get a notice neither warnings, and the template will load. 
7. Check how other templates like Product Category, Product Tag and Shop Archive Product load as always.

**Alternative: Test with a plugin like WooCommerce Product Brands avoiding creating the Taxonomy manually**

1. Clone this PR
2. Install [WooCommerce Product Brands](https://woocommerce.com/products/product-brands-for-woocommerce/) and create a brand navigating to Product -> Brands
3. Load a block theme with FSE like TT2
4. Load the file `taxonomy-product_brands.html` provided at the top in the theme `templates` folder
5. Navigate to the taxonomy archive in the frontend. 
6. You won't get a notice neither warnings, and the template will load. 
7. Check how other templates like Product Category, Product Tag and Shop Archive Product load as always.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Support custom Product Taxonomies in block template loader

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
