### PR TITLE
Add `$primary` param back to add_action method

### DIFF
--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -299,7 +299,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 				'%s',
 				'%s',
 				'%s',
-				'%d',
 				'%s',
 				'%s',
 				'%s',

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -620,6 +620,7 @@ class Note extends \WC_Data {
 	 * @param string $label          Action label (presented as button label).
 	 * @param string $url            Action URL, if navigation needed. Optional.
 	 * @param string $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
+	 * @param boolean $primary        Deprecated since version 3.4.0.
 	 * @param string $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
 	 */
 	public function add_action(
@@ -627,6 +628,7 @@ class Note extends \WC_Data {
 		$label,
 		$url = '',
 		$status = self::E_WC_ADMIN_NOTE_ACTIONED,
+		$primary = false,
 		$actioned_text = ''
 	) {
 		$name          = wc_clean( $name );

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstProductAndPayment.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstProductAndPayment.php
@@ -51,6 +51,7 @@ class InsightFirstProductAndPayment {
 			__( 'Yes', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 
@@ -59,6 +60,7 @@ class InsightFirstProductAndPayment {
 			__( 'No', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstSale.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstSale.php
@@ -54,6 +54,7 @@ class InsightFirstSale {
 			__( 'Yes', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 		$note->add_action(
@@ -61,6 +62,7 @@ class InsightFirstSale {
 			__( 'No', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As suggested [here](https://github.com/woocommerce/woocommerce-admin/pull/8474/files#r829672400), we should keep `$primary` parameter for backward compatibility.

### How to test the changes in this Pull Request:


![Screen Shot 2022-03-18 at 12 31 53](https://user-images.githubusercontent.com/4344253/158938001-3ac3374c-e66d-47f5-b07d-d600c662f0d0.png)



1. Use a fresh site
2. Update woocommerce_admin_install_timestamp to 1647318173 from option table to show InsightFirstProductAndPayment note
3. Go to Tools > Cron Events
4. Run wc_admin_daily
5. Go to WooCommerce > Home
6. Confirm "Insight" note are shown
7. Click yes or no button
8. Should see "Thanks for your feedback" text

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

N/A

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
