### PR TITLE
Updated wp-env mysql credentials in development documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,13 +102,12 @@ You can get the current MySQL port from the output of `wp-env start` command.
 
 1. Open your choice of MySQL tool.
 2. Use the following values to access the MySQL container.
-3. You can omit the username and password.
 
 | Name     | Value                 |
 | -------- | --------------------- |
 | Host     | 127.0.0.1             |
-| Username |                       |
-| Password |                       |
+| Username | root                  |
+| Password | password              |
 | Port     | Port from the command |
 
 ## HOWTOs


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

No user/password doesn't seem to work anymore, the updated set of credentials do seem to work.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
