### PR TITLE
Localize dimension and weight options when used in view context Fix/31486

### DIFF
--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -490,8 +490,8 @@ class WC_Product_CSV_Importer_Controller {
 	 * @return array
 	 */
 	protected function auto_map_columns( $raw_headers, $num_indexes = true ) {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 
 		/*
 		 * @hooked wc_importer_generic_mappings - 10
@@ -663,8 +663,8 @@ class WC_Product_CSV_Importer_Controller {
 		$meta = str_replace( 'meta:', '', $item );
 
 		// Available options.
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 		$options        = array(
 			'id'                 => __( 'ID', 'woocommerce' ),
 			'type'               => __( 'Type', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/importers/mappings/default.php
+++ b/plugins/woocommerce/includes/admin/importers/mappings/default.php
@@ -36,8 +36,8 @@ function wc_importer_default_english_mappings( $mappings ) {
 		return $mappings;
 	}
 
-	$weight_unit    = get_option( 'woocommerce_weight_unit' );
-	$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+	$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+	$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 	$new_mappings   = array(
 		'ID'                                      => 'id',
 		'Type'                                    => 'type',

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-shipping.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				array(
 					'id'          => '_weight',
 					'value'       => $product_object->get_weight( 'edit' ),
-					'label'       => __( 'Weight', 'woocommerce' ) . ' (' . get_option( 'woocommerce_weight_unit' ) . ')',
+					'label'       => __( 'Weight', 'woocommerce' ) . ' (' . __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' ) . ')',
 					'placeholder' => wc_format_localized_decimal( 0 ),
 					'desc_tip'    => true,
 					'description' => __( 'Weight in decimal form', 'woocommerce' ),
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			?>
 			<p class="form-field dimensions_field">
 				<?php /* translators: WooCommerce dimension unit*/ ?>
-				<label for="product_length"><?php printf( __( 'Dimensions (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?></label>
+				<label for="product_length"><?php printf( __( 'Dimensions (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ); ?></label>
 				<span class="wrap">
 					<input id="product_length" placeholder="<?php esc_attr_e( 'Length', 'woocommerce' ); ?>" class="input-text wc_input_decimal" size="6" type="text" name="_length" value="<?php echo esc_attr( wc_format_localized_decimal( $product_object->get_length( 'edit' ) ) ); ?>" />
 					<input id="product_width" placeholder="<?php esc_attr_e( 'Width', 'woocommerce' ); ?>" class="input-text wc_input_decimal" size="6" type="text" name="_width" value="<?php echo esc_attr( wc_format_localized_decimal( $product_object->get_width( 'edit' ) ) ); ?>" />

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -272,7 +272,7 @@ defined( 'ABSPATH' ) || exit;
 					$label = sprintf(
 						/* translators: %s: weight unit */
 						__( 'Weight (%s)', 'woocommerce' ),
-						esc_html__( get_option( 'woocommerce_weight_unit', 'woocommerce' ) )
+						esc_html__( get_option( 'woocommerce_weight_unit' ), 'woocommerce' )
 					);
 
 					woocommerce_wp_text_input(
@@ -303,7 +303,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								/* translators: %s: dimension unit */
 								esc_html__( 'Dimensions (L&times;W&times;H) (%s)', 'woocommerce' ),
-								esc_html__( get_option( 'woocommerce_dimension_unit', 'woocommerce' ) )
+								esc_html__( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' )
 							);
 							?>
 						</label>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -272,7 +272,7 @@ defined( 'ABSPATH' ) || exit;
 					$label = sprintf(
 						/* translators: %s: weight unit */
 						__( 'Weight (%s)', 'woocommerce' ),
-						esc_html( get_option( 'woocommerce_weight_unit' ) )
+						esc_html__( get_option( 'woocommerce_weight_unit', 'woocommerce' ) )
 					);
 
 					woocommerce_wp_text_input(
@@ -303,7 +303,7 @@ defined( 'ABSPATH' ) || exit;
 							printf(
 								/* translators: %s: dimension unit */
 								esc_html__( 'Dimensions (L&times;W&times;H) (%s)', 'woocommerce' ),
-								esc_html( get_option( 'woocommerce_dimension_unit' ) )
+								esc_html__( get_option( 'woocommerce_dimension_unit', 'woocommerce' ) )
 							);
 							?>
 						</label>

--- a/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
@@ -155,9 +155,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</span>
 				</label>
 				<label class="change-input">
-					<input type="text" name="_length" class="text length" placeholder="<?php printf( esc_attr__( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?>" value="">
-					<input type="text" name="_width" class="text width" placeholder="<?php printf( esc_attr__( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?>" value="">
-					<input type="text" name="_height" class="text height" placeholder="<?php printf( esc_attr__( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?>" value="">
+					<input type="text" name="_length" class="text length" placeholder="<?php printf( esc_attr__( 'Length (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ); ?>" value="">
+					<input type="text" name="_width" class="text width" placeholder="<?php printf( esc_attr__( 'Width (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ); ?>" value="">
+					<input type="text" name="_height" class="text height" placeholder="<?php printf( esc_attr__( 'Height (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ); ?>" value="">
 				</label>
 			</div>
 		<?php endif; ?>

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -121,13 +121,13 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 				'backorders'         => __( 'Backorders allowed?', 'woocommerce' ),
 				'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
 				/* translators: %s: weight */
-				'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), get_option( 'woocommerce_weight_unit' ) ),
+				'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' ) ),
 				/* translators: %s: length */
-				'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ),
 				/* translators: %s: width */
-				'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ),
 				/* translators: %s: Height */
-				'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' ) ),
 				'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),
 				'purchase_note'      => __( 'Purchase note', 'woocommerce' ),
 				'sale_price'         => __( 'Sale price', 'woocommerce' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -1728,8 +1728,8 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -640,8 +640,8 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -1657,8 +1657,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -412,8 +412,8 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -730,8 +730,8 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit    = __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
+		$dimension_unit = __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1293,7 +1293,7 @@ function wc_format_weight( $weight ) {
 	$weight_string = wc_format_localized_decimal( $weight );
 
 	if ( ! empty( $weight_string ) ) {
-		$weight_string .= ' ' . get_option( 'woocommerce_weight_unit' );
+		$weight_string .= ' ' . __( get_option( 'woocommerce_weight_unit' ), 'woocommerce' );
 	} else {
 		$weight_string = __( 'N/A', 'woocommerce' );
 	}
@@ -1312,7 +1312,7 @@ function wc_format_dimensions( $dimensions ) {
 	$dimension_string = implode( ' &times; ', array_filter( array_map( 'wc_format_localized_decimal', $dimensions ) ) );
 
 	if ( ! empty( $dimension_string ) ) {
-		$dimension_string .= ' ' . get_option( 'woocommerce_dimension_unit' );
+		$dimension_string .= ' ' . __( get_option( 'woocommerce_dimension_unit' ), 'woocommerce' );
 	} else {
 		$dimension_string = __( 'N/A', 'woocommerce' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I searched in the source code when the `woocommerce_weight_unit` and `woocommerce_dimension_unit` options were called in a display context. I then wrapped the returned values ​​in translation functions.

Closes # .

### How to test the changes in this Pull Request:

1. I've installed this branche on the local instance, translated (with loco-translate) weight and dimensions option with a random string. Then I added a product with dimension and weight, and looked at my product page to see if it was ok.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add translation functions on weight and dimensions units options, when needed

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.