### PR TITLE
add sort method to hide hidden columns

### DIFF
--- a/plugins/woocommerce/changelog/patch-1
+++ b/plugins/woocommerce/changelog/patch-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix for broken table layout when reordering products on the sorting screen.

--- a/plugins/woocommerce/client/legacy/js/admin/product-ordering.js
+++ b/plugins/woocommerce/client/legacy/js/admin/product-ordering.js
@@ -68,13 +68,13 @@ jQuery( function( $ ) {
 			});
 		},
 		sort: function (e, ui) {
-            ui.placeholder.find( 'td' ).each( function( key, value ) {
-                if ( ui.helper.find( 'td' ).eq(key).is( ':visible' ) ) {
+			ui.placeholder.find( 'td' ).each( function( key, value ) {
+				if ( ui.helper.find( 'td' ).eq( key ).is( ':visible' ) ) {
 					$( this ).show();
 				} else {
 					$( this ).hide();
 				}
-            });
+			});
         }
 	});
 });

--- a/plugins/woocommerce/client/legacy/js/admin/product-ordering.js
+++ b/plugins/woocommerce/client/legacy/js/admin/product-ordering.js
@@ -66,6 +66,15 @@ jQuery( function( $ ) {
 					$( this ).removeClass( 'alternate' );
 				}
 			});
-		}
+		},
+		sort: function (e, ui) {
+            ui.placeholder.find( 'td' ).each( function( key, value ) {
+                if ( ui.helper.find( 'td' ).eq(key).is( ':visible' ) ) {
+					$( this ).show();
+				} else {
+					$( this ).hide();
+				}
+            });
+        }
 	});
 });


### PR DESCRIPTION
Fix for woocommerce/woocommerce#31943

It adds a sort method to jQueryUI Sortable, solving a (known) bug which won't be fixed anymore (since jQueryUI won't get any updates anymore). The method will simply hide all hidden columns preventing it from breaking the table layout.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes woocommerce/woocommerce#31943

### How to test the changes in this Pull Request:

1. Go to 'Products' in wp-admin
2. Click on 'Sorting' (next to 'All', 'Published', 'Trashed', etc.)
3. Open 'Screen Options' and disable 1 or more columns
4. Drag a product to change order
5. See that the table stays the same as without dragging

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Fix: Sortable with hidden columns breaks table layout

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
