### PR TITLE
Add WcPay settings info to WC Tracker

### DIFF
--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -151,6 +151,9 @@ class WC_Tracker {
 		// Payment gateway info.
 		$data['gateways'] = self::get_active_payment_gateways();
 
+		// WcPay settings info.
+		$data['wcpay_settings'] = self::get_wcpay_settings();
+
 		// Shipping method info.
 		$data['shipping_methods'] = self::get_active_shipping_methods();
 
@@ -301,6 +304,15 @@ class WC_Tracker {
 			'active_plugins'   => $active_plugins,
 			'inactive_plugins' => $plugins,
 		);
+	}
+
+	/**
+	 * Get the settings of WooCommerce Payments plugin
+	 *
+	 * @return array
+	 */
+	private static function get_wcpay_settings() {
+		return get_option( 'woocommerce_woocommerce_payments_settings' );
 	}
 
 	/**
@@ -588,6 +600,7 @@ class WC_Tracker {
 
 		return $active_gateways;
 	}
+
 
 	/**
 	 * Get a list of all active shipping methods.


### PR DESCRIPTION
We would like to track some WcPay settings for answering data requests.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:
1. Install WooCommerce Paymentst plugin.
2. wp eval 'var_dump(WC_Tracker::get_tracking_data());'
should return values in which the wcpay_settings are also present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Track WcPay settings in WC Tracker.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
