### PR TITLE
Version bump WooCommerce Admin to 3.1.0-rc.1

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.0.3",
+		"woocommerce/woocommerce-admin": "3.1.0-rc.1",
 		"woocommerce/woocommerce-blocks": "6.7.1"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e21568a4ecc5101b7362700cf3949af",
+    "content-hash": "edd58bb30d9ec1e9ba74f499fb4a919b",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.0.3",
+            "version": "3.1.0-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "0b1abab35c62717f3121428fe7f378998ef4899c"
+                "reference": "0c7a42f0c934f7f2e44c0534e2cec6fcb8362180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0b1abab35c62717f3121428fe7f378998ef4899c",
-                "reference": "0b1abab35c62717f3121428fe7f378998ef4899c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0c7a42f0c934f7f2e44c0534e2cec6fcb8362180",
+                "reference": "0c7a42f0c934f7f2e44c0534e2cec6fcb8362180",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.0.3"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.1.0-rc.1"
             },
-            "time": "2022-01-06T22:46:17+00:00"
+            "time": "2022-01-13T02:42:30+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2926,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.1.0-rc.1

## New Feature Tests 

### Inbox - 320 character limit

On a new site, with English language settings:

1. Go to WooCommerce home screen
2. See that all Inbox notes are short in length (aproximately less than 320 characters).

### OBW: Hide the extensions header when no available plugins in the category

1. In a new JN site with WooCommerce, install WCAdmin 3.0.0-beta.1 or WCAdmin on the main branch
2. Go to setup wizard
3. Choose "Johor - Malaysia" as store country
4. Go through all steps until "Business details"
5. Go to "Free features" tab
6. Observe the "GET THE BASICS" header is NOT shown without any plugins

### OBW: Fix free extensions list isn't updated after store location or industry is changed

**Change store Industry**

1. Checkout to this branch
2. Go to the setup wizard
3. Choose any store location that supports WCPay, such as any state in the US
4. In the Industry step, make sure to not select CBD
5. Proceed through the setup until the Business Details step
6. Go to the "Free features" tab
7. Observe **WooCommerce Payments** is displayed in the suggested extensions
8. Without refreshing, go back to the **Industry** step
9. Select **CBD industry** and click on continue until Business Details step again
10. In the extension list, observe that WooCommerce Payments is **NOT** displayed.

**Change store country**

11. Repeat steps 3~7
12. Without refreshing, go back to the **Store Details** step
13. Choose any store location that **doesn't** supports WCPay, such as Malaysia (MY)
14. Go to Business Details step again
15. In the extension list, observe that WooCommerce Payments is **NOT** displayed.

### Fix PHP Warning on 'Add new product' page

1. On a Jurassic Ninja site.
2. Go to **WooCommerce** > **Home**.
3. Press **Add my products** in the task list.
4. Press **Add manually**.
5. No PHP warning should be visible.

## Changelog
```
== 3.1.0 01/13/2022 ==

- Fix: Fix Onboarding flow where extensions might not be selected and installed. #7979
- Fix: Fix pagination issue with Analytics Coupons page. #8001
- Fix: Fix select-control component label/value alignment. #8045
- Fix: Fix unexpected analytics report table filter results. #8072
- Fix: Prevent coupon move notice for new installs. #7995
- Fix: Remove calls to read_meta_data in the Note DataStore. #7988
- Fix: Fix free extensions list isn't updated after store location or industry is changed. #8099
- Fix: Fix misaligned "Rows per page" dropdown. #8113
- Fix: Hide the extensions header when no available plugins in the category. #8089
- Fix: Replace all docs.woocommerce.com links with woocommerce.com/document. #8105
- Fix: Fixing marketing task not displaying on Atomic sites #8150
- Add: Add featured pill for MailPoet and Google Listings in marketing task #8009
- Add: Add inbox_action_click track when a note gets clicked #8086
- Add: Activate promo note after WC Pay is activated. #8104
- Add: Add payment remind me later note. #8085
- Add: Add WC Pay welcome page #8083
- Update: Allow content data note props to be passed from remote sources #8047
- Update: Update @woocommerce/e2e-environment package to latest. #8000
- Dev: Add payment gateway suggestion docs and example extensions #7966
- Dev: Remove low performing inbox notes. #8054
- Dev: Remove navigation feedback note. #8055
- Tweak: OBW Update WC Pay label on recommended extensions list #8038
- Enhancement: Add SlotFill areas to header #7805
```