### PR TITLE
Add example of how to build from a release branch.

### DIFF
--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'By default the zip file is generated from the branch the workflow runs from, but you can specify an explicit reference to use instead here (e.g. refs/tags/tag_name). The resulting file will be available as an artifact on the workflow run.'
+        description: 'By default the zip file is generated from the branch the workflow runs from, but you can specify an explicit reference to use instead here (e.g. refs/tags/tag_name or refs/heads/release/x.x). The resulting file will be available as an artifact on the workflow run.'
         required: false
         default: ''
 jobs:


### PR DESCRIPTION
Just adding an extra example of how to build a release branch while still using the workflow file in `trunk` (may be helpful to build older releases).