### PR TITLE
Run k6 tests on PR after e2e and API

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -134,3 +134,67 @@ jobs:
                   USER_KEY: admin
                   USER_SECRET: password
               run: pnpx wc-api-tests test api
+
+    k6-tests-run:
+      name: Runs k6 Performance tests
+      runs-on: ubuntu-18.04
+      needs: [build]
+      steps:
+          - name: Create dirs.
+            run: |
+                mkdir -p code/woocommerce
+                mkdir -p package/woocommerce
+                mkdir -p tmp/woocommerce
+                mkdir -p node_modules
+          - name: Checkout code.
+            uses: actions/checkout@v2
+            with:
+                path: package/woocommerce
+
+          - name: Install PNPM and install dependencies
+            working-directory: package/woocommerce
+            run: |
+                npm install -g pnpm
+                pnpm install
+
+          - name: Workaround to use initialization file with prepopulated data.
+            working-directory: package/woocommerce/plugins/woocommerce/tests/e2e/docker
+            run: |
+                cp init-sample-products.sh initialize.sh
+
+          - name: Load docker images and start containers.
+            working-directory: package/woocommerce/plugins/woocommerce
+            run: pnpx wc-e2e docker:up 
+
+          - name: Move current directory to code. We will install zip file in this dir later.
+            run: mv ./package/woocommerce/plugins/woocommerce/* ./code/woocommerce
+
+          - name: Download WooCommerce ZIP.
+            uses: actions/download-artifact@v2
+            with:
+                name: woocommerce
+                path: tmp
+
+          - name: Extract and replace WooCommerce zip.
+            working-directory: tmp
+            run: |
+                unzip woocommerce.zip -d woocommerce
+                mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+
+          - name: Install dependencies again
+            working-directory: package/woocommerce
+            run: |
+                npm install -g pnpm
+                pnpm install
+
+          - name: Wait for the Docker container to be built
+            working-directory: package/woocommerce/plugins/woocommerce
+            run: pnpx wc-e2e docker:wait
+
+          - name: Install k6
+            run: |
+                curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
+      
+          - name: Run k6 tests
+            run: |
+              ./k6 run package/woocommerce/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js

--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `WC_E2E_FOLDER` for mapping plugin root to path within repo
 - Added the `resolveSingleE2EPath()` method which builds a path to a specific E2E test
 - Added the ability to take screenshots from multiple test failures (when retried) in `utils/take-screenshot.js`.
+- `docker:wait` to allow for waiting for env to be built without running tests
 
 ## Changed
 

--- a/packages/js/e2e-environment/bin/wc-e2e.sh
+++ b/packages/js/e2e-environment/bin/wc-e2e.sh
@@ -9,6 +9,7 @@ usage() {
 	echo 'scripts:'
 	echo '         docker:up [initialization-script] - boot docker container'
 	echo '         docker:down - shut down docker container'
+	echo '         docker:wait - wait for env to be built'
 	echo '         docker:ssh - open SSH shell into docker container'
 	echo '         docker:clear-all - remove all docker containers'
 	echo '         test:e2e [test-script] - run e2e test suite or specific test-script'
@@ -49,6 +50,9 @@ fi
 case $1 in
 	'docker:up')
 		./bin/docker-compose.sh up $2
+		;;
+	'docker:wait')
+		./bin/wait-for-build.sh
 		;;
 	'docker:down')
 		./bin/docker-compose.sh down

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -66,6 +66,7 @@
     "build": "pnpm run clean && pnpm run compile",
     "prepare": "pnpm run build",
     "docker:up": "./bin/docker-compose.sh up",
+	"docker:wait": "bash ./bin/wait-for-build.sh",
     "docker:down": "./bin/docker-compose.sh down",
     "docker:clear-all": "docker rmi --force $(docker images -q)",
     "docker:ssh": "docker exec -it $(node utils/get-app-name.js)_wordpress-www /bin/bash",

--- a/plugins/woocommerce/tests/performance/requests/merchant/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/orders.js
@@ -55,8 +55,8 @@ export function orders() {
 		);
 		api_x_wp_nonce = findBetween(
 			response.body,
-			'wp-json\\/","nonce":"',
-			'",'
+			'wp.apiFetch.createNonceMiddleware( "',
+			'" )'
 		);
 
 		// Create request header with nonce value for use in subsequent requests.

--- a/plugins/woocommerce/tests/performance/requests/shopper/single-product.js
+++ b/plugins/woocommerce/tests/performance/requests/shopper/single-product.js
@@ -5,7 +5,7 @@ import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
 import {
 	base_url,
 	product_url,
-	product_id,
+	product_sku,
 	think_time_min,
 	think_time_max,
 } from "../../config.js";
@@ -36,8 +36,8 @@ export function singleProduct() {
 		productPageTrend.add(response.timings.duration);
 		check(response, {
 			"is status 200": (r) => r.status === 200,
-			"body contains: product ID": (response) =>
-				response.body.includes(`id="product-${product_id}`),
+			"body contains: product SKU": (response) =>
+				response.body.includes(`class="sku">${product_sku}`),
 		});
 	});
 

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -1,0 +1,130 @@
+import { homePage } from '../requests/shopper/home.js';
+import { shopPage } from '../requests/shopper/shop-page.js';
+import { searchProduct } from '../requests/shopper/search-product.js';
+import { singleProduct } from '../requests/shopper/single-product.js';
+import { cart } from '../requests/shopper/cart.js';
+import { cartRemoveItem } from '../requests/shopper/cart-remove-item.js';
+import { checkoutGuest } from '../requests/shopper/checkout-guest.js';
+import { checkoutCustomerLogin } from '../requests/shopper/checkout-customer-login.js';
+import { myAccount } from '../requests/shopper/my-account.js';
+import { categoryPage } from '../requests/shopper/category-page.js';
+import { wpLogin } from '../requests/merchant/wp-login.js';
+import { products } from '../requests/merchant/products.js';
+import { addProduct } from '../requests/merchant/add-product.js';
+import { orders } from '../requests/merchant/orders.js';
+import { ordersSearch } from '../requests/merchant/orders-search.js';
+import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
+
+export let options = {
+    scenarios: {
+        homePageSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '60s',
+            exec: 'homePageFlow',
+        },
+        shopPageSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '60s',
+            startTime: '5s',
+            exec: 'shopPageFlow',
+        },
+        searchProductSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '60s',
+            startTime: '10s',
+            exec: 'searchProductFlow',
+        },
+        singleProductSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '60s',
+            startTime: '15s',
+            exec: 'singleProductFlow',
+        },
+        myAccountSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '60s',
+            startTime: '20s',
+            exec: 'myAccountFlow',
+        },
+        cartSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '60s',
+            startTime: '25s',
+            exec: 'cartFlow',
+        },
+        checkoutGuestSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '120s',
+            startTime: '30s',
+            exec: 'checkoutGuestFlow',
+        },
+        checkoutCustomerLoginSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '120s',
+            startTime: '40s',
+            exec: 'checkoutCustomerLoginFlow',
+        },
+        allMerchantSmoke: {
+            executor: 'per-vu-iterations',
+            vus: 1,
+            iterations: 3,
+            maxDuration: '360s',
+            exec: 'allMerchantFlow',
+        },
+    },
+	thresholds: {
+		checks: [ 'rate==1' ],
+	},
+};
+
+export function homePageFlow() {
+    homePage();
+}
+export function shopPageFlow() {
+    shopPage();
+}
+export function searchProductFlow() {
+    searchProduct();
+}
+export function singleProductFlow() {
+    singleProduct();
+    categoryPage();
+}
+export function checkoutGuestFlow() {
+    cart();
+    checkoutGuest();
+}
+export function checkoutCustomerLoginFlow() {
+    cart();
+    checkoutCustomerLogin();
+}
+export function myAccountFlow() {
+    myAccount();
+}
+export function cartFlow() {
+    cartRemoveItem();
+}
+export function allMerchantFlow() {
+    wpLogin();
+    homeWCAdmin();
+    orders();
+    ordersSearch();
+    products();
+    addProduct();
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the k6 Core Performance Tests to the workflow that runs on each PR.

To enable this it also includes some additional changes 

- Added a k6 test scenario specific to this action that runs the majority of the requests for both shopper and merchant flows. It doesn't currently include any requests that need additional data prerequisites such as coupons. It uses a threshold which requires 100% of checks to pass. This can be updated in the future to also check for a performance timing threshold once we establish a baseline.
-  Added a `docker:wait` command to the e2e environment package as an alternative to `test:e2e` to enable waiting for the environment to be ready without running the e2e tests afterwards
- Updated the correlation boundaries in merchant orders request to make it more robust.
- Updated the check in shopper single product view to make it more robust


Closes 97-gh-woocommerce/woocommerce-quality



### How to test the changes in this Pull Request:

1. Verify the syntax looks okay
2. Make sure the CI passes


