### PR TITLE
Use WC_Order meta data access methods.

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -36,7 +36,6 @@ class WC_Meta_Box_Order_Items {
 		}
 
 		$order = $theorder;
-		$data  = get_post_meta( $post->ID );
 
 		include __DIR__ . '/views/html-order-items.php';
 	}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -966,8 +966,6 @@ class WC_AJAX {
 
 			do_action( 'woocommerce_ajax_order_items_added', $added_items, $order );
 
-			$data = get_post_meta( $order_id );
-
 			// Get HTML to return.
 			ob_start();
 			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
@@ -1120,8 +1118,6 @@ class WC_AJAX {
 			if ( ! $rate_id ) {
 				throw new Exception( __( 'Invalid rate', 'woocommerce' ) );
 			}
-
-			$data = get_post_meta( $order_id );
 
 			// Add new tax.
 			$item = new WC_Order_Item_Tax();

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -502,7 +502,7 @@ class WC_Emails {
 
 				$fields[ $key ] = array(
 					'label' => wptexturize( $key ),
-					'value' => wptexturize( get_post_meta( $order->get_id(), $field, true ) ),
+					'value' => wptexturize( $order->get_meta( $field, true ) ),
 				);
 			}
 		}

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -428,8 +428,9 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 					case 'Completed':
 						/* translators: 1: Amount, 2: Authorization ID, 3: Transaction ID */
 						$order->add_order_note( sprintf( __( 'Payment of %1$s was captured - Auth ID: %2$s, Transaction ID: %3$s', 'woocommerce' ), $result->AMT, $result->AUTHORIZATIONID, $result->TRANSACTIONID ) );
-						update_post_meta( $order->get_id(), '_paypal_status', $result->PAYMENTSTATUS );
-						update_post_meta( $order->get_id(), '_transaction_id', $result->TRANSACTIONID );
+						$order->update_meta_data( '_paypal_status', $result->PAYMENTSTATUS );
+						$order->update_meta_data( '_transaction_id', $result->TRANSACTIONID );
+						$order->save_meta_data();
 						break;
 					default:
 						/* translators: 1: Authorization ID, 2: Payment status */

--- a/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -344,14 +344,23 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	 * @param array    $posted Posted data.
 	 */
 	protected function save_paypal_meta_data( $order, $posted ) {
+		$needs_save = false;
+
 		if ( ! empty( $posted['payment_type'] ) ) {
-			update_post_meta( $order->get_id(), 'Payment type', wc_clean( $posted['payment_type'] ) );
+			$order->update_meta_data( 'Payment type', wc_clean( $posted['payment_type'] ) );
+			$needs_save = true;
 		}
 		if ( ! empty( $posted['txn_id'] ) ) {
-			update_post_meta( $order->get_id(), '_transaction_id', wc_clean( $posted['txn_id'] ) );
+			$order->update_meta_data( '_transaction_id', wc_clean( $posted['txn_id'] ) );
+			$needs_save = true;
 		}
 		if ( ! empty( $posted['payment_status'] ) ) {
-			update_post_meta( $order->get_id(), '_paypal_status', wc_clean( $posted['payment_status'] ) );
+			$order->update_meta_data( '_paypal_status', wc_clean( $posted['payment_status'] ) );
+			$needs_save = true;
+		}
+
+		if ( $needs_save ) {
+			$order->save_meta_data();
 		}
 	}
 

--- a/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php
+++ b/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php
@@ -456,7 +456,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 	} elseif ( is_callable( array( $this, "get_{$key}" ) ) ) {
 			return $this->{"get_{$key}"}();
 		} else {
-			return get_post_meta( $this->get_id(), '_' . $key, true );
+			return $this->get_meta( '_' . $key, true );
 		}
 	}
 

