### PR TITLE
Fix 31859 issue: Subtotal check uses the wrong subtotal in orders

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -446,6 +446,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
+	 * Gets order subtotal tax.
+	 *
+	 * @return float
+	 */
+	public function get_subtotal_tax() {
+		$subtotal = NumberUtil::round( $this->get_cart_subtotal_tax_for_order(), wc_get_price_decimals() );
+		return apply_filters( 'woocommerce_order_get_subtotal_tax', (float) $subtotal, $this );
+	}
+
+	/**
 	 * Get taxes, merged by code, formatted ready for output.
 	 *
 	 * @return array
@@ -1692,6 +1702,19 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		return wc_remove_number_precision(
 			$this->get_rounded_items_total(
 				$this->get_values_for_total( 'subtotal' )
+			)
+		);
+	}
+	/**
+	 * Helper function.
+	 * If you add all items in this order in cart again, this would be the cart subtotal tax (assuming all other settings are same).
+	 *
+	 * @return float Cart subtotal tax.
+	 */
+	protected function get_cart_subtotal_tax_for_order() {
+		return wc_remove_number_precision(
+			$this->get_rounded_items_total(
+				$this->get_values_for_total( 'subtotal_tax' )
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -948,7 +948,7 @@ class WC_Discounts {
 
 			if ( $this->object->get_prices_include_tax() ) {
 				// Add tax to tax-exclusive subtotal.
-				$subtotal = $subtotal + wc_add_number_precision( NumberUtil::round( $this->object->get_total_tax(), wc_get_price_decimals() ) );
+				$subtotal = $subtotal + wc_add_number_precision( NumberUtil::round( $this->object->get_subtotal_tax(), wc_get_price_decimals() ) );
 			}
 
 			return $subtotal;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The "object subtotal" is calculated by the sum of items subtotal and the **total tax**, instead of the **subtotal tax**: it should use the subtotal tax to be correct!

Closes [#31859](https://github.com/woocommerce/woocommerce/issues/31859).

### How to test the changes in this Pull Request:

To test the behavior you can follow the steps mentioned in [#31859](https://github.com/woocommerce/woocommerce/issues/31859)

### Changelog entry

> Fix - object subtotal retrieved in Discounts class for orders when prices include tax
