### PR TITLE
Fix WooCommerce Admin JS unit tests

### DIFF
--- a/packages/js/explat/src/test/assignment-test.js
+++ b/packages/js/explat/src/test/assignment-test.js
@@ -10,11 +10,12 @@ import {
 	fetchExperimentAssignment,
 	fetchExperimentAssignmentWithAuth,
 } from '../assignment';
-global.fetch = jest
-	.fn()
-	.mockImplementation( () =>
-		Promise.resolve( { json: () => Promise.resolve( [] ) } )
-	);
+global.fetch = jest.fn().mockImplementation( () =>
+	Promise.resolve( {
+		json: () => Promise.resolve( {} ),
+		status: 200,
+	} )
+);
 global.wcTracks.isEnabled = true;
 
 const fetchMock = jest.spyOn( global, 'fetch' );

--- a/packages/js/js-tests/jest.config.js
+++ b/packages/js/js-tests/jest.config.js
@@ -10,7 +10,10 @@ module.exports = {
 			__dirname,
 			'build/mocks/woocommerce-settings'
 		),
-		'~/(.*)': path.resolve( __dirname, '../../client/$1' ),
+		'~/(.*)': path.resolve(
+			__dirname,
+			'../../../plugins/woocommerce-admin/client/$1'
+		),
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': path.resolve(
 			__dirname,
 			'build/mocks/static'

--- a/packages/js/js-tests/src/setup-globals.js
+++ b/packages/js/js-tests/src/setup-globals.js
@@ -107,7 +107,7 @@ wooCommercePackages.forEach( ( lib ) => {
 	} );
 } );
 
