### PR TITLE
Verify feature-disabling filters before loading the packages

### DIFF
--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -64,18 +64,18 @@ class Packages {
 		foreach ( self::$packages as $package_name => $package_class ) {
 			$filter_name = str_replace('-', '_', $package_name) . "_disabled";
  
-                        /**
-                         * Filter to control what optional WooCommerce features are disabled.
-                         * This codepath being called really early, only a plugin in mu-plugins
-                         * can add the filter early enough for it to be taken into account.
-                         * The filter name is the package name with underscores instead of dashes,
-                         * with _disabled as the suffix.
-                         *
-                         * @example add_filter( 'woocommerce_admin_disabled', '__return_true', 0, 1);
-                         * @example add_filter( 'woocommerce_blocks_disabled', '__return_true', 0, 1);
-                         *
-                         * @return true if the feature is to be disabled.
-                         */
+			/**
+			 * Filter to control what optional WooCommerce features are disabled.
+			 * This codepath being called really early, only a plugin in mu-plugins
+			 * can add the filter early enough for it to be taken into account.
+			 * The filter name is the package name with underscores instead of dashes,
+			 * with _disabled as the suffix.
+			 *
+			 * @example add_filter( 'woocommerce_admin_disabled', '__return_true', 0, 1);
+			 * @example add_filter( 'woocommerce_blocks_disabled', '__return_true', 0, 1);
+			 *
+			 * @return true if the feature is to be disabled.
+			 */
 			if ( ! apply_filters( $filter_name, false ) ) {
 				if ( ! self::package_exists( $package_name ) ) {
 					self::missing_package( $package_name );

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -66,8 +66,9 @@ class Packages {
  
 			/**
 			 * Filter to control what optional WooCommerce features are disabled.
-			 * This codepath being called really early, only a plugin in mu-plugins
-			 * can add the filter early enough for it to be taken into account.
+			 * This codepath being called early, only a plugin can add the filter
+			 * early enough for it to be taken into account, not a theme's functions.php.
+			 *
 			 * The filter name is the package name with underscores instead of dashes,
 			 * with _disabled as the suffix.
 			 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:
This PR verifies the feature-disabling filters, like the preexisting 'woocommerce_admin_disabled', or 'woocommerce_blocks_disabled', before even loading the packages. 

This spares quite a lot of CPU time when these features are not used (300ms on a low-end server - Intel(R) Atom(TM) CPU  C2750  @ 2.40GHz).

Note that for those filters to be called, they have to be set via a plugin, not the theme's functions.php, as the init on this class is performed quite early.

This is another way of achieving the same result as https://github.com/woocommerce/woocommerce/pull/31970 but I think it is cleaner.

### How to test the changes in this Pull Request:

Add a wp-content/mu-plugins/0--disable-wc-features.php file, containing :
```
add_filter( 'woocommerce_admin_disabled', '__return_true', 0, 1);
add_filter( 'woocommerce_blocks_disabled', '__return_true', 0, 1);
```
Verify that the blocks aren't in the list of available blocks anymore, and the woocommerce-admin parts not visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable? - No ; I don't think it's possible to test that automatically ?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Verify feature-disabling filters before loading the corresponding packages. As this code is ran early, adding filters should be done in mu-plugins/.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
