### PR TITLE
Add event tracking to Payments tab

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -216,7 +216,9 @@ abstract class WC_Settings_API {
 			}
 		}
 
-		return update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ), 'yes' );
+		$option_key = $this->get_option_key();
+        do_action( 'woocommerce_update_option', array( 'id' => $option_key ) );
+        return update_option( $option_key, apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ), 'yes' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -233,6 +233,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 		}
 		// phpcs:enable
 
+		do_action( 'woocommerce_update_option', array( 'id' => 'woocommerce_bacs_accounts' ) );
 		update_option( 'woocommerce_bacs_accounts', $accounts );
 	}
 


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
<!-- Mark completed items with an [x] -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up to [PR 31844](https://github.com/woocommerce/woocommerce/pull/31844).

This PR adds the code necessary to track the Payments tab.
It triggers the action `woocommerce_update_option` [in method `process_admin_options`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php#L204-L220) to add the option key to [the allowed options list](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php#L49) and saves it later.

### How to test the changes in this Pull Request:
0. Check out this branch.
1. The easiest way to test this PR is using the [WooCommerce Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper). Install and activate it. Be sure that [this PR](https://github.com/woocommerce/woocommerce-admin-test-helper/pull/25) has been merged, otherwise, you should set up the project and check out the branch `fix/8199`.
2. Go to `WooCommerce` -> `Status` -> `Logs` (URL `wp-admin/admin.php?page=wc-status&tab=logs`).
3. Select a `tracks-*` log from the dropdown.
4. Go to `WooCommerce` -> `Settings` -> `Payments` (URL `/wp-admin/admin.php?page=wc-settings&tab=checkout`).
![screenshot-woocommerce local-2022 02 04-15_13_34](https://user-images.githubusercontent.com/1314156/152581603-769f6b9b-c12f-407f-876d-e1e7c2a3d399.png)
5. Select a payment method, change any options, save it. E.g. Direct bank transfer (URL `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=bacs`).
Under the Log tab you should see something like:
```
DEBUG wcadmin_settings_change
DEBUG   - settings: woocommerce_bacs_settings
DEBUG   - tab: checkout
DEBUG   - section: bacs
```

### Other information:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
<!-- Mark completed items with an [x] -->
### Changelog entry
A follow-up to fix Payments tab tracking (https://github.com/woocommerce/woocommerce/pull/31844).
### FOR PR REVIEWER ONLY:
* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.