### PR TITLE
Add theme tracking for block themes.

### DIFF
--- a/plugins/woocommerce/changelog/add-block-theme-tracking
+++ b/plugins/woocommerce/changelog/add-block-theme-tracking
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Add tracking for block themes and theme switches.
+Add tracking for block themes.

--- a/plugins/woocommerce/changelog/add-block-theme-tracking
+++ b/plugins/woocommerce/changelog/add-block-theme-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add tracking for block themes and theme switches.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -181,15 +181,17 @@ class WC_Tracker {
 	 * @return array
 	 */
 	public static function get_theme_info() {
-		$theme_data        = wp_get_theme();
-		$theme_child_theme = wc_bool_to_string( is_child_theme() );
-		$theme_wc_support  = wc_bool_to_string( current_theme_supports( 'woocommerce' ) );
+		$theme_data           = wp_get_theme();
+		$theme_child_theme    = wc_bool_to_string( is_child_theme() );
+		$theme_wc_support     = wc_bool_to_string( current_theme_supports( 'woocommerce' ) );
+		$theme_is_block_theme = wc_bool_to_string( wc_current_theme_is_fse_theme() );
 
 		return array(
 			'name'        => $theme_data->Name, // @phpcs:ignore
 			'version'     => $theme_data->Version, // @phpcs:ignore
 			'child_theme' => $theme_child_theme,
 			'wc_support'  => $theme_wc_support,
+			'block_theme' => $theme_is_block_theme,
 		);
 	}
 

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -161,6 +161,7 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupons-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-order-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupon-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-theme-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Extensions_Tracking',
@@ -172,6 +173,7 @@ class WC_Site_Tracking {
 			'WC_Coupons_Tracking',
 			'WC_Order_Tracking',
 			'WC_Coupon_Tracking',
+			'WC_Theme_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -50,6 +50,6 @@ class WC_Theme_Tracking {
 			'theme_domain' => $theme_object->get( 'TextDomain' ),
 		);
 
-		WC_Tracks::record_event( 'woocommerce_activated_theme', $properties );
+		WC_Tracks::record_event( 'activated_theme', $properties );
 	}
 }

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -47,7 +47,7 @@ class WC_Theme_Tracking {
 
 		$properties = array(
 			'block_theme' => $is_block_theme,
-			'theme_domain' => $theme_object->get( 'TextDomain' ),
+			'theme_name' => $theme_object->get( 'Name' ),
 		);
 
 		WC_Tracks::record_event( 'activated_theme', $properties );

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * This class adds actions to track usage of a WooCommerce Order.
+ * This class adds actions to track usage of themes on a WooCommerce store.
  */
 class WC_Theme_Tracking {
 
@@ -21,7 +21,7 @@ class WC_Theme_Tracking {
 	}
 
 	/**
-	 * Tracking the initial theme being used for the first time.
+	 * Tracks the sites current theme the first time this code is run, and will only be run once.
 	 */
 	public function track_initial_theme() {
 		$has_been_initially_tracked = get_option( 'wc_has_tracked_default_theme' );

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -16,22 +16,40 @@ class WC_Theme_Tracking {
 	 * Init tracking.
 	 */
 	public function init() {
-		add_action( 'switch_theme', array( $this, 'track_theme_activated' ) );
+		$this->track_initial_theme();
+		add_action( 'switch_theme', array( $this, 'track_active_theme' ) );
+	}
+
+	/**
+	 * Tracking the initial theme being used for the first time.
+	 */
+	public function track_initial_theme() {
+		$has_been_initially_tracked = get_option( 'has_tracked_default_theme' );
+
+		if ( $has_been_initially_tracked ) {
+			return;
+		}
+
+		$this->track_active_theme();
+		add_option( 'has_tracked_default_theme', 'true' );
 	}
 
 	/**
 	 * Send a Tracks event when a theme is activated so that we can track active block themes.
 	 */
-	public function track_theme_activated() {
-		if ( ! function_exists( 'wc_current_theme_is_fse_theme' ) ) {
-			return;
+	public function track_active_theme() {
+		$is_block_theme = false;
+		$theme_object = wp_get_theme();
+
+		if ( function_exists( 'wc_current_theme_is_fse_theme' ) ) {
+			$is_block_theme = wc_current_theme_is_fse_theme();
 		}
 
 		$properties = array(
-			'block_theme' => wc_current_theme_is_fse_theme(),
+			'block_theme' => $is_block_theme,
+			'theme_domain' => $theme_object->get( 'TextDomain' ),
 		);
 
 		WC_Tracks::record_event( 'theme_activated', $properties );
 	}
 }
-

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -46,8 +46,8 @@ class WC_Theme_Tracking {
 		}
 
 		$properties = array(
-			'block_theme' => $is_block_theme,
-			'theme_name' => $theme_object->get( 'Name' ),
+			'block_theme'   => $is_block_theme,
+			'theme_name'    => $theme_object->get( 'Name' ),
 			'theme_version' => $theme_object->get( 'Version' ),
 		);
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * WooCommerce Theme Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of a WooCommerce Order.
+ */
+class WC_Theme_Tracking {
+
+	/**
+	 * Init tracking.
+	 */
+	public function init() {
+		add_action( 'switch_theme', array( $this, 'track_theme_activated' ) );
+	}
+
+	/**
+	 * Send a Tracks event when a theme is activated so that we can track active block themes.
+	 */
+	public function track_theme_activated() {
+		if ( ! function_exists( 'wc_current_theme_is_fse_theme' ) ) {
+			return;
+		}
+
+		$properties = array(
+			'block_theme' => wc_current_theme_is_fse_theme(),
+		);
+
+		WC_Tracks::record_event( 'theme_activated', $properties );
+	}
+}
+

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -48,6 +48,7 @@ class WC_Theme_Tracking {
 		$properties = array(
 			'block_theme' => $is_block_theme,
 			'theme_name' => $theme_object->get( 'Name' ),
+			'theme_version' => $theme_object->get( 'Version' ),
 		);
 
 		WC_Tracks::record_event( 'activated_theme', $properties );

--- a/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-theme-tracking.php
@@ -17,27 +17,27 @@ class WC_Theme_Tracking {
 	 */
 	public function init() {
 		$this->track_initial_theme();
-		add_action( 'switch_theme', array( $this, 'track_active_theme' ) );
+		add_action( 'switch_theme', array( $this, 'track_activated_theme' ) );
 	}
 
 	/**
 	 * Tracking the initial theme being used for the first time.
 	 */
 	public function track_initial_theme() {
-		$has_been_initially_tracked = get_option( 'has_tracked_default_theme' );
+		$has_been_initially_tracked = get_option( 'wc_has_tracked_default_theme' );
 
 		if ( $has_been_initially_tracked ) {
 			return;
 		}
 
-		$this->track_active_theme();
-		add_option( 'has_tracked_default_theme', 'true' );
+		$this->track_activated_theme();
+		add_option( 'wc_has_tracked_default_theme', 1 );
 	}
 
 	/**
 	 * Send a Tracks event when a theme is activated so that we can track active block themes.
 	 */
-	public function track_active_theme() {
+	public function track_activated_theme() {
 		$is_block_theme = false;
 		$theme_object = wp_get_theme();
 
@@ -50,6 +50,6 @@ class WC_Theme_Tracking {
 			'theme_domain' => $theme_object->get( 'TextDomain' ),
 		);
 
-		WC_Tracks::record_event( 'theme_activated', $properties );
+		WC_Tracks::record_event( 'woocommerce_activated_theme', $properties );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add Tracks events for theme activation so that we can track if WooCommerce stores have an active block theme or not.

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5714

### How to test the changes in this Pull Request:

1. Checkout PR to your local env.
2. Go to WooCommerce > Settings > Advanced > WooCommerce.com and ensure you have tracking allowed.
3. In WP Admin go to Appearance > Themes and activate a different theme (preferably a block theme such as TwentyTwentyTwo or Tove).
4. After 5-10 minutes, go to Tracks Live and search for the event `wcadmin_activated_theme` and confirm its existence.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add event tracking so we can track block themes vs non-block themes.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
