### PR TITLE
Bump woocommerce-admin to 3.3.0-rc.1

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-admin": "3.2.1",
+		"woocommerce/woocommerce-admin": "3.3.0-rc.1",
 		"woocommerce/woocommerce-blocks": "6.9.0"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95b6d7da4314500d65c7f840bf173dde",
+    "content-hash": "d2f240bf6cb97fa2dcacdbf8c5703a7a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -39,12 +39,12 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/AutoloadGenerator.php"
-                ],
                 "psr-4": {
                     "Automattic\\Jetpack\\Autoloader\\": "src"
-                }
+                },
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -543,16 +543,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "3.2.1",
+            "version": "3.3.0-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "5988146485fb915236dae0f46120f5c8d26256c8"
+                "reference": "4bb1b565463b260b542209e23df8236b8b3b975f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5988146485fb915236dae0f46120f5c8d26256c8",
-                "reference": "5988146485fb915236dae0f46120f5c8d26256c8",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/4bb1b565463b260b542209e23df8236b8b3b975f",
+                "reference": "4bb1b565463b260b542209e23df8236b8b3b975f",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +597,8 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Automattic\\WooCommerce\\Admin\\": "src/"
+                    "Automattic\\WooCommerce\\Admin\\": "src/",
+                    "Automattic\\WooCommerce\\Internal\\Admin\\": "src-internal/Admin/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -608,9 +609,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.2.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v3.3.0-rc.1"
             },
-            "time": "2022-02-24T02:22:41+00:00"
+            "time": "2022-03-15T20:23:32+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -727,16 +728,16 @@
         },
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.4.1",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225"
+                "reference": "49934ffea764864788334c1485fbb08a4b852031"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/49934ffea764864788334c1485fbb08a4b852031",
+                "reference": "49934ffea764864788334c1485fbb08a4b852031",
                 "shasum": ""
             },
             "require": {
@@ -771,9 +772,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/v1.5.0"
             },
