### PR TITLE
Removed duplicate height style in email-styles template

### DIFF
--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -224,6 +224,5 @@ img {
 	vertical-align: middle;
 	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
 	max-width: 100%;
-	height: auto;
 }
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request: Simply to remove a duplicate style spotted in the email-styles template CSS.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Mark completed items with an [x] -->

### Changelog entry
Remove unnecessary duplicate style in email-styles template.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
