### PR TITLE
Change attribute slug length requirement and add wc_create_attribute tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-attribute-slug-len
+++ b/plugins/woocommerce/changelog/fix-wc-attribute-slug-len
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change attribute slug length requirement and add wc_create_attribute tests

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-products.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-products.php
@@ -1929,7 +1929,7 @@ class WC_API_Products extends WC_API_Resource {
 			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
 		}
 
-		if ( strlen( $slug ) >= 28 ) {
+		if ( strlen( $slug ) > 28 ) {
 			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), 400 );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {
 			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), $slug ), 400 );

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-products.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-products.php
@@ -2482,7 +2482,7 @@ class WC_API_Products extends WC_API_Resource {
 			throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_name', sprintf( __( 'Missing parameter %s', 'woocommerce' ), 'name' ), 400 );
 		}
 
-		if ( strlen( $slug ) >= 28 ) {
+		if ( strlen( $slug ) > 28 ) {
 			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), 400 );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {
 			throw new WC_API_Exception( 'woocommerce_api_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), $slug ), 400 );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
@@ -604,7 +604,7 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	protected function validate_attribute_slug( $slug, $new_data = true ) {
-		if ( strlen( $slug ) >= 28 ) {
+		if ( strlen( $slug ) > 28 ) {
 			/* translators: %s: slug being validated */
 			return new WP_Error( 'woocommerce_rest_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), array( 'status' => 400 ) );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -483,7 +483,7 @@ function wc_create_attribute( $args ) {
 	}
 
 	// Validate slug.
-	if ( strlen( $slug ) >= 28 ) {
+	if ( strlen( $slug ) > 28 ) {
 		/* translators: %s: attribute slug */
 		return new WP_Error( 'invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), array( 'status' => 400 ) );
 	} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {

--- a/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-attribute-functions-test.php
@@ -114,6 +114,61 @@ class WC_Attribute_Functions_Test extends \WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Test wc_create_attribute() function.
+	 */
+	public function test_wc_create_attribute() {
+		$ids = array();
+
+		$ids[] = wc_create_attribute( array( 'name' => 'Brand' ) );
+		$this->assertInternalType(
+			'int',
+			end( $ids ),
+			'wc_create_attribute should return a numeric id on success.'
+		);
+
+		$ids[] = wc_create_attribute( array( 'name' => str_repeat( 'n', 28 ) ) );
+		$this->assertInternalType(
+			'int',
+			end( $ids ),
+			'Attribute creation should succeed when its slug is 28 characters long.'
+		);
+
+		$err = wc_create_attribute( array() );
+		$this->assertEquals(
+			'missing_attribute_name',
+			$err->get_error_code(),
+			'Attributes should not be allowed to be created without specifying a name.'
+		);
+
+		$err = wc_create_attribute( array( 'name' => str_repeat( 'n', 29 ) ) );
+		$this->assertEquals(
+			'invalid_product_attribute_slug_too_long',
+			$err->get_error_code(),
+			'Attribute slugs should not be allowed to be over 28 characters long.'
+		);
+
+		$err = wc_create_attribute( array( 'name' => 'Cat' ) );
+		$this->assertEquals(
+			'invalid_product_attribute_slug_reserved_name',
+			$err->get_error_code(),
+			'Attributes should not be allowed to be created with reserved names.'
+		);
+
+		register_taxonomy( 'pa_brand', array( 'product' ), array( 'labels' => array( 'name' => 'Brand' ) ) );
+		$err = wc_create_attribute( array( 'name' => 'Brand' ) );
+		$this->assertEquals(
+			'invalid_product_attribute_slug_already_exists',
+			$err->get_error_code(),
+			'Duplicate attribute slugs should not be allowed to exist.'
+		);
+		unregister_taxonomy( 'pa_brand' );
+
+		foreach ( $ids as $id ) {
+			wc_delete_attribute( $id );
+		}
+	}
+
 	public function get_attribute_names_and_slugs() {
 		return [
 			[ 'Dash Me', 'dash-me' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In my understanding the limiting factor for attribute slug length is wp_term_taxonomy table's taxonomy column being varchar(32). String "pa_" is prepended to this attribute slug, so 28+3 single-byte characters will fit into the table.

Reason for making this change is that all error messages seem to refer that 28 (inclusive) is the limit for slug length ("_28 characters max_").

### How to test the changes in this Pull Request:

1. Run unit test `vendor/bin/phpunit tests/php/includes/wc-attribute-functions-test.php`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