-            "time": "2020-05-03T08:27:20+00:00"
+            "time": "2022-02-22T21:01:25+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -857,12 +858,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2511,12 +2512,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2590,12 +2591,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2824,12 +2825,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Wikimedia\\AtEase\\": "src/Wikimedia/AtEase/"
-                },
                 "files": [
                     "src/Wikimedia/Functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Wikimedia\\AtEase\\": "src/Wikimedia/AtEase/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2926,5 +2927,5 @@
     "platform-overrides": {
         "php": "7.0.33"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -184,8 +184,8 @@ class WC_Unit_Tests_Bootstrap {
 		include $this->plugin_dir . '/uninstall.php';
 
 		// Initialize the WC API extensions.
-		\Automattic\WooCommerce\Admin\Install::create_tables();
-		\Automattic\WooCommerce\Admin\Install::create_events();
+		\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+		\Automattic\WooCommerce\Internal\Admin\Install::create_events();
 
 		WC_Install::install();
 

--- a/plugins/woocommerce/uninstall.php
+++ b/plugins/woocommerce/uninstall.php
@@ -28,8 +28,8 @@ wp_clear_scheduled_hook( 'woocommerce_cleanup_rate_limits' );
  */
 if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Drop WC Admin tables.
-	include_once dirname( __FILE__ ) . '/packages/woocommerce-admin/src/Install.php';
-	\Automattic\WooCommerce\Admin\Install::drop_tables();
+	include_once dirname( __FILE__ ) . '/packages/woocommerce-admin/src-internal/Admin/Install.php';
+    \Automattic\WooCommerce\Internal\Admin\Install::drop_tables();
 
 	include_once dirname( __FILE__ ) . '/includes/class-wc-install.php';
 


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 3.3.0-rc.1

## New Feature Tests

### Prompt a modal to save any unsaved changes in OBW

1. Start with a fresh install.
2. Navigate to WooCommerce -> Home to start the OBW.
3. Complete a few steps.
4. Click any of the previous steps and make some changes.
5. Click the next/previous step. You should be prompted by the modal to save your changes. Click the save button.
6. Go back to the step and confirm the changes.
7. Repeat the step, but click the disregard button for this time.
8. Confirm the changes are not saved for this time.

### Fix Google Listings plugin is always shown in free features despite already activated

1. Make sure the fallback payment suggestions file is used:
    - turn off `woocommerce_show_marketplace_suggestions` option using `wp-cli`:
      `wp option set woocommerce_show_marketplace_suggestions no`
2. Go to setup wizard's business details step -> free features tab
3. Observe that "Google Listings and Ads plugin" is displayed
4. Install and activate Google Listings and Ads plugin (https://woocommerce.com/products/google-listings-and-ads/)
5. Go to setup wizard's business details step -> free features tab
6. Observe the plugin is NOT present

### Fix view logic for Setup additional payment providers task

-   Start the onboarding wizard on a fresh install
-   Choose a supported country like US
-   Install WooCommerce Payments in the Business Details / Free Features step.
-   Do not complete the WooCommerce Payments set up.

**Case 1: WC Pay is not set up**

-   See that "Get paid with WooCommerce Payments" task is not ticked.
-   See that "Setup additional payment providers" is not shown.

<img width="529" alt="Screen Shot 2022-03-01 at 3 01 17 pm" src="https://user-images.githubusercontent.com/9312929/156120850-91dbffb9-04c8-4a9a-afa1-3430ed810ffa.png">

**Case 2 WC Pay is set up**

-   Set up WooCommerce Payments or cheat by adding `return true` to `src/Features/OnboardingTasks/Tasks/WooCommercePayments.php` [line 128](https://github.com/woocommerce/woocommerce-admin/blob/25458963affe344f8740004ad09aa6a9927e4cb5/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php#L128)
-   See that "Get paid with WooCommerce Payments" task is ticked.
-   See that "Setup additional payment providers" is shown.

<img width="526" alt="Screen Shot 2022-03-01 at 3 01 03 pm" src="https://user-images.githubusercontent.com/9312929/156121335-c4cfe575-9992-4896-a89d-444d1909548d.png">

### Fix setup wizard title and flash of content

1. Navigate to `wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard` directly via your browser's address bar
2. Note that the page content underneath (header, menu, etc) is not shown while the profile wizard is loading
3. In your browser's console run `document.body.classList.remove('woocommerce-admin-full-screen');`
4. This will result in a broken layout, but the important item to note here is that the header title is now "Setup Wizard" instead of "/setup-wizardStoreDetails"
5. Navigate to other pages to make sure no regressions have occurred

### OBW: fix copy on Business Details when "WooCommerce Shipping" is not listed

1. Create a test site using JN.
2. Start OBW and enter an address that is not in the US.
3. Choose "food and drink" from the Industry
4. When you get to the "Business Details", click "Free features".
5. Note that "WooCommerce Shipping" is not listed.
6. Confirm that the copy under the plugin list says: `By installing Jetpack plugin for free you agree to our Terms of Service.`.

![screenshot-one local-2022 02 16-18_11_29](https://user-images.githubusercontent.com/1314156/154358103-53f33091-0673-4637-87f1-925b2aa4c1ca.png)

7. No go to the first step and select an address in the US.
8. Go back to the "Business Details" step and click "Free features".
9. The text now should say: `By installing Jetpack and WooCommerce Shipping plugins for free you agree to our Terms of Service.`

![screenshot-one local-2022 02 16-18_12_27](https://user-images.githubusercontent.com/1314156/154358164-532abca7-6d9d-4497-a216-4f62d3ca5580.png)

10. Run the tests and confirm that everything is working well.

### Show single success message for theme install and activation

1. Navigate to the store setup wizard theme step
2. Choose a new theme
3. Note the single success toast notice

## Changelog

== 3.3.0 03/15/2022 == 
```
- Fix: Added random IDs to SVG checkmarks in stepper component #8222
- Fix: Fix Google Listings plugin is always shown in free features despite already activated. #8330
- Fix: Fix hidden notes in `admin/notes` endpoint when the user is not in the tasklist experiment. #8328
- Fix: Fix missing product name in variation analytic page for the deleted products. #8255
- Fix: Fix payments extensions displayed below the offline payments options. #8232
- Fix: Fix setup wizard title and flash of content #8201
- Fix: Fix too many pending run_remote_notifications actions. #8285
- Fix: Fix view logic for Setup additional payment providers task. #8391
- Fix: OBW: fix copy on Business Details when "WooCommerce Shipping" is not listed #8324
- Fix: Only add product data on REST requests and task list #8235
- Fix: Stop showing actioned inbox items #8394
- Add: Add asynchronous plugin install and activation endpoints #8079
- Update: Adjust time range and add an image for the Jetpack Backup note. #8293
- Update: Implement MailChimp API request threshold for MailchimpScheduler. #8342
- Update: Reintroduce CES on product add, product update, and order update. #8238
- Update: Replace mysql image with mariadb #8220
- Dev: Added a test for tracks event recording for PaymentGatewaySuggestions #8306
- Dev: Add README to hook reference generation script #8004
- Dev: Add reset WooCommerce functionality to E2E tests, so tests have a fresh state. #8219
- Dev: Enabled optional typescript checking on ./client subfolder #8372
- Dev: Fix formatting and add filter param for changelog types for the testing instructions script. #8256
- Dev: Refactor MerchantEmailNotifications #8304
- Dev: Remove preloaded countries from data endpoints and use data store instead. #8380
- Dev: Remove unused pre loaded setting data displaying all the routes. #8379
- Dev: Remove unused task styling classes #8234
- Dev: Update dependencies to support react 17 and drop support for IE11. #8305
- Dev: Update task list data structure to better handle new designs. #8332
- Tweak: OBW: Override Country/Region label line-height style to avoid truncated descenders. #8186
- Tweak: Show single success message for theme install and activation #8236
- Tweak: Use WC_VERSION as cache buster for assets #8308
- Performance: Avoid expensive get_notes() queries in CouponPageMoved admin_init actions by using new Notes::get_note_by_name() helper method. #8202
- Enhancement: Add chart color filter for overriding default chart colors. #8258
- Enhancement: Added Typescript type declarations to build for @woocommerce/components #8282
- Enhancement: Increase color selection limit to ten and add additional colors. #8258
- Enhancement: Made @woocommerce/components/Stepper a Typescript file #8286
- Enhancement: Prompts a modal to save any unsaved changes when the users try to move to a different step #8278
- Fix: Make sure the paid extension task is also shown for themes. #8412
- Fix: Reintroduce emphasis on inbox note action button. #8411
- Fix: Remove class ExtendedPayments. #8461
```

### UPDATE
I added the commit 8b18c09 which fixes a problem with the unit tests. The issue was related to an old reference to WC-Admin `Install.php`.