### PR TITLE
Fix: double "PHP version upgrade required" notice

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -138,6 +138,11 @@ class WC_Admin_Notices {
 			'php72_required_in_woo_65',
 			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 7.4 is recommended. <b><a href="https://developer.woocommerce.com/2022/01/05/new-requirement-for-woocommerce-6-5-php-7-2/">Learn more about this change.</a></b></p>', 'woocommerce' )
 		);
+
+		$wp_version_is_ok = version_compare( get_bloginfo( 'version' ), WC_NOTICE_MIN_WP_VERSION, '>=' );
+		if ( $wp_version_is_ok ) {
+			self::hide_notice( WC_PHP_MIN_REQUIREMENTS_NOTICE );
+		}
 	}
 
 	/**
@@ -209,12 +214,21 @@ class WC_Admin_Notices {
 
 			$hide_notice = sanitize_text_field( wp_unslash( $_GET['wc-hide-notice'] ) ); // WPCS: input var ok, CSRF ok.
 
-			self::remove_notice( $hide_notice );
-
-			update_user_meta( get_current_user_id(), 'dismissed_' . $hide_notice . '_notice', true );
-
-			do_action( 'woocommerce_hide_' . $hide_notice . '_notice' );
+			self::hide_notice( $hide_notice );
 		}
+	}
+
+	/**
+	 * Hide a single notice.
+	 *
+	 * @param $name Notice name.
+	 */
+	private static function hide_notice( $name ) {
+		self::remove_notice( $name );
+
+		update_user_meta( get_current_user_id(), 'dismissed_' . $name . '_notice', true );
+
+		do_action( 'woocommerce_hide_' . $name . '_notice' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/31557 added a new admin notice warning users about the upcoming PHP 7.2 requirement that will be in effect since WooCommerce 6.5. However, there's also a notice in place that recommends upgrading the PHP version if it's older than 7.2 and the WordPress version if it's older than 5.2; so for new WooCommerce installs the old recommendation notice is redundant unless a WordPress version upgrade is also required.

This pull request removes the old notice if the new one is being displayed, unless a WordPress version upgrade is also required.

### How to test the changes in this Pull Request:

1. Start in `trunk` and with a new WooCommerce install, or alternatively run the following to simulate a new install:

```bash
wp eval 'delete_user_meta(get_current_user_id(), "dismissed_php72_required_in_woo_65_notice"); delete_user_meta(get_current_user_id(), "dismissed_wp_php_min_requirements_7.2_5.2_notice"); WC_Admin_Notices::reset_admin_notices();' --user=<your user name or id>
```

2. Go to the WooCommerce orders page and you'll see two notices, "PHP version requirements will change soon" (the new notice) and "Update required: WooCommerce will soon require PHP version 7.2" (the old notice).

3. Run the command from 1 again and switch to the branch of this PR.

4. Reload the page and this time you should see only the "PHP version requirements will change soon" notice.

5. Open the `class-wc-admin-notices.php` file and replace all instances of `get_bloginfo( 'version' )` with `'5.0'`

6. Run the command from 1 again.

7. Reload the page and you should see the two notices again, but this time the old one also tells you that your WordPress version is outdated (so it's no longer redundant).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - double notice about the upcoming change in the PHP version requirement

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
