### PR TITLE
Add a primary key to the product attributes lookup table.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -175,6 +175,10 @@ class WC_Install {
 			'wc_update_630_create_product_attributes_lookup_table',
 			'wc_update_630_db_version',
 		),
+		'6.4.0' => array(
+			'wc_update_640_add_primary_key_to_product_attributes_lookup_table',
+			'wc_update_640_db_version',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2364,3 +2364,22 @@ function wc_update_630_create_product_attributes_lookup_table() {
 function wc_update_630_db_version() {
 	WC_Install::update_db_version( '6.3.0' );
 }
+
+/**
+ * Create the primary key for the product attributes lookup table if it doesn't exist already.
+ *
+ * @return bool Always false.
+ */
+function wc_update_640_add_primary_key_to_product_attributes_lookup_table() {
+	wc_get_container()->get( DataRegenerator::class )->create_table_primary_index();
+
+	return false;
+}
+
+/**
+ *
+ * Update DB version to 6.4.0.
+ */
+function wc_update_640_db_version() {
+	WC_Install::update_db_version( '6.4.0' );
+}

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -479,19 +479,9 @@ class DataRegenerator {
 	 * @return void
 	 */
 	public function create_table_primary_index() {
-		global $wpdb;
-
-		// phpcs:disable WordPress.DB.PreparedSQL
-		$wpdb->query(
-			"
-ALTER TABLE {$this->lookup_table_name}
-ADD PRIMARY KEY IF NOT EXISTS ( `product_or_parent_id`, `term_id`, `product_id`, `taxonomy` )"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL
-
-		wc_get_container()
-			->get( DatabaseUtil::class )
-			->drop_table_index( $this->lookup_table_name, 'product_or_parent_id_term_id' );
+		$database_util = wc_get_container()->get( DatabaseUtil::class );
+		$database_util->create_primary_key( $this->lookup_table_name, array( 'product_or_parent_id', 'term_id', 'product_id', 'taxonomy' ) );
+		$database_util->drop_table_index( $this->lookup_table_name, 'product_or_parent_id_term_id' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -482,6 +482,14 @@ class DataRegenerator {
 		$database_util = wc_get_container()->get( DatabaseUtil::class );
 		$database_util->create_primary_key( $this->lookup_table_name, array( 'product_or_parent_id', 'term_id', 'product_id', 'taxonomy' ) );
 		$database_util->drop_table_index( $this->lookup_table_name, 'product_or_parent_id_term_id' );
+
+		if ( empty( $database_util->get_index_columns( $this->lookup_table_name ) ) ) {
+			wc_get_logger()->error( "The creation of the primary key for the {$this->lookup_table_name} table failed" );
+		}
+
+		if ( ! empty( $database_util->get_index_columns( $this->lookup_table_name, 'product_or_parent_id_term_id' ) ) ) {
+			wc_get_logger()->error( "Dropping the product_or_parent_id_term_id index from the {$this->lookup_table_name} table failed" );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Utilities/DatabaseUtil.php
@@ -70,4 +70,37 @@ class DatabaseUtil {
 		//phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return $wpdb->query( "DROP TABLE IF EXISTS `{$table_name}`" );
 	}
+
+	/**
+	 * Drops a table index, if both the table and the index exist.
+	 *
+	 * @param string $table_name The name of the table that contains the index.
+	 * @param string $index_name The name of the index to be dropped.
+	 * @return bool True if the index has been dropped, false if either the table or the index don't exist.
+	 */
+	public function drop_table_index( string $table_name, string $index_name ): bool {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL
+
+		$index_count = intval(
+			$wpdb->get_var(
+				"
+SELECT COUNT(1) FROM INFORMATION_SCHEMA.STATISTICS
+WHERE table_name='$table_name'
+AND table_schema='" . DB_NAME . "'
+AND index_name='$index_name'"
+			)
+		);
+
+		if ( 0 === $index_count ) {
+			return false;
+		}
+
+		$wpdb->query( "ALTER TABLE $table_name DROP INDEX $index_name" );
+
+		// phpcs:enable WordPress.DB.PreparedSQL
+
+		return true;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/32066

Add a primary key to the product attributes lookup table, since [some hosting providers seem to require it](https://github.com/woocommerce/woocommerce/issues/31367#issuecomment-1066128680). The key is created on the four columns that uniquely identify each row.

Additionally, the `product_or_parent_id_term_id` index is removed, since it's now redundant (it spans part of the columns that are now in the primary key).

Errors will be logged via `wp_get_logger()->error()` if either the primary key can't be created or the `product_or_parent_id_term_id` index can't be removed.

### How to test the changes in this Pull Request:

1. Verify that a primary key is created for the product attributes lookup table on a new WooCommerce install. You can check the table indices with the following CLI command:

```bash
wp db query "SELECT index_name,column_name FROM INFORMATION_SCHEMA.STATISTICS WHERE table_name='$(wp db prefix)wc_product_attributes_lookup' AND table_schema='$(wp eval 'echo DB_NAME;')'"
```

You should get the following result:

```
+--------------------------------+------------------------+
| index_name                     | column_name            |
+--------------------------------+------------------------+
| PRIMARY                        | product_or_parent_id   |
| PRIMARY                        | term_id                |
| PRIMARY                        | product_id             |
| PRIMARY                        | taxonomy               |
| is_variation_attribute_term_id | is_variation_attribute |
| is_variation_attribute_term_id | term_id                |
+--------------------------------+------------------------+
```

Note how the list doesn't include a `product_or_parent_id_term_id` index.

2. Verify that the keys are created when WooCommerce is upgraded too, especially when upgrading from 6.3. You can run this to downgrade the database version, then trigger the database update when prompted in admin, then verify that the primary key has been created:

```bash
wp option set woocommerce_db_version 6.0.0
```

To test the error logging:

3. Create again the deleted index and drop the primary key, you can use this SQL:

```sql
ALTER TABLE wp_wc_product_attributes_lookup DROP PRIMARY KEY;
ALTER TABLE wp_wc_product_attributes_lookup ADD INDEX product_or_parent_id_term_id (product_id, product_or_parent_id);
```

4. Comment the lines of `DataRegenerator::create_table_primary_index` that do `$database_util->create_primary_key` and `$database_util->drop_table_index( $this->lookup_table_name, 'product_or_parent_id_term_id' );`

5. Either run the entire database version downgrade and update cycle again, or just run this in the command line:

```bash
wp eval "wc_get_container()->get(Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator::class)->create_table_primary_index();"
```

6. Verify that error entries have been added to the log (WooCommerce - Status - Logs, search the log for today).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Primary key for the product attributes lookup table.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
