### PR TITLE
Add checks around setup widget display when features are disabled

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -22,6 +22,11 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 	class WC_Admin_Dashboard_Setup {
 
 		/**
+		 * Check for task list initialization.
+		 */
+		private $initalized = false;
+
+		/**
 		 * The task list.
 		 */
 		private $task_list = null;
@@ -103,11 +108,12 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return array
 		 */
 		public function get_task_list() {
-			if ( $this->task_list ) {
+			if ( $this->task_list || $this->initalized ) {
 				return $this->task_list;
 			}
 
 			$this->set_task_list( TaskLists::get_list( 'setup' ) );
+			$this->initalized = true;
 			return $this->task_list;
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -168,10 +169,23 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return bool
 		 */
 		public function should_display_widget() {
-			return current_user_can( 'manage_woocommerce' ) &&
-				WC()->is_wc_admin_active() &&
-				! $this->get_task_list()->is_complete() &&
-				! $this->get_task_list()->is_hidden();
+			if ( ! class_exists( 'Automattic\WooCommerce\Admin\Features\Features' ) || ! class_exists( 'Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists' ) ) {
+				return false;
+			}
+
+			if ( ! Features::is_enabled( 'onboarding' ) || ! WC()->is_wc_admin_active() ) {
+				return false;
+			}
+
+			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				return false;
+			}
+
+			if ( ! $this->get_task_list() || $this->get_task_list()->is_complete() || $this->get_task_list()->is_hidden() ) {
+				return false;
+			}
+
+			return true;
 		}
 
 	}

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -130,6 +130,16 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests widget does not display when task list is unavailable.
+	 */
+	public function test_widget_does_not_display_when_no_task_list() {
+		$widget = $this->get_widget();
+		$widget->set_task_list( null );
+
+		$this->assertFalse( $widget->should_display_widget() );
+	}
+
+	/**
 	 * Tests the widget output when 1 task has been completed.
 	 */
 	public function test_initial_widget_output() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It's possible to disable certain features in WooCommerce Admin through the use of filters.  This PR checks to see if the onboarding feature is enabled.

It also checks to see if the task list and feature classes are available in preparation for some potential class moves that my be happening in the near future.

This widget probably should have been developed in WooCommerce Admin, but going to keep it here for the time being.

Closes #31755 .

### How to test the changes in this Pull Request:

1. Create a site with an incomplete and unhidden task list.
2. Note that you can see the setup widget in the WP dashboard.
3. Add the following to a plugin and activate:
```php
add_filter( 'woocommerce_admin_features', function( $features ) {
	array_splice( $features, array_search('onboarding', $features ), 1);
	return $features;
} );
```
4. Visit the dashboard and make sure the widget is not shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add checks around setup widget display when features are disabled

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
