### PR TITLE
Bump WooCommerce Admin version to 3.2.0-rc.1

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.1.0",
+		"woocommerce/woocommerce-admin": "3.2.0-rc.1",
 		"woocommerce/woocommerce-blocks": "6.7.3"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9b680722733ec1fae9414023f943830",
+    "content-hash": "c6e38b5cbb540e0f3bd563408d933541",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.1.0",
+            "version": "3.2.0-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "59dfff627d9b7b1d5396686e69b709a820f5e7e5"
+                "reference": "0e3d26c283f3cff3507469478a33b47ca7e70649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/59dfff627d9b7b1d5396686e69b709a820f5e7e5",
-                "reference": "59dfff627d9b7b1d5396686e69b709a820f5e7e5",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0e3d26c283f3cff3507469478a33b47ca7e70649",
+                "reference": "0e3d26c283f3cff3507469478a33b47ca7e70649",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.1.0"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.2.0-rc.1"
             },
-            "time": "2022-01-25T02:36:40+00:00"
+            "time": "2022-02-09T15:33:34+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2926,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.1.0-rc.1

## New Feature Tests 

### Fix category report query returns invalid net sales

1. Create a new store and finish the Onboarding flow
2. Go to **Products > Add New** and create a product called **Hoodie with Pocket** with the price $35
3. Create a new category called **Hoodie** with **Clothing** as the parent category in the **Product categories** on the right.
4. Select **Clothing** and **Hoodie with Pocket** as well and click **Update**
5. Create an order with a single item of **Hoodie with Pocket** (keep note of the total price)
6. Run the action scheduler (make sure all are run), you can do this manually by going to **WooCommerce > Status > Scheduled Actions**. If your queue is large, just make sure that the `wc-admin_import_orders` actions are run.
7. Go to **Analytics > Overview** and scroll down to the **Leaderboards**
8. Observe that the **Clothing** category has only **1** items sold and net sales is $35
9. Click on **Clothing** it will redirect to the Categories page and show the correct numbers
10. Now click on **Analytics > Categories** again and scroll down to the table
11. Observe that the **Clothing** category has only **1** items sold and net sales is $35

### Hide store address fields in regions that specify hidden #8172

1. Go to the store setup wizard
2. Change to a country like Guatemala that hides the post code
3. Verify that the post code is hidden and "Continue" still works as expected
4. Switch to a different country with all fields shown and make sure things still work as expected

### Add localized validation to store address #8123

**Store details**

