### PR TITLE
Add new filter to product archive description

### DIFF
--- a/plugins/woocommerce/changelog/add-product-archive-description-filter
+++ b/plugins/woocommerce/changelog/add-product-archive-description-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+New filter `woocommerce_taxonomy_archive_description_raw` added to provide a further way to modify product archive descriptions.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1238,9 +1238,10 @@ if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 	function woocommerce_taxonomy_archive_description() {
 		if ( is_product_taxonomy() && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$term = get_queried_object();
+			$term_description = apply_filters( 'woocommerce_taxonomy_archive_description_raw', $term->description, $term );
 
-			if ( $term && ! empty( $term->description ) ) {
-				echo '<div class="term-description">' . wc_format_content( wp_kses_post( $term->description ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			if ( $term && ! empty( $term_description) ) {
+				echo '<div class="term-description">' . wc_format_content( wp_kses_post( $term_description ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1239,17 +1239,22 @@ if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 		if ( is_product_taxonomy() && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$term = get_queried_object();
 			
-			/**
-			 * Filters the archive's raw description on taxonomy archives.
-			 *
-			 * @param string $term_description
-			 * @param string $term
-			 */
-			$term_description = apply_filters( 'woocommerce_taxonomy_archive_description_raw', $term->description, $term );
-
-			if ( $term && ! empty( $term_description) ) {
-				echo '<div class="term-description">' . wc_format_content( wp_kses_post( $term_description ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			if( $term ){
+				
+				/**
+				 * Filters the archive's raw description on taxonomy archives.
+				 *
+				 * @param string $term_description
+				 * @param WP_Term $term
+				 */
+				$term_description = apply_filters( 'woocommerce_taxonomy_archive_description_raw', $term->description, $term );
+				
+				if ( ! empty( $term_description) ) {
+					echo '<div class="term-description">' . wc_format_content( wp_kses_post( $term_description ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				}
+				
 			}
+			
 		}
 	}
 }

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1231,33 +1231,32 @@ if ( ! function_exists( 'woocommerce_template_loop_category_link_close' ) ) {
 }
 
 if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
-
 	/**
 	 * Show an archive description on taxonomy archives.
 	 */
 	function woocommerce_taxonomy_archive_description() {
 		if ( is_product_taxonomy() && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$term = get_queried_object();
-			
-			if( $term ){
-				
+
+			if ( $term ) {
 				/**
 				 * Filters the archive's raw description on taxonomy archives.
 				 *
-				 * @param string $term_description
-				 * @param WP_Term $term
+				 * @since 6.7.0
+				 *
+				 * @param string  $term_description Raw description text.
+				 * @param WP_Term $term             Term object for this taxonomy archive.
 				 */
 				$term_description = apply_filters( 'woocommerce_taxonomy_archive_description_raw', $term->description, $term );
-				
-				if ( ! empty( $term_description) ) {
+
+				if ( ! empty( $term_description ) ) {
 					echo '<div class="term-description">' . wc_format_content( wp_kses_post( $term_description ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				}
-				
 			}
-			
 		}
 	}
 }
+
 if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 
 	/**

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1238,6 +1238,13 @@ if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 	function woocommerce_taxonomy_archive_description() {
 		if ( is_product_taxonomy() && 0 === absint( get_query_var( 'paged' ) ) ) {
 			$term = get_queried_object();
+			
+			/**
+			 * Filters the archive's raw description on taxonomy archives.
+			 *
+			 * @param string $term_description
+			 * @param string $term
+			 */
 			$term_description = apply_filters( 'woocommerce_taxonomy_archive_description_raw', $term->description, $term );
 
 			if ( $term && ! empty( $term_description) ) {


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we wanted to set default archive description (if empty). Our only option is to replace woocommerce's woocommerce_taxonomy_archive_description() function. but this is not possible if our code run after 'after_setup_theme' hook. also changing woocommerce core function is not a good idea, maybe this function will updated in the future for security fixes but we still use the old function.

So I'm proposing we can add hook to filter this description.

### How to test the changes in this Pull Request:

1. use this code:
```
    add_action( 'woocommerce_taxonomy_archive_description_raw', function($description, $term){
    return 'This will replace current description';
    }, 10, 2 );
```
2. open product category page to see the result.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added new filter for product archive description

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
