### PR TITLE
Run @woocommerce/api tests in CI

### DIFF
--- a/.github/workflows/package-js-api.yml
+++ b/.github/workflows/package-js-api.yml
@@ -1,5 +1,4 @@
-name: woocommerce/api JS Package Tests
-description: Runs @woocommerce/api JS package tests when there are changes to the package.
+name: Tests for woocommerce/api JS package
 
 on:
   pull_request:

--- a/.github/workflows/package-js-api.yml
+++ b/.github/workflows/package-js-api.yml
@@ -5,8 +5,7 @@ on:
   pull_request:
     paths:
       - 'packages/js/api/**'
-    paths-ignore:
-      - '**.md'
+      - '!**.md'
 
 jobs:
   package_js_api:

--- a/.github/workflows/package-js-api.yml
+++ b/.github/workflows/package-js-api.yml
@@ -1,0 +1,22 @@
+name: woocommerce/api JS Package Tests
+description: Runs @woocommerce/api JS package tests when there are changes to the package.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/js/api/**'
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  package_js_api:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Install PNPM and install dependencies
+        run: npm install -g pnpm && pnpm install
+      - name: Run @woocommerce/api tests
+        run: cd packages/js/api && npm test

--- a/packages/js/api/src/index.ts
+++ b/packages/js/api/src/index.ts
@@ -1,3 +1,4 @@
+// Trigger CI 2
 export { HTTPClientFactory } from './http';
 export * from './models';
 export * from './services';

--- a/packages/js/api/src/index.ts
+++ b/packages/js/api/src/index.ts
@@ -1,3 +1,4 @@
+// Trigger CI
 export { HTTPClientFactory } from './http';
 export * from './models';
 export * from './services';

--- a/packages/js/api/src/index.ts
+++ b/packages/js/api/src/index.ts
@@ -1,4 +1,3 @@
-// Trigger CI
 export { HTTPClientFactory } from './http';
 export * from './models';
 export * from './services';

--- a/packages/js/api/src/index.ts
+++ b/packages/js/api/src/index.ts
@@ -1,4 +1,3 @@
-// Trigger CI 2
 export { HTTPClientFactory } from './http';
 export * from './models';
 export * from './services';


### PR DESCRIPTION
Runs @woocommerce/api tests in CI

Closes #31843

How to test:
- Merge this PR
- Watch Actions tab
- It should run @woocommerce/api tests when there are changes in the packages/js/api folder (except for md files)

I have tested it locally with [act](https://github.com/nektos/act) and I see that it executes successfully.

```
➜  woocommerce git:(trunk) ✗ act -j package_js_api
[woocommerce/api JS Package Tests/package_js_api] 🚀  Start image=nektos/act-environments-ubuntu:18.04
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker pull image=nektos/act-environments-ubuntu:18.04 platform= username= forcePull=false
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker create image=nektos/act-environments-ubuntu:18.04 platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker run image=nektos/act-environments-ubuntu:18.04 platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root workdir=
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker cp src=/home/lucas/local/data/www/woo/woocommerce/. dst=/home/lucas/local/data/www/woo/woocommerce
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker exec cmd=[mkdir -p /home/lucas/local/data/www/woo/woocommerce] user= workdir=
[woocommerce/api JS Package Tests/package_js_api] ⭐  Run actions/checkout@v2
[woocommerce/api JS Package Tests/package_js_api]   ✅  Success - actions/checkout@v2
[woocommerce/api JS Package Tests/package_js_api] ⭐  Run actions/setup-node@v2
INFO[0001]   ☁  git clone 'https://github.com/actions/setup-node' # ref=v2 
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker cp src=/home/lucas/.cache/act/actions-setup-node@v2/ dst=/var/run/act/actions/actions-setup-node@v2/
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/actions-setup-node@v2/] user= workdir=
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-node@v2/dist/setup/index.js] user= workdir=
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::isExplicit: 
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::explicit? false
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::evaluating 0 versions
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::match not found
| Attempting to download 16...
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::No manifest cached
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::Getting manifest from actions/node-versions@main
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::check 16.14.0 satisfies 16
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::x64===x64 && darwin===linux
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::x64===x64 && linux===linux
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::matched 16.14.0
| Acquiring 16.14.0 - x64 from https://github.com/actions/node-versions/releases/download/16.14.0-1816613615/node-16.14.0-linux-x64.tar.gz
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::Downloading https://github.com/actions/node-versions/releases/download/16.14.0-1816613615/node-16.14.0-linux-x64.tar.gz
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::Destination /tmp/16e670e2-3097-4299-9f9d-65ea135972b8
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::download complete
| Extracting ...
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::Checking tar --version
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::tar (GNU tar) 1.29%0ACopyright (C) 2015 Free Software Foundation, Inc.%0ALicense GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.%0AThis is free software: you are free to change and redistribute it.%0AThere is NO WARRANTY, to the extent permitted by law.%0A%0AWritten by John Gilmore and Jay Fenlason.
| [command]/bin/tar xz --strip 1 --warning=no-unknown-keyword -C /tmp/2c018ada-bb72-425a-a8b6-e459ec90570f -f /tmp/16e670e2-3097-4299-9f9d-65ea135972b8
| Adding to the cache ...
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::Caching tool node 16.14.0 x64
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::source dir: /tmp/2c018ada-bb72-425a-a8b6-e459ec90570f
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::destination /opt/hostedtoolcache/node/16.14.0/x64
[woocommerce/api JS Package Tests/package_js_api]   💬  ::debug::finished caching tool
| Done
[woocommerce/api JS Package Tests/package_js_api]   ❓  ##[add-matcher]/run/act/actions/actions-setup-node@v2/.github/tsc.json
[woocommerce/api JS Package Tests/package_js_api]   ❓  ##[add-matcher]/run/act/actions/actions-setup-node@v2/.github/eslint-stylish.json
[woocommerce/api JS Package Tests/package_js_api]   ❓  ##[add-matcher]/run/act/actions/actions-setup-node@v2/.github/eslint-compact.json
[woocommerce/api JS Package Tests/package_js_api]   ✅  Success - actions/setup-node@v2
[woocommerce/api JS Package Tests/package_js_api] ⭐  Run Install PNPM and install dependencies
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/lucas/local/data/www/woo/woocommerce/workflow/2] user= workdir=

| added 1 package, and audited 2 packages in 740ms
| 
| 1 package is looking for funding
|   run `npm fund` for details
| 
| found 0 vulnerabilities
| Scope: all 8 workspace projects
| Lockfile is up-to-date, resolution step is skipped
| Progress: resolved 1, reused 0, downloaded 0, added 0
| Packages: +2349
| 
| Packages are hard linked from the content-addressable store to the virtual store.
|   Content-addressable store is at: /home/lucas/local/data/www/woo/woocommerce/.pnpm-store/v3
|   Virtual store is at:             node_modules/.pnpm
| Progress: resolved 2349, reused 0, downloaded 41, added 35
| Progress: resolved 2349, reused 0, downloaded 116, added 155
| Progress: resolved 2349, reused 0, downloaded 200, added 257
| Progress: resolved 2349, reused 0, downloaded 423, added 491
| Progress: resolved 2349, reused 0, downloaded 591, added 664
| Progress: resolved 2349, reused 0, downloaded 793, added 904
| Progress: resolved 2349, reused 0, downloaded 1005, added 1121
| Progress: resolved 2349, reused 0, downloaded 1185, added 1313
| Progress: resolved 2349, reused 0, downloaded 1362, added 1491
| Progress: resolved 2349, reused 0, downloaded 1503, added 1632
| Progress: resolved 2349, reused 0, downloaded 1665, added 1803
| Progress: resolved 2349, reused 0, downloaded 1921, added 2057
| Progress: resolved 2349, reused 0, downloaded 2107, added 2254
| Progress: resolved 2349, reused 0, downloaded 2199, added 2349, done
| .../node_modules/core-js-pure postinstall$ node -e "try{require('./postinstall')}catch(e){}"
| .../core-js@2.6.12/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
| .../core-js@3.19.1/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
| .../node_modules/core-js-pure postinstall: Done
| .../deasync@0.1.21/node_modules/deasync install$ node ./build.js
| .../core-js@2.6.12/node_modules/core-js postinstall: Done
| .../node_modules/@parcel/watcher install$ node-gyp-build
| .../core-js@3.19.1/node_modules/core-js postinstall: Done
| .../.pnpm/husky@4.3.0/node_modules/husky install$ node husky install
| .../node-pty@0.9.0/node_modules/node-pty install$ node scripts/install.js
| .../node_modules/puppeteer-core install$ node install.js
| .../.pnpm/husky@4.3.0/node_modules/husky install: husky > Setting up git hooks
| .../node_modules/@parcel/watcher install: Done
| .../deasync@0.1.21/node_modules/deasync install: gyp info it worked if it ends with ok
| .../deasync@0.1.21/node_modules/deasync install: gyp info using node-gyp@8.4.1
| .../deasync@0.1.21/node_modules/deasync install: gyp info using node@16.14.0 | linux | x64
| .../node_modules/puppeteer install$ node install.js
| .../node_modules/puppeteer-core install: Done
| .../.pnpm/husky@4.3.0/node_modules/husky install: CI detected, skipping Git hooks installation.
| .../.pnpm/husky@4.3.0/node_modules/husky install: husky > Done
| .../.pnpm/husky@4.3.0/node_modules/husky install: Done
| .../.pnpm/husky@4.3.0/node_modules/husky postinstall$ opencollective-postinstall || exit 0
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info it worked if it ends with ok
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info using node-gyp@8.4.1
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info using node@16.14.0 | linux | x64
| .../deasync@0.1.21/node_modules/deasync install: gyp info find Python using Python version 3.6.9 found at "/usr/bin/python3"
| .../.pnpm/husky@4.3.0/node_modules/husky postinstall: Done
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info find Python using Python version 3.6.9 found at "/usr/bin/python3"
| .../deasync@0.1.21/node_modules/deasync install: gyp http GET https://nodejs.org/download/release/v16.14.0/node-v16.14.0-headers.tar.gz
| .../node-pty@0.9.0/node_modules/node-pty install: gyp http GET https://nodejs.org/download/release/v16.14.0/node-v16.14.0-headers.tar.gz
| .../node-pty@0.9.0/node_modules/node-pty install: gyp http 200 https://nodejs.org/download/release/v16.14.0/node-v16.14.0-headers.tar.gz
| .../deasync@0.1.21/node_modules/deasync install: gyp http 200 https://nodejs.org/download/release/v16.14.0/node-v16.14.0-headers.tar.gz
| .../node-pty@0.9.0/node_modules/node-pty install: gyp http GET https://nodejs.org/download/release/v16.14.0/SHASUMS256.txt
| .../deasync@0.1.21/node_modules/deasync install: gyp http GET https://nodejs.org/download/release/v16.14.0/SHASUMS256.txt
| .../deasync@0.1.21/node_modules/deasync install: gyp http 200 https://nodejs.org/download/release/v16.14.0/SHASUMS256.txt
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn /usr/bin/python3
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args [
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   'binding.gyp',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-f',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   'make',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-I',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/deasync@0.1.21/node_modules/deasync/build/config.gypi',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-I',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-I',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '/root/.cache/node-gyp/16.14.0/include/node/common.gypi',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dlibrary=shared_library',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dvisibility=default',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/16.14.0',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/16.14.0/<(target_arch)/node.lib',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dmodule_root_dir=/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/deasync@0.1.21/node_modules/deasync',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Dnode_engine=v8',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '--depth=.',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '--no-parallel',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '--generator-output',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   'build',
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args   '-Goutput_dir=.'
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args ]
| .../node-pty@0.9.0/node_modules/node-pty install: gyp http 200 https://nodejs.org/download/release/v16.14.0/SHASUMS256.txt
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn /usr/bin/python3
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args [
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   'binding.gyp',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-f',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   'make',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-I',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/node-pty@0.9.0/node_modules/node-pty/build/config.gypi',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-I',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-I',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '/root/.cache/node-gyp/16.14.0/include/node/common.gypi',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dlibrary=shared_library',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dvisibility=default',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/16.14.0',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/16.14.0/<(target_arch)/node.lib',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dmodule_root_dir=/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/node-pty@0.9.0/node_modules/node-pty',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Dnode_engine=v8',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '--depth=.',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '--no-parallel',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '--generator-output',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   'build',
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args   '-Goutput_dir=.'
| .../node-pty@0.9.0/node_modules/node-pty install: gyp info spawn args ]
| .../node-pty@0.9.0/node_modules/node-pty install: node:internal/modules/cjs/loader:936
| .../node-pty@0.9.0/node_modules/node-pty install:   throw err;
| .../node-pty@0.9.0/node_modules/node-pty install:   ^
| .../node-pty@0.9.0/node_modules/node-pty install: Error: Cannot find module 'nan'
| .../node-pty@0.9.0/node_modules/node-pty install: Require stack:
| .../node-pty@0.9.0/node_modules/node-pty install: - /home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/node-pty@0.9.0/node_modules/node-pty/[eval]
| .../node-pty@0.9.0/node_modules/node-pty install:     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
| .../node-pty@0.9.0/node_modules/node-pty install:     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
| .../node-pty@0.9.0/node_modules/node-pty install:     at Module.require (node:internal/modules/cjs/loader:1005:19)
| .../node-pty@0.9.0/node_modules/node-pty install:     at require (node:internal/modules/cjs/helpers:102:18)
| .../node-pty@0.9.0/node_modules/node-pty install:     at [eval]:1:1
| .../node-pty@0.9.0/node_modules/node-pty install:     at Script.runInThisContext (node:vm:129:12)
| .../node-pty@0.9.0/node_modules/node-pty install:     at Object.runInThisContext (node:vm:305:38)
| .../node-pty@0.9.0/node_modules/node-pty install:     at node:internal/process/execution:75:19
| .../node-pty@0.9.0/node_modules/node-pty install:     at [eval]-wrapper:6:22
| .../node-pty@0.9.0/node_modules/node-pty install:     at evalScript (node:internal/process/execution:74:60) {
| .../node-pty@0.9.0/node_modules/node-pty install:   code: 'MODULE_NOT_FOUND',
| .../node-pty@0.9.0/node_modules/node-pty install:   requireStack: [
| .../node-pty@0.9.0/node_modules/node-pty install:     '/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/node-pty@0.9.0/node_modules/node-pty/[eval]'
| .../node-pty@0.9.0/node_modules/node-pty install:   ]
| .../node-pty@0.9.0/node_modules/node-pty install: }
| .../node-pty@0.9.0/node_modules/node-pty install: gyp: Call to 'node -e "require('nan')"' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! configure error 
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! stack Error: `gyp` failed with exit code: 1
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! stack     at ChildProcess.onCpExit (/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp/lib/configure.js:259:16)
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! stack     at ChildProcess.emit (node:events:520:28)
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:291:12)
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! System Linux 5.16.7-1-MANJARO
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! command "/opt/hostedtoolcache/node/16.14.0/x64/bin/node" "/opt/hostedtoolcache/node/16.14.0/x64/lib/node_modules/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! cwd /home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/node-pty@0.9.0/node_modules/node-pty
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! node -v v16.14.0
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! node-gyp -v v8.4.1
| .../node-pty@0.9.0/node_modules/node-pty install: gyp ERR! not ok 
| .../node-pty@0.9.0/node_modules/node-pty install: Failed
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn make
| .../deasync@0.1.21/node_modules/deasync install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
| .../deasync@0.1.21/node_modules/deasync install: make: Entering directory '/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/deasync@0.1.21/node_modules/deasync/build'
| .../deasync@0.1.21/node_modules/deasync install:   CXX(target) Release/obj.target/deasync/src/deasync.o
| .../deasync@0.1.21/node_modules/deasync install:   SOLINK_MODULE(target) Release/obj.target/deasync.node
| .../deasync@0.1.21/node_modules/deasync install:   COPY Release/deasync.node
| .../deasync@0.1.21/node_modules/deasync install: make: Leaving directory '/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/deasync@0.1.21/node_modules/deasync/build'
| .../deasync@0.1.21/node_modules/deasync install: gyp info ok 
| .../deasync@0.1.21/node_modules/deasync install: Installed in `/home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/deasync@0.1.21/node_modules/deasync/bin/linux-x64-node-16/deasync.node`
| .../deasync@0.1.21/node_modules/deasync install: Done
| .../node_modules/puppeteer install: Chromium downloaded to /home/lucas/local/data/www/woo/woocommerce/node_modules/.pnpm/puppeteer@2.1.1/node_modules/puppeteer/.local-chromium/linux-722234
| .../node_modules/puppeteer install: Done
| .../@automattic/puppeteer-utils postinstall$ npm run build
| .../@automattic/puppeteer-utils postinstall: > @automattic/puppeteer-utils@0.0.1 build
| .../@automattic/puppeteer-utils postinstall: > babel --presets=@babel/preset-env src -d lib
| .../@automattic/puppeteer-utils postinstall: Successfully compiled 10 files with Babel (585ms).
| .../@automattic/puppeteer-utils postinstall: Done
| 
| dependencies:
| + @babel/core 7.12.9
| + @wordpress/babel-plugin-import-jsx-pragma 3.1.0
| + @wordpress/babel-preset-default 6.4.1
| + lodash 4.17.21
| + wp-textdomain 1.0.1
| 
| devDependencies:
| + @automattic/nx-composer 0.1.0
| + @nrwl/cli 13.3.5
| + @nrwl/devkit 13.3.5
| + @nrwl/linter 13.3.5
| + @nrwl/tao 13.3.4
| + @nrwl/web 13.3.5
| + @nrwl/workspace 13.3.5
| + @types/node 14.14.33
| + @woocommerce/eslint-plugin 1.3.0
| + @wordpress/prettier-config 1.1.1
| + chalk 4.1.2
| + glob 7.2.0
| + jest 27.3.1
| + mkdirp 1.0.4
| + node-stream-zip 1.15.0
| + prettier <- wp-prettier 2.2.1-beta-1
| + request 2.88.2
| + typescript 4.2.4
| 
| packages/js/api prepare$ pnpm run build
| packages/js/e2e-core-tests prepare$ pnpm run build
| packages/js/e2e-utils prepare$ pnpm run build
|  WARN  "prepare" script of "@woocommerce/api@0.2.0" inside "/home/lucas/local/data/www/woo/woocommerce/packages/js/api" is skipped as the working directory seems suspicious. To run this lifecycle script anyway, use "--unsafe-perm".
|  WARN  "prepare" script of "@woocommerce/e2e-core-tests@0.1.6" inside "/home/lucas/local/data/www/woo/woocommerce/packages/js/e2e-core-tests" is skipped as the working directory seems suspicious. To run this lifecycle script anyway, use "--unsafe-perm".
|  WARN  "prepare" script of "@woocommerce/e2e-utils@0.1.6" inside "/home/lucas/local/data/www/woo/woocommerce/packages/js/e2e-utils" is skipped as the working directory seems suspicious. To run this lifecycle script anyway, use "--unsafe-perm".
| packages/js/e2e-environment prepare$ pnpm run build
|  WARN  "prepare" script of "@woocommerce/e2e-environment@0.2.3" inside "/home/lucas/local/data/www/woo/woocommerce/packages/js/e2e-environment" is skipped as the working directory seems suspicious. To run this lifecycle script anyway, use "--unsafe-perm".
[woocommerce/api JS Package Tests/package_js_api]   ✅  Success - Install PNPM and install dependencies
[woocommerce/api JS Package Tests/package_js_api] ⭐  Run Run @woocommerce/api tests
[woocommerce/api JS Package Tests/package_js_api]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /home/lucas/local/data/www/woo/woocommerce/workflow/3] user= workdir=
| 
| > @woocommerce/api@0.2.0 test
| > jest
| 
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[config] (WARN) Unable to find the root of the project where ts-jest has been installed.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
| ts-jest[versions] (WARN) Version 4.4.4 of typescript installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=3.4.0 <4.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
|  PASS  src/http/axios/__tests__/axios-oauth-interceptor.spec.ts
|   AxiosOAuthInterceptor
|     ✓ should use basic auth for HTTPS (10ms)
|     ✓ should use OAuth 1.0a for HTTP (4ms)
|     ✓ should work with base URL (1ms)
| 
|  PASS  src/http/axios/__tests__/axios-response-interceptor.spec.ts
|   AxiosResponseInterceptor
|     ✓ should transform responses into an HTTPResponse (12ms)
|     ✓ should transform error responses into an HTTPResponse (2ms)
|     ✓ should bubble non-response errors (2ms)
| 
|  PASS  src/http/axios/__tests__/axios-client.spec.ts
|   AxiosClient
|     ✓ should transform to HTTPResponse (8ms)
|     ✓ should start extra interceptors (1ms)
| 
|  PASS  src/services/__tests__/setting-service.spec.ts
|   SettingService
|     ✓ should update address (10ms)
| 
|  PASS  src/framework/transformations/__tests__/add-property-transformation.spec.ts
|   AddPropertyTransformation
|     ✓ should add property when missing (4ms)
|     ✓ should not add property when present
| 
|  PASS  src/http/axios/__tests__/utils.spec.ts
|   buildURL
|     ✓ should use base when given no url (3ms)
|     ✓ should use url when given absolute (1ms)
|     ✓ should combine base and url (3ms)
|   buildURLWithParams
|     ✓ should do nothing without query string
|     ✓ should append query string (1ms)
| 
|  PASS  src/framework/transformations/__tests__/custom-transformation.spec.ts
|   CustomTransformation
|     ✓ should do nothing without hooks (9ms)
|     ✓ should execute hooks (2ms)
| 
|  PASS  src/http/axios/__tests__/axios-interceptor.spec.ts
|   AxiosInterceptor
|     ✓ should not break interceptor chaining for success (6ms)
|     ✓ should not break interceptor chaining for errors (1ms)
| 
|  PASS  src/framework/transformations/__tests__/property-type-transformation.spec.ts
|   PropertyTypeTransformation
|     ✓ should convert strings (3ms)
|     ✓ should convert integers (1ms)
|     ✓ should convert floats (1ms)
|     ✓ should convert booleans
|     ✓ should convert dates (1ms)
|     ✓ should use conversion callbacks (1ms)
|     ✓ should convert arrays (1ms)
|     ✓ should do nothing without property
|     ✓ should preserve null (1ms)
| 
|  PASS  src/framework/transformations/__tests__/ignore-property-transformation.spec.ts
|   IgnorePropertyTransformation
|     ✓ should remove ignored properties (4ms)
| 
|  PASS  src/framework/transformations/__tests__/key-change-transformation.spec.ts
|   KeyChangeTransformation
|     ✓ should transform to model (3ms)
|     ✓ should transform from model (1ms)
| 
|  PASS  src/http/axios/__tests__/axios-url-to-query-interceptor.spec.ts
|   AxiosURLToQueryInterceptor
|     ✓ should put path in query string (6ms)
| 
|  PASS  src/framework/transformations/__tests__/model-transformer-transformation.spec.ts (5.724s)
|   ModelTransformerTransformation
|     ✓ should execute child transformer (4ms)
|     ✓ should execute child transformer on array (2ms)
| 
|  PASS  src/repositories/rest/orders/__tests__/order-transformer.spec.ts (5.696s)
|   OrderTransformer
|     ✓ should transform an order JSON (10ms)
| 
|  PASS  src/repositories/rest/__tests__/shared.spec.ts (5.731s)
|   Shared REST Functions
|     ✓ restList (4ms)
|     ✓ restListChildren (1ms)
|     ✓ restCreate (1ms)
|     ✓ restRead (1ms)
|     ✓ restReadChildren (1ms)
|     ✓ restUpdate (1ms)
|     ✓ restUpdateChildren (1ms)
|     ✓ restDelete (1ms)
|     ✓ restDeleteChildren (1ms)
| 
|  PASS  src/framework/__tests__/model-transformer.spec.ts (5.729s)
|   ModelTransformer
|     ✓ should order transformers correctly (6ms)
|     ✓ should transform to model
|     ✓ should transform from model (1ms)
| 
|  PASS  src/framework/__tests__/model-repository.spec.ts (5.732s)
|   ModelRepository
|     ✓ should list (4ms)
|     ✓ should list child (1ms)
|     ✓ should throw error on list without callback (4ms)
|     ✓ should create (1ms)
|     ✓ should create child (1ms)
|     ✓ should throw error on create without callback
|     ✓ should read (1ms)
|     ✓ should read child
|     ✓ should throw error on read without callback (1ms)
|     ✓ should update
|     ✓ should update child (1ms)
|     ✓ should throw error on update without callback
|     ✓ should delete (1ms)
|     ✓ should delete child
|     ✓ should throw error on delete without callback
| 
Test Suites: 17 passed, 17 total
| Tests:       63 passed, 63 total
| Snapshots:   0 total
| Time:        6.116s
| Ran all test suites.
[woocommerce/api JS Package Tests/package_js_api]   ✅  Success - Run @woocommerce/api tests
```