### PR TITLE
update slack export to build version

### DIFF
--- a/packages/js/e2e-environment/index.js
+++ b/packages/js/e2e-environment/index.js
@@ -5,7 +5,7 @@ const babelConfig = require( './babel.config' );
 const esLintConfig = require( './.eslintrc.js' );
 const allE2EConfig = require( './config' );
 const allE2EUtils = require( './utils' );
-const slackUtils = require( './src/slack' );
+const slackUtils = require( './build/slack' );
 /**
  * External dependencies
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes the missing version bumps in package.json and changelog in #31846.

For the original issue it updates the main index to reference the slack utilities in the build folder instead of the source folder.

Closes #31748 .

### How to test the changes in this Pull Request:

1. Run E2E tests locally.

