### PR TITLE
Modify background color for <mark> elements

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -593,6 +593,10 @@ $tt2-gray: #f7f7f7;
 			padding: 0.7rem 2rem;
 		}
 	}
+
+	mark {
+		background: var( --wp--preset--color--secondary );
+	}
 }
 
 /**


### PR DESCRIPTION
Minor change for compatibility with Twenty Twenty-Two. This adjusts highlighting for `<mark>` elements from the browser default (typically bright yellow) to a salmon color taken from the TT2 Styles sheet.

So far as I can tell, we only use this element in two locations:

- My Account ▸ View Order ▸ Order Summary
- Order Tracking Shortcode output

<img width="636" alt="salmon-highlighting-for-marks" src="https://user-images.githubusercontent.com/3594411/149235413-84ac5e3f-5cf9-4c45-99a9-70bfb3689c52.png">

Note that I deliberately chose to apply this new rule to `.woocommerce mark` (simple, covers both locations, will cover also other mark elements if and when they might be added). It's possible to be more specific, but without changing the templates themselves getting more specific would be a tad brittle.

Updates #31324.
