### PR TITLE
Hook `set_session` at `woocommerce_after_calculate_totals` @ `1000`

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -47,7 +47,7 @@ final class WC_Cart_Session {
 	public function init() {
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
-		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ) );
+		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ), 1000 );
 		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_removed_coupon', array( $this, 'set_session' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR re-hooks `set_session` from `woocommerce_after_calculate_totals` @ `10` to `woocommerce_after_calculate_totals` @ `1000` to allow WooCommerce extensions to change cart totals before the session is updated.

closes #31710

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog

> Dev - The cart session is now updated later on during the `woocommerce_after_calculate_totals` action (priority 1000, instead of priority 10 as previously).

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
