### PR TITLE
Updated React Admin Build Output

### DIFF
--- a/packages/js/dependency-extraction-webpack-plugin/project.json
+++ b/packages/js/dependency-extraction-webpack-plugin/project.json
@@ -9,18 +9,6 @@
                  "action": "add",
                  "cwd": "packages/js/dependency-extraction-webpack-plugin"
              }
-         },
-         "build": {
-             "executor": "@nrwl/workspace:run-script",
-             "options": {
-                 "script": "build"
-             }
-         },
-         "test": {
-             "executor": "@nrwl/workspace:run-script",
-             "options": {
-                 "script": "test"
-             }
          }
      }
  }

--- a/packages/js/e2e-environment/config/default.json
+++ b/packages/js/e2e-environment/config/default.json
@@ -1,207 +1,208 @@
 {
   "url": "http://localhost:8084/",
+  "appName": "woocommerce_e2e",
   "users": {
-    "admin": {
-      "username": "admin",
-      "password": "password"
-    },
-    "customer": {
-      "username": "customer",
-      "password": "password"
-    }
+	"admin": {
+	  "username": "admin",
+	  "password": "password"
+	},
+	"customer": {
+	  "username": "customer",
+	  "password": "password"
+	}
   },
   "products": {
-    "simple": {
-      "name": "Simple product"
-    },
-    "variable": {
-      "name": "Variable Product with Three Attributes",
-      "defaultAttributes": [
-        {
-          "id": 0,
-          "name": "Size",
-          "option": "Medium"
-        },
-        {
-          "id": 0,
-          "name": "Colour",
-          "option": "Blue"
-        }
-      ],
-      "attributes": [
-        {
-          "id": 0,
-          "name": "Colour",
-          "isVisibleOnProductPage": true,
-          "isForVariations": true,
-          "options": [
-            "Red",
-            "Green",
-            "Blue"
-          ],
-          "sortOrder": 0
-        },
-        {
-          "id": 0,
-          "name": "Size",
-          "isVisibleOnProductPage": true,
-          "isForVariations": true,
-          "options": [
-            "Small",
-            "Medium",
-            "Large"
-          ],
-          "sortOrder": 0
-        },
-        {
-          "id": 0,
-          "name": "Logo",
-          "isVisibleOnProductPage": true,
-          "isForVariations": true,
-          "options": [
-            "Woo",
-            "WordPress"
-          ],
-          "sortOrder": 0
-        }
-      ]
-    },
-    "variations": [
-      {
-        "regularPrice": "19.99",
-        "attributes": [
-          {
-            "name": "Size",
-            "option": "Large"
-          },
-          {
-            "name": "Colour",
-            "option": "Red"
-          }
-        ]
-      },
-      {
-        "regularPrice": "18.99",
-        "attributes": [
-          {
-            "name": "Size",
-            "option": "Medium"
-          },
-          {
-            "name": "Colour",
-            "option": "Green"
-          }
-        ]
-      },
-      {
-        "regularPrice": "17.99",
-        "attributes": [
-          {
-            "name": "Size",
-            "option": "Small"
-          },
-          {
-            "name": "Colour",
-            "option": "Blue"
-          }
-        ]
-      }
-    ],
-    "grouped": {
-      "name": "Grouped Product with Three Children",
-      "groupedProducts": [
-        {
-          "name": "Base Unit",
-          "regularPrice": "29.99"
-        },
-        {
-          "name": "Add-on A",
-          "regularPrice": "11.95"
-        },
-        {
-          "name": "Add-on B",
-          "regularPrice": "18.97"
-        }
-      ]
-    },
-    "external": {
-      "name": "External product",
-      "regularPrice": "24.99",
-      "buttonText": "Buy now",
-      "externalUrl": "https://wordpress.org/plugins/woocommerce"
-    }
+	"simple": {
+	  "name": "Simple product"
+	},
+	"variable": {
+	  "name": "Variable Product with Three Attributes",
+	  "defaultAttributes": [
+		{
+		  "id": 0,
+		  "name": "Size",
+		  "option": "Medium"
+		},
+		{
+		  "id": 0,
+		  "name": "Colour",
+		  "option": "Blue"
+		}
+	  ],
+	  "attributes": [
+		{
+		  "id": 0,
+		  "name": "Colour",
+		  "isVisibleOnProductPage": true,
+		  "isForVariations": true,
+		  "options": [
+			"Red",
+			"Green",
+			"Blue"
+		  ],
+		  "sortOrder": 0
+		},
+		{
+		  "id": 0,
+		  "name": "Size",
+		  "isVisibleOnProductPage": true,
+		  "isForVariations": true,
+		  "options": [
+			"Small",
+			"Medium",
+			"Large"
+		  ],
+		  "sortOrder": 0
+		},
+		{
+		  "id": 0,
+		  "name": "Logo",
+		  "isVisibleOnProductPage": true,
+		  "isForVariations": true,
+		  "options": [
+			"Woo",
+			"WordPress"
+		  ],
+		  "sortOrder": 0
+		}
+	  ]
+	},
+	"variations": [
+	  {
+		"regularPrice": "19.99",
+		"attributes": [
+		  {
+			"name": "Size",
+			"option": "Large"
+		  },
+		  {
+			"name": "Colour",
+			"option": "Red"
+		  }
+		]
+	  },
+	  {
+		"regularPrice": "18.99",
+		"attributes": [
+		  {
+			"name": "Size",
+			"option": "Medium"
+		  },
+		  {
+			"name": "Colour",
+			"option": "Green"
+		  }
+		]
+	  },
+	  {
+		"regularPrice": "17.99",
+		"attributes": [
+		  {
+			"name": "Size",
+			"option": "Small"
+		  },
+		  {
+			"name": "Colour",
+			"option": "Blue"
+		  }
+		]
+	  }
+	],
+	"grouped": {
+	  "name": "Grouped Product with Three Children",
+	  "groupedProducts": [
+		{
+		  "name": "Base Unit",
+		  "regularPrice": "29.99"
+		},
+		{
+		  "name": "Add-on A",
+		  "regularPrice": "11.95"
+		},
+		{
+		  "name": "Add-on B",
+		  "regularPrice": "18.97"
+		}
+	  ]
+	},
+	"external": {
+	  "name": "External product",
+	  "regularPrice": "24.99",
+	  "buttonText": "Buy now",
+	  "externalUrl": "https://wordpress.org/plugins/woocommerce"
+	}
   },
   "coupons": {
-    "percentage": {
-      "code": "20percent",
-      "discountType": "percent",
-      "amount": "20.00"
-    }
+	"percentage": {
+	  "code": "20percent",
+	  "discountType": "percent",
+	  "amount": "20.00"
+	}
   },
   "addresses": {
-    "admin": {
-      "store": {
-        "email": "admin@woocommercecoree2etestsuite.com",
-        "firstname": "John",
-        "lastname": "Doe",
-        "company": "Automattic",
-        "country": "United States (US)",
-        "addressfirstline": "addr 1",
-        "addresssecondline": "addr 2",
-        "countryandstate": "United States (US) — California",
-        "city": "San Francisco",
-        "state": "CA",
-        "postcode": "94107"
-      }
-    },
-    "customer": {
-      "billing": {
-        "firstname": "John",
-        "lastname": "Doe",
-        "company": "Automattic",
-        "country": "United States (US)",
-        "addressfirstline": "addr 1",
-        "addresssecondline": "addr 2",
-        "city": "San Francisco",
-        "state": "CA",
-        "postcode": "94107",
-        "phone": "123456789",
-        "email": "john.doe@example.com"
-      },
-      "shipping": {
-        "firstname": "John",
-        "lastname": "Doe",
-        "company": "Automattic",
-        "country": "United States (US)",
-        "addressfirstline": "addr 1",
-        "addresssecondline": "addr 2",
-        "city": "San Francisco",
-        "state": "CA",
-        "postcode": "94107"
-      }
-    }
+	"admin": {
+	  "store": {
+		"email": "admin@woocommercecoree2etestsuite.com",
+		"firstname": "John",
+		"lastname": "Doe",
+		"company": "Automattic",
+		"country": "United States (US)",
+		"addressfirstline": "addr 1",
+		"addresssecondline": "addr 2",
+		"countryandstate": "United States (US) — California",
+		"city": "San Francisco",
+		"state": "CA",
+		"postcode": "94107"
+	  }
+	},
+	"customer": {
+	  "billing": {
+		"firstname": "John",
+		"lastname": "Doe",
+		"company": "Automattic",
+		"country": "United States (US)",
+		"addressfirstline": "addr 1",
+		"addresssecondline": "addr 2",
+		"city": "San Francisco",
+		"state": "CA",
+		"postcode": "94107",
+		"phone": "123456789",
+		"email": "john.doe@example.com"
+	  },
+	  "shipping": {
+		"firstname": "John",
+		"lastname": "Doe",
+		"company": "Automattic",
+		"country": "United States (US)",
+		"addressfirstline": "addr 1",
+		"addresssecondline": "addr 2",
+		"city": "San Francisco",
+		"state": "CA",
+		"postcode": "94107"
+	  }
+	}
   },
   "orders": {
-    "basicPaidOrder": {
-      "paymentMethod": "cod",
-      "status": "processing",
-      "billing": {
-        "firstName": "John",
-        "lastName": "Doe",
-        "email": "john.doe@example.com"
-      }
-    }
+	"basicPaidOrder": {
+	  "paymentMethod": "cod",
+	  "status": "processing",
+	  "billing": {
+		"firstName": "John",
+		"lastName": "Doe",
+		"email": "john.doe@example.com"
+	  }
+	}
   },
   "onboardingwizard": {
-    "industry": "Test industry",
-    "numberofproducts": "1 - 10",
-    "sellingelsewhere": "No"
+	"industry": "Test industry",
+	"numberofproducts": "1 - 10",
+	"sellingelsewhere": "No"
   },
   "settings": {
-    "shipping": {
-      "zonename": "United States",
-      "zoneregions": "United States (US)",
-      "shippingmethod": "Free shipping"
-    }
+	"shipping": {
+	  "zonename": "United States",
+	  "zoneregions": "United States (US)",
+	  "shippingmethod": "Free shipping"
+	}
   }
 }

