### PR TITLE
Basis of overlay used when processing Twenty Twenty-Two checkout.

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -26,6 +26,7 @@
 }
 
 @import "mixins";
+@import "animation";
 
 $tt2-gray: #f7f7f7;
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -855,6 +855,8 @@ $tt2-gray: #f7f7f7;
 	}
 
 	.woocommerce-checkout {
+		display: table;
+
 		h3 {
 			font-family: inherit;
 			font-size: var(--wp--preset--font-size--normal);
@@ -864,6 +866,11 @@ $tt2-gray: #f7f7f7;
 		.col2-set {
 			width: 43%;
 			float: right;
+		}
+
+		.blockUI.blockOverlay {
+			position: relative;
+			@include loader();
 		}
 
 		#customer_details {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -253,6 +253,10 @@ $tt2-gray: #f7f7f7;
 
 			a.add_to_cart_button {
 				padding: 0.8rem 2.7rem;
+
+				&.loading {
+					opacity: 0.5;
+				}
 			}
 
 			a.added_to_cart {


### PR DESCRIPTION
Aims to address a problem when running alongside Twenty Twenty-Two whereby the blocked UI overlay (that 'greys out' the checkout form and displays a spinner after submitting the form) was not visible.

https://user-images.githubusercontent.com/3594411/149248038-cb3add0d-265a-4ec8-a9ab-2a4c397e44eb.mov

Updates #31324.
