### PR TITLE
Correct type in @return tag (to string).

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1706,7 +1706,7 @@ $product_attributes_lookup_table_creation_sql
 	 * Gets the content of the sample refunds and return policy page.
 	 *
 	 * @since 5.6.0
-	 * @return HTML The content for the page
+	 * @return string The content for the page
 	 */
 	private static function get_refunds_return_policy_page_content() {
 		return <<<EOT


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A minor thing ... just corrects the return type for the `get_refunds_return_policy_page_content()` method (we return a string, not an object of type `HTML`). At least for me, this will prevent annoying warnings in my IDE :-)

### Changelog entry

Not required.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
