### PR TITLE
Fix issue #31477

### DIFF
--- a/plugins/woocommerce/changelog/31477-remove-coupon-js
+++ b/plugins/woocommerce/changelog/31477-remove-coupon-js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure observers of the `removed_coupon_in_checkout` event can access the coupon code successfully.

--- a/plugins/woocommerce/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/legacy/js/frontend/checkout.js
@@ -668,7 +668,7 @@ jQuery( function( $ ) {
 					if ( code ) {
 						$( 'form.woocommerce-checkout' ).before( code );
 
-						$( document.body ).trigger( 'removed_coupon_in_checkout', [ data.coupon_code ] );
+						$( document.body ).trigger( 'removed_coupon_in_checkout', [ data.coupon ] );
 						$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
 
 						// Remove coupon code from coupon field

--- a/plugins/woocommerce/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/legacy/js/frontend/checkout.js
@@ -653,8 +653,8 @@ jQuery( function( $ ) {
 			});
 
 			var data = {
-				security:		wc_checkout_params.remove_coupon_nonce,
-				coupon_code:	coupon
+				security: wc_checkout_params.remove_coupon_nonce,
+				coupon:   coupon
 			};
 
 			$.ajax({

--- a/plugins/woocommerce/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/legacy/js/frontend/checkout.js
@@ -653,8 +653,8 @@ jQuery( function( $ ) {
 			});
 
 			var data = {
-				security: wc_checkout_params.remove_coupon_nonce,
-				coupon:   coupon
+				security:		wc_checkout_params.remove_coupon_nonce,
+				coupon_code:	coupon
 			};
 
 			$.ajax({


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/31477

### How to test the changes in this Pull Request:

See https://github.com/woocommerce/woocommerce/issues/31477

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Guard against undefined `data.coupon_code` error in `frontend/checkout.js`.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
