### PR TITLE
Add extra UI for aborting/resuming the product attributes lookup table filling

### DIFF
--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -89,7 +89,7 @@ class LookupDataStore {
 							sprintf(
 								"<p><strong style='color: #E00000'>%s</strong></p><p>%s</p>",
 								__( 'WARNING: The product attributes lookup table regeneration process was aborted.', 'woocommerce' ),
-								__( 'This means that the table is probably in an inconsistent state. It\'s recommended to run a new regeneration process (Status - Tools - Regenerate the product attributes lookup table) before enabling the table usage.', 'woocommerce' )
+								__( 'This means that the table is probably in an inconsistent state. It\'s recommended to run a new regeneration process or to resume the aborted process (Status - Tools - Regenerate the product attributes lookup table/Resume the product attributes lookup table regeneration) before enabling the table usage.', 'woocommerce' )
 							) : null;
 
 						$settings[] = array(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We have received a few reports of people for which the filling of the new product attributes lookup table gets stuck, presumably (but yet to be investigated) because one of the scheduled actions that performs the filling process either fails or gets dramatically slowed down.

This pull requests adds two new tools (in WooCommerce - Status - Tools) intended to help store administrators when this happens:

- _Abort the product attributes lookup table regeneration_: this one appears only if a regeneration process is in progress. It deletes any pending regeneration scheduled action, deletes the `woocommerce_attribute_lookup_regeneration_in_progress` flagging option, and sets the `woocommerce_attribute_lookup_regeneration_aborted` flagging option.

- _Resume the product attributes lookup table regeneration_: this one appears only if a regeneration process was aborted (the `woocommerce_attribute_lookup_regeneration_aborted` option is set) and resumes the regeneration process by scheduling a new table filling action. The regeneration will contine at the point in which it stopped, this is possible because the "Abort..." tool won't delete the options that keep track of the filling process.

### How to test the changes in this Pull Request:

1. Let the starting point be a WooCommerce install in which the regeneration has finished (if the regeneration was already stuck you would start in step 4 instead), you should see the "Regenerate the product attributes lookup table" tool in WooCommerce - Status - Tools but no other related tool:

![image](https://user-images.githubusercontent.com/937723/153621484-3f0bd133-bb28-405a-bcd8-f4a443355167.png)
 
2. Temporarily add this piece of code in the `DataRegenerator::do_regeneration_step` method, right after the `$products_already_processed` variable is set; this will simulate a scheduled action failure that makes the regeneration process to be permanently stuck:

```php
if ( $products_already_processed >= 10 ) {
    throw new \Exception( 'OH NO!!' );
}
```

3. Run the "Regenerate..." tool. After a few page reloads (remember to remove the `action` parameter from the query string before reloading the tools page!) you'll see that the filling is stuck at 10 products, and if you go to the "Scheduled actions" tab you'll see an instance of `woocommerce_run_product_attribute_lookup_regeneration_callback` in "Failed" status.

4. From the moment in which the regeneration process has started (and regardless of whether the process is stuck or not) a new tool will appear right after the "Regenerate..." one: "Abort the product attributes lookup table regeneration"; run it.

![image](https://user-images.githubusercontent.com/937723/153622348-1cc727ad-e551-4313-9c4d-8b835014bc03.png)

5. Now the "Abort..." tool has been replaced with a "Resume..." tool:

![image](https://user-images.githubusercontent.com/937723/153622513-87044343-9410-4f04-9920-921952e0098b.png)

6. Verify that the information that allows the regeneration process to restart where it stopped is still in place:

```bash
wp option get woocommerce_attribute_lookup_last_product_id_to_process
wp option get woocommerce_attribute_lookup_processed_count
```

6. In the code snippet you added in 2 replace the `>= 10` condition with a `< 10` condition; this will help us proving that the "Resume..." tool doesn't start over.

7. Run the "Resume..." tool. From this point the regeneration process is in the same state as if it had never been aborted and resumed: the only available tool will be the "Regenerate..." one, it will show a disabled button with the count of products already processed (which will start at 10, where it stopped); and eventually the regeneration process will finish, causing the button of the tool to be enabled again.

8. After the regeneration process finishes run the commands from 6 again, these options shouldn't exist anymore.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - Extra tools for aborting and resuming the product attributes lookup table regeneration.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
