### PR TITLE
Use inline `onload` event instead of jQuery `load`

### DIFF
--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -244,10 +244,7 @@
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if (slider.vars.controlNav === "thumbnails") {
                 item = $('<img/>', {
-                  load: function (el) {
-                    el.currentTarget.width = el.currentTarget.naturalWidth;
-                    el.currentTarget.height = el.currentTarget.naturalHeight;
-                  },
+                  onload: 'this.width = this.naturalWidth; this.height = this.naturalHeight',
                   src: slide.attr('data-thumb'),
                   alt: slide.attr('alt')
                 })


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes issue on WooCommerce 6.1.0, related to #31407, as using jQuery `.load()` function triggers error and breaking flexslider gallery. Using inline `onload` event will achieve the expected output.

### How to test the changes in this Pull Request:

(Referenced from #31407)
1. In the single product page with more than one image, inspect the flexbox nav
2. The image thumbnail will be like this: `<img onload="this.width = this.naturalWidth; this.height = this.naturalHeight" src="t-shirt-100x100.jpg" draggable="false" width="100" height="100" alt="t-shirt">` (before was `<img src="t-shirt-100x100.jpg" draggable="false">`)

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
