### PR TITLE
Fix: `shopper.emptyCart()` issue.

### DIFF
--- a/packages/js/e2e-utils/src/flows/shopper.js
+++ b/packages/js/e2e-utils/src/flows/shopper.js
@@ -150,12 +150,8 @@ const shopper = {
 		if ( ( await page.$( '.remove' ) ) !== null ) {
 			let products = await page.$$( '.remove' );
 			while ( products && products.length > 0 ) {
-				products.forEach( async ( product ) => {
-					await page.evaluate( ( el ) => {
-						return el.click();
-					}, product );
-					await uiUnblocked();
-				} );
+				await page.click( '.remove' );
+				await uiUnblocked();
 				products = await page.$$( '.remove' );
 			}
 		}

--- a/packages/js/e2e-utils/src/flows/shopper.js
+++ b/packages/js/e2e-utils/src/flows/shopper.js
@@ -147,25 +147,30 @@ const shopper = {
 		} );
 
 		// Remove products if they exist
-		if ( await page.$( '.remove' ) !== null ) {
-			products = await page.$( '.remove' );
+		if ( ( await page.$( '.remove' ) ) !== null ) {
+			let products = await page.$$( '.remove' );
 			while ( products && products.length > 0 ) {
-				for (let p = 0; p < products.length; p++ ) {
-					await page.click( p );
+				products.forEach( async ( product ) => {
+					await page.evaluate( ( el ) => {
+						return el.click();
+					}, product );
 					await uiUnblocked();
-				}
-				products = await page.$( '.remove' );
+				} );
+				products = await page.$$( '.remove' );
 			}
 		}
 
 		// Remove coupons if they exist
-		if ( await page.$( '.woocommerce-remove-coupon' ) !== null ) {
+		if ( ( await page.$( '.woocommerce-remove-coupon' ) ) !== null ) {
 			await page.click( '.woocommerce-remove-coupon' );
 			await uiUnblocked();
 		}
 
-		await page.waitForSelector('.woocommerce-info');
-		await expect( page ).toMatchElement( '.woocommerce-info', { text: 'Your cart is currently empty.' } );
+		await page.waitForSelector( '.woocommerce-info' );
+		// eslint-disable-next-line jest/no-standalone-expect
+		await expect( page ).toMatchElement( '.woocommerce-info', {
+			text: 'Your cart is currently empty.',
+		} );
 	},
 
 	setCartQuantity: async ( productTitle, quantityValue ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31967.

### How to test the changes in this Pull Request:

1. Creat a test E2E test case.
2. Add a product to the cart.
3. Try shopper.emptyCart() after adding product to cart.
4. Run the test in the interactive mode.
5. See the products in the cart that are removed successfully.

Or check the GH Actions where I override the `emptyCart()` with the changes introduced in this PR:
- [The override helper](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5923/files#diff-ca4a8416e3651adb2e4de52a40d6ce7bdae89544db7f77fd09d9455e26c7a159R68-R94).
- [The test](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5923/files#diff-9dc97725b56d59c26af45911780454fe4f353b19fea38adb42e35045cbe2c4ebR99-R127) that uses `emptyCart()`.
- The GH Actions [log](https://github.com/woocommerce/woocommerce-gutenberg-products-block/runs/5315078430?check_suite_focus=true).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: shopper.emptyCart() issue.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
