### PR TITLE
Version bump WooCommerce Admin to 3.1.0 final

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.1.0-rc.1",
+		"woocommerce/woocommerce-admin": "3.1.0",
 		"woocommerce/woocommerce-blocks": "6.7.3"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a242ac197e1df02fe5690550ce0a0745",
+    "content-hash": "d9b680722733ec1fae9414023f943830",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.1.0-rc.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "0c7a42f0c934f7f2e44c0534e2cec6fcb8362180"
+                "reference": "59dfff627d9b7b1d5396686e69b709a820f5e7e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0c7a42f0c934f7f2e44c0534e2cec6fcb8362180",
-                "reference": "0c7a42f0c934f7f2e44c0534e2cec6fcb8362180",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/59dfff627d9b7b1d5396686e69b709a820f5e7e5",
+                "reference": "59dfff627d9b7b1d5396686e69b709a820f5e7e5",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.1.0-rc.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.1.0"
             },
-            "time": "2022-01-13T02:42:30+00:00"
+            "time": "2022-01-25T02:36:40+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the final version 3.1.0

## Bug fix tests

### Fix task ID class check and add tests around tracking

1. Delete the `woocommerce_task_list_tracked_completed_tasks` option in your database
2. Visit the homepage to trigger task list retrieval and tracks
3. Check that no errors appear in the error log
4. Visit `https://mc.a8c.com/tracks/live/?eventname=%25tasklist_%25&user=joshuaflow&useragent=` with your username and make sure the tracks come through `tasklist_task_completed` (may take up to ~20 min)
5. Make sure all tests pass

### Fix setup wizard free features checkbox re-check itself

1. Go to Business Features tab in Setup Wizard
2. Deselect all extensions and reselect only 1
3. Click continue
4. Observe the other extensions are **NOT** re-selected before it navigates to the next screen

## Changelog diff since last version https://github.com/woocommerce/woocommerce/pull/31641
```
- Fix: Fix setup wizard free features checkbox re-check itself. #8169
- Dev: Fix task ID class check and add tests around tracking #8185
```