### PR TITLE
Partially revert #31113 `is_ajax` deprecation.

### DIFF
--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -261,6 +261,7 @@ if ( ! function_exists( 'is_ajax' ) ) {
 	/**
 	 * Is_ajax - Returns true when the page is loaded via ajax.
 	 *
+	 * @see wp_doing_ajax() for an equivalent function provided by WordPress since 4.7.0
 	 * @return bool
 	 */
 	function is_ajax() {

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -256,6 +256,18 @@ if ( ! function_exists( 'is_lost_password_page' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_ajax' ) ) {
+
+	/**
+	 * Is_ajax - Returns true when the page is loaded via ajax.
+	 *
+	 * @return bool
+	 */
+	function is_ajax() {
+		return function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : Constants::is_defined( 'DOING_AJAX' );
+	}
+}
+
 if ( ! function_exists( 'is_store_notice_showing' ) ) {
 
 	/**

--- a/plugins/woocommerce/includes/wc-deprecated-functions.php
+++ b/plugins/woocommerce/includes/wc-deprecated-functions.php
@@ -1123,17 +1123,3 @@ function get_woocommerce_term_meta( $term_id, $key, $single = true ) {
 	wc_deprecated_function( 'get_woocommerce_term_meta', '3.6', 'get_term_meta' );
 	return function_exists( 'get_term_meta' ) ? get_term_meta( $term_id, $key, $single ) : get_metadata( 'woocommerce_term', $term_id, $key, $single );
 }
-
-if ( ! function_exists( 'is_ajax' ) ) {
-
-	/**
-	 * Is_ajax - Returns true when the page is loaded via ajax.
-	 *
-	 * @deprecated 6.1.0
-	 * @return bool
-	 */
-	function is_ajax() {
-		wc_deprecated_function( 'is_ajax', '6.1.0', 'wp_doing_ajax' );
-		return function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : Constants::is_defined( 'DOING_AJAX' );
-	}
-}


### PR DESCRIPTION
This commit reverts the deprecation if `is_ajax` that occurred in #31113. It leaves beind the changes to use the native function `wp_doing_ajax` instead. I'm rolling this back because we haven't done a deprecation in some time, and there were many reports of people running into issues with the deprecation notice being displayed (because of errors being displayed on the frontend) and that causing additional issues on their sites.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31638.

### How to test the changes in this Pull Request:

1. Tail your error log and make sure that you don't see any warnings about `is_ajax`'s deprecation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removes the revert warning about `is_ajax`

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
