### PR TITLE
Update WooCommerce Blocks package to 7.2.1

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "3.1.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-blocks": "7.2.0"
+		"woocommerce/woocommerce-blocks": "7.2.1"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 7.2.1. It is intended to target WooCommerce 6.4 for release. This supercedes https://github.com/woocommerce/woocommerce/pull/32075.

Details from all the different releases included in this pull:

## Blocks 7.2.1
[Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6072)
[Testing Instruction](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/721.md)

### Changelog entry

#### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug fixes

- Don't trigger class deprecations notices if headers are already sent [#6074](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6074)

### Changelog entry
> Dev - Update WooCommerce Blocks version to 7.2.1
