### PR TITLE
class-wc-geolocation.php: hide blog URL from third-party providers

### DIFF
--- a/plugins/woocommerce/changelog/pcarrier-hide_url
+++ b/plugins/woocommerce/changelog/pcarrier-hide_url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove blog URL from requests to external IP lookup services.

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -113,7 +113,13 @@ class WC_Geolocation {
 
 			foreach ( $ip_lookup_services_keys as $service_name ) {
 				$service_endpoint = $ip_lookup_services[ $service_name ];
-				$response         = wp_safe_remote_get( $service_endpoint, array( 'timeout' => 2, 'user-agent' => 'WooCommerce/' . wc()->version ) );
+				$response         = wp_safe_remote_get(
+					$service_endpoint,
+					array(
+						'timeout'    => 2,
+						'user-agent' => 'WooCommerce/' . wc()->version,
+					)
+				);
 
 				if ( ! is_wp_error( $response ) && rest_is_ip_address( $response['body'] ) ) {
 					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', wc_clean( $response['body'] ), $service_name );
@@ -276,7 +282,13 @@ class WC_Geolocation {
 
 			foreach ( $geoip_services_keys as $service_name ) {
 				$service_endpoint = $geoip_services[ $service_name ];
-				$response         = wp_safe_remote_get( sprintf( $service_endpoint, $ip_address ), array( 'timeout' => 2, 'user-agent' => 'WooCommerce/' . wc()->version ) );
+				$response         = wp_safe_remote_get(
+					sprintf( $service_endpoint, $ip_address ),
+					array(
+						'timeout'    => 2,
+						'user-agent' => 'WooCommerce/' . wc()->version,
+					)
+				);
 
 				if ( ! is_wp_error( $response ) && $response['body'] ) {
 					switch ( $service_name ) {

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -113,7 +113,9 @@ class WC_Geolocation {
 
 			foreach ( $ip_lookup_services_keys as $service_name ) {
 				$service_endpoint = $ip_lookup_services[ $service_name ];
-				$response         = wp_safe_remote_get( $service_endpoint, array( 'timeout' => 2 ) );
+				$response         = wp_safe_remote_get( $service_endpoint, array( 'timeout' => 2, 'user-agent' => 'WooCommerce/' . wc()->version ) );
+
+				// 'user-agent'          => apply_filters( 'http_headers_useragent', 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ), $url ),
 
 				if ( ! is_wp_error( $response ) && rest_is_ip_address( $response['body'] ) ) {
 					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', wc_clean( $response['body'] ), $service_name );
@@ -276,7 +278,7 @@ class WC_Geolocation {
 
 			foreach ( $geoip_services_keys as $service_name ) {
 				$service_endpoint = $geoip_services[ $service_name ];
-				$response         = wp_safe_remote_get( sprintf( $service_endpoint, $ip_address ), array( 'timeout' => 2 ) );
+				$response         = wp_safe_remote_get( sprintf( $service_endpoint, $ip_address ), array( 'timeout' => 2, 'user-agent' => 'WooCommerce/' . wc()->version ) );
 
 				if ( ! is_wp_error( $response ) && $response['body'] ) {
 					switch ( $service_name ) {

--- a/plugins/woocommerce/includes/class-wc-geolocation.php
+++ b/plugins/woocommerce/includes/class-wc-geolocation.php
@@ -115,8 +115,6 @@ class WC_Geolocation {
 				$service_endpoint = $ip_lookup_services[ $service_name ];
 				$response         = wp_safe_remote_get( $service_endpoint, array( 'timeout' => 2, 'user-agent' => 'WooCommerce/' . wc()->version ) );
 
-				// 'user-agent'          => apply_filters( 'http_headers_useragent', 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ), $url ),
-
 				if ( ! is_wp_error( $response ) && rest_is_ip_address( $response['body'] ) ) {
 					$external_ip_address = apply_filters( 'woocommerce_geolocation_ip_lookup_api_response', wc_clean( $response['body'] ), $service_name );
 					break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Override the user agent in class-wc-geolocation.php to avoid disclosing blog URLs to third-parties (exposed by default), and to indicate this plugin originates the traffic (as the maintainer of ident.me, this took me a while to figure out).

### How to test the changes in this Pull Request:

1. No idea.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
