### PR TITLE
Add rate_limit_remaining column to wc_rate_limits table

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1068,6 +1068,7 @@ CREATE TABLE {$wpdb->prefix}wc_rate_limits (
   rate_limit_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   rate_limit_key varchar(200) NOT NULL,
   rate_limit_expiry BIGINT UNSIGNED NOT NULL,
+  rate_limit_remaining smallint(10) NOT NULL DEFAULT '0',
   PRIMARY KEY  (rate_limit_id),
   UNIQUE KEY rate_limit_key (rate_limit_key($max_index_length))
 ) $collate;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces a `rate_limit_remaining` column in the `wc_rate_limits` table. This defaults to `0` (0 requests remaining) to ensure that it does not conflict with the existing implementation of rate limits in Woo core.

This was extracted from the https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5962 PR in blocks which will hopefully use this column for more advanced rate limiting that is currently possible.

In the above use case, we can extend `WC_Rate_Limiter` and make use of this column so we can have, for example, a limit of `10` requests in a `1` minute period. This allows us to accept multiple requests within a short duration of time, while still imposing rate limits on the client.

### How to test the changes in this Pull Request:

1. Unit tests should still pass - WC_Rate_Limiter has tests
2. De-activate and re-activate WooCommerce. Look at the schema of the `wc_rate_limits` table in the database. Confirm `rate_limit_remaining` column exists, and existing values in the table have a value of `0`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Introduce `rate_limit_remaining` column in the `wc_rate_limits` table.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