-const config = require( '../../../config/development.json' );
+const config = require( '../../../../plugins/woocommerce-admin/config/development.json' );
 
 // Check if test is jsdom or node
 if ( global.window ) {

--- a/plugins/woocommerce-admin/client/jest.config.js
+++ b/plugins/woocommerce-admin/client/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	rootDir: './',
-	preset: '../packages/js-tests/jest.config.js',
+	preset: '../../../packages/js/js-tests/jest.config.js',
 	globals: {
 		'ts-jest': {
 			diagnostics: {

--- a/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
@@ -9,7 +9,17 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import TransientNotices from '..';
 
-jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useDispatch: jest.fn(),
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
 
 useDispatch.mockReturnValue( {
 	removeNotice: jest.fn(),

--- a/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
@@ -17,10 +17,6 @@ jest.mock( '@wordpress/data', () => {
 	return {
 		...originalModule,
 		useDispatch: jest.fn(),
-		// Mock dispatch to avoid errors for @wordpress/viewport listener.
-		dispatch: jest.fn().mockReturnValue( {
-			setIsMatching: jest.fn(),
-		} ),
 	};
 } );
 

--- a/plugins/woocommerce-admin/client/tasks/test/task.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task.test.tsx
@@ -12,12 +12,30 @@ import { WooOnboardingTask } from '@woocommerce/onboarding';
  */
 import { Task } from '../task';
 
-jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
 
-jest.mock( '@woocommerce/navigation', () => ( {
-	getHistory: jest.fn(),
-	getNewPath: () => 'new-path',
-} ) );
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useDispatch: jest.fn(),
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
+
+jest.mock( '@woocommerce/navigation', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@woocommerce/navigation' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		getPersistedQuery: jest.fn().mockReturnValue( {} ),
+		getHistory: jest.fn(),
+		getNewPath: () => 'new-path',
+	};
+} );
 
 jest.mock( '@woocommerce/onboarding', () => ( {
 	WooOnboardingTask: {

--- a/plugins/woocommerce-admin/client/tasks/test/tasks.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/tasks.test.tsx
@@ -12,7 +12,18 @@ import userEvent from '@testing-library/user-event';
  */
 import { Tasks } from '../tasks';
 
-jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useDispatch: jest.fn().mockReturnValue( {} ),
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
+
 jest.mock( '@woocommerce/explat' );
 jest.mock( '@woocommerce/tracks' );
 

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -101,7 +101,6 @@
 		"@wordpress/components": "^19.5.0",
 		"@wordpress/compose": "^5.1.2",
 		"@wordpress/core-data": "^4.1.2",
-		"@wordpress/data": "^6.3.0",
 		"@wordpress/data-controls": "^2.3.2",
 		"@wordpress/date": "^4.3.1",
 		"@wordpress/dom": "^3.3.2",
@@ -277,6 +276,9 @@
 		"webpack-fix-style-only-entries": "^0.6.1",
 		"webpack-merge": "^5.8.0",
 		"webpack-rtl-plugin": "^2.0.0"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^6.3.0"
 	},
 	"engines": {
 		"node": ">=12.20.1 <15",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -64,7 +64,7 @@
 		"test:debug": "node --inspect-brk ./node_modules/.bin/jest --config client/jest.config.js --watch --runInBand --no-cache",
 		"test:client": "jest --config client/jest.config.js",
 		"test:packages": "pnpm run:packages -- test",
-		"test": "pnpm run:packages -- build && pnpm run test:client && pnpm run:packages -- test:nobuild",
+		"test": "pnpm nx build @woocommerce/js-tests && pnpm run test:client",
 		"test:e2e": "pnpm run build && test -z \"$(docker ps | grep woocommerce-admin-e2e)\" || pnpm exec wc-e2e docker:down && pnpm run e2e:docker-up && pnpm exec wc-e2e test:e2e",
 		"e2e:docker-up": "WC_E2E_FOLDER=../../../ pnpm exec wc-e2e docker:up ./tests/e2e/docker/initialize.sh",
 		"test-staged": "pnpm run test:client -- --bail --findRelatedTests",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1156,7 +1156,6 @@ importers:
       '@wordpress/compose': ^5.1.2
       '@wordpress/core-data': ^4.1.2
       '@wordpress/custom-templated-path-webpack-plugin': ^2.1.2
-      '@wordpress/data': ^6.3.0
       '@wordpress/data-controls': ^2.3.2
       '@wordpress/date': ^4.3.1
       '@wordpress/dom': ^3.3.2
@@ -1274,7 +1273,6 @@ importers:
       '@wordpress/components': 19.6.1_978f344c876a57c1143ffe356b90df31
       '@wordpress/compose': 5.2.1_react@17.0.2
       '@wordpress/core-data': 4.2.1_react@17.0.2
-      '@wordpress/data': 6.4.1_react@17.0.2
       '@wordpress/data-controls': 2.4.1_react@17.0.2
       '@wordpress/date': 4.4.1
       '@wordpress/dom': 3.4.1
@@ -5405,16 +5403,6 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
     dev: false
 
-  /@babel/plugin-transform-template-literals/7.16.0_@babel+core@7.17.8:
-    resolution: {integrity: sha512-Rd4Ic89hA/f7xUSJQk5PnC+4so50vBoBfxjdQAdvngwidM8jYIBVxBZ/sARxD4e0yMXRbJVDrYf7dyRtIIKT6Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.14.5
-    dev: true
-
   /@babel/plugin-transform-template-literals/7.16.7_@babel+core@7.17.8:
     resolution: {integrity: sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==}
     engines: {node: '>=6.9.0'}
@@ -6554,12 +6542,12 @@ packages:
     dependencies:
       ajv: 6.12.6
       debug: 4.3.3
-      espree: 9.0.0
+      espree: 9.3.1
       globals: 13.12.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -7478,7 +7466,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.10.3
+      '@types/node': 17.0.21
       '@types/yargs': 15.0.14
       chalk: 4.1.2
 
@@ -8486,7 +8474,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.3
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.1_92cb4b81c6b9f71cf92f0bdb85e4210c:
@@ -8733,7 +8721,7 @@ packages:
     resolution: {integrity: sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
     dependencies:
-      '@types/node': 16.10.3
+      '@types/node': 17.0.21
     dev: false
 
   /@slack/types/1.10.0:
@@ -8889,7 +8877,7 @@ packages:
     peerDependencies:
       '@storybook/addon-actions': '*'
     dependencies:
-      '@storybook/addon-actions': 6.4.19
+      '@storybook/addon-actions': 6.4.19_react-dom@17.0.2+react@17.0.2
       global: 4.4.0
     dev: true
 
@@ -11073,7 +11061,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/plugin-transform-template-literals': 7.16.0_@babel+core@7.17.8
+      '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.8
       '@babel/preset-react': 7.16.7_@babel+core@7.17.8
       '@storybook/addons': 6.4.19_react-dom@17.0.2+react@17.0.2
       '@storybook/core-client': 6.4.19_e7281081368b6c9b5567d9536ed3f600
@@ -11202,7 +11190,7 @@ packages:
       react-docgen-typescript: 2.2.2_typescript@4.6.2
       tslib: 2.3.1
       typescript: 4.6.2
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11931,7 +11919,7 @@ packages:
   /@types/cheerio/0.22.30:
     resolution: {integrity: sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==}
     dependencies:
-      '@types/node': 16.10.3
+      '@types/node': 17.0.21
 
   /@types/color-convert/2.0.0:
     resolution: {integrity: sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==}
@@ -12023,7 +12011,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 16.10.3
+      '@types/node': 17.0.21
 
   /@types/hast/2.3.4:
     resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
@@ -12060,7 +12048,7 @@ packages:
   /@types/is-stream/1.1.0:
     resolution: {integrity: sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==}
     dependencies:
-      '@types/node': 16.10.3
+      '@types/node': 17.0.21
     dev: false
 
   /@types/istanbul-lib-coverage/2.0.3:
@@ -12340,7 +12328,7 @@ packages:
   /@types/webpack-sources/0.1.9:
     resolution: {integrity: sha512-bvzMnzqoK16PQIC8AYHNdW45eREJQMd6WG/msQWX5V2+vZmODCOPb4TJcbgRljTZZTwTM4wUMcsI8FftNA7new==}
     dependencies:
-      '@types/node': 16.10.3
+      '@types/node': 17.0.21
       '@types/source-list-map': 0.1.2
       source-map: 0.6.1
     dev: true
@@ -12399,7 +12387,6 @@ packages:
       re-resizable: 4.11.0
     transitivePeerDependencies:
       - react
-      - react-dom
     dev: true
 
   /@types/wordpress__data-controls/2.2.0:
@@ -18148,7 +18135,7 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
-      fast-glob: 3.2.7
+      fast-glob: 3.2.11
       glob-parent: 6.0.2
       globby: 12.2.0
       normalize-path: 3.0.0
@@ -21685,7 +21672,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /file-loader/6.2.0_webpack@5.64.1:
@@ -23654,7 +23641,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /html-webpack-plugin/5.5.0_webpack@5.70.0:
@@ -30951,7 +30938,7 @@ packages:
       postcss: 7.0.39
       schema-utils: 3.1.1
       semver: 7.3.5
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /postcss-loader/6.2.0_postcss@8.3.0+webpack@5.64.1:
@@ -32426,7 +32413,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /raw-loader/4.0.2_webpack@5.64.1:
@@ -35458,7 +35445,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 2.7.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /style-loader/2.0.0_webpack@5.70.0:
@@ -36202,7 +36189,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.10.0_acorn@7.4.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - acorn
@@ -36222,7 +36209,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.10.0
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - acorn
@@ -37470,7 +37457,7 @@ packages:
       loader-utils: 2.0.2
       mime-types: 2.1.34
       schema-utils: 3.1.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /url-parse-lax/1.0.0:
@@ -38025,7 +38012,7 @@ packages:
       mime: 2.5.2
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
       webpack-log: 2.0.0
     dev: true
 
@@ -38108,7 +38095,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0_webpack-cli@4.9.2
     dev: true
 
   /webpack-fix-style-only-entries/0.6.1:
@@ -38292,7 +38279,7 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.46.0
       watchpack: 1.7.5
-      webpack-cli: 3.3.12_webpack@5.70.0
+      webpack-cli: 3.3.12_webpack@4.46.0
       webpack-sources: 1.4.3
     dev: true
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix running `woocommerce-admin` js unit tests:

1. Updated configs to point to correct paths
2. Updated `jest.mock` to fix `UnhandledPromiseRejection`. For node >= 16, We need to mock responses properly to not return rejections.
3. Update WCA `test` command to only run `./client` tests since packages have been moved to the project root directory.
4. Moved `@wordpress/data` from `devDependencies` to `peerDependencies`. `@wordpress/data` in `devDependencies` somehow would make all related tests fail in the monorepo.

### How to test the changes in this Pull Request:

1. Run `pnpm nx run-many --target=test --all --exclude=@woocommerce/api,@woocommerce/api-core-tests,@woocommerce/e2e-core-tests,@woocommerce/e2e-environment,@woocommerce/e2e-utils,woocommerce,woocommerce-legacy-assets,@woocommerce/dependency-extraction-webpack-plugin,@woocommerce/admin-e2e-tests,@woocommerce/onboarding,@woocommerce/js-tests, @woocommerce/notices,@woocommerce/tracks --skip-nx-cache` without errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
