### PR TITLE
Adding parse_file_path filters to support remote file systems

### DIFF
--- a/plugins/woocommerce/changelog/changelog-32317
+++ b/plugins/woocommerce/changelog/changelog-32317
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add woocommerce_download_parse_remote_file_path and woocommerce_download_parse_file_path filters to modify the parse_file_path method file_path return. #32317

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -277,6 +277,13 @@ class WC_Download_Handler {
 		// Paths that begin with '//' are always remote URLs.
 		if ( '//' === substr( $file_path, 0, 2 ) ) {
 			$file_path = ( is_ssl() ? 'https:' : 'http:' ) . $file_path;
+			
+			/**
+			 * Filter the remote filepath for download.
+			 *
+			 * @since 6.5.0
+			 * @param string $file_path File path.
+			 */
 			return array(
 				'remote_file' => true,
 				'file_path'   => apply_filters( 'woocommerce_download_parse_remote_file_path', $file_path ),
@@ -297,7 +304,14 @@ class WC_Download_Handler {
 			$remote_file = false;
 			$file_path   = $parsed_file_path['path'];
 		}
-
+		
+		/**
+		* Filter the filepath for download.
+		*
+		* @since 6.5.0
+		* @param string  $file_path File path.
+		* @param bool $remote_file Remote File Indicator.
+		*/
 		return array(
 			'remote_file' => $remote_file,
 			'file_path'   => apply_filters( 'woocommerce_download_parse_file_path', $file_path, $remote_file )

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -276,7 +276,7 @@ class WC_Download_Handler {
 
 		// Paths that begin with '//' are always remote URLs.
 		if ( '//' === substr( $file_path, 0, 2 ) ) {
-			$file_path = (is_ssl() ? 'https:' : 'http:') . $file_path;
+			$file_path = ( is_ssl() ? 'https:' : 'http:' ) . $file_path;
 			return array(
 				'remote_file' => true,
 				'file_path'   => apply_filters( 'woocommerce_download_parse_remote_file_path', $file_path ),

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -279,7 +279,7 @@ class WC_Download_Handler {
 			$file_path = (is_ssl() ? 'https:' : 'http:') . $file_path;
 			return array(
 				'remote_file' => true,
-				'file_path'   => apply_filters( 'woocommerce_download_parse_file_path', $file_path, true ),
+				'file_path'   => apply_filters( 'woocommerce_download_parse_remote_file_path', $file_path, true ),
 			);
 		}
 

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -276,9 +276,10 @@ class WC_Download_Handler {
 
 		// Paths that begin with '//' are always remote URLs.
 		if ( '//' === substr( $file_path, 0, 2 ) ) {
+			$file_path = (is_ssl() ? 'https:' : 'http:') . $file_path;
 			return array(
 				'remote_file' => true,
-				'file_path'   => is_ssl() ? 'https:' . $file_path : 'http:' . $file_path,
+				'file_path'   => apply_filters( 'woocommerce_download_parse_file_path', $file_path, true ),
 			);
 		}
 
@@ -299,7 +300,7 @@ class WC_Download_Handler {
 
 		return array(
 			'remote_file' => $remote_file,
-			'file_path'   => $file_path,
+			'file_path'   => apply_filters( 'woocommerce_download_parse_file_path', $file_path, $remote_file )
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -277,7 +277,7 @@ class WC_Download_Handler {
 		// Paths that begin with '//' are always remote URLs.
 		if ( '//' === substr( $file_path, 0, 2 ) ) {
 			$file_path = ( is_ssl() ? 'https:' : 'http:' ) . $file_path;
-			
+
 			/**
 			 * Filter the remote filepath for download.
 			 *
@@ -304,7 +304,7 @@ class WC_Download_Handler {
 			$remote_file = false;
 			$file_path   = $parsed_file_path['path'];
 		}
-		
+
 		/**
 		* Filter the filepath for download.
 		*
@@ -314,7 +314,7 @@ class WC_Download_Handler {
 		*/
 		return array(
 			'remote_file' => $remote_file,
-			'file_path'   => apply_filters( 'woocommerce_download_parse_file_path', $file_path, $remote_file )
+			'file_path'   => apply_filters( 'woocommerce_download_parse_file_path', $file_path, $remote_file ),
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -279,7 +279,7 @@ class WC_Download_Handler {
 			$file_path = (is_ssl() ? 'https:' : 'http:') . $file_path;
 			return array(
 				'remote_file' => true,
-				'file_path'   => apply_filters( 'woocommerce_download_parse_remote_file_path', $file_path, true ),
+				'file_path'   => apply_filters( 'woocommerce_download_parse_remote_file_path', $file_path ),
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32314 .

This PR will add 2 filters to the file path that's being returned by the `parse_file_path` method, so, on distributed file systems, the path could be adjusted accordingly.

The existing problem is that, a file path like "vip://wp-content/uploads/" which is handled by a custom filesystem wrapper, is going to be stripped of the "vip://wp-content/" part ending in a WooCommerce download error due to incorrect file path.

The filters are named:
- `woocommerce_download_parse_remote_file_path`
- `woocommerce_download_parse_file_path`

### How to test the changes in this Pull Request:

1.  merge the PR
2. `add_filter` for any of the above-mentioned filters
3. create a downloadable product
4. check in the frontend for the adjusted values

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adding `woocommerce_download_parse_remote_file_path` and `woocommerce_download_parse_file_path` filters to modify the `parse_file_path` method `file_path` return.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
