### PR TITLE
Refactor merchant logout

### DIFF
--- a/packages/js/e2e-utils/src/flows/merchant.js
+++ b/packages/js/e2e-utils/src/flows/merchant.js
@@ -77,7 +77,8 @@ const merchant = {
 		} );
 
 		// Confirm logout using XPath, which works on all languages.
-		await expect( page ).toClick( '//a[contains(@href,\'action=logout\')]' );
+		const elements = await page.$x('//a[contains(@href,\'action=logout\')]')
+		await elements[0].click()
 
 		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 	},

--- a/packages/js/e2e-utils/src/flows/merchant.js
+++ b/packages/js/e2e-utils/src/flows/merchant.js
@@ -72,17 +72,14 @@ const merchant = {
 	},
 
 	logout: async () => {
-		// Log out link in admin bar is not visible so can't be clicked directly.
-		const logoutLinks = await page.$$eval(
-			'#wp-admin-bar-logout a',
-			( am ) => am.filter( ( e ) => e.href ).map( ( e ) => e.href )
-		);
+		await page.goto( WP_ADMIN_LOGIN + '?action=logout', {
+			waitUntil: 'networkidle0',
+		} );
 
-		if ( logoutLinks && logoutLinks[0] ) {
-			await page.goto(logoutLinks[0], {
-				waitUntil: 'networkidle0',
-			});
-		}
+		// Confirm logout using XPath, which works on all languages.
+		await expect( page ).toClick( '//a[contains(@href,\'action=logout\')]' );
+
+		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 	},
 
 	openAllOrdersView: async () => {


### PR DESCRIPTION
This PR refactors the merchant logout, to visit the logout URL instead of clicking in the admin top bar, which aims to reduce test flakiness.

Closes #32003