### PR TITLE
Add composer bin-dir config to load correct executable

### DIFF
--- a/plugins/woocommerce/bin/composer/mozart/composer.json
+++ b/plugins/woocommerce/bin/composer/mozart/composer.json
@@ -5,6 +5,7 @@
   "config": {
     "platform": {
       "php": "7.3"
-    }
+    },
+	"bin-dir": "../../../vendor/bin"
   }
 }

--- a/plugins/woocommerce/bin/composer/phpcs/composer.json
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.json
@@ -5,6 +5,7 @@
   "config": {
     "platform": {
       "php": "7.0"
-    }
+    },
+	"bin-dir": "../../../vendor/bin"
   }
 }

--- a/plugins/woocommerce/bin/composer/phpunit/composer.json
+++ b/plugins/woocommerce/bin/composer/phpunit/composer.json
@@ -7,6 +7,7 @@
   "config": {
     "platform": {
       "php": "7.0"
-    }
+    },
+	"bin-dir": "../../../vendor/bin"
   }
 }

--- a/plugins/woocommerce/bin/composer/wp/composer.json
+++ b/plugins/woocommerce/bin/composer/wp/composer.json
@@ -7,6 +7,7 @@
   "config": {
     "platform": {
       "php": "7.0"
-    }
+    },
+	"bin-dir": "../../../vendor/bin"
   }
 }


### PR DESCRIPTION
As `composer-bin-plugin` has been used to migrate the dev-dependencies into its suggested target and locates all the bin executables within the original bin. But doing so some VSCode extensions like **PHP Sniffer & Beautifier** parses the composer lock file within the directory and tries to locate package name `squizlabs/php_codesniffer` and locates the correct executable files. Since all our executable resides within the main `bin` directory we have to suggest its location within split `compsoer.json`  else it will search executable within `bin/composer/phpcs/vendor/bin` which doesn't reside.

Ref: https://github.com/valeryan/vscode-phpsab/blob/4e9baf88c76551cf431d7ebe910c78f0647a29ea/src/resolvers/composer-path-resolver.ts#L154