### PR TITLE
Style the 2022 theme store notice.

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -1224,6 +1224,7 @@ $tt2-gray: #f7f7f7;
 	}
 }
 
+
 .wp-block-search {
 	.wp-block-search__label {
 		font-weight: normal;
@@ -1264,3 +1265,22 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 }
+
+.woocommerce-store-notice {
+	color: var(--wp--preset--color--black);
+	border-top: 2px solid var( --wp--preset--color--primary );
+	background: $tt2-gray;
+	padding: 2rem;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+	margin: 0;
+
+	.woocommerce-store-notice__dismiss-link {
+		float: right;
+		margin-right: 4rem;
+	}
+}
+

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -1224,7 +1224,6 @@ $tt2-gray: #f7f7f7;
 	}
 }
 
-
 .wp-block-search {
 	.wp-block-search__label {
 		font-weight: normal;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR seeks to add styling to the store-wide notice in the 2022 theme. I made the decision to bottom-align the notice. If that needs to change LMK!

| **Before** | **After** |
|-----|-----|
| ![Screen Shot 2022-01-18 at 5 12 11 PM](https://user-images.githubusercontent.com/63922/150039560-09409e00-a377-4550-bbac-cffc45a12fb1.png) | ![Screen Shot 2022-01-18 at 5 11 23 PM](https://user-images.githubusercontent.com/63922/150039630-650e4e32-9b78-4d0d-9f5c-83a386b6a383.png) |

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix - 2022 theme store notice styling.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
