### PR TITLE
Add a timeout to the beforeAll hook for the Shopper Checkout Create Account E2E test

### DIFF
--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-create-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-create-account.test.js
@@ -44,7 +44,7 @@ const runCheckoutCreateAccountTest = () => {
 			await shopper.addToCartFromShopPage( productId );
 			await uiUnblocked();
 			await shopper.goToCheckout();
-		});
+		}, 45000 );
 
 		it('can create an account during checkout', async () => {
 			// Fill all the details for a new customer


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where the `beforeAll` hook in the `Shopper Checkout Create Account` test times out when executed locally in headless mode. The fix is to set the timeout for that specific `beforeAll` block to 45 seconds which gives it enough time to fully resolve.

Closes #31680.

### How to test the changes in this Pull Request:

```sh
$ pnpm install
$ cd plugins/woocommerce
$ pnpx wc-e2e docker:up
$ pnpx wc-e2e test:e2e
```
