### PR TITLE
bump e2e-environment to WP 5.9.X default

### DIFF
--- a/packages/js/e2e-environment/bin/docker-compose.sh
+++ b/packages/js/e2e-environment/bin/docker-compose.sh
@@ -10,7 +10,7 @@ if [[ $1 ]]; then
 	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
 		export WORDPRESS_VERSION=$WP_VERSION
 	else
-		export WORDPRESS_VERSION="5.8.0"
+		export WORDPRESS_VERSION="5.9"
 	fi
 
 	if [[ $LATEST_WP_VERSION_MINUS ]]; then


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the fallback WP version for the docker container to be 5.9.X. 

### How to test the changes in this Pull Request:

1. Review change
2. Run `pnpx wc-e2e docker:up`