--- a/plugins/woocommerce-admin/bin/generate-feature-config.php
+++ b/plugins/woocommerce-admin/bin/generate-feature-config.php
@@ -17,7 +17,7 @@ $phase = getenv( 'WC_ADMIN_PHASE' );
 if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 	$phase = 'plugin'; // Default to plugin when running `pnpm run build`.
 }
-$config_json = file_get_contents( 'config/' . $phase . '.json' );
+$config_json = file_get_contents( __DIR__ . '/../../../packages/config/' . $phase . '.json' );
 $config      = json_decode( $config_json );
 
 $write  = "<?php\n";

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -21,7 +21,7 @@
 		"preinstall": "npx only-allow pnpm",
 		"prebuild": "pnpm run install-if-deps-outdated",
 		"run:packages": "pnpm run --filter ./packages",
-		"build": "pnpm run build:feature-config && pnpm run build:packages && cross-env NODE_ENV=production webpack",
+		"build": "pnpm run build:feature-config && cross-env NODE_ENV=production webpack",
 		"analyze": "cross-env NODE_ENV=production ANALYZE=true webpack",
 		"postbuild": "pnpm run -s i18n:pot && pnpm run -s i18n:build",
 		"build:feature-config": "php bin/generate-feature-config.php",

--- a/plugins/woocommerce-admin/project.json
+++ b/plugins/woocommerce-admin/project.json
@@ -1,0 +1,20 @@
+{
+	"root": "plugins/woocommerce-admin/",
+	"sourceRoot": "plugins/woocommerce-admin",
+	"projectType": "application",
+	"targets": {
+		"changelog": {
+			"executor": "./tools/executors/changelogger:changelog",
+			"options": {
+				"action": "add",
+				"cwd": "plugins/woocommerce"
+			}
+		},
+		"build": {
+			"executor": "@nrwl/workspace:run-script",
+			"options": {
+				"script": "build"
+			}
+		}
+	}
+}

