### PR TITLE
Ensures the order item price is a float

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -169,7 +169,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		// Add SKU and PRICE to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
-			$data['price'] = $item->get_quantity() ? wc_format_decimal( $item->get_total() / $item->get_quantity(), $this->request['dp'] ) : 0;
+			$data['price'] = $item->get_quantity() ? ( (float) wc_format_decimal( $item->get_total() / $item->get_quantity(), $this->request['dp'] ) ) : 0;
 		}
 
 		// Add parent_name if the product is a variation.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/31593 we use
wc_format_decimal to properly round floating point prices. However,
this function returns a string whereas we previously returned a float.
Here we're casting the resulting string back to a float to avoid
breaking changes in existing apps.

### How to test the changes in this Pull Request:

1. Make a request to /wp-json/wc/v3/orders
2. Find a product in `line_items`
3. Observe the `price` is now a float instead of a string

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
