### PR TITLE
Feature/css custom props - followup #29575

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -37,6 +37,18 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			$screen    = get_current_screen();
 			$screen_id = $screen ? $screen->id : '';
 
+			// Get the content of the custom-properties.css
+			if ( apply_filters( 'enqueue_woo_global_styles' , true ) ) {
+
+				wp_register_style( 'woocommerce-inline', false ); // phpcs:ignore
+				wp_enqueue_style( 'woocommerce-inline' );
+
+				// Allow users to replace or add inline styles to wc global style
+				$wc_inline_style = apply_filters( 'wc_global_styles', file_get_contents( WC()->plugin_url() . '/assets/css/custom-properties.css' ) );
+
+				wp_add_inline_style( 'woocommerce-inline', $wc_inline_style );
+			}
+
 			// Register admin styles.
 			wp_register_style( 'woocommerce_admin_menu_styles', WC()->plugin_url() . '/assets/css/menu.css', array(), $version );
 			wp_register_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), $version );

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -431,11 +431,23 @@ class WC_Frontend_Scripts {
 		wp_register_style( 'woocommerce-inline', false ); // phpcs:ignore
 		wp_enqueue_style( 'woocommerce-inline' );
 
+		// Used to hold the whole inline css
+		$wc_inline_style = '';
+
+		// Get the content of the custom-properties.css
+		if ( apply_filters( 'enqueue_woo_global_styles' , true ) )
+			$wc_inline_style .= file_get_contents( self::get_asset_url( 'assets/css/custom-properties.css' ) );
+
 		if ( true === wc_string_to_bool( get_option( 'woocommerce_checkout_highlight_required_fields', 'yes' ) ) ) {
-			wp_add_inline_style( 'woocommerce-inline', '.woocommerce form .form-row .required { visibility: visible; }' );
+			$wc_inline_style .= '.woocommerce form .form-row .required { visibility: visible; }';
 		} else {
-			wp_add_inline_style( 'woocommerce-inline', '.woocommerce form .form-row .required { visibility: hidden; }' );
+			$wc_inline_style .= '.woocommerce form .form-row .required { visibility: hidden; }';
 		}
+
+		// Allow users to replace or add inline styles to wc global style
+		$wc_inline_style =  apply_filters( 'wc_global_styles' , $wc_inline_style );
+
+		wp_add_inline_style( 'woocommerce-inline', $wc_inline_style );
 	}
 
 	/**

--- a/plugins/woocommerce/legacy/Gruntfile.js
+++ b/plugins/woocommerce/legacy/Gruntfile.js
@@ -35,7 +35,6 @@ module.exports = function ( grunt ) {
 		// Minify .js files.
 		uglify: {
 			options: {
-				ie8: true,
 				parse: {
 					strict: false,
 				},
@@ -89,6 +88,13 @@ module.exports = function ( grunt ) {
 
 		// Minify all .css files.
 		cssmin: {
+			options: {
+				compatibility: {
+					properties: {
+						colors: false,
+					}
+				}
+			},
 			minify: {
 				files: [
 					{

--- a/plugins/woocommerce/legacy/css/_mixins.scss
+++ b/plugins/woocommerce/legacy/css/_mixins.scss
@@ -286,3 +286,40 @@
 		text-decoration: none !important;
 	}
 }
+
+@function set_value($val, $val2) {
+	@if (type-of($val) == string) {
+		@return calc(#{$val} + #{$val2});
+	} @else {
+		@return $val + $val2;
+	}
+}
+
+@function gen-custom-prop($color, $hue: false, $saturation: false, $luminosity: false, $alpha: false) {
+
+	@if (type_of($color) == string) {
+		@error("Error in _variables.scss: colors needs to be a list like 150, 100%, 50% and not " + $color)
+	}
+
+	$h: nth($color, 1);
+	$s: nth($color, 2);
+	$l: nth($color, 3);
+
+	@if($hue != false) {
+		$h: set_value($h, $hue);
+	}
+
+	@if($saturation != false) {
+		$s: set_value($s, $saturation);
+	}
+
+	@if($luminosity != false) {
+		$l: set_value($l, $luminosity);
+	}
+
+	@if($alpha != false) {
+		@return unquote("hsla(#{$h}, #{$s}, #{$l}, #{$alpha})");
+	}
+
+	@return unquote("hsl(#{$h}, #{$s}, #{$l})");
+}

--- a/plugins/woocommerce/legacy/css/_mixins.scss
+++ b/plugins/woocommerce/legacy/css/_mixins.scss
@@ -88,7 +88,7 @@
  * Deprecated
  * Vendor prefix no longer required.
  */
-@mixin text_shadow($shadow_x: 3px, $shadow_y: 3px, $shadow_rad: 3px, $shadow_color: #fff) {
+@mixin text_shadow($shadow_x: 3px, $shadow_y: 3px, $shadow_rad: 3px, $shadow_color: var(--wc-white)) {
 	text-shadow: $shadow_x $shadow_y $shadow_rad $shadow_color;
 }
 
@@ -96,7 +96,7 @@
  * Deprecated
  * Vendor prefix no longer required.
  */
-@mixin vertical_gradient($from: #000, $to: #fff) {
+@mixin vertical_gradient($from: var(--wc-black), $to: var(--wc-white)) {
 	background-color: $from;
 	background: -webkit-linear-gradient($from, $to);
 }
@@ -130,12 +130,12 @@
 
 	@if lightness($a) >= 65% {
 
-		@include text_shadow(0, -1px, 0, rgba(0, 0, 0, $opacity));
+		@include text_shadow(0, -1px, 0, wc-shade( 0, black, $opacity ));
 	}
 
 	@else {
 
-		@include text_shadow(0, 1px, 0, rgba(255, 255, 255, $opacity));
+		@include text_shadow(0, 1px, 0, wc-shade( 0, black, $opacity ));
 	}
 }
 
@@ -254,7 +254,11 @@
 	text-decoration: none;
 }
 
-@mixin loader() {
+@mixin loader($color: false) {
+
+	@if ($color == false) {
+		$color: wc-shade( 0, 'black', 75% );
+	}
 
 	&::before {
 		height: 1em;
@@ -272,7 +276,7 @@
 		line-height: 1;
 		text-align: center;
 		font-size: 2em;
-		color: rgba(#000, 0.75);
+		color: $color;
 	}
 }
 
@@ -295,9 +299,10 @@
 	}
 }
 
