### PR TITLE
Remove smoke test label on failure

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -102,4 +102,4 @@ jobs:
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'run: smoke tests'   
+          labels: 'run: smoke tests'

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -50,7 +50,7 @@ jobs:
           UPDATE_WC: 1
           DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
-          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.j
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
 
       - name: Post Smoke tests results comment on PR
         if: always()
@@ -81,7 +81,7 @@ jobs:
           UPDATE_WC: 1
           DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
-          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.j
+          pnpx wc-e2e test:e2e
 
       - name: Post E2E tests results comment on PR
         if: always()
@@ -96,36 +96,9 @@ jobs:
             await script({github, context})
 
       - name: Remove label from pull request.
-        if: always() && ${{ contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) }}
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'run: smoke tests'
-
-      - name: Remove label from pull request 2.
-        if: |
-            always() && 
-            ${{ contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) }}
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            labels: 'run: smoke tests'
-            
-      - name: Remove label from pull request 3.
-        if: |
-          ${{ always() 
-            && contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) 
-          }}
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: 'run: smoke tests'    
-
-      - name: Remove label from pull request 4.
         if: |
           always() 
            && contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) 
-          
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -50,7 +50,7 @@ jobs:
           UPDATE_WC: 1
           DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
-          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.j
 
       - name: Post Smoke tests results comment on PR
         if: always()
@@ -81,7 +81,7 @@ jobs:
           UPDATE_WC: 1
           DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
-          pnpx wc-e2e test:e2e
+          pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.j
 
       - name: Post E2E tests results comment on PR
         if: always()
@@ -101,3 +101,32 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'run: smoke tests'
+
+      - name: Remove label from pull request 2.
+        if: |
+            always() && 
+            ${{ contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) }}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            labels: 'run: smoke tests'
+            
+      - name: Remove label from pull request 3.
+        if: |
+          ${{ always() 
+            && contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) 
+          }}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'run: smoke tests'    
+
+      - name: Remove label from pull request 4.
+        if: |
+          always() 
+           && contains( github.event.pull_request.labels.*.name, format('run{0} smoke tests', ':')) 
+          
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'run: smoke tests'   

--- a/packages/js/e2e-environment/bin/post-results-to-github-pr.js
+++ b/packages/js/e2e-environment/bin/post-results-to-github-pr.js
@@ -5,14 +5,22 @@ const resultsFile = path.resolve( __dirname, '../../../../plugins/woocommerce/te
 
 const buildOutput = ( results ) => {
 	const { TITLE, SMOKE_TEST_URL } = process.env;
+	const resultKeys = Object.keys( results );
 
 	let output = `## ${ TITLE }:\n\n`;
 	output += `**Test URL:** ${ SMOKE_TEST_URL }\n`;
-	output += `**Total Number of Passed Tests:** ${ results.numTotalTests }\n`;
-	output += `**Total Number of Failed Tests:** ${ results.numFailedTests }\n`;
-	output += `**Total Number of Test Suites:** ${ results.numTotalTestSuites }\n`;
-	output += `**Total Number of Passed Test Suites:** ${ results.numPassedTestSuites }\n`;
-	output += `**Total Number of Failed Test Suites:** ${ results.numFailedTestSuites }\n`;
+
+	resultKeys.forEach( ( key ) => {
+		// The keys that we care about all start with 'num'
+		if ( key.includes( 'num' ) ) {
+			// match only capitalized words
+			const words = key.match( /[A-Z][a-z]+/g );
+
+			output += `**Total Number of ${ words.join( ' ' ) }:** ${
+				results[ key ]
+			}\n`;
+		}
+	} );
 
 	return output;
 };

--- a/packages/js/e2e-environment/bin/post-results-to-github-pr.js
+++ b/packages/js/e2e-environment/bin/post-results-to-github-pr.js
@@ -1,7 +1,8 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { resolveLocalE2ePath } = require( '../utils' );
 
-const resultsFile = path.resolve( __dirname, '../test-results.json' );
+const resultsFile = resolveLocalE2ePath( 'test-results.json' );
 
 const buildOutput = ( results ) => {
 	const { TITLE, SMOKE_TEST_URL } = process.env;

--- a/packages/js/e2e-environment/bin/post-results-to-github-pr.js
+++ b/packages/js/e2e-environment/bin/post-results-to-github-pr.js
@@ -35,7 +35,7 @@ module.exports = async ( { github, context } ) => {
 		output = buildOutput( results );
 	} else {
 		output = `## Test Results Not Found! \n\n`;
-		output += 'The path to the `test-results.json` file may need to be updated in the `post-results-to-github-pr.js` script';
+		output += 'The path to the `test-results.json` file may need to be updated.';
 	}
 
 	await github.rest.issues.createComment( {

--- a/packages/js/e2e-environment/bin/post-results-to-github-pr.js
+++ b/packages/js/e2e-environment/bin/post-results-to-github-pr.js
@@ -1,8 +1,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { resolveLocalE2ePath } = require( '../utils' );
 
-const resultsFile = resolveLocalE2ePath( 'test-results.json' );
+const resultsFile = path.resolve( __dirname, '../../../../plugins/woocommerce/tests/e2e/test-results.json' );
 
 const buildOutput = ( results ) => {
 	const { TITLE, SMOKE_TEST_URL } = process.env;
@@ -27,7 +26,8 @@ module.exports = async ( { github, context } ) => {
 
 		output = buildOutput( results );
 	} else {
-		output = `## Test Results Not Found!`;
+		output = `## Test Results Not Found! \n\n`;
+		output += 'The path to the `test-results.json` file may need to be updated in the `post-results-to-github-pr.js` script';
 	}
 
 	await github.rest.issues.createComment( {

--- a/packages/js/e2e-environment/bin/post-results-to-github-pr.js
+++ b/packages/js/e2e-environment/bin/post-results-to-github-pr.js
@@ -1,7 +1,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 
-const resultsFile = path.resolve( __dirname, '../../../../plugins/woocommerce/tests/e2e/test-results.json' );
+const resultsFile = path.resolve( __dirname, '../test-results.json' );
 
 const buildOutput = ( results ) => {
 	const { TITLE, SMOKE_TEST_URL } = process.env;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the workflow step that removes the run: smoke tests label after smoke tests are done on PRs.

Addresses #31398 .

### How to test the changes in this Pull Request:

1. Create a PR
2. Add run: smoke tests label
3. Wait for tests to complete and observe comments on the associated PR
