### PR TITLE
Prevent GH mirror workflow to run in forks

### DIFF
--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -4,7 +4,7 @@ on:
     branches: ["trunk", "release/**"]
 jobs:
   build:
-    if: github.repository_owner == 'woocommerce'
+    if: github.repository == 'woocommerce/woocommerce'
     name: Build WooCommerce zip
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +24,7 @@ jobs:
           path: ${{ steps.build.outputs.zip_path }}
           retention-days: 7
   mirror:
-    if: github.repository_owner == 'woocommerce'
+    if: github.repository == 'woocommerce/woocommerce'
     name: Push to Mirror
     runs-on: ubuntu-latest
     needs: [build]

--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -1,70 +1,64 @@
 name: Mirrors
 on:
-    push:
-        branches: ['trunk', 'release/**']
+  push:
+    branches: ["trunk", "release/**"]
 jobs:
-    build:
-        name: Build WooCommerce zip
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-
-            - name: Build
-              id: build
-              uses: woocommerce/action-build@trunk
-              env:
-                  BUILD_ENV: mirrors
-
-            - name: Upload PR zip
-              uses: actions/upload-artifact@v2
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  name: woocommerce
-                  path: ${{ steps.build.outputs.zip_path }}
-                  retention-days: 7
-
-    mirror:
-        name: Push to Mirror
-        runs-on: ubuntu-latest
-        needs: [build]
-        steps:
-            - name: Create directories
-              run: |
-                  mkdir -p tmp/woocommerce-build
-                  mkdir -p monorepo
-
-            - name: Checkout monorepo
-              uses: actions/checkout@v2
-              with:
-                  path: monorepo
-
-            - name: Download WooCommerce ZIP
-              uses: actions/download-artifact@v2
-              with:
-                  name: woocommerce
-                  path: tmp/woocommerce-build
-
-            - name: Extract and replace WooCommerce zip.
-              working-directory: tmp/woocommerce-build
-              run: |
-                  mkdir -p woocommerce/woocommerce-production
-                  unzip woocommerce.zip -d woocommerce/woocommerce-production
-                  mv woocommerce/woocommerce-production/woocommerce/* woocommerce/woocommerce-production
-                  rm -rf woocommerce/woocommerce-production/woocommerce
-
-            - name: Set up mirror
-              working-directory: tmp/woocommerce-build
-              run: |
-                  touch mirrors.txt
-                  echo "woocommerce/woocommerce-production" >> mirrors.txt
-
-            - name: Push to mirror
-              uses: Automattic/action-push-to-mirrors@v1
-              with:
-                  source-directory: ${{ github.workspace }}/monorepo
-                  token: ${{ secrets.API_TOKEN_GITHUB }}
-                  username: matticbot
-                  working-directory: ${{ github.workspace }}/tmp/woocommerce-build
-              timeout-minutes: 5 # 2021-01-18: Successful runs seem to take about half a minute.
+  build:
+    if: github.repository_owner == 'woocommerce'
+    name: Build WooCommerce zip
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        id: build
+        uses: woocommerce/action-build@trunk
+        env:
+          BUILD_ENV: mirrors
+      - name: Upload PR zip
+        uses: actions/upload-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: woocommerce
+          path: ${{ steps.build.outputs.zip_path }}
+          retention-days: 7
+  mirror:
+    if: github.repository_owner == 'woocommerce'
+    name: Push to Mirror
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Create directories
+        run: |
+          mkdir -p tmp/woocommerce-build
+          mkdir -p monorepo
+      - name: Checkout monorepo
+        uses: actions/checkout@v2
+        with:
+          path: monorepo
+      - name: Download WooCommerce ZIP
+        uses: actions/download-artifact@v2
+        with:
+          name: woocommerce
+          path: tmp/woocommerce-build
+      - name: Extract and replace WooCommerce zip.
+        working-directory: tmp/woocommerce-build
+        run: |
+          mkdir -p woocommerce/woocommerce-production
+          unzip woocommerce.zip -d woocommerce/woocommerce-production
+          mv woocommerce/woocommerce-production/woocommerce/* woocommerce/woocommerce-production
+          rm -rf woocommerce/woocommerce-production/woocommerce
+      - name: Set up mirror
+        working-directory: tmp/woocommerce-build
+        run: |
+          touch mirrors.txt
+          echo "woocommerce/woocommerce-production" >> mirrors.txt
+      - name: Push to mirror
+        uses: Automattic/action-push-to-mirrors@v1
+        with:
+          source-directory: ${{ github.workspace }}/monorepo
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          username: matticbot
+          working-directory: ${{ github.workspace }}/tmp/woocommerce-build
+        timeout-minutes: 5 # 2021-01-18: Successful runs seem to take about half a minute.


### PR DESCRIPTION
Also fixed the coding standards of this file.

It uses `if: github.repository_owner == 'woocommerce'` to prevent the workflow to run in forks.

**Steps to test:**

1. Fork this repository
2. Merge this code into `trunk`
3. Try to merge more code into `trunk` and check if the ` Push to Mirror` workflow starts, it should skip and display a "This check was skipped" message.