### PR TITLE
Update store setup widget to use task list API

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -162,7 +162,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return bool
 		 */
 		private function should_display_widget() {
-			return WC()->is_wc_admin_active() &&
+			return current_user_can( 'manage_woocommerce' ) &&
+				WC()->is_wc_admin_active() &&
 				'yes' !== get_option( 'woocommerce_task_list_complete' ) &&
 				'yes' !== get_option( 'woocommerce_task_list_hidden' );
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -20,40 +21,14 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 	class WC_Admin_Dashboard_Setup {
 
 		/**
-		 * List of tasks.
-		 *
-		 * @var array
+		 * The task list.
 		 */
-		private $tasks = array(
-			'store_details'        => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&path=%2Fsetup-wizard',
-			),
-			'products'             => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&task=products',
-			),
-			'woocommerce-payments' => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&path=%2Fpayments%2Fconnect',
-			),
-			'payments'             => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&task=payments',
-			),
-			'tax'                  => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&task=tax',
-			),
-			'shipping'             => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&task=shipping',
-			),
-			'appearance'           => array(
-				'completed'   => false,
-				'button_link' => 'admin.php?page=wc-admin&task=appearance',
-			),
-		);
+		private $task_list = null;
+
+		/**
+		 * The tasks.
+		 */
+		private $tasks = null;
 
 		/**
 		 * # of completed tasks.
@@ -66,10 +41,10 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * WC_Admin_Dashboard_Setup constructor.
 		 */
 		public function __construct() {
+			$this->task_list = TaskLists::get_list( 'setup' );
+			$this->tasks     = $this->task_list->get_viewable_tasks();
+
 			if ( $this->should_display_widget() ) {
-				$this->populate_general_tasks();
-				$this->populate_payment_tasks();
-				$this->completed_tasks_count = $this->get_completed_tasks_count();
 				add_meta_box(
 					'wc_admin_dashboard_setup',
 					__( 'WooCommerce Setup', 'woocommerce' ),
@@ -93,8 +68,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 				return;
 			}
 
-			$button_link           = $task['button_link'];
-			$completed_tasks_count = $this->completed_tasks_count;
+			$button_link           = $this->get_button_link( $task );
+			$completed_tasks_count = $this->get_completed_tasks_count();
 			$tasks_count           = count( $this->tasks );
 
 			// Given 'r' (circle element's r attr), dashoffset = ((100-$desired_percentage)/100) * PI * (r*2).
@@ -106,25 +81,14 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		}
 
 		/**
-		 * Populate tasks from the database.
-		 */
-		private function populate_general_tasks() {
-			$tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', array() );
-			foreach ( $tasks as $task ) {
-				if ( isset( $this->tasks[ $task ] ) ) {
-					$this->tasks[ $task ]['completed']   = true;
-					$this->tasks[ $task ]['button_link'] = wc_admin_url( $this->tasks[ $task ]['button_link'] );
-				}
-			}
-		}
-
-		/**
-		 * Getter for $tasks
+		 * Get the button link for a given task.
 		 *
-		 * @return array
+		 * @param Task $task Task.
+		 * @return string
 		 */
-		public function get_tasks() {
-			return $this->tasks;
+		public function get_button_link( $task ) {
+			$url = $task->get_json()['actionUrl'];
+			return $url ? $url : 'admin.php?page=wc-admin&task=' . $task->get_id();
 		}
 
 		/**
@@ -134,7 +98,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 			$completed_tasks = array_filter(
 				$this->tasks,
 				function( $task ) {
-					return $task['completed'];
+					return $task->is_complete();
 				}
 			);
 
@@ -147,8 +111,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return array|null
 		 */
 		private function get_next_task() {
-			foreach ( $this->get_tasks() as $task ) {
-				if ( false === $task['completed'] ) {
+			foreach ( $this->task_list->get_viewable_tasks() as $task ) {
+				if ( false === $task->is_complete() ) {
 					return $task;
 				}
 			}
@@ -164,49 +128,10 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		private function should_display_widget() {
 			return current_user_can( 'manage_woocommerce' ) &&
 				WC()->is_wc_admin_active() &&
-				'yes' !== get_option( 'woocommerce_task_list_complete' ) &&
-				'yes' !== get_option( 'woocommerce_task_list_hidden' );
+				! $this->task_list->is_complete() &&
+				! $this->task_list->is_hidden();
 		}
 
-		/**
-		 * Populate payment tasks's visibility and completion
-		 */
-		private function populate_payment_tasks() {
-			$is_woo_payment_installed = is_plugin_active( 'woocommerce-payments/woocommerce-payments.php' );
-			$country                  = explode( ':', get_option( 'woocommerce_default_country', 'US:CA' ) )[0];
-
-			// woocommerce-payments requires its plugin activated and country must be US.
-			if ( ! $is_woo_payment_installed || 'US' !== $country ) {
-				unset( $this->tasks['woocommerce-payments'] );
-			}
-
-			// payments can't be used when woocommerce-payments exists and country is US.
-			if ( $is_woo_payment_installed && 'US' === $country ) {
-				unset( $this->tasks['payments'] );
-			}
-
-			if ( isset( $this->tasks['payments'] ) ) {
-				$gateways                             = WC()->payment_gateways->get_available_payment_gateways();
-				$enabled_gateways                     = array_filter(
-					$gateways,
-					function ( $gateway ) {
-						return 'yes' === $gateway->enabled;
-					}
-				);
-				$this->tasks['payments']['completed'] = ! empty( $enabled_gateways );
-			}
-
-			if ( isset( $this->tasks['woocommerce-payments'] ) ) {
-				$wc_pay_is_connected = false;
-				if ( class_exists( '\WC_Payments' ) ) {
-					$wc_payments_gateway = \WC_Payments::get_gateway();
-					$wc_pay_is_connected = method_exists( $wc_payments_gateway, 'is_connected' )
-						? $wc_payments_gateway->is_connected()
-						: false;
-				}
-				$this->tasks['woocommerce-payments']['completed'] = $wc_pay_is_connected;
-			}
-		}
 	}
 
 endif;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -67,6 +67,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 
 			$button_link           = $this->get_button_link( $task );
 			$completed_tasks_count = $this->get_completed_tasks_count();
+			$step_number           = $this->get_completed_tasks_count() + 1;
 			$tasks_count           = count( $this->get_tasks() );
 
 			// Given 'r' (circle element's r attr), dashoffset = ((100-$desired_percentage)/100) * PI * (r*2).

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -88,7 +88,14 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 */
 		public function get_button_link( $task ) {
 			$url = $task->get_json()['actionUrl'];
-			return $url ? $url : 'admin.php?page=wc-admin&task=' . $task->get_id();
+
+			if ( substr( $url, 0, 4 ) === 'http' ) {
+				return $url;
+			} elseif ( $url ) {
+				return wc_admin_url( '&path=' . $url );
+			}
+
+			return admin_url( 'admin.php?page=wc-admin&task=' . $task->get_id() );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -41,9 +41,6 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * WC_Admin_Dashboard_Setup constructor.
 		 */
 		public function __construct() {
-			$this->task_list = TaskLists::get_list( 'setup' );
-			$this->tasks     = $this->task_list->get_viewable_tasks();
-
 			if ( $this->should_display_widget() ) {
 				add_meta_box(
 					'wc_admin_dashboard_setup',
@@ -99,6 +96,27 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		}
 
 		/**
+		 * Get the task list.
+		 *
+		 * @return array
+		 */
+		public function get_task_list() {
+			if ( $this->task_list ) {
+				return $this->task_list;
+			}
+
+			$this->set_task_list( TaskLists::get_list( 'setup' ) );
+			return $this->task_list;
+		}
+
+		/**
+		 * Set the task list.
+		 */
+		public function set_task_list( $task_list ) {
+			return $this->task_list = $task_list;
+		}
+
+		/**
 		 * Get the tasks.
 		 *
 		 * @return array
@@ -108,7 +126,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 				return $this->tasks;
 			}
 
-			$this->tasks = $this->task_list->get_viewable_tasks();
+			$this->tasks = $this->get_task_list()->get_viewable_tasks();
 			return $this->tasks;
 		}
 
@@ -148,11 +166,11 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 *
 		 * @return bool
 		 */
-		private function should_display_widget() {
+		public function should_display_widget() {
 			return current_user_can( 'manage_woocommerce' ) &&
 				WC()->is_wc_admin_active() &&
-				! $this->task_list->is_complete() &&
-				! $this->task_list->is_hidden();
+				! $this->get_task_list()->is_complete() &&
+				! $this->get_task_list()->is_hidden();
 		}
 
 	}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 
 			$button_link           = $this->get_button_link( $task );
 			$completed_tasks_count = $this->get_completed_tasks_count();
-			$tasks_count           = count( $this->tasks );
+			$tasks_count           = count( $this->get_tasks() );
 
 			// Given 'r' (circle element's r attr), dashoffset = ((100-$desired_percentage)/100) * PI * (r*2).
 			$progress_percentage = ( $completed_tasks_count / $tasks_count ) * 100;
@@ -99,11 +99,27 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		}
 
 		/**
+		 * Get the tasks.
+		 *
+		 * @return array
+		 */
+		public function get_tasks() {
+			if ( $this->tasks ) {
+				return $this->tasks;
+			}
+
+			$this->tasks = $this->task_list->get_viewable_tasks();
+			return $this->tasks;
+		}
+
+		/**
 		 * Return # of completed tasks
+		 *
+		 * @return integer
 		 */
 		public function get_completed_tasks_count() {
 			$completed_tasks = array_filter(
-				$this->tasks,
+				$this->get_tasks(),
 				function( $task ) {
 					return $task->is_complete();
 				}
@@ -118,7 +134,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return array|null
 		 */
 		private function get_next_task() {
-			foreach ( $this->task_list->get_viewable_tasks() as $task ) {
+			foreach ( $this->get_tasks() as $task ) {
 				if ( false === $task->is_complete() ) {
 					return $task;
 				}

--- a/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		  <circle r="6.5" cx="10" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="0"></circle>
 		  <circle class="bar" r="6.5" cx="190" cy="10" fill="transparent" stroke-dasharray="40.859" stroke-dashoffset="<?php echo esc_attr( $circle_dashoffset ); ?>" transform='rotate(-90 100 100)'></circle>
 		</svg>
-		<span><?php echo esc_html_e( 'Step', 'woocommerce' ); ?> <?php echo esc_html( $completed_tasks_count ); ?> <?php echo esc_html_e( 'of', 'woocommerce' ); ?> <?php echo esc_html( $tasks_count ); ?></span>
+		<span><?php echo esc_html_e( 'Step', 'woocommerce' ); ?> <?php echo esc_html( $step_number ); ?> <?php echo esc_html_e( 'of', 'woocommerce' ); ?> <?php echo esc_html( $tasks_count ); ?></span>
 	</span>
 
 	<div class="description">

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -172,10 +172,11 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 
 		$completed_tasks_count = $this->get_widget()->get_completed_tasks_count();
 		$tasks_count           = count( $this->get_widget()->get_tasks() );
+		$step_number           = $completed_tasks_count + 1;
 		if ( $completed_tasks_count === $tasks_count ) {
 			$this->assertEmpty( $this->get_widget_output() );
 		} else {
-			$this->assertRegexp( "/Step ${completed_tasks_count} of 6/", $this->get_widget_output() );
+			$this->assertRegexp( "/Step ${step_number} of 6/", $this->get_widget_output() );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -102,7 +102,6 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 			'Step 0 of 6',
 			'You&#039;re almost there! Once you complete store setup you can start receiving orders.',
 			'Start selling',
-			'admin.php\?page=wc-admin&amp;path=%2Fsetup-wizard',
 		);
 
 		foreach ( $required_strings as $required_string ) {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\Admin
  */
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
+
 /**
  * Class WC_Admin_Dashboard_Setup_Test
  */
@@ -17,6 +19,16 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// Set default country to non-US so that 'payments' task gets added but 'woocommerce-payments' doesn't,
 		// by default it won't be considered completed but we can manually change that as needed.
 		update_option( 'woocommerce_default_country', 'JP' );
+		$password   = wp_generate_password( 8, false, false );
+		$this->admin = wp_insert_user(
+			array(
+				'user_login' => "test_admin$password",
+				'user_pass'  => $password,
+				'user_email' => "admin$password@example.com",
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->admin );
 
 		parent::setUp();
 	}
@@ -52,36 +64,69 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		return ob_get_clean();
 	}
 
-	/**
-	 * Tests widget does not get rendered when woocommerce_task_list_hidden or woocommerce_task_list_hidden
-	 * is true.
-	 *
-	 * @dataProvider should_display_widget_data_provider
-	 *
-	 * @param array $options a set of options.
-	 */
-	public function test_widget_does_not_get_rendered( array $options ) {
-		global $wp_meta_boxes;
-
-		foreach ( $options as $name => $value ) {
-			update_option( $name, $value );
-		}
-
-		$this->get_widget();
-		$this->assertNull( $wp_meta_boxes );
-	}
 
 	/**
-	 * Given both woocommerce_task_list_hidden and woocommerce_task_list_complete are false
-	 * Then the widget should be added to the $wp_meta_boxes
+	 * Given the task list is not hidden and is not complete, make sure the widget is rendered.
 	 */
-	public function test_widget_gets_rendered_when_both_options_are_false() {
+	public function test_widget_render() {
+		// Force the "payments" task to be considered incomplete.
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			function() {
+				return array();
+			}
+		);
 		global $wp_meta_boxes;
-		update_option( 'woocommerce_task_list_complete', false );
-		update_option( 'woocommerce_task_list_hidden', false );
+		$task_list = $this->get_widget()->get_task_list();
+		$task_list->unhide();
 
 		$this->get_widget();
 		$this->assertArrayHasKey( 'wc_admin_dashboard_setup', $wp_meta_boxes['dashboard']['normal']['high'] );
+	}
+
+	/**
+	 * Tests widget does not display when task list is complete.
+	 */
+	public function test_widget_does_not_display_when_task_list_complete() {
+		$task_list = new class {
+			public function is_complete() {
+				return true;
+			}
+		};
+		$widget    = $this->get_widget();
+		$widget->set_task_list( $task_list );
+
+		$this->assertFalse( $widget->should_display_widget() );
+	}
+	
+	/**
+	 * Tests widget does not display when task list is hidden.
+	 */
+	public function test_widget_does_not_display_when_task_list_hidden() {
+		$widget = $this->get_widget();
+		$widget->get_task_list()->hide();
+
+		$this->assertFalse( $widget->should_display_widget() );
+	}
+
+	/**
+	 * Tests widget does not display when user cannot manage woocommerce.
+	 */
+	public function test_widget_does_not_display_when_missing_capabilities() {
+		$password  = wp_generate_password( 8, false, false );
+		$author    = wp_insert_user(
+			array(
+				'user_login' => "test_author$password",
+				'user_pass'  => $password,
+				'user_email' => "author$password@example.com",
+				'role'       => 'author',
+			)
+		);
+		wp_set_current_user( $author );
+
+		$widget = $this->get_widget();
+
+		$this->assertFalse( $widget->should_display_widget() );
 	}
 
 	/**
@@ -99,7 +144,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		$html = $this->get_widget_output();
 
 		$required_strings = array(
-			'Step 0 of 6',
+			'Step \d+ of \d+',
 			'You&#039;re almost there! Once you complete store setup you can start receiving orders.',
 			'Start selling',
 		);
@@ -132,26 +177,5 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		} else {
 			$this->assertRegexp( "/Step ${completed_tasks_count} of 6/", $this->get_widget_output() );
 		}
-	}
-
-
-	/**
-	 * Provides dataset that controls output of `should_display_widget`
-	 */
-	public function should_display_widget_data_provider() {
-		return array(
-			array(
-				array(
-					'woocommerce_task_list_complete' => 'yes',
-					'woocommerce_task_list_hidden'   => 'no',
-				),
-			),
-			array(
-				array(
-					'woocommerce_task_list_complete' => 'no',
-					'woocommerce_task_list_hidden'   => 'yes',
-				),
-			),
-		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -125,21 +125,12 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 			}
 		);
 
-		$completed_tasks = array( 'payments' );
-		$tasks           = $this->get_widget()->get_tasks();
-		$tasks_count     = count( $tasks );
-		unset( $tasks['payments'] ); // That one is completed already.
-		foreach ( $tasks as $key => $task ) {
-			array_push( $completed_tasks, $key );
-			update_option( 'woocommerce_task_list_tracked_completed_tasks', $completed_tasks );
-			$completed_tasks_count = count( $completed_tasks );
-			// When all tasks are completed, assert that the widget output is empty.
-			// As widget won't be rendered when tasks are completed.
-			if ( $completed_tasks_count === $tasks_count ) {
-				$this->assertEmpty( $this->get_widget_output() );
-			} else {
-				$this->assertRegexp( "/Step ${completed_tasks_count} of 6/", $this->get_widget_output() );
-			}
+		$completed_tasks_count = $this->get_widget()->get_completed_tasks_count();
+		$tasks_count           = count( $this->get_widget()->get_tasks() );
+		if ( $completed_tasks_count === $tasks_count ) {
+			$this->assertEmpty( $this->get_widget_output() );
+		} else {
+			$this->assertRegexp( "/Step ${completed_tasks_count} of 6/", $this->get_widget_output() );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update the widget visibility capabilities and use the new task list API to retrieve tasks instead of hard-coding them.

### How to test the changes in this Pull Request:

#### Testing capabilities

1. Start with a fresh site with an unfinished task list
2. Go to the WordPress Dashboard page
3. Note as an admin that you can see the `WooCommerce Setup` widget
4. Create a user role that should not be able to manage WooCommerce but can view the dashboard (e.g., Author)
5. Log in with that user and navigate to the dashboard.
6. Note that the `WooCommerce Setup` widget is not visible

#### Testing tasks

1. Navigate to the WordPress dashboard
2. Note that the correct number of tasks are shown (complete/total) for the `WooCommerce Setup` widget
3. Click on the action button `Start selling` and make sure you’re redirected to the correct page
4. Repeat this process for multiple tasks, taking special attention for the “store details/setup” task since it uses a custom URL passed via the API

### Changelog entry

> Update store setup widget to use task list API

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
