### PR TITLE
Add LV postcode formatting and tests

### DIFF
--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -993,6 +993,11 @@ function wc_format_postcode( $postcode, $country ) {
 		case 'NL':
 			$postcode = substr_replace( $postcode, ' ', 4, 0 );
 			break;
+		case 'LV':
+			if ( preg_match( '/(?:LV)?-?(\d+)/i', $postcode, $matches ) ) {
+				$postcode = count( $matches ) >= 2 ? "LV-$matches[1]" : $postcode;
+			}
+			break;
 	}
 
 	return apply_filters( 'woocommerce_format_postcode', trim( $postcode ), $country );

--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -801,6 +801,12 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// JP postcode.
 		$this->assertEquals( '999-9999', wc_format_postcode( '9999999', 'JP' ) );
 
+		// Test LV postcode without mandatory country code.
+		$this->assertEquals( 'LV-1337', wc_format_postcode( '1337', 'LV' ) );
+
+		// Test LV postcode with incorrect format (no dash).
+		$this->assertEquals( 'LV-1337', wc_format_postcode( 'lv1337', 'LV' ) );
+
 		// Test empty NL postcode.
 		$this->assertEquals( '', wc_format_postcode( '', 'NL' ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Include mandatory ISO 3166-1 alpha-2 country code when formatting Latvian (LV) postcodes with wc_format_postcode().

- [The Latvian post](https://www.pasts.lv/en/For_Companies/Useful_Information/The_Book_of_Postal_Codes/) includes a LV-prefix in all of its postal codes.
- Multiple [online sources](https://en.wikipedia.org/wiki/Postal_codes_in_Latvia) state that the country code prefix is mandatory in Latvian postcode format (LV-NNNN).
- Many package courier APIs return an error when making transactions with Latvian postal codes without the LV-prefix.

### How to test the changes in this Pull Request:

1. Run the following unit tests `vendor/bin/phpunit tests/legacy/unit-tests/formatting/functions.php`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Include mandatory ISO 3166-1 alpha-2 country code when formatting Latvian (LV) postcodes with wc_format_postcode().

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
