### PR TITLE
Add database indices for the product attributes lookup table

### DIFF
--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2345,13 +2345,15 @@ function wc_update_600_db_version() {
  * @return false Always false, since the LookupDataStore class handles all the data filling process.
  */
 function wc_update_630_create_product_attributes_lookup_table() {
-	$data_store = wc_get_container()->get( LookupDataStore::class );
+	$data_store       = wc_get_container()->get( LookupDataStore::class );
+	$data_regenerator = wc_get_container()->get( DataRegenerator::class );
+
 	if ( $data_store->check_lookup_table_exists() ) {
-		return false;
+		$data_regenerator->maybe_create_table_indices();
+	} else {
+		$data_regenerator->initiate_regeneration();
 	}
 
-	$data_regenerator = wc_get_container()->get( DataRegenerator::class );
-	$data_regenerator->initiate_regeneration();
 	return false;
 }
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -141,6 +141,8 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
+		$this->maybe_create_table_indices();
+
 		$last_existing_product_id =
 			WC()->call_function(
 				'wc_get_products',
@@ -163,6 +165,41 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 		update_option( 'woocommerce_attribute_lookup_processed_count', 0 );
 
 		return true;
+	}
+
+	/**
+	 * Create the indices for the lookup table unless they exist already.
+	 */
+	public function maybe_create_table_indices() {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query(
+			"
+IF (SELECT COUNT(1)
+	FROM INFORMATION_SCHEMA.STATISTICS
+	WHERE table_schema=' " . $wpdb->dbname . "'
+	AND table_name='" . $this->lookup_table_name . "'
+	AND index_name='product_or_parent_id_term_id')=0
+THEN
+	ALTER TABLE wp_wc_product_attributes_lookup
+	ADD INDEX product_or_parent_id_term_id (product_or_parent_id, term_id);
+END IF;"
+		);
+
+		$wpdb->query(
+			"
+IF (SELECT COUNT(1)
+	FROM INFORMATION_SCHEMA.STATISTICS
+	WHERE table_schema=' " . $wpdb->dbname . "'
+	AND table_name='" . $this->lookup_table_name . "'
+	AND index_name='is_variation_attribute_term_id')=0
+THEN
+	ALTER TABLE wp_wc_product_attributes_lookup
+	ADD INDEX is_variation_attribute_term_id (is_variation_attribute, term_id);
+END IF;"
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**
@@ -247,7 +284,6 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 	 * Cleanup/final option setup after the regeneration has been completed.
 	 *
 	 * @param bool $enable_usage Whether the table usage should be enabled or not.
-	 *
 	 */
 	private function finalize_regeneration( bool $enable_usage ) {
 		delete_option( 'woocommerce_attribute_lookup_last_product_id_to_process' );

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -174,31 +174,39 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 		global $wpdb;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( 'DROP PROCEDURE IF EXISTS __create_wc_product_attributes_lookup_indices;' );
 		$wpdb->query(
 			"
+CREATE PROCEDURE __create_wc_product_attributes_lookup_indices()
+
+BEGIN
+
 IF (SELECT COUNT(1)
 	FROM INFORMATION_SCHEMA.STATISTICS
-	WHERE table_schema=' " . $wpdb->dbname . "'
+	WHERE table_schema='" . $wpdb->dbname . "'
 	AND table_name='" . $this->lookup_table_name . "'
 	AND index_name='product_or_parent_id_term_id')=0
 THEN
-	ALTER TABLE wp_wc_product_attributes_lookup
+	ALTER TABLE " . $this->lookup_table_name . "
 	ADD INDEX product_or_parent_id_term_id (product_or_parent_id, term_id);
-END IF;"
-		);
+END IF;
 
-		$wpdb->query(
-			"
 IF (SELECT COUNT(1)
 	FROM INFORMATION_SCHEMA.STATISTICS
-	WHERE table_schema=' " . $wpdb->dbname . "'
+	WHERE table_schema='" . $wpdb->dbname . "'
 	AND table_name='" . $this->lookup_table_name . "'
 	AND index_name='is_variation_attribute_term_id')=0
 THEN
-	ALTER TABLE wp_wc_product_attributes_lookup
+	ALTER TABLE " . $this->lookup_table_name . '
 	ADD INDEX is_variation_attribute_term_id (is_variation_attribute, term_id);
-END IF;"
+END IF;
+
+END;
+'
 		);
+
+		$wpdb->query( 'CALL __create_wc_product_attributes_lookup_indices();' );
+		$wpdb->query( 'DROP PROCEDURE IF EXISTS __create_wc_product_attributes_lookup_indices;' );
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add two database indices to the product attributes lookup table, these are intended to improve the performance of the table querying when there's a lot of products and attributes, see https://github.com/woocommerce/woocommerce/issues/31688.

The indices will be created during the database migration to v6.3, regardless of whether the lookup table already existed at that point or not.

Closes #31688.

### How to test the changes in this Pull Request:

The first scenario to test is a new install or an upgrade from v6.2 or earlier, where the lookup table doesn't exist. In order to simulate this scenario if you are already in the current `trunk` where the lookup table exists and there's no UI to delete it anymore, this you can do the following:

1. Run this command to downgrade the database version:

```bash
wp option set woocommerce_db_version 6.0.0
```

2. Temporarily modify the `delete_all_attributes_lookup_data` method in the `DataRegenerator` class so that it's public.

3. Run this command to delete the lookup table and all the related information:

```bash
wp eval 'wc_get_container()->get(\Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator::class)->delete_all_attributes_lookup_data();'
```

Once that's done, or if you start fresh, continue with the following:

4. Run the following command, it should give no results as the indices don't exist yet:

```bash
wp db query "SELECT index_name,column_name FROM INFORMATION_SCHEMA.STATISTICS WHERE table_name='$(wp db prefix)wc_product_attributes_lookup' AND table_schema='$(wp eval 'echo DB_NAME;')'"
```

5. Go to your WooCommerce admin area, you'll see a "Database update required" banner, click the "Update database" button.

6. Wait until the database update finishes. Then run the command from 4 again and this time you should get four entries:

```
+--------------------------------+------------------------+
| index_name                     | column_name            |
+--------------------------------+------------------------+
| product_or_parent_id_term_id   | product_or_parent_id   |
| product_or_parent_id_term_id   | term_id                |
| is_variation_attribute_term_id | is_variation_attribute |
| is_variation_attribute_term_id | term_id                |
+--------------------------------+------------------------+
```

The second scenario tests the update when the lookup table already exists (it was created via tools page), in this case the database migration won't try to recreate the table but it will go and create the indices. So, coming from the previous scenario, or having created the tables via a previous migration to 6.3 or via the dedicated tool:

7. Run the following commands to make sure that the indices don't exist (they will fail if the indices don't actually exist); after you do this run the command from 4 again to be sure:

```bash
wp db query "ALTER TABLE $(wp db prefix)wc_product_attributes_lookup DROP INDEX product_or_parent_id_term_id;"
wp db query "ALTER TABLE $(wp db prefix)wc_product_attributes_lookup DROP INDEX is_variation_attribute_term_id;"
```

8. Repeat steps 1, 5 and 6. The table won't have been created again (if it had data before the database update, it will still have the same data), but the indices will be in place.

The last scenario proves that the database update is safe when the table AND the indices already exist, too.  So coming from the previous scenario, just repeat steps 1, 5 and 6 again; everything should proceed smoothly this time too.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enhancement - Add indices to the product attributes lookup table.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
