### PR TITLE
API: Orders: Add payment_url

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -257,7 +257,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function get_formatted_item_data( $order ) {
-		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds' );
+		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url' );
 		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
 		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
 		// These fields are dependent on other fields.
@@ -316,6 +316,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							'total'  => '-' . wc_format_decimal( $refund->get_amount(), $this->request['dp'] ),
 						);
 					}
+					break;
+				case 'payment_url':
+					$data['payment_url'] = $order->get_checkout_payment_url();
 					break;
 			}
 		}
@@ -382,6 +385,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			'fee_lines',
 			'coupon_lines',
 			'refunds',
+			'payment_url',
 		);
 
 		$data = array_intersect_key( $data, array_flip( $allowed_fields ) );
@@ -1773,6 +1777,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 						),
 					),
+				),
+				'payment_url' => array(
+					'description' => __( 'Order payment URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'set_paid'             => array(
 					'description' => __( 'Define if the order is paid. It will set the status to processing and reduce stock items.', 'woocommerce' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -769,7 +769,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 42, count( $properties ) );
+		$this->assertEquals( 43, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -1139,7 +1139,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 42, count( $properties ) );
+		$this->assertEquals( 43, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -66,6 +66,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			'coupon_lines',
 			'currency_symbol',
 			'refunds',
+			'payment_url',
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -66,6 +66,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 			'coupon_lines',
 			'currency_symbol',
 			'refunds',
+			'payment_url',
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the payment URL to the order response if we request it. This is
helpful for sharing payment links from the apps.

### How to test the changes in this Pull Request:

1. GET /wp-json/wc/v3/orders/:id
2. Observe that the payment_url field is returned in the response.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Make the payment_url field available via the REST API's orders endpoint.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
