### PR TITLE
Fixed clear cart after payment for block-based themes(Twenty Twenty-Two).

### DIFF
--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -192,7 +192,7 @@ function wc_clear_cart_after_payment() {
 		}
 	}
 }
-add_action( 'get_header', 'wc_clear_cart_after_payment' );
+add_action( 'template_redirect', 'wc_clear_cart_after_payment', 20 );
 
 /**
  * Get the subtotal.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently, `wc_clear_cart_after_payment` is attached to `get_header` action, which is for clear cart on order received page. Twenty Twenty-Two theme does not trigger the` get_header` action. So, for the payment gateways which are not clear the cart after payment, the cart remains as it is.
This PR replaces `get_header` action with  `template_redirect` to fix this issue.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29445.

### How to test the changes in this Pull Request:

Preparation:

1. Activate Twenty Twenty-Two theme.
2. Install and setup any payment gateway plugin which does not clear the cart after payment (example: [WooCommerce PayFast Gateway](https://wordpress.org/plugins/woocommerce-payfast-gateway/))

Prime the persistent cart:

1. Login as a customer and add some items to the cart.
2. Log out.
3. Log back in.

Now to test:

1. Your cart should already be populated; go ahead and check out (and be sure to use the noted payment gateway, or one that behaves in a similar fashion).
2. After paying, you should be returned to the order-received page.
3. Now navigate to the cart page:
    1. Using earlier code (ie, WooCommerce 6.2.1) you should notice that the cart remains populated ❌
    2. With this branch, the cart should have been successfully cleared ✅

If you need an alternative to PayFast when testing, feel free to reach out to a member of `@woocommerce/proton` for guidance.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Avoid depending on the presence of a theme header template to clear the cart after payment is made.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
