### PR TITLE
exclude test results from package publish

### DIFF
--- a/packages/js/e2e-environment/.gitignore
+++ b/packages/js/e2e-environment/.gitignore
@@ -1,2 +1,3 @@
 config/default.json
 docker/wp-cli/initialize.sh
+test-results.json


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR excludes `test-results.json` from the e2e-environment package.

### How to test the changes in this Pull Request:

1. `cd plugins/woocommerce`
2. `PNPM=$(which pnpm)`
3. `cd ../../packages/js/e2e-environment`
4. `$PNPM pack`
5. `tar -tvf woocommerce-e2e-environment-0.2.3.tgz`
6. Confirm `test-results.json` in not in the archive.
