### PR TITLE
Fix typos in phpdocs and comments

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -877,7 +877,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @since  3.0.0
 	 * @param  int  $item_id ID of item to get.
-	 * @param  bool $load_from_db Prior to 3.2 this item was loaded direct from WC_Order_Factory, not this object. This param is here for backwards compatility with that. If false, uses the local items variable instead.
+	 * @param  bool $load_from_db Prior to 3.2 this item was loaded direct from WC_Order_Factory, not this object. This param is here for backwards compatibility with that. If false, uses the local items variable instead.
 	 * @return WC_Order_Item|false
 	 */
 	public function get_item( $item_id, $load_from_db = true ) {
@@ -1139,7 +1139,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$data_store = $coupon->get_data_store();
 
-		// Check specific for guest checkouts here as well since WC_Cart handles that seperately in check_customer_coupons.
+		// Check specific for guest checkouts here as well since WC_Cart handles that separately in check_customer_coupons.
 		if ( $data_store && 0 === $this->get_customer_id() ) {
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
 			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
@@ -1251,7 +1251,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 
 			/**
-			 * Allow developers to filter this coupon before it get's re-applied to the order.
+			 * Allow developers to filter this coupon before it gets re-applied to the order.
 			 *
 			 * @since 3.2.0
 			 */

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -2,7 +2,7 @@
 /**
  * Abstract payment gateway
  *
- * Hanldes generic payment gateway functionality which is extended by idividual payment gateways.
+ * Handles generic payment gateway functionality which is extended by individual payment gateways.
  *
  * @class WC_Payment_Gateway
  * @version 2.1.0

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -432,7 +432,7 @@ class WC_Admin_Notices {
 	 * @since 3.6.0
 	 */
 	public static function regenerating_lookup_table_notice() {
-		// See if this is still relevent.
+		// See if this is still relevant.
 		if ( ! wc_update_product_lookup_tables_is_running() ) {
 			self::remove_notice( 'regenerating_lookup_table' );
 			return;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-webhooks-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-webhooks-table-list.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 }
 
 /**
- * Webooks table list class.
+ * Webhooks table list class.
  */
 class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -275,7 +275,7 @@ class WC_Admin {
 	 *
 	 * @since 3.6.2
 	 *
-	 * @param array $args Scehduled action post type registration args.
+	 * @param array $args Scheduled action post type registration args.
 	 *
 	 * @return array
 	 */

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1154,7 +1154,7 @@ class WC_Helper {
 		/**
 		 * Check if plugins have WC headers, if not then clear cache and fetch again.
 		 * WC Headers will not be present if `wc_enable_wc_plugin_headers` hook was added after a `get_plugins` call -- for example when WC is activated/updated.
-		 * Also, get_plugins call is expensive so we should clear this cache very conservatively.
+		 * Also, get_plugins call is expensive, so we should clear this cache very conservatively.
 		 */
 		if ( ! empty( $plugins ) && ! array_key_exists( 'Woo', current( $plugins ) ) ) {
 			wp_clean_plugins_cache( false );

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -608,7 +608,7 @@ class WC_Product_CSV_Importer_Controller {
 	}
 
 	/**
-	 * Map columns using the user's lastest import mappings.
+	 * Map columns using the user's latest import mappings.
 	 *
 	 * @param  array $headers Header columns.
 	 * @return array

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -105,7 +105,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: coupon_code.
+	 * Render column: coupon_code.
 	 */
 	protected function render_coupon_code_column() {
 		global $post;
@@ -119,20 +119,20 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: type.
+	 * Render column: type.
 	 */
 	protected function render_type_column() {
 		echo esc_html( wc_get_coupon_type( $this->object->get_discount_type() ) );
 	}
 
 	/**
-	 * Render columm: amount.
+	 * Render column: amount.
 	 */
 	protected function render_amount_column() {
 		echo esc_html( wc_format_localized_price( $this->object->get_amount() ) );
 	}
 	/**
-	 * Render columm: products.
+	 * Render column: products.
 	 */
 	protected function render_products_column() {
 		$product_ids = $this->object->get_product_ids();
@@ -145,7 +145,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: usage_limit.
+	 * Render column: usage_limit.
 	 */
 	protected function render_usage_limit_column() {
 		$usage_limit = $this->object->get_usage_limit();
@@ -158,7 +158,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: usage.
+	 * Render column: usage.
 	 */
 	protected function render_usage_column() {
 		$usage_count = $this->object->get_usage_count();
@@ -173,7 +173,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: expiry_date.
+	 * Render column: expiry_date.
 	 */
 	protected function render_expiry_date_column() {
 		$expiry_date = $this->object->get_date_expires();
@@ -186,7 +186,7 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: description.
+	 * Render column: description.
 	 */
 	protected function render_description_column() {
 		echo wp_kses_post( $this->object->get_description() ? $this->object->get_description() : '&ndash;' );

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -169,7 +169,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: order_number.
+	 * Render column: order_number.
 	 */
 	protected function render_order_number_column() {
 		$buyer = '';
@@ -202,7 +202,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: order_status.
+	 * Render column: order_status.
 	 */
 	protected function render_order_status_column() {
 		$tooltip                 = '';
@@ -239,7 +239,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: order_date.
+	 * Render column: order_date.
 	 */
 	protected function render_order_date_column() {
 		$order_timestamp = $this->object->get_date_created() ? $this->object->get_date_created()->getTimestamp() : '';
@@ -268,7 +268,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: order_total.
+	 * Render column: order_total.
 	 */
 	protected function render_order_total_column() {
 		if ( $this->object->get_payment_method_title() ) {
@@ -280,7 +280,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: wc_actions.
+	 * Render column: wc_actions.
 	 */
 	protected function render_wc_actions_column() {
 		echo '<p>';
@@ -315,7 +315,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: billing_address.
+	 * Render column: billing_address.
 	 */
 	protected function render_billing_address_column() {
 		$address = $this->object->get_formatted_billing_address();
@@ -333,7 +333,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	}
 
 	/**
-	 * Render columm: shipping_address.
+	 * Render column: shipping_address.
 	 */
 	protected function render_shipping_address_column() {
 		$address = $this->object->get_formatted_shipping_address();

--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -68,7 +68,7 @@ class WC_Marketplace_Updater {
 	}
 
 	/**
-	 * Used when an error has occured when fetching suggestions.
+	 * Used when an error has occurred when fetching suggestions.
 	 * Re-schedules the job earlier than the main weekly one.
 	 */
 	public static function retry() {

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -411,7 +411,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			$this->report_data->total_shipping_tax_refunded += floatval( $value->total_shipping_tax < 0 ? $value->total_shipping_tax * -1 : $value->total_shipping_tax );
 			$this->report_data->total_shipping_refunded     += floatval( $value->total_shipping < 0 ? $value->total_shipping * -1 : $value->total_shipping );
 
-			// Only applies to parial.
+			// Only applies to partial.
 			if ( isset( $value->order_item_count ) ) {
 				$this->report_data->refunded_order_items += floatval( $value->order_item_count < 0 ? $value->order_item_count * -1 : $value->order_item_count );
 			}
@@ -422,7 +422,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		$this->report_data->total_shipping     = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_shipping' ) ) - $this->report_data->total_shipping_refunded, 2 );
 		$this->report_data->total_shipping_tax = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_shipping_tax' ) ) - $this->report_data->total_shipping_tax_refunded, 2 );
 
-		// Total the refunds and sales amounts. Sales subract refunds. Note - total_sales also includes shipping costs.
+		// Total the refunds and sales amounts. Sales subtract refunds. Note - total_sales also includes shipping costs.
 		$this->report_data->total_sales = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_sales' ) ) - $this->report_data->total_refunds, 2 );
 		$this->report_data->net_sales   = wc_format_decimal( $this->report_data->total_sales - $this->report_data->total_shipping - max( 0, $this->report_data->total_tax ) - max( 0, $this->report_data->total_shipping_tax ), 2 );
 

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-date.php
@@ -104,7 +104,7 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 			),
 		);
 
-		// We exlude on-hold orders are they are still pending payment.
+		// We exclude on-hold orders are they are still pending payment.
 		$tax_rows_orders = $this->get_order_report_data(
 			array(
 				'data'         => $query_data,

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		/**
 		 * Add this page to settings.
 		 *
-		 * @param array $pages The setings array where we'll add ourselves.
+		 * @param array $pages The settings array where we'll add ourselves.
 		 *
 		 * @return mixed
 		 */

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-tax.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-tax.php
@@ -309,7 +309,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.NonceVerification.Missing
 		$posted_countries = wc_clean( wp_unslash( $_POST['tax_rate_country'] ) );
 
-		// get the tax rate id of the first submited row.
+		// get the tax rate id of the first submitted row.
 		$first_tax_rate_id = key( $posted_countries );
 
 		// get the order position of the first tax rate id.

--- a/plugins/woocommerce/includes/class-wc-api.php
+++ b/plugins/woocommerce/includes/class-wc-api.php
@@ -83,7 +83,7 @@ class WC_API extends WC_Legacy_API {
 	 *
 	 * @since 3.7.0
 	 * @param string $endpoint Endpoint.
-	 * @param array  $params Params to passwith request.
+	 * @param array  $params Params to pass with request.
 	 * @return array|\WP_Error
 	 */
 	public function get_endpoint_data( $endpoint, $params = array() ) {

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -422,7 +422,7 @@ final class WC_Cart_Totals {
 			} else {
 				/**
 				 * If we want all customers to pay the same price on this store, we should not remove base taxes from a VAT exempt user's price,
-				 * but just the relevent tax rate. See issue #20911.
+				 * but just the relevant tax rate. See issue #20911.
 				 */
 				$base_tax_rates = $item->tax_rates;
 			}
@@ -864,7 +864,7 @@ final class WC_Cart_Totals {
 	protected function calculate_totals() {
 		$this->set_total( 'total', NumberUtil::round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ), 0 ) );
 		$items_tax = array_sum( $this->get_merged_taxes( false, array( 'items' ) ) );
-		// Shipping and fee taxes are rounded seperately because they were entered excluding taxes (as opposed to item prices, which may or may not be including taxes depending upon settings).
+		// Shipping and fee taxes are rounded separately because they were entered excluding taxes (as opposed to item prices, which may or may not be including taxes depending upon settings).
 		$shipping_and_fee_taxes = NumberUtil::round( array_sum( $this->get_merged_taxes( false, array( 'fees', 'shipping' ) ) ), wc_get_price_decimals() );
 		$this->cart->set_total_tax( $items_tax + $shipping_and_fee_taxes );
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -626,7 +626,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	/**
 	 * Empties the cart and optionally the persistent cart too.
 	 *
-	 * @param bool $clear_persistent_cart Should the persistant cart be cleared too. Defaults to true.
+	 * @param bool $clear_persistent_cart Should the persistent cart be cleared too. Defaults to true.
 	 */
 	public function empty_cart( $clear_persistent_cart = true ) {
 

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -263,7 +263,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Get the "indvidual use" checkbox status.
+	 * Get the "individual use" checkbox status.
 	 *
 	 * @since  3.0.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -540,7 +540,7 @@ class WC_Discounts {
 	 * until the amount is expired, discounting 1 cent at a time.
 	 *
 	 * @since 3.2.0
-	 * @param  WC_Coupon $coupon Coupon object if appliable. Passed through filters.
+	 * @param  WC_Coupon $coupon Coupon object if applicable. Passed through filters.
 	 * @param  array     $items_to_apply Array of items to apply the coupon to.
 	 * @param  int       $amount Fixed discount amount to apply.
 	 * @return int Total discounted.

--- a/plugins/woocommerce/includes/class-wc-logger.php
+++ b/plugins/woocommerce/includes/class-wc-logger.php
@@ -143,7 +143,7 @@ class WC_Logger implements WC_Logger_Interface {
 
 			foreach ( $this->handlers as $handler ) {
 				/**
-				 * Filter the logging message. Returning null will prevent logging from occuring since 5.3.
+				 * Filter the logging message. Returning null will prevent logging from occurring since 5.3.
 				 *
 				 * @since 3.1
 				 * @param string $message Log message.

--- a/plugins/woocommerce/includes/class-wc-privacy-erasers.php
+++ b/plugins/woocommerce/includes/class-wc-privacy-erasers.php
@@ -95,14 +95,14 @@ class WC_Privacy_Erasers {
 		 * Allow extensions to remove data for this customer and adjust the response.
 		 *
 		 * @since 3.4.0
-		 * @param array    $response Array resonse data. Must include messages, num_items_removed, num_items_retained, done.
+		 * @param array    $response Array response data. Must include messages, num_items_removed, num_items_retained, done.
 		 * @param WC_Order $order A customer object.
 		 */
 		return apply_filters( 'woocommerce_privacy_erase_personal_data_customer', $response, $customer );
 	}
 
 	/**
-	 * Finds and erases data which could be used to identify a person from WooCommerce data assocated with an email address.
+	 * Finds and erases data which could be used to identify a person from WooCommerce data associated with an email address.
 	 *
 	 * Orders are erased in blocks of 10 to avoid timeouts.
 	 *
@@ -350,7 +350,7 @@ class WC_Privacy_Erasers {
 			wc_delete_order_note( $note->id );
 		}
 
-		// Add note that this event occured.
+		// Add note that this event occurred.
 		$order->add_order_note( __( 'Personal data removed.', 'woocommerce' ) );
 
 		/**
@@ -406,7 +406,7 @@ class WC_Privacy_Erasers {
 		 * Allow extensions to remove data for tokens and adjust the response.
 		 *
 		 * @since 3.4.0
-		 * @param array $response Array resonse data. Must include messages, num_items_removed, num_items_retained, done.
+		 * @param array $response Array response data. Must include messages, num_items_removed, num_items_retained, done.
 		 * @param array $tokens   Array of tokens.
 		 */
 		return apply_filters( 'woocommerce_privacy_erase_personal_data_tokens', $response, $tokens );

--- a/plugins/woocommerce/includes/class-wc-privacy.php
+++ b/plugins/woocommerce/includes/class-wc-privacy.php
@@ -36,7 +36,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		// Cleanup orders daily - this is a callback on a daily cron event.
 		add_action( 'woocommerce_cleanup_personal_data', array( $this, 'queue_cleanup_personal_data' ) );
 
-		// Handles custom anonomization types not included in core.
+		// Handles custom anonymization types not included in core.
 		add_filter( 'wp_privacy_anonymize_data', array( $this, 'anonymize_custom_data_types' ), 10, 3 );
 
 		// When this is fired, data is removed in a given order. Called from bulk actions.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -350,7 +350,7 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Returns the session.
 	 *
-	 * @param string $customer_id Custo ID.
+	 * @param string $customer_id Customer ID.
 	 * @param mixed  $default Default session value.
 	 * @return string|array
 	 */

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -485,7 +485,7 @@ class WC_Tax {
 	}
 
 	/**
-	 * Get's an arrau of matching rates from location and tax class. $customer parameter is used to preserve backward compatibility for filter.
+	 * Get's an array of matching rates from location and tax class. $customer parameter is used to preserve backward compatibility for filter.
 	 *
 	 * @param string $tax_class Tax class to get rates for.
 	 * @param array  $location  Location to compute rates for. Should be in form: array( country, state, postcode, city).
@@ -1224,7 +1224,7 @@ class WC_Tax {
 
 		// Drop the locations into the rates array.
 		foreach ( $locations as $location ) {
-			// Don't set them for unexistent rates.
+			// Don't set them for nonexistent rates.
 			if ( ! isset( $rates[ $location->tax_rate_id ] ) ) {
 				continue;
 			}

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-download-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-download-data-store.php
@@ -348,7 +348,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 	/**
 	 * Get array of download ids by specified args.
 	 *
-	 * @param  array $args Arguments to filter downloads. $args['return'] accepts the following values: 'objects' (default), 'ids' or a comma separeted list of fields (for example: 'order_id,user_id,user_email').
+	 * @param  array $args Arguments to filter downloads. $args['return'] accepts the following values: 'objects' (default), 'ids' or a comma separated list of fields (for example: 'order_id,user_id,user_email').
 	 * @return array Can be an array of permission_ids, an array of WC_Customer_Download objects or an array of arrays containing specified fields depending on the value of $args['return'].
 	 */
 	public function get_downloads( $args = array() ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -310,7 +310,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	 * Return a zone ID from an instance ID.
 	 *
 	 * @since  3.0.0
-	 * @param  int $id Instnace ID.
+	 * @param  int $id Instance ID.
 	 * @return int
 	 */
 	public function get_zone_id_by_instance_id( $id ) {

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -606,7 +606,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse download file urls, we should allow shortcodes here.
 	 *
-	 * Allow shortcodes if present, othersiwe esc_url the value.
+	 * Allow shortcodes if present, otherwise esc_url the value.
 	 *
 	 * @param string $value Field value.
 	 *

--- a/plugins/woocommerce/includes/interfaces/class-wc-shipping-zone-data-store-interface.php
+++ b/plugins/woocommerce/includes/interfaces/class-wc-shipping-zone-data-store-interface.php
@@ -44,7 +44,7 @@ interface WC_Shipping_Zone_Data_Store_Interface {
 	/**
 	 * Delete a method instance.
 	 *
-	 * @param int $instance_id Intance ID.
+	 * @param int $instance_id Instance ID.
 	 */
 	public function delete_method( $instance_id );
 

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-api.php
@@ -274,14 +274,14 @@ class WC_Legacy_API {
 	/**
 	 * Rest API Init.
 	 *
-	 * @deprecated 3.7.0 - REST API clases autoload.
+	 * @deprecated 3.7.0 - REST API classes autoload.
 	 */
 	public function rest_api_init() {}
 
 	/**
 	 * Include REST API classes.
 	 *
-	 * @deprecated 3.7.0 - REST API clases autoload.
+	 * @deprecated 3.7.0 - REST API classes autoload.
 	 */
 	public function rest_api_includes() {
 		$this->rest_api_init();

--- a/plugins/woocommerce/includes/queue/class-wc-action-queue.php
+++ b/plugins/woocommerce/includes/queue/class-wc-action-queue.php
@@ -114,7 +114,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	}
 
 	/**
-	 * Get the date and time for the next scheduled occurence of an action with a given hook
+	 * Get the date and time for the next scheduled occurrence of an action with a given hook
 	 * (an optionally that matches certain args and group), if any.
 	 *
 	 * @param string $hook The hook that the job will trigger.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php
@@ -210,7 +210,7 @@ class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
 		/**
 		 * Filter the location list returned from the API.
 		 *
-		 * Allows modification of the loction data right before it is returned.
+		 * Allows modification of the location data right before it is returned.
 		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param array            $item     The original list of continent(s), countries, and states.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php
@@ -157,7 +157,7 @@ class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
 		/**
 		 * Filter the states list for a country returned from the API.
 		 *
-		 * Allows modification of the loction data right before it is returned.
+		 * Allows modification of the location data right before it is returned.
 		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param array            $data     The original country's states list.

--- a/plugins/woocommerce/includes/rest-api/Package.php
+++ b/plugins/woocommerce/includes/rest-api/Package.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Deprecated notice: This class is deprecated as of version 4.5.0. WooCommerce API is now part of core and not packaged seperately.
+ * Deprecated notice: This class is deprecated as of version 4.5.0. WooCommerce API is now part of core and not packaged separately.
  *
  * Returns information about the package and handles init.
  *

--- a/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -335,7 +335,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	 *
 	 * @deprecated 2.4.0
 	 * @param  float  $cost Cost.
-	 * @param  float  $percent_adjustment Percent adjusment.
+	 * @param  float  $percent_adjustment Percent adjustment.
 	 * @param  string $percent_operator Percent operator.
 	 * @param  float  $base_price Base price.
 	 * @return float

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-client.php
@@ -41,7 +41,7 @@ class WC_Tracks_Client {
 	}
 
 	/**
-	 * Check if identiy cookie is set, if not set it.
+	 * Check if identity cookie is set, if not set it.
 	 *
 	 * @return void
 	 */
@@ -125,7 +125,7 @@ class WC_Tracks_Client {
 	}
 
 	/**
-	 * Create a timestap representing milliseconds since 1970-01-01
+	 * Create a timestamp representing milliseconds since 1970-01-01
 	 *
 	 * @return string A string representing a timestamp.
 	 */

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -72,7 +72,7 @@ function wc_get_attribute_taxonomies() {
 	 */
 	$raw_attribute_taxonomies = (array) array_filter( apply_filters( 'woocommerce_attribute_taxonomies', $raw_attribute_taxonomies ) );
 
-	// Index by ID for easer lookups.
+	// Index by ID for easier lookups.
 	$attribute_taxonomies = array();
 
 	foreach ( $raw_attribute_taxonomies as $result ) {

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -89,7 +89,7 @@ function wc_get_raw_referer() {
  * Add to cart messages.
  *
  * @param int|array $products Product ID list or single product ID.
- * @param bool      $show_qty Should qty's be shown? Added in 2.6.0.
+ * @param bool      $show_qty Should quantities be shown? Added in 2.6.0.
  * @param bool      $return   Return message rather than add it.
  *
  * @return mixed

--- a/plugins/woocommerce/includes/wc-rest-functions.php
+++ b/plugins/woocommerce/includes/wc-rest-functions.php
@@ -169,7 +169,7 @@ function wc_rest_set_uploaded_image_as_attachment( $upload, $id = 0 ) {
  * Validate reports request arguments.
  *
  * @since 2.6.0
- * @param mixed           $value   Value to valdate.
+ * @param mixed           $value   Value to validate.
  * @param WP_REST_Request $request Request instance.
  * @param string          $param   Param to validate.
  * @return WP_Error|boolean

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @param  int|WC_Product $product        Product ID or product instance.
  * @param  int|null       $stock_quantity Stock quantity.
- * @param  string         $operation      Type of opertion, allows 'set', 'increase' and 'decrease'.
+ * @param  string         $operation      Type of operation, allows 'set', 'increase' and 'decrease'.
  * @param  bool           $updating       If true, the product object won't be saved here as it will be updated later.
  * @return bool|int|null
  */

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -789,7 +789,7 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 }
 
 /**
- * Get the terms and conditons page ID.
+ * Get the terms and conditions page ID.
  *
  * @since 3.4.0
  * @return int
@@ -823,7 +823,7 @@ function wc_terms_and_conditions_checkbox_enabled() {
 }
 
 /**
- * Get the terms and conditons checkbox text, if set.
+ * Get the terms and conditions checkbox text, if set.
  *
  * @since 3.4.0
  * @return string
@@ -1408,15 +1408,15 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	 */
 	function woocommerce_get_product_thumbnail( $size = 'woocommerce_thumbnail', $attr = array(), $placeholder = true ) {
 		global $product;
-		
+
 		if ( ! is_array( $attr ) ) {
 			$attr = array();
 		}
-		
+
 		if ( ! is_bool( $placeholder ) ) {
 			$placeholder = true;
 		}
-		
+
 		$image_size = apply_filters( 'single_product_archive_thumbnail_size', $size );
 
 		return $product ? $product->get_image( $image_size, $attr, $placeholder ) : '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

> Dev - Fix typos in phpdocs and comments.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
