### PR TITLE
Make sure the reply is from issue author before triggering

### DIFF
--- a/.github/workflows/update-feedback-labels.yml
+++ b/.github/workflows/update-feedback-labels.yml
@@ -5,6 +5,7 @@ jobs:
   feedback:
     if: |
       github.actor != 'github-actions' &&
+      github.actor == github.event.issue.user.login &&
       github.event.issue &&
       github.event.issue.state == 'open' &&
       contains(github.event.issue.labels.*.name, 'needs: author feedback')


### PR DESCRIPTION
This PR fixes the issue when an issue has a reply, it removes the `needs: author feedback` without first checking if the reply came from the author themselves.

**Test:**

Prereq:
Two GH accounts for testing.

* Create a test issue with one GitHub account.
* Use another GitHub account to add the `needs: author feedback`.
* With the same account, add a reply to the created issue.
* Ensure the `needs: author feedback` is not removed.
* Now with the GitHub account that created the issue, add a reply to the issue.
* Ensure the `needs: author feedback` is now removed and `needs: triage feedback` is added.