### PR TITLE
Enclose in double quotes and use correct ticks

### DIFF
--- a/.github/workflows/triage-replies.yml
+++ b/.github/workflows/triage-replies.yml
@@ -98,14 +98,14 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Thanks for the suggestion @${{ github.event.issue.user.login }},\n\n\
-              While we appreciate you sharing your ideas with us, it doesn’t fit in with our current priorities for the project.\n\
+              body: "Thanks for the suggestion @${{ github.event.issue.user.login }},\n\n\
+              While we appreciate you sharing your ideas with us, it doesn't fit in with our current priorities for the project.\n\
               At some point, we may revisit our priorities and look through the list of suggestions like this one to see if it \
               warrants a second look.\n\n\
               In the meantime, we are going to close this issue with the `votes needed` label and evaluate over time if this \
               issue collects more feedback.\n\n\
-              Don’t be alarmed if you don’t see any activity on this issue for a while. \
-              We'll keep an eye on the popularity of this request.'
+              Don't be alarmed if you don't see any activity on this issue for a while. \
+              We'll keep an eye on the popularity of this request."
             })
       - name: Close votes needed issue
         uses: actions/github-script@v5


### PR DESCRIPTION
`needs: votes` label triggers a workflow which is broken due to the tick marks used.

This PR fixes the tick marks.

**Test**:

* Create a dummy issue.
* Add the `needs: votes` label.
* After the action has finish running, ensure you see a bot comment and issue closed.
