### PR TITLE
Fire action hook when Woocommerce reads an invalid product

### DIFF
--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -164,6 +164,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$post_object = get_post( $product->get_id() );
 
 		if ( ! $product->get_id() || ! $post_object || 'product' !== $post_object->post_type ) {
+			do_action( 'woocommerce_read_invalid_product', $product );
 			throw new Exception( __( 'Invalid product.', 'woocommerce' ) );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Changes: adding an action hook immediately before an exception is thrown when reading an invalid product in the product data store.
Reason: Need to check if there is orphaned data for this product elsewhere and act on it appropriately. For us, we have orphaned products in old carts in wp_usermeta.

Closes # .

### How to test the changes in this Pull Request:

1. Log in with a new or existing user to the front-end of a Woocommerce site
2. Add items to your cart
3. Log out
4. Delete one of the products in the cart from the wp_posts and wp_postmeta tables only
5. Log into the front-end with the same account as in step 1. 
6. Go to the cart page. The action should fire.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Added an action hook immediately before an exception is thrown when reading an invalid product in the product data store.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
