### PR TITLE
Bump woocommerce-admin version to 3.2.1

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.2.0",
+		"woocommerce/woocommerce-admin": "3.2.1",
 		"woocommerce/woocommerce-blocks": "6.9.0"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d49f5ebd31570346366bcd20792cc712",
+    "content-hash": "95b6d7da4314500d65c7f840bf173dde",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "e406f6673d69305382903cedde17b9db7f36355c"
+                "reference": "5988146485fb915236dae0f46120f5c8d26256c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/e406f6673d69305382903cedde17b9db7f36355c",
-                "reference": "e406f6673d69305382903cedde17b9db7f36355c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5988146485fb915236dae0f46120f5c8d26256c8",
+                "reference": "5988146485fb915236dae0f46120f5c8d26256c8",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +608,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.2.0"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.2.1"
             },
-            "time": "2022-02-22T17:56:31+00:00"
+            "time": "2022-02-24T02:22:41+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2926,5 +2926,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.2.1

## Bug Fix Tests 

### Make $customer_id public again #8371

1. Download and install [WooCommerce Square](https://woocommerce.com/document/woocommerce-square/) plugin
2. Go to Plugins > WooCommerce Square > Configure
3. Enable sandbox mode and setup sandbox account with Square
4. Go to WooCommerce > Settings > Payments and enable Square payments
5. Create a test product
6. Attempt to purchase the product via customer facing UI using WooCommerce Square payments. You can use the [test credit cards here](https://developer.squareup.com/docs/devtools/sandbox/payments#card-present-success-state-values)
7. Make sure purchase is successful

## Changelog

```
== 3.2.1 02/22/2022 == 

- Fix: Fix backwards compatibility with SkyVerge payment gateway. #8371
```