### PR TITLE
e2e-core-test package cleanup

### DIFF
--- a/packages/js/e2e-core-tests/project.json
+++ b/packages/js/e2e-core-tests/project.json
@@ -9,6 +9,36 @@
 				"action": "add",
 				"cwd": "packages/js/e2e-core-tests"
 			}
+		},
+	  "build": {
+		"executor": "@nrwl/workspace:run-script",
+		"options": {
+		  "script": "build"
+		}
+	  },
+	  "clean": {
+		"executor": "@nrwl/workspace:run-script",
+		"options": {
+		  "script": "clean"
+		}
+	  },
+	  "compile": {
+		"executor": "@nrwl/workspace:run-script",
+		"options": {
+		  "script": "compile"
+		}
+	  },
+	  "prepare": {
+		"executor": "@nrwl/workspace:run-script",
+		"options": {
+		  "script": "prepare"
+		}
+	  },
+	  "lint": {
+		"executor": "@nrwl/workspace:run-script",
+		"options": {
+		  "script": "lint"
+		}
 		}
 	}
 }

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-refund.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-refund.test.js
@@ -7,7 +7,6 @@ const {
 	verifyCheckboxIsSet,
 	verifyValueOfInputField,
 	uiUnblocked,
-	evalAndClick,
 	createOrder,
 	clickAndWaitForSelector,
 } = require( '@woocommerce/e2e-utils' );

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-status-filters.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-status-filters.test.js
@@ -1,8 +1,6 @@
 /**
  * Internal dependencies
  */
