### PR TITLE
Fix styling of "pay for order" form.

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -747,6 +747,12 @@ $tt2-gray: #f7f7f7;
 						color: var(--wp--preset--color--black);
 					}
 				}
+
+				&.woocommerce-orders-table__cell-order-actions {
+					a.button {
+						display: block;
+					}
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -890,7 +890,8 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	.woocommerce-checkout {
+	.woocommerce-checkout,
+	&.woocommerce-order-pay {
 		display: table;
 
 		h3 {
@@ -929,11 +930,13 @@ $tt2-gray: #f7f7f7;
 
 		.woocommerce-billing-fields__field-wrapper,
 		.woocommerce-checkout-review-order-table,
-		.woocommerce-checkout-payment {
+		.woocommerce-checkout-payment,
+		#payment {
 			margin-top: 4rem;
 		}
 
-		.woocommerce-checkout-review-order-table {
+		.woocommerce-checkout-review-order-table,
+		#order_review .shop_table {
 			border-collapse: collapse;
 			width: 100%;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31671.

In addition to fixing the styling of the "pay for order" form, this PR also fixes the lack of separation between order action buttons on the "my account > orders" page.

| **Before** | **After** |
|------|-----|
| ![Screen Shot 2022-01-18 at 4 51 39 PM](https://user-images.githubusercontent.com/63922/150037615-689f75d6-f058-4d60-823e-69d8f23755c3.png) | ![Screen Shot 2022-01-18 at 4 39 15 PM](https://user-images.githubusercontent.com/63922/150037639-e696469f-19ac-4bd1-8ae9-ee42f1148fc6.png) |
| ![Screen Shot 2022-01-18 at 4 51 19 PM](https://user-images.githubusercontent.com/63922/150037690-6b3c7d69-8996-4a1e-b6c0-09f20d2f9502.png) | ![Screen Shot 2022-01-18 at 4 49 34 PM](https://user-images.githubusercontent.com/63922/150037711-72b3cf4e-83e4-4208-8795-90fad6e7e6dd.png) |


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix: 2022 theme pay for order form styling.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
