### PR TITLE
Update version to 6.1.1 in class-woocommerce.php

### DIFF
--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -27,7 +27,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '6.1.0';
+	public $version = '6.1.1';
 
 	/**
 	 * WooCommerce Schema version.


### PR DESCRIPTION
This PR updates the version in `class-woocommerce.php` to prepare for the 6.1.1. release.