### PR TITLE
Add code comments clarifying database updates on new WooCommerce installs

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -21,6 +21,13 @@ class WC_Install {
 	/**
 	 * DB updates and callbacks that need to be run per version.
 	 *
+	 * Please note that these functions are invoked when WooCommerce is updated from a previous version,
+	 * but NOT when WooCommerce is newly installed.
+	 *
+	 * Database schema changes must be incorporated to the SQL returned by get_schema, which is applied
+	 * via dbDelta at both install and update time. If any other kind of database change is required
+	 * at install time (e.g. populating tables), use the 'woocommerce_installed' hook.
+	 *
 	 * @var array
 	 */
 	private static $db_updates = array(

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2,7 +2,15 @@
 /**
  * WooCommerce Updates
  *
- * Functions for updating data, used by the background updater.
+ * Functions for updating data, used by the background updater. These functions must be included
+ * in the list returned by WC_Install::get_db_update_callbacks.
+ *
+ * Please note that these functions are invoked when WooCommerce is updated from a previous version,
+ * but NOT when WooCommerce is newly installed.
+ *
+ * Database schema changes must be incorporated to the SQL returned by WC_Install::get_schema, which is applied
+ * via dbDelta at both install and update time. If any other kind of database change is required
+ * at install time (e.g. populating tables), use the 'woocommerce_installed' hook.
  *
  * @package WooCommerce\Functions
  * @version 3.3.0


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The update functions in `wc-update-functions.php` run when WooCommerce is updated from a previous version, but not when it's newly installed. This commit adds a couple of code comments explaining that to prevent issues like the one fixed by https://github.com/woocommerce/woocommerce/pull/31911 from happening again.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
