### PR TITLE
Fixed - woocommerce_order_tracking shortcode causes fatal error if a refund ID is entered #31760 Fixed/#31760

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -31,8 +31,6 @@ defined( 'ABSPATH' ) || exit;
 				'description' => __( 'This text will be shown on the button linking to the external product.', 'woocommerce' ),
 			)
 		);
-		
-		do_action( 'woocommerce_product_options_external' );
 		?>
 	</div>
 

--- a/includes/shortcodes/class-wc-shortcode-order-tracking.php
+++ b/includes/shortcodes/class-wc-shortcode-order-tracking.php
@@ -51,7 +51,7 @@ class WC_Shortcode_Order_Tracking {
 			} else {
 				$order = wc_get_order( apply_filters( 'woocommerce_shortcode_order_tracking_order_id', $order_id ) );
 
-				if ( $order && $order->get_id() && strtolower( $order->get_billing_email() ) === strtolower( $order_email ) ) {
+				if ( $order && $order->get_id() && 'shop_order_refund' !== $order->get_type() && strtolower( $order->get_billing_email() ) === strtolower( $order_email ) ) {
 					do_action( 'woocommerce_track_order', $order->get_id() );
 					wc_get_template(
 						'order/tracking.php',


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31760

I have added a solution that will fix this issue. Added another condition where it will check the type of the order and if the order type is `shop_order_refund` then it will show the error message.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