--- a/plugins/woocommerce-admin/src-internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce-admin/src-internal/Admin/FeaturePlugin.php
@@ -150,8 +150,8 @@ class FeaturePlugin {
 	protected function define_constants() {
 		$this->define( 'WC_ADMIN_APP', 'wc-admin-app' );
 		$this->define( 'WC_ADMIN_ABSPATH', dirname( __DIR__, 2 ) . '/' );
-		$this->define( 'WC_ADMIN_DIST_JS_FOLDER', 'dist/' );
-		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'dist/' );
+		$this->define( 'WC_ADMIN_DIST_JS_FOLDER', 'assets/client/admin/' );
+		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'assets/client/admin/' );
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		$this->define( 'WC_ADMIN_IMAGES_FOLDER_URL', plugins_url( 'images', WC_ADMIN_PLUGIN_FILE ) );
 

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -16,7 +16,7 @@ const ForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 const AsyncChunkSrcVersionParameterPlugin = require( './chunk-src-version-param' );
 const UnminifyWebpackPlugin = require( './unminify' );
 const { webpackConfig: styleConfig } = require( '@woocommerce/style-build' );
-const WooCommerceDependencyExtractionWebpackPlugin = require( './packages/dependency-extraction-webpack-plugin/src/index' );
+const WooCommerceDependencyExtractionWebpackPlugin = require( '../../packages/js/dependency-extraction-webpack-plugin/src/index' );
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const WC_ADMIN_PHASE = process.env.WC_ADMIN_PHASE || 'development';
@@ -39,7 +39,7 @@ const wcAdminPackages = [
 
 const entryPoints = {};
 wcAdminPackages.forEach( ( name ) => {
-	entryPoints[ name ] = `./packages/${ name }`;
+	entryPoints[ name ] = `../../packages/js/${ name }`;
 } );
 
 const wpAdminScripts = [
@@ -72,7 +72,7 @@ const webpackConfig = {
 				: `[name]/index${ suffix }.js`;
 		},
 		chunkFilename: `chunks/[name]${ suffix }.js`,
-		path: path.join( __dirname, 'dist' ),
+		path: path.join( __dirname, '/../woocommerce/assets/client/admin' ),
 		library: [ 'wc', '[modulename]' ],
 		libraryTarget: 'window',
 		uniqueName: '__wcAdmin_webpackJsonp',
@@ -148,7 +148,7 @@ const webpackConfig = {
 		new CopyWebpackPlugin({
 
 			patterns: wcAdminPackages.map( ( packageName ) => ( {
-				from: `./packages/${ packageName }/build-style/*.css`,
+				from: `../../packages/js/${ packageName }/build-style/*.css`,
 				to: `./${ packageName }/[name][ext]`,
 				noErrorOnMissing: true
 			} ) )

--- a/plugins/woocommerce/.gitignore
+++ b/plugins/woocommerce/.gitignore
@@ -5,6 +5,7 @@
 # All JS
 /assets/js/**
 /assets/js/*.js
+/assets/client
 
 # Behat/CLI Tests
 tests/cli/installer

--- a/workspace.json
+++ b/workspace.json
@@ -7,6 +7,7 @@
         "@woocommerce/e2e-environment": "packages/js/e2e-environment",
         "@woocommerce/e2e-utils": "packages/js/e2e-utils",
         "woocommerce": "plugins/woocommerce",
+        "woocommerce-admin": "plugins/woocommerce-admin",
         "woocommerce-legacy-assets": "plugins/woocommerce/legacy",
         "woocommerce-beta-tester": "plugins/woocommerce-beta-tester",
         "@woocommerce/admin-e2e-tests": "packages/js/admin-e2e-tests",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request updates the output of the webpack build for WooCommerce Admin to drop the files into `plugins/woocommerce/assets/client/admin`. This will be the new home for these files.

### How to test the changes in this Pull Request:

1. Run `pnpm nx build woocommerce-admin`. We will likely rename this eventually, but for now it works!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