-@function gen-custom-prop($color, $hue: false, $saturation: false, $luminosity: false, $alpha: false) {
+@function gen-custom-prop( $color, $hue: false, $saturation: false, $luminosity: false, $alpha: false ) {
 
 	@if (type_of($color) == string) {
+		$color: hsl($color);
 		@error("Error in _variables.scss: colors needs to be a list like 150, 100%, 50% and not " + $color)
 	}
 
@@ -322,4 +327,27 @@
 	}
 
 	@return unquote("hsl(#{$h}, #{$s}, #{$l})");
+}
+
+@function wc-hsl(  $h, $s: 100%, $l: 50%, $a : false ) {
+
+	@if (type_of($h) == string) {
+		$h: 'var(--wc--#{$h}-hue)';
+	} @else if (type_of($h) != number) {
+		$h: 0;
+	}
+
+	@if($a != false) {
+		@return unquote("hsla(#{$h}, #{$s}, #{$l}, #{$a})");
+	}
+
+	@return unquote("hsl(#{$h}, #{$s}, #{$l})");
+}
+
+@function wc-shade( $l, $tone : 'white', $alpha: 100% ) {
+	@if (type_of($tone) == string) {
+		@return hsla(0, 0%, calc( var(--wc--#{$tone}-luma) * #{$l * .01}), $alpha );
+	} @else {
+		@return hsla(0, 0%, $l * 1%, $alpha );
+	}
 }

--- a/plugins/woocommerce/legacy/css/_mixins.scss
+++ b/plugins/woocommerce/legacy/css/_mixins.scss
@@ -130,12 +130,12 @@
 
 	@if lightness($a) >= 65% {
 
-		@include text_shadow(0, -1px, 0, wc-shade( 0, black, $opacity ));
+		@include text_shadow(0, -1px, 0, wc-shade( 0,'black', $opacity ));
 	}
 
 	@else {
 
-		@include text_shadow(0, 1px, 0, wc-shade( 0, black, $opacity ));
+		@include text_shadow(0, 1px, 0, wc-shade( 100,'white', $opacity ));
 	}
 }
 
@@ -329,7 +329,7 @@
 	@return unquote("hsl(#{$h}, #{$s}, #{$l})");
 }
 
-@function wc-hsl(  $h, $s: 100%, $l: 50%, $a : false ) {
+@function wc-hsl( $h, $s: 100%, $l: 50%, $a : false ) {
 
 	@if (type_of($h) == string) {
 		$h: 'var(--wc--#{$h}-hue)';

--- a/plugins/woocommerce/legacy/css/_variables.scss
+++ b/plugins/woocommerce/legacy/css/_variables.scss
@@ -8,31 +8,46 @@ $red:           	#a00 !default;
 $orange:        	#ffba00 !default;
 $blue:          	#2ea2cc !default;
 
-$primary:           #a46497 !default;                                  // Primary color for buttons (alt)
-$primarytext:       desaturate(lighten($primary, 50%), 18%) !default;    // Text on primary color bg
+$wc-primary: var(--wc-hue), var(--wc-sat), var(--wc-luma);									// Primary color for buttons (alt)
+$wc-primary-text: var(--wc-hue), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%);		// Text on primary color bg
 
-$secondary:         desaturate(lighten($primary, 40%), 21%) !default;    // Secondary buttons
-$secondarytext:     desaturate(darken($secondary, 60%), 21%) !default;   // Text on secondary color bg
+$wc-secondary: var(--wc-hue), var(--wc-sat--secondary), calc(var(--wc-luma) + 40%); 		// Secondary buttons
+$wc-secondary-text: var(--wc-hue), var(--wc-sat--secondary), calc(var(--wc-luma) - 20%); 	// Text on secondary color bg
 
-$highlight:         adjust-hue($primary, 150deg) !default;               // Prices, In stock labels, sales flash
-$highlightext:      desaturate(lighten($highlight, 50%), 18%) !default;  // Text on highlight color bg
+$wc-highlight: var(--wc-hue--highlight), var(--wc-sat), var(--wc-luma); 								// Prices, In stock labels, sales flash
+$wc-highlight-text: var(--wc-hue--highlight), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%); 	// Text on highlight color bg
 
-$contentbg:         #fff !default;                                     // Content BG - Tabs (active state)
-$subtext:           #767676 !default;                                  // small, breadcrumbs etc
 
 // export vars as CSS vars
 :root {
+	// base color values
+	--wc-hue: 312;
+	--wc-hue--highlight: calc(var(--wc-hue) + 150);
+
+	--wc-sat: 26%;
+	--wc-sat--secondary: calc(var(--wc-sat) - 21%);
+
+	--wc-luma: 52%;
+	--wc-luma-white: 100%;
+
+	// WooCommerce base colors
 	--woocommerce: #{$woocommerce};
-	--wc-green: #{$green};
-	--wc-red: #{$red};
-	--wc-orange: #{$orange};
-	--wc-blue: #{$blue};
-	--wc-primary: #{$primary};
-	--wc-primary-text: #{$primarytext};
-	--wc-secondary: #{$secondary};
-	--wc-secondary-text: #{$secondarytext};
-	--wc-highlight: #{$highlight};
-	--wc-highligh-text: #{$highlightext};
-	--wc-content-bg: #{$contentbg};
-	--wc-subtext: #{$subtext};
+	--wc-green: var(--wp--preset--color--vivid-green-cyan, #{$green});
+	--wc-red: var(--wp--preset--color--vivid-red, #{$red});
+	--wc-orange: var(--wp--preset--color--luminous-vivid-amber, #{$orange});
+	--wc-blue: var(--wp--preset--color--pale-cyan-blue, #{$blue});
+	--wc-white: hsl(0,0%,var(--wc-luma-white));
+	--wc-gray: hsl(0,0%,calc(var(--wc-luma-white) * .46));
+	--wc-black: hsl(0,0%,calc(var(--wc-luma-white) * 0));
+
+	// theme colors
+	--wc-primary: hsl(#{$wc-primary});
+	--wc-primary-text: hsl(#{$wc-primary-text});
+	--wc-secondary: hsl(#{$wc-secondary});
+	--wc-secondary-text: hsl(#{$wc-secondary-text});
+	--wc-highlight: hsl(#{$wc-highlight});
+	--wc-highlight-text: hsl(#{$wc-highlight-text});
+
+	--wc-content-bg: var(--wc-white);
+	--wc-subtext: var(--wc-gray);
 }

--- a/plugins/woocommerce/legacy/css/_variables.scss
+++ b/plugins/woocommerce/legacy/css/_variables.scss
@@ -2,54 +2,13 @@
  * WooCommerce CSS Variables
  */
 
-$woocommerce:   	#a46497 !default;
-$green:         	#7ad03a !default;
-$red:           	#a00 !default;
-$orange:        	#ffba00 !default;
-$blue:          	#2ea2cc !default;
+$woocommerce-brand: 312, 26%, 52%;
 
-$wc-primary: var(--wc-hue), var(--wc-sat), var(--wc-luma);									// Primary color for buttons (alt)
-$wc-primary-text: var(--wc-hue), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%);		// Text on primary color bg
+$wc-primary: var(--wc--primary-hue), var(--wc--primary-sat), var(--wc--primary-luma);									// Primary color for buttons (alt)
+$wc-primary-text: var(--wc--primary-hue), calc(var(--wc--primary-sat) - 18%), calc(var(--wc--primary-luma) + 50%);		// Text on primary color bg
 
-$wc-secondary: var(--wc-hue), var(--wc-sat--secondary), var(--wc-luma--secondary) ; 		// Secondary buttons
-$wc-secondary-text: var(--wc-hue), var(--wc-sat--secondary), var(--wc-luma--secondary-text); 	// Text on secondary color bg
+$wc-secondary: var(--wc--primary-hue), var(--wc--secondary-sat), var(--wc--secondary-luma) ; 		// Secondary buttons
+$wc-secondary-text: var(--wc--primary-hue), var(--wc--secondary-sat), var(--wc--secondary-luma--text); 	// Text on secondary color bg
 
-$wc-highlight: var(--wc-hue--highlight), var(--wc-sat), var(--wc-luma); 								// Prices, In stock labels, sales flash
-$wc-highlight-text: var(--wc-hue--highlight), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%); 	// Text on highlight color bg
-
-
-// export vars as CSS vars
-:root {
-	// base color values
-	--wc-hue: 312;
-	--wc-hue--highlight: calc(var(--wc-hue) + 150);
-
-	--wc-sat: 26%;
-	--wc-sat--secondary: calc(var(--wc-sat) - 21%);
-
-	--wc-luma: 52%;
-	--wc-luma--secondary-text: calc(var(--wc-luma) - 20%);
-	--wc-luma--secondary: calc(var(--wc-luma) + 40%);
-	--wc-luma--white: 100%;
-
-	// WooCommerce base colors
-	--woocommerce: #{$woocommerce};
-	--wc-green: var(--wp--preset--color--vivid-green-cyan, #{$green});
-	--wc-red: var(--wp--preset--color--vivid-red, #{$red});
-	--wc-orange: var(--wp--preset--color--luminous-vivid-amber, #{$orange});
-	--wc-blue: var(--wp--preset--color--pale-cyan-blue, #{$blue});
-	--wc-white: hsl(0,0%,var(--wc-luma--white));
-	--wc-gray: hsl(0,0%,calc(var(--wc-luma-white) * .46));
-	--wc-black: hsl(0,0%,calc(var(--wc-luma-white) * 0));
-
-	// theme colors
-	--wc-primary: hsl(#{$wc-primary});
-	--wc-primary-text: hsl(#{$wc-primary-text});
-	--wc-secondary: hsl(#{$wc-secondary});
-	--wc-secondary-text: hsl(#{$wc-secondary-text});
-	--wc-highlight: hsl(#{$wc-highlight});
-	--wc-highlight-text: hsl(#{$wc-highlight-text});
-
-	--wc-content-bg: var(--wc-white);
-	--wc-subtext: var(--wc-gray);
-}
+$wc-highlight: var(--wc--highlight-hue), var(--wc--primary-sat), var(--wc--primary-luma); 								// Prices, In stock labels, sales flash
+$wc-highlight-text: var(--wc--highlight-hue), calc(var(--wc--primary-sat) - 18%), calc(var(--wc--primary-luma) + 50%); 	// Text on highlight color bg

--- a/plugins/woocommerce/legacy/css/_variables.scss
+++ b/plugins/woocommerce/legacy/css/_variables.scss
@@ -11,8 +11,8 @@ $blue:          	#2ea2cc !default;
 $wc-primary: var(--wc-hue), var(--wc-sat), var(--wc-luma);									// Primary color for buttons (alt)
 $wc-primary-text: var(--wc-hue), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%);		// Text on primary color bg
 
-$wc-secondary: var(--wc-hue), var(--wc-sat--secondary), calc(var(--wc-luma) + 40%); 		// Secondary buttons
-$wc-secondary-text: var(--wc-hue), var(--wc-sat--secondary), calc(var(--wc-luma) - 20%); 	// Text on secondary color bg
+$wc-secondary: var(--wc-hue), var(--wc-sat--secondary), var(--wc-luma--secondary) ; 		// Secondary buttons
+$wc-secondary-text: var(--wc-hue), var(--wc-sat--secondary), var(--wc-luma--secondary-text); 	// Text on secondary color bg
 
 $wc-highlight: var(--wc-hue--highlight), var(--wc-sat), var(--wc-luma); 								// Prices, In stock labels, sales flash
 $wc-highlight-text: var(--wc-hue--highlight), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%); 	// Text on highlight color bg
@@ -28,7 +28,9 @@ $wc-highlight-text: var(--wc-hue--highlight), calc(var(--wc-sat) - 18%), calc(va
 	--wc-sat--secondary: calc(var(--wc-sat) - 21%);
 
 	--wc-luma: 52%;
-	--wc-luma-white: 100%;
+	--wc-luma--secondary-text: calc(var(--wc-luma) - 20%);
+	--wc-luma--secondary: calc(var(--wc-luma) + 40%);
+	--wc-luma--white: 100%;
 
 	// WooCommerce base colors
 	--woocommerce: #{$woocommerce};
@@ -36,7 +38,7 @@ $wc-highlight-text: var(--wc-hue--highlight), calc(var(--wc-sat) - 18%), calc(va
 	--wc-red: var(--wp--preset--color--vivid-red, #{$red});
 	--wc-orange: var(--wp--preset--color--luminous-vivid-amber, #{$orange});
 	--wc-blue: var(--wp--preset--color--pale-cyan-blue, #{$blue});
-	--wc-white: hsl(0,0%,var(--wc-luma-white));
+	--wc-white: hsl(0,0%,var(--wc-luma--white));
 	--wc-gray: hsl(0,0%,calc(var(--wc-luma-white) * .46));
 	--wc-black: hsl(0,0%,calc(var(--wc-luma-white) * 0));
 

--- a/plugins/woocommerce/legacy/css/activation.scss
+++ b/plugins/woocommerce/legacy/css/activation.scss
@@ -4,6 +4,11 @@
  */
 
 /**
+ * Imports
+ */
+@import "mixins";
+
+/**
  * Styling begins
  */
 div.woocommerce-message {
@@ -11,7 +16,7 @@ div.woocommerce-message {
 	position: relative;
 
 	&.updated {
-		border-left-color: #cc99c2 !important;
+		border-left-color: wc-hsl( orchid, calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 18% ) ) !important;
 	}
 }
 
@@ -19,18 +24,18 @@ p.woocommerce-actions,
 .woocommerce-message {
 
 	.button-primary {
-		background: #bb77ae;
-		border-color: #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-		color: #fff;
-		text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+		background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+		border-color: var(--woocommerce);
+		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+		color: var(--wc-white);
+		text-shadow: 0 -1px 1px var(--woocommerce), 1px 0 1px var(--woocommerce), 0 1px 1px var(--woocommerce), -1px 0 1px var(--woocommerce);
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: #a36597;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			background: var(--woocommerce);
+			border-color: var(--woocommerce);
+			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 		}
 	}
 

--- a/plugins/woocommerce/legacy/css/activation.scss
+++ b/plugins/woocommerce/legacy/css/activation.scss
@@ -16,7 +16,7 @@ div.woocommerce-message {
 	position: relative;
 
 	&.updated {
-		border-left-color: wc-hsl( orchid, calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 18% ) ) !important;
+		border-left-color: wc-hsl( 'orchid', var(--wc--primary-sat), calc( var(--wc--primary-luma) + 28% ) ) !important;
 	}
 }
 
@@ -24,7 +24,7 @@ p.woocommerce-actions,
 .woocommerce-message {
 
 	.button-primary {
-		background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+		background: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) + 10% ) );
 		border-color: var(--woocommerce);
 		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 		color: var(--wc-white);

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -34,7 +34,7 @@
 		width: 100%;
 
 		&__title {
-			color: #fff;
+			color: var(--wc-white);
 			font-size: 32px;
 			font-style: normal;
 			font-weight: 400;
@@ -44,7 +44,7 @@
 		}
 
 		&__description {
-			color: #fff;
+			color: var(--wc-white);
 			font-size: 16px;
 			line-height: 24px;
 			margin-bottom: 24px;
@@ -58,7 +58,7 @@
 			position: relative;
 
 			input {
-				border: 1px solid #ddd;
+				border: 1px solid wc-shade( 87 );
 				box-shadow: none;
 				font-size: 13px;
 				height: 48px;
@@ -81,8 +81,8 @@
 	}
 
 	.top-bar {
-		background: #fff;
-		box-shadow: inset 0 -1px 0 #ccc;
+		background: var(--wc-content-bg);
+		box-shadow: inset 0 -1px 0 wc-shade( 80 );
 		display: block;
 		height: 60px;
 		margin: 0 0 16px;
@@ -93,8 +93,8 @@
 	}
 
 	.current-section-dropdown {
-		background: #fff;
-		border: 1px solid #a7aaad;
+		background: var(--wc-content-bg);
+		border: 1px solid #{wc-hsl( 'blue',  3%, 66%)};
 		margin-bottom: 20px;
 		position: relative;
 		width: 100%;
@@ -104,7 +104,7 @@
 		}
 
 		ul {
-			background: #fff;
+			background: var(--wc-content-bg);
 			border-radius: 2px;
 			display: none;
 			flex-direction: column;
@@ -118,7 +118,7 @@
 			z-index: 10;
 
 			@media only screen and (min-width: 600px) {
-				border: 1px solid #1e1e1e;
+				border: 1px solid wc-shade( 12 );
 				left: -1px;
 				top: 48px;
 			}
@@ -151,7 +151,7 @@
 				border: none;
 				box-shadow: none;
 				box-sizing: border-box;
-				color: #1e1e1e;
+				color: wc-shade( 12 );
 				display: inline-block;
 				text-decoration: none;
 				outline: none;
@@ -198,9 +198,9 @@
 	}
 
 	.update-plugins .update-count {
-		background-color: #d54e21;
+		background-color: var(--wc-red);
 		border-radius: 10px;
-		color: #fff;
+		color: var(--wc-white);
 		display: inline-block;
 		font-size: 9px;
 		font-weight: 600;
@@ -260,16 +260,16 @@
 
 	.addons-wcs-banner-block {
 		align-items: center;
-		background: #fff;
-		border: 1px solid #ddd;
+		background: var(--wc-content-bg);
+		border: 1px solid wc-shade( 87 );
 		display: flex;
 		margin: 0 0 1em 0;
 		padding: 2em 2em 1em;
 	}
 
 	.addons-wcs-banner-block-image {
-		background: #f7f7f7;
-		border: 1px solid #e6e6e6;
+		background: wc-shade( 96 );
+		border: 1px solid wc-shade( 66 );
 		margin-right: 2em;
 		padding: 4em;
 		max-width: 200px;
@@ -365,8 +365,8 @@
 	}
 
 	.addons-button-solid {
-		background-color: #674399;
-		color: #fff;
+		background-color: #{wc-hsl( 'purple',  39%, 43%)};
+		color: var(--wc-white);
 	}
 
 	.addons-button-promoted {
@@ -387,47 +387,47 @@
 	}
 
 	.addons-button-solid:hover {
-		color: #fff;
+		color: var(--wc-white);
 		opacity: 0.8;
 	}
 
 	.addons-button-outline-green {
-		border: 1px solid #73ae39;
-		color: #73ae39;
+		border: 1px solid #{wc-hsl( 'green',  50%, 45%)};
+		color: #{wc-hsl( 'green',  50%, 45%)};
 	}
 
 	.addons-button-outline-green:hover {
-		color: #73ae39;
+		color: #{wc-hsl( 'green',  50%, 45%)};
 		opacity: 0.8;
 	}
 
 	.addons-button-outline-purple {
-		border: 1px solid #674399;
-		color: #674399;
+		border: 1px solid #{wc-hsl( 'purple',  39%, 43%)};
+		color: #{wc-hsl( 'purple',  39%, 43%)};
 	}
 
 	.addons-button-outline-purple:hover {
-		color: #674399;
+		color: #{wc-hsl( 'purple',  39%, 43%)};
 		opacity: 0.8;
 	}
 
 	.addons-button-outline-white {
-		border: 1px solid #fff;
-		color: #fff;
+		border: 1px solid var(--wc-white);
+		color: var(--wc-white);
 	}
 
 	.addons-button-outline-white:hover {
-		color: #fff;
+		color: var(--wc-white);
 		opacity: 0.8;
 	}
 
 	.addons-button-installed {
-		background: #e6e6e6;
-		color: #3c3c3c;
+		background: wc-shade( 66 );
+		color: wc-shade( 23 );
 	}
 
 	.addons-button-installed:hover {
-		color: #3c3c3c;
+		color: wc-shade( 23 );
 		opacity: 0.8;
 	}
 
@@ -476,7 +476,7 @@
 
 		.addon-product-group-see-more,
 		.addon-product-group-see-more:visited {
-			color: #007cba; /* Primary / Blue */
+			color: var(--wc-blue);
 			display: block;
 			font-size: 13px;
 			text-decoration: none;
@@ -511,8 +511,8 @@
 		}
 
 		li {
-			background: #fff;
-			border: 1px solid #dcdcde;
+			background: var(--wc-content-bg);
+			border: 1px solid wc-shade( 87 );
 			border-radius: 2px;
 			box-sizing: border-box;
 			display: flex;
@@ -580,7 +580,7 @@
 
 				h2,
 				h3 {
-					color: #007cba;
+					color: var(--wc-blue);
 					font-size: 20px;
 					font-weight: 400;
 					letter-spacing: -0.32px;
@@ -591,7 +591,7 @@
 				}
 
 				.addons-buttons-banner-details h2 {
-					color: #1d2327; // Gray / Gray 90
+					color: wc-shade( 10 ); // Gray / Gray 90
 				}
 
 				&.featured,
@@ -600,7 +600,7 @@
 					.label {
 						align-items: center;
 						border-radius: 2px;
-						background: #dcdcde;
+						background: wc-shade( 87 );
 						display: flex;
 						flex-direction: row;
 						height: 20px;
@@ -619,12 +619,12 @@
 					}
 
 					h2 {
-						color: #2c3338;
+						color: wc-shade( 20 );
 					}
 				}
 
 				p {
-					color: #2c3338;
+					color: wc-shade( 20 );
 					font-size: 14px;
 					line-height: 20px;
 					margin: 14px 64px 0 0;
@@ -638,32 +638,32 @@
 				}
 
 				.product-developed-by {
-					color: #50575e; /* Gray 60 */
+					color: wc-shade( 40 );
 					font-size: 12px;
 					line-height: 20px;
 					margin-top: 4px;
 
 					.product-vendor-link {
-						color: #50575e; /* Gray 60 */
+						color: wc-shade( 40 );
 					}
 				}
 
 				.product-developed-by {
-					color: #50575e; // Gray 60
+					color: wc-shade( 40 );
 					font-size: 12px;
 					font-family: sans-serif;
 					line-height: 20px;
 					margin-top: 4px;
 
 					.product-vendor-link {
-						color: #50575e; // Gray 60
+						color: wc-shade( 40 );
 					}
 				}
 			}
 
 			.product-footer {
 				align-items: center;
-				border-top: 1px solid #dcdcde;
+				border-top: 1px solid wc-shade( 87 );
 				display: flex;
 				flex-direction: row;
 				justify-content: space-between;
@@ -671,11 +671,11 @@
 
 				.price {
 					font-size: 16px;
-					color: #1d2327;
+					color: wc-shade( 10 );
 				}
 
 				.price-suffix {
-					color: #646970; // Gray 50
+					color: wc-shade( 50 );
 				}
 
 				.product-reviews-block {
@@ -704,7 +704,7 @@
 					}
 
 					.product-reviews-count {
-						color: #646970; // Gray 50
+						color: wc-shade( 50 );
 						font-size: 12px;
 						font-family: sans-serif;
 						line-height: 24px;
@@ -714,9 +714,9 @@
 				}
 
 				.button {
-					background-color: #fff;
-					border-color: #007cba;
-					color: #007cba;
+					background-color: var(--wc-content-bg);
+					border-color: var(--wc-blue);
+					color: var(--wc-blue);
 					float: right;
 					font-size: 13px;
 					height: 36px;
@@ -763,15 +763,15 @@
 
 			.button.addons-buttons-banner-button,
 			.button.addons-buttons-banner-button:hover {
-				background: #fff;
-				border: 1.5px solid #624594;
-				color: #624594;
+				background: var(--wc-content-bg);
+				border: 1.5px solid var(--wc-purple);
+				color: var(--wc-purple);
 				padding: 4px 12px;
 				margin-right: 16px;
 
 				&.addons-buttons-banner-button-primary {
-					background-color: #624594;
-					color: #fff;
+					background-color: var(--wc-purple);
+					color: var(--wc-white);
 				}
 			}
 		}
@@ -779,8 +779,8 @@
 
 	.storefront {
 		max-width: 990px;
-		background: url(../images/storefront-bg.jpg) bottom right #f6f6f6;
-		border: 1px solid #ddd;
+		background: url(../images/storefront-bg.jpg) bottom right wc-shade( 96 );
+		border: 1px solid wc-shade( 87 );
 		margin: 1em auto;
 		padding: 24px;
 		overflow: hidden;
@@ -792,7 +792,7 @@
 			max-width: 400px;
 			height: auto;
 			margin: 0 auto 16px;
-			box-shadow: 0 1px 6px rgba(0, 0, 0, 0.1);
+			box-shadow: 0 1px 6px wc-shade( 0, black, 10% );
 		}
 
 		p:last-of-type {
@@ -830,8 +830,8 @@
 	width: 100%;
 
 	&.is-current {
-		border-bottom: 2px solid #1e1e1e;
-		color: #1e1e1e;
+		border-bottom: 2px solid wc-shade( 12 );
+		color: wc-shade( 12 );
 	}
 }
 
@@ -857,9 +857,9 @@
 	max-width: 1200px;
 
 	.update-plugins .update-count {
-		background-color: #d54e21;
+		background-color: var(--wc-deep-orange);
 		border-radius: 10px;
-		color: #fff;
+		color: var(--wc-white);
 		display: inline-block;
 		font-size: 9px;
 		font-weight: 600;
@@ -908,23 +908,23 @@
 
 	a.button-primary,
 	button.button-primary {
-		background: #bb77ae;
-		border-color: #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-		color: #fff;
+		background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+		border-color: var(--woocommerce);
+		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+		color: var(--wc-white);
 		text-shadow:
-			0 -1px 1px #a36597,
-			1px 0 1px #a36597,
-			0 1px 1px #a36597,
-			-1px 0 1px #a36597;
+			0 -1px 1px var(--woocommerce),
+			1px 0 1px var(--woocommerce),
+			0 1px 1px var(--woocommerce),
+			-1px 0 1px var(--woocommerce);
 		display: inline-block;
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: #a36597;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			background: var(--woocommerce);
+			border-color: var(--woocommerce);
+			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 		}
 	}
 }
@@ -934,7 +934,7 @@
 	overflow: hidden;
 
 	&.updated {
-		border-left-color: #cc99c2 !important;
+		border-left-color: #{wc-hsl( 'orchid',  33%, 70%)} !important;
 	}
 
 	a.skip,
@@ -1013,7 +1013,7 @@ mark.amount {
   * Help Tip
   */
 .woocommerce-help-tip {
-	color: #666;
+	color: wc-shade( 40 );
 	display: inline-block;
 	font-size: 1.1em;
 	font-style: normal;
@@ -1055,7 +1055,7 @@ table.wc_status_table {
 
 		th,
 		td {
-			background: #fcfcfc;
+			background: wc-shade( 99 );
 		}
 	}
 
@@ -1091,16 +1091,19 @@ table.wc_status_table {
 		}
 
 		mark.yes {
-			color: $green;
+			color: var(--wc-green);
 		}
 
 		mark.no {
-			color: #999;
+			color: wc-shade( 60 );
 		}
 
-		mark.error,
+		mark.error {
+			color: var(--wc-error);
+		}
+
 		.red {
-			color: $red;
+			color: var(--wc-red);
 		}
 
 		ul {
@@ -1162,7 +1165,7 @@ table.wc_status_table--tools {
 		font-size: 80%;
 		font-weight: bold;
 		line-height: 1;
-		color: #fff;
+		color: var(--wc-white);
 		text-align: center;
 		white-space: nowrap;
 		vertical-align: baseline;
@@ -1186,26 +1189,26 @@ table.wc_status_table--tools {
 
 	.log-level--emergency,
 	.log-level--alert {
-		background-color: #ff4136;
+		background-color: var(--wc-error);
 	}
 
 	.log-level--critical,
 	.log-level--error {
-		background-color: #ff851b;
+		background-color: var(--wc-warning);
 	}
 
 	.log-level--warning,
 	.log-level--notice {
-		color: #222;
-		background-color: #ffdc00;
+		color: wc-shade( 13 );
+		background-color: var(--wc-alert);
 	}
 
 	.log-level--info {
-		background-color: #0074d9;
+		background-color: var(--wc-info);
 	}
 
 	.log-level--debug {
-		background-color: #3d9970;
+		background-color: var(--wc-success);
 	}
 
 	// Adjust log table columns only when table is not collapsed
@@ -1235,9 +1238,9 @@ table.wc_status_table--tools {
 }
 
 #log-viewer {
-	background: #fff;
-	border: 1px solid #e5e5e5;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	background: var(--wc-content-bg);
+	border: 1px solid wc-shade( 90 );
+	box-shadow: 0 1px 1px wc-shade( 0, black, 4% );
 	padding: 5px 20px;
 
 	pre {
@@ -1362,10 +1365,10 @@ ul.wc_coupon_list {
 			display: inline-block;
 			position: relative;
 			padding: 0 0.5em;
-			background-color: #fff;
-			border: 1px solid #aaa;
-			-webkit-box-shadow: 0 1px 0 #dfdfdf;
-			box-shadow: 0 1px 0 #dfdfdf;
+			background-color: var(--wc-content-bg);
+			border: 1px solid wc-shade( 66 );
+			-webkit-box-shadow: 0 1px 0 wc-shade( 87 );
+			box-shadow: 0 1px 0 wc-shade( 87 );
 
 			border-radius: 4px;
 			margin-right: 5px;
@@ -1379,17 +1382,17 @@ ul.wc_coupon_list {
 				cursor: pointer;
 
 				span {
-					color: #888;
+					color: wc-shade( 53 );
 
 					&:hover {
-						color: #000;
+						color: var(--wc-black);
 					}
 				}
 			}
 
 			.remove-coupon {
 				text-decoration: none;
-				color: #888;
+				color: wc-shade( 53 );
 				position: absolute;
 				top: 7px;
 				right: 20px;
@@ -1404,7 +1407,7 @@ ul.wc_coupon_list {
 				}
 
 				&:hover::before {
-					color: $red;
+					color: var(--wc-red);
 				}
 			}
 		}
@@ -1416,8 +1419,8 @@ ul.wc_coupon_list_block {
 	padding-bottom: 2px;
 
 	li {
-		border-top: 1px solid #fff;
-		border-bottom: 1px solid #ccc;
+		border-top: 1px solid var(--wc-white);
+		border-bottom: 1px solid wc-shade( 80 );
 		line-height: 2.5em;
 		margin: 0;
 		padding: 0.5em 0;
@@ -1475,7 +1478,7 @@ ul.wc_coupon_list_block {
 		font-size: 21px;
 		font-weight: normal;
 		line-height: 1.2;
-		text-shadow: 1px 1px 1px white;
+		text-shadow: 1px 1px 1px var(--wc-white);
 		padding: 0;
 	}
 
@@ -1485,12 +1488,12 @@ ul.wc_coupon_list_block {
 
 	h3,
 	h4 {
-		color: #333;
+		color: wc-shade( 20 );
 		margin: 1.33em 0 0;
 	}
 
 	p {
-		color: #777;
+		color: wc-shade( 47 );
 	}
 
 	p.order_number {
@@ -1572,7 +1575,7 @@ ul.wc_coupon_list_block {
 			small {
 				display: block;
 				margin: 5px 0 0;
-				color: #999;
+				color: wc-shade( 60 );
 			}
 		}
 
@@ -1608,7 +1611,7 @@ ul.wc_coupon_list_block {
 		}
 
 		p.none_set {
-			color: #999;
+			color: wc-shade( 60 );
 		}
 
 		div.edit_address {
@@ -1644,13 +1647,13 @@ ul.wc_coupon_list_block {
 			margin: 0 0 0 6px;
 			overflow: hidden;
 			position: relative;
-			color: #999;
+			color: wc-shade( 60 );
 			border: 0;
 			float: right;
 
 			&:hover,
 			&:focus {
-				color: #000;
+				color: var(--wc-black);
 			}
 
 			&::after {
@@ -1691,8 +1694,8 @@ ul.wc_coupon_list_block {
 	zoom: 1;
 
 	li {
-		border-top: 1px solid #fff;
-		border-bottom: 1px solid #ddd;
+		border-top: 1px solid var(--wc-white);
+		border-bottom: 1px solid wc-shade( 87 );
 		padding: 6px 0;
 		margin: 0;
 		line-height: 1.6em;
@@ -1749,13 +1752,13 @@ ul.wc_coupon_list_block {
 	.inside {
 		margin: 0;
 		padding: 0;
-		background: #fefefe;
+		background: wc-shade( 99 );
 	}
 
 	.wc-order-data-row {
-		border-bottom: 1px solid #dfdfdf;
+		border-bottom: 1px solid wc-shade( 87 );
 		padding: 1.5em 2em;
-		background: #f8f8f8;
+		background: wc-shade( 97 );
 
 		@include clearfix();
 		line-height: 2em;
@@ -1808,7 +1811,7 @@ ul.wc_coupon_list_block {
 		}
 
 		.refunded-total {
-			color: $red;
+			color: var(--wc-red);
 		}
 
 		.label-highlight {
@@ -1819,7 +1822,7 @@ ul.wc_coupon_list_block {
 	.refund-actions {
 		margin-top: 5px;
 		padding-top: 12px;
-		border-top: 1px solid #dfdfdf;
+		border-top: 1px solid wc-shade( 87 );
 
 		.button {
 			float: right;
@@ -1837,7 +1840,7 @@ ul.wc_coupon_list_block {
 	}
 
 	h3 small {
-		color: #999;
+		color: wc-shade( 60 );
 	}
 
 	.amount {
@@ -1880,17 +1883,16 @@ ul.wc_coupon_list_block {
 
 		table.woocommerce_order_items {
 			width: 100%;
-			background: #fff;
+			background: var(--wc-content-bg);
 
 			thead th {
 				text-align: left;
 				padding: 1em;
 				font-weight: normal;
-				color: #999;
-				background: #f8f8f8;
+				color: wc-shade( 60 );
+				background: wc-shade( 97 );
 				-webkit-touch-callout: none;
 				-webkit-user-select: none;
-				-khtml-user-select: none;
 				-moz-user-select: none;
 				-ms-user-select: none;
 				user-select: none;
@@ -1920,7 +1922,7 @@ ul.wc_coupon_list_block {
 				text-align: left;
 				line-height: 1.5em;
 				vertical-align: top;
-				border-bottom: 1px solid #f8f8f8;
+				border-bottom: 1px solid wc-shade( 97 );
 
 				textarea {
 					width: 100%;
@@ -1947,11 +1949,11 @@ ul.wc_coupon_list_block {
 			}
 
 			tbody tr:last-child td {
-				border-bottom: 1px solid #dfdfdf;
+				border-bottom: 1px solid wc-shade( 87 );
 			}
 
 			tbody tr:first-child td {
-				border-top: 8px solid #f8f8f8;
+				border-top: 8px solid wc-shade( 97 );
 			}
 
 			tbody#order_line_items tr:first-child td {
@@ -1967,8 +1969,8 @@ ul.wc_coupon_list_block {
 					width: 38px;
 					height: 38px;
 					border: 2px solid #e8e8e8;
-					background: #f8f8f8;
-					color: #ccc;
+					background: wc-shade( 97 );
+					color: wc-shade( 80 );
 					position: relative;
 					font-size: 21px;
 					display: block;
@@ -1999,7 +2001,7 @@ ul.wc_coupon_list_block {
 					display: block;
 					margin-top: 0.5em;
 					font-size: 0.92em !important;
-					color: #888;
+					color: wc-shade( 53 );
 				}
 			}
 
@@ -2023,7 +2025,7 @@ ul.wc_coupon_list_block {
 
 				label {
 					white-space: nowrap;
-					color: #999;
+					color: wc-shade( 60 );
 					font-size: 0.833em;
 
 					input {
@@ -2046,9 +2048,9 @@ ul.wc_coupon_list_block {
 
 				.split-input {
 					display: inline-block;
-					background: #fff;
-					border: 1px solid #ddd;
-					box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.07);
+					background: var(--wc-content-bg);
+					border: 1px solid wc-shade( 87 );
+					box-shadow: inset 0 1px 2px wc-shade( 0, black, 7% );
 					margin: 1px 0;
 					min-width: 80px;
 					overflow: hidden;
@@ -2077,21 +2079,21 @@ ul.wc_coupon_list_block {
 							background: transparent;
 
 							&::-webkit-input-placeholder {
-								color: #ddd;
+								color: wc-shade( 87 );
 							}
 						}
 					}
 
 					div.input:first-child {
-						border-bottom: 1px dashed #ddd;
-						background: #fff;
+						border-bottom: 1px dashed wc-shade( 87 );
+						background: var(--wc-content-bg);
 
 						label {
-							color: #ccc;
+							color: wc-shade( 80 );
 						}
 
 						input {
-							color: #ccc;
+							color: wc-shade( 80 );
 						}
 					}
 				}
@@ -2110,7 +2112,7 @@ ul.wc_coupon_list_block {
 				.wc-order-item-discount,
 				.wc-order-item-refund-fields {
 					font-size: 0.92em !important;
-					color: #888;
+					color: wc-shade( 53 );
 				}
 
 				.wc-order-item-taxes,
@@ -2151,7 +2153,7 @@ ul.wc_coupon_list_block {
 			}
 
 			.calculated {
-				border-color: #ae8ca2;
+				border-color: #{wc-hsl( 'orchid',  17%, 62%)};
 				border-style: dotted;
 			}
 
@@ -2163,7 +2165,7 @@ ul.wc_coupon_list_block {
 			table.display_meta {
 				margin: 0.5em 0 0;
 				font-size: 0.92em !important;
-				color: #888;
+				color: wc-shade( 53 );
 
 				tr {
 
@@ -2195,7 +2197,7 @@ ul.wc_coupon_list_block {
 						}
 
 						input:focus + textarea {
-							border-top-color: #999;
+							border-top-color: wc-shade( 60 );
 						}
 
 						p {
@@ -2211,7 +2213,7 @@ ul.wc_coupon_list_block {
 			}
 
 			.refund_by {
-				border-bottom: 1px dotted #999;
+				border-bottom: 1px dotted wc-shade( 60 );
 			}
 
 			tr.fee .thumb div {
@@ -2225,7 +2227,7 @@ ul.wc_coupon_list_block {
 				&::before {
 
 					@include icon("\e007");
-					color: #ccc;
+					color: wc-shade( 80 );
 				}
 			}
 
@@ -2240,7 +2242,7 @@ ul.wc_coupon_list_block {
 				&::before {
 
 					@include icon("\e014");
-					color: #ccc;
+					color: wc-shade( 80 );
 				}
 			}
 
@@ -2257,7 +2259,7 @@ ul.wc_coupon_list_block {
 					&::before {
 
 						@include icon("\e01a");
-						color: #ccc;
+						color: wc-shade( 80 );
 					}
 				}
 
@@ -2286,11 +2288,11 @@ ul.wc_coupon_list_block {
 					&::before {
 
 						@include icon_dashicons("\f153");
-						color: #999;
+						color: wc-shade( 60 );
 					}
 
 					&:hover::before {
-						color: $red;
+						color: var(--wc-red);
 					}
 				}
 
@@ -2301,7 +2303,7 @@ ul.wc_coupon_list_block {
 
 			small.refunded {
 				display: block;
-				color: $red;
+				color: var(--wc-red);
 				white-space: nowrap;
 				margin-top: 0.5em;
 
@@ -2330,7 +2332,7 @@ ul.wc_coupon_list_block {
 		vertical-align: middle;
 
 		a {
-			color: #ccc;
+			color: wc-shade( 80 );
 			display: inline-block;
 			cursor: pointer;
 			padding: 0 0 0.5em;
@@ -2352,7 +2354,7 @@ ul.wc_coupon_list_block {
 			&:hover {
 
 				&::before {
-					color: #999;
+					color: wc-shade( 60 );
 				}
 			}
 
@@ -2377,7 +2379,7 @@ ul.wc_coupon_list_block {
 			}
 
 			&:hover::before {
-				color: $red;
+				color: var(--wc-red);
 			}
 		}
 	}
@@ -2422,7 +2424,7 @@ ul.wc_coupon_list_block {
 	}
 
 	h3 small {
-		color: #999;
+		color: wc-shade( 60 );
 	}
 }
 
@@ -2483,7 +2485,7 @@ ul.wc_coupon_list_block {
 
 		time {
 			display: block;
-			color: #999;
+			color: wc-shade( 60 );
 			margin: 3px 0;
 		}
 	}
@@ -2567,7 +2569,7 @@ ul.wc_coupon_list_block {
 
 	small.meta {
 		display: block;
-		color: #999;
+		color: wc-shade( 60 );
 		font-size: inherit;
 		margin: 3px 0;
 	}
@@ -2652,7 +2654,7 @@ ul.wc_coupon_list_block {
 		}
 
 		tbody tr {
-			border-top: 1px solid #f5f5f5;
+			border-top: 1px solid wc-shade( 96 );
 		}
 
 		tbody tr:hover:not(.status-trash):not(.no-link) td {
@@ -2715,7 +2717,7 @@ ul.wc_coupon_list_block {
 
 			.description {
 				display: block;
-				color: #999;
+				color: wc-shade( 60 );
 			}
 		}
 
@@ -2748,7 +2750,7 @@ ul.wc_coupon_list_block {
 			}
 
 			&:hover {
-				border: 2px solid #00a0d2;
+				border: 2px solid #{wc-hsl( 'blue',  100%, 41%)};
 			}
 		}
 
@@ -2766,38 +2768,38 @@ ul.wc_coupon_list_block {
 .order-status {
 	display: inline-flex;
 	line-height: 2.5em;
-	color: #777;
-	background: #e5e5e5;
+	color: wc-shade( 47 );
+	background: wc-shade( 90 );
 	border-radius: 4px;
-	border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+	border-bottom: 1px solid wc-shade( 0, black, 5% );
 	margin: -0.25em 0;
 	cursor: inherit !important;
 	white-space: nowrap;
 	max-width: 100%;
 
 	&.status-completed {
-		background: #c8d7e1;
-		color: #2e4453;
+		background: #{wc-hsl( 'info',  29%, 83%)};
+		color: #{wc-hsl( 'info',  29%, 25%)};
 	}
 
 	&.status-on-hold {
-		background: #f8dda7;
-		color: #94660c;
+		background: #{wc-hsl( 'warning',  85%, 83%)};
+		color: #{wc-hsl( 'warning',  85%, 31%)};
 	}
 
 	&.status-failed {
-		background: #eba3a3;
-		color: #761919;
+		background: #{wc-hsl( 'error',  65%, 83%)};
+		color: #{wc-hsl( 'error',  65%, 31%)};
 	}
 
 	&.status-processing {
-		background: #c6e1c6;
-		color: #5b841b;
+		background: #{wc-hsl( 'success',  50%, 82%)};
+		color: #{wc-hsl( 'success',  50%, 31%)};
 	}
 
 	&.status-trash {
-		background: #eba3a3;
-		color: #761919;
+		background: #{wc-hsl( 'error',  65%, 83%)};
+		color: #{wc-hsl( 'error',  65%, 31%)};
 	}
 
 	> span {
@@ -2829,9 +2831,8 @@ ul.wc_coupon_list_block {
 		th,
 		td {
 			padding: 1em 1.5em;
-			text-align: left;
 			border: 0;
-			border-bottom: 1px solid #eee;
+			border-bottom: 1px solid #{wc-shade( 93 )};
 			margin: 0;
 			background: transparent;
 			box-shadow: none;
@@ -2845,7 +2846,7 @@ ul.wc_coupon_list_block {
 		}
 
 		th {
-			border-color: #ccc;
+			border-color: wc-shade( 80 );
 		}
 
 		tr:last-child td {
@@ -2942,7 +2943,7 @@ ul.wc_coupon_list_block {
 
 	.wc-action-button {
 		margin: 0 0 0 -1px !important;
-		border: 1px solid #ccc;
+		border: 1px solid wc-shade( 80 );
 		padding: 0 10px !important;
 		border-radius: 0 !important;
 		float: none;
@@ -2960,7 +2961,7 @@ ul.wc_coupon_list_block {
 
 	.wc-action-button:hover,
 	.wc-action-button:focus {
-		border: 1px solid #999;
+		border: 1px solid wc-shade( 60 );
 		z-index: 2;
 	}
 
@@ -3034,7 +3035,7 @@ ul.wc_coupon_list_block {
 
 	@include ir();
 	margin: 0 auto;
-	color: #999;
+	color: wc-shade( 60 );
 
 	&::after {
 
@@ -3047,7 +3048,7 @@ ul.wc_coupon_list_block {
 
 	@include ir();
 	margin: 0 auto;
-	color: #999;
+	color: wc-shade( 60 );
 
 	&::after {
 
@@ -3096,7 +3097,7 @@ ul.order_notes {
 
 		.note_content {
 			padding: 10px;
-			background: #efefef;
+			background: wc-shade( 93 );
 			position: relative;
 
 			p {
@@ -3108,17 +3109,17 @@ ul.order_notes {
 
 		p.meta {
 			padding: 10px;
-			color: #999;
+			color: wc-shade( 60 );
 			margin: 0;
 			font-size: 11px;
 
 			.exact-date {
-				border-bottom: 1px dotted #999;
+				border-bottom: 1px dotted wc-shade( 60 );
 			}
 		}
 
 		a.delete_note {
-			color: $red;
+			color: var(--wc-red);
 		}
 
 		.note_content::after {
@@ -3131,35 +3132,35 @@ ul.order_notes {
 			height: 0;
 			border-width: 10px 10px 0 0;
 			border-style: solid;
-			border-color: #efefef transparent;
+			border-color: wc-shade( 93 ) transparent;
 		}
 	}
 
 	li.system-note {
 
 		.note_content {
-			background: #d7cad2;
+			background: #{wc-hsl( 'red',  14%, 81%)};
 		}
 
 		.note_content::after {
-			border-color: #d7cad2 transparent;
+			border-color: #{wc-hsl( 'red',  14%, 81%)} transparent;
 		}
 	}
 
 	li.customer-note {
 
 		.note_content {
-			background: #a7cedc;
+			background: #{wc-hsl( 'blue',  43%, 73%)};
 		}
 
 		.note_content::after {
-			border-color: #a7cedc transparent;
+			border-color: #{wc-hsl( 'blue',  43%, 73%)} transparent;
 		}
 	}
 }
 
 .add_note {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid wc-shade( 87 );
 	padding: 10px 10px 0;
 
 	h4 {
@@ -3198,7 +3199,7 @@ table.wp-list-table {
 				font-family: "Dashicons";
 				text-align: center;
 				line-height: 1;
-				color: #999;
+				color: wc-shade( 60 );
 				display: block;
 				width: 17px;
 				height: 100%;
@@ -3247,7 +3248,7 @@ table.wp-list-table {
 	}
 
 	.row-actions {
-		color: #999;
+		color: wc-shade( 60 );
 	}
 
 	.row-actions span.id {
@@ -3264,7 +3265,7 @@ table.wp-list-table {
 	}
 
 	span.na {
-		color: #999;
+		color: wc-shade( 60 );
 	}
 
 	.column-sku {
@@ -3319,15 +3320,15 @@ table.wp-list-table {
 		}
 
 		&.instock {
-			color: $green;
+			color: var(--wc-green);
 		}
 
 		&.outofstock {
-			color: #a44;
+			color: #{wc-hsl( 'error',  43%, 46%)};
 		}
 
 		&.onbackorder {
-			color: #eaa600;
+			color: #{wc-hsl( 'alert',  100%, 46%)};
 		}
 	}
 
@@ -3372,7 +3373,7 @@ table.wp-list-table {
 			}
 
 			td.qty {
-				color: #999;
+				color: wc-shade( 60 );
 				padding-right: 6px;
 				text-align: left;
 			}
@@ -3381,8 +3382,8 @@ table.wp-list-table {
 }
 
 mark.notice {
-	background: #fff;
-	color: $red;
+	background: var(--wc-content-bg);
+	color: var(--wc-error);
 	margin: 0 0 0 10px;
 }
 
@@ -3427,7 +3428,7 @@ table.wc_input_table {
 	}
 
 	span.tips {
-		color: $blue;
+		color: var(--wc-tips--color);
 	}
 
 	th {
@@ -3437,10 +3438,10 @@ table.wc_input_table {
 
 	td {
 		padding: 0;
-		border-right: 1px solid #dfdfdf;
-		border-bottom: 1px solid #dfdfdf;
+		border-right: 1px solid wc-shade( 87 );
+		border-bottom: 1px solid wc-shade( 87 );
 		border-top: 0;
-		background: #fff;
+		background: var(--wc-content-bg);
 		cursor: default;
 
 		input[type="text"],
@@ -3475,7 +3476,7 @@ table.wc_input_table {
 	}
 
 	tr.current td {
-		background-color: #fefbcc;
+		background-color: #{wc-hsl( 'yellow',  96%, 90%)};
 	}
 
 	.item_cost,
@@ -3499,7 +3500,7 @@ table.wc_input_table {
 	.ui-sortable:not(.ui-sortable-disabled) td.sort {
 		cursor: move;
 		font-size: 15px;
-		background: #f9f9f9;
+		background: wc-shade( 98 );
 		text-align: center;
 		vertical-align: middle;
 
@@ -3508,7 +3509,7 @@ table.wc_input_table {
 			font-family: "Dashicons";
 			text-align: center;
 			line-height: 1;
-			color: #999;
+			color: wc-shade( 60 );
 			display: block;
 			width: 17px;
 			float: left;
@@ -3516,7 +3517,7 @@ table.wc_input_table {
 		}
 
 		&:hover::before {
-			color: #333;
+			color: wc-shade( 20 );
 		}
 	}
 
@@ -3580,7 +3581,7 @@ table.wc_shipping {
 	}
 
 	tr:nth-child(odd) td {
-		background: #f9f9f9;
+		background: wc-shade( 98 );
 	}
 
 	td.name {
@@ -3617,8 +3618,7 @@ table.wc_shipping {
 				content: "\f333";
 				font-family: "Dashicons";
 				text-align: center;
-				line-height: 1;
-				color: #999;
+				color: wc-shade( 60 );
 				display: block;
 				width: 24px;
 				float: left;
@@ -3672,7 +3672,7 @@ table.wc_shipping {
 			}
 
 			.wc-move-disabled {
-				color: #d5d5d5 !important;
+				color: wc-shade( 83 ) !important;
 				cursor: default;
 				pointer-events: none;
 			}
@@ -3688,7 +3688,7 @@ table.wc_shipping {
 
 		span {
 			font-weight: normal;
-			color: #999;
+			color: wc-shade( 60 );
 			margin: 0 0 0 4px !important;
 		}
 	}
@@ -3731,7 +3731,7 @@ table.wc_shipping {
 
 			.select2-choices {
 				padding: 8px 8px 4px;
-				border-color: #ddd;
+				border-color: wc-shade( 87 );
 				min-height: 0;
 				line-height: 1;
 
@@ -3765,7 +3765,7 @@ table.wc_shipping {
 
 		.description {
 			font-size: 0.9em;
-			color: #999;
+			color: wc-shade( 60 );
 		}
 	}
 }
@@ -3810,7 +3810,7 @@ table.wc-shipping-classes {
 		line-height: 24px;
 		padding: 1em !important;
 		font-size: 14px;
-		background: #fff;
+		background: var(--wc-content-bg);
 		display: table-cell !important;
 
 		li {
@@ -3840,7 +3840,7 @@ table.wc-shipping-classes {
 		overflow: hidden;
 		position: relative;
 		padding: 7.5em 7.5% !important;
-		border-bottom: 2px solid #eee2ec;
+		border-bottom: 2px solid #{wc-hsl( 'orchid',  26%, 91%)};
 
 		&.wc-shipping-zone-method-blank-state {
 			padding: 2em !important;
@@ -3852,13 +3852,13 @@ table.wc-shipping-classes {
 
 		p,
 		li {
-			color: #a46497;
+			color: var(--woocommerce);
 			font-size: 1.5em;
 			line-height: 1.5em;
 			margin: 0 0 1em;
 			position: relative;
 			z-index: 1;
-			text-shadow: 1px 1px 1px white;
+			text-shadow: 1px 1px 1px var(--wc-white);
 
 			&.main {
 				font-size: 2em;
@@ -3875,7 +3875,7 @@ table.wc-shipping-classes {
 			font-family: "WooCommerce";
 			text-align: center;
 			line-height: 1;
-			color: #eee2ec;
+			color: #{wc-hsl( 'orchid',  26%, 91%)};
 			display: block;
 			width: 1em;
 			font-size: 40em;
@@ -3889,8 +3889,8 @@ table.wc-shipping-classes {
 			background-color: #804877;
 			border-color: #804877;
 			box-shadow:
-				inset 0 1px 0 rgba(255, 255, 255, 0.2),
-				0 1px 0 rgba(0, 0, 0, 0.15);
+				inset 0 1px 0 wc-shade( 100 , 'white', 2% ),
+				0 1px 0 wc-shade( 0, black, 15% );
 			margin: 0;
 			opacity: 1;
 			text-shadow:
@@ -3909,7 +3909,7 @@ table.wc-shipping-classes {
 	.wc-shipping-zone-method-rows {
 
 		tr:nth-child(even) td {
-			background: #f9f9f9;
+			background: wc-shade( 98 );
 		}
 	}
 
@@ -3917,14 +3917,14 @@ table.wc-shipping-classes {
 	.wc-shipping-class-rows tr:nth-child(odd) {
 
 		td {
-			background: #f9f9f9;
+			background: wc-shade( 98 );
 		}
 	}
 
 	tbody.wc-shipping-zone-rows {
 
 		td {
-			border-top: 2px solid #f9f9f9;
+			border-top: 2px solid wc-shade( 98 );
 		}
 
 		tr:first-child {
@@ -3938,8 +3938,8 @@ table.wc-shipping-classes {
 	tr.wc-shipping-zone-worldwide {
 
 		td {
-			background: #f9f9f9;
-			border-top: 2px solid #e1e1e1;
+			background: wc-shade( 98 );
+			border-top: 2px solid wc-shade( 88 );
 		}
 	}
 
@@ -3958,8 +3958,7 @@ table.wc-shipping-classes {
 			content: "\f333";
 			font-family: "Dashicons";
 			text-align: center;
-			line-height: 1;
-			color: #999;
+			color: wc-shade( 60 );
 			display: block;
 			width: 17px;
 			float: left;
@@ -3968,7 +3967,7 @@ table.wc-shipping-classes {
 		}
 
 		&:hover::before {
-			color: #333;
+			color: wc-shade( 20 );
 		}
 	}
 
@@ -3979,8 +3978,7 @@ table.wc-shipping-classes {
 			content: "\f319";
 			font-family: "dashicons";
 			text-align: center;
-			line-height: 1;
-			color: #999;
+			color: wc-shade( 60 );
 			display: block;
 			width: 17px;
 			float: left;
@@ -4013,7 +4011,7 @@ table.wc-shipping-classes {
 
 		a.wc-shipping-zone-delete:hover,
 		a.wc-shipping-class-delete:hover {
-			color: red;
+			color: var(--wc-red);
 		}
 	}
 
@@ -4060,7 +4058,7 @@ table.wc-shipping-classes {
 				@include icon;
 				font-family: "Dashicons";
 				content: "\f502";
-				color: #999;
+				color: wc-shade( 60 );
 				vertical-align: middle;
 				line-height: 24px;
 				font-size: 16px;
@@ -4071,7 +4069,7 @@ table.wc-shipping-classes {
 				cursor: not-allowed;
 
 				&::before {
-					color: #ccc;
+					color: wc-shade( 80 );
 				}
 			}
 		}
@@ -4081,7 +4079,7 @@ table.wc-shipping-classes {
 		width: 25%;
 
 		.wc-shipping-zone-method-delete {
-			color: red;
+			color: var(--wc-red);
 		}
 	}
 
@@ -4139,7 +4137,7 @@ table.wc-shipping-classes {
 		display: block;
 		width: 16px;
 		height: 16px;
-		background: #fff;
+		background: var(--wc-content-bg);
 		position: absolute;
 		top: 0;
 		right: 0;
@@ -4147,8 +4145,8 @@ table.wc-shipping-classes {
 	}
 
 	&.woocommerce-input-toggle--disabled {
-		border-color: #999;
-		background-color: #999;
+		border-color: wc-shade( 60 );
+		background-color: wc-shade( 60 );
 
 		&::before {
 			right: auto;
@@ -4167,7 +4165,7 @@ table.wc-shipping-classes {
 
 	form .form-table {
 		width: 100%;
-		background: #fff;
+		background: var(--wc-content-bg);
 		margin: 0 0 1.5em;
 
 		tr {
@@ -4226,7 +4224,7 @@ table.wc-shipping-classes {
 	.wc-shipping-zone-method-description {
 		margin: 0.75em 1px 0;
 		line-height: 1.5em;
-		color: #999;
+		color: wc-shade( 60 );
 		font-style: italic;
 	}
 
@@ -4260,19 +4258,19 @@ img.help_tip {
 .status-manual::before {
 
 	@include icon("\e008");
-	color: #999;
+	color: wc-shade( 60 );
 }
 
 .status-enabled::before {
 
 	@include icon("\e015");
-	color: $woocommerce;
+	color: var(--wc-woocommerce);
 }
 
 .status-disabled::before {
 
 	@include icon("\e013");
-	color: #ccc;
+	color: wc-shade( 80 );
 }
 
 .woocommerce {
@@ -4293,7 +4291,7 @@ img.help_tip {
 		margin-left: 0.5em;
 
 		a {
-			color: #a46497;
+			color: var(--woocommerce);
 		}
 	}
 
@@ -4312,7 +4310,7 @@ img.help_tip {
 	}
 
 	textarea[disabled="disabled"] {
-		background: #dfdfdf !important;
+		background: wc-shade( 87 ) !important;
 	}
 
 	table.form-table {
@@ -4409,7 +4407,7 @@ img.help_tip {
 
 		span.help_tip {
 			cursor: help;
-			color: $blue;
+			color: var(--wc-tips--color);
 		}
 
 		th {
@@ -4476,9 +4474,9 @@ img.help_tip {
 			z-index: 100;
 			display: none;
 			position: absolute;
-			border: 1px solid #ccc;
+			border: 1px solid wc-shade( 80 );
 			border-radius: 3px;
-			box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+			box-shadow: 0 1px 3px wc-shade( 0, black, 20% );
 
 			.ui-slider {
 				border: 0 !important;
@@ -4494,7 +4492,7 @@ img.help_tip {
 		}
 
 		.iris-error {
-			background-color: #ffafaf;
+			background-color: wc-hsl(  'red', 100%, 85% );
 		}
 
 		.colorpickpreview {
@@ -4502,7 +4500,7 @@ img.help_tip {
 			line-height: 1em;
 			display: inline-block;
 			width: 26px;
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 			font-size: 14px;
 		}
 
@@ -4603,7 +4601,7 @@ img.help_tip {
 				padding: 0;
 				width: 30px;
 				height: 30px;
-				box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+				box-shadow: inset 0 0 0 1px wc-shade( 0, black, 20% );
 				font-size: 16px;
 				border-radius: 4px;
 				margin-right: 3px;
@@ -4633,7 +4631,7 @@ img.help_tip {
 }
 
 #wp-excerpt-editor-container {
-	background: #fff;
+	background: var(--wc-content-bg);
 }
 
 #product_variation-parent #parent_id {
@@ -4641,7 +4639,7 @@ img.help_tip {
 }
 
 #postimagediv img {
-	border: 1px solid #d5d5d5;
+	border: 1px solid wc-shade( 83 );
 	max-width: 100%;
 }
 
@@ -4668,9 +4666,9 @@ img.help_tip {
 				width: 80px;
 				float: left;
 				cursor: move;
-				border: 1px solid #d5d5d5;
+				border: 1px solid wc-shade( 83 );
 				margin: 9px 9px 0 0;
-				background: #f7f7f7;
+				background: wc-shade( 95 );
 
 				@include border-radius(2px);
 				position: relative;
@@ -4684,7 +4682,7 @@ img.help_tip {
 			}
 
 			li.wc-metabox-sortable-placeholder {
-				border: 3px dashed #ddd;
+				border: 3px dashed wc-shade( 87 );
 				position: relative;
 
 				&::after {
@@ -4692,7 +4690,7 @@ img.help_tip {
 					@include icon_dashicons("\f161");
 					font-size: 2.618em;
 					line-height: 72px;
-					color: #ddd;
+					color: wc-shade( 87 );
 				}
 			}
 
@@ -4713,7 +4711,6 @@ img.help_tip {
 
 					a {
 						width: 1em;
-						height: 1em;
 						margin: 0;
 						height: 0;
 						display: block;
@@ -4732,8 +4729,8 @@ img.help_tip {
 						&::before {
 
 							@include icon_dashicons("\f153");
-							color: #999;
-							background: #fff;
+							color: wc-shade( 60 );
+							background: var(--wc-content-bg);
 							border-radius: 50%;
 							height: 1em;
 							width: 1em;
@@ -4741,7 +4738,7 @@ img.help_tip {
 						}
 
 						&:hover::before {
-							color: $red;
+							color: var(--wc-red);
 						}
 					}
 				}
@@ -4782,7 +4779,7 @@ img.help_tip {
 
 		label:first-child {
 			margin-right: 1em;
-			border-right: 1px solid #dfdfdf;
+			border-right: 1px solid wc-shade( 87 );
 		}
 
 		input,
@@ -4840,7 +4837,7 @@ img.help_tip {
 #woocommerce-coupon-data {
 
 	.panel-wrap {
-		background: #fff;
+		background: var(--wc-content-bg);
 	}
 
 	.woocommerce_options_panel,
@@ -4881,7 +4878,7 @@ img.help_tip {
 		padding: 0 0 10px;
 		position: relative;
 		background-color: #fafafa;
-		border-right: 1px solid #eee;
+		border-right: 1px solid #{wc-shade( 93 )};
 		box-sizing: border-box;
 
 		&::after {
@@ -4893,7 +4890,7 @@ img.help_tip {
 			bottom: -9999em;
 			left: 0;
 			background-color: #fafafa;
-			border-right: 1px solid #eee;
+			border-right: 1px solid #{wc-shade( 93 )};
 		}
 
 		li {
@@ -4909,7 +4906,7 @@ img.help_tip {
 				box-shadow: none;
 				text-decoration: none;
 				line-height: 20px !important;
-				border-bottom: 1px solid #eee;
+				border-bottom: 1px solid #{wc-shade( 93 )};
 
 				span {
 					margin-left: 0.618em;
@@ -4974,7 +4971,7 @@ img.help_tip {
 			&.active a {
 				color: #555;
 				position: relative;
-				background-color: #eee;
+				background-color: #{wc-shade( 93 )};
 			}
 		}
 	}
@@ -5119,13 +5116,13 @@ img.help_tip {
 				&::before {
 
 					@include icon_dashicons("\f153");
-					color: #999;
+					color: wc-shade( 60 );
 				}
 
 				&:hover {
 
 					&::before {
-						color: $red;
+						color: var(--wc-red);
 					}
 				}
 			}
@@ -5136,7 +5133,7 @@ img.help_tip {
 			cursor: move;
 			font-size: 15px;
 			text-align: center;
-			background: #f9f9f9;
+			background: wc-shade( 98 );
 			padding-right: 7px !important;
 
 			&::before {
@@ -5144,7 +5141,7 @@ img.help_tip {
 				font-family: "Dashicons";
 				text-align: center;
 				line-height: 1;
-				color: #999;
+				color: wc-shade( 60 );
 				display: block;
 				width: 17px;
 				float: left;
@@ -5152,7 +5149,7 @@ img.help_tip {
 			}
 
 			&:hover::before {
-				color: #333;
+				color: wc-shade( 20 );
 			}
 		}
 	}
@@ -5178,7 +5175,7 @@ img.help_tip {
 			font-family: "Dashicons";
 			text-align: center;
 			line-height: 28px;
-			color: #999;
+			color: wc-shade( 60 );
 			display: block;
 			width: 17px;
 			float: left;
@@ -5186,7 +5183,7 @@ img.help_tip {
 		}
 
 		&:hover::before {
-			color: #777;
+			color: wc-shade( 47 );
 		}
 	}
 
@@ -5246,7 +5243,7 @@ img.help_tip {
 		.req {
 			font-weight: 700;
 			font-style: normal;
-			color: $red;
+			color: var(--wc-red);
 		}
 	}
 
@@ -5306,8 +5303,8 @@ img.help_tip {
 	}
 
 	.options_group {
-		border-top: 1px solid white;
-		border-bottom: 1px solid #eee;
+		border-top: 1px solid var(--wc-white);
+		border-bottom: 1px solid #{wc-shade( 93 )};
 
 		&:first-child {
 			border-top: 0;
@@ -5384,7 +5381,7 @@ img.help_tip {
 #simple_product_options {
 	padding: 12px;
 	font-style: italic;
-	color: #666;
+	color: wc-shade( 40 );
 }
 
 /**
@@ -5394,8 +5391,8 @@ img.help_tip {
 
 	.toolbar {
 		margin: 0 !important;
-		border-top: 1px solid white;
-		border-bottom: 1px solid #eee;
+		border-top: 1px solid var(--wc-white);
+		border-bottom: 1px solid #{wc-shade( 93 )};
 		padding: 9px 12px !important;
 
 		&:first-child {
@@ -5425,7 +5422,7 @@ img.help_tip {
 
 	.expand-close {
 		margin-right: 2px;
-		color: #777;
+		color: wc-shade( 47 );
 		font-size: 12px;
 		font-style: italic;
 
@@ -5449,20 +5446,20 @@ img.help_tip {
 	}
 
 	.wc-metaboxes {
-		border-bottom: 1px solid #eee;
+		border-bottom: 1px solid #{wc-shade( 93 )};
 	}
 
 	.wc-metabox-sortable-placeholder {
 		border-color: #bbb;
-		background-color: #f5f5f5;
+		background-color: wc-shade( 96 );
 		margin-bottom: 9px;
 		border-width: 1px;
 		border-style: dashed;
 	}
 
 	.wc-metabox {
-		background: #fff;
-		border-bottom: 1px solid #eee;
+		background: var(--wc-content-bg);
+		border-bottom: 1px solid #{wc-shade( 93 )};
 		margin: 0 !important;
 
 		select {
@@ -5517,7 +5514,7 @@ img.help_tip {
 			}
 
 			a.delete {
-				color: red;
+				color: var(--wc-red);
 				font-weight: normal;
 				line-height: 26px;
 				text-decoration: none;
@@ -5526,7 +5523,6 @@ img.help_tip {
 			}
 
 			strong {
-				font-weight: normal;
 				line-height: 26px;
 				font-weight: 700;
 			}
@@ -5574,7 +5570,7 @@ img.help_tip {
 			position: relative;
 			background-color: #fdfdfd;
 			padding: 1em;
-			border-top: 1px solid #eee;
+			border-top: 1px solid #{wc-shade( 93 )};
 
 			td {
 				text-align: left;
@@ -5646,14 +5642,14 @@ img.help_tip {
 	line-height: 24px;
 
 	.displaying-num {
-		color: #777;
+		color: wc-shade( 47 );
 		font-size: 12px;
 		font-style: italic;
 	}
 
 	a {
 		padding: 0 10px 3px;
-		background: rgba(0, 0, 0, 0.05);
+		background: wc-shade( 0, black, 5% );
 		font-size: 16px;
 		font-weight: 400;
 		text-decoration: none;
@@ -5664,7 +5660,7 @@ img.help_tip {
 	a.disabled:focus,
 	a.disabled:hover {
 		color: #a0a5aa;
-		background: rgba(0, 0, 0, 0.05);
+		background: wc-shade( 0, black, 5% );
 	}
 }
 
@@ -5678,7 +5674,7 @@ img.help_tip {
 
 .woocommerce_variable_attributes {
 	background-color: #fdfdfd;
-	border-top: 1px solid #eee;
+	border-top: 1px solid #{wc-shade( 93 )};
 
 	.data {
 
@@ -5734,7 +5730,8 @@ img.help_tip {
 	}
 
 	.options {
-		border: 1px solid #eee;
+		border-color: #{wc-shade( 93 )};
+		border-style: solid;
 		border-width: 1px 0;
 		padding: 0.25em 0;
 
@@ -5848,7 +5845,7 @@ img.tips {
 		#tiptip_arrow_inner {
 			margin-top: -7px;
 			margin-left: -6px;
-			border-top-color: #333;
+			border-top-color: wc-shade( 20 );
 		}
 	}
 
@@ -5858,7 +5855,7 @@ img.tips {
 		#tiptip_arrow_inner {
 			margin-top: -5px;
 			margin-left: -6px;
-			border-bottom-color: #333;
+			border-bottom-color: wc-shade( 20 );
 		}
 	}
 
@@ -5868,7 +5865,7 @@ img.tips {
 		#tiptip_arrow_inner {
 			margin-top: -6px;
 			margin-left: -5px;
-			border-right-color: #333;
+			border-right-color: wc-shade( 20 );
 		}
 	}
 
@@ -5878,7 +5875,7 @@ img.tips {
 		#tiptip_arrow_inner {
 			margin-top: -6px;
 			margin-left: -7px;
-			border-left-color: #333;
+			border-left-color: wc-shade( 20 );
 		}
 	}
 }
@@ -5886,18 +5883,18 @@ img.tips {
 #tiptip_content,
 .chart-tooltip,
 .wc_error_tip {
-	color: #fff;
+	color: var(--wc-white);
 	font-size: 0.8em;
 	max-width: 150px;
-	background: #333;
+	background: wc-shade( 20 );
 	text-align: center;
 	border-radius: 3px;
 	padding: 0.618em 1em;
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+	box-shadow: 0 1px 3px wc-shade( 0, black, 20% );
 
 	code {
 		padding: 1px;
-		background: #888;
+		background: wc-shade( 53 );
 	}
 }
 
@@ -5966,7 +5963,7 @@ img.ui-datepicker-trigger {
   * Reports
   */
 .woocommerce-reports-remove-filter {
-	color: red;
+	color: var(--wc-red);
 	text-decoration: none;
 }
 
@@ -6018,14 +6015,14 @@ img.ui-datepicker-trigger {
 
 		div.stats_range,
 		h3.stats_range {
-			border-bottom-color: #dfdfdf;
+			border-bottom-color: wc-shade( 87 );
 			margin: 0;
 			padding: 0 !important;
 
 			.export_csv {
 				float: right;
 				line-height: 26px;
-				border-left: 1px solid #dfdfdf;
+				border-left: 1px solid wc-shade( 87 );
 				padding: 10px;
 				display: block;
 				text-decoration: none;
@@ -6042,8 +6039,8 @@ img.ui-datepicker-trigger {
 				margin: 0;
 				padding: 0;
 				zoom: 1;
-				background: #f5f5f5;
-				border-bottom: 1px solid #ccc;
+				background: wc-shade( 96 );
+				border-bottom: 1px solid wc-shade( 80 );
 
 				&::before,
 				&::after {
@@ -6064,18 +6061,18 @@ img.ui-datepicker-trigger {
 					font-size: 14px;
 
 					a {
-						border-right: 1px solid #dfdfdf;
+						border-right: 1px solid wc-shade( 87 );
 						padding: 10px;
 						display: block;
 						text-decoration: none;
 					}
 
 					&.active {
-						background: #fff;
-						box-shadow: 0 4px 0 0 #fff;
+						background: var(--wc-content-bg);
+						box-shadow: 0 4px 0 0 var(--wc-white);
 
 						a {
-							color: #777;
+							color: wc-shade( 47 );
 						}
 					}
 
@@ -6093,7 +6090,7 @@ img.ui-datepicker-trigger {
 								margin: 0 10px 0 0;
 								background: transparent;
 								border: 0;
-								color: #777;
+								color: wc-shade( 47 );
 								text-align: center;
 								box-shadow: none;
 
@@ -6125,7 +6122,7 @@ img.ui-datepicker-trigger {
 			li.chart-widget {
 				margin: 0 0 1em;
 				background: #fafafa;
-				border: 1px solid #dfdfdf;
+				border: 1px solid wc-shade( 87 );
 
 				&::after {
 					content: ".";
@@ -6136,18 +6133,18 @@ img.ui-datepicker-trigger {
 				}
 
 				h4 {
-					background: #fff;
-					border: 1px solid #dfdfdf;
-					border-left-width: 0;
-					border-right-width: 0;
+					background: var(--wc-content-bg);
+					border-style: solid;
+					border-color: wc-shade( 87 );
+					border-width: 0;
+					border-bottom: 1px;
 					padding: 10px;
 					margin: 0;
-					color: $blue;
-					border-top-width: 0;
-					background-image: linear-gradient(to top, #ececec, #f9f9f9);
+					color: var(--wc-tips--color);
+					background-image: linear-gradient(to top, wc-shade( 92 ), wc-shade( 98 ));
 
 					&.section_title:hover {
-						color: $red;
+						color: var(--wc-red);
 					}
 				}
 
@@ -6167,7 +6164,7 @@ img.ui-datepicker-trigger {
 					}
 
 					&.open {
-						color: #333;
+						color: wc-shade( 20 );
 
 						span::after {
 							display: none;
@@ -6176,7 +6173,7 @@ img.ui-datepicker-trigger {
 				}
 
 				.section {
-					border-bottom: 1px solid #dfdfdf;
+					border-bottom: 1px solid wc-shade( 87 );
 
 					.select2-container {
 						width: 100% !important;
@@ -6193,7 +6190,7 @@ img.ui-datepicker-trigger {
 					td {
 						padding: 7px 10px;
 						vertical-align: top;
-						border-top: 1px solid #e5e5e5;
+						border-top: 1px solid wc-shade( 90 );
 						line-height: 1.4em;
 					}
 
@@ -6202,7 +6199,7 @@ img.ui-datepicker-trigger {
 					}
 
 					td.count {
-						background: #f5f5f5;
+						background: wc-shade( 96 );
 					}
 
 					td.name {
@@ -6225,7 +6222,7 @@ img.ui-datepicker-trigger {
 					}
 
 					tr.active td {
-						background: #f5f5f5;
+						background: wc-shade( 96 );
 					}
 				}
 
@@ -6246,7 +6243,7 @@ img.ui-datepicker-trigger {
 				.select_all,
 				.select_none {
 					float: right;
-					color: #999;
+					color: wc-shade( 60 );
 					margin-left: 4px;
 					margin-top: 10px;
 				}
@@ -6263,24 +6260,24 @@ img.ui-datepicker-trigger {
 			list-style: none outside;
 			margin: 0 0 1em;
 			padding: 0;
-			border: 1px solid #dfdfdf;
+			border: 1px solid wc-shade( 87 );
 			border-right-width: 0;
 			border-bottom-width: 0;
-			background: #fff;
+			background: var(--wc-content-bg);
 
 			li {
-				border-right: 5px solid #aaa;
-				color: #aaa;
+				border-right: 5px solid wc-shade( 66 );
+				color: wc-shade( 66 );
 				padding: 1em;
 				display: block;
 				margin: 0;
 				transition: all ease 0.5s;
-				box-shadow: inset 0 -1px 0 0 #dfdfdf;
+				box-shadow: inset 0 -1px 0 0 wc-shade( 87 );
 
 				strong {
 					font-size: 1.618em;
 					line-height: 1.2em;
-					color: #464646;
+					color: wc-shade( 27 );
 					font-weight: normal;
 					display: block;
 					font-family:
@@ -6290,18 +6287,18 @@ img.ui-datepicker-trigger {
 						sans-serif;
 
 					del {
-						color: #e74c3c;
+						color: var(--wc-alert);
 						font-weight: normal;
 					}
 				}
 
 				&:hover {
 					box-shadow:
-						inset 0 -1px 0 0 #dfdfdf,
-						inset 300px 0 0 rgba(156, 93, 144, 0.1);
-					border-right: 5px solid #9c5d90 !important;
+						inset 0 -1px 0 0 wc-shade( 87 ),
+						inset 300px 0 0 #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ), .1 )};
+					border-right: 5px solid #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ) )} !important;
 					padding-left: 1.5em;
-					color: #9c5d90;
+					color: #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ) )};
 				}
 			}
 		}
@@ -6314,7 +6311,7 @@ img.ui-datepicker-trigger {
 				float: left;
 				margin: 0;
 				padding: 6px 0 0;
-				border-top: 4px solid #999;
+				border-top: 4px solid wc-shade( 60 );
 				text-align: center;
 				box-sizing: border-box;
 				width: 50%;
@@ -6337,17 +6334,17 @@ img.ui-datepicker-trigger {
 		.chart-prompt {
 			line-height: 650px;
 			margin: 0;
-			color: #999;
+			color: wc-shade( 60 );
 			font-size: 1.2em;
 			font-style: italic;
 			text-align: center;
 		}
 
 		.chart-container {
-			background: #fff;
+			background: var(--wc-content-bg);
 			padding: 12px;
 			position: relative;
-			border: 1px solid #dfdfdf;
+			border: 1px solid wc-shade( 87 );
 			border-radius: 3px;
 		}
 
@@ -6358,7 +6355,7 @@ img.ui-datepicker-trigger {
 				border-right: 0;
 				margin: 0 8px 0 0;
 				float: left;
-				border-top: 4px solid #aaa;
+				border-top: 4px solid wc-shade( 66 );
 			}
 		}
 	}
@@ -6432,7 +6429,7 @@ table.bar_chart {
 
 	thead th {
 		text-align: left;
-		color: #ccc;
+		color: wc-shade( 80 );
 		padding: 6px 0;
 	}
 
@@ -6443,22 +6440,22 @@ table.bar_chart {
 			width: 25%;
 			text-align: left !important;
 			font-weight: normal !important;
-			border-bottom: 1px solid #fee;
+			border-bottom: 1px solid #{wc-hsl( 'red',  100%, 95%)};
 		}
 
 		td {
 			text-align: right;
 			line-height: 24px;
 			padding: 6px 6px 6px 0;
-			border-bottom: 1px solid #fee;
+			border-bottom: 1px solid #{wc-hsl( 'red',  100%, 95%)};
 
 			span {
-				color: #8a4b75;
+				color: #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10 ) )};
 				display: block;
 			}
 
 			span.alt {
-				color: #47a03e;
+				color: var(--wc-green);
 				margin-top: 6px;
 			}
 		}
@@ -6467,13 +6464,13 @@ table.bar_chart {
 			position: relative;
 			text-align: left;
 			padding: 6px 6px 6px 0;
-			border-bottom: 1px solid #fee;
+			border-bottom: 1px solid #{wc-hsl( 'red',  100%, 95%)};
 
 			span,
 			a {
 				text-decoration: none;
 				clear: both;
-				background: #8a4b75;
+				background: #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10 ) )};
 				float: left;
 				display: block;
 				line-height: 24px;
@@ -6483,12 +6480,12 @@ table.bar_chart {
 
 			span.alt {
 				clear: both;
-				background: #47a03e;
+				background: var(--wc-green);
 
 				span {
 					margin: 0;
-					color: #c5dec2 !important;
-					text-shadow: 0 1px 0 #47a03e;
+					color: #{wc-hsl( 'green',  50%, 80%)} !important;
+					text-shadow: 0 1px 0 var(--wc-green);
 					background: transparent;
 				}
 			}
@@ -6526,17 +6523,17 @@ table.bar_chart {
 	padding: 5em 0 0;
 
 	.woocommerce-BlankState-message {
-		color: #aaa;
+		color: wc-shade( 66 );
 		margin: 0 auto 1.5em;
 		line-height: 1.5em;
 		font-size: 1.2em;
 		max-width: 500px;
 
 		&::before {
-			color: #ddd;
+			color: wc-shade( 87 );
 			text-shadow:
-				0 -1px 1px rgba(0, 0, 0, 0.2),
-				0 1px 0 rgba(255, 255, 255, 0.8);
+				0 -1px 1px wc-shade( 0, black, 20% ),
+				0 1px 0 wc-shade( 100 , 'white', 8% );
 			font-size: 8em;
 			display: block;
 			position: relative !important;
@@ -6563,7 +6560,7 @@ table.bar_chart {
 	margin: auto;
 
 	.woocommerce-BlankState-message {
-		color: #444;
+		color: wc-shade( 27 );
 		font-size: 1.5em;
 		margin: 0 auto 1em;
 	}
@@ -6817,7 +6814,6 @@ table.bar_chart {
 		}
 
 		.addons-wcs-banner-block-image {
-			padding: 1em;
 			text-align: center;
 			width: 100%;
 			padding: 2em 0;
@@ -6841,7 +6837,7 @@ table.bar_chart {
 
 	.wc-backbone-modal-content {
 		position: fixed;
-		background: #fff;
+		background: var(--wc-content-bg);
 		z-index: 100000;
 		left: 50%;
 		top: 50%;
@@ -6880,7 +6876,7 @@ table.bar_chart {
 	right: 0;
 	bottom: 0;
 	min-height: 360px;
-	background: #000;
+	background: var(--wc-black);
 	opacity: 0.7;
 	z-index: 99900;
 }
@@ -6896,9 +6892,9 @@ table.bar_chart {
 
 	.wc-backbone-modal-header {
 		height: auto;
-		background: #fcfcfc;
+		background: wc-shade( 99 );
 		padding: 1em 1.5em;
-		border-bottom: 1px solid #ddd;
+		border-bottom: 1px solid wc-shade( 87 );
 
 		h1 {
 			margin: 0;
@@ -6909,7 +6905,7 @@ table.bar_chart {
 
 		.modal-close-link {
 			cursor: pointer;
-			color: #777;
+			color: wc-shade( 47 );
 			height: 54px;
 			width: 54px;
 			padding: 0;
@@ -6918,13 +6914,13 @@ table.bar_chart {
 			right: 0;
 			text-align: center;
 			border: 0;
-			border-left: 1px solid #ddd;
+			border-left: 1px solid wc-shade( 87 );
 			background-color: transparent;
 			transition: color 0.1s ease-in-out, background 0.1s ease-in-out;
 
 			&::before {
 				font: normal 22px/50px "dashicons" !important;
-				color: #666;
+				color: wc-shade( 40 );
 				display: block;
 				content: "\f335";
 				font-weight: 300;
@@ -6932,9 +6928,9 @@ table.bar_chart {
 
 			&:hover,
 			&:focus {
-				background: #ddd;
-				border-color: #ccc;
-				color: #000;
+				background: wc-shade( 87 );
+				border-color: wc-shade( 80 );
+				color: var(--wc-black);
 			}
 
 			&:focus {
@@ -7013,9 +7009,9 @@ table.bar_chart {
 		bottom: 0;
 		z-index: 100;
 		padding: 1em 1.5em;
-		background: #fcfcfc;
-		border-top: 1px solid #dfdfdf;
-		box-shadow: 0 -4px 4px -4px rgba(0, 0, 0, 0.1);
+		background: wc-shade( 99 );
+		border-top: 1px solid wc-shade( 87 );
+		box-shadow: 0 -4px 4px -4px wc-shade( 0, black, 10% );
 
 		.inner {
 			text-align: right;
@@ -7047,21 +7043,21 @@ table.bar_chart {
 
 	.description {
 		display: block;
-		color: #999;
+		color: wc-shade( 60 );
 		padding-top: 4px;
 	}
 }
 
 .select2-dropdown {
-	border-color: #ddd;
+	border-color: wc-shade( 87 );
 }
 
 .select2-dropdown--below {
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 1px 1px wc-shade( 0, black, 10% );
 }
 
 .select2-dropdown--above {
-	box-shadow: 0 -1px 1px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 -1px 1px wc-shade( 0, black, 10% );
 }
 
 .select2-container {
@@ -7071,7 +7067,7 @@ table.bar_chart {
 	}
 
 	.select2-selection {
-		border-color: #ddd;
+		border-color: wc-shade( 87 );
 	}
 
 	.select2-search__field {
@@ -7111,7 +7107,7 @@ table.bar_chart {
 	}
 
 	.select2-selection__clear {
-		color: #999;
+		color: wc-shade( 60 );
 		margin-top: -1px;
 		z-index: 1;
 	}
@@ -7142,20 +7138,20 @@ table.bar_chart {
 	}
 
 	.select2-dropdown {
-		border-color: #007cba;
+		border-color: var(--wc-blue);
 
 		&::after {
 			position: absolute;
 			left: 0;
 			right: 0;
 			height: 1px;
-			background: #fff;
+			background: var(--wc-content-bg);
 			content: "";
 		}
 	}
 
 	.select2-dropdown--below {
-		box-shadow: 0 0 0 1px #007cba, 0 2px 1px rgba(0, 0, 0, 0.1);
+		box-shadow: 0 0 0 1px var(--wc-blue), 0 2px 1px wc-shade( 0, black, 10% );
 
 		&::after {
 			top: -1px;
@@ -7163,7 +7159,7 @@ table.bar_chart {
 	}
 
 	.select2-dropdown--above {
-		box-shadow: 0 0 0 1px #007cba, 0 -2px 1px rgba(0, 0, 0, 0.1);
+		box-shadow: 0 0 0 1px var(--wc-blue), 0 -2px 1px wc-shade( 0, black, 10% );
 
 		&::after {
 			bottom: -1px;
@@ -7182,7 +7178,7 @@ table.bar_chart {
 
 		.select2-selection--single {
 			height: 30px;
-			border-color: #7e8993;
+			border-color: #{wc-hsl( 'blue',  9%, 53%)};
 
 			@media only screen and (max-width: 782px) {
 				height: 40px;
@@ -7200,7 +7196,7 @@ table.bar_chart {
 				}
 
 				&:hover {
-					color: #007cba;
+					color: var(--wc-blue);
 				}
 			}
 
@@ -7226,13 +7222,13 @@ table.bar_chart {
 		&.select2-container--focus .select2-selection--single,
 		&.select2-container--open .select2-selection--single,
 		&.select2-container--open .select2-selection--multiple {
-			border-color: #007cba;
-			box-shadow: 0 0 0 1px #007cba;
+			border-color: var(--wc-blue);
+			box-shadow: 0 0 0 1px var(--wc-blue);
 		}
 
 		.select2-selection--multiple {
 			min-height: 30px;
-			border-color: #7e8993;
+			border-color: #{wc-hsl( 'blue',  9%, 53%)};
 			border-radius: 4px;
 		}
 
@@ -7289,32 +7285,31 @@ table.bar_chart {
 			}
 
 			.select2-dropdown--below {
-				box-shadow: 0 0 0 1px $color, 0 2px 1px rgba(0, 0, 0, 0.1);
+				box-shadow: 0 0 0 1px $color, 0 2px 1px wc-shade( 0, black, 10% );
 			}
 
 			.select2-dropdown--above {
-				box-shadow: 0 0 0 1px $color, 0 -2px 1px rgba(0, 0, 0, 0.1);
+				box-shadow: 0 0 0 1px $color, 0 -2px 1px wc-shade( 0, black, 10% );
 			}
 
 			.select2-selection--single .select2-selection__rendered:hover {
 				color: $color;
 			}
 
-			.select2-container.select2-container--focus
-			.select2-selection--single,
-			.select2-container.select2-container--open
-			.select2-selection--single,
-			.select2-container.select2-container--open
-			.select2-selection--multiple {
-				border-color: $color;
-				box-shadow: 0 0 0 1px $color;
+			.select2-container.select2-container-- {
+				&focus .select2-selection--single,
+				&open .select2-selection--single,
+				&open .select2-selection--multiple {
+					border-color: $color;
+					box-shadow: 0 0 0 1px $color;
+				}
 			}
 
-			.select2-container--default
-			.select2-results__option--highlighted[aria-selected],
-			.select2-container--default
-			.select2-results__option--highlighted[data-selected] {
-				background-color: $color;
+			.select2-container--default .select2-results__option--highlighted {
+				&[aria-selected],
+				&[data-selected] {
+					background-color: $color;
+				}
 			}
 		}
 	}
@@ -7357,7 +7352,7 @@ table.bar_chart {
 		margin: 0;
 		list-style: none outside;
 		overflow: hidden;
-		color: #ccc;
+		color: wc-shade( 80 );
 		width: 100%;
 		display: -webkit-inline-flex;
 		display: -ms-inline-flexbox;
@@ -7370,13 +7365,13 @@ table.bar_chart {
 			margin: 0;
 			text-align: center;
 			position: relative;
-			border-bottom: 4px solid #ccc;
+			border-bottom: 4px solid wc-shade( 80 );
 			line-height: 1.4em;
 		}
 
 		li::before {
 			content: "";
-			border: 4px solid #ccc;
+			border: 4px solid wc-shade( 80 );
 			border-radius: 100%;
 			width: 4px;
 			height: 4px;
@@ -7385,25 +7380,25 @@ table.bar_chart {
 			left: 50%;
 			margin-left: -6px;
 			margin-bottom: -8px;
-			background: #fff;
+			background: var(--wc-content-bg);
 		}
 
 		li.active {
-			border-color: #a16696;
-			color: #a16696;
+			border-color: var(--woocommerce);
+			color: var(--woocommerce);
 
 			&::before {
-				border-color: #a16696;
+				border-color: var(--woocommerce);
 			}
 		}
 
 		li.done {
-			border-color: #a16696;
-			color: #a16696;
+			border-color: var(--woocommerce);
+			color: var(--woocommerce);
 
 			&::before {
-				border-color: #a16696;
-				background: #a16696;
+				border-color: var(--woocommerce);
+				background: var(--woocommerce);
 			}
 		}
 	}
@@ -7412,33 +7407,31 @@ table.bar_chart {
 		font-size: 1.25em;
 		padding: 0.5em 1em !important;
 		line-height: 1.5em !important;
-		margin-right: 0.5em;
-		margin-bottom: 2px;
 		height: auto !important;
 		border-radius: 4px;
-		background-color: #bb77ae;
-		border-color: #a36597;
+		background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+		border-color: var(--woocommerce);
 		-webkit-box-shadow:
-			inset 0 1px 0 rgba(255, 255, 255, 0.25),
-			0 1px 0 #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+			inset 0 1px 0 wc-shade( 100 , 'white', 25% ),
+			0 1px 0 var(--woocommerce);
+		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 		text-shadow:
-			0 -1px 1px #a36597,
-			1px 0 1px #a36597,
-			0 1px 1px #a36597,
-			-1px 0 1px #a36597;
+			0 -1px 1px var(--woocommerce),
+			1px 0 1px var(--woocommerce),
+			0 1px 1px var(--woocommerce),
+			-1px 0 1px var(--woocommerce);
 		margin: 0;
 		opacity: 1;
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: #a36597;
-			border-color: #a36597;
+			background: var(--woocommerce);
+			border-color: var(--woocommerce);
 			-webkit-box-shadow:
-				inset 0 1px 0 rgba(255, 255, 255, 0.25),
-				0 1px 0 #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+				inset 0 1px 0 wc-shade( 100 , 'white', 25% ),
+				0 1px 0 var(--woocommerce);
+			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 		}
 	}
 
@@ -7448,7 +7441,7 @@ table.bar_chart {
 
 	.wc-actions {
 		overflow: hidden;
-		border-top: 1px solid #eee;
+		border-top: 1px solid #{wc-shade( 93 )};
 		margin: 0;
 		padding: 23px 24px 24px;
 		line-height: 3em;
@@ -7458,23 +7451,23 @@ table.bar_chart {
 		}
 
 		.woocommerce-importer-toggle-advanced-options {
-			color: #999;
+			color: wc-shade( 60 );
 		}
 	}
 
 	.woocommerce-exporter,
 	.woocommerce-importer,
 	.wc-progress-form-content {
-		background: #fff;
+		background: var(--wc-content-bg);
 		overflow: hidden;
 		padding: 0;
 		margin: 0 0 16px;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+		box-shadow: 0 1px 3px wc-shade( 0, black, 13% );
 		color: #555;
 		text-align: left;
 
 		header {
-			border-bottom: 1px solid #eee;
+			border-bottom: 1px solid #{wc-shade( 93 )};
 			margin: 0;
 			padding: 24px 24px 0;
 		}
@@ -7492,7 +7485,6 @@ table.bar_chart {
 		}
 
 		p {
-			font-size: 1em;
 			line-height: 1.75em;
 			font-size: 16px;
 			color: #555;
@@ -7533,10 +7525,10 @@ table.bar_chart {
 			}
 
 			.woocommerce-importer-file-url-field-wrapper {
-				border: 1px solid #ddd;
-				-webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.07);
-				box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.07);
-				background-color: #fff;
+				border: 1px solid wc-shade( 87 );
+				-webkit-box-shadow: inset 0 1px 2px wc-shade( 0, black, 7% );
+				box-shadow: inset 0 1px 2px wc-shade( 0, black, 7% );
+				background-color: var(--wc-content-bg);
 				color: #32373c;
 				outline: 0;
 				line-height: 1;
@@ -7545,9 +7537,8 @@ table.bar_chart {
 				code {
 					background: none;
 					font-size: smaller;
-					padding: 0;
 					margin: 0;
-					color: #999;
+					color: wc-shade( 60 );
 					padding: 7px 0 0 7px;
 					display: inline-block;
 				}
@@ -7574,15 +7565,13 @@ table.bar_chart {
 			width: 100%;
 			height: 42px;
 			margin: 0 auto 24px;
-			display: block;
 			-webkit-appearance: none;
-			border: none;
 			display: none;
-			background: #f5f5f5;
-			border: 2px solid #eee;
+			background: wc-shade( 96 );
+			border: 2px solid #{wc-shade( 93 )};
 			border-radius: 4px;
 			padding: 0;
-			box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.2);
+			box-shadow: 0 1px 0 0 wc-shade( 100 , 'white', 2% );
 		}
 
 		progress::-webkit-progress-bar {
@@ -7595,25 +7584,25 @@ table.bar_chart {
 
 		progress::-webkit-progress-value {
 			border-radius: 3px;
-			box-shadow: inset 0 1px 1px 0 rgba(255, 255, 255, 0.4);
-			background: #a46497;
-			background: linear-gradient(to bottom, #a46497, #66405f), #a46497;
+			box-shadow: inset 0 1px 1px 0 wc-shade( 100 , 'white', 4% );
+			background: var(--woocommerce);
+			background: linear-gradient(to bottom, var(--woocommerce), #66405f), var(--woocommerce);
 			transition: width 1s ease;
 		}
 
 		progress::-moz-progress-bar {
 			border-radius: 3px;
-			box-shadow: inset 0 1px 1px 0 rgba(255, 255, 255, 0.4);
-			background: #a46497;
-			background: linear-gradient(to bottom, #a46497, #66405f), #a46497;
+			box-shadow: inset 0 1px 1px 0 wc-shade( 100 , 'white', 4% );
+			background: var(--woocommerce);
+			background: linear-gradient(to bottom, var(--woocommerce), #66405f), var(--woocommerce);
 			transition: width 1s ease;
 		}
 
 		progress::-ms-fill {
 			border-radius: 3px;
-			box-shadow: inset 0 1px 1px 0 rgba(255, 255, 255, 0.4);
-			background: #a46497;
-			background: linear-gradient(to bottom, #a46497, #66405f), #a46497;
+			box-shadow: inset 0 1px 1px 0 wc-shade( 100 , 'white', 4% );
+			background: var(--woocommerce);
+			background: linear-gradient(to bottom, var(--woocommerce), #66405f), var(--woocommerce);
 			transition: width 1s ease;
 		}
 
@@ -7682,7 +7671,7 @@ table.bar_chart {
 				width: 50%;
 
 				.description {
-					color: #999;
+					color: wc-shade( 60 );
 					margin-top: 4px;
 					display: block;
 
@@ -7706,7 +7695,7 @@ table.bar_chart {
 			&::before {
 
 				@include icon("\e015");
-				color: #a16696;
+				color: var(--woocommerce);
 				position: static;
 				font-size: 100px;
 				display: block;
@@ -7729,7 +7718,7 @@ table.bar_chart {
 }
 
 .wc-quick-edit-warning {
-	color: darkred;
+	color: wc-hsl( red , 100%, 30%);
 	font-weight: bold;
 }
 
@@ -7816,19 +7805,19 @@ table.bar_chart {
 				position: static;
 
 				li {
-					background: #fff;
-					border: 1px solid #ccc;
+					background: var(--wc-content-bg);
+					border: 1px solid wc-shade( 80 );
 					border-radius: 32px;
 					font-size: 14px;
 					line-height: 20px;
 					margin: 12px 12px 0 0;
 
 					&.current {
-						background: #007cba;
-						border: 1px solid #007cba;
+						background: var(--wc-blue);
+						border: 1px solid var(--wc-blue);
 
 						a {
-							color: #fff;
+							color: var(--wc-white);
 						}
 
 						a::after {
@@ -7841,7 +7830,7 @@ table.bar_chart {
 				a:visited,
 				a:hover,
 				a:active {
-					color: #2c3338;
+					color: wc-shade( 20 );
 					padding: 10px 16px !important;
 				}
 			}

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -94,7 +94,7 @@
 
 	.current-section-dropdown {
 		background: var(--wc-content-bg);
-		border: 1px solid #{wc-hsl( 'blue',  3%, 66%)};
+		border: 1px solid wc-hsl( 'blue', 3%, 66%);
 		margin-bottom: 20px;
 		position: relative;
 		width: 100%;
@@ -365,7 +365,7 @@
 	}
 
 	.addons-button-solid {
-		background-color: #{wc-hsl( 'purple',  39%, 43%)};
+		background-color: wc-hsl( 'purple',  39%, 43%);
 		color: var(--wc-white);
 	}
 
@@ -392,22 +392,22 @@
 	}
 
 	.addons-button-outline-green {
-		border: 1px solid #{wc-hsl( 'green',  50%, 45%)};
-		color: #{wc-hsl( 'green',  50%, 45%)};
+		border: 1px solid wc-hsl( 'green',  50%, 45%);
+		color: wc-hsl( 'green',  50%, 45%);
 	}
 
 	.addons-button-outline-green:hover {
-		color: #{wc-hsl( 'green',  50%, 45%)};
+		color: wc-hsl( 'green',  50%, 45%);
 		opacity: 0.8;
 	}
 
 	.addons-button-outline-purple {
-		border: 1px solid #{wc-hsl( 'purple',  39%, 43%)};
-		color: #{wc-hsl( 'purple',  39%, 43%)};
+		border: 1px solid wc-hsl( 'purple',  39%, 43%);
+		color: wc-hsl( 'purple',  39%, 43%);
 	}
 
 	.addons-button-outline-purple:hover {
-		color: #{wc-hsl( 'purple',  39%, 43%)};
+		color: wc-hsl( 'purple',  39%, 43%);
 		opacity: 0.8;
 	}
 
@@ -792,7 +792,7 @@
 			max-width: 400px;
 			height: auto;
 			margin: 0 auto 16px;
-			box-shadow: 0 1px 6px wc-shade( 0, black, 10% );
+			box-shadow: 0 1px 6px wc-shade( 0, 'black', 10% );
 		}
 
 		p:last-of-type {
@@ -908,7 +908,7 @@
 
 	a.button-primary,
 	button.button-primary {
-		background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+		background: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) );
 		border-color: var(--woocommerce);
 		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 		color: var(--wc-white);
@@ -1240,7 +1240,7 @@ table.wc_status_table--tools {
 #log-viewer {
 	background: var(--wc-content-bg);
 	border: 1px solid wc-shade( 90 );
-	box-shadow: 0 1px 1px wc-shade( 0, black, 4% );
+	box-shadow: 0 1px 1px wc-shade( 0, 'black', 4% );
 	padding: 5px 20px;
 
 	pre {
@@ -1936,7 +1936,7 @@ ul.wc_coupon_list_block {
 				textarea {
 					font-size: 14px;
 					padding: 4px;
-					color: #555;
+					color: wc-shade( 33 );
 				}
 
 				&:last-child {
@@ -1968,7 +1968,7 @@ ul.wc_coupon_list_block {
 				.wc-order-item-thumbnail {
 					width: 38px;
 					height: 38px;
-					border: 2px solid #e8e8e8;
+					border: 2px solid wc_shade( 91 );
 					background: wc-shade( 97 );
 					color: wc-shade( 80 );
 					position: relative;
@@ -2050,7 +2050,7 @@ ul.wc_coupon_list_block {
 					display: inline-block;
 					background: var(--wc-content-bg);
 					border: 1px solid wc-shade( 87 );
-					box-shadow: inset 0 1px 2px wc-shade( 0, black, 7% );
+					box-shadow: inset 0 1px 2px wc-shade( 0, 'black', 7% );
 					margin: 1px 0;
 					min-width: 80px;
 					overflow: hidden;
@@ -2064,7 +2064,7 @@ ul.wc_coupon_list_block {
 						label {
 							font-size: 0.75em;
 							padding: 4px 6px 0;
-							color: #555;
+							color: wc-shade( 33 );
 							display: block;
 						}
 
@@ -2075,7 +2075,7 @@ ul.wc_coupon_list_block {
 							box-shadow: none;
 							margin: 0;
 							padding: 0 6px 4px;
-							color: #555;
+							color: wc-shade( 33 );
 							background: transparent;
 
 							&::-webkit-input-placeholder {
@@ -2153,7 +2153,7 @@ ul.wc_coupon_list_block {
 			}
 
 			.calculated {
-				border-color: #{wc-hsl( 'orchid',  17%, 62%)};
+				border-color: wc-hsl( 'orchid',  17%, 62%);
 				border-style: dotted;
 			}
 
@@ -2750,7 +2750,7 @@ ul.wc_coupon_list_block {
 			}
 
 			&:hover {
-				border: 2px solid #{wc-hsl( 'blue',  100%, 41%)};
+				border: 2px solid wc-hsl( 'blue', 100%, 41%);
 			}
 		}
 
@@ -2771,35 +2771,35 @@ ul.wc_coupon_list_block {
 	color: wc-shade( 47 );
 	background: wc-shade( 90 );
 	border-radius: 4px;
-	border-bottom: 1px solid wc-shade( 0, black, 5% );
+	border-bottom: 1px solid wc-shade( 0, 'black', 5% );
 	margin: -0.25em 0;
 	cursor: inherit !important;
 	white-space: nowrap;
 	max-width: 100%;
 
 	&.status-completed {
-		background: #{wc-hsl( 'info',  29%, 83%)};
-		color: #{wc-hsl( 'info',  29%, 25%)};
+		background: wc-hsl( 'info',  29%, 83%);
+		color: wc-hsl( 'info',  29%, 25%);
 	}
 
 	&.status-on-hold {
-		background: #{wc-hsl( 'warning',  85%, 83%)};
-		color: #{wc-hsl( 'warning',  85%, 31%)};
+		background: wc-hsl( 'warning',  85%, 83%);
+		color: wc-hsl( 'warning',  85%, 31%);
 	}
 
 	&.status-failed {
-		background: #{wc-hsl( 'error',  65%, 83%)};
-		color: #{wc-hsl( 'error',  65%, 31%)};
+		background: wc-hsl( 'error',  65%, 83%);
+		color: wc-hsl( 'error',  65%, 31%);
 	}
 
 	&.status-processing {
-		background: #{wc-hsl( 'success',  50%, 82%)};
-		color: #{wc-hsl( 'success',  50%, 31%)};
+		background: wc-hsl( 'success',  50%, 82%);
+		color: wc-hsl( 'success',  50%, 31%);
 	}
 
 	&.status-trash {
-		background: #{wc-hsl( 'error',  65%, 83%)};
-		color: #{wc-hsl( 'error',  65%, 31%)};
+		background: wc-hsl( 'error',  65%, 83%);
+		color: wc-hsl( 'error',  65%, 31%);
 	}
 
 	> span {
@@ -3139,7 +3139,7 @@ ul.order_notes {
 	li.system-note {
 
 		.note_content {
-			background: #{wc-hsl( 'red',  14%, 81%)};
+			background: wc-hsl( 'red',  14%, 81%);
 		}
 
 		.note_content::after {
@@ -3150,11 +3150,11 @@ ul.order_notes {
 	li.customer-note {
 
 		.note_content {
-			background: #{wc-hsl( 'blue',  43%, 73%)};
+			background: wc-hsl( 'blue', 43%, 73%);
 		}
 
 		.note_content::after {
-			border-color: #{wc-hsl( 'blue',  43%, 73%)} transparent;
+			border-color: #{wc-hsl( 'blue', 43%, 73%)} transparent;
 		}
 	}
 }
@@ -3324,11 +3324,11 @@ table.wp-list-table {
 		}
 
 		&.outofstock {
-			color: #{wc-hsl( 'error',  43%, 46%)};
+			color: wc-hsl( 'error',  43%, 46%);
 		}
 
 		&.onbackorder {
-			color: #{wc-hsl( 'alert',  100%, 46%)};
+			color: wc-hsl( 'alert',  100%, 46%);
 		}
 	}
 
@@ -3476,7 +3476,7 @@ table.wc_input_table {
 	}
 
 	tr.current td {
-		background-color: #{wc-hsl( 'yellow',  96%, 90%)};
+		background-color: wc-hsl( 'yellow',  96%, 90%);
 	}
 
 	.item_cost,
@@ -3638,7 +3638,7 @@ table.wc_shipping {
 				background: transparent;
 				border: none;
 				box-shadow: none;
-				color: #82878c;
+				color: wc-hsl( 'blue', 4%, 53% );
 				text-indent: -9999px;
 				cursor: pointer;
 				outline: none;
@@ -3660,7 +3660,7 @@ table.wc_shipping {
 
 			button:hover,
 			button:focus {
-				color: #191e23;
+				color: wc-shade( 34 );
 			}
 
 			.wc-move-down::before {
@@ -3840,7 +3840,7 @@ table.wc-shipping-classes {
 		overflow: hidden;
 		position: relative;
 		padding: 7.5em 7.5% !important;
-		border-bottom: 2px solid #{wc-hsl( 'orchid',  26%, 91%)};
+		border-bottom: 2px solid wc-hsl( 'orchid',  26%, 91%);
 
 		&.wc-shipping-zone-method-blank-state {
 			padding: 2em !important;
@@ -3875,7 +3875,7 @@ table.wc-shipping-classes {
 			font-family: "WooCommerce";
 			text-align: center;
 			line-height: 1;
-			color: #{wc-hsl( 'orchid',  26%, 91%)};
+			color: wc-hsl( 'orchid',  26%, 91%);
 			display: block;
 			width: 1em;
 			font-size: 40em;
@@ -3886,18 +3886,18 @@ table.wc-shipping-classes {
 		}
 
 		.button-primary {
-			background-color: #804877;
-			border-color: #804877;
+			background-color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 13% ) );
+			border-color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 13% ) );
 			box-shadow:
 				inset 0 1px 0 wc-shade( 100 , 'white', 2% ),
-				0 1px 0 wc-shade( 0, black, 15% );
+				0 1px 0 wc-shade( 0, 'black', 15% );
 			margin: 0;
 			opacity: 1;
 			text-shadow:
-				0 -1px 1px #8a4f7f,
-				1px 0 1px #8a4f7f,
-				0 1px 1px #8a4f7f,
-				-1px 0 1px #8a4f7f;
+				0 -1px 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) ),
+				1px 0 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) ),
+				0 1px 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) ),
+				-1px 0 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) );
 			font-size: 1.5em;
 			padding: 0.75em 1em;
 			height: auto;
@@ -4020,7 +4020,7 @@ table.wc-shipping-classes {
 	}
 
 	td.wc-shipping-zone-methods {
-		color: #555;
+		color: wc-shade( 33 );
 
 		.method_disabled {
 			text-decoration: line-through;
@@ -4031,7 +4031,7 @@ table.wc-shipping-classes {
 			padding-right: 32px;
 
 			li {
-				color: #555;
+				color: wc-shade( 33 );
 				display: inline;
 				margin: 0;
 			}
@@ -4123,8 +4123,8 @@ table.wc-shipping-classes {
 .woocommerce-input-toggle {
 	height: 16px;
 	width: 32px;
-	border: 2px solid #935687;
-	background-color: #935687;
+	border: 2px solid wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 7% ) );
+	background-color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 7% ) );
 	display: inline-block;
 	text-indent: -9999px;
 	border-radius: 10em;
@@ -4476,7 +4476,7 @@ img.help_tip {
 			position: absolute;
 			border: 1px solid wc-shade( 80 );
 			border-radius: 3px;
-			box-shadow: 0 1px 3px wc-shade( 0, black, 20% );
+			box-shadow: 0 1px 3px wc-shade( 0, 'black', 20% );
 
 			.ui-slider {
 				border: 0 !important;
@@ -4492,7 +4492,7 @@ img.help_tip {
 		}
 
 		.iris-error {
-			background-color: wc-hsl(  'red', 100%, 85% );
+			background-color: wc-hsl( 'red', 100%, 85% );
 		}
 
 		.colorpickpreview {
@@ -4601,7 +4601,7 @@ img.help_tip {
 				padding: 0;
 				width: 30px;
 				height: 30px;
-				box-shadow: inset 0 0 0 1px wc-shade( 0, black, 20% );
+				box-shadow: inset 0 0 0 1px wc-shade( 0, 'black', 20% );
 				font-size: 16px;
 				border-radius: 4px;
 				margin-right: 3px;
@@ -4877,7 +4877,7 @@ img.help_tip {
 		line-height: 1em;
 		padding: 0 0 10px;
 		position: relative;
-		background-color: #fafafa;
+		background-color: wc-shade(98);
 		border-right: 1px solid #{wc-shade( 93 )};
 		box-sizing: border-box;
 
@@ -4889,7 +4889,7 @@ img.help_tip {
 			position: absolute;
 			bottom: -9999em;
 			left: 0;
-			background-color: #fafafa;
+			background-color: wc-shade(98);
 			border-right: 1px solid #{wc-shade( 93 )};
 		}
 
@@ -4969,7 +4969,7 @@ img.help_tip {
 			}
 
 			&.active a {
-				color: #555;
+				color: wc-shade( 33 );
 				position: relative;
 				background-color: #{wc-shade( 93 )};
 			}
@@ -5023,7 +5023,7 @@ img.help_tip {
 .woocommerce_options_panel,
 .panel {
 	padding: 9px;
-	color: #555;
+	color: wc-shade( 33 );
 
 	.form-field .woocommerce-help-tip {
 		font-size: 1.4em;
@@ -5596,7 +5596,7 @@ img.help_tip {
 					display: block;
 					font-size: 14px;
 					padding: 4px;
-					color: #555;
+					color: wc-shade( 33 );
 				}
 
 				select,
@@ -5649,7 +5649,7 @@ img.help_tip {
 
 	a {
 		padding: 0 10px 3px;
-		background: wc-shade( 0, black, 5% );
+		background: wc-shade( 0, 'black', 5% );
 		font-size: 16px;
 		font-weight: 400;
 		text-decoration: none;
@@ -5660,7 +5660,7 @@ img.help_tip {
 	a.disabled:focus,
 	a.disabled:hover {
 		color: #a0a5aa;
-		background: wc-shade( 0, black, 5% );
+		background: wc-shade( 0, 'black', 5% );
 	}
 }
 
@@ -5890,7 +5890,7 @@ img.tips {
 	text-align: center;
 	border-radius: 3px;
 	padding: 0.618em 1em;
-	box-shadow: 0 1px 3px wc-shade( 0, black, 20% );
+	box-shadow: 0 1px 3px wc-shade( 0, 'black', 20% );
 
 	code {
 		padding: 1px;
@@ -6121,7 +6121,7 @@ img.ui-datepicker-trigger {
 
 			li.chart-widget {
 				margin: 0 0 1em;
-				background: #fafafa;
+				background: wc-shade(98);
 				border: 1px solid wc-shade( 87 );
 
 				&::after {
@@ -6295,10 +6295,10 @@ img.ui-datepicker-trigger {
 				&:hover {
 					box-shadow:
 						inset 0 -1px 0 0 wc-shade( 87 ),
-						inset 300px 0 0 #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ), .1 )};
+						inset 300px 0 0 wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ), .1 );
 					border-right: 5px solid #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ) )} !important;
 					padding-left: 1.5em;
-					color: #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ) )};
+					color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5 ) );
 				}
 			}
 		}
@@ -6440,17 +6440,17 @@ table.bar_chart {
 			width: 25%;
 			text-align: left !important;
 			font-weight: normal !important;
-			border-bottom: 1px solid #{wc-hsl( 'red',  100%, 95%)};
+			border-bottom: 1px solid wc-hsl( 'red',  100%, 95%);
 		}
 
 		td {
 			text-align: right;
 			line-height: 24px;
 			padding: 6px 6px 6px 0;
-			border-bottom: 1px solid #{wc-hsl( 'red',  100%, 95%)};
+			border-bottom: 1px solid wc-hsl( 'red',  100%, 95%);
 
 			span {
-				color: #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10 ) )};
+				color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10 ) );
 				display: block;
 			}
 
@@ -6464,13 +6464,13 @@ table.bar_chart {
 			position: relative;
 			text-align: left;
 			padding: 6px 6px 6px 0;
-			border-bottom: 1px solid #{wc-hsl( 'red',  100%, 95%)};
+			border-bottom: 1px solid wc-hsl( 'red',  100%, 95%);
 
 			span,
 			a {
 				text-decoration: none;
 				clear: both;
-				background: #{wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10 ) )};
+				background: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10 ) );
 				float: left;
 				display: block;
 				line-height: 24px;
@@ -6532,7 +6532,7 @@ table.bar_chart {
 		&::before {
 			color: wc-shade( 87 );
 			text-shadow:
-				0 -1px 1px wc-shade( 0, black, 20% ),
+				0 -1px 1px wc-shade( 0, 'black', 20% ),
 				0 1px 0 wc-shade( 100 , 'white', 8% );
 			font-size: 8em;
 			display: block;
@@ -7011,7 +7011,7 @@ table.bar_chart {
 		padding: 1em 1.5em;
 		background: wc-shade( 99 );
 		border-top: 1px solid wc-shade( 87 );
-		box-shadow: 0 -4px 4px -4px wc-shade( 0, black, 10% );
+		box-shadow: 0 -4px 4px -4px wc-shade( 0, 'black', 10% );
 
 		.inner {
 			text-align: right;
@@ -7053,11 +7053,11 @@ table.bar_chart {
 }
 
 .select2-dropdown--below {
-	box-shadow: 0 1px 1px wc-shade( 0, black, 10% );
+	box-shadow: 0 1px 1px wc-shade( 0, 'black', 10% );
 }
 
 .select2-dropdown--above {
-	box-shadow: 0 -1px 1px wc-shade( 0, black, 10% );
+	box-shadow: 0 -1px 1px wc-shade( 0, 'black', 10% );
 }
 
 .select2-container {
@@ -7151,7 +7151,7 @@ table.bar_chart {
 	}
 
 	.select2-dropdown--below {
-		box-shadow: 0 0 0 1px var(--wc-blue), 0 2px 1px wc-shade( 0, black, 10% );
+		box-shadow: 0 0 0 1px var(--wc-blue), 0 2px 1px wc-shade( 0, 'black', 10% );
 
 		&::after {
 			top: -1px;
@@ -7159,7 +7159,7 @@ table.bar_chart {
 	}
 
 	.select2-dropdown--above {
-		box-shadow: 0 0 0 1px var(--wc-blue), 0 -2px 1px wc-shade( 0, black, 10% );
+		box-shadow: 0 0 0 1px var(--wc-blue), 0 -2px 1px wc-shade( 0, 'black', 10% );
 
 		&::after {
 			bottom: -1px;
@@ -7178,7 +7178,7 @@ table.bar_chart {
 
 		.select2-selection--single {
 			height: 30px;
-			border-color: #{wc-hsl( 'blue',  9%, 53%)};
+			border-color: wc-hsl( 'blue', 9%, 53%);
 
 			@media only screen and (max-width: 782px) {
 				height: 40px;
@@ -7228,7 +7228,7 @@ table.bar_chart {
 
 		.select2-selection--multiple {
 			min-height: 30px;
-			border-color: #{wc-hsl( 'blue',  9%, 53%)};
+			border-color: wc-hsl( 'blue', 9%, 53%);
 			border-radius: 4px;
 		}
 
@@ -7285,11 +7285,11 @@ table.bar_chart {
 			}
 
 			.select2-dropdown--below {
-				box-shadow: 0 0 0 1px $color, 0 2px 1px wc-shade( 0, black, 10% );
+				box-shadow: 0 0 0 1px $color, 0 2px 1px wc-shade( 0, 'black', 10% );
 			}
 
 			.select2-dropdown--above {
-				box-shadow: 0 0 0 1px $color, 0 -2px 1px wc-shade( 0, black, 10% );
+				box-shadow: 0 0 0 1px $color, 0 -2px 1px wc-shade( 0, 'black', 10% );
 			}
 
 			.select2-selection--single .select2-selection__rendered:hover {
@@ -7409,29 +7409,29 @@ table.bar_chart {
 		line-height: 1.5em !important;
 		height: auto !important;
 		border-radius: 4px;
-		background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
-		border-color: var(--woocommerce);
+		background-color: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) );
+		border-color: wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
 		-webkit-box-shadow:
 			inset 0 1px 0 wc-shade( 100 , 'white', 25% ),
-			0 1px 0 var(--woocommerce);
-		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+			0 1px 0 wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
+		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
 		text-shadow:
-			0 -1px 1px var(--woocommerce),
-			1px 0 1px var(--woocommerce),
-			0 1px 1px var(--woocommerce),
-			-1px 0 1px var(--woocommerce);
+			0 -1px 1px wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) ),
+			1px 0 1px wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) ),
+			0 1px 1px wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) ),
+			-1px 0 1px wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
 		margin: 0;
 		opacity: 1;
 
 		&:hover,
 		&:focus,
 		&:active {
-			background: var(--woocommerce);
-			border-color: var(--woocommerce);
+			background: wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
+			border-color: wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
 			-webkit-box-shadow:
 				inset 0 1px 0 wc-shade( 100 , 'white', 25% ),
-				0 1px 0 var(--woocommerce);
-			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+				0 1px 0 wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
+			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 wc-hsl( 'orchid',  var(--wc--primary-sat), var(--wc--primary-luma) );
 		}
 	}
 
@@ -7462,8 +7462,8 @@ table.bar_chart {
 		overflow: hidden;
 		padding: 0;
 		margin: 0 0 16px;
-		box-shadow: 0 1px 3px wc-shade( 0, black, 13% );
-		color: #555;
+		box-shadow: 0 1px 3px wc-shade( 0, 'black', 13% );
+		color: wc-shade( 33 );
 		text-align: left;
 
 		header {
@@ -7478,7 +7478,7 @@ table.bar_chart {
 
 		h2 {
 			margin: 0 0 24px;
-			color: #555;
+			color: wc-shade( 33 );
 			font-size: 24px;
 			font-weight: normal;
 			line-height: 1em;
@@ -7487,7 +7487,7 @@ table.bar_chart {
 		p {
 			line-height: 1.75em;
 			font-size: 16px;
-			color: #555;
+			color: wc-shade( 33 );
 			margin: 0 0 24px;
 		}
 
@@ -7508,7 +7508,7 @@ table.bar_chart {
 			padding: 0 0 24px 0;
 
 			label {
-				color: #555;
+				color: wc-shade( 33 );
 				font-weight: normal;
 			}
 
@@ -7526,10 +7526,10 @@ table.bar_chart {
 
 			.woocommerce-importer-file-url-field-wrapper {
 				border: 1px solid wc-shade( 87 );
-				-webkit-box-shadow: inset 0 1px 2px wc-shade( 0, black, 7% );
-				box-shadow: inset 0 1px 2px wc-shade( 0, black, 7% );
+				-webkit-box-shadow: inset 0 1px 2px wc-shade( 0, 'black', 7% );
+				box-shadow: inset 0 1px 2px wc-shade( 0, 'black', 7% );
 				background-color: var(--wc-content-bg);
-				color: #32373c;
+				color: wc-hsl( 'blue', 10%, 22%);
 				outline: 0;
 				line-height: 1;
 				display: block;
@@ -7718,7 +7718,7 @@ table.bar_chart {
 }
 
 .wc-quick-edit-warning {
-	color: wc-hsl( red , 100%, 30%);
+	color: wc-hsl( 'red' , 100%, 30%);
 	font-weight: bold;
 }
 

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -7272,13 +7272,13 @@ table.bar_chart {
   */
 .admin-color {
 	$wp_admin_colors: (
-		blue: #096484,
-		coffee: #c7a589,
-		ectoplasm: #a3b745,
-		midnight: #e14d43,
-		ocean: #9ebaa0,
-		sunrise: #dd823b,
-		light: #04a4cc,
+		"blue": #096484,
+		"coffee": #c7a589,
+		"ectoplasm": #a3b745,
+		"midnight": #e14d43,
+		"ocean": #9ebaa0,
+		"sunrise": #dd823b,
+		"light": #04a4cc
 	);
 
 	@each $name, $color in $wp_admin_colors {

--- a/plugins/woocommerce/legacy/css/auth.scss
+++ b/plugins/woocommerce/legacy/css/auth.scss
@@ -1,3 +1,9 @@
+/**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
+
 body {
 	background: #f1f1f1;
 	box-shadow: none;
@@ -17,8 +23,8 @@ body {
 }
 
 .wc-auth-content {
-	background: #fff;
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+	background: var(--wc-content-bg);
+	box-shadow: 0 1px 3px wc-shade( 0 , black, 13% );
 	overflow: hidden;
 	padding: 24px 24px 0;
 	zoom: 1;
@@ -26,13 +32,13 @@ body {
 	h1, h2, h3, table {
 		border: 0;
 		clear: none;
-		color: #666;
+		color: wc-shade( 40 );
 		margin: 0 0 24px;
 		padding: 0;
 	}
 
 	p, ul {
-		color: #666;
+		color: wc-shade( 40 );
 		font-size: 1em;
 		line-height: 1.75em;
 		margin: 0 0 24px;
@@ -43,7 +49,7 @@ body {
 	}
 
 	a {
-		color: #a16696;
+		color: var(--woocommerce);
 		&:hover, &:focus {
 			color: #111;
 		}
@@ -51,7 +57,7 @@ body {
 
 	.wc-auth-login {
 		label {
-			color: #999;
+			color: wc-shade( 60 );
 			display: block;
 			margin-bottom: 0.5em;
 		}
@@ -82,8 +88,8 @@ body {
 	}
 }
 .wc-auth-logged-in-as {
-	background: #f5f5f5;
-	border-bottom: 2px solid #eee;
+	background: wc-shade( 96 );
+	border-bottom: 2px solid #{wc-shade( 93 )};
 	line-height: 70px;
 	margin: 0 0 24px;
 	padding: 0 1em 0 0;
@@ -108,11 +114,10 @@ body {
 	padding-left: 24px;
 
 	.button {
-		background: #f7f7f7;
-		border-bottom-width: 2px;
+		background: wc-shade( 96 );
 		border: 1px solid #d7d7d7;
 		box-sizing: border-box;
-		color: #777;
+		color: wc-shade( 47 );
 		float: right;
 		font-size: 1.25em;
 		height: auto;
@@ -122,21 +127,21 @@ body {
 		width: 50%;
 
 		&:hover, &:focus {
-			background: #fcfcfc;
+			background: wc-shade( 99 );
 		}
 	}
 	.button-primary {
 		background: #ad6ea1;
-		border-color: #a16696;
+		border-color: var(--woocommerce);
 		box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.2 ), 0 1px 0 rgba( 0, 0, 0, 0.15 );
-		color: #fff;
+		color: var(--wc-white);
 		float: right;
 		opacity: 1;
 		text-shadow: 0 -1px 1px #8a4f7f, 1px 0 1px #8a4f7f, 0 1px 1px #8a4f7f, -1px 0 1px #8a4f7f;
 
 		&:hover, &:focus {
 			background: #b472a8;
-			color: #fff;
+			color: var(--wc-white);
 		}
 	}
 	.wc-auth-approve {

--- a/plugins/woocommerce/legacy/css/auth.scss
+++ b/plugins/woocommerce/legacy/css/auth.scss
@@ -5,7 +5,7 @@
 @import "variables";
 
 body {
-	background: #f1f1f1;
+	background: wc-shade( 94 );
 	box-shadow: none;
 	margin: 100px auto 24px;
 	padding: 0;
@@ -24,7 +24,7 @@ body {
 
 .wc-auth-content {
 	background: var(--wc-content-bg);
-	box-shadow: 0 1px 3px wc-shade( 0 , black, 13% );
+	box-shadow: 0 1px 3px wc-shade( 0 ,'black', 13% );
 	overflow: hidden;
 	padding: 24px 24px 0;
 	zoom: 1;
@@ -51,7 +51,7 @@ body {
 	a {
 		color: var(--woocommerce);
 		&:hover, &:focus {
-			color: #111;
+			color: wc-shade( 7 );
 		}
 	}
 
@@ -115,7 +115,7 @@ body {
 
 	.button {
 		background: wc-shade( 96 );
-		border: 1px solid #d7d7d7;
+		border: 1px solid wc-shade( 84 );
 		box-sizing: border-box;
 		color: wc-shade( 47 );
 		float: right;
@@ -131,16 +131,19 @@ body {
 		}
 	}
 	.button-primary {
-		background: #ad6ea1;
+		background: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) + 5% ) );
 		border-color: var(--woocommerce);
-		box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.2 ), 0 1px 0 rgba( 0, 0, 0, 0.15 );
+		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 20% ), 0 1px 0 wc-shade( 100 , 'black', 15% );
 		color: var(--wc-white);
 		float: right;
 		opacity: 1;
-		text-shadow: 0 -1px 1px #8a4f7f, 1px 0 1px #8a4f7f, 0 1px 1px #8a4f7f, -1px 0 1px #8a4f7f;
+		text-shadow: 0 -1px 1px wc-hsl( 'orchid', var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) ),
+			1px 0 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) ),
+			0 1px 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) ),
+			-1px 0 1px wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 10% ) );
 
 		&:hover, &:focus {
-			background: #b472a8;
+			background: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) + 10% ) );
 			color: var(--wc-white);
 		}
 	}

--- a/plugins/woocommerce/legacy/css/custom-properties.scss
+++ b/plugins/woocommerce/legacy/css/custom-properties.scss
@@ -5,7 +5,7 @@
 @import "mixins";
 
 :root {
-	--woocommerce: #{wc-hsl(  312, 26%, 52% )};
+	--woocommerce: #{wc-hsl( 312, 26%, 52% )};
 
 	// base color values
 	--wc--primary-hue: 312;
@@ -37,8 +37,6 @@
 	--wc--success-hue: var(--wc--green-hue);
 	--wc--info-hue: var(--wc--blue-hue);
 
-	--wc-tips--color: var(--wc-blue);
-
 	// WooCommerce base colors
 	--wc-red: #{wc-hsl( 'red', 80%)};
 	--wc-deep-orange: #{wc-hsl( 'deep-orange', 80%)};
@@ -47,6 +45,7 @@
 	--wc-green: #{wc-hsl( 'green', 50%)};
 	--wc-blue: #{wc-hsl( 'blue', 60%)};
 	--wc-purple: #{wc-hsl( 'purple', 36%, 42%)};
+	--wc-woocommerce: #{wc-hsl( 'orchid', 26%, 52%)};
 
 	--wc-black: hsl(0,0%,var(--wc--black-luma));
 	--wc-white: hsl(0,0%,var(--wc--white-luma));
@@ -68,23 +67,25 @@
 
 	--wc-content-bg: var(--wc-white);
 	--wc-subtext: var(--wc-gray);
+
+	--wc-tips--color: var(--wc-blue);
 }
 
 // GENERATE CUSTOM PROPERTIES - color variation with opacity
-// #{gen-custom-prop( $wc-primary, false, -50%, false, 25% )}; // the primary color desaturated at 50% and with 25% of opacity
+// #{gen-custom-prop( $wc-primary, false, -50%, false, 25% )}; // the primary color 50% desaturated and 25% opacity
 
 // WC-HSL - generate variations of a color
-// wc-hsl( xyz, 85%, 83%);
+// wc-hsl( 'xyz', 85%, 83%);
 // note: this will output the xyz color hue with 85% of saturation and 83% of lightness
 // "xyz" is a short for --wc--xyz-hue variable so you need to define a --wc--COLOR-hue for each color used.
 
-// WC-GRAY - generate tints and tones of a color (with opacity)
+// WC-SHADE - generate tints and tones of a color (with opacity)
 // A) passing a number 0-100 will output the corresponding shade of gray
 // wc-shade( 80 ); // gray 80
 // B) pass a shade amount, the base color and optionally an opacity
 // $shade - the shade of the yxz tone (not a color! this function use the lightness and not the hue)
 // $opacity - the opacity of that shade
 // "xyz" is a short for --wc--xyz-luma variable so you need to define a --wc--COLOR-luma for each tone used.
-// wc-shade( $shade, xyz, $opacity );
-// wc-shade( $shade, xyz, 10% ); // rgba(0,0,0,.1);
+// wc-shade( $shade, 'xyz', $opacity );
+// wc-shade( $shade, 'xyz', 10% ); // rgba(0,0,0,.1);
 

--- a/plugins/woocommerce/legacy/css/custom-properties.scss
+++ b/plugins/woocommerce/legacy/css/custom-properties.scss
@@ -1,0 +1,90 @@
+/**
+ * WooCommerce CSS Custom Properties
+ */
+@import "variables";
+@import "mixins";
+
+:root {
+	--woocommerce: #{wc-hsl(  312, 26%, 52% )};
+
+	// base color values
+	--wc--primary-hue: 312;
+	--wc--highlight-hue: calc(var(--wc--primary-hue) + 150);
+
+	--wc--red-hue: 0;
+	--wc--deep-orange-hue: 22;
+	--wc--orange-hue: 44;
+	--wc--yellow-hue: 60;
+	--wc--green-hue: 94;
+	--wc--blue-hue: 196;
+	--wc--purple-hue: 265;
+	--wc--orchid-hue: 312;
+
+	--wc--primary-sat: 26%;
+	--wc--secondary-sat: calc(var(--wc--primary-sat) - 21%);
+
+	--wc--primary-luma: 52%;
+	--wc--secondary-luma--text: calc(var(--wc--primary-luma) - 20%);
+	--wc--secondary-luma: calc(var(--wc--primary-luma) + 40%);
+
+	--wc--black-luma: 0%;
+	--wc--white-luma: 100%;
+
+	// color mappings
+	--wc--error-hue: var(--wc--red-hue);
+	--wc--warning-hue: var(--wc--deep-orange-hue);
+	--wc--alert-hue: var(--wc--orange-hue);
+	--wc--success-hue: var(--wc--green-hue);
+	--wc--info-hue: var(--wc--blue-hue);
+
+	--wc-tips--color: var(--wc-blue);
+
+	// WooCommerce base colors
+	--wc-red: #{wc-hsl( 'red', 80%)};
+	--wc-deep-orange: #{wc-hsl( 'deep-orange', 80%)};
+	--wc-orange: #{wc-hsl( 'orange', 80%)};
+	--wc-yellow: #{wc-hsl( 'yellow', 100%)};
+	--wc-green: #{wc-hsl( 'green', 50%)};
+	--wc-blue: #{wc-hsl( 'blue', 60%)};
+	--wc-purple: #{wc-hsl( 'purple', 36%, 42%)};
+
+	--wc-black: hsl(0,0%,var(--wc--black-luma));
+	--wc-white: hsl(0,0%,var(--wc--white-luma));
+	--wc-gray: #{wc-shade( 46 )};
+
+	// theme colors
+	--wc-primary: hsl(#{$wc-primary});
+	--wc-primary-text: hsl(#{$wc-primary-text});
+	--wc-secondary: hsl(#{$wc-secondary});
+	--wc-secondary-text: hsl(#{$wc-secondary-text});
+	--wc-highlight: hsl(#{$wc-highlight});
+	--wc-highlight-text: hsl(#{$wc-highlight-text});
+
+	--wc-error: #{wc-hsl( 'error',  80%)};
+	--wc-warning: #{wc-hsl( 'warning',  100%)};
+	--wc-alert: #{wc-hsl( 'alert',  100%)};
+	--wc-success: #{wc-hsl( 'success',  60%)};
+	--wc-info: #{wc-hsl( 'info',  60%)};
+
+	--wc-content-bg: var(--wc-white);
+	--wc-subtext: var(--wc-gray);
+}
+
+// GENERATE CUSTOM PROPERTIES - color variation with opacity
+// #{gen-custom-prop( $wc-primary, false, -50%, false, 25% )}; // the primary color desaturated at 50% and with 25% of opacity
+
+// WC-HSL - generate variations of a color
+// wc-hsl( xyz, 85%, 83%);
+// note: this will output the xyz color hue with 85% of saturation and 83% of lightness
+// "xyz" is a short for --wc--xyz-hue variable so you need to define a --wc--COLOR-hue for each color used.
+
+// WC-GRAY - generate tints and tones of a color (with opacity)
+// A) passing a number 0-100 will output the corresponding shade of gray
+// wc-shade( 80 ); // gray 80
+// B) pass a shade amount, the base color and optionally an opacity
+// $shade - the shade of the yxz tone (not a color! this function use the lightness and not the hue)
+// $opacity - the opacity of that shade
+// "xyz" is a short for --wc--xyz-luma variable so you need to define a --wc--COLOR-luma for each tone used.
+// wc-shade( $shade, xyz, $opacity );
+// wc-shade( $shade, xyz, 10% ); // rgba(0,0,0,.1);
+

--- a/plugins/woocommerce/legacy/css/dashboard-setup.scss
+++ b/plugins/woocommerce/legacy/css/dashboard-setup.scss
@@ -5,13 +5,19 @@
  */
 
 /**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
+
+/**
  * Styling begins
  */
 
 .dashboard-widget-finish-setup {
 
 	.progress-wrapper {
-		border: 1px solid #757575;
+		border: 1px solid wc-shade( 46 );
 		border-radius: 16px;
 		font-size: 0.9em;
 		padding: 2px 8px 2px 8px;
@@ -22,7 +28,7 @@
 	.progress-wrapper > span {
 		position: relative;
 		top: -3px;
-		color: #757575;
+		color: wc-shade( 46 );
 	}
 
 	.description div {
@@ -41,12 +47,12 @@
 		margin-left: -3px;
 
 		circle {
-			stroke: #f0f0f0;
+			stroke: wc-shade( 94 );
 			stroke-width: 1px;
 		}
 
 		.bar {
-			stroke: #949494;
+			stroke: wc-shade( 58 );
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/legacy/css/dashboard.scss
@@ -23,8 +23,8 @@ ul.woocommerce_stats {
 		text-align: center;
 		float: left;
 		font-size: 0.8em;
-		border-left: 1px solid #fff;
-		border-right: 1px solid #ececec;
+		border-left: 1px solid var(--wc-white);
+		border-right: 1px solid wc-shade( 92 );
 		box-sizing: border-box;
 	}
 
@@ -73,12 +73,12 @@ ul.woocommerce_stats {
 			padding: 0;
 			box-sizing: border-box;
 			margin: 0;
-			border-top: 1px solid #ececec;
-			color: #aaa;
+			border-top: 1px solid wc-shade( 92 );
+			color: wc-shade(66);
 
 			a {
 				display: block;
-				color: #aaa;
+				color: wc-shade( 66 );
 				padding: 9px 12px;
 				transition: all ease 0.5s;
 				position: relative;
@@ -101,15 +101,15 @@ ul.woocommerce_stats {
 					line-height: 1.2em;
 					font-weight: normal;
 					display: block;
-					color: #21759b;
+					color: #{wc-hsl( 'blue',  65%, 39%)};
 				}
 
 				&:hover {
-					color: #2ea2cc;
+					color: #{wc-hsl( 'blue',  65%, 50%)};
 
 					&::before,
 					strong {
-						color: #2ea2cc !important;
+						color: #{wc-hsl( 'blue',  65%, 50%)} !important;
 					}
 				}
 
@@ -120,7 +120,7 @@ ul.woocommerce_stats {
 					position: relative;
 					width: auto;
 					line-height: 1.2em;
-					color: #464646;
+					color: wc-shade( 27 );
 					float: left;
 					margin-right: 12px;
 					margin-bottom: 12px;
@@ -150,11 +150,11 @@ ul.woocommerce_stats {
 		}
 
 		li.processing-orders {
-			border-right: 1px solid #ececec;
+			border-right: 1px solid wc-shade( 92 );
 
 			a::before {
 				content: "\e011";
-				color: $green;
+				color: var(--wc-green);
 			}
 		}
 
@@ -162,16 +162,16 @@ ul.woocommerce_stats {
 
 			a::before {
 				content: "\e033";
-				color: #999;
+				color: wc-shade( 60 );
 			}
 		}
 
 		li.low-in-stock {
-			border-right: 1px solid #ececec;
+			border-right: 1px solid wc-shade( 92 );
 
 			a::before {
 				content: "\e016";
-				color: $orange;
+				color: var(--wc-alert);
 			}
 		}
 
@@ -179,7 +179,7 @@ ul.woocommerce_stats {
 
 			a::before {
 				content: "\e013";
-				color: $red;
+				color: var(--wc-error);
 			}
 		}
 	}
@@ -196,7 +196,7 @@ ul.woocommerce_stats {
 		line-height: 1.4;
 		margin: -0.2em 0 0 0;
 		font-weight: normal;
-		color: #999;
+		color: wc-shade( 60 );
 	}
 
 	blockquote {
@@ -221,7 +221,7 @@ ul.woocommerce_stats {
 
 		&::before {
 			content: "\e021\e021\e021\e021\e021";
-			color: darken(#ccc, 10%);
+			color: wc-shade( 85 );
 			float: left;
 			top: 0;
 			left: 0;
@@ -246,7 +246,7 @@ ul.woocommerce_stats {
 			left: 0;
 			letter-spacing: 0.1em;
 			letter-spacing: 0\9; // IE8 & below hack ;-(
-			color: #9c5d90;
+			color: #{gen-custom-prop( $woocommerce-brand, false, false, -5% )};
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/dashboard.scss
+++ b/plugins/woocommerce/legacy/css/dashboard.scss
@@ -80,7 +80,6 @@ ul.woocommerce_stats {
 				display: block;
 				color: wc-shade( 66 );
 				padding: 9px 12px;
-				transition: all ease 0.5s;
 				position: relative;
 				font-size: 12px;
 
@@ -101,26 +100,26 @@ ul.woocommerce_stats {
 					line-height: 1.2em;
 					font-weight: normal;
 					display: block;
-					color: #{wc-hsl( 'blue',  65%, 39%)};
+					color: wc-hsl( 'blue', 65%, 37%);
 				}
 
 				&:hover {
-					color: #{wc-hsl( 'blue',  65%, 50%)};
+					color: wc-hsl( 'blue', 65%, 50%);
 
 					&::before,
 					strong {
-						color: #{wc-hsl( 'blue',  65%, 50%)} !important;
+						color: #{wc-hsl( 'blue', 65%, 50%)};
 					}
 				}
 
 				&::before {
-
 					@include icon();
 					font-size: 2em;
 					position: relative;
 					width: auto;
 					line-height: 1.2em;
 					color: wc-shade( 27 );
+					transition: all ease 0.175s;
 					float: left;
 					margin-right: 12px;
 					margin-bottom: 12px;
@@ -149,16 +148,20 @@ ul.woocommerce_stats {
 			}
 		}
 
-		li.processing-orders {
+		.processing-orders {
 			border-right: 1px solid wc-shade( 92 );
+
+			&:hover a::before {
+				color: wc-hsl('green', 50%, 70%);
+			}
 
 			a::before {
 				content: "\e011";
-				color: var(--wc-green);
+				color: wc-hsl('green', 50%, 50%);
 			}
 		}
 
-		li.on-hold-orders {
+		.on-hold-orders {
 
 			a::before {
 				content: "\e033";
@@ -166,20 +169,28 @@ ul.woocommerce_stats {
 			}
 		}
 
-		li.low-in-stock {
+		.low-in-stock {
 			border-right: 1px solid wc-shade( 92 );
+
+			&:hover a::before {
+				color: wc-hsl('red', 80%, 70%);
+			}
 
 			a::before {
 				content: "\e016";
-				color: var(--wc-alert);
+				color: wc-hsl('red', 80%, 50%);
 			}
 		}
 
-		li.out-of-stock {
+		.out-of-stock {
+
+			&:hover a::before {
+				color: wc-hsl('orange', 80%, 70%);
+			}
 
 			a::before {
 				content: "\e013";
-				color: var(--wc-error);
+				color: wc-hsl('orange', 80%, 50%);
 			}
 		}
 	}
@@ -246,7 +257,7 @@ ul.woocommerce_stats {
 			left: 0;
 			letter-spacing: 0.1em;
 			letter-spacing: 0\9; // IE8 & below hack ;-(
-			color: #{gen-custom-prop( $woocommerce-brand, false, false, -5% )};
+			color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 5% ) );
 		}
 	}
 }
@@ -270,3 +281,4 @@ ul.woocommerce_stats {
 		}
 	}
 }
+

--- a/plugins/woocommerce/legacy/css/helper.scss
+++ b/plugins/woocommerce/legacy/css/helper.scss
@@ -2,25 +2,13 @@
   General table styling
 ------------------------------------------------------------------------------*/
 
-$white: #fff;
 
-// Grays
-$gray:                   #87a6bc;
-$gray-light:             lighten($gray, 33%); //#f3f6f8
-$gray-dark:              darken($gray, 38%); //#2e4453
+/**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
 
-// $gray-text: ideal for standard, non placeholder text
-// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
-$gray-text:              $gray-dark;
-$gray-text-min:          darken($gray, 18%); //#537994
-
-$woo_pink1: #955a89;
-$woo_pink2: #bb77ae;
-
-
-$color_text_blue: #0073aa;
-$color_button_primary: $woo_pink1;
-$color_button_secondary: $woo_pink2;
 
 /*------------------------------------------------------------------------------
   Tab navigation
@@ -52,11 +40,11 @@ $color_button_secondary: $woo_pink2;
 	.button:hover,
 	.button:focus,
 	.button:active {
-		background-color: $color_button_primary;
+		background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
 		border-width: 0;
 		box-shadow: none;
 		border-radius: 3px;
-		color: #fff;
+		color: var(--wc-white);
 		height: auto;
 		padding: 3px 14px;
 		text-align: center;
@@ -67,8 +55,8 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		&.button-secondary {
-			background-color: #e6e6e6;
-			color: #3c3c3c;
+			background-color: wc-shade( 66 );
+			color: wc-shade( 23 );
 			text-shadow: none;
 		}
 	}
@@ -89,7 +77,7 @@ $color_button_secondary: $woo_pink2;
 		position: relative;
 
 		.chevron {
-			color: #e1e1e1;
+			color: wc-shade( 88 );
 			border-bottom-width: 0;
 			line-height: 1;
 			padding: 0;
@@ -128,7 +116,7 @@ $color_button_secondary: $woo_pink2;
 		text-decoration: none;
 
 		&.current {
-			color: #000;
+			color: var(--wc-black);
 			font-weight: 600;
 		}
 	}
@@ -139,8 +127,8 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	@media only screen and (max-width: 600px) {
-		background-color: #fff;
-		border: 1px solid #e1e1e1;
+		background-color: var(--wc-content-bg);
+		border: 1px solid wc-shade( 88 );
 		border-radius: 4px;
 		font-size: 14px;
 
@@ -156,7 +144,7 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		li {
-			border-bottom: 1px solid #e1e1e1;
+			border-bottom: 1px solid wc-shade( 88 );
 		}
 
 		label,
@@ -191,10 +179,10 @@ $color_button_secondary: $woo_pink2;
 
 		&:focus,
 		&:hover {
-			box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
+			box-shadow: 0 3px 5px wc-shade( 0, black, 20% );
 
 			label {
-				border-bottom: 1px solid #e1e1e1;
+				border-bottom: 1px solid wc-shade( 88 );
 			}
 
 			li {
@@ -230,9 +218,9 @@ $color_button_secondary: $woo_pink2;
 
 	.button-update,
 	.button-update:hover {
-		background-color: #e6e6e6;
+		background-color: wc-shade( 66 );
 		border-radius: 4px;
-		color: #333;
+		color: wc-shade( 20 );
 		font-weight: 800;
 		font-size: 10px;
 		line-height: 20px;
@@ -254,8 +242,8 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	.user-info {
-		background-color: #fff;
-		border: 1px solid #e1e1e1;
+		background-color: var(--wc-content-bg);
+		border: 1px solid wc-shade( 88 );
 		border-radius: 4px;
 		font-size: 12px;
 		line-height: 26px;
@@ -275,7 +263,7 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		&:hover {
-			box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
+			box-shadow: 0 3px 5px wc-shade( 0, black, 20% );
 		}
 
 		header {
@@ -304,13 +292,13 @@ $color_button_secondary: $woo_pink2;
 			display: none;
 
 			p {
-				border-top: 1px solid #e1e1e1;
+				border-top: 1px solid wc-shade( 88 );
 				padding: 6px 14px;
 				text-align: center;
 			}
 
 			.actions {
-				border-top: 1px solid #e1e1e1;
+				border-top: 1px solid wc-shade( 88 );
 				display: flex;
 			}
 
@@ -331,12 +319,12 @@ $color_button_secondary: $woo_pink2;
 				}
 
 				&:first-child {
-					border-right: 1px solid #e1e1e1;
+					border-right: 1px solid wc-shade( 88 );
 				}
 
 				&:hover {
 					background-color: #a26897;
-					color: #fff;
+					color: var(--wc-white);
 				}
 			}
 
@@ -374,7 +362,7 @@ $color_button_secondary: $woo_pink2;
 	.striped > tbody > :nth-child(odd),
 	ul.striped > :nth-child(odd),
 	.alternate {
-		background-color: #fff;
+		background-color: var(--wc-content-bg);
 	}
 
 	table.widefat,
@@ -418,13 +406,12 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	.wp-list-table__row {
-		background-color: rgba(0, 0, 0, 0);
+		background-color: transparent;
 
 		td {
 			align-items: center;
-			background-color: #fff;
+			background-color: var(--wc-content-bg);
 			border: 0;
-			//border-top: 1px solid #e5e5e5;
 			padding: 16px 22px;
 			vertical-align: middle;
 
@@ -440,7 +427,7 @@ $color_button_secondary: $woo_pink2;
 		&.is-ext-header {
 
 			td {
-				border-top: 1px solid #e1e1e1;
+				border-top: 1px solid wc-shade( 88 );
 			}
 
 			@media only screen and (max-width: 782px) {
@@ -463,7 +450,7 @@ $color_button_secondary: $woo_pink2;
 
 		&:last-child td {
 			border-bottom: 24px solid #f1f1f1;
-			box-shadow: inset 0 -1px 0 #e1e1e1;
+			box-shadow: inset 0 -1px 0 wc-shade( 88 );
 		}
 	}
 
@@ -475,7 +462,7 @@ $color_button_secondary: $woo_pink2;
 		width: 100%;
 
 		&::before {
-			background-color: #e1e1e1;
+			background-color: wc-shade( 88 );
 			content: " ";
 			position: absolute;
 			top: 0;
@@ -494,7 +481,7 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	.wp-list-table__ext-title {
-		color: $color_text_blue;
+		color: #{wc-hsl( 'blue',  100%, 33%)};
 		font-size: 18px;
 		font-weight: 600;
 		width: 60%;
@@ -510,7 +497,7 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	.wp-list-table__ext-description {
-		color: #333;
+		color: wc-shade( 20 );
 		padding-left: 12px;
 		width: 40%;
 
@@ -524,7 +511,7 @@ $color_button_secondary: $woo_pink2;
 		position: relative;
 
 		&.update-available::after {
-			background-color: #ffc322;
+			background-color: var(--wc-alert);
 			content: " ";
 			position: absolute;
 			top: 0;
@@ -534,7 +521,7 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		&.expired::after {
-			background-color: #b81c23;
+			background-color: var(--wc-error);
 			content: " ";
 			position: absolute;
 			top: 0;
@@ -544,15 +531,15 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		.dashicons-update {
-			color: #ffc322;
+			color: var(--wc-alert);
 		}
 
 		.dashicons-info {
-			color: #b81c23;
+			color: var(--wc-error);
 		}
 
 		p {
-			color: #333;
+			color: wc-shade( 20 );
 			margin: 0;
 		}
 
@@ -568,7 +555,7 @@ $color_button_secondary: $woo_pink2;
 		text-align: right;
 
 		&::after {
-			background-color: #e1e1e1;
+			background-color: wc-shade( 88 );
 			content: " ";
 			position: absolute;
 			top: 0;
@@ -585,7 +572,7 @@ $color_button_secondary: $woo_pink2;
 			position: relative;
 
 			&::before {
-				background-color: #e1e1e1;
+				background-color: wc-shade( 88 );
 				content: " ";
 				height: 1px;
 				position: absolute;
@@ -637,7 +624,7 @@ $color_button_secondary: $woo_pink2;
 		padding: 0 !important;
 
 		&::after {
-			background-color: #e1e1e1;
+			background-color: wc-shade( 88 );
 			content: " ";
 			position: absolute;
 			top: 0;
@@ -656,7 +643,7 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		&::before {
-			background-color: #e1e1e1;
+			background-color: wc-shade( 88 );
 			content: " ";
 			height: 1px;
 			position: absolute;
@@ -738,19 +725,19 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	td.color-bar.expired {
-		border-left-color: #b81c23;
+		border-left-color: var(--wc-error);
 	}
 
 	td.color-bar.expiring {
-		border-left-color: orange;
+		border-left-color: var(--wc-warning);
 	}
 
 	td.color-bar.update-available {
-		border-left-color: #8fae1b;
+		border-left-color: var(--wc-success);
 	}
 
 	td.color-bar.expiring.update-available {
-		border-left-color: #8fae1b;
+		border-left-color: var(--wc-success);
 	}
 }
 
@@ -761,8 +748,8 @@ $color_button_secondary: $woo_pink2;
 .wc-helper {
 
 	.connect-wrapper {
-		background-color: #fff;
-		border: 1px solid #e5e5e5;
+		background-color: var(--wc-content-bg);
+		border: 1px solid wc-shade( 90 );
 		margin-bottom: 25px;
 		overflow: auto;
 	}
@@ -778,7 +765,7 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		img {
-			border: 1px solid #e5e5e5;
+			border: 1px solid wc-shade( 90 );
 			height: 34px;
 			width: 34px;
 		}
@@ -797,7 +784,7 @@ $color_button_secondary: $woo_pink2;
 			display: none;
 
 			&:hover {
-				color: $woo_pink1;
+				color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
 				cursor: pointer;
 			}
 		}
@@ -828,7 +815,7 @@ $color_button_secondary: $woo_pink2;
 			}
 
 			.chevron {
-				color: #e1e1e1;
+				color: wc-shade( 88 );
 				display: block;
 				margin: 10px;
 				transform: rotateX(0deg);
@@ -836,7 +823,7 @@ $color_button_secondary: $woo_pink2;
 
 			.buttons {
 				display: none;
-				border-top: 1px solid #e1e1e1;
+				border-top: 1px solid wc-shade( 88 );
 				padding: 10px 20px;
 
 				&.active {
@@ -855,8 +842,8 @@ $color_button_secondary: $woo_pink2;
 .wc-helper {
 
 	.start-container {
-		background-color: #fff;
-		border-left: 4px solid #cc99c2;
+		background-color: var(--wc-content-bg);
+		border-left: 4px solid #{wc-hsl( 'orchid',  33%, 70%)};
 		padding: 45px 20px 20px 30px;
 		position: relative;
 		overflow: hidden;
@@ -868,7 +855,7 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	.start-container::before {
-		color: #eee2ec;
+		color: #{wc-hsl( 'orchid',  26%, 91%)};
 		content: "\e01C";
 		display: block;
 		font-family: WooCommerce;
@@ -944,7 +931,7 @@ $color_button_secondary: $woo_pink2;
 
 .form-toggle__switch {
 	align-self: flex-start;
-	background: lighten($gray, 20%);
+	background: #{wc-hsl( 'blue',  28%, 83%)};
 	border-radius: 12px;
 	box-sizing: border-box;
 	display: inline-block;
@@ -967,7 +954,7 @@ $color_button_secondary: $woo_pink2;
 
 	&::after {
 		border-radius: 50%;
-		background: $white;
+		background: var(--wc-white);
 		left: 0;
 		transition: all 0.2s ease;
 	}
@@ -977,7 +964,7 @@ $color_button_secondary: $woo_pink2;
 	}
 
 	.accessible-focus &:focus {
-		box-shadow: 0 0 0 2px $woo_pink1;
+		box-shadow: 0 0 0 2px #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
 	}
 
 
@@ -988,7 +975,7 @@ $color_button_secondary: $woo_pink2;
 	z-index: 1;
 
 	.form-toggle__label-content {
-		color: #87a6bc;
+		color: #{wc-hsl( 'blue',  28%, 63%)};
 		flex: 0 1 100%;
 		font-size: 13px;
 		line-height: 16px;
@@ -1008,29 +995,29 @@ $color_button_secondary: $woo_pink2;
 	.accessible-focus &:focus {
 
 		+ .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px $woo_pink1;
+			box-shadow: 0 0 0 2px #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
 		}
 
 		&:checked + .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px $woo_pink2;
+			box-shadow: 0 0 0 2px #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) - 5 ) )};
 		}
 	}
 
 	& + .form-toggle__label .form-toggle__switch {
-		background: lighten($gray, 10%);
+		background: #{wc-hsl( 'blue',  28%, 73%)};
 	}
 
 	&:not(:disabled) {
 
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: lighten($gray, 20%);
+			background: #{wc-hsl( 'blue',  28%, 83%)};
 		}
 	}
 
 	&.active {
 
 		+ .form-toggle__label .form-toggle__switch {
-			background: $woo_pink1;
+			background: wc-hsl( orchid , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 
 			&::after {
 				left: 8px;
@@ -1038,7 +1025,7 @@ $color_button_secondary: $woo_pink2;
 		}
 
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: $woo_pink2;
+			background: wc-hsl( orchid , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) - 5 ) );
 		}
 	}
 
@@ -1054,13 +1041,13 @@ $color_button_secondary: $woo_pink2;
 .form-toggle.is-toggling {
 
 	+ .form-toggle__label .form-toggle__switch {
-		background: $woo_pink1;
+		background: wc-hsl( orchid , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 	}
 
 	&:checked {
 
 		+ .form-toggle__label .form-toggle__switch {
-			background: lighten($gray, 20%);
+			background: wc-hsl( blue , 28%, 83%);
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/helper.scss
+++ b/plugins/woocommerce/legacy/css/helper.scss
@@ -40,7 +40,7 @@
 	.button:hover,
 	.button:focus,
 	.button:active {
-		background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
+		background-color: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 		border-width: 0;
 		box-shadow: none;
 		border-radius: 3px;
@@ -67,7 +67,7 @@
 }
 
 .wc-helper .subscription-filter {
-	color: #2e4453;
+	color: wc-hsl( 'blue', 29%, 25% );
 	font-size: 13px;
 	line-height: 13px;
 	margin: 22px 0;
@@ -88,13 +88,13 @@
 	}
 
 	li {
-		color: #0073aa;
+		color: wc-hsl( 'blue', 100%, 33% );
 		display: inline-block;
 		padding: 0 4px 0 8px;
 		position: relative;
 
 		&::before {
-			background-color: #979797;
+			background-color: wc-shade( 59 );
 			content: " ";
 			position: absolute;
 			top: 0;
@@ -112,7 +112,7 @@
 	}
 
 	a {
-		color: #0073aa;
+		color: wc-hsl( 'blue', 100%, 33% );
 		text-decoration: none;
 
 		&.current {
@@ -122,7 +122,7 @@
 	}
 
 	.count {
-		color: #555d66;
+		color: wc-hsl( 'blue', 10%, 22% );
 		font-weight: 400;
 	}
 
@@ -172,14 +172,14 @@
 		}
 
 		span.chevron {
-			color: #555;
+			color: wc-shade( 33 );
 			opacity: 0.5;
 			transform: rotateX(180deg);
 		}
 
 		&:focus,
 		&:hover {
-			box-shadow: 0 3px 5px wc-shade( 0, black, 20% );
+			box-shadow: 0 3px 5px wc-shade( 0,'black', 20% );
 
 			label {
 				border-bottom: 1px solid wc-shade( 88 );
@@ -263,11 +263,11 @@
 		}
 
 		&:hover {
-			box-shadow: 0 3px 5px wc-shade( 0, black, 20% );
+			box-shadow: 0 3px 5px wc-shade( 0,'black', 20% );
 		}
 
 		header {
-			color: #555;
+			color: wc-shade( 33 );
 			font-weight: 600;
 			padding: 6px 14px;
 			position: relative;
@@ -381,7 +381,7 @@
 	.widefat thead tr td,
 	.widefat tfoot tr th,
 	.widefat tfoot tr td {
-		color: #32373c;
+		color: wc-hsl( 'blue', 10%, 22% );
 		padding-bottom: 15px;
 		padding-top: 10px;
 	}
@@ -449,7 +449,7 @@
 		}
 
 		&:last-child td {
-			border-bottom: 24px solid #f1f1f1;
+			border-bottom: 24px solid wc-shade( 94 );
 			box-shadow: inset 0 -1px 0 wc-shade( 88 );
 		}
 	}
@@ -481,7 +481,7 @@
 	}
 
 	.wp-list-table__ext-title {
-		color: #{wc-hsl( 'blue',  100%, 33%)};
+		color: wc-hsl( 'blue', 100%, 33%);
 		font-size: 18px;
 		font-weight: 600;
 		width: 60%;
@@ -674,7 +674,7 @@
 	.wp-list-table__licence-label {
 
 		label {
-			color: #23282d;
+			color: wc-hsl( 'blue', 12%, 16% );
 			font-weight: 600;
 			line-height: 30px;
 		}
@@ -784,7 +784,7 @@
 			display: none;
 
 			&:hover {
-				color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
+				color: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 				cursor: pointer;
 			}
 		}
@@ -843,7 +843,7 @@
 
 	.start-container {
 		background-color: var(--wc-content-bg);
-		border-left: 4px solid #{wc-hsl( 'orchid',  33%, 70%)};
+		border-left: 4px solid wc-hsl( 'orchid',  33%, 70%);
 		padding: 45px 20px 20px 30px;
 		position: relative;
 		overflow: hidden;
@@ -855,7 +855,7 @@
 	}
 
 	.start-container::before {
-		color: #{wc-hsl( 'orchid',  26%, 91%)};
+		color: wc-hsl( 'orchid',  26%, 91%);
 		content: "\e01C";
 		display: block;
 		font-family: WooCommerce;
@@ -931,7 +931,7 @@
 
 .form-toggle__switch {
 	align-self: flex-start;
-	background: #{wc-hsl( 'blue',  28%, 83%)};
+	background: wc-hsl( 'blue', 28%, 83%);
 	border-radius: 12px;
 	box-sizing: border-box;
 	display: inline-block;
@@ -964,7 +964,7 @@
 	}
 
 	.accessible-focus &:focus {
-		box-shadow: 0 0 0 2px #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
+		box-shadow: 0 0 0 2px wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 	}
 
 
@@ -975,7 +975,7 @@
 	z-index: 1;
 
 	.form-toggle__label-content {
-		color: #{wc-hsl( 'blue',  28%, 63%)};
+		color: wc-hsl( 'blue', 28%, 63%);
 		flex: 0 1 100%;
 		font-size: 13px;
 		line-height: 16px;
@@ -995,29 +995,29 @@
 	.accessible-focus &:focus {
 
 		+ .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) )};
+			box-shadow: 0 0 0 2px wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 		}
 
 		&:checked + .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) - 5 ) )};
+			box-shadow: 0 0 0 2px wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) - 5 ) );
 		}
 	}
 
 	& + .form-toggle__label .form-toggle__switch {
-		background: #{wc-hsl( 'blue',  28%, 73%)};
+		background: wc-hsl( 'blue', 28%, 73%);
 	}
 
 	&:not(:disabled) {
 
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: #{wc-hsl( 'blue',  28%, 83%)};
+			background: wc-hsl( 'blue', 28%, 83%);
 		}
 	}
 
 	&.active {
 
 		+ .form-toggle__label .form-toggle__switch {
-			background: wc-hsl( orchid , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
+			background: wc-hsl( 'orchid' , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 
 			&::after {
 				left: 8px;
@@ -1025,7 +1025,7 @@
 		}
 
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: wc-hsl( orchid , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) - 5 ) );
+			background: wc-hsl( 'orchid' , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) - 5 ) );
 		}
 	}
 
@@ -1041,13 +1041,13 @@
 .form-toggle.is-toggling {
 
 	+ .form-toggle__label .form-toggle__switch {
-		background: wc-hsl( orchid , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
+		background: wc-hsl( 'orchid' , calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 10 ) );
 	}
 
 	&:checked {
 
 		+ .form-toggle__label .form-toggle__switch {
-			background: wc-hsl( blue , 28%, 83%);
+			background: wc-hsl( 'blue' , 28%, 83%);
 		}
 	}
 }

--- a/plugins/woocommerce/legacy/css/marketplace-suggestions.scss
+++ b/plugins/woocommerce/legacy/css/marketplace-suggestions.scss
@@ -6,19 +6,14 @@
 @import "mixins";
 @import "variables";
 
-$suggestions-pale-gray: #ddd;
-$suggestions-metabox-pale-gray: #eee;
-
-$suggestions-copy-text: #444;
-
 a.suggestion-dismiss {
 	border: none;
 	box-shadow: none;
-	color: $suggestions-pale-gray;
+	color: wc-shade( 87 );
 }
 
 a.suggestion-dismiss:hover {
-	color: #aaa;
+	color: wc-shade( 66 );
 }
 
 a.suggestion-dismiss::before {
@@ -94,7 +89,7 @@ a.suggestion-dismiss::before {
 			p {
 				margin: 0;
 				margin-top: 4px;
-				color: $suggestions-copy-text;
+				color: wc-shade( 27 );
 			}
 		}
 
@@ -139,7 +134,6 @@ a.suggestion-dismiss::before {
 			h4 {
 				font-size: 1.1em;
 				margin: 0;
-				margin-bottom: 0;
 			}
 		}
 	}
@@ -284,8 +278,8 @@ a.suggestion-dismiss::before {
 .marketplace-suggestions-container.showing-suggestion[data-marketplace-suggestions-context="product-edit-meta-tab-body"] {
 
 	border: none;
-	border-top: 1px solid $suggestions-metabox-pale-gray;
-	border-bottom: 1px solid $suggestions-metabox-pale-gray;
+	border-top: 1px solid #{wc-shade( 93 )};
+	border-bottom: 1px solid #{wc-shade( 93 )};
 }
 
 .marketplace-suggestions-container.showing-suggestion[data-marketplace-suggestions-context="products-list-empty-header"],
@@ -295,10 +289,10 @@ a.suggestion-dismiss::before {
 .marketplace-suggestions-container.showing-suggestion[data-marketplace-suggestions-context="orders-list-empty-footer"],
 .marketplace-suggestions-container.showing-suggestion[data-marketplace-suggestions-context="orders-list-empty-body"] {
 
-	border: 1px solid $suggestions-pale-gray;
+	border: 1px solid wc-shade( 87 );
 	border-bottom: none;
 
 	&:last-child {
-		border-bottom: 1px solid $suggestions-pale-gray;
+		border-bottom: 1px solid wc-shade( 87 );
 	}
 }

--- a/plugins/woocommerce/legacy/css/menu.scss
+++ b/plugins/woocommerce/legacy/css/menu.scss
@@ -43,8 +43,8 @@ span.mce_woocommerce_shortcodes_button {
 	.wc_plugin_upgrade_notice {
 		font-weight: normal;
 		background: #fff8e5 !important;
-		border-left: 4px solid #ffb900;
-		border-top: 1px solid #ffb900;
+		border-left: 4px solid var(--wc-yellow);
+		border-top: 1px solid var(--wc-yellow);
 		padding: 9px 0 9px 12px !important;
 		margin: 0 -12px 0 -16px !important;
 
@@ -138,8 +138,8 @@ span.mce_woocommerce_shortcodes_button {
 		padding: 0.75em 1em;
 		line-height: 1.5em;
 		font-size: 2em;
-		border-bottom: 1px solid #eee;
-		color: #fff;
+		border-bottom: 1px solid #{wc-shade( 93 )};
+		color: var(--wc-white);
 		background: #96578a;
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
@@ -175,7 +175,7 @@ span.mce_woocommerce_shortcodes_button {
 	}
 
 	.actions {
-		border-top: 1px solid #eee;
+		border-top: 1px solid #{wc-shade( 93 )};
 		margin: 0;
 		padding: 1em 0 2em 0;
 		overflow: hidden;
@@ -186,24 +186,24 @@ span.mce_woocommerce_shortcodes_button {
 
 		a.button-primary {
 			float: right;
-			background: #bb77ae;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-			color: #fff;
+			background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+			border-color: var(--woocommerce);
+			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+			color: var(--wc-white);
 			text-shadow:
-				0 -1px 1px #a36597,
-				1px 0 1px #a36597,
-				0 1px 1px #a36597,
-				-1px 0 1px #a36597;
+				0 -1px 1px var(--woocommerce),
+				1px 0 1px var(--woocommerce),
+				0 1px 1px var(--woocommerce),
+				-1px 0 1px var(--woocommerce);
 
 			&:hover,
 			&:focus,
 			&:active {
-				background: #a36597;
-				border-color: #a36597;
+				background: var(--woocommerce);
+				border-color: var(--woocommerce);
 				box-shadow:
-					inset 0 1px 0 rgba(255, 255, 255, 0.25),
-					0 1px 0 #a36597;
+					inset 0 1px 0 wc-shade( 100 , 'white', 25% ),
+					0 1px 0 var(--woocommerce);
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/menu.scss
+++ b/plugins/woocommerce/legacy/css/menu.scss
@@ -140,7 +140,7 @@ span.mce_woocommerce_shortcodes_button {
 		font-size: 2em;
 		border-bottom: 1px solid #{wc-shade( 93 )};
 		color: var(--wc-white);
-		background: #96578a;
+		background: wc-hsl( 'orchid', var(--wc--primary-sat), calc(var(--wc--primary-luma) - 5%));
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
 		text-shadow: none;
@@ -186,7 +186,7 @@ span.mce_woocommerce_shortcodes_button {
 
 		a.button-primary {
 			float: right;
-			background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+			background: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) );
 			border-color: var(--woocommerce);
 			box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 			color: var(--wc-white);

--- a/plugins/woocommerce/legacy/css/network-order-widget.scss
+++ b/plugins/woocommerce/legacy/css/network-order-widget.scss
@@ -62,33 +62,33 @@
 						color: wc-shade( 47 );
 						background: wc-shade( 90 );
 						border-radius: 4px;
-						border-bottom: 1px solid wc-shade( 0, black, 5% );
+						border-bottom: 1px solid wc-shade( 0,'black', 5% );
 						margin: -.5em 0;
 						cursor: inherit !important;
 
 						&.status-completed {
-							background: #{wc-hsl( 'info',  29%, 83%)};
-							color: #{wc-hsl( 'info',  29%, 25%)};
+							background: wc-hsl( 'info',  29%, 83%);
+							color: wc-hsl( 'info',  29%, 25%);
 						}
 
 						&.status-on-hold {
-							background: #{wc-hsl( 'warning',  85%, 83%)};
-							color: #{wc-hsl( 'warning',  85%, 31%)};
+							background: wc-hsl( 'warning',  85%, 83%);
+							color: wc-hsl( 'warning',  85%, 31%);
 						}
 
 						&.status-failed {
-							background: #{wc-hsl( 'error',  65%, 83%)};
-							color: #{wc-hsl( 'error',  65%, 31%)};
+							background: wc-hsl( 'error',  65%, 83%);
+							color: wc-hsl( 'error',  65%, 31%);
 						}
 
 						&.status-processing {
-							background: #{wc-hsl( 'success',  50%, 82%)};
-							color: #{wc-hsl( 'success',  50%, 31%)};
+							background: wc-hsl( 'success',  50%, 82%);
+							color: wc-hsl( 'success',  50%, 31%);
 						}
 
 						&.status-trash {
-							background: #{wc-hsl( 'error',  65%, 83%)};
-							color: #{wc-hsl( 'error',  65%, 31%)};
+							background: wc-hsl( 'error',  65%, 83%);
+							color: wc-hsl( 'error',  65%, 31%);
 						}
 					}
 				}

--- a/plugins/woocommerce/legacy/css/network-order-widget.scss
+++ b/plugins/woocommerce/legacy/css/network-order-widget.scss
@@ -1,3 +1,9 @@
+/**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
+
 #woocommerce_network_orders {
 	.inside {
 		margin: 0;
@@ -43,7 +49,7 @@
 		.woocommerce-network-order-table {
 			tbody {
 				th, td {
-					border-top: 1px solid #f5f5f5;
+					border-top: 1px solid wc-shade( 96 );
 				}
 				td {
 					vertical-align: middle;
@@ -51,38 +57,38 @@
 
 					.order-status {
 						display: inline-flex;
-						padding: 0px 1em;
+						padding: 0 1em;
 						line-height: 2.5em;
-						color: #777;
-						background: #E5E5E5;
+						color: wc-shade( 47 );
+						background: wc-shade( 90 );
 						border-radius: 4px;
-						border-bottom: 1px solid rgba(0,0,0,0.05);
+						border-bottom: 1px solid wc-shade( 0, black, 5% );
 						margin: -.5em 0;
 						cursor: inherit !important;
 
 						&.status-completed {
-							background: #C8D7E1;
-							color: #2e4453;
+							background: #{wc-hsl( 'info',  29%, 83%)};
+							color: #{wc-hsl( 'info',  29%, 25%)};
 						}
 
 						&.status-on-hold {
-							background: #f8dda7;
-							color: #94660c;
+							background: #{wc-hsl( 'warning',  85%, 83%)};
+							color: #{wc-hsl( 'warning',  85%, 31%)};
 						}
 
 						&.status-failed {
-							background: #eba3a3;
-							color: #761919;
+							background: #{wc-hsl( 'error',  65%, 83%)};
+							color: #{wc-hsl( 'error',  65%, 31%)};
 						}
 
 						&.status-processing {
-							background: #C6E1C6;
-							color: #5B841B;
+							background: #{wc-hsl( 'success',  50%, 82%)};
+							color: #{wc-hsl( 'success',  50%, 31%)};
 						}
 
 						&.status-trash {
-							background: #eba3a3;
-							color: #761919;
+							background: #{wc-hsl( 'error',  65%, 83%)};
+							color: #{wc-hsl( 'error',  65%, 31%)};
 						}
 					}
 				}

--- a/plugins/woocommerce/legacy/css/prettyPhoto.scss
+++ b/plugins/woocommerce/legacy/css/prettyPhoto.scss
@@ -18,7 +18,7 @@
 	border-radius: 100%;
 	height: 1em;
 	width: 1em;
-	text-shadow: 0 1px 2px wc-shade( 0, black, 50% );
+	text-shadow: 0 1px 2px wc-shade( 0,'black', 50% );
 	background-color: wc-shade( 27 );
 	color: var(--wc-white) !important;
 	font-size: 16px !important;
@@ -37,7 +37,7 @@ div.pp_woocommerce {
 	.pp_content_container {
 		background: var(--wc-content-bg);
 		border-radius: 3px;
-		box-shadow: 0 1px 30px wc-shade( 0, black, 25% );
+		box-shadow: 0 1px 30px wc-shade( 0,'black', 25% );
 		padding: 20px 0;
 		@include clearfix();
 	}
@@ -54,9 +54,9 @@ div.pp_woocommerce {
 		ul {
 			li {
 				a {
-					border: 1px solid wc-shade( 0, black, 50% );
+					border: 1px solid wc-shade( 0,'black', 50% );
 					background: var(--wc-content-bg);
-					box-shadow: 0 1px 2px wc-shade( 0, black, 20% );
+					box-shadow: 0 1px 2px wc-shade( 0,'black', 20% );
 					border-radius: 2px;
 					display: block;
 
@@ -468,7 +468,7 @@ a.pp_arrow_next {
 }
 
 .pp_gallery ul a {
-	border: 1px wc-shade( 0, black, 50% ) solid;
+	border: 1px wc-shade( 0,'black', 50% ) solid;
 	display: block;
 	float: left;
 	height: 33px;

--- a/plugins/woocommerce/legacy/css/prettyPhoto.scss
+++ b/plugins/woocommerce/legacy/css/prettyPhoto.scss
@@ -18,15 +18,15 @@
 	border-radius: 100%;
 	height: 1em;
 	width: 1em;
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-	background-color: #444;
-	color: #fff !important;
+	text-shadow: 0 1px 2px wc-shade( 0, black, 50% );
+	background-color: wc-shade( 27 );
+	color: var(--wc-white) !important;
 	font-size: 16px !important;
 	line-height: 1em;
 	@include transition();
 
 	&:hover {
-		background-color: #000;
+		background-color: var(--wc-black);
 	}
 }
 
@@ -35,9 +35,9 @@
  */
 div.pp_woocommerce {
 	.pp_content_container {
-		background: #fff;
+		background: var(--wc-content-bg);
 		border-radius: 3px;
-		box-shadow: 0 1px 30px rgba(0, 0, 0, 0.25);
+		box-shadow: 0 1px 30px wc-shade( 0, black, 25% );
 		padding: 20px 0;
 		@include clearfix();
 	}
@@ -47,27 +47,27 @@ div.pp_woocommerce {
 	}
 
 	div.ppt {
-		color: black;
+		color: var(--wc-black);
 	}
 
 	.pp_gallery {
 		ul {
 			li {
 				a {
-					border: 1px solid rgba(0, 0, 0, 0.5);
-					background: #fff;
-					box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+					border: 1px solid wc-shade( 0, black, 50% );
+					background: var(--wc-content-bg);
+					box-shadow: 0 1px 2px wc-shade( 0, black, 20% );
 					border-radius: 2px;
 					display: block;
 
 					&:hover {
-						border-color: #000;
+						border-color: var(--wc-black);
 					}
 				}
 
 				&.selected {
 					a {
-						border-color: #000;
+						border-color: var(--wc-black);
 					}
 				}
 			}
@@ -302,7 +302,7 @@ div.pp_pic_holder a:focus {
 }
 
 div.pp_overlay {
-	background: #000;
+	background: var(--wc-black);
 	display: none;
 	left: 0;
 	position: absolute;
@@ -468,8 +468,7 @@ a.pp_arrow_next {
 }
 
 .pp_gallery ul a {
-	border: 1px #000 solid;
-	border: 1px rgba(0, 0, 0, 0.5) solid;
+	border: 1px wc-shade( 0, black, 50% ) solid;
 	display: block;
 	float: left;
 	height: 33px;
@@ -478,7 +477,7 @@ a.pp_arrow_next {
 
 .pp_gallery ul a:hover,
 .pp_gallery li.selected a {
-	border-color: #fff;
+	border-color: var(--wc-white);
 }
 
 .pp_gallery ul a img {
@@ -596,7 +595,7 @@ a.pp_close {
 }
 
 div.ppt {
-	color: #fff !important;
+	color: var(--wc-white) !important;
 	font-weight: 700;
 	display: none;
 	font-size: 17px;

--- a/plugins/woocommerce/legacy/css/privacy.scss
+++ b/plugins/woocommerce/legacy/css/privacy.scss
@@ -5,6 +5,12 @@
  */
 
 /**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
+
+/**
  * Styling begins
  */
 
@@ -33,7 +39,7 @@
 // 5.4 support for white background and padding.
 .branch-5-4 .policy-text ul:not(.privacy-policy-tutorial):not(.wp-policy-help),
 .branch-5-4 .policy-text ol:not(.privacy-policy-tutorial):not(.wp-policy-help) {
-	background-color: #fff;
+	background-color: var(--wc-content-bg);
 	margin: 0;
 	padding: 1em;
 }

--- a/plugins/woocommerce/legacy/css/select2.scss
+++ b/plugins/woocommerce/legacy/css/select2.scss
@@ -1,3 +1,9 @@
+/**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
+
 .select2-container {
     box-sizing: border-box;
     display: inline-block;
@@ -69,8 +75,8 @@
 }
 
 .select2-dropdown {
-    background-color: white;
-    border: 1px solid #aaa;
+    background-color: var(--wc-white);
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
     box-sizing: border-box;
     display: block;
@@ -150,7 +156,7 @@
     width: auto;
     opacity: 0;
     z-index: 99;
-    background-color: #fff;
+    background-color: var(--wc-content-bg);
     filter: alpha(opacity=0);
 }
 
@@ -166,13 +172,13 @@
 }
 
 .select2-container--default .select2-selection--single {
-    background-color: #fff;
-    border: 1px solid #aaa;
+    background-color: var(--wc-content-bg);
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
 }
 
 .select2-container--default .select2-selection--single .select2-selection__rendered {
-    color: #444;
+    color: wc-shade( 27 );
     line-height: 28px;
 }
 
@@ -183,7 +189,7 @@
 }
 
 .select2-container--default .select2-selection--single .select2-selection__placeholder {
-    color: #999;
+    color: wc-shade( 60 );
 }
 
 .select2-container--default .select2-selection--single .select2-selection__arrow {
@@ -195,7 +201,7 @@
 }
 
 .select2-container--default .select2-selection--single .select2-selection__arrow b {
-    border-color: #888 transparent transparent transparent;
+    border-color: wc-shade( 53 ) transparent transparent transparent;
     border-style: solid;
     border-width: 5px 4px 0 4px;
     height: 0;
@@ -217,7 +223,7 @@
 }
 
 .select2-container--default.select2-container--disabled .select2-selection--single {
-    background-color: #eee;
+    background-color: #{wc-shade( 93 )};
     cursor: default;
 }
 
@@ -226,13 +232,13 @@
 }
 
 .select2-container--default.select2-container--open .select2-selection--single .select2-selection__arrow b {
-    border-color: transparent transparent #888 transparent;
+    border-color: transparent transparent wc-shade( 53 ) transparent;
 	border-width: 0 4px 5px 4px;
 }
 
 .select2-container--default .select2-selection--multiple {
-    background-color: white;
-    border: 1px solid #aaa;
+    background-color: var(--wc-white);
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
     cursor: text;
 }
@@ -256,7 +262,7 @@
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
-    color: #999;
+    color: wc-shade( 60 );
     margin-top: 5px;
     float: left;
 }
@@ -271,7 +277,7 @@
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice {
     background-color: #e4e4e4;
-    border: 1px solid #aaa;
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
     cursor: default;
     float: left;
@@ -281,7 +287,7 @@
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
-    color: #999;
+    color: wc-shade( 60 );
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
@@ -289,7 +295,7 @@
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
-    color: #333;
+    color: wc-shade( 20 );
 }
 
 .select2-container--default[dir="rtl"] .select2-selection--multiple .select2-selection__choice,
@@ -314,7 +320,7 @@
 }
 
 .select2-container--default.select2-container--disabled .select2-selection--multiple {
-    background-color: #eee;
+    background-color: #{wc-shade( 93 )};
     cursor: default;
 }
 
@@ -335,7 +341,7 @@
 }
 
 .select2-container--default .select2-search--dropdown .select2-search__field {
-    border: 1px solid #aaa;
+    border: 1px solid wc-shade( 66 );
 }
 
 .select2-container--default .select2-search--inline .select2-search__field {
@@ -356,12 +362,12 @@
 }
 
 .select2-container--default .select2-results__option[aria-disabled=true] {
-    color: #999;
+    color: wc-shade( 60 );
 }
 
 .select2-container--default .select2-results__option[data-selected=true],
 .select2-container--default .select2-results__option[aria-selected=true] {
-    background-color: #ddd;
+    background-color: wc-shade( 87 );
 }
 
 .select2-container--default .select2-results__option .select2-results__option {
@@ -400,7 +406,7 @@
 .select2-container--default .select2-results__option--highlighted[data-selected],
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
     background-color: #0073aa;
-    color: white;
+    color: var(--wc-white);
 }
 
 .select2-container--default .select2-results__group {
@@ -410,13 +416,12 @@
 }
 
 .select2-container--classic .select2-selection--single {
-    background-color: #f7f7f7;
-    border: 1px solid #aaa;
+    background-color: wc-shade( 96 );
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
     outline: 0;
-    background-image: linear-gradient(to bottom, white 50%, #eeeeee 100%);
+    background-image: linear-gradient(to bottom, var(--wc-white) 50%, wc-shade( 93 ) 100%);
     background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFFFF', endColorstr='#FFEEEEEE', GradientType=0);
 }
 
 .select2-container--classic .select2-selection--single:focus {
@@ -424,7 +429,7 @@
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__rendered {
-    color: #444;
+    color: wc-shade( 27 );
     line-height: 28px;
 }
 
@@ -436,13 +441,13 @@
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__placeholder {
-    color: #999;
+    color: wc-shade( 60 );
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__arrow {
-    background-color: #ddd;
+    background-color: wc-shade( 87 );
     border: none;
-    border-left: 1px solid #aaa;
+    border-left: 1px solid wc-shade( 66 );
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
     height: 26px;
@@ -450,13 +455,12 @@
     top: 1px;
     right: 1px;
     width: 20px;
-    background-image: linear-gradient(to bottom, #eeeeee 50%, #cccccc 100%);
+    background-image: linear-gradient(to bottom, var(--woocommerce) 50%, wc-shade( 80 ) 100%);
     background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFEEEEEE', endColorstr='#FFCCCCCC', GradientType=0);
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__arrow b {
-    border-color: #888 transparent transparent transparent;
+    border-color: wc-shade( 53 ) transparent transparent transparent;
     border-style: solid;
     border-width: 5px 4px 0 4px;
     height: 0;
@@ -474,7 +478,7 @@
 
 .select2-container--classic[dir="rtl"] .select2-selection--single .select2-selection__arrow {
     border: none;
-    border-right: 1px solid #aaa;
+    border-right: 1px solid wc-shade( 66 );
     border-radius: 0;
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
@@ -492,7 +496,7 @@
 }
 
 .select2-container--classic.select2-container--open .select2-selection--single .select2-selection__arrow b {
-    border-color: transparent transparent #888 transparent;
+    border-color: transparent transparent wc-shade( 53 ) transparent;
     border-width: 0 4px 5px 4px;
 }
 
@@ -500,23 +504,21 @@
     border-top: none;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    background-image: linear-gradient(to bottom, white 0%, #eeeeee 50%);
+    background-image: linear-gradient(to bottom, var(--wc-white) 0%, var(--woocommerce) 50%);
     background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFFFF', endColorstr='#FFEEEEEE', GradientType=0);
 }
 
 .select2-container--classic.select2-container--open.select2-container--below .select2-selection--single {
     border-bottom: none;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    background-image: linear-gradient(to bottom, #eeeeee 50%, white 100%);
+    background-image: linear-gradient(to bottom, var(--woocommerce) 50%, var(--wc-white) 100%);
     background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFEEEEEE', endColorstr='#FFFFFFFF', GradientType=0);
 }
 
 .select2-container--classic .select2-selection--multiple {
-    background-color: white;
-    border: 1px solid #aaa;
+    background-color: var(--wc-white);
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
     cursor: text;
     outline: 0;
@@ -538,7 +540,7 @@
 
 .select2-container--classic .select2-selection--multiple .select2-selection__choice {
     background-color: #e4e4e4;
-    border: 1px solid #aaa;
+    border: 1px solid wc-shade( 66 );
     border-radius: 4px;
     cursor: default;
     float: left;
@@ -548,7 +550,7 @@
 }
 
 .select2-container--classic .select2-selection--multiple .select2-selection__choice__remove {
-    color: #888;
+    color: wc-shade( 53 );
     cursor: pointer;
     display: inline-block;
     font-weight: bold;
@@ -590,7 +592,7 @@
 }
 
 .select2-container--classic .select2-search--dropdown .select2-search__field {
-    border: 1px solid #aaa;
+    border: 1px solid wc-shade( 66 );
     outline: 0;
 }
 
@@ -600,7 +602,7 @@
 }
 
 .select2-container--classic .select2-dropdown {
-    background-color: white;
+    background-color: var(--wc-white);
     border: 1px solid transparent;
 }
 
@@ -628,7 +630,7 @@
 .select2-container--classic .select2-results__option--highlighted[data-selected],
 .select2-container--classic .select2-results__option--highlighted[aria-selected] {
     background-color: #3875d7;
-    color: white;
+    color: var(--wc-white);
 }
 
 .select2-container--classic .select2-results__group {

--- a/plugins/woocommerce/legacy/css/select2.scss
+++ b/plugins/woocommerce/legacy/css/select2.scss
@@ -405,7 +405,7 @@
 
 .select2-container--default .select2-results__option--highlighted[data-selected],
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
-    background-color: #0073aa;
+    background-color: wc-hsl( 'blue', 100%, 33% );
     color: var(--wc-white);
 }
 
@@ -425,7 +425,7 @@
 }
 
 .select2-container--classic .select2-selection--single:focus {
-    border: 1px solid #0073aa;
+    border: 1px solid wc-hsl( 'blue', 100%, 33% );
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__rendered {
@@ -455,7 +455,7 @@
     top: 1px;
     right: 1px;
     width: 20px;
-    background-image: linear-gradient(to bottom, var(--woocommerce) 50%, wc-shade( 80 ) 100%);
+    background-image: linear-gradient(to bottom, wc-shade( 93 ) 50%, wc-shade( 80 ) 100%);
     background-repeat: repeat-x;
 }
 
@@ -479,15 +479,13 @@
 .select2-container--classic[dir="rtl"] .select2-selection--single .select2-selection__arrow {
     border: none;
     border-right: 1px solid wc-shade( 66 );
-    border-radius: 0;
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-    left: 1px;
+	border-radius: 4px 0 0 4px;
+	left: 1px;
     right: auto;
 }
 
 .select2-container--classic.select2-container--open .select2-selection--single {
-    border: 1px solid #0073aa;
+    border: 1px solid wc-hsl( 'blue', 100%, 33% );
 }
 
 .select2-container--classic.select2-container--open .select2-selection--single .select2-selection__arrow {
@@ -504,7 +502,7 @@
     border-top: none;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    background-image: linear-gradient(to bottom, var(--wc-white) 0%, var(--woocommerce) 50%);
+    background-image: linear-gradient(to bottom, var(--wc-white) 0%, wc-shade( 93 ) 50%);
     background-repeat: repeat-x;
 }
 
@@ -512,7 +510,7 @@
     border-bottom: none;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    background-image: linear-gradient(to bottom, var(--woocommerce) 50%, var(--wc-white) 100%);
+    background-image: linear-gradient(to bottom, wc-shade( 93 ) 50%, var(--wc-white) 100%);
     background-repeat: repeat-x;
 }
 
@@ -525,7 +523,7 @@
 }
 
 .select2-container--classic .select2-selection--multiple:focus {
-    border: 1px solid #0073aa;
+    border: 1px solid wc-hsl( 'blue', 100%, 33% );
 }
 
 .select2-container--classic .select2-selection--multiple .select2-selection__rendered {
@@ -558,7 +556,7 @@
 }
 
 .select2-container--classic .select2-selection--multiple .select2-selection__choice__remove:hover {
-    color: #555;
+    color: wc-shade( 33 );
 }
 
 .select2-container--classic[dir="rtl"] .select2-selection--multiple .select2-selection__choice {
@@ -576,7 +574,7 @@
 }
 
 .select2-container--classic.select2-container--open .select2-selection--multiple {
-    border: 1px solid #0073aa;
+    border: 1px solid wc-hsl( 'blue', 100%, 33% );
 }
 
 .select2-container--classic.select2-container--open.select2-container--above .select2-selection--multiple {
@@ -629,7 +627,7 @@
 
 .select2-container--classic .select2-results__option--highlighted[data-selected],
 .select2-container--classic .select2-results__option--highlighted[aria-selected] {
-    background-color: #3875d7;
+    background-color: wc-hsl( 'blue', 65%, 53% );
     color: var(--wc-white);
 }
 
@@ -640,5 +638,5 @@
 }
 
 .select2-container--classic.select2-container--open .select2-dropdown {
-    border-color: #0073aa;
+    border-color: wc-hsl( 'blue', 100%, 33% );
 }

--- a/plugins/woocommerce/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/legacy/css/twenty-nineteen.scss
@@ -11,8 +11,8 @@
 $headings: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",sans-serif;
 $body: "NonBreakingSpaceOverride", "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
 
-$body-color: #111;
-$highlights-color: #0073aa;
+$body-color: wc-shade( 7 );
+$highlights-color: wc-hsl( 'blue', 100%, 33% );
 
 :root {
 	--wc--black-luma: 7;
@@ -146,7 +146,7 @@ a.button {
 		}
 
 		&.button {
-			background: #111;
+			background: wc-shade( 7 );
 		}
 	}
 }
@@ -840,7 +840,7 @@ table.variations {
 				font-weight: 600;
 
 				&:hover {
-					color: #005177;
+					color: wc-hsl( 'blue', 100%, 23% );
 					text-decoration: underline;
 				}
 			}
@@ -1032,9 +1032,9 @@ table.variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid wc-shade( 0, black, 20% );
-	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
-	background: wc-shade( 0, black, 5% );
+	border: 1px solid wc-shade( 0,'black', 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0,'black', 10% );
+	background: wc-shade( 0,'black', 5% );
 }
 
 .woocommerce-terms-and-conditions-link {

--- a/plugins/woocommerce/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/legacy/css/twenty-nineteen.scss
@@ -1,4 +1,8 @@
-@import 'mixins';
+/**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
 
 /**
  * Sass variables
@@ -10,30 +14,16 @@ $body: "NonBreakingSpaceOverride", "Hoefler Text", "Baskerville Old Face", Garam
 $body-color: #111;
 $highlights-color: #0073aa;
 
+:root {
+	--wc--black-luma: 7;
+	--wc--highlight-hue: 199;
+	--wc--primary-luma: 33%;
+}
+
 /**
  * Fonts
  */
- @font-face {
-	font-family: 'star';
-	src: url('../fonts/star.eot');
-	src: url('../fonts/star.eot?#iefix') format('embedded-opentype'),
-		url('../fonts/star.woff') format('woff'),
-		url('../fonts/star.ttf') format('truetype'),
-		url('../fonts/star.svg#star') format('svg');
-	font-weight: normal;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: 'WooCommerce';
-	src: url('../fonts/WooCommerce.eot');
-	src: url('../fonts/WooCommerce.eot?#iefix') format('embedded-opentype'),
-		url('../fonts/WooCommerce.woff') format('woff'),
-		url('../fonts/WooCommerce.ttf') format('truetype'),
-		url('../fonts/WooCommerce.svg#WooCommerce') format('svg');
-	font-weight: normal;
-	font-style: normal;
-}
+@import "fonts";
 
 /**
  * Global elements
@@ -43,12 +33,12 @@ a.button {
 	text-align: center;
 	box-sizing: border-box;
 	word-break: break-all;
-	color: #fff;
+	color: var(--wc-white);
 	text-decoration: none !important;
 
 	&:hover,
 	&:visited {
-		color: #fff;
+		color: var(--wc-white);
 	}
 }
 
@@ -104,17 +94,14 @@ a.button {
 	left: 0;
 	display: inline-block;
 	background: $highlights-color;
-	color: #fff;
-	display: inline-block;
+	color: var(--wc-white);
 	font-family: $headings;
 	font-size: 0.71111em;
 	font-weight: 700;
 	letter-spacing: -0.02em;
 	line-height: 1.2;
 	padding: 0.5rem;
-	position: absolute;
 	text-transform: uppercase;
-	top: 0;
 	z-index: 1;
 }
 
@@ -135,7 +122,7 @@ a.button {
 .woocommerce-info {
 	margin-bottom: 1.5rem;
 	padding: 1rem;
-	background: #eee;
+	background: wc-shade( 93 );
 	font-size: 0.88889em;
 	font-family: $headings;
 	list-style: none;
@@ -143,19 +130,19 @@ a.button {
 }
 
 .woocommerce-message {
-	background: #eee;
+	background: wc-shade( 93 );
 	color: $body-color;
 }
 
 .woocommerce-error,
 .woocommerce-info {
-	color: #fff;
+	color: var(--wc-white);
 
 	a {
-		color: #fff;
+		color: var(--wc-white);
 
 		&:hover {
-			color: #fff;
+			color: var(--wc-white);
 		}
 
 		&.button {
@@ -174,7 +161,7 @@ a.button {
 
 .woocommerce-store-notice {
 	background: $highlights-color;
-	color: #fff;
+	color: var(--wc-white);
 	padding: 1rem;
 	position: absolute;
 	top: 0;
@@ -189,11 +176,11 @@ a.button {
 
 .woocommerce-store-notice__dismiss-link {
 	float: right;
-	color: #fff;
+	color: var(--wc-white);
 
 	&:hover {
 		text-decoration: underline;
-		color: #fff;
+		color: var(--wc-white);
 	}
 }
 
@@ -267,7 +254,7 @@ ul.products {
 		}
 
 		.woocommerce-placeholder {
-			border: 1px solid #F2F2F2;
+			border: 1px solid wc-shade( 5 );
 		}
 
 		.button {
@@ -331,11 +318,11 @@ a.remove {
 	border-radius: 100%;
 	text-decoration: none !important;
 	background: firebrick;
-	color: #fff;
+	color: var(--wc-white);
 
 	&:hover {
-		background: #000;
-		color: #fff !important;
+		background: var(--wc-black);
+		color: var(--wc-white) !important;
 	}
 }
 
@@ -445,12 +432,12 @@ table.variations {
 	}
 
 	.zoomImg {
-		background-color: #fff;
+		background-color: var(--wc-content-bg);
 		opacity: 0;
 	}
 
 	.woocommerce-product-gallery__image--placeholder {
-		border: 1px solid #F2F2F2;
+		border: 1px solid wc-shade( 5 );
 	}
 
 	.woocommerce-product-gallery__image:nth-child(n+2) {
@@ -690,7 +677,7 @@ table.variations {
 			float: left;
 			margin-top: 7px;
 			line-height: 20px;
-			color: #fff;
+			color: var(--wc-white);
 			margin-right: .5rem;
 		}
 	}
@@ -720,7 +707,7 @@ table.variations {
 			font-size: 16px;
 			text-align: center;
 			border-radius: 100%;
-			border: 1px solid black;
+			border: 1px solid var(--wc-black);
 			margin-right: 0.25rem;
 		}
 	}
@@ -754,7 +741,7 @@ table.variations {
 		z-index: 2;
 		width: 1em;
 		height: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 		border-radius: 1em;
 		cursor: ew-resize;
 		outline: none;
@@ -769,12 +756,12 @@ table.variations {
 		display: block;
 		border: 0;
 		border-radius: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 	}
 
 	.price_slider_wrapper .ui-widget-content {
 		border-radius: 1em;
-		background-color: #666;
+		background-color: wc-shade( 40 );
 		border: 0;
 	 }
 
@@ -841,7 +828,7 @@ table.variations {
 		li {
 			list-style: none;
 			padding: 0.5rem 0;
-			border-bottom: 1px solid #ccc;
+			border-bottom: 1px solid wc-shade( 80 );
 
 			&:first-child {
 				padding-top: 0;
@@ -956,12 +943,12 @@ table.variations {
 .checkout-button {
 	display: block;
 	padding: 1rem 2rem;
-	border: 2px solid #000;
+	border: 2px solid var(--wc-black);
 	text-align: center;
 	font-weight: 800;
 
 	&:hover {
-		border-color: #999;
+		border-color: wc-shade( 60 );
 	}
 
 	&:after {
@@ -1008,7 +995,7 @@ table.variations {
 				display: block;
 				width: 14px;
 				height: 14px;
-				background: white;
+				background: var(--wc-white);
 				position: absolute;
 				top: 7px;
 				right: 17px;
@@ -1026,8 +1013,8 @@ table.variations {
 		}
 
 		input[type=checkbox]:checked + span:before {
-			border-color: #000;
-			background: #000;
+			border-color: var(--wc-black);
+			background: var(--wc-black);
 		}
 	}
 }
@@ -1045,9 +1032,9 @@ table.variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid rgba(0,0,0,.2);
-	box-shadow: inset 0 1px 2px rgba(0,0,0,.1);
-	background: rgba(0,0,0,.05);
+	border: 1px solid wc-shade( 0, black, 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
+	background: wc-shade( 0, black, 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1072,7 +1059,7 @@ table.variations {
 	.woocommerce-input-wrapper {
 		.description {
 			background: royalblue;
-			color: #fff;
+			color: var(--wc-white);
 			border-radius: 3px;
 			padding: 1rem;
 			margin: 0.5rem 0 0;
@@ -1081,7 +1068,7 @@ table.variations {
 			position: relative;
 
 			a {
-				color: #fff;
+				color: var(--wc-white);
 				text-decoration: underline;
 				border: 0;
 				box-shadow: none;
@@ -1089,7 +1076,7 @@ table.variations {
 
 			&:before {
 				left: 50%;
-				top: 0%;
+				top: 0;
 				margin-top: -4px;
 				transform: translatex(-50%) rotate(180deg);
 				content: "";
@@ -1120,7 +1107,7 @@ table.variations {
 		height: 46px;
 	}
 	.select2-container--focus .select2-selection {
-		border-color: black;
+		border-color: var(--wc-black);
 	}
 }
 
@@ -1150,7 +1137,7 @@ table.variations {
 
 	.payment_box {
 		padding: 1rem;
-		background: #eee;
+		background: wc-shade( 93 );
 
 		ul,
 		ol {
@@ -1163,7 +1150,7 @@ table.variations {
 			padding: 1.5rem;
 			padding-bottom: 0;
 			border: 0;
-			background: #f6f6f6;
+			background: wc-shade( 96 );
 		}
 
 		li {
@@ -1205,9 +1192,9 @@ table.variations {
 				display: inline-block;
 				width: 16px;
 				height: 16px;
-				border: 2px solid white;
-				box-shadow: 0 0 0 2px black;
-				background: white;
+				border: 2px solid var(--wc-white);
+				box-shadow: 0 0 0 2px var(--wc-black);
+				background: var(--wc-white);
 				margin-left: 4px;
 				margin-right: 0.5rem;
 				border-radius: 100%;
@@ -1217,7 +1204,7 @@ table.variations {
 
 		&:checked + label {
 			&:before {
-				background: black;
+				background: var(--wc-black);
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/legacy/css/twenty-seventeen.scss
@@ -14,11 +14,11 @@
  * Mixins
  */
 @mixin link() {
-	box-shadow: 0 1px 0 rgba(15, 15, 15, 1);
+	box-shadow: 0 1px 0 wc-shade( 96 );
 	transition: box-shadow ease-in-out 130ms;
 
 	&:hover {
-		box-shadow: 0 3px 0 rgba(15, 15, 15, 1);
+		box-shadow: 0 3px 0 wc-shade( 96 );
 	}
 }
 
@@ -122,7 +122,7 @@
 	}
 
 	a.page-numbers:hover {
-		background-color: #767676;
+		background-color: wc-shade( 46 );
 		color: var(--wc-white);
 	}
 }
@@ -501,7 +501,7 @@ table.variations {
 		&.active {
 
 			a {
-				box-shadow: 0 3px 0 rgba(15, 15, 15, 1);
+				box-shadow: 0 3px 0 wc-shade( 96 );
 			}
 		}
 	}
@@ -789,7 +789,7 @@ table.variations {
 				box-shadow: none;
 
 				&:hover {
-					box-shadow: 0 3px 0 rgba(15, 15, 15, 1);
+					box-shadow: 0 3px 0 wc-shade( 96 );
 				}
 			}
 
@@ -803,7 +803,7 @@ table.variations {
 			&.is-active {
 
 				a {
-					box-shadow: 0 3px 0 rgba(15, 15, 15, 1);
+					box-shadow: 0 3px 0 wc-shade( 96 );
 				}
 			}
 		}
@@ -994,9 +994,9 @@ table.variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid wc-shade( 0, black, 20% );
-	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
-	background: wc-shade( 0, black, 5% );
+	border: 1px solid wc-shade( 0,'black', 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0,'black', 10% );
+	background: wc-shade( 0,'black', 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1009,12 +1009,12 @@ table.variations {
 		margin-bottom: 2px;
 		margin-left: 0.25em;
 		border-width: 6px 6px 0 6px;
-		border-color: #111 transparent transparent transparent;
+		border-color: wc-shade( 7 ) transparent transparent transparent;
 	}
 
 	&.woocommerce-terms-and-conditions-link--open::after {
 		border-width: 0 6px 6px 6px;
-		border-color: transparent transparent #111 transparent;
+		border-color: transparent transparent wc-shade( 7 ) transparent;
 	}
 }
 
@@ -1183,7 +1183,7 @@ table.variations {
 	}
 
 	.checkout-button {
-		border: 2px solid #555;
+		border: 2px solid wc-shade( 33 );
 
 		&:hover {
 			border-color: var(--wc-white);
@@ -1212,7 +1212,7 @@ table.variations {
 
 		.select2-selection--single {
 			background-color: wc-shade( 20 );
-			border: 1px solid #555;
+			border: 1px solid wc-shade( 33 );
 
 			.select2-selection__rendered {
 				color: wc-shade( 80 );

--- a/plugins/woocommerce/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/legacy/css/twenty-seventeen.scss
@@ -2,34 +2,13 @@
  * Twenty Seventeen integration styles
  */
 @import "mixins";
+@import "variables";
 @import "animation";
 
 /**
  * Fonts
  */
-@font-face {
-	font-family: "star";
-	src: url("../fonts/star.eot");
-	src:
-		url("../fonts/star.eot?#iefix") format("embedded-opentype"),
-		url("../fonts/star.woff") format("woff"),
-		url("../fonts/star.ttf") format("truetype"),
-		url("../fonts/star.svg#star") format("svg");
-	font-weight: normal;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: "WooCommerce";
-	src: url("../fonts/WooCommerce.eot");
-	src:
-		url("../fonts/WooCommerce.eot?#iefix") format("embedded-opentype"),
-		url("../fonts/WooCommerce.woff") format("woff"),
-		url("../fonts/WooCommerce.ttf") format("truetype"),
-		url("../fonts/WooCommerce.svg#WooCommerce") format("svg");
-	font-weight: normal;
-	font-style: normal;
-}
+@import "fonts";
 
 /**
  * Mixins
@@ -44,13 +23,13 @@
 }
 
 @mixin link_white() {
-	color: #fff;
-	box-shadow: 0 1px 0 rgba(#fff, 1) !important;
+	color: var(--wc-white);
+	box-shadow: 0 1px 0 var(--wc-white) !important;
 	transition: box-shadow ease-in-out 130ms;
 
 	&:hover {
-		color: #fff !important;
-		box-shadow: 0 3px 0 rgba(#fff, 1) !important;
+		color: var(--wc-white) !important;
+		box-shadow: 0 3px 0 var(--wc-white) !important;
 	}
 }
 
@@ -104,8 +83,7 @@
 .woocommerce-breadcrumb {
 	padding-bottom: 2em;
 	margin-bottom: 4em;
-	border-bottom: 1px solid #eee;
-	font-size: 13px;
+	border-bottom: 1px solid wc-shade( 93 );
 	font-size: 0.8125rem;
 
 	a {
@@ -117,8 +95,7 @@
 .woocommerce-pagination {
 	padding-top: 2em;
 	margin-top: 4em;
-	border-top: 1px solid #eee;
-	font-size: 13px;
+	border-top: 1px solid wc-shade( 93 );
 	font-size: 0.8125rem;
 
 	ul.page-numbers {
@@ -131,7 +108,7 @@
 	.next.page-numbers,
 	.prev.page-numbers {
 		padding: 0.5em 1em;
-		background: #ddd;
+		background: wc-shade( 87 );
 		display: inline-block;
 		font-size: 1em;
 		float: none;
@@ -141,23 +118,22 @@
 	}
 
 	span.page-numbers {
-		background-color: #fff;
+		background-color: var(--wc-content-bg);
 	}
 
 	a.page-numbers:hover {
 		background-color: #767676;
-		color: #fff;
+		color: var(--wc-white);
 	}
 }
 
 .onsale {
-	background-color: #fff;
+	background-color: var(--wc-content-bg);
 	position: absolute;
 	top: 0;
 	left: 0;
 	display: inline-block;
 	padding: 0.5em 1em;
-	font-size: 13px;
 	font-size: 0.8125rem;
 	text-transform: uppercase;
 	font-weight: 800;
@@ -181,22 +157,22 @@
 .woocommerce-info {
 	margin-bottom: 1.5em;
 	padding: 2em;
-	background: #eee;
+	background: wc-shade( 93 );
 }
 
 .woocommerce-message {
 	background: teal;
-	color: #fff;
+	color: var(--wc-white);
 }
 
 .woocommerce-error {
 	background: firebrick;
-	color: #fff;
+	color: var(--wc-white);
 }
 
 .woocommerce-info {
 	background: royalblue;
-	color: #fff;
+	color: var(--wc-white);
 }
 
 .woocommerce-message,
@@ -211,7 +187,7 @@
 
 .woocommerce-store-notice {
 	background: royalblue;
-	color: #fff;
+	color: var(--wc-white);
 	padding: 1em;
 	position: absolute;
 	top: 0;
@@ -226,11 +202,11 @@
 
 .woocommerce-store-notice__dismiss-link {
 	float: right;
-	color: #fff;
+	color: var(--wc-white);
 
 	&:hover {
 		text-decoration: underline;
-		color: #fff;
+		color: var(--wc-white);
 	}
 }
 
@@ -256,7 +232,7 @@ ul.products {
 		}
 
 		.woocommerce-placeholder {
-			border: 1px solid #f2f2f2;
+			border: 1px solid wc-shade( 5 );
 		}
 
 		.button {
@@ -311,7 +287,6 @@ ul.products {
 }
 
 .woocommerce-loop-product__title {
-	font-size: 13px;
 	font-size: 0.8125rem;
 	text-transform: uppercase;
 	font-weight: 800;
@@ -327,11 +302,11 @@ a.remove {
 	text-align: center;
 	border-radius: 100%;
 	box-shadow: none !important;
-	border: 1px solid #000;
+	border: 1px solid var(--wc-black);
 
 	&:hover {
-		background: #000;
-		color: #fff !important;
+		background: var(--wc-black);
+		color: var(--wc-white) !important;
 	}
 }
 
@@ -440,12 +415,12 @@ table.variations {
 	}
 
 	.zoomImg {
-		background-color: #fff;
+		background-color: var(--wc-content-bg);
 		opacity: 0;
 	}
 
 	.woocommerce-product-gallery__image--placeholder {
-		border: 1px solid #f2f2f2;
+		border: 1px solid wc-shade( 5 );
 	}
 
 	.woocommerce-product-gallery__image:nth-child(n+2) {
@@ -541,7 +516,6 @@ table.variations {
 	}
 
 	.comment-reply-title {
-		font-size: 22px;
 		font-size: 1.375rem;
 		font-weight: 300;
 		line-height: 1.4;
@@ -688,7 +662,7 @@ table.variations {
 			font-size: 16px;
 			text-align: center;
 			border-radius: 100%;
-			border: 1px solid black;
+			border: 1px solid var(--wc-black);
 			margin-right: 0.25em;
 		}
 	}
@@ -723,7 +697,7 @@ table.variations {
 		z-index: 2;
 		width: 1em;
 		height: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 		border-radius: 1em;
 		cursor: ew-resize;
 		outline: none;
@@ -738,12 +712,12 @@ table.variations {
 		display: block;
 		border: 0;
 		border-radius: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 	}
 
 	.price_slider_wrapper .ui-widget-content {
 		border-radius: 1em;
-		background-color: #666;
+		background-color: wc-shade( 40 );
 		border: 0;
 	}
 
@@ -804,12 +778,12 @@ table.variations {
 	.woocommerce-MyAccount-navigation {
 		float: right;
 		width: 25%;
-		border-top: 1px solid #ddd;
+		border-top: 1px solid wc-shade( 87 );
 
 		li {
 			list-style: none;
 			padding: 0.5em 0;
-			border-bottom: 1px solid #ddd;
+			border-bottom: 1px solid wc-shade( 87 );
 
 			a {
 				box-shadow: none;
@@ -823,7 +797,7 @@ table.variations {
 				content: "→";
 				display: inline-block;
 				margin-right: 0.25em;
-				color: #ddd;
+				color: wc-shade( 87 );
 			}
 
 			&.is-active {
@@ -933,14 +907,14 @@ table.variations {
 .checkout-button {
 	display: block;
 	padding: 1em 2em;
-	border: 2px solid #000;
+	border: 2px solid var(--wc-black);
 	text-align: center;
 	font-weight: 800;
 	box-shadow: none !important;
 
 	&:hover {
 		box-shadow: none !important;
-		border-color: #999;
+		border-color: wc-shade( 60 );
 	}
 
 	&::after {
@@ -981,7 +955,7 @@ table.variations {
 				display: block;
 				width: 14px;
 				height: 14px;
-				background: white;
+				background: var(--wc-white);
 				position: absolute;
 				top: 7px;
 				right: 17px;
@@ -999,8 +973,8 @@ table.variations {
 		}
 
 		input[type=checkbox]:checked + span::before {
-			border-color: #000;
-			background: #000;
+			border-color: var(--wc-black);
+			background: var(--wc-black);
 		}
 	}
 }
@@ -1020,9 +994,9 @@ table.variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid rgba(0, 0, 0, 0.2);
-	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-	background: rgba(0, 0, 0, 0.05);
+	border: 1px solid wc-shade( 0, black, 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
+	background: wc-shade( 0, black, 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1050,7 +1024,7 @@ table.variations {
 
 		.description {
 			background: royalblue;
-			color: #fff;
+			color: var(--wc-white);
 			border-radius: 3px;
 			padding: 1em;
 			margin: 0.5em 0 0;
@@ -1059,7 +1033,7 @@ table.variations {
 			position: relative;
 
 			a {
-				color: #fff;
+				color: var(--wc-white);
 				text-decoration: underline;
 				border: 0;
 				box-shadow: none;
@@ -1067,7 +1041,7 @@ table.variations {
 
 			&::before {
 				left: 50%;
-				top: 0%;
+				top: 0;
 				margin-top: -4px;
 				transform: translateX(-50%) rotate(180deg);
 				content: "";
@@ -1103,7 +1077,7 @@ table.variations {
 	}
 
 	.select2-container--focus .select2-selection {
-		border-color: black;
+		border-color: var(--wc-black);
 	}
 }
 
@@ -1124,11 +1098,11 @@ table.variations {
 
 .wc_payment_method {
 	list-style: none;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid wc-shade( 87 );
 
 	.payment_box {
 		padding: 2em;
-		background: #eee;
+		background: wc-shade( 93 );
 
 		ul,
 		ol {
@@ -1142,7 +1116,7 @@ table.variations {
 			padding: 1.5em;
 			padding-bottom: 0;
 			border: 0;
-			background: #f6f6f6;
+			background: wc-shade( 96 );
 		}
 
 		li {
@@ -1178,9 +1152,9 @@ table.variations {
 				display: inline-block;
 				width: 16px;
 				height: 16px;
-				border: 2px solid white;
-				box-shadow: 0 0 0 2px black;
-				background: white;
+				border: 2px solid var(--wc-white);
+				box-shadow: 0 0 0 2px var(--wc-black);
+				background: var(--wc-white);
 				margin-left: 4px;
 				margin-right: 0.5em;
 				border-radius: 100%;
@@ -1191,7 +1165,7 @@ table.variations {
 		&:checked + label {
 
 			&::before {
-				background: black;
+				background: var(--wc-black);
 			}
 		}
 	}
@@ -1200,11 +1174,11 @@ table.variations {
 .colors-dark {
 
 	.page-numbers {
-		color: #444;
+		color: wc-shade( 27 );
 
 		&.next,
 		&.prev {
-			color: #ddd;
+			color: wc-shade( 87 );
 		}
 	}
 
@@ -1212,14 +1186,14 @@ table.variations {
 		border: 2px solid #555;
 
 		&:hover {
-			border-color: #fff;
+			border-color: var(--wc-white);
 		}
 	}
 
 	.wc_payment_method {
 
 		.payment_box {
-			background: #333;
+			background: wc-shade( 20 );
 		}
 	}
 
@@ -1228,26 +1202,26 @@ table.variations {
 		.select2-results {
 
 			.select2-results__options {
-				background: #333;
+				background: wc-shade( 20 );
 			}
 
 			.select2-results__option[data-selected="true"] {
-				color: #333;
+				color: wc-shade( 20 );
 			}
 		}
 
 		.select2-selection--single {
-			background-color: #333;
+			background-color: wc-shade( 20 );
 			border: 1px solid #555;
 
 			.select2-selection__rendered {
-				color: #ccc;
+				color: wc-shade( 80 );
 			}
 		}
 	}
 
 	.select2-container--focus .select2-selection {
-		border-color: white;
+		border-color: var(--wc-white);
 	}
 }
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
@@ -1,4 +1,8 @@
+/**
+ * Imports
+ */
 @import "mixins";
+@import "variables";
 
 /**
  * Sass variables
@@ -8,34 +12,15 @@ $headings: var(--heading--font-family);
 $body: var(--global--font-secondary);
 
 $body-color: currentColor;
-$highlights-color: #88a171;
+:root{
+	--wc-highlight: #88a171;
+}
+
 
 /**
  * Fonts
  */
-@font-face {
-	font-family: star;
-	src: url(../fonts/star.eot);
-	src:
-		url(../fonts/star.eot?#iefix) format("embedded-opentype"),
-		url(../fonts/star.woff) format("woff"),
-		url(../fonts/star.ttf) format("truetype"),
-		url(../fonts/star.svg#star) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: WooCommerce;
-	src: url(../fonts/WooCommerce.eot);
-	src:
-		url(../fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
-		url(../fonts/WooCommerce.woff) format("woff"),
-		url(../fonts/WooCommerce.ttf) format("truetype"),
-		url(../fonts/WooCommerce.svg#WooCommerce) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
+@import "fonts";
 
 /**
  * Global elements
@@ -81,7 +66,7 @@ a.button {
 		}
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 	}
 
@@ -164,8 +149,8 @@ a.button {
 	position: absolute;
 	top: -0.7rem;
 	right: -0.7rem;
-	background: $highlights-color;
-	color: #fff;
+	background: var(--wc-highlight);
+	color: var(--wc-white);
 	font-family: $headings;
 	font-size: 1.2rem;
 	font-weight: 700;
@@ -235,14 +220,14 @@ a.button {
 }
 
 .woocommerce-error {
-	color: #fff;
+	color: var(--wc-white);
 	background: #b22222;
 
 	a {
-		color: #fff;
+		color: var(--wc-white);
 
 		&:hover {
-			color: #fff;
+			color: var(--wc-white);
 		}
 
 		&.button {
@@ -265,28 +250,28 @@ a.button {
 
 .woocommerce-message,
 .woocommerce-info {
-	background: #eee;
-	color: #000;
-	border-top: 2px solid $highlights-color;
+	background: wc-shade( 93 );
+	color: var(--wc-black);
+	border-top: 2px solid var(--wc-highlight);
 
 	a {
-		color: #444;
+		color: wc-shade( 27 );
 
 		&:hover {
-			color: #000;
+			color: var(--wc-black);
 		}
 
 		&.button {
-			background: $highlights-color;
+			background: var(--wc-highlight);
 			color: #f5efe0;
 		}
 	}
 }
 
 .woocommerce-store-notice {
-	background: #eee;
-	color: #000;
-	border-top: 2px solid $highlights-color;
+	background: wc-shade( 93 );
+	color: var(--wc-black);
+	border-top: 2px solid var(--wc-highlight);
 	padding: 2rem;
 	position: absolute;
 	top: 0;
@@ -301,11 +286,11 @@ a.button {
 
 .woocommerce-store-notice__dismiss-link {
 	float: right;
-	color: #000;
+	color: var(--wc-black);
 
 	&:hover {
 		text-decoration: none;
-		color: #000;
+		color: var(--wc-black);
 	}
 }
 
@@ -424,7 +409,7 @@ ul.products {
 		}
 
 		.woocommerce-placeholder {
-			border: 1px solid #f2f2f2;
+			border: 1px solid wc-shade( 5 );
 		}
 
 		.button {
@@ -494,12 +479,12 @@ a.remove {
 	text-align: center;
 	border-radius: 100%;
 	text-decoration: none !important;
-	background: #fff;
-	color: #000;
+	background: var(--wc-content-bg);
+	color: var(--wc-black);
 
 	&:hover {
-		background: $highlights-color;
-		color: #fff !important;
+		background: var(--wc-highlight);
+		color: var(--wc-white) !important;
 	}
 }
 
@@ -627,12 +612,12 @@ dl.variation,
 	.woocommerce-Tabs-panel--reviews {
 
 		table {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 
 			tr,
 			td,
 			th {
-				border: 1px solid #ddd;
+				border: 1px solid wc-shade( 87 );
 			}
 		}
 
@@ -641,7 +626,7 @@ dl.variation,
 		}
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 	}
 
@@ -686,12 +671,12 @@ a.reset_variations {
 	}
 
 	.zoomImg {
-		background-color: #fff;
+		background-color: var(--wc-content-bg);
 		opacity: 0;
 	}
 
 	.woocommerce-product-gallery__image--placeholder {
-		border: 1px solid #f2f2f2;
+		border: 1px solid wc-shade( 5 );
 	}
 
 	.woocommerce-product-gallery__image:nth-child(n+2) {
@@ -1032,7 +1017,7 @@ a.reset_variations {
 			float: left;
 			margin-top: 7px;
 			line-height: 20px;
-			color: #fff;
+			color: var(--wc-white);
 			margin-right: 0.5rem;
 		}
 	}
@@ -1070,7 +1055,7 @@ a.reset_variations {
 			font-size: 16px;
 			text-align: center;
 			border-radius: 100%;
-			border: 1px solid #000;
+			border: 1px solid var(--wc-black);
 			margin-right: 0.25rem;
 		}
 	}
@@ -1105,7 +1090,7 @@ a.reset_variations {
 		z-index: 2;
 		width: 1em;
 		height: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 		border-radius: 1em;
 		cursor: ew-resize;
 		outline: none;
@@ -1120,12 +1105,12 @@ a.reset_variations {
 		display: block;
 		border: 0;
 		border-radius: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 	}
 
 	.price_slider_wrapper .ui-widget-content {
 		border-radius: 1em;
-		background-color: #666;
+		background-color: wc-shade( 40 );
 		border: 0;
 	}
 
@@ -1219,10 +1204,10 @@ a.reset_variations {
 				box-shadow: none;
 				text-decoration: none;
 				font-weight: 600;
-				color: #aaa;
+				color: wc-shade( 66 );
 
 				&:hover {
-					color: #000;
+					color: var(--wc-black);
 					text-decoration: underline;
 				}
 			}
@@ -1231,7 +1216,7 @@ a.reset_variations {
 
 				a {
 					text-decoration: underline;
-					color: $highlights-color;
+					color: var(--wc-highlight);
 				}
 			}
 		}
@@ -1284,7 +1269,7 @@ a.reset_variations {
 			}
 
 			input {
-				border: 3px solid black;
+				border: 3px solid var(--wc-black);
 			}
 
 			.form-row {
@@ -1297,7 +1282,7 @@ a.reset_variations {
 			}
 
 			.select2-selection {
-				border: 2px solid black;
+				border: 2px solid var(--wc-black);
 				height: 3rem;
 				padding-top: 0.5rem;
 				margin-top: -1rem;
@@ -1357,7 +1342,7 @@ a.reset_variations {
 		}
 
 		thead {
-			border-bottom: 1px solid #ddd;
+			border-bottom: 1px solid wc-shade( 87 );
 		}
 
 		.button {
@@ -1448,12 +1433,12 @@ a.reset_variations {
 .checkout-button {
 	display: block;
 	padding: 1rem 2rem;
-	border: 2px solid #000;
+	border: 2px solid var(--wc-black);
 	text-align: center;
 	font-weight: 800;
 
 	&:hover {
-		border-color: #999;
+		border-color: wc-shade( 60 );
 	}
 
 	&::after {
@@ -1507,14 +1492,14 @@ a.reset_variations {
 
 		.select2-search__field {
 			height: 3rem;
-			background: #eee;
+			background: wc-shade( 93 );
 		}
 	}
 
 	p.form-row {
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 	}
 
@@ -1533,7 +1518,7 @@ a.reset_variations {
 }
 
 .woocommerce-form-coupon {
-	background: #eee;
+	background: wc-shade( 93 );
 	padding: 1rem;
 	font-size: 0.88889em;
 	color: var(--form--color-text);
@@ -1630,9 +1615,9 @@ a.reset_variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid rgba(0, 0, 0, 0.2);
-	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-	background: rgba(0, 0, 0, 0.05);
+	border: 1px solid wc-shade( 0, black, 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
+	background: wc-shade( 0, black, 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1753,7 +1738,7 @@ a.reset_variations {
 		.form-row.woocommerce-invalid {
 
 			input.input-text {
-				border: 2px solid $highlights-color;
+				border: 2px solid var(--wc-highlight);
 			}
 		}
 
@@ -1763,7 +1748,7 @@ a.reset_variations {
 
 		.description {
 			background: #4169e1;
-			color: #fff;
+			color: var(--wc-white);
 			border-radius: 3px;
 			padding: 1rem;
 			margin: 0.5rem 0 0;
@@ -1772,7 +1757,7 @@ a.reset_variations {
 			position: relative;
 
 			a {
-				color: #fff;
+				color: var(--wc-white);
 				text-decoration: underline;
 				border: 0;
 				box-shadow: none;
@@ -1848,7 +1833,7 @@ a.reset_variations {
 
 		.select2-search__field {
 			height: 3rem;
-			background: #eee;
+			background: wc-shade( 93 );
 		}
 	}
 }
@@ -1941,11 +1926,11 @@ a.reset_variations {
 		}
 
 		tfoot {
-			border-top: 1px solid #ddd;
+			border-top: 1px solid wc-shade( 87 );
 
 			/* Targeting total */
 			tr:last-of-type {
-				border-top: 1px solid #ddd;
+				border-top: 1px solid wc-shade( 87 );
 
 				.woocommerce-Price-amount {
 					font-weight: 700;
@@ -1973,7 +1958,7 @@ a.reset_variations {
 
 	.payment_box {
 		padding: 1rem;
-		background: #eee;
+		background: wc-shade( 93 );
 		color: var(--global--color-dark-gray);
 
 		a,
@@ -1994,7 +1979,7 @@ a.reset_variations {
 			padding: 1.5rem;
 			padding-bottom: 0;
 			border: 0;
-			background: #f6f6f6;
+			background: wc-shade( 96 );
 		}
 
 		li {
@@ -2019,12 +2004,12 @@ a.reset_variations {
 		input[type=radio] {
 
 			& + label::before {
-				background: #fff !important;
-				border: var(--form--border-width) solid #000 !important;
+				background: var(--wc-white) !important;
+				border: var(--form--border-width) solid var(--wc-black) !important;
 			}
 
 			&:checked + label::before {
-				background: #000 !important;
+				background: var(--wc-black) !important;
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
@@ -13,7 +13,8 @@ $body: var(--global--font-secondary);
 
 $body-color: currentColor;
 :root{
-	--wc-highlight: #88a171;
+	--wc--highlight-hue: 91;
+	--wc-highlight: hsl(var(--wc--highlight-hue),20%,53%);
 }
 
 
@@ -231,7 +232,7 @@ a.button {
 		}
 
 		&.button {
-			background: #111;
+			background: wc-shade( 7 );
 		}
 	}
 
@@ -1615,9 +1616,9 @@ a.reset_variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid wc-shade( 0, black, 20% );
-	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
-	background: wc-shade( 0, black, 5% );
+	border: 1px solid wc-shade( 0,'black', 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0,'black', 10% );
+	background: wc-shade( 0,'black', 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1747,7 +1748,7 @@ a.reset_variations {
 	.woocommerce-input-wrapper {
 
 		.description {
-			background: #4169e1;
+			background: wc-hsl( 'blue', 73%, 57% );
 			color: var(--wc-white);
 			border-radius: 3px;
 			padding: 1rem;
@@ -1772,7 +1773,7 @@ a.reset_variations {
 				position: absolute;
 				border-width: 4px 6px 0 6px;
 				border-style: solid;
-				border-color: #4169e1 transparent transparent transparent;
+				border-color: wc-hsl( 'blue', 73%, 57% ) transparent transparent transparent;
 				z-index: 100;
 				display: block;
 			}

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -115,7 +115,7 @@ $tt2-gray: wc-shade( 96 );
 		a.button {
 			margin-top: -0.5rem;
 			border: none;
-			background: #{wc-hsl( 'orchid',  5%, 92%)};
+			background: wc-hsl( 'orchid',  5%, 92%);
 			color: var(--wp--preset--color--black);
 			padding: 0.5rem 1rem;
 
@@ -382,13 +382,13 @@ $tt2-gray: wc-shade( 96 );
 			padding: 0;
 			border-bottom-style: solid;
 			border-bottom-width: 1px;
-			border-bottom-color: #{wc-hsl( 'purple',  5%, 90%)};
+			border-bottom-color: wc-hsl( 'purple',  5%, 90%);
 
 			li {
-				background: #{wc-hsl( 'purple',  5%, 90%)};
+				background: wc-hsl( 'purple',  5%, 90%);
 				margin: 0;
 				padding: 0.5em 1em 0.5em 1em;
-				border-color: #{wc-hsl( 'purple',  5%, 90%)};
+				border-color: wc-hsl( 'purple',  5%, 90%);
 				border-top-left-radius: 5px;
 				border-top-right-radius: 5px;
 				float: left;
@@ -399,7 +399,7 @@ $tt2-gray: wc-shade( 96 );
 				font-size: var(--wp--preset--font-size--medium);
 
 				&:first-child {
-					border-left-color: #{wc-hsl( 'purple',  5%, 90%)};
+					border-left-color: wc-hsl( 'purple',  5%, 90%);
 					margin-left: 1em;
 				}
 
@@ -725,7 +725,7 @@ $tt2-gray: wc-shade( 96 );
 				button {
 					margin-bottom: 1rem;
 					border: none;
-					background: #{wc-hsl( 'orchid',  5%, 92%)};
+					background: wc-hsl( 'orchid',  5%, 92%);
 					color: var(--wp--preset--color--black);
 					padding: 0.5rem 1rem 0.5rem 1rem;
 
@@ -818,7 +818,7 @@ $tt2-gray: wc-shade( 96 );
 			button[name='apply_coupon'],
 			button[name='update_cart'] {
 				padding: 1rem 2rem;
-				border: 2px solid #{wc-hsl( 'orchid',  5%, 92%)};
+				border: 2px solid wc-hsl( 'orchid',  5%, 92%);
 				margin: 0;
 			}
 
@@ -942,11 +942,11 @@ $tt2-gray: wc-shade( 96 );
 			}
 
 			tbody {
-				border-bottom: 1px solid #{wc-hsl( 'purple',  5%, 80%)};
+				border-bottom: 1px solid wc-hsl( 'purple',  5%, 80%);
 			}
 
 			tr.order-total {
-				border-top: 1px solid #{wc-hsl( 'purple',  5%, 80%)};
+				border-top: 1px solid wc-hsl( 'purple',  5%, 80%);
 			}
 
 			.product-quantity {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -1,34 +1,11 @@
 /**
 * Fonts
 */
-@font-face {
-	font-family: star;
-	src: url(../fonts/star.eot);
-	src:
-		url(../fonts/star.eot?#iefix) format("embedded-opentype"),
-		url(../fonts/star.woff) format("woff"),
-		url(../fonts/star.ttf) format("truetype"),
-		url(../fonts/star.svg#star) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: WooCommerce;
-	src: url(../fonts/WooCommerce.eot);
-	src:
-		url(../fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
-		url(../fonts/WooCommerce.woff) format("woff"),
-		url(../fonts/WooCommerce.ttf) format("truetype"),
-		url(../fonts/WooCommerce.svg#WooCommerce) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
 @import "mixins";
 @import "animation";
+@import "fonts";
 
-$tt2-gray: #f7f7f7;
+$tt2-gray: wc-shade( 96 );
 
 /**
  * Main layout.
@@ -92,7 +69,7 @@ $tt2-gray: #f7f7f7;
 		border-radius: 2rem;
 		line-height: 2.6rem;
 		font-size: 0.8rem;
-		padding: 0rem 0.5rem 0rem 0.5rem;
+		padding: 0 0.5rem 0 0.5rem;
 	}
 
 	.price ins, bdi {
@@ -138,7 +115,7 @@ $tt2-gray: #f7f7f7;
 		a.button {
 			margin-top: -0.5rem;
 			border: none;
-			background: #ebe9eb;
+			background: #{wc-hsl( 'orchid',  5%, 92%)};
 			color: var(--wp--preset--color--black);
 			padding: 0.5rem 1rem;
 
@@ -190,7 +167,7 @@ $tt2-gray: #f7f7f7;
 		text-align: center;
 		word-break: break-word;
 		background-color: var( --wp--preset--color--primary );
-		color: #fff;
+		color: var(--wc-white);
 		border: 1px solid var(--wp--preset--color--black);
 		padding: 1rem 2rem;
 		margin-top: 1rem;
@@ -405,13 +382,13 @@ $tt2-gray: #f7f7f7;
 			padding: 0;
 			border-bottom-style: solid;
 			border-bottom-width: 1px;
-			border-bottom-color: #EAE9EB;
+			border-bottom-color: #{wc-hsl( 'purple',  5%, 90%)};
 
 			li {
-				background: #EAE9EB;
+				background: #{wc-hsl( 'purple',  5%, 90%)};
 				margin: 0;
 				padding: 0.5em 1em 0.5em 1em;
-				border-color: #EAE9EB;
+				border-color: #{wc-hsl( 'purple',  5%, 90%)};
 				border-top-left-radius: 5px;
 				border-top-right-radius: 5px;
 				float: left;
@@ -422,7 +399,7 @@ $tt2-gray: #f7f7f7;
 				font-size: var(--wp--preset--font-size--medium);
 
 				&:first-child {
-					border-left-color: #EAE9EB;
+					border-left-color: #{wc-hsl( 'purple',  5%, 90%)};
 					margin-left: 1em;
 				}
 
@@ -618,7 +595,7 @@ $tt2-gray: #f7f7f7;
 
 	.return-to-shop {
 		a.button {
-			background-color: #fff;
+			background-color: var(--wc-content-bg);
 			color: var( --wp--preset--color--primary );
 			border: 2px solid var( --wp--preset--color--primary );
 			padding: 0.7rem 2rem;
@@ -688,7 +665,7 @@ $tt2-gray: #f7f7f7;
 		&:checked + label {
 
 			&::before {
-				background: radial-gradient(circle at center, black 45%, white 0);
+				background: radial-gradient(circle at center, var(--wc-black) 45%, var(--wc-white) 0);
 			}
 		}
 	}
@@ -748,7 +725,7 @@ $tt2-gray: #f7f7f7;
 				button {
 					margin-bottom: 1rem;
 					border: none;
-					background: #ebe9eb;
+					background: #{wc-hsl( 'orchid',  5%, 92%)};
 					color: var(--wp--preset--color--black);
 					padding: 0.5rem 1rem 0.5rem 1rem;
 
@@ -766,7 +743,7 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 	}
-	
+
 	table.shop_table,
 	table.shop_table_responsive {
 		tbody {
@@ -841,7 +818,7 @@ $tt2-gray: #f7f7f7;
 			button[name='apply_coupon'],
 			button[name='update_cart'] {
 				padding: 1rem 2rem;
-				border: 2px solid #ebe9eb;
+				border: 2px solid #{wc-hsl( 'orchid',  5%, 92%)};
 				margin: 0;
 			}
 
@@ -965,11 +942,11 @@ $tt2-gray: #f7f7f7;
 			}
 
 			tbody {
-				border-bottom: 1px solid #d2ced2;
+				border-bottom: 1px solid #{wc-hsl( 'purple',  5%, 80%)};
 			}
 
 			tr.order-total {
-				border-top: 1px solid #d2ced2;
+				border-top: 1px solid #{wc-hsl( 'purple',  5%, 80%)};
 			}
 
 			.product-quantity {
@@ -988,7 +965,7 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
-		button#place_order {
+		#place_order {
 			width: 100%;
 			text-transform: uppercase;
 		}
@@ -1200,7 +1177,7 @@ $tt2-gray: #f7f7f7;
 		> p:first-of-type,
 		p.form-row-first,
 		p.form-row-last {
-			margin-block-start: 0px;
+			margin-block-start: 0;
 		}
 	}
 
@@ -1208,7 +1185,7 @@ $tt2-gray: #f7f7f7;
 
 		.woocommerce-MyAccount-content {
 			form > h3 {
-				margin-block-start: 0px;
+				margin-block-start: 0;
 			}
 		}
 	}
@@ -1256,7 +1233,7 @@ $tt2-gray: #f7f7f7;
 			.wc-block-product-search__button {
 				display: flex;
 				background-color: var( --wp--preset--color--primary );
-				color: #fff;
+				color: var(--wc-white);
 				border: 1px solid var(--wp--preset--color--black);
 				padding: 1rem 1.2rem;
 				margin: 0 0 0 .7rem;

--- a/plugins/woocommerce/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty.scss
@@ -11,7 +11,7 @@
 $headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-serif;
 $body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", serif;
 
-$body-color: #111;
+$body-color: wc-shade( 7 );
 $highlights-color: #cd2653;
 
 /**
@@ -207,7 +207,7 @@ a.button {
 		}
 
 		&.button {
-			background: #111;
+			background: wc-shade( 7 );
 		}
 	}
 
@@ -1288,8 +1288,8 @@ a.reset_variations {
 
 		.button {
 			background: wc-shade( 98 );
-			border: 1px solid #555;
-			color: #555;
+			border: 1px solid wc-shade( 33 );
+			color: wc-shade( 33 );
 		}
 
 		button[name="update_cart"] {
@@ -1393,7 +1393,7 @@ a.reset_variations {
 				width: 14px;
 				height: 14px;
 				border: 2px solid var(--wc-white);
-				box-shadow: 0 0 0 2px #6d6d6d;
+				box-shadow: 0 0 0 2px wc-shade( 43 );
 				background: var(--wc-content-bg);
 				margin-left: 4px;
 				margin-right: 1.2rem;
@@ -1405,7 +1405,7 @@ a.reset_variations {
 		&:checked + label {
 
 			&::before {
-				background: #555;
+				background: wc-shade( 33 );
 			}
 		}
 	}
@@ -1596,9 +1596,9 @@ a.reset_variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid wc-shade( 0, black, 20% );
-	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
-	background: wc-shade( 0, black, 5% );
+	border: 1px solid wc-shade( 0,'black', 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0,'black', 10% );
+	background: wc-shade( 0,'black', 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1733,7 +1733,7 @@ a.reset_variations {
 	.woocommerce-input-wrapper {
 
 		.description {
-			background: #4169e1;
+			background: wc-hsl( 'blue', 73%, 57% );
 			color: var(--wc-white);
 			border-radius: 3px;
 			padding: 1rem;
@@ -1758,7 +1758,7 @@ a.reset_variations {
 				position: absolute;
 				border-width: 4px 6px 0 6px;
 				border-style: solid;
-				border-color: #4169e1 transparent transparent transparent;
+				border-color: wc-hsl( 'blue', 73%, 57% ) transparent transparent transparent;
 				z-index: 100;
 				display: block;
 			}
@@ -1840,7 +1840,7 @@ a.reset_variations {
 				width: 14px;
 				height: 14px;
 				border: 2px solid var(--wc-white);
-				box-shadow: 0 0 0 2px #6d6d6d;
+				box-shadow: 0 0 0 2px wc-shade( 27 );
 				background: var(--wc-content-bg);
 				margin-left: 4px;
 				margin-right: 1.2rem;
@@ -1852,7 +1852,7 @@ a.reset_variations {
 		&:checked + label {
 
 			&::before {
-				background: #555;
+				background: wc-shade( 33 );
 			}
 		}
 	}
@@ -1996,7 +1996,7 @@ a.reset_variations {
 				width: 14px;
 				height: 14px;
 				border: 2px solid var(--wc-white);
-				box-shadow: 0 0 0 2px #6d6d6d;
+				box-shadow: 0 0 0 2px wc-shade( 27 );
 				background: var(--wc-content-bg);
 				margin-left: 4px;
 				margin-right: 1.2rem;
@@ -2008,7 +2008,7 @@ a.reset_variations {
 		&:checked + label {
 
 			&::before {
-				background: #555;
+				background: wc-shade( 33 );
 			}
 		}
 	}

--- a/plugins/woocommerce/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty.scss
@@ -1,4 +1,8 @@
+/**
+ * Imports
+ */
 @import "mixins";
+@import "variables";
 
 /**
  * Sass variables
@@ -13,29 +17,7 @@ $highlights-color: #cd2653;
 /**
  * Fonts
  */
-@font-face {
-	font-family: star;
-	src: url(../fonts/star.eot);
-	src:
-		url(../fonts/star.eot?#iefix) format("embedded-opentype"),
-		url(../fonts/star.woff) format("woff"),
-		url(../fonts/star.ttf) format("truetype"),
-		url(../fonts/star.svg#star) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
-
-@font-face {
-	font-family: WooCommerce;
-	src: url(../fonts/WooCommerce.eot);
-	src:
-		url(../fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
-		url(../fonts/WooCommerce.woff) format("woff"),
-		url(../fonts/WooCommerce.ttf) format("truetype"),
-		url(../fonts/WooCommerce.svg#WooCommerce) format("svg");
-	font-weight: 400;
-	font-style: normal;
-}
+@import "fonts";
 
 /**
  * Global elements
@@ -45,12 +27,12 @@ a.button {
 	text-align: center;
 	box-sizing: border-box;
 	word-break: break-word;
-	color: #fff;
+	color: var(--wc-white);
 	text-decoration: none !important;
 
 	&:hover,
 	&:visited {
-		color: #fff;
+		color: var(--wc-white);
 		text-decoration: underline !important;
 	}
 }
@@ -83,7 +65,7 @@ a.button {
 		}
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 	}
 
@@ -101,13 +83,13 @@ a.button {
 			border: 0;
 
 			tbody {
-				border-bottom: 1px solid #ddd;
+				border-bottom: 1px solid wc-shade( 87 );
 			}
 
 			tfoot {
 
 				tr:last-of-type {
-					border-top: 1px solid #ddd;
+					border-top: 1px solid wc-shade( 87 );
 
 					.woocommerce-Price-amount {
 						font-weight: 700;
@@ -158,7 +140,7 @@ a.button {
 	left: 0;
 	display: inline-block;
 	background: $highlights-color;
-	color: #fff;
+	color: var(--wc-white);
 	font-family: $headings;
 	font-size: 1.7rem;
 	font-weight: 700;
@@ -188,7 +170,7 @@ a.button {
 .woocommerce-info {
 	margin-bottom: 5rem;
 	margin-left: 0;
-	background: #eee;
+	background: wc-shade( 93 );
 	font-size: 0.88889em;
 	font-family: $headings;
 	list-style: none;
@@ -209,19 +191,19 @@ a.button {
 }
 
 .woocommerce-message {
-	background: #eee;
+	background: wc-shade( 93 );
 	color: $body-color;
 }
 
 .woocommerce-error {
-	color: #fff;
+	color: var(--wc-white);
 	background: #b22222;
 
 	a {
-		color: #fff;
+		color: var(--wc-white);
 
 		&:hover {
-			color: #fff;
+			color: var(--wc-white);
 		}
 
 		&.button {
@@ -243,15 +225,15 @@ a.button {
 }
 
 .woocommerce-info {
-	background: #eee;
-	color: #000;
+	background: wc-shade( 93 );
+	color: var(--wc-black);
 	border-top: 2px solid $highlights-color;
 
 	a {
-		color: #444;
+		color: wc-shade( 27 );
 
 		&:hover {
-			color: #000;
+			color: var(--wc-black);
 		}
 
 		&.button {
@@ -262,8 +244,8 @@ a.button {
 }
 
 .woocommerce-store-notice {
-	background: #eee;
-	color: #000;
+	background: wc-shade( 93 );
+	color: var(--wc-black);
 	border-top: 2px solid $highlights-color;
 	padding: 2rem;
 	position: absolute;
@@ -279,11 +261,11 @@ a.button {
 
 .woocommerce-store-notice__dismiss-link {
 	float: right;
-	color: #000;
+	color: var(--wc-black);
 
 	&:hover {
 		text-decoration: none;
-		color: #000;
+		color: var(--wc-black);
 	}
 }
 
@@ -393,7 +375,7 @@ ul.products {
 		}
 
 		.woocommerce-placeholder {
-			border: 1px solid #f2f2f2;
+			border: 1px solid wc-shade( 5 );
 		}
 
 		.button {
@@ -455,12 +437,12 @@ a.remove {
 	text-align: center;
 	border-radius: 100%;
 	text-decoration: none !important;
-	background: #fff;
-	color: #000;
+	background: var(--wc-content-bg);
+	color: var(--wc-black);
 
 	&:hover {
 		background: $highlights-color;
-		color: #fff !important;
+		color: var(--wc-white) !important;
 	}
 }
 
@@ -574,12 +556,12 @@ dl.variation,
 	.woocommerce-Tabs-panel--reviews {
 
 		table {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 
 			tr,
 			td,
 			th {
-				border: 1px solid #ddd;
+				border: 1px solid wc-shade( 87 );
 			}
 		}
 
@@ -588,7 +570,7 @@ dl.variation,
 		}
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 	}
 
@@ -632,12 +614,12 @@ a.reset_variations {
 	}
 
 	.zoomImg {
-		background-color: #fff;
+		background-color: var(--wc-content-bg);
 		opacity: 0;
 	}
 
 	.woocommerce-product-gallery__image--placeholder {
-		border: 1px solid #f2f2f2;
+		border: 1px solid wc-shade( 5 );
 	}
 
 	.woocommerce-product-gallery__image:nth-child(n+2) {
@@ -971,7 +953,7 @@ a.reset_variations {
 			float: left;
 			margin-top: 7px;
 			line-height: 20px;
-			color: #fff;
+			color: var(--wc-white);
 			margin-right: 0.5rem;
 		}
 	}
@@ -1009,7 +991,7 @@ a.reset_variations {
 			font-size: 16px;
 			text-align: center;
 			border-radius: 100%;
-			border: 1px solid #000;
+			border: 1px solid var(--wc-black);
 			margin-right: 0.25rem;
 		}
 	}
@@ -1044,7 +1026,7 @@ a.reset_variations {
 		z-index: 2;
 		width: 1em;
 		height: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 		border-radius: 1em;
 		cursor: ew-resize;
 		outline: none;
@@ -1059,12 +1041,12 @@ a.reset_variations {
 		display: block;
 		border: 0;
 		border-radius: 1em;
-		background-color: #000;
+		background-color: var(--wc-black);
 	}
 
 	.price_slider_wrapper .ui-widget-content {
 		border-radius: 1em;
-		background-color: #666;
+		background-color: wc-shade( 40 );
 		border: 0;
 	}
 
@@ -1158,10 +1140,10 @@ a.reset_variations {
 				box-shadow: none;
 				text-decoration: none;
 				font-weight: 600;
-				color: #aaa;
+				color: wc-shade( 66 );
 
 				&:hover {
-					color: #000;
+					color: var(--wc-black);
 					text-decoration: underline;
 				}
 			}
@@ -1206,7 +1188,7 @@ a.reset_variations {
 		}
 
 		thead {
-			border-bottom: 1px solid #ddd;
+			border-bottom: 1px solid wc-shade( 87 );
 		}
 
 		.button {
@@ -1222,14 +1204,14 @@ a.reset_variations {
 			tr:nth-child(2n) {
 
 				td {
-					background: #eee;
+					background: wc-shade( 93 );
 				}
 			}
 
 			tr:nth-child(2n+1) {
 
 				td {
-					background: #fff;
+					background: var(--wc-content-bg);
 				}
 			}
 		}
@@ -1238,11 +1220,11 @@ a.reset_variations {
 	.woocommerce-EditAccountForm {
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 
 		fieldset {
-			border: 0.2rem solid #ddd;
+			border: 0.2rem solid wc-shade( 87 );
 		}
 
 		button {
@@ -1299,20 +1281,20 @@ a.reset_variations {
 			width: 200px !important;
 			float: left;
 			margin-right: 0.25rem;
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 			padding-top: 1.55rem;
 			padding-bottom: 1.59rem;
 		}
 
 		.button {
-			background: #f9f9f9;
+			background: wc-shade( 98 );
 			border: 1px solid #555;
 			color: #555;
 		}
 
 		button[name="update_cart"] {
-			background: #fff;
-			color: #000;
+			background: var(--wc-content-bg);
+			color: var(--wc-black);
 		}
 	}
 
@@ -1320,7 +1302,7 @@ a.reset_variations {
 
 		input {
 			width: 8rem;
-			border: 1px solid #eee;
+			border: 1px solid wc-shade( 93 );
 		}
 	}
 
@@ -1345,7 +1327,7 @@ a.reset_variations {
 		tbody {
 
 			tr {
-				border-top: 1px solid #eee;
+				border-top: 1px solid wc-shade( 93 );
 			}
 		}
 
@@ -1410,9 +1392,9 @@ a.reset_variations {
 				display: inline-block;
 				width: 14px;
 				height: 14px;
-				border: 2px solid #fff;
+				border: 2px solid var(--wc-white);
 				box-shadow: 0 0 0 2px #6d6d6d;
-				background: #fff;
+				background: var(--wc-content-bg);
 				margin-left: 4px;
 				margin-right: 1.2rem;
 				border-radius: 100%;
@@ -1463,12 +1445,12 @@ a.reset_variations {
 .checkout-button {
 	display: block;
 	padding: 1rem 2rem;
-	border: 2px solid #000;
+	border: 2px solid var(--wc-black);
 	text-align: center;
 	font-weight: 800;
 
 	&:hover {
-		border-color: #999;
+		border-color: wc-shade( 60 );
 	}
 
 	&::after {
@@ -1505,7 +1487,7 @@ a.reset_variations {
 		line-height: 48px;
 		font-family: $headings;
 		font-size: 1.6rem;
-		color: #000;
+		color: var(--wc-black);
 		padding-left: 1.8rem;
 	}
 
@@ -1514,7 +1496,7 @@ a.reset_variations {
 	}
 
 	.select2-container--focus .select2-selection {
-		border-color: #000;
+		border-color: var(--wc-black);
 	}
 
 	.select2-results__option {
@@ -1525,14 +1507,14 @@ a.reset_variations {
 
 		.select2-search__field {
 			height: 4rem;
-			background: #eee;
+			background: wc-shade( 93 );
 		}
 	}
 
 	p.form-row {
 
 		input {
-			border: 1px solid #ddd;
+			border: 1px solid wc-shade( 87 );
 		}
 	}
 }
@@ -1575,7 +1557,7 @@ a.reset_variations {
 				display: block;
 				width: 14px;
 				height: 14px;
-				background: #fff;
+				background: var(--wc-content-bg);
 				position: absolute;
 				top: 3px;
 				right: 17px;
@@ -1593,8 +1575,8 @@ a.reset_variations {
 		}
 
 		input[type="checkbox"]:checked + span::before {
-			border-color: #000;
-			background: #000;
+			border-color: var(--wc-black);
+			background: var(--wc-black);
 		}
 	}
 }
@@ -1614,9 +1596,9 @@ a.reset_variations {
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid rgba(0, 0, 0, 0.2);
-	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-	background: rgba(0, 0, 0, 0.05);
+	border: 1px solid wc-shade( 0, black, 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
+	background: wc-shade( 0, black, 5% );
 }
 
 .woocommerce-terms-and-conditions-link {
@@ -1685,7 +1667,7 @@ a.reset_variations {
 			}
 
 			input {
-				border: 1px solid #ddd;
+				border: 1px solid wc-shade( 87 );
 			}
 
 			label {
@@ -1734,7 +1716,7 @@ a.reset_variations {
 
 				.cart-subtotal,
 				.order-total {
-					border-top: 1px solid #ddd;
+					border-top: 1px solid wc-shade( 87 );
 				}
 			}
 		}
@@ -1752,7 +1734,7 @@ a.reset_variations {
 
 		.description {
 			background: #4169e1;
-			color: #fff;
+			color: var(--wc-white);
 			border-radius: 3px;
 			padding: 1rem;
 			margin: 0.5rem 0 0;
@@ -1761,7 +1743,7 @@ a.reset_variations {
 			position: relative;
 
 			a {
-				color: #fff;
+				color: var(--wc-white);
 				text-decoration: underline;
 				border: 0;
 				box-shadow: none;
@@ -1791,10 +1773,10 @@ a.reset_variations {
 		}
 	}
 
-	input#coupon_code {
+	#coupon_code {
 		padding-top: 1.55rem;
 		padding-bottom: 1.59rem;
-		border: 1px solid #ddd;
+		border: 1px solid wc-shade( 87 );
 	}
 
 	button[name="apply_coupon"] {
@@ -1820,7 +1802,7 @@ a.reset_variations {
 		line-height: 48px;
 		font-family: $headings;
 		font-size: 1.6rem;
-		color: #000;
+		color: var(--wc-black);
 		padding-left: 1.8rem;
 	}
 
@@ -1829,7 +1811,7 @@ a.reset_variations {
 	}
 
 	.select2-container--focus .select2-selection {
-		border-color: #000;
+		border-color: var(--wc-black);
 	}
 
 	.select2-results__option {
@@ -1840,7 +1822,7 @@ a.reset_variations {
 
 		.select2-search__field {
 			height: 4rem;
-			background: #eee;
+			background: wc-shade( 93 );
 		}
 	}
 }
@@ -1857,9 +1839,9 @@ a.reset_variations {
 				display: inline-block;
 				width: 14px;
 				height: 14px;
-				border: 2px solid #fff;
+				border: 2px solid var(--wc-white);
 				box-shadow: 0 0 0 2px #6d6d6d;
-				background: #fff;
+				background: var(--wc-content-bg);
 				margin-left: 4px;
 				margin-right: 1.2rem;
 				border-radius: 100%;
@@ -1922,11 +1904,11 @@ a.reset_variations {
 		}
 
 		tfoot {
-			border-top: 1px solid #ddd;
+			border-top: 1px solid wc-shade( 87 );
 
 			/* Targeting total */
 			tr:last-of-type {
-				border-top: 1px solid #ddd;
+				border-top: 1px solid wc-shade( 87 );
 
 				.woocommerce-Price-amount {
 					font-weight: 700;
@@ -1954,7 +1936,7 @@ a.reset_variations {
 
 	.payment_box {
 		padding: 1rem;
-		background: #eee;
+		background: wc-shade( 93 );
 
 		ul,
 		ol {
@@ -1968,7 +1950,7 @@ a.reset_variations {
 			padding: 1.5rem;
 			padding-bottom: 0;
 			border: 0;
-			background: #f6f6f6;
+			background: wc-shade( 96 );
 		}
 
 		li {
@@ -2013,9 +1995,9 @@ a.reset_variations {
 				display: inline-block;
 				width: 14px;
 				height: 14px;
-				border: 2px solid #fff;
+				border: 2px solid var(--wc-white);
 				box-shadow: 0 0 0 2px #6d6d6d;
-				background: #fff;
+				background: var(--wc-content-bg);
 				margin-left: 4px;
 				margin-right: 1.2rem;
 				border-radius: 100%;
@@ -2211,7 +2193,7 @@ a.reset_variations {
 				&:nth-child(2n) {
 
 					td {
-						background: #fff;
+						background: var(--wc-content-bg);
 					}
 				}
 
@@ -2464,7 +2446,7 @@ a.reset_variations {
 			}
 
 			thead {
-				border-bottom: 1px solid #ddd;
+				border-bottom: 1px solid wc-shade( 87 );
 			}
 
 			.button {

--- a/plugins/woocommerce/legacy/css/wc-setup.scss
+++ b/plugins/woocommerce/legacy/css/wc-setup.scss
@@ -1,5 +1,11 @@
 /* stylelint-disable no-descending-specificity */
 
+/**
+ * Imports
+ */
+@import "mixins";
+@import "variables";
+
 /* @deprecated 4.6.0 */
 body {
 	margin: 65px auto 24px;
@@ -45,10 +51,10 @@ body {
 }
 
 .wc-setup-content {
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+	box-shadow: 0 1px 3px wc-shade( 0, black, 13% );
 	padding: 2em;
 	margin: 0 0 20px;
-	background: #fff;
+	background: var(--wc-content-bg);
 	overflow: hidden;
 	zoom: 1;
 	text-align: left;
@@ -60,7 +66,7 @@ body {
 		margin: 0 0 20px;
 		border: 0;
 		padding: 0;
-		color: #666;
+		color: wc-shade( 40 );
 		clear: none;
 		font-weight: 500;
 	}
@@ -69,17 +75,17 @@ body {
 		margin: 20px 0;
 		font-size: 1em;
 		line-height: 1.75;
-		color: #666;
+		color: wc-shade( 40 );
 	}
 
 	table {
 		font-size: 1em;
 		line-height: 1.75;
-		color: #666;
+		color: wc-shade( 40 );
 	}
 
 	a {
-		color: #a16696;
+		color: var(--woocommerce);
 
 		&:hover,
 		&:focus {
@@ -112,7 +118,7 @@ body {
 				line-height: 1.5;
 				display: block;
 				margin-top: 0.25em;
-				color: #999;
+				color: wc-shade( 60 );
 				font-style: italic;
 			}
 
@@ -162,7 +168,7 @@ body {
 		}
 
 		td {
-			border: 1px solid #f5f5f5;
+			border: 1px solid wc-shade( 96 );
 			padding: 6px;
 			text-align: center;
 			vertical-align: middle;
@@ -178,7 +184,7 @@ body {
 
 			&.sort {
 				cursor: move;
-				color: #ccc;
+				color: wc-shade( 80 );
 
 				&::before {
 					content: "\f333";
@@ -187,7 +193,7 @@ body {
 			}
 
 			&.readonly {
-				background: #f5f5f5;
+				background: wc-shade( 96 );
 			}
 		}
 
@@ -234,7 +240,7 @@ body {
 
 	.wc-setup-pages {
 		width: 100%;
-		border-top: 1px solid #eee;
+		border-top: 1px solid wc-shade( 93 );
 
 		thead th {
 			display: none;
@@ -248,7 +254,7 @@ body {
 		th,
 		td {
 			padding: 14px 0;
-			border-bottom: 1px solid #eee;
+			border-bottom: 1px solid wc-shade( 93 );
 
 			&:first-child {
 				padding-right: 9px;
@@ -262,7 +268,7 @@ body {
 		.page-options {
 
 			p {
-				color: #777;
+				color: wc-shade( 47 );
 				margin: 6px 0 0 24px;
 				line-height: 1.75;
 
@@ -332,11 +338,11 @@ body {
 			.setup-product {
 
 				a.button {
-					background-color: #f7f7f7;
-					border-color: #ccc;
+					background-color: wc-shade( 96 );
+					border-color: wc-shade( 80 );
 					color: #23282d;
-					box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #ccc;
-					text-shadow: 1px 0 1px #eee, 0 1px 1px #eee;
+					box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 wc-shade( 80 );
+					text-shadow: 1px 0 1px wc-shade( 93 ), 0 1px 1px wc-shade( 93 );
 					font-size: 1em;
 					height: auto;
 					line-height: 1.75;
@@ -348,25 +354,25 @@ body {
 					&:hover,
 					&:focus,
 					&:active {
-						background: #f5f5f5;
-						border-color: #aaa;
+						background: wc-shade( 96 );
+						border-color: wc-shade( 66 );
 					}
 				}
 
 				a.button-primary {
-					color: #fff;
-					background-color: #bb77ae;
-					border-color: #a36597;
-					box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-					text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+					color: var(--wc-white);
+					background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+					border-color: var(--woocommerce);
+					box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+					text-shadow: 0 -1px 1px var(--woocommerce), 1px 0 1px var(--woocommerce), 0 1px 1px var(--woocommerce), -1px 0 1px var(--woocommerce);
 
 					&:hover,
 					&:focus,
 					&:active {
-						color: #fff;
-						background: #a36597;
-						border-color: #a36597;
-						box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+						color: var(--wc-white);
+						background: var(--woocommerce);
+						border-color: var(--woocommerce);
+						box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 					}
 				}
 			}
@@ -402,7 +408,7 @@ body {
 		padding: 24px 24px 0;
 		margin: 0 0 24px;
 		overflow: hidden;
-		background: #f5f5f5;
+		background: wc-shade( 96 );
 
 		p {
 			padding: 0;
@@ -440,8 +446,8 @@ body {
 				width: 16px;
 				left: 0;
 				top: 3px;
-				border: 1px solid #aaa;
-				background-color: #fff;
+				border: 1px solid wc-shade( 66 );
+				background-color: var(--wc-content-bg);
 				border-radius: 3px;
 			}
 
@@ -453,7 +459,7 @@ body {
 				transform: rotate(-45deg);
 				left: 4px;
 				top: 7px;
-				color: #fff;
+				color: var(--wc-white);
 			}
 		}
 
@@ -478,7 +484,7 @@ body {
 
 .woocommerce-tracker {
 	margin: 24px 0;
-	border: 1px solid #eee;
+	border: 1px solid wc-shade( 93 );
 	padding: 20px;
 	border-radius: 4px;
 	overflow: hidden;
@@ -518,7 +524,7 @@ body {
 	margin: 0;
 	list-style: none outside;
 	overflow: hidden;
-	color: #ccc;
+	color: wc-shade( 80 );
 	width: 100%;
 	display: inline-flex;
 
@@ -529,11 +535,11 @@ body {
 		margin: 0;
 		text-align: center;
 		position: relative;
-		border-bottom: 4px solid #ccc;
+		border-bottom: 4px solid wc-shade( 80 );
 		line-height: 1.4;
 
 		a {
-			color: #a16696;
+			color: var(--woocommerce);
 			text-decoration: none;
 			padding: 1.5em;
 			margin: -1.5em;
@@ -550,7 +556,7 @@ body {
 
 	li::before {
 		content: "";
-		border: 4px solid #ccc;
+		border: 4px solid wc-shade( 80 );
 		border-radius: 100%;
 		width: 4px;
 		height: 4px;
@@ -559,26 +565,26 @@ body {
 		left: 50%;
 		margin-left: -6px;
 		margin-bottom: -8px;
-		background: #fff;
+		background: var(--wc-content-bg);
 	}
 
 	li.active {
-		border-color: #a16696;
-		color: #a16696;
+		border-color: var(--woocommerce);
+		color: var(--woocommerce);
 		font-weight: 700;
 
 		&::before {
-			border-color: #a16696;
+			border-color: var(--woocommerce);
 		}
 	}
 
 	li.done {
-		border-color: #a16696;
-		color: #a16696;
+		border-color: var(--woocommerce);
+		color: var(--woocommerce);
 
 		&::before {
-			border-color: #a16696;
-			background: #a16696;
+			border-color: var(--woocommerce);
+			background: var(--woocommerce);
 		}
 	}
 }
@@ -591,19 +597,19 @@ body {
 
 .wc-setup .wc-setup-actions .button-primary,
 .woocommerce-tracker .button-primary {
-	background-color: #bb77ae;
-	border-color: #a36597;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-	text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+	background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+	border-color: var(--woocommerce);
+	box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
+	text-shadow: 0 -1px 1px var(--woocommerce), 1px 0 1px var(--woocommerce), 0 1px 1px var(--woocommerce), -1px 0 1px var(--woocommerce);
 	margin: 0;
 	opacity: 1;
 
 	&:hover,
 	&:focus,
 	&:active {
-		background: #a36597;
-		border-color: #a36597;
-		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+		background: var(--woocommerce);
+		border-color: var(--woocommerce);
+		box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 	}
 }
 
@@ -627,7 +633,7 @@ body {
 
 	.wc-wizard-storefront-intro {
 		padding: 40px 40px 0;
-		background: #f5f5f5;
+		background: wc-shade( 96 );
 		text-align: center;
 
 		img {
@@ -692,7 +698,7 @@ body {
 
 // List of services
 .wc-wizard-services {
-	border: 1px solid #eee;
+	border: 1px solid wc-shade( 93 );
 	padding: 0;
 	margin: 0 0 1em;
 	list-style: none outside;
@@ -713,8 +719,8 @@ body {
 	flex-wrap: nowrap;
 	justify-content: space-between;
 	padding: 0;
-	border-bottom: 1px solid #eee;
-	color: #666;
+	border-bottom: 1px solid wc-shade( 93 );
+	color: wc-shade( 40 );
 	align-items: center;
 
 	&:last-child {
@@ -786,7 +792,7 @@ body {
 		.wc-wizard-service-settings-description {
 			display: block;
 			font-style: italic;
-			color: #999;
+			color: wc-shade( 60 );
 		}
 	}
 
@@ -821,7 +827,7 @@ body {
 			display: block;
 			width: 16px;
 			height: 16px;
-			background: #fff;
+			background: var(--wc-content-bg);
 			position: absolute;
 			top: 0;
 			right: 0;
@@ -829,8 +835,8 @@ body {
 		}
 
 		&.disabled {
-			border-color: #999;
-			background-color: #999;
+			border-color: wc-shade( 60 );
+			background-color: wc-shade( 60 );
 
 			&::before {
 				right: auto;
@@ -873,7 +879,7 @@ body {
 	.wc-wizard-service-enable::before {
 		content: "\f343"; // up chevron
 		font-family: dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
-		color: #666;
+		color: wc-shade( 40 );
 		font-size: 25px;
 		margin-top: -7px;
 		margin-left: -5px;
@@ -960,15 +966,15 @@ body {
 
 		input {
 			width: 95px; // match dropdown height
-			border: 1px solid #aaa;
-			border-color: #ddd;
+			border: 1px solid wc-shade( 66 );
+			border-color: wc-shade( 87 );
 			border-radius: 4px;
 			height: 28px;
 			padding-left: 8px;
 			padding-right: 24px;
 			font-size: 14px;
-			color: #444;
-			background-color: #fff;
+			color: wc-shade( 27 );
+			background-color: var(--wc-content-bg);
 			display: inline-block;
 		}
 	}
@@ -980,7 +986,7 @@ body {
 	}
 
 	.shipping-method-setting input::placeholder {
-		color: #e1e1e1;
+		color: wc-shade( 88 );
 	}
 }
 
@@ -1015,7 +1021,7 @@ body {
 
 	.wc-wizard-feature-item {
 		flex-basis: calc(50% - 4em - 3px); // two columns, account for padding and borders
-		border: 1px solid #eee;
+		border: 1px solid wc-shade( 93 );
 		padding: 2em;
 	}
 
@@ -1124,7 +1130,7 @@ h3.jetpack-reasons {
 .wc-setup .wc-setup-actions .plugin-install-info {
 	display: block;
 	font-style: italic;
-	color: #999;
+	color: wc-shade( 60 );
 	font-size: 14px;
 	line-height: 1.5;
 	margin: 5px 0;
@@ -1151,7 +1157,7 @@ h3.jetpack-reasons {
 }
 
 .plugin-install-source {
-	$background: rgba(#bb77ae, 0.15);
+	$background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ), .15 )};
 	background: $background;
 
 	&:not(.wc-wizard-service-item) {
@@ -1160,7 +1166,7 @@ h3.jetpack-reasons {
 }
 
 .location-prompt {
-	color: #666;
+	color: wc-shade( 40 );
 	font-size: 13px;
 	font-weight: 500;
 	margin-bottom: 0.5em;
@@ -1169,16 +1175,15 @@ h3.jetpack-reasons {
 }
 
 .location-input {
-	border: 1px solid #aaa;
-	border-color: #ddd;
+	border: 1px solid wc-shade( 87 );
 	border-radius: 4px;
 	height: 30px;
 	width: calc(100% - 8px - 8px - 2px);
 	padding-left: 8px;
 	padding-right: 8px;
 	font-size: 16px;
-	color: #444;
-	background-color: #fff;
+	color: wc-shade( 27 );
+	background-color: var(--wc-content-bg);
 	display: block;
 
 	&.dropdown {
@@ -1238,18 +1243,17 @@ h3.jetpack-reasons {
 .wc-wizard-service-settings {
 
 	.payment-email-input {
-		border: 1px solid #aaa;
-		border-color: #ddd;
+		border: 1px solid wc-shade( 87 );
 		border-radius: 4px;
 		height: 30px;
 		padding: 0 8px;
 		font-size: 14px;
-		color: #444;
-		background-color: #fff;
+		color: wc-shade( 27 );
+		background-color: var(--wc-content-bg);
 		display: inline-block;
 
 		&[disabled] {
-			color: #aaa;
+			color: wc-shade( 66 );
 		}
 	}
 }
@@ -1258,14 +1262,13 @@ h3.jetpack-reasons {
 	display: flex;
 
 	.newsletter-form-email {
-		border: 1px solid #aaa;
-		border-color: #ddd;
+		border: 1px solid wc-shade( 87 );
 		border-radius: 4px;
 		height: 42px;
 		padding: 0 8px;
 		font-size: 16px;
-		color: #666;
-		background-color: #fff;
+		color: wc-shade( 40 );
+		background-color: var(--wc-content-bg);
 		display: inline-block;
 		margin-right: 6px;
 		flex-grow: 1;
@@ -1283,7 +1286,7 @@ h3.jetpack-reasons {
 }
 
 .wc-wizard-next-steps {
-	border: 1px solid #eee;
+	border: 1px solid wc-shade( 93 );
 	border-radius: 4px;
 	list-style: none;
 	padding: 0;
@@ -1294,7 +1297,7 @@ h3.jetpack-reasons {
 
 	.wc-wizard-next-step-item {
 		display: flex;
-		border-top: 1px solid #eee;
+		border-top: 1px solid wc-shade( 93 );
 
 		&:first-child {
 			border-top: 0;
@@ -1340,7 +1343,7 @@ h3.jetpack-reasons {
 	}
 
 	.wc-wizard-additional-steps {
-		border-top: 1px solid #eee;
+		border-top: 1px solid wc-shade( 93 );
 
 		.wc-wizard-next-step-description {
 			margin-bottom: 0;
@@ -1381,7 +1384,7 @@ p.jetpack-terms {
 	p {
 		margin-top: 0;
 		margin-bottom: 0.5em;
-		color: #444;
+		color: wc-shade( 27 );
 	}
 
 	a {
@@ -1482,7 +1485,7 @@ p.jetpack-terms {
 	}
 
 	.recommended-item-icon {
-		border: 1px solid #fff;
+		border: 1px solid var(--wc-white);
 		border-radius: 7px;
 		height: 3.5em;
 		margin-right: 1em;

--- a/plugins/woocommerce/legacy/css/wc-setup.scss
+++ b/plugins/woocommerce/legacy/css/wc-setup.scss
@@ -10,7 +10,7 @@
 body {
 	margin: 65px auto 24px;
 	box-shadow: none;
-	background: #f1f1f1;
+	background: wc-shade( 94 );
 	padding: 0;
 }
 
@@ -42,16 +42,16 @@ body {
 	}
 
 	#tiptip_content {
-		background: #5f6973;
+		background: wc-hsl( 'blue', 10%, 41% );
 	}
 
 	#tiptip_holder.tip_top #tiptip_arrow_inner {
-		border-top-color: #5f6973;
+		border-top-color: wc-hsl( 'blue', 10%, 41% );
 	}
 }
 
 .wc-setup-content {
-	box-shadow: 0 1px 3px wc-shade( 0, black, 13% );
+	box-shadow: 0 1px 3px wc-shade( 0, 'black', 13% );
 	padding: 2em;
 	margin: 0 0 20px;
 	background: var(--wc-content-bg);
@@ -89,7 +89,7 @@ body {
 
 		&:hover,
 		&:focus {
-			color: #111;
+			color: wc-shade( 7 );
 		}
 	}
 
@@ -340,7 +340,7 @@ body {
 				a.button {
 					background-color: wc-shade( 96 );
 					border-color: wc-shade( 80 );
-					color: #23282d;
+					color: wc-hsl( 'blue', 12%, 16% );
 					box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 wc-shade( 80 );
 					text-shadow: 1px 0 1px wc-shade( 93 ), 0 1px 1px wc-shade( 93 );
 					font-size: 1em;
@@ -361,7 +361,7 @@ body {
 
 				a.button-primary {
 					color: var(--wc-white);
-					background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+					background-color: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) );
 					border-color: var(--woocommerce);
 					box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 					text-shadow: 0 -1px 1px var(--woocommerce), 1px 0 1px var(--woocommerce), 0 1px 1px var(--woocommerce), -1px 0 1px var(--woocommerce);
@@ -378,7 +378,7 @@ body {
 			}
 
 			li a::before {
-				color: #82878c;
+				color: wc-hsl( 'blue', 4%, 53% );
 				font: 400 20px/1 dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 				speak: never;
 				display: inline-block;
@@ -472,12 +472,12 @@ body {
 		}
 
 		input[type="checkbox"]:focus + label::before {
-			outline: rgb(59, 153, 252) auto 5px;
+			outline: wc-hsl( 'blue', 97%, 60% ) auto 5px;
 		}
 
 		input[type="checkbox"]:checked + label::before {
-			background: #935687;
-			border-color: #935687;
+			background: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 7% ) );
+			border-color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 7% ) );
 		}
 	}
 }
@@ -548,7 +548,7 @@ body {
 
 			&:hover,
 			&:focus {
-				color: #111;
+				color: wc-shade( 7 );
 				text-decoration: underline;
 			}
 		}
@@ -597,7 +597,7 @@ body {
 
 .wc-setup .wc-setup-actions .button-primary,
 .woocommerce-tracker .button-primary {
-	background-color: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) )};
+	background-color: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ) );
 	border-color: var(--woocommerce);
 	box-shadow: inset 0 1px 0 wc-shade( 100 , 'white', 25% ), 0 1px 0 var(--woocommerce);
 	text-shadow: 0 -1px 1px var(--woocommerce), 1px 0 1px var(--woocommerce), 0 1px 1px var(--woocommerce), -1px 0 1px var(--woocommerce);
@@ -623,7 +623,7 @@ body {
 
 .wc-setup-footer-links {
 	font-size: 0.85em;
-	color: #7b7b7b;
+	color: wc-shade( 48 );
 	margin: 1.18em auto;
 	display: inline-block;
 	text-align: center;
@@ -728,7 +728,7 @@ body {
 	}
 
 	.payment-gateway-fee {
-		color: #a6a6a6;
+		color: wc-shade( 65 );
 	}
 
 	.wc-wizard-service-name {
@@ -811,8 +811,8 @@ body {
 	.wc-wizard-service-toggle {
 		height: 16px;
 		width: 32px;
-		border: 2px solid #935687;
-		background-color: #935687;
+		border: 2px solid wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 7% ) );
+		background-color: wc-hsl( 'orchid',  var(--wc--primary-sat), calc( var(--wc--primary-luma) - 7% ) );
 		display: inline-block;
 		text-indent: -9999px;
 		border-radius: 10em;
@@ -954,7 +954,7 @@ body {
 	.wc-wizard-service-description {
 		display: flex;
 		flex-direction: column;
-		color: #a6a6a6;
+		color: wc-shade( 65 );
 	}
 
 	.wc-wizard-service-item:not(:first-child) .wc-wizard-service-description {
@@ -966,8 +966,7 @@ body {
 
 		input {
 			width: 95px; // match dropdown height
-			border: 1px solid wc-shade( 66 );
-			border-color: wc-shade( 87 );
+			border: 1px solid wc-shade( 87 );
 			border-radius: 4px;
 			height: 28px;
 			padding-left: 8px;
@@ -981,7 +980,7 @@ body {
 
 	.shipping-method-description,
 	.shipping-method-setting .description {
-		color: #7e7e7e;
+		color: wc-shade( 49 );
 		font-size: 0.9em;
 	}
 
@@ -1097,7 +1096,7 @@ h3.jetpack-reasons {
 
 		.wc-setup-step__new_onboarding-welcome,
 		.wc-setup-step__new_onboarding-plugin-info {
-			color: #7c7c7c;
+			color: wc-shade( 49 );
 			font-size: 12px;
 		}
 	}
@@ -1157,7 +1156,7 @@ h3.jetpack-reasons {
 }
 
 .plugin-install-source {
-	$background: #{wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ), .15 )};
+	$background: wc-hsl( 'orchid',  calc(var(--wc--primary-sat) + 5%), calc( var(--wc--primary-luma) + 8% ), .15 );
 	background: $background;
 
 	&:not(.wc-wizard-service-item) {
@@ -1361,7 +1360,7 @@ h3.jetpack-reasons {
 }
 
 p.next-steps-help-text {
-	color: #9f9f9f;
+	color: wc-shade( 62 );
 	padding: 0 2em;
 	text-align: center;
 	font-size: 0.9em;
@@ -1376,8 +1375,8 @@ p.jetpack-terms {
 }
 
 .woocommerce-error {
-	background: #ffe6e5;
-	border-color: #ffc5c2;
+	background: wc-hsl( 'red',  100%, 94% );
+	border-color: wc-hsl( 'red',  100%, 88% );
 	padding: 1em;
 	margin-bottom: 1em;
 
@@ -1388,7 +1387,7 @@ p.jetpack-terms {
 	}
 
 	a {
-		color: #ff645c;
+		color: wc-hsl( 'red',  100%, 68% );
 	}
 
 	.reconnect-reminder {
@@ -1457,7 +1456,7 @@ p.jetpack-terms {
 }
 
 .wc-setup-content .recommended-step {
-	border: 1px solid #ebebeb;
+	border: 1px solid wc-shade( 92 );
 	border-radius: 4px;
 	padding: 2.5em;
 }
@@ -1492,38 +1491,38 @@ p.jetpack-terms {
 		margin-left: 4px;
 
 		&.recommended-item-icon-wc_admin {
-			background-color: #96588a;
+			background-color: var(--wc-orchid);
 			padding: 0.5em;
 			height: 2em;
 		}
 
 		&.recommended-item-icon-storefront_theme {
-			background-color: #f4a224;
+			background-color: var(--wc-deep-orange);
 			max-height: 3em;
 			max-width: 3em;
 			padding: ( 3.5em - 3em ) *.5;
 		}
 
 		&.recommended-item-icon-automated_taxes {
-			background-color: #d0011b;
+			background-color: var(--wc-red);
 			max-height: 1.75em;
 			padding: ( 3.5em - 1.75em ) *.5;
 		}
 
 		&.recommended-item-icon-mailchimp {
-			background-color: #ffe01b;
+			background-color: var(--wc-orange);
 			height: 2em;
 			padding: ( 3.5em - 2em ) *.5;
 		}
 
 		&.recommended-item-icon-woocommerce_services {
-			background-color: #f0f0f0;
+			background-color: wc-shade( 94 );
 			max-height: 1.5em;
 			padding: 1.3em 0.7em;
 		}
 
 		&.recommended-item-icon-shipstation {
-			background-color: #f0f0f0;
+			background-color: wc-shade( 94 );
 			padding: 0.3em;
 		}
 	}
@@ -1546,7 +1545,7 @@ p.jetpack-terms {
 
 .wc-wizard-service-info {
 	padding: 1em 2em;
-	background-color: #fafafa;
+	background-color: wc-shade(98);
 }
 
 .help_tip {

--- a/plugins/woocommerce/legacy/css/wc-setup.scss
+++ b/plugins/woocommerce/legacy/css/wc-setup.scss
@@ -1498,19 +1498,19 @@ p.jetpack-terms {
 			background-color: #f4a224;
 			max-height: 3em;
 			max-width: 3em;
-			padding: calc( ( 3.5em - 3em ) / 2 );
+			padding: ( 3.5em - 3em ) *.5;
 		}
 
 		&.recommended-item-icon-automated_taxes {
 			background-color: #d0011b;
 			max-height: 1.75em;
-			padding: calc( ( 3.5em - 1.75em ) / 2 );
+			padding: ( 3.5em - 1.75em ) *.5;
 		}
 
 		&.recommended-item-icon-mailchimp {
 			background-color: #ffe01b;
 			height: 2em;
-			padding: calc( ( 3.5em - 2em ) / 2 );
+			padding: ( 3.5em - 2em ) *.5;
 		}
 
 		&.recommended-item-icon-woocommerce_services {

--- a/plugins/woocommerce/legacy/css/woocommerce-layout.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce-layout.scss
@@ -147,7 +147,6 @@
 			padding: 0;
 			position: relative;
 			width: 22.05%;
-			margin-left: 0;
 		}
 
 		li.first {
@@ -592,8 +591,8 @@
 		padding-right: 7.6923%;
 		padding-top: 7.6923%;
 		margin-bottom: 7.6923%;
-		background: #fff;
-		box-shadow: 0 0 1px rgba(0, 0, 0, 0.15);
+		background: var(--wc-content-bg);
+		box-shadow: 0 0 1px wc-shade( 0, black, 15% );
 
 		.page-title {
 			margin-left: 0;

--- a/plugins/woocommerce/legacy/css/woocommerce-layout.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce-layout.scss
@@ -426,7 +426,7 @@
 		}
 
 		.show-password-input.display-password::after {
-			color: #585858;
+			color: wc-shade( 34 );
 		}
 	}
 
@@ -592,7 +592,7 @@
 		padding-top: 7.6923%;
 		margin-bottom: 7.6923%;
 		background: var(--wc-content-bg);
-		box-shadow: 0 0 1px wc-shade( 0, black, 15% );
+		box-shadow: 0 0 1px wc-shade( 0,'black', 15% );
 
 		.page-title {
 			margin-left: 0;

--- a/plugins/woocommerce/legacy/css/woocommerce-smallscreen.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce-smallscreen.scss
@@ -59,7 +59,7 @@
 
 			&:nth-child( 2n ) {
 				td {
-					background-color: wc-shade( 0, black, 2.5% );
+					background-color: wc-shade( 0,'black', 2.5% );
 				}
 			}
 		}

--- a/plugins/woocommerce/legacy/css/woocommerce-smallscreen.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce-smallscreen.scss
@@ -59,7 +59,7 @@
 
 			&:nth-child( 2n ) {
 				td {
-					background-color: rgba(0, 0, 0, 0.025);
+					background-color: wc-shade( 0, black, 2.5% );
 				}
 			}
 		}

--- a/plugins/woocommerce/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce.scss
@@ -26,14 +26,14 @@ p.demo_store,
 	font-size: 1em;
 	padding: 1em 0;
 	text-align: center;
-	background-color: $primary;
-	color: $primarytext;
+	background-color: var( --wc-primary );
+	color: var( --wc-primary-text );
 	z-index: 99998;
 	box-shadow: 0 1px 1em rgba(0, 0, 0, 0.2);
 	display: none;
 
 	a {
-		color: $primarytext;
+		color: var( --wc-primary-text );
 		text-decoration: underline;
 	}
 }
@@ -95,7 +95,7 @@ p.demo_store,
 
 	small.note {
 		display: block;
-		color: $subtext;
+		color: var( --wc-subtext );
 		font-size: 0.857em;
 		margin-top: 10px;
 	}
@@ -106,10 +106,10 @@ p.demo_store,
 		margin: 0 0 1em;
 		padding: 0;
 		font-size: 0.92em;
-		color: $subtext;
+		color: var( --wc-subtext );
 
 		a {
-			color: $subtext;
+			color: var( --wc-subtext );
 		}
 	}
 
@@ -133,7 +133,7 @@ p.demo_store,
 
 		span.price,
 		p.price {
-			color: $highlight;
+			color: var( --wc-highlight );
 			font-size: 1.25em;
 
 			ins {
@@ -153,7 +153,7 @@ p.demo_store,
 		}
 
 		.stock {
-			color: $highlight;
+			color: var( --wc-highlight );
 		}
 
 		.out-of-stock {
@@ -327,8 +327,8 @@ p.demo_store,
 				position: relative;
 
 				li {
-					border: 1px solid darken($secondary, 10%);
-					background-color: $secondary;
+					border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
+					background-color: var( --wc-secondary );
 					display: inline-block;
 					position: relative;
 					z-index: 0;
@@ -340,19 +340,19 @@ p.demo_store,
 						display: inline-block;
 						padding: 0.5em 0;
 						font-weight: 700;
-						color: $secondarytext;
+						color: var( --wc-secondary-text );
 						text-decoration: none;
 
 						&:hover {
 							text-decoration: none;
-							color: lighten($secondarytext, 10%);
+							color: #{gen-custom-prop( $wc-secondary-text, false, false, 10% )};
 						}
 					}
 
 					&.active {
-						background: $contentbg;
+						background: var( --wc-content-bg );
 						z-index: 2;
-						border-bottom-color: $contentbg;
+						border-bottom-color: var( --wc-content-bg );
 
 						a {
 							color: inherit;
@@ -360,17 +360,17 @@ p.demo_store,
 						}
 
 						&::before {
-							box-shadow: 2px 2px 0 $contentbg;
+							box-shadow: 2px 2px 0 var( --wc-content-bg );
 						}
 
 						&::after {
-							box-shadow: -2px 2px 0 $contentbg;
+							box-shadow: -2px 2px 0 var( --wc-content-bg );
 						}
 					}
 
 					&::before,
 					&::after {
-						border: 1px solid darken($secondary, 10%);
+						border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 						position: absolute;
 						bottom: -1px;
 						width: 5px;
@@ -383,14 +383,14 @@ p.demo_store,
 						left: -5px;
 						border-bottom-right-radius: 4px;
 						border-width: 0 1px 1px 0;
-						box-shadow: 2px 2px 0 $secondary;
+						box-shadow: 2px 2px 0 var( --wc-secondary );
 					}
 
 					&::after {
 						right: -5px;
 						border-bottom-left-radius: 4px;
 						border-width: 0 0 1px 1px;
-						box-shadow: -2px 2px 0 $secondary;
+						box-shadow: -2px 2px 0 var( --wc-secondary );
 					}
 				}
 
@@ -400,7 +400,7 @@ p.demo_store,
 					width: 100%;
 					bottom: 0;
 					left: 0;
-					border-bottom: 1px solid darken($secondary, 10%);
+					border-bottom: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 					z-index: 1;
 				}
 			}
@@ -533,8 +533,8 @@ p.demo_store,
 		left: -0.5em;
 		margin: 0;
 		border-radius: 100%;
-		background-color: $highlight;
-		color: $highlightext;
+		background-color: var( --wc-highlight );
+		color: var( --wc-highlight );
 		font-size: 0.857em;
 		z-index: 9;
 	}
@@ -602,7 +602,7 @@ p.demo_store,
 		}
 
 		.price {
-			color: $highlight;
+			color: var( --wc-highlight );
 			display: block;
 			font-weight: normal;
 			margin-bottom: 0.5em;
@@ -624,7 +624,7 @@ p.demo_store,
 				font-size: 0.67em;
 				margin: -2px 0 0 0;
 				text-transform: uppercase;
-				color: rgba(desaturate($highlight, 75%), 0.5);
+				color: #{gen-custom-prop( $wc-highlight, false, -75%, false, .5 )};
 			}
 		}
 	}
@@ -649,12 +649,12 @@ p.demo_store,
 			white-space: nowrap;
 			padding: 0;
 			clear: both;
-			border: 1px solid darken($secondary, 10%);
+			border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			border-right: 0;
 			margin: 1px;
 
 			li {
-				border-right: 1px solid darken($secondary, 10%);
+				border-right: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 				padding: 0;
 				margin: 0;
 				float: left;
@@ -677,8 +677,8 @@ p.demo_store,
 				span.current,
 				a:hover,
 				a:focus {
-					background: $secondary;
-					color: darken($secondary, 40%);
+					background: var( --wc-secondary );
+					color: #{gen-custom-prop( $wc-secondary, false, false, -40% )};
 				}
 			}
 		}
@@ -702,8 +702,8 @@ p.demo_store,
 		font-weight: 700;
 		border-radius: 3px;
 		left: auto;
-		color: $secondarytext;
-		background-color: $secondary;
+		color: var( --wc-secondary-text );
+		background-color: var( --wc-secondary );
 		border: 0;
 		display: inline-block;
 		background-image: none;
@@ -734,20 +734,20 @@ p.demo_store,
 		}
 
 		&:hover {
-			background-color: darken($secondary, 5%);
+			background-color: #{gen-custom-prop( $wc-secondary, false, false, -5% )};
 			text-decoration: none;
 			background-image: none;
-			color: $secondarytext;
+			color: var( --wc-secondary-text );
 		}
 
 		&.alt {
-			background-color: $primary;
-			color: $primarytext;
+			background-color: var( --wc-primary );
+			color: var( --wc-primary-text );
 			-webkit-font-smoothing: antialiased;
 
 			&:hover {
-				background-color: darken($primary, 5%);
-				color: $primarytext;
+				background-color: #{gen-custom-prop( $wc-primary, false, false, -5% )};
+				color: var( --wc-primary-text );
 			}
 
 			&.disabled,
@@ -756,8 +756,8 @@ p.demo_store,
 			&.disabled:hover,
 			&:disabled:hover,
 			&:disabled[disabled]:hover {
-				background-color: $primary;
-				color: $primarytext;
+				background-color: var( --wc-primary );
+				color: var( --wc-primary-text );
 			}
 		}
 
@@ -771,7 +771,7 @@ p.demo_store,
 
 			&:hover {
 				color: inherit;
-				background-color: $secondary;
+				background-color: var( --wc-secondary );
 			}
 		}
 	}
@@ -793,13 +793,13 @@ p.demo_store,
 
 		h2 small {
 			float: right;
-			color: $subtext;
+			color: var( --wc-subtext );
 			font-size: 15px;
 			margin: 10px 0 0;
 
 			a {
 				text-decoration: none;
-				color: $subtext;
+				color: var( --wc-subtext );
 			}
 		}
 
@@ -845,7 +845,7 @@ p.demo_store,
 					border: 0;
 
 					.meta {
-						color: $subtext;
+						color: var( --wc-subtext );
 						font-size: 0.75em;
 					}
 
@@ -857,15 +857,15 @@ p.demo_store,
 						padding: 3px;
 						width: 32px;
 						height: auto;
-						background: $secondary;
-						border: 1px solid darken($secondary, 3%);
+						background: var( --wc-secondary );
+						border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -3% )};
 						margin: 0;
 						box-shadow: none;
 					}
 
 					.comment-text {
 						margin: 0 0 0 50px;
-						border: 1px solid darken($secondary, 3%);
+						border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -3% )};
 						border-radius: 4px;
 						padding: 1em 1em 0;
 
@@ -891,7 +891,7 @@ p.demo_store,
 				}
 
 				#respond {
-					border: 1px solid darken($secondary, 3%);
+					border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -3% )};
 					border-radius: 4px;
 					padding: 1em 1em 0;
 					margin: 20px 0 0 50px;
@@ -919,7 +919,7 @@ p.demo_store,
 
 		&::before {
 			content: "\73\73\73\73\73";
-			color: darken($secondary, 10%);
+			color: #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			float: left;
 			top: 0;
 			left: 0;
@@ -1263,7 +1263,7 @@ p.demo_store,
 	.widget_shopping_cart {
 
 		.total {
-			border-top: 3px double $secondary;
+			border-top: 3px double var( --wc-secondary );
 			padding: 4px 0 0;
 
 			strong {
@@ -1402,13 +1402,13 @@ p.demo_store,
 		&.woocommerce-invalid {
 
 			label {
-				color: $red;
+				color: var( --wc-red );
 			}
 
 			.select2-container,
 			input.input-text,
 			select {
-				border-color: $red;
+				border-color: var( --wc-red );
 			}
 		}
 
@@ -1437,7 +1437,7 @@ p.demo_store,
 	form.login,
 	form.checkout_coupon,
 	form.register {
-		border: 1px solid darken($secondary, 10%);
+		border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 		padding: 20px;
 		margin: 2em 0;
 		text-align: left;
@@ -1488,7 +1488,7 @@ p.demo_store,
 			text-transform: uppercase;
 			font-size: 0.715em;
 			line-height: 1;
-			border-right: 1px dashed darken($secondary, 10%);
+			border-right: 1px dashed #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			padding-right: 2em;
 			margin-left: 0;
 			padding-left: 0;
@@ -1582,7 +1582,7 @@ p.demo_store,
 		.woocommerce-widget-layered-nav-list__item--chosen a::before {
 
 			@include iconbefore( "\e013" );
-			color: $red;
+			color: var( --wc-red );
 		}
 	}
 
@@ -1609,7 +1609,7 @@ p.demo_store,
 				&::before {
 
 					@include iconbefore( "\e013" );
-					color: $red;
+					color: var( --wc-red );
 					vertical-align: inherit;
 					margin-right: 0.5em;
 				}
@@ -1649,7 +1649,7 @@ p.demo_store,
 			z-index: 2;
 			width: 1em;
 			height: 1em;
-			background-color: $primary;
+			background-color: var( --wc-primary );
 			border-radius: 1em;
 			cursor: ew-resize;
 			outline: none;
@@ -1666,12 +1666,12 @@ p.demo_store,
 			display: block;
 			border: 0;
 			border-radius: 1em;
-			background-color: $primary;
+			background-color: var( --wc-primary );
 		}
 
 		.price_slider_wrapper .ui-widget-content {
 			border-radius: 1em;
-			background-color: darken($primary, 30%);
+			background-color: #{gen-custom-prop( $wc-primary, false, false, -30% )};
 			border: 0;
 		}
 
@@ -1722,7 +1722,7 @@ p.demo_store,
 		li.chosen a::before {
 
 			@include iconbefore( "\e013" );
-			color: $red;
+			color: var( --wc-red );
 		}
 	}
 
@@ -1759,9 +1759,9 @@ p.demo_store,
 	padding: 1em 2em 1em 3.5em;
 	margin: 0 0 2em;
 	position: relative;
-	background-color: lighten($secondary, 5%);
-	color: $secondarytext;
-	border-top: 3px solid $primary;
+	background-color: #{gen-custom-prop( $wc-secondary, false, false, 5% )};
+	color: var( --wc-secondary-text );
+	border-top: 3px solid var( --wc-primary );
 	list-style: none outside;
 
 	@include clearfix();
@@ -1907,7 +1907,7 @@ p.demo_store,
 		td.actions .coupon .input-text {
 			float: left;
 			box-sizing: border-box;
-			border: 1px solid darken($secondary, 10%);
+			border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			padding: 6px 6px 5px;
 			margin: 0 4px 0 0;
 			outline: 0;
@@ -1953,7 +1953,7 @@ p.demo_store,
 		.cart_totals {
 
 			p small {
-				color: $subtext;
+				color: var( --wc-subtext );
 				font-size: 0.83em;
 			}
 
@@ -1983,7 +1983,7 @@ p.demo_store,
 				}
 
 				small {
-					color: $subtext;
+					color: var( --wc-subtext );
 				}
 
 				select {
@@ -1992,12 +1992,12 @@ p.demo_store,
 			}
 
 			.discount td {
-				color: $highlight;
+				color: var( --wc-highlight );
 			}
 
 			tr td,
 			tr th {
-				border-top: 1px solid $secondary;
+				border-top: 1px solid var( --wc-secondary );
 			}
 
 			.woocommerce-shipping-destination {
@@ -2030,7 +2030,7 @@ p.demo_store,
 
 		.create-account small {
 			font-size: 11px;
-			color: $subtext;
+			color: var( --wc-subtext );
 			font-weight: normal;
 		}
 
@@ -2046,7 +2046,7 @@ p.demo_store,
 	}
 
 	#payment {
-		background: $secondary;
+		background: var( --wc-secondary );
 		border-radius: 5px;
 
 		ul.payment_methods {
@@ -2054,7 +2054,7 @@ p.demo_store,
 			@include clearfix();
 			text-align: left;
 			padding: 1em;
-			border-bottom: 1px solid darken($secondary, 10%);
+			border-bottom: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			margin: 0;
 			list-style: none outside;
 
@@ -2100,25 +2100,25 @@ p.demo_store,
 			font-size: 0.92em;
 			border-radius: 2px;
 			line-height: 1.5;
-			background-color: darken($secondary, 5%);
-			color: $secondarytext;
+			background-color: #{gen-custom-prop( $wc-secondary, false, false, -5% )};
+			color: var( --wc-secondary-text );
 
 			input.input-text,
 			textarea {
-				border-color: darken($secondary, 15%);
-				border-top-color: darken($secondary, 20%);
+				border-color: #{gen-custom-prop( $wc-secondary, false, false, -15% )};
+				border-top-color: #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			::-webkit-input-placeholder {
-				color: darken($secondary, 20%);
+				color: #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			:-moz-placeholder {
-				color: darken($secondary, 20%);
+				color: #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			:-ms-input-placeholder {
-				color: darken($secondary, 20%);
+				color:  #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			.woocommerce-SavedPaymentMethods {
@@ -2191,7 +2191,7 @@ p.demo_store,
 
 			span.help {
 				font-size: 0.857em;
-				color: $subtext;
+				color: var( --wc-subtext );
 				font-weight: normal;
 			}
 
@@ -2206,7 +2206,7 @@ p.demo_store,
 			&::before {
 				content: "";
 				display: block;
-				border: 1em solid darken($secondary, 5%); /* arrow size / color */
+				border: 1em solid  #{gen-custom-prop( $wc-secondary, false, false, -5% )}; /* arrow size / color */
 				border-right-color: transparent;
 				border-left-color: transparent;
 				border-top-color: transparent;

--- a/plugins/woocommerce/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce.scss
@@ -29,7 +29,7 @@ p.demo_store,
 	background-color: var( --wc-primary );
 	color: var( --wc-primary-text );
 	z-index: 99998;
-	box-shadow: 0 1px 1em wc-shade( 0, black, 20% );
+	box-shadow: 0 1px 1em wc-shade( 0, 'black', 20% );
 	display: none;
 
 	a {
@@ -1042,7 +1042,7 @@ p.demo_store,
 	 */
 	table.shop_attributes {
 		border: 0;
-		border-top: 1px dotted wc-shade( 0, black, 10% );
+		border-top: 1px dotted wc-shade( 0, 'black', 10% );
 		margin-bottom: 1.618em;
 		width: 100%;
 
@@ -1051,7 +1051,7 @@ p.demo_store,
 			font-weight: 700;
 			padding: 8px;
 			border-top: 0;
-			border-bottom: 1px dotted wc-shade( 0, black, 10% );
+			border-bottom: 1px dotted wc-shade( 0, 'black', 10% );
 			margin: 0;
 			line-height: 1.5;
 		}
@@ -1060,7 +1060,7 @@ p.demo_store,
 			font-style: italic;
 			padding: 0;
 			border-top: 0;
-			border-bottom: 1px dotted wc-shade( 0, black, 10% );
+			border-bottom: 1px dotted wc-shade( 0, 'black', 10% );
 			margin: 0;
 			line-height: 1.5;
 
@@ -1072,12 +1072,12 @@ p.demo_store,
 
 		tr:nth-child(even) td,
 		tr:nth-child(even) th {
-			background: wc-shade( 0, black, 2.5% );
+			background: wc-shade( 0, 'black', 2.5% );
 		}
 	}
 
 	table.shop_table {
-		border: 1px solid wc-shade( 0, black, 10% );
+		border: 1px solid wc-shade( 0, 'black', 10% );
 		margin: 0 -1px 24px 0;
 		text-align: left;
 		width: 100%;
@@ -1091,7 +1091,7 @@ p.demo_store,
 		}
 
 		td {
-			border-top: 1px solid wc-shade( 0, black, 10% );
+			border-top: 1px solid wc-shade( 0, 'black', 10% );
 			padding: 9px 12px;
 			vertical-align: middle;
 			line-height: 1.5em;
@@ -1117,7 +1117,7 @@ p.demo_store,
 		tfoot th,
 		tbody th {
 			font-weight: 700;
-			border-top: 1px solid wc-shade( 0, black, 10% );
+			border-top: 1px solid wc-shade( 0, 'black', 10% );
 		}
 	}
 
@@ -1223,7 +1223,7 @@ p.demo_store,
 			dl {
 				margin: 0;
 				padding-left: 1em;
-				border-left: 2px solid wc-shade( 0, black, 10% );
+				border-left: 2px solid wc-shade( 0, 'black', 10% );
 
 				@include clearfix();
 
@@ -1414,7 +1414,7 @@ p.demo_store,
 			.select2-container,
 			input.input-text,
 			select {
-				border-color: #{wc-hsl( 'green',  50%, 40%)};
+				border-color: wc-hsl( 'green',  50%, 40%);
 			}
 		}
 
@@ -1523,7 +1523,7 @@ p.demo_store,
 		address {
 			font-style: normal;
 			margin-bottom: 0;
-			border: 1px solid wc-shade( 0, black, 10% );
+			border: 1px solid wc-shade( 0, 'black', 10% );
 			border-bottom-width: 2px;
 			border-right-width: 2px;
 			text-align: left;
@@ -2231,9 +2231,9 @@ p.demo_store,
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid wc-shade( 0, black, 20% );
-	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
-	background: wc-shade( 0, black, 5% );
+	border: 1px solid wc-shade( 0, 'black', 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0, 'black', 10% );
+	background: wc-shade( 0, 'black', 5% );
 }
 
 .woocommerce-invalid {
@@ -2258,23 +2258,23 @@ p.demo_store,
 	font-size: 1em;
 
 	&.strong {
-		background-color: #{wc-hsl( 'success',  40%, 80%)};
-		border-color: #{wc-hsl( 'success',  40%, 60%)};
+		background-color: wc-hsl( 'success',  40%, 80%);
+		border-color: wc-hsl( 'success',  40%, 60%);
 	}
 
 	&.short {
-		background-color: #{wc-hsl( 'error',  70%, 80%)};
-		border-color: #{wc-hsl( 'error',  70%, 60%)};
+		background-color: wc-hsl( 'error',  70%, 80%);
+		border-color: wc-hsl( 'error',  70%, 60%);
 	}
 
 	&.bad {
-		background-color: #{wc-hsl( 'warning',  90%, 80%)};
-		border-color: #{wc-hsl( 'warning',  90%, 60%)};
+		background-color: wc-hsl( 'warning',  90%, 80%);
+		border-color: wc-hsl( 'warning',  90%, 60%);
 	}
 
 	&.good {
-		background-color: #{wc-hsl('alert', 80%, 80%)};
-		border-color: #{wc-hsl('alert', 80%, 60%)};
+		background-color: wc-hsl('alert', 80%, 80%);
+		border-color: wc-hsl('alert', 80%, 60%);
 	}
 }
 

--- a/plugins/woocommerce/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce.scss
@@ -29,7 +29,7 @@ p.demo_store,
 	background-color: var( --wc-primary );
 	color: var( --wc-primary-text );
 	z-index: 99998;
-	box-shadow: 0 1px 1em rgba(0, 0, 0, 0.2);
+	box-shadow: 0 1px 1em wc-shade( 0, black, 20% );
 	display: none;
 
 	a {
@@ -82,14 +82,14 @@ p.demo_store,
 		text-align: center;
 		line-height: 1;
 		border-radius: 100%;
-		color: red !important; // Required for default theme compatibility
+		color: var(--wc-error) !important; // Required for default theme compatibility
 		text-decoration: none;
 		font-weight: 700;
 		border: 0;
 
 		&:hover {
-			color: #fff !important; // Required for default theme compatibility
-			background: red;
+			color: var(--wc-white) !important; // Required for default theme compatibility
+			background: var(--wc-error);
 		}
 	}
 
@@ -157,7 +157,7 @@ p.demo_store,
 		}
 
 		.out-of-stock {
-			color: red;
+			color: var(--wc-error);
 		}
 
 		.woocommerce-product-rating {
@@ -189,12 +189,12 @@ p.demo_store,
 			}
 
 			.woocommerce-product-gallery__wrapper .zoomImg {
-				background-color: #fff;
+				background-color: var(--wc-content-bg);
 				opacity: 0;
 			}
 
 			.woocommerce-product-gallery__image--placeholder {
-				border: 1px solid #f2f2f2;
+				border: 1px solid wc-shade( 5 );
 			}
 
 			.woocommerce-product-gallery__image:nth-child(n+2) {
@@ -210,7 +210,7 @@ p.demo_store,
 				z-index: 9;
 				width: 36px;
 				height: 36px;
-				background: #fff;
+				background: var(--wc-content-bg);
 				text-indent: -9999px;
 				border-radius: 100%;
 				box-sizing: content-box;
@@ -220,7 +220,7 @@ p.demo_store,
 					display: block;
 					width: 10px;
 					height: 10px;
-					border: 2px solid #000;
+					border: 2px solid var(--wc-black);
 					border-radius: 100%;
 					position: absolute;
 					top: 9px;
@@ -233,7 +233,7 @@ p.demo_store,
 					display: block;
 					width: 2px;
 					height: 8px;
-					background: #000;
+					background: var(--wc-black);
 					border-radius: 6px;
 					position: absolute;
 					top: 19px;
@@ -524,7 +524,6 @@ p.demo_store,
 		min-height: 3.236em;
 		min-width: 3.236em;
 		padding: 0.202em;
-		font-size: 1em;
 		font-weight: 700;
 		position: absolute;
 		text-align: center;
@@ -590,7 +589,7 @@ p.demo_store,
 		}
 
 		.woocommerce-placeholder {
-			border: 1px solid #f2f2f2;
+			border: 1px solid wc-shade( 5 );
 		}
 
 		.star-rating {
@@ -689,7 +688,7 @@ p.demo_store,
 	a.button,
 	button.button,
 	input.button,
-	#respond input#submit {
+	#respond #submit {
 		font-size: 100%;
 		margin: 0;
 		line-height: 1;
@@ -838,7 +837,6 @@ p.demo_store,
 				li {
 					padding: 0;
 					margin: 0 0 20px;
-					border: 0;
 					position: relative;
 					background: 0;
 					border: 0;
@@ -1044,7 +1042,7 @@ p.demo_store,
 	 */
 	table.shop_attributes {
 		border: 0;
-		border-top: 1px dotted rgba(0, 0, 0, 0.1);
+		border-top: 1px dotted wc-shade( 0, black, 10% );
 		margin-bottom: 1.618em;
 		width: 100%;
 
@@ -1053,7 +1051,7 @@ p.demo_store,
 			font-weight: 700;
 			padding: 8px;
 			border-top: 0;
-			border-bottom: 1px dotted rgba(0, 0, 0, 0.1);
+			border-bottom: 1px dotted wc-shade( 0, black, 10% );
 			margin: 0;
 			line-height: 1.5;
 		}
@@ -1062,7 +1060,7 @@ p.demo_store,
 			font-style: italic;
 			padding: 0;
 			border-top: 0;
-			border-bottom: 1px dotted rgba(0, 0, 0, 0.1);
+			border-bottom: 1px dotted wc-shade( 0, black, 10% );
 			margin: 0;
 			line-height: 1.5;
 
@@ -1074,12 +1072,12 @@ p.demo_store,
 
 		tr:nth-child(even) td,
 		tr:nth-child(even) th {
-			background: rgba(0, 0, 0, 0.025);
+			background: wc-shade( 0, black, 2.5% );
 		}
 	}
 
 	table.shop_table {
-		border: 1px solid rgba(0, 0, 0, 0.1);
+		border: 1px solid wc-shade( 0, black, 10% );
 		margin: 0 -1px 24px 0;
 		text-align: left;
 		width: 100%;
@@ -1093,7 +1091,7 @@ p.demo_store,
 		}
 
 		td {
-			border-top: 1px solid rgba(0, 0, 0, 0.1);
+			border-top: 1px solid wc-shade( 0, black, 10% );
 			padding: 9px 12px;
 			vertical-align: middle;
 			line-height: 1.5em;
@@ -1119,7 +1117,7 @@ p.demo_store,
 		tfoot th,
 		tbody th {
 			font-weight: 700;
-			border-top: 1px solid rgba(0, 0, 0, 0.1);
+			border-top: 1px solid wc-shade( 0, black, 10% );
 		}
 	}
 
@@ -1225,7 +1223,7 @@ p.demo_store,
 			dl {
 				margin: 0;
 				padding-left: 1em;
-				border-left: 2px solid rgba(0, 0, 0, 0.1);
+				border-left: 2px solid wc-shade( 0, black, 10% );
 
 				@include clearfix();
 
@@ -1321,8 +1319,8 @@ p.demo_store,
 		.woocommerce-input-wrapper {
 
 			.description {
-				background: #1e85be;
-				color: #fff;
+				background: var(--wc-tips--color);
+				color: var(--wc-white);
 				border-radius: 3px;
 				padding: 1em;
 				margin: 0.5em 0 0;
@@ -1331,7 +1329,7 @@ p.demo_store,
 				position: relative;
 
 				a {
-					color: #fff;
+					color: var(--wc-white);
 					text-decoration: underline;
 					border: 0;
 					box-shadow: none;
@@ -1339,14 +1337,14 @@ p.demo_store,
 
 				&::before {
 					left: 50%;
-					top: 0%;
+					top: 0;
 					margin-top: -4px;
 					transform: translateX(-50%) rotate(180deg);
 					content: "";
 					position: absolute;
 					border-width: 4px 6px 0 6px;
 					border-style: solid;
-					border-color: #1e85be transparent transparent transparent;
+					border-color: var(--wc-tips--color) transparent transparent transparent;
 					z-index: 100;
 					display: block;
 				}
@@ -1359,7 +1357,7 @@ p.demo_store,
 		}
 
 		.required {
-			color: red;
+			color: var(--wc-error);
 			font-weight: 700;
 			border: 0 !important;
 			text-decoration: none;
@@ -1416,7 +1414,7 @@ p.demo_store,
 			.select2-container,
 			input.input-text,
 			select {
-				border-color: darken($green, 5%);
+				border-color: #{wc-hsl( 'green',  50%, 40%)};
 			}
 		}
 
@@ -1443,7 +1441,7 @@ p.demo_store,
 		border-radius: 5px;
 	}
 
-	ul#shipping_method {
+	#shipping_method {
 		list-style: none outside;
 		margin: 0;
 		padding: 0;
@@ -1525,7 +1523,7 @@ p.demo_store,
 		address {
 			font-style: normal;
 			margin-bottom: 0;
-			border: 1px solid rgba(0, 0, 0, 0.1);
+			border: 1px solid wc-shade( 0, black, 10% );
 			border-bottom-width: 2px;
 			border-right-width: 2px;
 			text-align: left;
@@ -1799,28 +1797,28 @@ p.demo_store,
 }
 
 .woocommerce-message {
-	border-top-color: #8fae1b;
+	border-top-color: var(--wc-success);
 
 	&::before {
 		content: "\e015";
-		color: #8fae1b;
+		color: var(--wc-success);
 	}
 }
 
 .woocommerce-info {
-	border-top-color: #1e85be;
+	border-top-color: var(--wc-info);
 
 	&::before {
-		color: #1e85be;
+		color: var(--wc-info);
 	}
 }
 
 .woocommerce-error {
-	border-top-color: #b81c23;
+	border-top-color: var(--wc-error);
 
 	&::before {
 		content: "\e016";
-		color: #b81c23;
+		color: var(--wc-error);
 	}
 }
 
@@ -2233,21 +2231,25 @@ p.demo_store,
 }
 
 .woocommerce-terms-and-conditions {
-	border: 1px solid rgba(0, 0, 0, 0.2);
-	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-	background: rgba(0, 0, 0, 0.05);
+	border: 1px solid wc-shade( 0, black, 20% );
+	box-shadow: inset 0 1px 2px wc-shade( 0, black, 10% );
+	background: wc-shade( 0, black, 5% );
 }
 
 .woocommerce-invalid {
 
 	#terms {
-		outline: 2px solid red;
+		outline: 2px solid var(--wc-error);
 		outline-offset: 2px;
 	}
 }
 
 /**
  * Password strength meter
+ * strong -> green
+ * short -> red
+ * bad -> orange
+ * good -> yellow
  */
 .woocommerce-password-strength {
 	text-align: center;
@@ -2256,23 +2258,23 @@ p.demo_store,
 	font-size: 1em;
 
 	&.strong {
-		background-color: #c1e1b9;
-		border-color: #83c373;
+		background-color: #{wc-hsl( 'success',  40%, 80%)};
+		border-color: #{wc-hsl( 'success',  40%, 60%)};
 	}
 
 	&.short {
-		background-color: #f1adad;
-		border-color: #e35b5b;
+		background-color: #{wc-hsl( 'error',  70%, 80%)};
+		border-color: #{wc-hsl( 'error',  70%, 60%)};
 	}
 
 	&.bad {
-		background-color: #fbc5a9;
-		border-color: #f78b53;
+		background-color: #{wc-hsl( 'warning',  90%, 80%)};
+		border-color: #{wc-hsl( 'warning',  90%, 60%)};
 	}
 
 	&.good {
-		background-color: #ffe399;
-		border-color: #ffc733;
+		background-color: #{wc-hsl('alert', 80%, 80%)};
+		border-color: #{wc-hsl('alert', 80%, 60%)};
 	}
 }
 

--- a/plugins/woocommerce/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce.scss
@@ -534,7 +534,7 @@ p.demo_store,
 		margin: 0;
 		border-radius: 100%;
 		background-color: var( --wc-highlight );
-		color: var( --wc-highlight );
+		color: var( --wc-highlight-text );
 		font-size: 0.857em;
 		z-index: 9;
 	}
@@ -665,7 +665,6 @@ p.demo_store,
 				span {
 					margin: 0;
 					text-decoration: none;
-					padding: 0;
 					line-height: 1;
 					font-size: 1em;
 					font-weight: normal;


### PR DESCRIPTION
Originally created by @helgatheviking #29575

### All Submissions:

Closes https://github.com/woocommerce/woocommerce/issues/29574 .

How to test the changes in this Pull Request:
- Rebuild the CSS files 

### Changes proposed in this Pull Request:
- Replace SCSS color variables with CSS color variables. This will allow a theme to override the CSS root variable and have that change propagate to all the places where that color variable is used. Currently, overriding the root variable does nothing as the colors are still hard-coded into the CSS when built from the SCSS.

### How to test the changes in this Pull Request:
1. Check the inlined style in header (woocommerce-inline-inline-css), has to contain the css custom props
2. Check the compiled css style and search for /(#[a-fA-F0-9]{9}|#[a-fA-F0-9]{7}|#[a-fA-F0-9]{4}|rgb(.*\))|rgba(.*\)))/ to check that all colors have been converted
3. With devtools change the --wc--primary-hue to another value, button and highlight will change.  do the same in admin section and nothing happens (the reason is because in the wp-admin section the --wc-orchid color was used)
4. added a filter "enqueue_woo_global_styles" in to let the user to modify/add/remove the woo-commerce inline style. 

### FOR PR REVIEWER ONLY:
- I used this... file_get_contents, I don't know if this can create any security issue.