### PR TITLE
remove pnpm rule, fix utils build

### DIFF
--- a/packages/js/api-core-tests/package.json
+++ b/packages/js/api-core-tests/package.json
@@ -4,7 +4,6 @@
   "description": "API tests for WooCommerce",
   "main": "index.js",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "test": "jest",
     "test:api": "jest --group=api",
     "test:hello": "jest --group=hello",

--- a/packages/js/api/package.json
+++ b/packages/js/api/package.json
@@ -26,7 +26,6 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "clean": "rm -rf ./dist ./tsconfig.tsbuildinfo",
     "compile": "tsc -b",
     "build": "pnpm run clean && npm run compile",

--- a/packages/js/e2e-core-tests/package.json
+++ b/packages/js/e2e-core-tests/package.json
@@ -45,7 +45,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
 	"prepare": "pnpm run build",
 	"clean": "rm -rf ./build ./build-module",
 	"compile": "node ./../bin/build.js",

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -35,7 +35,8 @@
     "jest-each": "25.5.0",
     "jest-puppeteer": "^4.4.0",
     "node-stream-zip": "^1.13.6",
-	"readline-sync": "^1.4.10",
+    "puppeteer": "2.1.1",
+    "readline-sync": "^1.4.10",
     "request": "^2.88.2",
     "sprintf-js": "^1.1.2"
   },

--- a/packages/js/e2e-utils/package.json
+++ b/packages/js/e2e-utils/package.json
@@ -41,7 +41,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "clean": "rm -rf ./build ./build-module",
     "compile": "node ./../bin/build.js",
     "build": "pnpm run clean && pnpm run compile",

--- a/packages/js/e2e-utils/src/factories/simple-product.js
+++ b/packages/js/e2e-utils/src/factories/simple-product.js
@@ -17,8 +17,8 @@ export function simpleProductFactory( httpClient ) {
 		} );
 
 		return {
-			name: params.name ?? faker.commerce.productName(),
-			regularPrice: params.regularPrice ?? faker.commerce.price(),
+			name: params.name ? params.name : faker.commerce.productName(),
+			regularPrice: params.regularPrice ? params.regularPrice : faker.commerce.price(),
 		};
 	} );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,7 @@ importers:
       jest-puppeteer: ^4.4.0
       ndb: ^1.1.5
       node-stream-zip: ^1.13.6
+      puppeteer: 2.1.1
       readline-sync: ^1.4.10
       request: ^2.88.2
       semver: ^7.3.2
@@ -172,7 +173,7 @@ importers:
       '@jest/test-sequencer': 25.5.4
       '@slack/web-api': 6.5.1
       '@woocommerce/api': link:../api
-      '@wordpress/e2e-test-utils': 4.16.1_jest@25.5.4
+      '@wordpress/e2e-test-utils': 4.16.1_jest@25.5.4+puppeteer@2.1.1
       '@wordpress/jest-preset-default': 7.1.3_@babel+core@7.12.9+jest@25.5.4
       app-root-path: 3.0.0
       commander: 4.1.1
@@ -180,8 +181,9 @@ importers:
       jest: 25.5.4
       jest-circus: 25.1.0
       jest-each: 25.5.0
-      jest-puppeteer: 4.4.0
+      jest-puppeteer: 4.4.0_puppeteer@2.1.1
       node-stream-zip: 1.15.0
+      puppeteer: 2.1.1
       readline-sync: 1.4.10
       request: 2.88.2
       sprintf-js: 1.1.2
@@ -5346,7 +5348,7 @@ packages:
       - react-native
     dev: false
 
-  /@wordpress/e2e-test-utils/4.16.1_jest@25.5.4:
+  /@wordpress/e2e-test-utils/4.16.1_jest@25.5.4+puppeteer@2.1.1:
     resolution: {integrity: sha512-Dpsq5m0VSvjIhro2MjACSzkOkOf1jGEryzgEMW1ikbT6YI+motspHfGtisKXgYhZJOnjV4PwuEg+9lPVnd971g==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -5359,6 +5361,7 @@ packages:
       jest: 25.5.4
       lodash: 4.17.21
       node-fetch: 2.6.5
+      puppeteer: 2.1.1
     transitivePeerDependencies:
       - react-native
     dev: false
@@ -13271,13 +13274,14 @@ packages:
       jest-resolve: 27.3.1
     dev: true
 
-  /jest-puppeteer/4.4.0:
+  /jest-puppeteer/4.4.0_puppeteer@2.1.1:
     resolution: {integrity: sha512-ZaiCTlPZ07B9HW0erAWNX6cyzBqbXMM7d2ugai4epBDKpKvRDpItlRQC6XjERoJELKZsPziFGS0OhhUvTvQAXA==}
     peerDependencies:
       puppeteer: '>= 1.5.0 < 3'
     dependencies:
       expect-puppeteer: 4.4.0
       jest-environment-puppeteer: 4.4.0
+      puppeteer: 2.1.1
     transitivePeerDependencies:
       - supports-color
     dev: false


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the `npx only-allow pnpm` from the e2e packages. The rule prevents installing the packages with `npm` in another project.

A second build issue I found where the `??` ternary operator is not built correctly under `pnpm`. Since `jest` uses Babel with local files the issue only surfaces when the built package is used in a separate project. 

A third issue is that the environment package is relying on the `puppeteer` dependency in `@automattic/puppeteer-utils`. As we are deprecating that, we need to update the dependency.

Closes #31576 .

### How to test the changes in this Pull Request:

1. Run E2E tests
