### PR TITLE
Show full path to test-result.json file

### DIFF
--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `post-results-to-github-pr.js` to post smoke test results to a GitHub PR.
 - Added jest flags to generate a json test report
 - Added more entries to `default.json`
+- Print the full path to `test-results.json` when the tests ends to make it easier to find the test results file.
 
 ## Added
 

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -75,7 +75,7 @@ if ( program.args.length == 1 ) {
 }
 
 let jestCommand = 'jest';
-let outputFile = __dirname + '/test-results.json';
+let outputFile = process.cwd() + '/test-results.json';
 const jestArgs = [
 	'--maxWorkers=1',
 	'--rootDir=./',

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -75,12 +75,13 @@ if ( program.args.length == 1 ) {
 }
 
 let jestCommand = 'jest';
+let outputFile = __dirname + '/test-results.json';
 const jestArgs = [
 	'--maxWorkers=1',
 	'--rootDir=./',
 	'--verbose',
 	'--json',
-	'--outputFile=test-results.json',
+	'--outputFile=' + outputFile,
 	...program.args,
 ];
 
@@ -109,6 +110,7 @@ const jestProcess = spawnSync( jestCommand, jestArgs, {
 	env: envVars,
 } );
 
+console.log( 'Test result file path: ' +  outputFile );
 console.log( 'Jest exit code: ' + jestProcess.status );
 
 // Pass Jest exit code to npm

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -110,7 +110,7 @@ const jestProcess = spawnSync( jestCommand, jestArgs, {
 	env: envVars,
 } );
 
-console.log( 'Test result file path: ' +  outputFile );
+console.log( 'Test result file path: ' + outputFile );
 console.log( 'Jest exit code: ' + jestProcess.status );
 
 // Pass Jest exit code to npm

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -75,7 +75,7 @@ if ( program.args.length == 1 ) {
 }
 
 let jestCommand = 'jest';
-let outputFile = process.cwd() + '/test-results.json';
+let outputFile = resolveLocalE2ePath('/test-results.json');
 const jestArgs = [
 	'--maxWorkers=1',
 	'--rootDir=./',


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It seems that there's no way to show the full path on the line `Test results written to: test-results.json`, as Jest uses `path.relative` to convert a full path to a relative one:

`Test results written to: ${path.relative(cwd, filePath)}\n`

https://github.com/facebook/jest/blob/main/packages/jest-core/src/runJest.ts#L112 

So when we feed it a full path, like this: `'--outputFile=' + __dirname + '/test-results.json',` it just prints:

`Test results written to: bin/test-results.json`

One way around it is to print our own line with the full path:

```
Test results written to: bin/test-results.json
Test result file path: /home/lucas/local/data/www/woo/woocommerce/packages/js/e2e-environment/bin/test-results.json
Jest exit code: 1
```

Unfortunately, I don't see a way in Jest source code to hide the original string `Test results written to`, so it's a bit of a duplicate, but seems the only way to go, given we don't control the third-party code.


Closes #31544

### How to test the changes in this Pull Request:

1. Run npm run test:e2e
2. Assert that you see a line at the end with the full path to the test-results.json file
3. Assert that the file exists and it contains the test results

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
