### PR TITLE
Fix row actions to show in the order overview. (edit, quick edit, trash etc.)

### DIFF
--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -76,7 +76,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * @return array
 	 */
 	protected function get_row_actions( $actions, $post ) {
-		return array();
+		return $actions;
 	}
 
 	/**


### PR DESCRIPTION
Prevented bug where the row-actions didn't show

### All Submissions:

* [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Go to woocommerce -> orders
2. Try hover a order and see if the buttons "Edit", "Quick Edit", "Trash" shows

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
- Fixed row actions in the order overview

### FOR PR REVIEWER ONLY:

* [ x ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
