### PR TITLE
Enable searching for products by SKU

### DIFF
--- a/plugins/woocommerce/changelog/api-28508-search-including-sku
+++ b/plugins/woocommerce/changelog/api-28508-search-including-sku
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds  a `search_sku` parameter to the v3 products endpoint. Allows for partial match search of the product SKU field.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -279,11 +279,6 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	/**
 	 * Add a where clause for matching the SKU field.
 	 *
-	 * If the content search and the sku search have the same value, the extra clause we're adding here should be nested
-	 * with the other content fields that get covered (e.g. post_title, post_excerpt, post_content) and the operator
-	 * should be 'OR'. If the content and sku searches are different, then both should need to match, so the clause
-	 * should just get tacked on to the rest of the WHERE statement and the operator should be 'AND'.
-	 *
 	 * @param string $where Where clause used to search posts.
 	 * @return string
 	 */

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -16,10 +16,34 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public static function wpSetUpBeforeClass() {
-		self::$products[] = WC_Helper_Product::create_simple_product( true, array( 'name' => 'Pancake', 'sku' => 'pancake-1' ) );
-		self::$products[] = WC_Helper_Product::create_simple_product( true, array( 'name' => 'Waffle 1', 'sku' => 'pancake-2' ) );
-		self::$products[] = WC_Helper_Product::create_simple_product( true, array( 'name' => 'French Toast', 'sku' => 'waffle-2' ) );
-		self::$products[] = WC_Helper_Product::create_simple_product( true, array( 'name' => 'Waffle 3', 'sku' => 'waffle-3' ) );
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Pancake',
+				'sku'  => 'pancake-1',
+			)
+		);
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Waffle 1',
+				'sku'  => 'pancake-2',
+			)
+		);
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'French Toast',
+				'sku'  => 'waffle-2',
+			)
+		);
+		self::$products[] = WC_Helper_Product::create_simple_product(
+			true,
+			array(
+				'name' => 'Waffle 3',
+				'sku'  => 'waffle-3',
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28508

#### Why we cannot use `sku` parameter

Searching products by SKU has been requested in Woo mobile apps in the past (ref p7bje6-2GK-p2), and I'm giving it a try to implement this for 2022 Q1 HACK Week. Currenctly, we have a `sku` parameter, but it has some issues for the use case in mobile:

- Only products with full SKU match are returned. This is used for validating SKU in the product inventory settings in mobile, and we most likley want to keep this behavior
- `search` and `sku` conditions are joined by `AND`, thus only products with the query in both product name/content/excerpt AND sku are returned
- If we make separate requests to `/wc/v3/products?search=woo` and `/wc/v3/products?sku=woo`, the total results might not match the requested page size and requires some custom handling to support pagination

#### Proposed solution

This PR attempted to support SKU search by introducing a new parameter `search_includes_sku: bool`. When `search_includes_sku` parameter is `true`, `wc_product_meta_lookup` table is joined and a `WHERE` condition is added to also (`OR`) find products with partial SKU match in the lookup table.

It seems like in core (Products tab), partial SKU match is already included in each search query (`s`):

https://github.com/woocommerce/woocommerce/blob/aa8b7a4a6b7d21ccddaac360766c4daa396b9a98/plugins%2Fwoocommerce%2Fincludes%2Fdata-stores%2Fclass-wc-product-data-store-cpt.php#L1651

We could also include the SKU search in the existing `search` parameter, but I thought it's safer to not affect pre-existing search usage given the performance impact.

### How to test the changes in this Pull Request:

Prerequisites: the test site has at least one product with a non-empty SKU (e.g. `woo-tshirt`) that isn't also in the product name of the same product

1. Run `{{site_url}}/wp-json/wc/v3/products?search={{sku_substring}}` (e.g. `search=Woo`) --> the product in the prequisite should not be returned, only products with matched name or other core product attributes are returned
2. Run the request in the previous step with `search_includes_sku=true` --> the product in the prequisite should be returned, along with other products returned in the previous step
3. Feel free to try other SKU substrings and letter casing in the search query (e.g. `tshirt`, `Tshirt`, `Woo-tshirt`)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.