### PR TITLE
Fix typo in wc api exception code

### DIFF
--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-products.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-products.php
@@ -819,7 +819,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			$update = wp_update_term( $id, 'product_cat', $data );
 			if ( is_wp_error( $update ) ) {
-				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_catgory', __( 'Could not edit the category', 'woocommerce' ), 400 );
+				throw new WC_API_Exception( 'woocommerce_api_cannot_edit_product_category', __( 'Could not edit the category', 'woocommerce' ), 400 );
 			}
 
 			if ( ! empty( $data['display'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Rename WC_API_Exception code _woocommerce_api_cannot_edit_product_catgory_ into _woocommerce_api_cannot_edit_product_category_

Some third party code may be dependent on this typo, but a [quick search](https://www.google.com/search?q=%22woocommerce_api_cannot_edit_product_catgory%22) doesn't find anything open source.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Typo fix in error message string.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
