### PR TITLE
Checkout tweaks for 2022 compatibility

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -957,6 +957,10 @@ $tt2-gray: #f7f7f7;
 		input[type='radio'] {
 			margin-right: .6rem;
 		}
+
+		li.wc_payment_method {
+			margin-bottom: 1rem;
+		}
 	}
 
 	.woocommerce-thankyou-order-received {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -168,6 +168,17 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
+	.woocommerce-NoticeGroup-checkout {
+		ul.woocommerce-error[role='alert'] {
+			&::before {
+				display: none;
+			}
+			li {
+				display: inherit;
+			}
+		}
+	}
+
 	a.button,
 	button[name='add-to-cart'],
 	input[name='submit'],
@@ -585,7 +596,7 @@ $tt2-gray: #f7f7f7;
  * Form fields
  */
 .woocommerce-page {
-	
+
 	form {
 
 		.input-text {
@@ -631,6 +642,11 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
+		& ~ .payment_box {
+			padding-left: 3rem;
+			margin-top: 1rem;
+		}
+
 		&:checked + label {
 
 			&::before {
@@ -668,7 +684,7 @@ $tt2-gray: #f7f7f7;
 	}
 
 	table.shop_table_responsive {
-			
+
 		width: 100%;
 		text-align: left;
 		border-collapse: collapse;
@@ -697,7 +713,7 @@ $tt2-gray: #f7f7f7;
 					background: #ebe9eb;
 					color: var(--wp--preset--color--black);
 					padding: 0.5rem 1rem 0.5rem 1rem;
-		
+
 					&:hover,
 					&:visited {
 						color: var(--wp--preset--color--black);
@@ -764,7 +780,7 @@ $tt2-gray: #f7f7f7;
 
 			.product-thumbnail {
 				width: 7.5rem;
-	
+
 				a {
 					img {
 						width: 117px;
@@ -889,9 +905,12 @@ $tt2-gray: #f7f7f7;
 				padding: 1rem 1rem 1rem 0;
 			}
 
-			tbody,
-			tr.woocommerce-shipping-totals {
+			tbody {
 				border-bottom: 1px solid #d2ced2;
+			}
+
+			tr.order-total {
+				border-top: 1px solid #d2ced2;
 			}
 
 			.product-quantity {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -964,15 +964,25 @@ $tt2-gray: #f7f7f7;
 	}
 
 	.woocommerce-thankyou-order-received {
+		margin-top: 0;
+	}
+
+	.woocommerce-thankyou-order-received,
+	h2.woocommerce-column__title {
 		font-family: var(--wp--preset--font-family--source-serif-pro);
 		font-size: var(--wp--preset--font-size--large);
 		font-weight: 300;
+	}
+
+	.woocommerce-order > * {
+		margin-bottom: var( --wp--style--block-gap );
 	}
 
 	ul.woocommerce-order-overview {
 		font-size: var(--wp--preset--font-size--small);
 		display: flex;
 		padding-left: 0;
+		width: 100%;
 
 		li {
 			display: inline;
@@ -995,6 +1005,27 @@ $tt2-gray: #f7f7f7;
 		address {
 			padding: 2rem;
 			border: 1px solid var(--wp--preset--color--black);
+			font-style: inherit;
+
+			p[class^='woocommerce-customer-details--'] {
+				&:first-of-type {
+					margin-top: 2rem;
+				}
+
+				margin-top: 1rem;
+				margin-bottom: 0;
+			}
+
+			.woocommerce-customer-details--phone::before {
+				content: '\01F4DE';
+				margin-right: 1rem;
+			}
+
+			.woocommerce-customer-details--email::before {
+				content: '\2709';
+				margin-right: 1rem;
+				font-size: 1.8rem;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -933,6 +933,20 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
+	form.checkout_coupon {
+		background: $tt2-gray;
+		padding-left: 1.5rem;
+		float: left;
+		// 1.5 rem is to account for extra padding we added above.
+		width: calc(100% - 1.5rem);
+
+		.form-row {
+			button[name='apply_coupon'] {
+				margin-top: 0;
+			}
+		}
+	}
+
 	ul.wc_payment_methods,
 	ul.woocommerce-shipping-methods {
 		margin-top: 0;

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -175,6 +175,7 @@ $tt2-gray: #f7f7f7;
 			}
 			li {
 				display: inherit;
+				margin-bottom: 1rem;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR contains some tweaks on the checkout form CSS:
1. Styling for Apply coupon form on the checkout page
2. Some minor styling for the order review section
3. Styling for errors in the checkout form


### How to test the changes in this Pull Request:

1. Go to the checkout page after adding a few products in the cart.
2. Make sure shipping and payment-related information is displayed properly.
3. Submit an empty form and make sure error messages are displayed properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Better styling for checkout form for 2022 theme.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
