### PR TITLE
Add wc_format_postcode tests for IE and PT postcodes

### DIFF
--- a/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/formatting/functions.php
@@ -795,6 +795,12 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// UK postcode.
 		$this->assertEquals( 'PCRN 1ZZ', wc_format_postcode( 'pcrn1zz', 'GB' ) );
 
+		// IE postcode.
+		$this->assertEquals( 'D02 AF30', wc_format_postcode( 'D02AF30', 'IE' ) );
+
+		// PT postcode.
+		$this->assertEquals( '1000-205', wc_format_postcode( '1000205', 'PT' ) );
+
 		// BR/PL postcode.
 		$this->assertEquals( '99999-999', wc_format_postcode( '99999999', 'BR' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add missing wc_format_postcode tests for IE and PT postcodes.

### How to test the changes in this Pull Request:

1. Run the following unit tests `vendor/bin/phpunit tests/legacy/unit-tests/formatting/functions.php`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
