### PR TITLE
update testresult.json handling to copy the file to the local folder

### DIFF
--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `post-results-to-github-pr.js` to post smoke test results to a GitHub PR.
 - Added jest flags to generate a json test report
 - Added more entries to `default.json`
-- Print the full path to `test-results.json` when the tests ends to make it easier to find the test results file.
+- Save `test-results.json` from test runs to the `tests/e2e` folder.
 - Added `await` for every call to `shopper.logout`
 - Updated `getLatestReleaseZipUrl()` to allow passing in an authorization token and simplified arguments to just the repository name
 - Added `upload.ini` which increases the limits for uploading files (such as for plugins) in the Docker environment

--- a/packages/js/e2e-environment/README.md
+++ b/packages/js/e2e-environment/README.md
@@ -114,6 +114,10 @@ await takeScreenshotFor( 'name of current step' );
 
 Screenshots will be saved to `tests/e2e/screenshots`. This folder is cleared at the beginning of each test run.
 
+#### Test results
+
+The test results are saved in `json` format in `tests/e2e/test-results.json`.
+
 ### Override default test timeout
 
 To override the default timeout for the tests, you can use the `DEFAULT_TIMEOUT_OVERRIDE` flag and pass in a maximum timeout in milliseconds. For example, you can pass it in when running the tests from the command line:

--- a/packages/js/e2e-environment/bin/e2e-test-integration.js
+++ b/packages/js/e2e-environment/bin/e2e-test-integration.js
@@ -76,7 +76,7 @@ if ( program.args.length == 1 ) {
 }
 
 let jestCommand = 'jest';
-let outputFile = resolveLocalE2ePath('/test-results.json');
+let outputFile = 'test-results.json';
 const jestArgs = [
 	'--maxWorkers=1',
 	'--rootDir=./',
@@ -111,7 +111,11 @@ const jestProcess = spawnSync( jestCommand, jestArgs, {
 	env: envVars,
 } );
 
-console.log( 'Test result file path: ' + outputFile );
+let results = resolvePackagePath( outputFile );
+if ( fs.existsSync( results ) ) {
+	let localResults = resolveLocalE2ePath( outputFile );
+	fs.copyFileSync( results, localResults );
+}
 console.log( 'Jest exit code: ' + jestProcess.status );
 
 // Pass Jest exit code to npm


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a followup PR to #31625. In https://github.com/woocommerce/woocommerce/pull/31625#issuecomment-1011258539 I requested that the file be copied to the local environment. The PR was merged with it being saved there. In my comment I should have explained that there was a secondary reason for saving the file to the package.

The test counts are inconsistent between runs due to retries being counted in some way. From #31567:

```
Total Number of Passed Tests: 191
Total Number of Failed Tests: 47
Total Number of Test Suites: 42
Total Number of Passed Test Suites: 29
Total Number of Failed Test Suites: 10
```

and

```
Total Number of Passed Tests: 197
Total Number of Failed Tests: 47
Total Number of Test Suites: 42
Total Number of Passed Test Suites: 29
Total Number of Failed Test Suites: 10
```
 
This PR updates the changes in #31625 to save the results in the package, copy the file, and adds a brief section to the documentation indicating the location of the file.

### How to test the changes in this Pull Request:

1. Run E2E tests locally
2. Verify that `tests/e2e/test-results.json` is created.
