### PR TITLE
Fix/#31990 - Guest order: Billing and shipping address not visible on order confirmation page

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -31,8 +31,6 @@ defined( 'ABSPATH' ) || exit;
 				'description' => __( 'This text will be shown on the button linking to the external product.', 'woocommerce' ),
 			)
 		);
-		
-		do_action( 'woocommerce_product_options_external' );
 		?>
 	</div>
 

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -109,6 +109,5 @@ if ( $show_downloads ) {
  */
 do_action( 'woocommerce_after_order_details', $order );
 
-if ( $show_customer_details ) {
-	wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
-}
+wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
+


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31990.
Here as we need to show the address either billing or shipping whichever is set up by admin from the WooCommerce setting for both logged in and guest users. So there is no need for the condition to check if the user is logged in. 

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
