### PR TITLE
Update wc-account-functions.php

### DIFF
--- a/plugins/woocommerce/changelog/account-page-address-translation
+++ b/plugins/woocommerce/changelog/account-page-address-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Correct the usage of 'address' and 'addresses' within `wc_get_account_menu_items()`.

--- a/plugins/woocommerce/includes/wc-account-functions.php
+++ b/plugins/woocommerce/includes/wc-account-functions.php
@@ -99,7 +99,7 @@ function wc_get_account_menu_items() {
 		'dashboard'       => __( 'Dashboard', 'woocommerce' ),
 		'orders'          => __( 'Orders', 'woocommerce' ),
 		'downloads'       => __( 'Downloads', 'woocommerce' ),
-		'edit-address'    => _n( 'Addresses', 'Address', (int) wc_shipping_enabled(), 'woocommerce' ),
+		'edit-address'    => _n( 'Address', 'Addresses', ( 1 + (int) wc_shipping_enabled() ), 'woocommerce' ),
 		'payment-methods' => __( 'Payment methods', 'woocommerce' ),
 		'edit-account'    => __( 'Account details', 'woocommerce' ),
 		'customer-logout' => __( 'Logout', 'woocommerce' ),


### PR DESCRIPTION
Correct order of single/plural translation strings to prevent confusion with translations and translators.

**Problem**
For this specific translation string, the plural variant is actually set as the single and vice-versa. This is very confusing in code, as well as for translators and in translations.

**Important**
Additionally, the translation `.pot` and translations should be correct accordingly. Some, like the Dutch translation, already use the correct single/plural order. (Which, without this pull request, shows the wrong version..)

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Look at the menu item title with Shipping enabled vs. disabled.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Corrected the single/plural order of the "Address"/"Addresses" menu title in the My Account area.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
