### PR TITLE
Subscriptions - add tracking params to WCCOM URLs

### DIFF
--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -223,7 +223,10 @@ class WC_Helper {
 
 				$action['message']     .= ' ' . __( 'To enable this update you need to <strong>purchase</strong> a new subscription.', 'woocommerce' );
 				$action['button_label'] = __( 'Purchase', 'woocommerce' );
-				$action['button_url']   = $subscription['product_url'];
+				$action['button_url']   = self::add_utm_params_to_url_for_subscription_link(
+					$subscription['product_url'],
+					'purchase'
+				);
 
 				$subscription['actions'][] = $action;
 			} elseif ( $subscription['expired'] && ! empty( $subscription['master_user_email'] ) ) {
@@ -238,7 +241,10 @@ class WC_Helper {
 				$action = array(
 					'message'      => sprintf( __( 'This subscription has expired. Please <strong>renew</strong> to receive updates and support.', 'woocommerce' ) ),
 					'button_label' => __( 'Renew', 'woocommerce' ),
-					'button_url'   => 'https://woocommerce.com/my-account/my-subscriptions/',
+					'button_url'   => self::add_utm_params_to_url_for_subscription_link(
+						'https://woocommerce.com/my-account/my-subscriptions/',
+						'renew'
+					),
 					'status'       => 'expired',
 					'icon'         => 'dashicons-info',
 				);
@@ -250,7 +256,10 @@ class WC_Helper {
 				$action = array(
 					'message'      => __( 'Subscription is <strong>expiring</strong> soon.', 'woocommerce' ),
 					'button_label' => __( 'Enable auto-renew', 'woocommerce' ),
-					'button_url'   => 'https://woocommerce.com/my-account/my-subscriptions/',
+					'button_url'   => self::add_utm_params_to_url_for_subscription_link(
+						'https://woocommerce.com/my-account/my-subscriptions/',
+						'auto-renew'
+					),
 					'status'       => 'expired',
 					'icon'         => 'dashicons-info',
 				);
@@ -261,7 +270,10 @@ class WC_Helper {
 				$action = array(
 					'message'      => sprintf( __( 'This subscription is expiring soon. Please <strong>renew</strong> to continue receiving updates and support.', 'woocommerce' ) ),
 					'button_label' => __( 'Renew', 'woocommerce' ),
-					'button_url'   => 'https://woocommerce.com/my-account/my-subscriptions/',
+					'button_url'   => self::add_utm_params_to_url_for_subscription_link(
+						'https://woocommerce.com/my-account/my-subscriptions/',
+						'renew'
+					),
 					'status'       => 'expired',
 					'icon'         => 'dashicons-info',
 				);
@@ -309,7 +321,10 @@ class WC_Helper {
 					/* translators: %s: version number */
 					'message'      => sprintf( __( 'Version %s is <strong>available</strong>. To enable this update you need to <strong>purchase</strong> a new subscription.', 'woocommerce' ), esc_html( $updates[ $data['_product_id'] ]['version'] ) ),
 					'button_label' => __( 'Purchase', 'woocommerce' ),
-					'button_url'   => $data['_product_url'],
+					'button_url'   => self::add_utm_params_to_url_for_subscription_link(
+						$data['_product_url'],
+						'purchase'
+					),
 					'status'       => 'expired',
 					'icon'         => 'dashicons-info',
 				);
@@ -320,7 +335,10 @@ class WC_Helper {
 					/* translators: 1: subscriptions docs 2: subscriptions docs */
 					'message'      => sprintf( __( 'To receive updates and support for this extension, you need to <strong>purchase</strong> a new subscription or consolidate your extensions to one connected account by <strong><a href="%1$s" title="Sharing Docs">sharing</a> or <a href="%2$s" title="Transferring Docs">transferring</a></strong> this extension to this connected account.', 'woocommerce' ), 'https://docs.woocommerce.com/document/managing-woocommerce-com-subscriptions/#section-10', 'https://docs.woocommerce.com/document/managing-woocommerce-com-subscriptions/#section-5' ),
 					'button_label' => __( 'Purchase', 'woocommerce' ),
-					'button_url'   => $data['_product_url'],
+					'button_url'   => self::add_utm_params_to_url_for_subscription_link(
+						$data['_product_url'],
+						'purchase'
+					),
 					'status'       => 'expired',
 					'icon'         => 'dashicons-info',
 				);
@@ -348,6 +366,28 @@ class WC_Helper {
 		// We have an active connection.
 		include self::get_view_filename( 'html-main.php' );
 		return;
+	}
+
+	/**
+	 * Add tracking parameters to buttons (Renew, Purchase, etc.) on subscriptions page
+	 *
+	 * @param string $url URL to product page or to https://woocommerce.com/my-account/my-subscriptions/
+	 * @param string $utm_content value of utm_content query parameter used for tracking
+	 *
+	 * @return string URL including utm parameters for tracking
+	 */
+	public static function add_utm_params_to_url_for_subscription_link( $url, $utm_content ) {
+		$utm_params = 'utm_source=subscriptionsscreen&' .
+					  'utm_medium=product&' .
+					  'utm_campaign=wcaddons&' .
+					  'utm_content=' . $utm_content;
+
+		// there are already some URL parameters
+		if ( strpos( $url, '?' ) ) {
+			return $url . '&' . $utm_params;
+		}
+
+		return $url . '?' . $utm_params;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/views/html-main.php
+++ b/plugins/woocommerce/includes/admin/helper/views/html-main.php
@@ -75,7 +75,7 @@
 				<tr class="wp-list-table__row is-ext-header">
 					<td class="wp-list-table__ext-details">
 						<div class="wp-list-table__ext-title">
-							<a href="<?php echo esc_url( $subscription['product_url'] ); ?>" target="_blank">
+							<a href="<?php echo esc_url( WC_Helper::add_utm_params_to_url_for_subscription_link( $subscription['product_url'], 'product-name' ) ); ?>" target="_blank">
 								<?php echo esc_html( $subscription['product_name'] ); ?>
 							</a>
 						</div>
@@ -206,7 +206,9 @@
 					<tr class="wp-list-table__row is-ext-header">
 						<td class="wp-list-table__ext-details color-bar autorenews">
 							<div class="wp-list-table__ext-title">
-								<a href="<?php echo esc_url( $data['_product_url'] ); ?>" target="_blank"><?php echo esc_html( $data['Name'] ); ?></a>
+								<a href="<?php echo esc_url( WC_Helper::add_utm_params_to_url_for_subscription_link( $data['_product_url'], 'product-name' ) ); ?>" target="_blank">
+									<?php echo esc_html( $data['Name'] ); ?>
+								</a>
 							</div>
 							<div class="wp-list-table__ext-description">
 							</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 12397-gh-Automattic/woocommerce.com

Google analytics parameters were added to the following links on My Subscriptions (`wp-admin/admin.php?page=wc-addons&section=helper`) page:
* Product name
* Purchase button
* Renew button

This is will be used to be able to tell how many people end up on the WCCOM product page or My Subscriptions page from this page.

### How to test the changes in this Pull Request:

1. Go to My Subscriptions (`wp-admin/admin.php?page=wc-addons&section=helper`) page
2. Check links related to the following elements:
 * Product name
 * Purchase buttons
 * Renew buttons
 * Auto-renew buttons 
3. Links should contain parameters:
```
'utm_source'   => 'subscriptionsscreen',
'utm_medium'   => 'product',
'utm_campaign' => 'wcaddons',
'utm_content'  => [ button clicked ], // one of: product-name, renew, purchase, auto-renew
```

![Screenshot 2022-03-18 at 14 37 14](https://user-images.githubusercontent.com/4765119/159021537-a0cd8dcc-8b0b-4a96-b009-eff75625bd94.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.