### PR TITLE
Echo the escaped text (required field asterix)

### DIFF
--- a/plugins/woocommerce/templates/checkout/terms.php
+++ b/plugins/woocommerce/templates/checkout/terms.php
@@ -28,7 +28,7 @@ if ( apply_filters( 'woocommerce_checkout_show_terms', true ) && function_exists
 			<p class="form-row validate-required">
 				<label class="woocommerce-form__label woocommerce-form__label-for-checkbox checkbox">
 				<input type="checkbox" class="woocommerce-form__input woocommerce-form__input-checkbox input-checkbox" name="terms" <?php checked( apply_filters( 'woocommerce_terms_is_checked_default', isset( $_POST['terms'] ) ), true ); // WPCS: input var ok, csrf ok. ?> id="terms" />
-					<span class="woocommerce-terms-and-conditions-checkbox-text"><?php wc_terms_and_conditions_checkbox_text(); ?></span>&nbsp;<abbr class="required" title="<?php esc_attr__( 'required', 'woocommerce' ); ?>">*</abbr>
+					<span class="woocommerce-terms-and-conditions-checkbox-text"><?php wc_terms_and_conditions_checkbox_text(); ?></span>&nbsp;<abbr class="required" title="<?php esc_attr_e( 'required', 'woocommerce' ); ?>">*</abbr>
 				</label>
 				<input type="hidden" name="terms-field" value="1" />
 			</p>


### PR DESCRIPTION
Minor fix (we need to echo our escaped attribute).

No changelog needed, this is a correction from an earlier PR.