### PR TITLE
Implement queries for non-synchronized orders, and revamp COT related settings

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -273,6 +274,12 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 						break;
 
+					case 'info':
+						echo '<tr><th scope="row" class="titledesc"/><td style="' . esc_html( $value['css'] ) . '">';
+						echo wp_kses_post( wpautop( wptexturize( $value['text'] ) ) );
+						echo '</td></tr>';
+						break;
+
 					// Section Ends.
 					case 'sectionend':
 						if ( ! empty( $value['id'] ) ) {
@@ -417,6 +424,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					// Radio inputs.
 					case 'radio':
 						$option_value = $value['value'];
+						$disabled_values = ArrayUtil::get_value_or_default($value, 'disabled', array());
 
 						?>
 						<tr valign="top">
@@ -435,6 +443,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 												name="<?php echo esc_attr( $value['id'] ); ?>"
 												value="<?php echo esc_attr( $key ); ?>"
 												type="radio"
+												<?php if(in_array($key, $disabled_values)) { echo 'disabled'; } ?>
 												style="<?php echo esc_attr( $value['css'] ); ?>"
 												class="<?php echo esc_attr( $value['class'] ); ?>"
 												<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -275,7 +275,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						break;
 
 					case 'info':
-						echo '<tr><th scope="row" class="titledesc"/><td style="' . esc_html( $value['css'] ) . '">';
+						echo '<tr><th scope="row" class="titledesc"/><td style="' . esc_attr( $value['css'] ) . '">';
 						echo wp_kses_post( wpautop( wptexturize( $value['text'] ) ) );
 						echo '</td></tr>';
 						break;
@@ -443,7 +443,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 												name="<?php echo esc_attr( $value['id'] ); ?>"
 												value="<?php echo esc_attr( $key ); ?>"
 												type="radio"
-												<?php if(in_array($key, $disabled_values)) { echo 'disabled'; } ?>
+												<?php if( in_array( $key, $disabled_values ) ) { echo 'disabled'; } ?>
 												style="<?php echo esc_attr( $value['css'] ); ?>"
 												class="<?php echo esc_attr( $value['class'] ); ?>"
 												<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -322,19 +322,19 @@ class CustomOrdersTableController {
 
 			if ( $sync_is_pending ) {
 				$initial_pending_count = $sync_status['initial_pending_count'];
+				$current_pending_count = $sync_status['current_pending_count'];
 				if ( $initial_pending_count ) {
-					$text = sprintf(
-						/* translators: %1$s=current number of orders pending sync, %2$s=initial number of orders pending sync */
-						__( 'There are %1$s orders (out of a total of %2$s) pending sync!', 'woocommerce' ),
-						$sync_status['current_pending_count'],
-						$initial_pending_count
-					);
+					$text =
+						sprintf(
+							/* translators: %1$s=current number of orders pending sync, %2$s=initial number of orders pending sync */
+							_n( 'There\'s %1$s order (out of a total of %2$s) pending sync!', 'There are %1$s orders (out of a total of %2$s) pending sync!', $current_pending_count, 'woocommerce' ),
+							$current_pending_count,
+							$initial_pending_count
+						);
 				} else {
-					$text = sprintf(
-						/* translators: %1$s=current number of orders pending sync */
-						__( 'There are %1$s orders pending sync!', 'woocommerce' ),
-						$sync_status['current_pending_count']
-					);
+					$text =
+						/* translators: %s=initial number of orders pending sync */
+						sprintf( _n( 'There\'s %s order pending sync!', 'There are %s orders pending sync!', $current_pending_count, 'woocommerce' ), $current_pending_count, 'woocommerce' );
 				}
 
 				if ( $this->data_synchronizer->pending_data_sync_is_in_progress() ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -338,10 +338,10 @@ class CustomOrdersTableController {
 				}
 
 				if ( $this->data_synchronizer->pending_data_sync_is_in_progress() ) {
-					$text .= __( '<br/>Syncrhonization for these orders is currently in progress.', 'woocommerce' );
+					$text .= __( "<br/>Synchronization for these orders is currently in progress.<br/>The authoritative table can't be changed until sync completes.", 'woocommerce' );
+				} else {
+					$text .= __( "<br/>The authoritative table can't be changed until these orders are synchronized.", 'woocommerce' );
 				}
-
-				$text .= __( "<br/>The authoritative table can't be changed until sync completes.", 'woocommerce' );
 
 				$settings[] = array(
 					'type' => 'info',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -92,6 +92,38 @@ class CustomOrdersTableController {
 			999,
 			2
 		);
+
+		add_filter(
+			'updated_option',
+			function( $option, $old_value, $value ) {
+				$this->process_updated_option( $option, $old_value, $value );
+			},
+			999,
+			3
+		);
+
+		add_filter(
+			'pre_update_option',
+			function( $value, $option, $old_value ) {
+				return $this->process_pre_update_option( $option, $old_value, $value );
+			},
+			999,
+			3
+		);
+
+		add_filter(
+			DataSynchronizer::PENDING_SYNCHRONIZATION_FINISHED_ACTION,
+			function() {
+				$this->process_sync_finished();
+			}
+		);
+
+		add_action(
+			'woocommerce_update_options_advanced_custom_data_stores',
+			function() {
+				$this->process_options_updated();
+			}
+		);
 	}
 
 	/**
@@ -213,6 +245,7 @@ class CustomOrdersTableController {
 		}
 
 		$this->data_synchronizer->create_database_tables();
+		update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
 	}
 
 	/**
@@ -258,40 +291,182 @@ class CustomOrdersTableController {
 			return $settings;
 		}
 
-		$title_item = array(
-			'title' => __( 'Custom orders tables', 'woocommerce' ),
-			'type'  => 'title',
-			'desc'  => sprintf(
-				/* translators: %1$s = <strong> tag, %2$s = </strong> tag. */
-				__( '%1$sWARNING:%2$s This feature is currently under development and may cause database instability. For contributors only.', 'woocommerce' ),
-				'<strong>',
-				'</strong>'
-			),
-		);
-
 		if ( $this->data_synchronizer->check_orders_table_exists() ) {
-			$settings[] = $title_item;
+			$settings[] = array(
+				'title' => __( 'Custom orders tables', 'woocommerce' ),
+				'type'  => 'title',
+				'id'    => 'cot-title',
+				'desc'  => sprintf(
+					/* translators: %1$s = <strong> tag, %2$s = </strong> tag. */
+					__( '%1$sWARNING:%2$s This feature is currently under development and may cause database instability. For contributors only.', 'woocommerce' ),
+					'<strong>',
+					'</strong>'
+				),
+			);
+
+			$sync_status     = $this->data_synchronizer->get_sync_status();
+			$sync_is_pending = 0 !== $sync_status['current_pending_count'];
 
 			$settings[] = array(
-				'title'         => __( 'Enable tables usage', 'woocommerce' ),
-				'desc'          => __( 'Use the custom orders tables as the main orders data store.', 'woocommerce' ),
+				'title'         => __( 'Data store for orders', 'woocommerce' ),
 				'id'            => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 				'default'       => 'no',
-				'type'          => 'checkbox',
+				'type'          => 'radio',
+				'options'       => array(
+					'yes' => __( 'Use the WooCommerce orders tables', 'woocommerce' ),
+					'no'  => __( 'Use the WordPress posts table', 'woocommerce' ),
+				),
 				'checkboxgroup' => 'start',
+				'disabled'      => $sync_is_pending ? array( 'yes', 'no' ) : array(),
 			);
+
+			if ( $sync_is_pending ) {
+				$initial_pending_count = $sync_status['initial_pending_count'];
+				if ( $initial_pending_count ) {
+					$text = sprintf(
+						/* translators: %1$s=current number of orders pending sync, %2$s=initial number of orders pending sync */
+						__( 'There are %1$s orders (out of a total of %2$s) pending sync!', 'woocommerce' ),
+						$sync_status['current_pending_count'],
+						$initial_pending_count
+					);
+				} else {
+					$text = sprintf(
+						/* translators: %1$s=current number of orders pending sync */
+						__( 'There are %1$s orders pending sync!', 'woocommerce' ),
+						$sync_status['current_pending_count']
+					);
+				}
+
+				if ( $this->data_synchronizer->pending_data_sync_is_in_progress() ) {
+					$text .= __( '<br/>Syncrhonization for these orders is currently in progress.', 'woocommerce' );
+				}
+
+				$text .= __( "<br/>The authoritative table can't be changed until sync completes.", 'woocommerce' );
+
+				$settings[] = array(
+					'type' => 'info',
+					'id'   => 'cot-out-of-sync-warning',
+					'css'  => 'color: #C00000',
+					'text' => $text,
+				);
+			}
+
+			$settings[] = array(
+				'desc' => __( 'Keep the posts table and the orders tables synchronized', 'woocommerce' ),
+				'id'   => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+				'type' => 'checkbox',
+			);
+
+			if ( $sync_is_pending ) {
+				if ( $this->data_synchronizer->data_sync_is_enabled() ) {
+					$message    = $this->custom_orders_table_usage_is_enabled() ?
+						__( 'Switch to using the posts table as the authoritative data store for orders when sync finishes', 'woocommerce' ) :
+						__( 'Switch to using the orders table as the authoritative data store for orders when sync finishes', 'woocommerce' );
+					$settings[] = array(
+						'desc' => $message,
+						'id'   => DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION,
+						'type' => 'checkbox',
+					);
+				}
+			}
 		} else {
-			$title_item['desc'] = sprintf(
-				/* translators: %1$s = <em> tag, %2$s = </em> tag. */
-				__( 'Create the tables first by going to %1$sWooCommerce > Status > Tools%2$s and running %1$sCreate the custom orders tables%2$s.', 'woocommerce' ),
-				'<em>',
-				'</em>'
+			$settings[] = array(
+				'title' => __( 'Custom orders tables', 'woocommerce' ),
+				'type'  => 'title',
+				'desc'  => sprintf(
+					/* translators: %1$s = <em> tag, %2$s = </em> tag. */
+					__( 'Create the tables first by going to %1$sWooCommerce > Status > Tools%2$s and running %1$sCreate the custom orders tables%2$s.', 'woocommerce' ),
+					'<em>',
+					'</em>'
+				),
 			);
-			$settings[] = $title_item;
 		}
 
 		$settings[] = array( 'type' => 'sectionend' );
 
 		return $settings;
+	}
+
+	/**
+	 * Handler for the individual setting updated hook.
+	 *
+	 * @param string $option Setting name.
+	 * @param mixed  $old_value Old value of the setting.
+	 * @param mixed  $value New value of the setting.
+	 */
+	private function process_updated_option( $option, $old_value, $value ) {
+		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option && 'no' === $value ) {
+			$this->data_synchronizer->cleanup_synchronization_state();
+		}
+	}
+
+	/**
+	 * Handler for the setting pre-update hook.
+	 * We use it to verify that authoritative orders table switch doesn't happen while sync is pending.
+	 *
+	 * @param string $option Setting name.
+	 * @param mixed  $old_value Old value of the setting.
+	 * @param mixed  $value New value of the setting.
+	 *
+	 * @throws \Exception Attempt to change the authoritative orders table while orders sync is pending.
+	 */
+	private function process_pre_update_option( $option, $old_value, $value ) {
+		if ( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION !== $option || $value === $old_value || false === $old_value ) {
+			return $value;
+		}
+
+		$sync_is_pending = 0 !== $this->data_synchronizer->get_current_orders_pending_sync_count();
+		if ( $sync_is_pending ) {
+			throw new \Exception( "The authoritative table for orders storage can't be changed while there are orders out of sync" );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Handler for the synchronization finished hook.
+	 * Here we switch the authoritative table if needed.
+	 */
+	private function process_sync_finished() {
+		if ( $this->auto_flip_authoritative_table_enabled() ) {
+			return;
+		}
+
+		update_option( DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
+
+		if ( $this->custom_orders_table_usage_is_enabled() ) {
+			update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+		} else {
+			update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		}
+	}
+
+	/**
+	 * Is the automatic authoritative table switch setting set?
+	 *
+	 * @return bool
+	 */
+	private function auto_flip_authoritative_table_enabled(): bool {
+		return 'yes' === get_option( DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION );
+	}
+
+	/**
+	 * Handler for the all settings updated hook.
+	 */
+	private function process_options_updated() {
+		$data_sync_is_enabled = $this->data_synchronizer->data_sync_is_enabled();
+
+		// Disabling the sync implies disabling the automatic authoritative table switch too.
+		if ( ! $data_sync_is_enabled && $this->auto_flip_authoritative_table_enabled() ) {
+			update_option( DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
+		}
+
+		// Enabling the sync implies starting it too, if needed.
+		// We do this check here, and not in process_pre_update_option, so that if for some reason
+		// the setting is enabled but no sync is in process, sync will start by just saving the
+		// settings even without modifying them.
+		if ( $data_sync_is_enabled && ! $this->data_synchronizer->pending_data_sync_is_in_progress() ) {
+			$this->data_synchronizer->start_synchronizing_pending_orders();
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -283,7 +283,7 @@ WHERE orders.date_updated_gmt != posts.post_modified_gmt";
 			$this->cleanup_synchronization_state();
 
 			/**
-			 * Hook to signal that the orders tables synchronization process has finised (nothing left to synchronize).
+			 * Hook to signal that the orders tables synchronization process has finished (nothing left to synchronize).
 			 */
 			do_action( self::PENDING_SYNCHRONIZATION_FINISHED_ACTION );
 		} else {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -159,12 +159,10 @@ class DataSynchronizer {
 			$missing_orders_count_sql = "SELECT COUNT(1) FROM $orders_table WHERE post_id IS NULL";
 		} else {
 			$missing_orders_count_sql = "
-SELECT COUNT(1) FROM (
-	SELECT posts.ID,orders.post_id FROM $wpdb->posts posts
-	LEFT JOIN $orders_table orders ON posts.ID = orders.post_id
-	WHERE posts.post_type='shop_order' AND orders.post_id IS NULL
-	AND posts.post_status != 'auto-draft'
-) x";
+SELECT COUNT( posts.ID ) FROM $wpdb->posts posts
+LEFT JOIN $orders_table orders ON posts.ID = orders.post_id
+WHERE posts.post_type='shop_order' AND orders.post_id IS NULL
+AND posts.post_status != 'auto-draft'";
 		}
 
 		$sql = "


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Redesign the custom orders table settings UI and behavior according to the latest agreed specification (p7bje6-3LN-p2#comment-6886).
- Add SQL queries to get the count of orders that need to be synchronized, and their ids.

The settings page (WooCommerce > Settings > Advanced > Custom data stores) now looks like this when there aren't any orders out of sync:

![image](https://user-images.githubusercontent.com/937723/157840539-803736d8-f2fb-4b21-85e8-353374278563.png)

These settings can be freely modified.

Now, let's assume that sync is disabled and there are some orders of out of sync. The settings page will now look like this:

![image](https://user-images.githubusercontent.com/937723/157844690-5f4a8a75-1d27-4221-ba9b-c75cdde3681c.png)

Note how the authoritative table can't be changed. There's also a check in the backend to prevent that setting from being changed if there are out of sync orders (an exception will be thrown).

Setting _Keep the posts table and the orders tables synchronized_ and saving will start a synchronization process (not implemented yet), this will be done using Action Scheduler and each run will syncrhonize a batch of orders. The settings will change as follows once that happens:

![image](https://user-images.githubusercontent.com/937723/157841764-7653c463-7c30-4a84-b8a8-38f0d88bab8f.png)

Note how the warning message now says that sync is in progress, and includes the count of orders that were out of sync when the process started (this UI can be refined later by adding an actual progress bar or similar). Notice also the new _Switch to using the orders/posts table as the authoritative data store for orders when sync finishes_ option: if set, the authoritative table for storing orders will be switched (from posts to orders or viceversa) once no more out of sync orders remain.

Worth noting that the _Switch to using the orders/posts table as the authoritative data store for orders when sync finishes_ option will be automatically turned off once the table switch has happened. It will also be turned off if _Keep the posts table and the orders tables synchronized_ itself is turned off. This is to prevent accidental/unexpected table switches.

There's one case in which orders can get out of sync even when we have automatic sync turned on: when some 3rd party code does direct modifications in the posts table. Automatic sync ensures that changes in an order propagate to the backup table only when the changes is made by WooCommerce itself.

![image](https://user-images.githubusercontent.com/937723/157844855-3cd92ff2-f609-4fe0-87a1-aad26a982de5.png)

When that happens, a synchronization process can be triggered by just saving the settings with the _Keep the posts table and the orders tables synchronized_ setting on, even if it was already on (no need to turn it off, save, and turn it on again).

Closes #31769.
Closes #31770.
Closes #31771.

### How to test the changes in this Pull Request:

#### Initial setup

1. Enable the feature by adding the following code snippet somewhere, for example at the end of `woocommerce.php`:

```php
wc_get_container()
   ->get('Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController')
   ->show_feature();
```

2. If you hadn't created the orders table previously, go to _Status - Tools_ and run the  "Create and  fill custom orders table" tool.

3. You can use the following SQL commands to populate the orders table with data from the posts table and force some of them to be out of sync (adjust  the `LIMIT` clauses and the number of `(null)` entries as desired):

```sql
/* Create some synchronized entries in orders table */
INSERT INTO wp_wc_orders (post_id,date_created_gmt,date_updated_gmt)
SELECT ID,post_date_gmt,post_modified_gmt from wp_posts 
WHERE post_type='shop_order' AND post_status != 'auto-draft' LIMIT 10;

/* Create some entries in orders table that don't exist in posts table */
INSERT INTO wp_wc_orders (post_id) VALUES (null),(null),(null);

/* Make some of the entries that exist in both tables to be out of sync */
UPDATE wp_wc_orders SET date_updated_gmt=now() WHERE post_id IS NOT null LIMIT 2;
```

##### Testing settings and scheduled actions with the fake out of sync orders count

This pull request introduces a mechanism to declare a fake count of orders out of sync, intended to ease the testing of the feature while it's in development. This mechanism is an option named `woocommerce_fake_orders_pending_sync_count`. If it exists (it must be a number >= 0) the following will happen:

* The count of orders out of sync returned by `DataSynchronizer::get_current_orders_pending_sync_count` will be the value of this option, no actual database access will be performed.
* The `DataSynchronizer::do_pending_orders_synchronization` method, which will be run by Action Scheduler, will simply update the value of this option with its current value minus one, until it reaches zero; no actual database access will be performed (note however that at the time of submitting this pull request the actual synchronization isn't implemented yet, so no database access would have been performed anyway).

So with this, here's how to test:

1. Set the fake out of sync orders count to zero (you can simply use `wp option set woocommerce_fake_orders_pending_sync_count 0`).
2. Go to _WooCommerce > Settings > Advanced > Custom data stores_, verify that there's no warning about out of sync orders and that you can modiify all the settings. Make sure to leave the 'Keep the posts table and the orders tables synchronized' setting turned off.
3. Set the fake count to any non-zero value and reload the settings pages. Now you'll see the warning about out of sync orders and you aren't able to modify the 'Data store for orders' setting.
4. Set the 'Keep the posts table and the orders tables synchronized' settting on and reload the settings page. Now the warning message will include "Synchronization for these orders is currently in progress" as well as the count of orders that you had initially set in the option.
5. Let Action Scheduler do its job (e.g. reload the settings page). You'll see that the out of sync orders count in the warning message decreases (but the initial count doesn't). Eventually it will reach zero and you'll go back to the initial state (no warning, you can change the authorittative table).
6. Repeat from 3 but this time, when the settings page reloads after you have enabled the syncrhonization, set the 'Switch to using the posts/orders table as the authoritative data store for orders when sync finishes' setting on and save. Now once the syncrhonization has finished you'll see that the authoritative table ('Data store for orders') has changed. Repeat to verify that the process is symmetrical.
7. Repeat from 3 but this time set 'Keep the posts table and the orders tables synchronized' off and save in the middle of the synchronization process. You'll see that "Synchronization for these orders is currently in progress" in the warning disappears. Set it on and save again, the synchronization will resume from the point in which it was turned off (the new initial out of sync orders count will be the current count as it was when it was turned off).
8. Repeat 6 and then set 'Keep the posts table and the orders tables synchronized' off and save. Turn sync on and verify that 'Switch to using the posts/orders table as the authoritative data store for orders when sync finishes' has been turned off automatically.

#### Testing the query for out of sync order ids

Temporarily modify `DataSynchronizer::get_ids_of_orders_pending_sync` so that it's `public` and run it from CLI as follows:

```
wp eval 'echo var_dump(wc_get_container()->get(\Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class)->get_ids_of_orders_pending_sync(type, limit));'
```

where `type` is the value of one of the `ID_TYPE_...` constants (see the header of `get_ids_of_orders_pending_sync` for details) and `limit` is the maximum number of ids to return.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Queries for non-synchronized orders

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
