### PR TITLE
Update WooCommerce blocks package to 6.7.3

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -22,7 +22,7 @@
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
 		"woocommerce/woocommerce-admin": "3.1.0-rc.1",
-		"woocommerce/woocommerce-blocks": "6.7.1"
+		"woocommerce/woocommerce-blocks": "6.7.3"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edd58bb30d9ec1e9ba74f499fb4a919b",
+    "content-hash": "a242ac197e1df02fe5690550ce0a0745",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -614,16 +614,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v6.7.1",
+            "version": "v6.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "d215803d7310046050bde26420c3082edcdbf866"
+                "reference": "742439da222272235190cbf14cc5ea0d4f178fa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d215803d7310046050bde26420c3082edcdbf866",
-                "reference": "d215803d7310046050bde26420c3082edcdbf866",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/742439da222272235190cbf14cc5ea0d4f178fa5",
+                "reference": "742439da222272235190cbf14cc5ea0d4f178fa5",
                 "shasum": ""
             },
             "require": {
@@ -662,9 +662,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v6.7.1"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v6.7.3"
             },
-            "time": "2022-01-07T16:15:03+00:00"
+            "time": "2022-01-24T10:38:10+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 6.7.3. It is intended to target WooCommerce 6.2 for release.
Details from all the different releases included in this pull:


## Blocks 6.7.3

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5617)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/f7cff09f1d60bf129cdd2e2942127c7734f90e13/docs/testing/releases/673.md)

## Blocks 6.7.2

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5572)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/d73b47b741a199e21279a656905154c4130b6926/docs/testing/releases/672.md)



### Changelog entry

#### Bug Fixes

- Enable Mini Cart template parts only for experimental builds. ([#5606](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5606))
#### Various

- Update WooCommerce plugin slug for Block Templates. ([#5519](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5519))


> Dev - Update WooCommerce Blocks version to 6.7.3