1. Navigate to the Store Details step of the profiler
2. Change the country/region to US.
3. Check that all fields are still required
4. Change your country to Australia
5. Make sure post code and city labels are updated (you can check this [list here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-countries.php#L795-L1528) for other country requirements by shortcode)
6. Change the country to Hong Kong
7. Check that zip/postal is no longer required

**Tasks**

1. Delete any shipping zones you might have
2. Clear your address in **WooCommerce > Settings** aside from the country/region.
3. Visit the Shipping task in the task list
4. It should prompt you to put in the store address.
5. This should follow the same store address validation as the Store Details step.

### Enhance report chart i18n support #8129

1. Go to **Analytics > Overview**
2. Observe chart texts show normally in English/site language.
3. Select different "stats" by click on the 3 dots on the right hand and enabling other stats, now repeat step 2 until all options are confirmed.
4. Go to **Settings > General**
5. Change the "Site Language" to another languages like "Português do Brasil"
6. Repeat 1 ~ 3 steps

### Add MailPoet to Installed marketing extensions #8091

1. Go to **Marketing > Overview**
2. MailPoet is not shown in **Installed marketing extensions**
3. Go to **Plugins** and install but don't activate **MailPoet 3**
4. Go to **Marketing > Overview**
5. See MailPoet in **Installed marketing extensions**
6. Click **Activate**
7. Click **Finish Setup**
8. Finish MailPoet setup (fill with dummy data)
9. Go to **Marketing > Overview**
10. See MailPoet links to Docs, Support, and Settings

### Add additional store profiler track for the business details tab. #8265

1. Open your console and make sure you have tracks outputted ( `localStorage.setItem( 'debug', 'wc-admin:*' );` )
2. Go to the Onboarding wizard and step through until the business details `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details`
3. A `storeprofiler_step_view` should be triggered with `business-details` as the step.
4. Fill out the dropdowns and click continue
5. A `storeprofiler_step_complete` should of fired with a `step` prop of `business-details`. A new `storeprofiler_step_view` should of also fired with `business-features` as a step. Now select some free features and click continue.
6. A `storeprofiler_step_complete` should of fired with a `step` prop of `business-features`.
7. Check the general styling of the business features tab to make sure things look good still.
## Changelog

== 3.2.0 02/08/2022 == 
```
- Fix: changed email validation in Store Details onboarding task to more closely match PHP backend validation. #8197
- Fix: Disallow whitespace as the platform name input. #8090
- Fix: Ensure setup-wizard redirection on homescreen is stable. #8114
- Fix: Fix category report query returns invalid net sales. #8153
- Fix: Fix clicking the error message opens the dropdown. #8094
- Fix: Fix country/region selection not preserved in store details task. #8228
- Fix: Fixed email address not being optional in OBW #8263
- Fix: Fix get_automated_tax_supported_countries doesn't include UK. #8180
- Fix: Fix incorrect date options when the "Default Date Range" is set from Analytics settings. #8189
- Fix: Fix incorrectly displayed note created date. #8179
- Fix: Fix incorrect screen reader text generated for data points on charts table. #8181
- Fix: Fix incorrect total count of downloads on the analytics download report. #8182
- Fix: Fix misaligned status column on order report. #8121
- Fix: Fix shipping rate error message overlaps with the 'Proceed' button. #8165
- Fix: Fix Shipping task sometimes skipping the set shipping costs step. #8260
- Fix: Fix Uncaught TypeError count(NULL) for php8+ in Marketing.php. #8213
- Fix: Fix undefined derived_currency value for the track 'wcadmin_storeprofiler_store_details_continue'. #8193
- Fix: Fix variations table product filter query. #8120
- Fix: Make sure WooCommerce Payments tasklist_payment_setup is triggered again. #8146
- Fix: Preserve HTML markup in server-side error messages received from sample product import request. #8173
- Fix: Remove border between email input and newsletter checkbox in OBW store details. #8148
- Fix: Reset "install_timestamp" if it's not numeric to avoid TypeError. #8100
- Fix: Truncate the long site title with an ellipses on the second line. #8112
- Add: Add additional store profiler track for the business details tab. #8265
- Add: Add countries data store #8119
- Add: Add extra tracking for plugin installation performance during onboarding. #8042
- Add: Adding tooltip to describe the lack of refund deductions from revenue summaries. #8187
- Add: Add localized validation to store address #8123
- Add: Add Magento migration note #8145
- Add: Add REST endpoint to retrieve address locales #8116
- Add: Add Spain to Square country suggestion list. #8210
- Add: Change the reviews empty state panels logic #8147
- Update: Add custom error for store details email and allow continue #8110
- Update: Adding "allow-plugins" property for composer configuration. #8139
- Dev: Remove wc-admin-settings package and rename getSetting to getAdminSetting. #8057
- Tweak: Grow and center buttons in all WooCommerce ellipsis menu popover containers. #8168
- Tweak: Hide store address fields in regions that specify hidden #8172
- Tweak: Make activity panel badges margin consistent. #8152
- Tweak: Padding tweak for marketing tools plugin list headings. #8171
- Performance: Speed up customer syncing action. #8021
- Enhancement: Enhance report chart i18n support. #8129
- Enhancement: Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter. #8231
- Enhancement: Show MailPoet in Installed marketing extensions. #8091
- Enhancement: Update headercard to use filter to add ExPlat parameter #8233
```