### PR TITLE
Exclude the project root when ran in GitHub CI

### DIFF
--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Changed
+- Updated `resolveSingleE2EPath` 
+  - it resolves the full path if the filePath is valid
+  - otherwise, it removes `tests/e2e` from the given filePath before resolving a full path.
+
 ## Added
 
 - Added `post-results-to-github-pr.js` to post test results to a GitHub PR.

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -107,8 +107,9 @@ const resolveSingleE2EPath = ( filePath, exclude = [ 'woocommerce' ] ) => {
 	// If running in GitHub CI, add the project root to the exclude array
 	// This is done because the project root is always duplicated in GitHub CI
 	if ( GITHUB_ACTIONS ) {
-		const appPathArray = appPath.split( '/' );
-		const projectRoot = appPathArray[ appPathArray.length - 2 ];
+		const trimmedPath = appPath.replace( /\/$/, '' );
+		const appPathArray = trimmedPath.split( '/' );
+		const projectRoot = appPathArray[ appPathArray.length - 1 ];
 		exclude.push( projectRoot );
 	}
 

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -101,8 +101,16 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
  * @return {string}
  */
 const resolveSingleE2EPath = ( filePath, exclude = [ 'woocommerce' ] ) => {
-	const { SMOKE_TEST_URL } = process.env;
+	const { SMOKE_TEST_URL, GITHUB_ACTIONS } = process.env;
 	let prunedPath;
+
+	// If running in GitHub CI, add the project root to the exclude array
+	// This is done because the project root is always duplicated in GitHub CI
+	if ( GITHUB_ACTIONS ) {
+		const appPathArray = appPath.split( '/' );
+		const projectRoot = appPathArray[ appPathArray.length - 2 ];
+		exclude.push( projectRoot );
+	}
 
 	// Removes 'plugins/woocommerce/' from path only for tests against a smoke test site.
 	if ( SMOKE_TEST_URL ) {

--- a/packages/js/e2e-environment/utils/test-config.js
+++ b/packages/js/e2e-environment/utils/test-config.js
@@ -100,37 +100,16 @@ const resolvePackagePath = ( filename, packageName = '' ) => {
  * @param {Array} exclude An array of directories that won't be removed in the event that duplicates exist.
  * @return {string}
  */
-const resolveSingleE2EPath = ( filePath, exclude = [ 'woocommerce' ] ) => {
+const resolveSingleE2EPath = ( filePath ) => {
 	const { SMOKE_TEST_URL, GITHUB_ACTIONS } = process.env;
-	let prunedPath;
+	const localPath = resolveLocalE2ePath( filePath );
 
-	// If running in GitHub CI, add the project root to the exclude array
-	// This is done because the project root is always duplicated in GitHub CI
-	if ( GITHUB_ACTIONS ) {
-		const trimmedPath = appPath.replace( /\/$/, '' );
-		const appPathArray = trimmedPath.split( '/' );
-		const projectRoot = appPathArray[ appPathArray.length - 1 ];
-		exclude.push( projectRoot );
-	}
-
-	// Removes 'plugins/woocommerce/' from path only for tests against a smoke test site.
-	if ( SMOKE_TEST_URL ) {
-		prunedPath = filePath.replace( 'plugins/woocommerce/', '' );
+	if ( fs.existsSync( localPath ) ) {
+		return localPath;
 	} else {
-		prunedPath = filePath;
+		const prunedPath = filePath.replace( 'tests/e2e', '' );
+		return resolveLocalE2ePath( prunedPath );
 	}
-
-	const pathArray = resolveLocalE2ePath( prunedPath ).split( '/' );
-
-	// removes duplicate directories from the path
-	return pathArray
-		.filter( ( element, index, arr ) => {
-			return (
-				arr.indexOf( element ) === index ||
-				exclude.indexOf( element ) !== -1
-			);
-		} )
-		.join( '/' );
 };
 
 // Copy local test configuration file if it exists.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR ensures that the relative path when resolving for a single test script is correct by not removing the duplicated project root.

Closes #31907.

### How to test the changes in this Pull Request:

```
pnpm i 
npx wc-e2e docker:up 
npx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
npx wc-e2e test:e2e specs/smoke-tests/update-woocommerce.js
npx wc-e2e test:e2e
```

All tests should pass
