### PR TITLE
Fix wc_get_price_excluding_tax ignoring the woocommerce_adjust_non_base_location_prices filter.

### DIFF
--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -1085,10 +1085,10 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 	if ( $product->is_taxable() && wc_prices_include_tax() ) {
 		$order       = ArrayUtil::get_value_or_default( $args, 'order' );
 		$customer_id = $order ? $order->get_customer_id() : 0;
-		if ( apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) || ! $customer_id ) {
+		if ( apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
 			$tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		} else {
-			$customer  = wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Customer::class, $customer_id );
+			$customer  = $customer_id ? wc_get_container()->get( LegacyProxy::class )->get_instance_of( WC_Customer::class, $customer_id ) : null;
 			$tax_rates = WC_Tax::get_rates( $product->get_tax_class(), $customer );
 		}
 		$remove_taxes = WC_Tax::calc_tax( $line_price, $tax_rates, true );

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -105,6 +105,10 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 				$this->assertEquals( $order->get_customer_id(), $customer_id_passed_to_wc_customer_constructor );
 				$this->assertFalse( $get_base_rates_invoked );
 				$this->assertSame( $customer, $customer_passed_to_get_rates );
+			} elseif ( ! $customer_id && $set_filter ) {
+				$this->assertFalse( $customer_id_passed_to_wc_customer_constructor );
+				$this->assertNull( $customer_passed_to_get_rates );
+				$this->assertFalse( $get_base_rates_invoked );
 			} else {
 				$this->assertFalse( $customer_id_passed_to_wc_customer_constructor );
 				$this->assertFalse( $customer_passed_to_get_rates );
@@ -114,8 +118,8 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 			wc_get_price_excluding_tax( $product );
 
 			$this->assertFalse( $customer_id_passed_to_wc_customer_constructor );
-			$this->assertFalse( $customer_passed_to_get_rates );
-			$this->assertTrue( $get_base_rates_invoked );
+			$this->assertEquals( $set_filter ? null : false, $customer_passed_to_get_rates );
+			$this->assertEquals( ! $set_filter, $get_base_rates_invoked );
 		}
 
 		// phpcs:enable Squiz.Commenting


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The commit [#d98112e](https://github.com/woocommerce/woocommerce/commit/d98112e0140724a9ad5c00991211a1901e7b7525) broke the `wc_get_price_excluding_tax` function when the `woocommerce_adjust_non_base_location_prices` filter returns false.

The function now only removes the taxes of the customer location if an order is passed as a parameter, ignoring the `woocommerce_adjust_non_base_location_prices` filter.

The issue causes that for the configuration: Price entered with tax, Display price in the shop "exclude tax," and `woocommerce_adjust_non_base_location_prices` set to false, the shop displays incorrect prices.

This PR fixes the issue by setting the customer to null when no order is passed as a parameter. 
Fix #31721 
The PR also keep the functionality introduced in the PR [#30692](https://github.com/woocommerce/woocommerce/pull/30692)

### How to test the changes in this Pull Request:

1. Follow the steps of #31721
2. Follow the steps of the PR [#30692](https://github.com/woocommerce/woocommerce/pull/30692)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed: wc_get_price_excluding_tax does not remove the customer location taxes when the filter woocommerce_adjust_non_base_location_prices returns false.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
