### PR TITLE
Remove the need for duplicate `plugins/woocommerce` in path when running a single E2E test

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -50,7 +50,7 @@ jobs:
           UPDATE_WC: 1
           DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
-          pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/smoke-tests/update-woocommerce.js
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
 
       - name: Post Smoke tests results comment on PR
         if: always()

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -49,7 +49,7 @@ jobs:
           USER_KEY: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
           USER_SECRET: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
         run: |
-          pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/smoke-tests/update-woocommerce.js
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
           pnpx wc-e2e test:e2e
           pnpx wc-api-tests test api
 
@@ -150,5 +150,5 @@ jobs:
           PLUGIN_NAME: ${{ matrix.plugin }}
           GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
         run: |
-          pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/smoke-tests/upload-plugin.js
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/upload-plugin.js
           pnpm nx test-e2e woocommerce

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -50,7 +50,7 @@ jobs:
           USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
           USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
         run: |
-          pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/smoke-tests/update-woocommerce.js
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
           pnpx wc-e2e test:e2e
           pnpx wc-api-tests test api
   test-wp-version:
@@ -174,5 +174,5 @@ jobs:
           PLUGIN_NAME: ${{ matrix.plugin }}
           GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
         run: |
-          pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/smoke-tests/upload-plugin.js
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/upload-plugin.js
           pnpm nx test-e2e woocommerce

--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Fixed
 
+- Added the `removePathDuplicates` method which fixes the need prepend `plugins/woocommerce` and/or `tests/e2e` when executing a single test
+  - It still supports the use of `plugins/woocommerce` and/or `tests/e2e` to avoid any breaking changes
+
+## Fixed
+
 - Added the ability to take screenshots from multiple test failures (when retried) in `utils/take-screenshot.js`.
 
 ## Added

--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Fixed
 