--- a/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php
+++ b/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php
@@ -333,11 +333,12 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 */
 	public function set_address( $address, $type = 'billing' ) {
 		foreach ( $address as $key => $value ) {
-			update_post_meta( $this->get_id(), "_{$type}_" . $key, $value );
+			$this->update_meta_data( "_{$type}_" . $key, $value );
 			if ( is_callable( array( $this, "set_{$type}_{$key}" ) ) ) {
 				$this->{"set_{$type}_{$key}"}( $value );
 			}
 		}
+		$this->save_meta_data();
 	}
 
 	/**
@@ -355,34 +356,35 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 			case 'total' :
 				$amount = wc_format_decimal( $amount, wc_get_price_decimals() );
 				$this->set_total( $amount );
-				update_post_meta( $this->get_id(), '_order_total', $amount );
+				$this->update_meta_data( '_order_total', $amount );
 				break;
 			case 'cart_discount' :
 				$amount = wc_format_decimal( $amount );
 				$this->set_discount_total( $amount );
-				update_post_meta( $this->get_id(), '_cart_discount', $amount );
+				$this->update_meta_data( '_cart_discount', $amount );
 				break;
 			case 'cart_discount_tax' :
 				$amount = wc_format_decimal( $amount );
 				$this->set_discount_tax( $amount );
-				update_post_meta( $this->get_id(), '_cart_discount_tax', $amount );
+				$this->update_meta_data( '_cart_discount_tax', $amount );
 				break;
 			case 'shipping' :
 				$amount = wc_format_decimal( $amount );
 				$this->set_shipping_total( $amount );
-				update_post_meta( $this->get_id(), '_order_shipping', $amount );
+				$this->update_meta_data( '_order_shipping', $amount );
 				break;
 			case 'shipping_tax' :
 				$amount = wc_format_decimal( $amount );
 				$this->set_shipping_tax( $amount );
-				update_post_meta( $this->get_id(), '_order_shipping_tax', $amount );
+				$this->update_meta_data( '_order_shipping_tax', $amount );
 				break;
 			case 'tax' :
 				$amount = wc_format_decimal( $amount );
 				$this->set_cart_tax( $amount );
-				update_post_meta( $this->get_id(), '_order_tax', $amount );
+				$this->update_meta_data( '_order_tax', $amount );
 				break;
 		}
+		$this->save_meta_data();
 
 		return true;
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -140,7 +140,8 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$this->assertEmpty( $order->get_payment_tokens() );
 
 		$token = WC_Helper_Payment_Token::create_cc_token();
-		update_post_meta( $order->get_id(), '_payment_tokens', array( $token->get_id() ) );
+		$order->update_meta_data( '_payment_tokens', array( $token->get_id() ) );
+		$order->save_meta_data();
 
 		$this->assertCount( 1, $order->get_payment_tokens() );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/payment-tokens/payment-tokens.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/payment-tokens/payment-tokens.php
@@ -29,7 +29,8 @@ class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 		$this->assertEmpty( WC_Payment_Tokens::get_order_tokens( $order->get_id() ) );
 
 		$token = WC_Helper_Payment_Token::create_cc_token();
-		update_post_meta( $order->get_id(), '_payment_tokens', array( $token->get_id() ) );
+		$order->update_meta_data( '_payment_tokens', array( $token->get_id() ) );
+		$order->save_meta_data();
 
 		$this->assertCount( 1, WC_Payment_Tokens::get_order_tokens( $order->get_id() ) );
 

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
@@ -29,8 +29,8 @@ class WC_Gateway_Paypal_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
-		update_post_meta( $order->get_id(), '_paypal_status', 'pending' );
-		update_post_meta( $order->get_id(), '_transaction_id', $this->transaction_id_26960 );
+		$order->update_meta_data( '_paypal_status', 'pending' );
+		$order->update_meta_data( '_transaction_id', $this->transaction_id_26960 );
 		$order->set_payment_method( 'paypal' );
 		$order->save();
 
@@ -56,8 +56,8 @@ class WC_Gateway_Paypal_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
-		update_post_meta( $order->get_id(), '_paypal_status', 'pending' );
-		update_post_meta( $order->get_id(), '_transaction_id', $this->transaction_id_26960 );
+		$order->update_meta_data( '_paypal_status', 'pending' );
+		$order->update_meta_data( '_transaction_id', $this->transaction_id_26960 );
 		$order->set_payment_method( 'paypal' );
 		$order->save();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially addresses #31597. (Further refactoring will be in separate PRs)

This PR seeks to remove the direct usage of `get_post_meta()` and `update_post_meta()` for accessing WC_Order metadata. There were a few calls to `get_post_meta()` without specifying a meta key that were removed since the return value was unused.

### How to test the changes in this Pull Request:

I'd like some feedback on how best to test these changes. There are manual steps to take that I'm aware of and some cases are covered by unit tests, but I'm sure we could do better - and what about the legacy code?

1. Ensure all order item metabox functions work (on edit order, add items, fees, refund, etc)
2. Test placing an order with the PayPal Standard gateway (verify order meta, verify IPN function)
3. Verify filtered in `woocommerce_email_order_meta_fields` are correctly displayed in transactional order emails

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement - use Order classes to access metadata.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
