### PR TITLE
Suppress wp.console.withState deprecation warning

### DIFF
--- a/plugins/woocommerce/tests/e2e/config/jest.setup.js
+++ b/plugins/woocommerce/tests/e2e/config/jest.setup.js
@@ -11,7 +11,9 @@ const { addConsoleSuppression, updateReadyPageStatus, setupJestRetries } = requi
 const { DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 // @todo: remove this once https://github.com/woocommerce/woocommerce-admin/issues/6992 has been addressed
-addConsoleSuppression( 'woocommerce_shared_settings', false );
+addConsoleSuppression('woocommerce_shared_settings', false);
+// @todo: remove this once https://github.com/woocommerce/woocommerce/issues/31867 has been addressed
+addConsoleSuppression('wp.compose.withState', false);
 
 /**
  * Uses the WordPress API to delete all existing posts


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Suppresses the deprecation warning [reported here](https://github.com/woocommerce/woocommerce/issues/31867) in e2e test output.

Closes #31867

### How to test the changes in this Pull Request:

1. Pull this branch
2. `pnpm nx docker-up woocommerce`
3. `pnpm nx test-e2e woocommerce`
4. Ensure that no deprecation warnings for `wp.compose.withState` are displayed in the test output.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Suppresses the wp.compose.withState deprecation warning in e2e test output.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
