### PR TITLE
Add legacy wc_format_postcode tests along with new tests for IE and PT postcodes

### DIFF
--- a/plugins/woocommerce/changelog/feature-postcode-format-tests
+++ b/plugins/woocommerce/changelog/feature-postcode-format-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Adds test coverage for formatting of Portugese and Irish postcodes. Since it does not add user-facing functionality, a changelog entry is not needed.
+
+

--- a/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
@@ -22,10 +22,7 @@ class WC_Formatting_Functions_Test extends \WC_Unit_Test_Case {
 	 * Test wc_format_postcode() function.
 	 */
 	public function test_wc_format_postcode() {
-		// IE postcode.
-		$this->assertEquals( 'D02 AF30', wc_format_postcode( 'D02AF30', 'IE' ) );
-
-		// PT postcode.
-		$this->assertEquals( '1000-205', wc_format_postcode( '1000205', 'PT' ) );
+		$this->assertEquals( 'D02 AF30', wc_format_postcode( 'D02AF30', 'IE' ), 'Test formatting of IE postcodes.' );
+		$this->assertEquals( '1000-205', wc_format_postcode( '1000205', 'PT' ), 'Test formatting of PT postcodes.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
@@ -17,4 +17,15 @@ class WC_Formatting_Functions_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'DUMMYCOUPON', wc_sanitize_coupon_code( 'DUMMYCOUPON' ) );
 		$this->assertEquals( 'a&amp;a', wc_sanitize_coupon_code( 'a&a' ) );
 	}
+
+	/**
+	 * Test wc_format_postcode() function.
+	 */
+	public function test_wc_format_postcode() {
+		// IE postcode.
+		$this->assertEquals( 'D02 AF30', wc_format_postcode( 'D02AF30', 'IE' ) );
+
+		// PT postcode.
+		$this->assertEquals( '1000-205', wc_format_postcode( '1000205', 'PT' ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add legacy wc_format_postcode tests along with new tests for IE and PT postcodes.

### How to test the changes in this Pull Request:

1. Run the following unit tests `vendor/bin/phpunit tests/php/includes/wc-formatting-functions-test.php`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
