### PR TITLE
Center product cards (2022 Theme)

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -231,6 +231,7 @@ $tt2-gray: #f7f7f7;
 			}
 
 			h2.woocommerce-loop-product__title {
+				color: var( --wp--preset--color--primary );
 				font-family: var( --wp--preset--font-family--system-font );
 				font-size: 1.2rem;
 				text-decoration: none;

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -471,9 +471,8 @@ $tt2-gray: #f7f7f7;
 		line-height: 1;
 		width: 5.4rem;
 		font-family: star;
-		margin-bottom: 0.7rem;
 		color: var( --wp--preset--color--secondary );
-		margin-top: 1rem;
+		margin: 1rem auto .7rem auto;
 
 		&::before {
 			content: "\73\73\73\73\73";

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -223,6 +223,7 @@ $tt2-gray: #f7f7f7;
 		li.product {
 			list-style: none;
 			margin-top: var(--wp--style--block-gap);
+			text-align: center;
 
 			a.woocommerce-loop-product__link {
 				text-decoration: none;
@@ -230,6 +231,7 @@ $tt2-gray: #f7f7f7;
 			}
 
 			h2.woocommerce-loop-product__title {
+				font-family: var( --wp--preset--font-family--system-font );
 				font-size: 1.2rem;
 				text-decoration: none;
 				margin-bottom: 0;
@@ -585,7 +587,7 @@ $tt2-gray: #f7f7f7;
  * Form fields
  */
 .woocommerce-page {
-	
+
 	form {
 
 		.input-text {
@@ -668,7 +670,7 @@ $tt2-gray: #f7f7f7;
 	}
 
 	table.shop_table_responsive {
-			
+
 		width: 100%;
 		text-align: left;
 		border-collapse: collapse;
@@ -697,7 +699,7 @@ $tt2-gray: #f7f7f7;
 					background: #ebe9eb;
 					color: var(--wp--preset--color--black);
 					padding: 0.5rem 1rem 0.5rem 1rem;
-		
+
 					&:hover,
 					&:visited {
 						color: var(--wp--preset--color--black);
@@ -764,7 +766,7 @@ $tt2-gray: #f7f7f7;
 
 			.product-thumbnail {
 				width: 7.5rem;
-	
+
 				a {
 					img {
 						width: 117px;


### PR DESCRIPTION
Small adjustments to product cards (alignment is now centered, font family is now sans-serif for the product titles).

Updates #31600.

<details>
<summary>Before and after</summary>
<img width="1051" alt="after" src="https://user-images.githubusercontent.com/3594411/149205661-41ac9bec-e352-4360-aafc-521f7f7b8401.png">

:point_up: <strong>After</strong> → centered, product title is sans-serif, color is primary accent color.

<img width="1073" alt="before" src="https://user-images.githubusercontent.com/3594411/149205589-719250e8-cb72-4c08-9c66-cb7bcfd9938a.png">

:point_up: <strong>Before</strong> → left aligned, title is serif, color is black (not obviously a link).
</details>