### PR TITLE
Limit input widths to number inputs in Twenty Twenty One theme. 

### DIFF
--- a/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
@@ -601,7 +601,7 @@ dl.variation,
 			margin-right: 0.5rem;
 		}
 
-		input {
+		input[type="number"] {
 			width: 5em;
 		}
 	}


### PR DESCRIPTION
Follow up to #31698. Testing instructions should be the same.

Current display of radio inputs:
![image](https://user-images.githubusercontent.com/507025/151274115-113ab345-e158-4775-90e1-b9c987919901.png)

### Changelog entry

> Tweak - Adjust input styles for the Twenty Twenty One theme.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
