### PR TITLE
[6.2] Bump `WooCommerce::$version` and `package.json` versions to 6.2.0

### DIFF
--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -27,7 +27,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '6.1.0';
+	public $version = '6.2.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce",
   "title": "WooCommerce",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "homepage": "https://woocommerce.com/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Bumps `WooCommerce::$version` to and `package.json`'s version to`6.2.0`.

We have several WooCommerce extensions where we need to do different things depending on the WooCommerce version. We use `WC()->version` to detect the current WC version.

Currently, this check isn't working in the 6.2 beta/branch because the version number hasn't been bumped in the `release/6.2` branch.

Now that 6.2 has been branched, `WooCommerce::$version` should show `6.2.0` as the version, rather than `6.1.0`.

### How to test the changes in this Pull Request:

N/A

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~~[ ] Have you written new tests for your changes, as applicable?~~
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Bump `WooCommerce::$version` to `6.2.0`.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
