### PR TITLE
use OS path separator in installFiles

### DIFF
--- a/packages/js/e2e-core-tests/installFiles/index.js
+++ b/packages/js/e2e-core-tests/installFiles/index.js
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+
+const buildPath = ( filename ) => `installFiles${path.sep}${filename}`;
+
 module.exports = {
-	testSpecs: 'installFiles/scaffold-tests.json',
-	defaultJson: 'installFiles/default-test-config.json',
-	initializeSh: 'installFiles/initialize.sh.default',
+	testSpecs: buildPath( 'scaffold-tests.json' ),
+	defaultJson: buildPath( 'default-test-config.json' ),
+	initializeSh: buildPath( 'initialize.sh.default' ),
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the `installFiles` paths in the e2e-core-tests package to use the current OS separator.

Closes #31456 .

### How to test the changes in this Pull Request:

1. Move the `tests` folder to `tests-x`
2. Run `pnpx wc-e2e install @woocommerce/e2e-core-tests`
3. Check that the tests files were created correctly.
```
$ npx wc-e2e install @woocommerce/e2e-core-tests
Created sample test configuration to 'tests/e2e/config/default-woocommerce.e2e-core-tests.json'.
Creating folder /Users/ronrennick/Sites/solaris/wccom-product-compatibility/tests/e2e/docker
Created sample test container initialization script to 'tests/e2e/docker/woocommerce.e2e-core-tests.sh'.
Creating folder /Users/ronrennick/Sites/solaris/wccom-product-compatibility/tests/e2e/specs
Creating folder /Users/ronrennick/Sites/solaris/wccom-product-compatibility/tests/e2e/specs/front-end
Writing tests/e2e/specs/front-end/cart-begin.test.js
Writing tests/e2e/specs/front-end/cart-calculate-shipping.test.js
Writing tests/e2e/specs/front-end/cart-coupons.test.js
Writing tests/e2e/specs/front-end/checkout-begin.test.js
Writing tests/e2e/specs/front-end/checkout-coupons.test.js
Writing tests/e2e/specs/front-end/checkout-create-account.test.js
Writing tests/e2e/specs/front-end/checkout-login-account.test.js
Writing tests/e2e/specs/front-end/my-account-create-account.test.js
Writing tests/e2e/specs/front-end/my-account-pay-order.test.js
Writing tests/e2e/specs/front-end/my-account.test.js
Writing tests/e2e/specs/front-end/order-email-receiving.test.js
Writing tests/e2e/specs/front-end/product-browse-search-sort.test.js
Writing tests/e2e/specs/front-end/single-product-page.test.js
Writing tests/e2e/specs/front-end/variable-product-updates.test.js
Creating folder /Users/ronrennick/Sites/solaris/wccom-product-compatibility/tests/e2e/specs/rest-api
Writing tests/e2e/specs/rest-api/api.test.js
Creating folder /Users/ronrennick/Sites/solaris/wccom-product-compatibility/tests/e2e/specs/wp-admin
Writing tests/e2e/specs/wp-admin/create-coupon.test.js
Writing tests/e2e/specs/wp-admin/create-order.test.js
Writing tests/e2e/specs/wp-admin/create-shipping-classes.test.js
Writing tests/e2e/specs/wp-admin/create-shipping-zones.test.js
Writing tests/e2e/specs/wp-admin/create-simple-product.test.js
Writing tests/e2e/specs/wp-admin/create-variable-product.test.js
Writing tests/e2e/specs/wp-admin/order-coupon.test.js
Writing tests/e2e/specs/wp-admin/order-customer-payment-page.test.js
Writing tests/e2e/specs/wp-admin/order-edit.test.js
Writing tests/e2e/specs/wp-admin/order-emails.test.js
Writing tests/e2e/specs/wp-admin/order-refund.test.js
Writing tests/e2e/specs/wp-admin/order-searching.test.js
Writing tests/e2e/specs/wp-admin/order-status-filters.test.js
Writing tests/e2e/specs/wp-admin/product-edit.test.js
Writing tests/e2e/specs/wp-admin/product-import-csv.test.js
Writing tests/e2e/specs/wp-admin/product-search.test.js
Writing tests/e2e/specs/wp-admin/update-general-settings.test.js
Writing tests/e2e/specs/wp-admin/update-product-settings.test.js
Writing tests/e2e/specs/wp-admin/update-tax-settings.test.js
Writing tests/e2e/specs/wp-admin/wccom-connect.test.js
```
4. Restore the original `tests` folder
