### PR TITLE
Update docs of @woocommerce/api 

### DIFF
--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -1,6 +1,6 @@
 # WooCommerce API Client
 
-An API client for interacting with WooCommerce installations that works both on Browser and Node environments. Here are the current and planned
+An API client for interacting with WooCommerce installations that works both in the browser and in Node environments. Here are the current and planned
 features:
 
 - [x] TypeScript Definitions \*

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -8,7 +8,7 @@ features:
 - [X] Partial support to Repositories, to simplify interaction with basic data types \*
 - [x] Service classes for common activities such as changing settings
 
-_\* TypeScript Definitions and Repositories are only supported for [Products](https://woocommerce.github.io/woocommerce-rest-api-docs/#products), and partially supported for [Orders](https://woocommerce.github.io/woocommerce-rest-api-docs/#orders)._
+_\* TypeScript Definitions and Repositories are currently only supported for [Products](https://woocommerce.github.io/woocommerce-rest-api-docs/#products), and partially supported for [Orders](https://woocommerce.github.io/woocommerce-rest-api-docs/#orders)._
 
 ## Differences from @woocommerce/woocomerce-rest-api
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -8,7 +8,7 @@ features:
 - [X] Partial support to Repositories, to simplify interaction with basic data types \*
 - [x] Service classes for common activities such as changing settings
 
-\* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders.
+_\* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders._
 
 ## Diferences between this and @woocommerce/woocomerce-rest-api
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -10,7 +10,7 @@ features:
 
 _\* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders._
 
-## Diferences between this and @woocommerce/woocomerce-rest-api
+## Differences from @woocommerce/woocomerce-rest-api
 
 WooCommerce has two API clients in JavaScript for interacting with WooCommerce installation. This one, and [@woocommerce/woocomerce-rest-api](https://www.npmjs.com/package/@woocommerce/woocommerce-rest-api).
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -14,7 +14,7 @@ _\* TypeScript Definitions and Repositories are currently only supported for [Pr
 
 WooCommerce has two API clients in JavaScript for interacting with a WooCommerce installation's RESTful API. This package, and the [@woocommerce/woocomerce-rest-api](https://www.npmjs.com/package/@woocommerce/woocommerce-rest-api) package.
 
-The main difference between them is the Repositories and the TypeScript definitions for the supported endpoints. When using Axios directly, as you can do with both libraries, you query the WooCommerce API in a raw object format, following the API documentation parameters.  With Repositories, you have the parameters as properties of an object, so you have auto-complete and strict types, for instance.
+The main difference between them is the Repositories and the TypeScript definitions for the supported endpoints. When using Axios directly, as you can do with both libraries, you query the WooCommerce API in a raw object format, following the [API documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/#introduction) parameters. Comparatively, with the Repositories provided in this package, you have the parameters as properties of an object, which gives you the benefits of auto-complete and strict types, for instance.
 
 ## Usage
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -3,12 +3,12 @@
 An API client for interacting with WooCommerce installations that works both on Browser and Node environments. Here are the current and planned
 features:
 
-- [x] TypeScript Definitions*
+- [x] TypeScript Definitions \*
 - [x] Axios API Client with support for OAuth & basic auth
-- [X] Partial support to Repositories, to simplify interaction with basic data types*
-- [x] Service classes for common activities such as changing settings4
+- [X] Partial support to Repositories, to simplify interaction with basic data types \*
+- [x] Service classes for common activities such as changing settings
 
-* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders.
+\* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders.
 
 ## Diferences between this and @woocommerce/woocomerce-rest-api
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -1,12 +1,20 @@
 # WooCommerce API Client
 
-An isometric API client for interacting with WooCommerce installations. Here are the current and planned
+An API client for interacting with WooCommerce installations that works both on Browser and Node environments. Here are the current and planned
 features:
 
-- [x] TypeScript Definitions
+- [x] TypeScript Definitions*
 - [x] Axios API Client with support for OAuth & basic auth
-- [x] Repositories to simplify interaction with basic data types
-- [x] Service classes for common activities such as changing settings
+- [X] Partial support to Repositories, to simplify interaction with basic data types*
+- [x] Service classes for common activities such as changing settings4
+
+* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders.
+
+## Diferences between this and @woocommerce/woocomerce-rest-api
+
+WooCommerce has two API clients in JavaScript for interacting with WooCommerce installation. This one, and [@woocommerce/woocomerce-rest-api](https://www.npmjs.com/package/@woocommerce/woocommerce-rest-api).
+
+The main difference between them is the Repositories and the TypeScript definitions for the supported endpoints. When using Axios directly, as you can do with both libraries, you query the WooCommerce API in a raw object format, following the API documentation parameters.  With Repositories, you have the parameters as properties of an object, so you have auto-complete and strict types, for instance.
 
 ## Usage
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -8,7 +8,7 @@ features:
 - [X] Partial support to Repositories, to simplify interaction with basic data types \*
 - [x] Service classes for common activities such as changing settings
 
-_\* TypeScript Definitions and Repositories are only supported for Products, and partially supported for Orders._
+_\* TypeScript Definitions and Repositories are only supported for [Products](https://woocommerce.github.io/woocommerce-rest-api-docs/#products), and partially supported for [Orders](https://woocommerce.github.io/woocommerce-rest-api-docs/#orders)._
 
 ## Differences from @woocommerce/woocomerce-rest-api
 

--- a/packages/js/api/README.md
+++ b/packages/js/api/README.md
@@ -12,7 +12,7 @@ _\* TypeScript Definitions and Repositories are currently only supported for [Pr
 
 ## Differences from @woocommerce/woocomerce-rest-api
 
-WooCommerce has two API clients in JavaScript for interacting with WooCommerce installation. This one, and [@woocommerce/woocomerce-rest-api](https://www.npmjs.com/package/@woocommerce/woocommerce-rest-api).
+WooCommerce has two API clients in JavaScript for interacting with a WooCommerce installation's RESTful API. This package, and the [@woocommerce/woocomerce-rest-api](https://www.npmjs.com/package/@woocommerce/woocommerce-rest-api) package.
 
 The main difference between them is the Repositories and the TypeScript definitions for the supported endpoints. When using Axios directly, as you can do with both libraries, you query the WooCommerce API in a raw object format, following the API documentation parameters.  With Repositories, you have the parameters as properties of an object, so you have auto-complete and strict types, for instance.
 


### PR DESCRIPTION
- Remove word "isometric", the correct word is "isomorphic", but I've went for  "works both on Browser and Node" instead.
- Added asterisks on "TypeScript definitions and Repositories" feature list
- Added a section outlining the differences between this package and @woocommerce/woocommerce-rest-api

Closes #32005