### PR TITLE
Allow limited HTML when rendering failure messages (CSV import).

### DIFF
--- a/plugins/woocommerce/includes/admin/importers/views/html-csv-import-done.php
+++ b/plugins/woocommerce/includes/admin/importers/views/html-csv-import-done.php
@@ -81,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						?>
 						<tr>
 							<th><code><?php echo esc_html( $error_data['row'] ); ?></code></th>
-							<td><?php echo esc_html( $error->get_error_message() ); ?></td>
+							<td><?php echo wp_kses_post( $error->get_error_message() ); ?></td>
 						</tr>
 						<?php
 					}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the product CSV importer is used, any errors (an example might be where a downloadable file has a disallowed mimetype) will be presented to the user when the task completes.

These error messages are nicely formatted with HTML, however when exposed in this particular context the level of escaping is too high, and exposes the HTML tags:

<img width="719" alt="csv-importer-exhibit-1" src="https://user-images.githubusercontent.com/3594411/156100328-e84784d6-4be1-4fd8-9a6c-da03ecf86bc1.png">

One solution would be to strip the tags completely, but the error messages would not be very clear (and any links would be useless). Much better if we allow a decent range of HTML tags to give us something like the following:

<img width="715" alt="csv-importer-exhibit-2" src="https://user-images.githubusercontent.com/3594411/156100525-f6685dee-092c-408d-8326-e72425480fea.png">

### How to test the changes in this Pull Request:

1. Go to **Products ▸ Import** and upload a file containing the CSV I shared below.
2. Once the import completes it should indicate it failed to import 1 product. Click the provided link to view the import log.
3. Without this change, you will see the escaped HTML tags. With this change, you will see the HTML properly rendered.

Sample CSV:

```csv
Type,Name,Published,"Is featured?","Visibility in catalog","Short description",Description,"Date sale price starts","Date sale price ends","Tax status","Tax class","In stock?",Stock,"Backorders allowed?","Sold individually?","Weight (lbs)","Length (in)","Width (in)","Height (in)","Allow customer reviews?","Purchase note","Sale price","Regular price",Categories,Tags,"Shipping class",Images,"Download limit","Download expiry days",Parent,"Grouped products",Upsells,Cross-sells,"External URL","Button text",Position,"Attribute 1 name","Attribute 1 value(s)","Attribute 1 visible","Attribute 1 global","Attribute 2 name","Attribute 2 value(s)","Attribute 2 visible","Attribute 2 global","Meta: _wpcom_is_markdown","Download 1 name","Download 1 URL","Download 2 name","Download 2 URL"
"simple, downloadable, virtual",Album,1,0,visible,"This is a simple, virtual product.","Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sagittis orci ac odio dictum tincidunt. Donec ut metus leo. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed luctus, dui eu sagittis sodales, nulla nibh sagittis augue, vel porttitor diam enim non metus. Vestibulum aliquam augue neque. Phasellus tincidunt odio eget ullamcorper efficitur. Cras placerat ut turpis pellentesque vulputate. Nam sed consequat tortor. Curabitur finibus sapien dolor. Ut eleifend tellus nec erat pulvinar dignissim. Nam non arcu purus. Vivamus et massa massa.",,,taxable,,1,,0,0,,,,,1,,,15,Music,,,https://woocommercecore.mystagingwebsite.com/wp-content/uploads/2017/12/album-1.jpg,1,1,,,,,,,0,,,,,,,,,1,"Single 1",https://woocommerce.lab/disallowed.zzz,"Single 2",https://woocommerce.lab/bad.zzz
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Change level of escaping used to render the CSV import error log.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
