### PR TITLE
Update `@woo…/number` code docs, define & export type declarations. 

### DIFF
--- a/packages/js/number/src/index.js
+++ b/packages/js/number/src/index.js
@@ -45,12 +45,14 @@ export function numberFormat(
 }
 
 /**
- * Formats a number string based on `type` as average or number.
+ * Formats a number as average or number string according to the given `type`.
+ *  - `type = 'average'` returns a rounded `Number`
+ *  - `type = 'number'` returns a formatted `String`
  *
  * @param {NumberConfig} numberConfig number formatting configuration object.
  * @param {string}       type         of number to format, `'average'` or `'number'`
  * @param {number}       value        to format.
- * @return {?string} A formatted string.
+ * @return {string | number | null} A formatted string.
  */
 export function formatValue( numberConfig, type, value ) {
 	if ( ! Number.isFinite( value ) ) {

--- a/packages/js/number/src/index.js
+++ b/packages/js/number/src/index.js
@@ -1,14 +1,20 @@
 const numberFormatter = require( 'locutus/php/strings/number_format' );
 
 /**
+ * Number formatting configuration object
+ *
+ * @typedef {Object} NumberConfig
+ * @property {number} [precision]         Decimal precision.
+ * @property {string} [decimalSeparator]  Decimal separator.
+ * @property {string} [thousandSeparator] Character used to separate thousands groups.
+ */
+
+/**
  * Formats a number using site's current locale
  *
  * @see http://locutus.io/php/strings/number_format/
- * @param {Object}        numberConfig                   number formatting configuration object.
- * @param {number}        numberConfig.precision
- * @param {string}        numberConfig.decimalSeparator
- * @param {string}        numberConfig.thousandSeparator
- * @param {number|string} number                         number to format
+ * @param {NumberConfig}  numberConfig Number formatting configuration object.
+ * @param {number|string} number       number to format
  * @return {?string} A formatted string.
  */
 export function numberFormat(
@@ -39,11 +45,11 @@ export function numberFormat(
 }
 
 /**
- * Formats a number string based on type of `average` or `number`.
+ * Formats a number string based on `type` as average or number.
  *
- * @param {Object} numberConfig number formatting configuration object.
- * @param {string} type         of number to format, average or number
- * @param {number} value        to format.
+ * @param {NumberConfig} numberConfig number formatting configuration object.
+ * @param {string}       type         of number to format, `'average'` or `'number'`
+ * @param {number}       value        to format.
  * @return {?string} A formatted string.
  */
 export function formatValue( numberConfig, type, value ) {

--- a/packages/js/number/src/index.js
+++ b/packages/js/number/src/index.js
@@ -15,7 +15,7 @@ const numberFormatter = require( 'locutus/php/strings/number_format' );
  * @see http://locutus.io/php/strings/number_format/
  * @param {NumberConfig}  numberConfig Number formatting configuration object.
  * @param {number|string} number       number to format
- * @return {?string} A formatted string.
+ * @return {string} A formatted string.
  */
 export function numberFormat(
 	{ precision = null, decimalSeparator = '.', thousandSeparator = ',' },

--- a/packages/js/number/tsconfig-cjs.json
+++ b/packages/js/number/tsconfig-cjs.json
@@ -1,6 +1,7 @@
 {
     "extends": "../tsconfig-cjs",
     "compilerOptions": {
+        "declaration": true,
         "outDir": "build"
     }
 }

--- a/packages/js/number/tsconfig.json
+++ b/packages/js/number/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../tsconfig",
 	"compilerOptions": {
+		"declaration": true,
 		"rootDir": "src",
 		"outDir": "build-module"
 	}


### PR DESCRIPTION
Redo [woocommerce/woocommerce-admin@8cdc828.](https://github.com/woocommerce/woocommerce-admin/pull/7840)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As per the Dependency Extraction Webpack Plugin installing this package in another plugin serves only type checking purposes (see https://github.com/WordPress/gutenberg/issues/35630#issuecomment-946642827), it would be beneficial to actually define and export those types.

I also updated the docs for the function I find the most confusing and a few return types which I find wrong.

This PR
- Defines `NumberConfig` data type, export type declarations. (8cdc828)
- Updates `formatValue` docs, (5d7d53f)
	- explains "based on type"
		Now it clearly explains what and in what type is returned for specific `type` parameter values.	
	- fixes the returned value's type.
		It's not only `null` or `string` but may also be a `number`
- Fix returned type of numberFormat. (baa0c5d)
	`locutus/php/strings/number_format` seems to always return a `String`.

### How to test the changes in this Pull Request:

-   `npm install @woocommerce/number`
-   Somewhere in your codebase's JSDoc use `{import('@woocommerce/number').NumberConfig}`

### Screenshots

![image](https://user-images.githubusercontent.com/17435/138722378-674edd0c-67b3-495f-a94d-ab3cd678f379.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [n/a] Have you written new tests for your changes, as applicable?
* [n/a] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Export data types from `@woocommerce/number`.

### Additional notes:
_Originally discussed at https://github.com/woocommerce/woocommerce-admin/pull/7840#issuecomment-965824769_
1. This data type could be used further in `@woocommerce/currency` to make the code docs shorter.
2. Personally, I find the `formatValue` API confusing, as it returns type `string` for `type='number'` parameter, and type `number` for `type='average'`. I'm not sure if that was desired, given the lack of tests.  Alternatively, we could change the implementation and make sure it always returns a `?string` as the docs stated before. But that may be an effectively breaking change.
3. Also We could set a default value for `formatValue`'s `type` parameter, to make sure it would never return `undefined`, which currently may be a result of an invalid param given.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