-const config = require( 'config' );
-
 const {
 	merchant,
 	withRestApi,

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-edit-details.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-edit-details.test.js
@@ -7,8 +7,13 @@ const {
 	merchant,
 	uiUnblocked,
 	verifyAndPublish,
-	createSimpleProduct
+	createSimpleProduct,
 } = require( '@woocommerce/e2e-utils' );
+
+/**
+ * External dependencies
+ */
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 let productId;
 

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-new.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-new.test.js
@@ -11,7 +11,7 @@ const {
 	setBrowserViewport,
 	verifyAndPublish,
 	waitForSelector,
-	waitForSelectorWithoutThrow
+	waitForSelectorWithoutThrow,
 } = require( '@woocommerce/e2e-utils' );
 const {
 	waitAndClick,

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-general.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-general.test.js
@@ -5,7 +5,7 @@
 const {
 	merchant,
 	settingsPageSaveChanges,
-	verifyValueOfInputField
+	verifyValueOfInputField,
 } = require( '@woocommerce/e2e-utils' );
 
 /**

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-product.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-product.test.js
@@ -8,7 +8,7 @@ const {
 	settingsPageSaveChanges,
 	unsetCheckbox,
 	verifyCheckboxIsSet,
-	verifyCheckboxIsUnset
+	verifyCheckboxIsUnset,
 } = require( '@woocommerce/e2e-utils' );
 
 const runProductSettingsTest = () => {

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-shipping-classes.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-shipping-classes.test.js
@@ -2,6 +2,10 @@
  * Internal dependencies
  */
 const { merchant, withRestApi } = require('@woocommerce/e2e-utils');
+
+/**
+ * External dependencies
+ */
 const { lorem, helpers } = require('faker');
 
 const runAddShippingClassesTest = () => {

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -12,11 +12,7 @@ const {
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 const config = require( 'config' );
 const firstProductPrice = config.has( 'products.simple.price' ) ? config.get( 'products.simple.price' ) : '9.99';

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-coupons.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-coupons.test.js
@@ -3,7 +3,6 @@
  */
 const {
 	shopper,
-	createCoupon,
 	createSimpleProduct,
 	uiUnblocked,
 	applyCoupon,
@@ -14,11 +13,7 @@ const { getCouponId, getCouponsTable } = require( '../utils/coupons' );
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 const runCartApplyCouponsTest = () => {
 	describe('Cart applying coupons', () => {

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart.test.js
@@ -5,17 +5,13 @@ const {
 	shopper,
 	withRestApi,
 	createSimpleProduct,
-	uiUnblocked
+	uiUnblocked,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-coupons.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-coupons.test.js
@@ -3,7 +3,6 @@
  */
 const {
 	shopper,
-	createCoupon,
 	createSimpleProduct,
 	uiUnblocked,
 	applyCoupon,
@@ -15,11 +14,7 @@ const { getCouponId, getCouponsTable } = require( '../utils/coupons' );
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 
 const runCheckoutApplyCouponsTest = () => {

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-create-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-create-account.test.js
@@ -15,11 +15,7 @@
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 const config = require( 'config' );
 const customerBilling = config.get( 'addresses.customer.billing' );

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-login-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-login-account.test.js
@@ -13,11 +13,7 @@
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, describe, beforeAll } = require( '@jest/globals' );
 
 const config = require('config');
 

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout.test.js
@@ -9,6 +9,11 @@ const {
 	uiUnblocked,
 } = require( '@woocommerce/e2e-utils' );
 
+/**
+ * External dependencies
+ */
+const { it, describe, beforeAll, afterAll } = require( '@jest/globals' );
+
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 const singleProductPrice = config.has('products.simple.price') ? config.get('products.simple.price') : '9.99';

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account-create-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account-create-account.test.js
@@ -9,6 +9,11 @@ const {
 	withRestApi,
 } = require( '@woocommerce/e2e-utils' );
 
+/**
+ * External dependencies
+ */
+const { it, describe, beforeAll, afterAll } = require( '@jest/globals' );
+
 const customerEmailAddress = 'john.doe.test@example.com';
 
 const runMyAccountCreateAccountTest = () => {

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account-pay-order.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account-pay-order.test.js
@@ -9,6 +9,11 @@ const {
 	uiUnblocked
 } = require( '@woocommerce/e2e-utils' );
 
+/**
+ * External dependencies
+ */
+const { it, describe, beforeAll, afterAll } = require( '@jest/globals' );
+
 let simplePostIdValue;
 let orderNum;
 const config = require( 'config' );

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account.test.js
@@ -6,6 +6,11 @@ const {
 	shopper,
 } = require( '@woocommerce/e2e-utils' );
 
+/**
+ * External dependencies
+ */
+const { it, describe } = require( '@jest/globals' );
+
 const pages = [
 	['Orders', 'my-account/orders', shopper.goToOrders],
 	['Downloads', 'my-account/downloads', shopper.goToDownloads],

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-order-email-receiving.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-order-email-receiving.test.js
@@ -10,21 +10,17 @@
 	deleteAllEmailLogs,
 } = require( '@woocommerce/e2e-utils' );
 
+/**
+ * External dependencies
+ */
+const { it, describe, beforeAll, afterAll } = require( '@jest/globals' );
+
 let simplePostIdValue;
 let orderId;
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 const customerEmail = config.get( 'addresses.customer.billing.email' );
 const storeName = 'WooCommerce Core E2E Test Suite';
-
-/**
- * External dependencies
- */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
 
 const runOrderEmailReceivingTest = () => {
 	describe('Shopper Order Email Receiving', () => {

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-product-browse-search-sort.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-product-browse-search-sort.test.js
@@ -11,11 +11,7 @@ const {
 /**
  * External dependencies
  */
-const {
-	it,
-	describe,
-	beforeAll,
-} = require( '@jest/globals' );
+const { it, beforeAll } = require( '@jest/globals' );
 
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-single-product.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-single-product.test.js
@@ -6,9 +6,13 @@ const {
 	createSimpleProduct,
 	createVariableProduct,
 	createGroupedProduct,
-	uiUnblocked
+	uiUnblocked,
 } = require( '@woocommerce/e2e-utils' );
 
+/**
+ * External dependencies
+ */
+const { it, describe, beforeAll } = require( '@jest/globals' );
 const config = require( 'config' );
 
 // Variables for simple product

--- a/packages/js/e2e-utils/src/factories/grouped-product.js
+++ b/packages/js/e2e-utils/src/factories/grouped-product.js
@@ -2,10 +2,8 @@ import { GroupedProduct } from '@woocommerce/api';
 import { Factory } from 'fishery';
 
 /**
- * Creates a new factory for creating variable products.
- * This does not include creating product variations.
- * Instead, use `variationFactory()` for that.
- * 
+ * Creates a new factory for creating grouped products.
+ *
  * @param {HTTPClient} httpClient The HTTP client we will give the repository.
  * @return {AsyncFactory} The factory for creating models.
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is general cleanup of imports in the e2e-core-tests package. It also includes `nx` script configuration missing from the package.

### How to test the changes in this Pull Request:

1. Run `pnpm i` in the `plugins/woocommerce` folder
2. Run `pnpm nx build woocommerce`. 
3. Depending on your local memory limit the `.pot` generation may fail. This issue isn't related to this PR.
4. Run E2E tests
