### PR TITLE
Create and fill the product attributes lookup table during a clean install of WooCommerce

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper as WCConnectionHelper;
 
@@ -849,6 +850,8 @@ class WC_Install {
 		 */
 		$max_index_length = 191;
 
+		$product_attributes_lookup_table_creation_sql = wc_get_container()->get( DataRegenerator::class )->get_table_creation_sql();
+
 		$tables = "
 CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
   session_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -1068,6 +1071,7 @@ CREATE TABLE {$wpdb->prefix}wc_rate_limits (
   PRIMARY KEY  (rate_limit_id),
   UNIQUE KEY rate_limit_key (rate_limit_key($max_index_length))
 ) $collate;
+$product_attributes_lookup_table_creation_sql
 		";
 
 		return $tables;
@@ -1103,6 +1107,7 @@ CREATE TABLE {$wpdb->prefix}wc_rate_limits (
 			"{$wpdb->prefix}woocommerce_tax_rates",
 			"{$wpdb->prefix}wc_reserved_stock",
 			"{$wpdb->prefix}wc_rate_limits",
+			wc_get_container()->get( DataRegenerator::class )->get_lookup_table_name(),
 		);
 
 		/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2348,7 +2348,11 @@ function wc_update_630_create_product_attributes_lookup_table() {
 	$data_store       = wc_get_container()->get( LookupDataStore::class );
 	$data_regenerator = wc_get_container()->get( DataRegenerator::class );
 
-	if ( $data_store->check_lookup_table_exists() ) {
+	/**
+	 * If the table exists and contains data, it was manually created by user before the migration ran.
+	 * If the table exists but is empty, it was likely created right now via dbDelta, so a table regenerations is needed.
+	 */
+	if ( $data_store->check_lookup_table_exists() && $data_store->lookup_table_has_data() ) {
 		$data_regenerator->maybe_create_table_indices();
 	} else {
 		$data_regenerator->initiate_regeneration();

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2352,9 +2352,7 @@ function wc_update_630_create_product_attributes_lookup_table() {
 	 * If the table exists and contains data, it was manually created by user before the migration ran.
 	 * If the table exists but is empty, it was likely created right now via dbDelta, so a table regenerations is needed.
 	 */
-	if ( $data_store->check_lookup_table_exists() && $data_store->lookup_table_has_data() ) {
-		$data_regenerator->maybe_create_table_indices();
-	} else {
+	if ( ! $data_store->check_lookup_table_exists() || ! $data_store->lookup_table_has_data() ) {
 		$data_regenerator->initiate_regeneration();
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -161,49 +161,6 @@ class DataRegenerator {
 	}
 
 	/**
-	 * Create the indices for the lookup table unless they exist already.
-	 */
-	public function maybe_create_table_indices() {
-		global $wpdb;
-
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( 'DROP PROCEDURE IF EXISTS __create_wc_product_attributes_lookup_indices;' );
-		$wpdb->query(
-			"
-CREATE PROCEDURE __create_wc_product_attributes_lookup_indices()
-
-BEGIN
-
-IF (SELECT COUNT(1)
-	FROM INFORMATION_SCHEMA.STATISTICS
-	WHERE table_schema='" . $wpdb->dbname . "'
-	AND table_name='" . $this->lookup_table_name . "'
-	AND index_name='product_or_parent_id_term_id')=0
-THEN
-	ALTER TABLE " . $this->lookup_table_name . "
-	ADD INDEX product_or_parent_id_term_id (product_or_parent_id, term_id);
-END IF;
-
-IF (SELECT COUNT(1)
-	FROM INFORMATION_SCHEMA.STATISTICS
-	WHERE table_schema='" . $wpdb->dbname . "'
-	AND table_name='" . $this->lookup_table_name . "'
-	AND index_name='is_variation_attribute_term_id')=0
-THEN
-	ALTER TABLE " . $this->lookup_table_name . '
-	ADD INDEX is_variation_attribute_term_id (is_variation_attribute, term_id);
-END IF;
-
-END;
-'
-		);
-
-		$wpdb->query( 'CALL __create_wc_product_attributes_lookup_indices();' );
-		$wpdb->query( 'DROP PROCEDURE IF EXISTS __create_wc_product_attributes_lookup_indices;' );
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-	}
-
-	/**
 	 * Action scheduler callback, performs one regeneration step and then
 	 * schedules the next step if necessary.
 	 */

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -124,8 +124,6 @@ class LookupDataStore {
 	/**
 	 * Check if the lookup table exists in the database.
 	 *
-	 * TODO: Remove this method and references to it once the lookup table is created via data migration.
-	 *
 	 * @return bool
 	 */
 	public function check_lookup_table_exists() {
@@ -680,5 +678,17 @@ class LookupDataStore {
 	 */
 	public function regeneration_was_aborted(): bool {
 		return 'yes' === get_option( 'woocommerce_attribute_lookup_regeneration_aborted' );
+	}
+
+	/**
+	 * Check if the lookup table contains any entry at all.
+	 *
+	 * @return bool True if the table contains entries, false if the table is empty.
+	 */
+	public function lookup_table_has_data(): bool {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return ( (int) $wpdb->get_var( "SELECT EXISTS (SELECT 1 FROM {$this->lookup_table_name})" ) ) !== 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/31256 was implemented with the wrong assumption that database migration functions are executed during a clean install of WooCommerce, but actually these functions are run only during an upgrade from a previous WooCommerce version. As a result, the table was not created during a clean install, and the feature wasn't visible at all. This pull request fixes this.

### How to test the changes in this Pull Request:

1. Build a WooCommerce .zip file from this branch, and use it to perform a clean install on a WordPress instance.
2. Verify that the tools page shows a "Regenerate the product attributes lookup table" entry.
3. Verify that Settings - Products has an "Advanced" section that allows controlling the feature.
4. Verify that the "Use the product attributes lookup table for catalog filtering" option in the above settings section is checked.
5. Verify that the above is true too when upgrading from a previous version of WooCommerce, in two cases: the lookup table had been already created via the dedicated tool, and the lookup table didn't exist previously. If the table already existed it should still be populated with the appropriate data, without needing to trigger a regeneration.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Product attributes lookup table not being created during a clean install of WooCommerce

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
