### PR TITLE
Add new filter to product archive description

### DIFF
--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1240,7 +1240,7 @@ if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 			$term = get_queried_object();
 
 			if ( $term && ! empty( $term->description ) ) {
-				echo '<div class="term-description">' . wc_format_content( wp_kses_post( $term->description ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '<div class="term-description">' . wc_format_content( wp_kses_post( apply_filters( 'woocommerce_taxonomy_archive_description_raw', $term->description, $term ) ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we wanted to set default archive description (if empty). Our only option is to replace woocommerce's woocommerce_taxonomy_archive_description(). but this is not possible if our code run after 'after_setup_theme' hook.

So I'm proposing we can add hook to filter this description.

Closes # .

### How to test the changes in this Pull Request:

1. use this code
add_action( 'woocommerce_taxonomy_archive_description_raw', function($description, $term){
return 'This will replace current description';
}, 10, 2 );
2. open product category page which doesnt have description set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