-- Added the `removePathDuplicates` method which fixes the need prepend `plugins/woocommerce` and/or `tests/e2e` when executing a single test
-  - It still supports the use of `plugins/woocommerce` and/or `tests/e2e` to avoid any breaking changes
+- Added the `resolveSingleE2EPath` method which builds a path to a specific E2E test
+  - It still supports the use of `plugins/woocommerce` and/or `tests/e2e` in file paths to avoid any breaking changes
 
 ## Fixed
 

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -8,7 +8,7 @@ const {
 	getAppRoot,
 	resolveLocalE2ePath,
 	resolvePackagePath,
-	removePathDuplicates,
+	resolveSingleE2EPath,
 } = require( '../utils' );
 const {
 	WC_E2E_SCREENSHOTS,
@@ -67,7 +67,7 @@ if ( ! JEST_PUPPETEER_CONFIG ) {
 if ( program.args.length == 1 ) {
 	// Check for both absolute and relative paths
 	const testSpecAbs = path.resolve( program.args[ 0 ] );
-	const testSpecRel = removePathDuplicates( program.args[ 0 ] );
+	const testSpecRel = resolveSingleE2EPath( program.args[ 0 ] );
 	if ( fs.existsSync( testSpecAbs ) ) {
 		process.env.jest_test_spec = testSpecAbs;
 	} else if ( fs.existsSync( testSpecRel ) ) {

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -8,6 +8,7 @@ const {
 	getAppRoot,
 	resolveLocalE2ePath,
 	resolvePackagePath,
+	removePathDuplicates,
 } = require( '../utils' );
 const {
 	WC_E2E_SCREENSHOTS,
@@ -66,7 +67,7 @@ if ( ! JEST_PUPPETEER_CONFIG ) {
 if ( program.args.length == 1 ) {
 	// Check for both absolute and relative paths
 	const testSpecAbs = path.resolve( program.args[ 0 ] );
-	const testSpecRel = path.resolve( appPath, program.args[ 0 ] );
+	const testSpecRel = removePathDuplicates( program.args[ 0 ] );
 	if ( fs.existsSync( testSpecAbs ) ) {
 		process.env.jest_test_spec = testSpecAbs;
 	} else if ( fs.existsSync( testSpecRel ) ) {

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -12,7 +12,7 @@ const appPath = getAppRoot();
  */
 const resolveLocalE2ePath = ( filename = '' ) => {
 	const { WC_E2E_FOLDER } = process.env;
-	const localPath = `${WC_E2E_FOLDER}/tests/e2e/${filename}`;
+	const localPath = `${ WC_E2E_FOLDER }/tests/e2e/${ filename }`;
 	const resolvedPath = path.resolve(
 		appPath,
 		localPath.indexOf( '/' ) == 0 ? localPath.slice( 1 ) : localPath
@@ -26,7 +26,7 @@ const resolveLocalE2ePath = ( filename = '' ) => {
  *
  * @param {string} packageName Name of the installed package.
  * @param {boolean} allowRecurse Allow a recursive call. Default true.
- * @return {object}
+ * @return {Object}
  */
 const resolvePackage = ( packageName, allowRecurse = true ) => {
 	const resolvedPackage = {};
@@ -101,8 +101,20 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
  * @param {Array} exclude An array of strings that won't be removed in the event that duplicates exist
  * @return {string}
  */
-const removePathDuplicates = ( filePath, exclude = [] ) => {
-	const pathArray = resolveLocalE2ePath( filePath ).split( '/' );
+const removePathDuplicates = ( filePath, exclude = [ 'woocommerce' ] ) => {
+	const { SMOKE_TEST_URL } = process.env;
+	let prunedPath;
+
+	/**
+	 * Removes 'plugins/woocommerce/' from path only tests against a smoke test site.
+	 */
+	if ( SMOKE_TEST_URL ) {
+		prunedPath = filePath.replace( 'plugins/woocommerce/', '' );
+	} else {
+		prunedPath = filePath;
+	}
+
+	const pathArray = resolveLocalE2ePath( prunedPath ).split( '/' );
 	return pathArray
 		.filter( ( element, index, arr ) => {
 			return (
@@ -113,11 +125,10 @@ const removePathDuplicates = ( filePath, exclude = [] ) => {
 		.join( '/' );
 };
 
-
 // Copy local test configuration file if it exists.
 const localTestConfigFile = resolveLocalE2ePath( 'config/default.json' );
 const defaultConfigFile = resolvePackagePath( 'config/default/default.json' );
-const testConfigFile = resolvePackagePath(  'config/default.json' );
+const testConfigFile = resolvePackagePath( 'config/default.json' );
 
 if ( fs.existsSync( localTestConfigFile ) ) {
 	fs.copyFileSync( localTestConfigFile, testConfigFile );

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -94,14 +94,13 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
 };
 
 /**
- * Removes duplicates from a file path in order to allow backwards support for executing tests commands
- * that may prepend `plugins/woocommerce` and/or `tests/e2e`.
+ * Resolves the path a single E2E test
  *
  * @param {string} filePath Path to a specific test file
- * @param {Array} exclude An array of strings that won't be removed in the event that duplicates exist.
+ * @param {Array} exclude An array of directories that won't be removed in the event that duplicates exist.
  * @return {string}
  */
-const removePathDuplicates = ( filePath, exclude = [ 'woocommerce' ] ) => {
+const resolveSingleE2EPath = ( filePath, exclude = [ 'woocommerce' ] ) => {
 	const { SMOKE_TEST_URL } = process.env;
 	let prunedPath;
 
@@ -113,6 +112,8 @@ const removePathDuplicates = ( filePath, exclude = [ 'woocommerce' ] ) => {
 	}
 
 	const pathArray = resolveLocalE2ePath( prunedPath ).split( '/' );
+
+	// removes duplicate directories from the path
 	return pathArray
 		.filter( ( element, index, arr ) => {
 			return (
@@ -195,5 +196,5 @@ module.exports = {
 	resolveLocalE2ePath,
 	resolvePackage,
 	resolvePackagePath,
-	removePathDuplicates,
+	resolveSingleE2EPath,
 };

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -95,7 +95,7 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
 
 /**
  * Removes duplicates from a file path in order to allow backwards support for executing tests commands
- * that prepend `plugins/woocommerce` and/or `tests/e2e`.
+ * that may prepend `plugins/woocommerce` and/or `tests/e2e`.
  *
  * @param {string} filePath Path to a specific test file
  * @param {Array} exclude An array of strings that won't be removed in the event that duplicates exist.

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -93,6 +93,27 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
 	return resolvedPath;
 };
 
+/**
+ * Removes duplicates from a file path in order to allow backwards support for executing tests commands
+ * that prepend `plugins/woocommerce` and/or `tests/e2e.
+ *
+ * @param {string} filePath Path to a specific test file
+ * @param {Array} exclude An array of strings that won't be removed in the event that duplicates exist
+ * @return {string}
+ */
+const removePathDuplicates = ( filePath, exclude = [] ) => {
+	const pathArray = resolveLocalE2ePath( filePath ).split( '/' );
+	return pathArray
+		.filter( ( element, index, arr ) => {
+			return (
+				arr.indexOf( element ) === index ||
+				exclude.indexOf( element ) !== -1
+			);
+		} )
+		.join( '/' );
+};
+
+
 // Copy local test configuration file if it exists.
 const localTestConfigFile = resolveLocalE2ePath( 'config/default.json' );
 const defaultConfigFile = resolvePackagePath( 'config/default/default.json' );
@@ -165,4 +186,5 @@ module.exports = {
 	resolveLocalE2ePath,
 	resolvePackage,
 	resolvePackagePath,
+	removePathDuplicates,
 };

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -95,19 +95,17 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
 
 /**
  * Removes duplicates from a file path in order to allow backwards support for executing tests commands
- * that prepend `plugins/woocommerce` and/or `tests/e2e.
+ * that prepend `plugins/woocommerce` and/or `tests/e2e`.
  *
  * @param {string} filePath Path to a specific test file
- * @param {Array} exclude An array of strings that won't be removed in the event that duplicates exist
+ * @param {Array} exclude An array of strings that won't be removed in the event that duplicates exist.
  * @return {string}
  */
 const removePathDuplicates = ( filePath, exclude = [ 'woocommerce' ] ) => {
 	const { SMOKE_TEST_URL } = process.env;
 	let prunedPath;
 
-	/**
-	 * Removes 'plugins/woocommerce/' from path only tests against a smoke test site.
-	 */
+	// Removes 'plugins/woocommerce/' from path only for tests against a smoke test site.
 	if ( SMOKE_TEST_URL ) {
 		prunedPath = filePath.replace( 'plugins/woocommerce/', '' );
 	} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->


### Changes proposed in this Pull Request:

This PR enables executing a single E2E test using a relative path without having to prepend `plugins/woocommerce` and/or `tests/e2e` to the file path. This means any of the following commands would successfully execute `create-order.test.js`.

- `pnpx wc-e2e test:e2e specs/wp-admin/create-order.test.js`
- `pnpx wc-e2e test:e2e tests/e2e/specs/wp-admin/create-order.test.js`
- `pnpx wc-e2e test:e2e plugins/woocommerce/tests/e2e/specs/wp-admin/create-order.test.js`

Closes #31362
Closes #31467.

### How to test the changes in this Pull Request:
#### Step 1: Run a single test
```sh
$ pnpm install
$ cd plugins/woocommerce
$ pnpx wc-e2e docker:up 
```
Run a single test using any `pnpx wc-e2e test:e2e` and any of the following paths:

- specs/wp-admin/create-order.test.js
- tests/e2e/specs/wp-admin/create-order.test.js
- plugins/woocommerce/tests/e2e/specs/wp-admin/create-order.test.js

#### Step 2: Run a smoke test
1. Add `run: smoke tests` label
2. Wait for tests to complete

