### PR TITLE
Include missing data in Tracks events, add event prefix filter.

### DIFF
--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -72,7 +72,7 @@ class WC_Site_Tracking {
 					return;
 				}
 
-				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
+				var eventName = '<?php echo esc_attr( WC_Tracks::get_event_prefix() ); ?>' + name;
 				var eventProperties = properties || {};
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -16,6 +16,15 @@ class WC_Tracks {
 	const PREFIX = 'wcadmin_';
 
 	/**
+	 * Get event name prefix.
+	 *
+	 * @return string Filtered event prefix.
+	 */
+	public static function get_event_prefix() {
+		return apply_filters( 'woocommerce_tracks_event_prefix', self::PREFIX );
+	}
+
+	/**
 	 * Get total product counts.
 	 *
 	 * @return int Number of products.
@@ -88,7 +97,7 @@ class WC_Tracks {
 		if ( $user instanceof WP_User && 'wptests_capabilities' === $user->cap_key ) {
 			return false;
 		}
-		$prefixed_event_name = self::PREFIX . $event_name;
+		$prefixed_event_name = self::get_event_prefix() . $event_name;
 
 		$data = array(
 			'_en' => $prefixed_event_name,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is in support of some upcoming work for Woo.

There is a need to change the Tracks event prefix for our events, so a new `woocommerce_tracks_event_prefix` filter was added.

Additionally, there is a data discrepancy between Tracks events fired using the PHP `WC_Tracks::record_event()` and JS `window.wcTracks.recordEvent()` - namely the JS version only includes part of the blog details. This PR resolves that discrepancy.

### How to test the changes in this Pull Request:

1. Verify that usage tracking is enabled on your test store
2. Add a `woocommerce_tracks_event_prefix` filter like: `add_filter( 'woocommerce_tracks_event_prefix', function() { return 'testing_'; } );`
3. Go to WooCommerce > Home
4. Use the network tab in devtools to verify the tracks event (`t.gif` requests) have the new event prefix (`_en` param) and contain blog details like `wc_version`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Tweak - fix data discrepancy in event tracking.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
