### PR TITLE
Add ability for code-based notes to update

### DIFF
--- a/plugins/woocommerce-admin/tests/notes/class-wc-tests-note-traits.php
+++ b/plugins/woocommerce-admin/tests/notes/class-wc-tests-note-traits.php
@@ -124,6 +124,170 @@ class WC_Tests_NoteTraits extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test update_note_field_if_changed method should update note1 and return true.
+	 * @return void
+	 */
+	public function test_should_update_note_name_and_return_true() {
+		// Test name is different from note1.
+		$note1 = $this->createMock( Note::class );
+		$note1->expects( $this->once() )
+			->method( 'get_name' )
+			->willReturn( 'old name' );
+
+		$note1->expects( $this->once() )
+			->method( 'set_name' )
+			->with( 'new name' );
+
+		$note2 = $this->createMock( Note::class );
+		$note2->expects( $this->exactly( 2 ) )
+			->method( 'get_name' )
+			->willReturn( 'new name' );
+
+		$this->assertTrue( self::update_note_field_if_changed( $note1, $note2, 'name' ) );
+
+		// Test actions are the same as note1.
+		$actions1 = array(
+			(object) array(
+				'id'            => '1',
+				'name'          => 'action1',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => '',
+				'nonce_name'    => 0,
+				'nonce_action'  => 0,
+			),
+			(object) array(
+				'id'            => '2',
+				'name'          => 'action2',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => 'text',
+				'nonce_name'    => 0,
+				'nonce_action'  => 0,
+			),
+		);
+
+		$actions2 = array(
+			(object) array(
+				'name'          => 'action1',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => '',
+				'nonce_name'    => null,
+				'nonce_action'  => null,
+			),
+			(object) array(
+				'name'          => 'new action',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => 'text',
+				'nonce_name'    => null,
+				'nonce_action'  => null,
+			),
+		);
+
+		$note1->expects( $this->once() )
+			->method( 'get_actions' )
+			->willReturn( $actions1 );
+
+		$note1->expects( $this->once() )
+		->method( 'set_actions' )
+		->with( $actions2 );
+
+		$note2 = $this->createMock( Note::class );
+		$note2->expects( $this->exactly( 2 ) )
+		->method( 'get_actions' )
+		->willReturn( $actions2 );
+
+		$this->assertTrue( self::update_note_field_if_changed( $note1, $note2, 'actions' ) );
+	}
+
+	/**
+	 * Test update_note_field_if_changed method should not update the note1 and return false.
+	 * @return void
+	 */
+	public function test_should_not_update_note_name_and_return_false() {
+		// Test name is same as note1.
+		$note1 = $this->createMock( Note::class );
+		$note1->expects( $this->once() )
+			->method( 'get_name' )
+			->willReturn( 'name' );
+
+		$note1->expects( $this->exactly( 0 ) )
+			->method( 'set_name' );
+
+		$note2 = $this->createMock( Note::class );
+		$note2->expects( $this->once() )
+			->method( 'get_name' )
+			->willReturn( 'name' );
+
+		$this->assertFalse( self::update_note_field_if_changed( $note1, $note2, 'name' ) );
+
+		// Test actions are the same as note1.
+		$actions1 = array(
+			(object) array(
+				'id'            => '1',
+				'name'          => 'action1',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => '',
+				'nonce_name'    => 0,
+				'nonce_action'  => 0,
+			),
+			(object) array(
+				'id'            => '2',
+				'name'          => 'action2',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => 'text',
+				'nonce_name'    => 0,
+				'nonce_action'  => 0,
+			),
+		);
+
+		$actions2 = array(
+			(object) array(
+				'name'          => 'action1',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => '',
+				'nonce_name'    => null,
+				'nonce_action'  => null,
+			),
+			(object) array(
+				'name'          => 'action2',
+				'label'         => 'wca',
+				'query'         => '?query',
+				'status'        => Note::E_WC_ADMIN_NOTE_ACTIONED,
+				'actioned_text' => 'text',
+				'nonce_name'    => null,
+				'nonce_action'  => null,
+			),
+		);
+
+		$note1->expects( $this->once() )
+			->method( 'get_actions' )
+			->willReturn( $actions1 );
+
+		$note1->expects( $this->exactly( 0 ) )
+			->method( 'set_actions' );
+
+		$note2 = $this->createMock( Note::class );
+		$note2->expects( $this->exactly( 1 ) )
+			->method( 'get_actions' )
+			->willReturn( $actions2 );
+
+		$this->assertFalse( self::update_note_field_if_changed( $note1, $note2, 'actions' ) );
+	}
+
+	/**
 	 * Data provider providing methods that should not throw
 	 * an exception regardless of the data store being available.
 	 *

--- a/plugins/woocommerce-admin/tests/notes/class-wc-tests-note-traits.php
+++ b/plugins/woocommerce-admin/tests/notes/class-wc-tests-note-traits.php
@@ -58,6 +58,17 @@ class WC_Tests_NoteTraits extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test should convert to array if it's a stdClass object.
+	 * @return void
+	 */
+	public function test_possibly_convert_object_to_array() {
+		$this->assertEquals( self::possibly_convert_object_to_array( new stdClass() ), array() );
+		$this->assertEquals( self::possibly_convert_object_to_array( 1 ), 1 );
+		$this->assertEquals( self::possibly_convert_object_to_array( 'string' ), 'string' );
+	}
+
+
+	/**
 	 * Method required to use NoteTraits.
 	 *
 	 * @return Note

--- a/plugins/woocommerce-admin/tests/notes/class-wc-tests-note-traits.php
+++ b/plugins/woocommerce-admin/tests/notes/class-wc-tests-note-traits.php
@@ -195,13 +195,13 @@ class WC_Tests_NoteTraits extends WC_Unit_Test_Case {
 			->willReturn( $actions1 );
 
 		$note1->expects( $this->once() )
-		->method( 'set_actions' )
-		->with( $actions2 );
+			->method( 'set_actions' )
+			->with( $actions2 );
 
 		$note2 = $this->createMock( Note::class );
 		$note2->expects( $this->exactly( 2 ) )
-		->method( 'get_actions' )
-		->willReturn( $actions2 );
+			->method( 'get_actions' )
+			->willReturn( $actions2 );
 
 		$this->assertTrue( self::update_note_field_if_changed( $note1, $note2, 'actions' ) );
 	}

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -164,14 +164,19 @@ trait NoteTraits {
 			return;
 		}
 
-		$need_save = false;
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'title' );
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'content' ) || $need_save;
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'content_data' ) || $need_save;
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'type' ) || $need_save;
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'locale' ) || $need_save;
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'source' ) || $need_save;
-		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'actions' ) || $need_save;
+		$need_save = in_array(
+			true,
+			array(
+				self::update_note_field_if_changed( $note_in_db, $note, 'title' ),
+				self::update_note_field_if_changed( $note_in_db, $note, 'content' ),
+				self::update_note_field_if_changed( $note_in_db, $note, 'content_data' ),
+				self::update_note_field_if_changed( $note_in_db, $note, 'type' ),
+				self::update_note_field_if_changed( $note_in_db, $note, 'locale' ),
+				self::update_note_field_if_changed( $note_in_db, $note, 'source' ),
+				self::update_note_field_if_changed( $note_in_db, $note, 'actions' )
+			),
+			true
+		);
 
 		if ( $need_save ) {
 			$note_in_db->save();

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -164,13 +164,21 @@ trait NoteTraits {
 			return;
 		}
 
-		// Update note content if it's changed.
-		$latest_note_content = $note->get_content();
-		if ( $note_in_db->get_content() !== $latest_note_content ) {
-			$note_in_db->set_content( $latest_note_content );
+		$need_save = false;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'title' );
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'content' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'content_data' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'type' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'locale' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'source' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'actions' ) || $need_save;
+
+		if ( $need_save ) {
 			$note_in_db->save();
 		}
 	}
+
+
 	/**
 	 * Get if the note has been actioned.
 	 *
@@ -190,5 +198,66 @@ trait NoteTraits {
 		}
 
 		return false;
+	}
+
+/**
+	 * Update a note field of note1 if it's different from note2 with getter and setter.
+	 *
+	 * @param Note   $note1 Note to update.
+	 * @param Note   $note2 Note to compare against.
+	 * @param string $field_name Field to update.
+	 * @return bool True if the field was updated.
+	 */
+	private static function update_note_field_if_changed( $note1, $note2, $field_name ) {
+		// We need to serialize the stdObject to compare it.
+		$note1_field_value = self::possibly_convert_object_to_array(
+			call_user_func( array( $note1, 'get_' . $field_name ) )
+		);
+		$note2_field_value = self::possibly_convert_object_to_array(
+			call_user_func( array( $note2, 'get_' . $field_name ) )
+		);
+
+		if ( 'actions' === $field_name ) {
+			// We need to individually compare the action fields because action object from db is different from action object of note.
+			// For example, action object from db has "id".
+			$diff        = array_udiff(
+				$note1_field_value,
+				$note2_field_value,
+				function( $action1, $action2 ) {
+					if ( $action1->name === $action2->name &&
+						$action1->label === $action2->label &&
+						$action1->query === $action2->query ) {
+						return 0;
+					}
+					return -1;
+				}
+			);
+			$need_update = count( $diff ) > 0;
+		} else {
+			$need_update = $note1_field_value !== $note2_field_value;
+		}
+
+		if ( $need_update ) {
+			call_user_func(
+				array( $note1, 'set_' . $field_name ),
+				// Get note2 field again because it may have been changed during the comparison.
+				call_user_func( array( $note2, 'get_' . $field_name ) )
+			);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Convert a value to array if it's a stdClass.
+	 *
+	 * @param mixed $obj variable to convert.
+	 * @return mixed
+	 */
+	private static function possibly_convert_object_to_array( $obj ) {
+		if ( $obj instanceof \stdClass ) {
+			return (array) $obj;
+		}
+		return $obj;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32138.

This PR adds the ability to update other note attributes when they're changed.



### How to test the changes in this Pull Request:

1. Update woocommerce_admin_install_timestamp option value to 3 days ago. Get this timestamp on macOS with date -v-3d +"%s".
2. Delete the Install Woo mobile app note in the database. delete from wp_wc_admin_notes w[here](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Notes/Note.php#L57) name = 'wc-admin-mobile-app';
3. Install WP Crontrol and Run the wc_admin_daily cron event.
4. See that the "Install Woo mobile app" note is on Home Screen.
5. Change the value of set_title in the src/Notes/MobileApp.php
6. Run the wc_admin_daily cron event.
7. Confirm the note title is updated on the Home screen or wp_wc_admin_notes table.
8. Repeat 5~7 steps with different attributes: Content data, Type, Source, Actions.
9. For testing locale, change the locale value here.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add ability for code-based notes to update. 

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
