### PR TITLE
Changes to class-wc-auth that allows it to work with sso auth - update PR #29977

### DIFF
--- a/plugins/woocommerce/includes/class-wc-auth.php
+++ b/plugins/woocommerce/includes/class-wc-auth.php
@@ -324,6 +324,36 @@ class WC_Auth {
 
 			// Login endpoint.
 			if ( 'login' === $route && ! is_user_logged_in() ) {
+				/**
+				 * If a merchant is using the WordPress SSO (handled through Jetpack)
+				 * to manage their authorisation then it is likely they'll find that
+				 * their username and password do not work through this form. We
+				 * instead need to redirect them to the WordPress login so that they
+				 * can then be redirected back here with a valid token.
+				 */
+
+				// Check if Jetpack is installed and activated.
+				if ( class_exists( 'Jetpack' ) && Jetpack::connection()->is_active() ) {
+
+					// Check if the user is using the WordPress.com SSO.
+					if ( Jetpack::is_module_active( 'sso' ) ) {
+
+						$redirect_url = $this->build_url( $data, 'authorize' );
+
+						// Build the SSO URL.
+						$login_url = Jetpack_SSO::get_instance()->build_sso_button_url(
+							array(
+								'redirect_to' => rawurlencode( esc_url_raw( $redirect_url ) ),
+								'action'      => 'login',
+							)
+						);
+
+						// Perform the redirect.
+						wp_safe_redirect( $login_url );
+						exit;
+					}
+				}
+
 				wc_get_template(
 					'auth/form-login.php',
 					array(


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is an attempt to fix an issue with the wc-auth endpoint which doesn't work alongside WordPress' SSO implementation. The issue came to light when someone was testing the connection flow for the Facebook for Woocommerce plugin on their site which makes use of the wc-auth endpoint:

https://user-images.githubusercontent.com/1573005/119368147-98443080-bcaa-11eb-9ced-1257233970a7.mov

WordPress SSO is handled via the Jetpack plugin so this PR aims to ensure that the login hook that Jetpack uses is correctly triggered by the wc-auth endpoint. The below video shows it working:


https://user-images.githubusercontent.com/4209011/159723947-d16cbf41-28b6-4cc4-8c1e-fa08ff9b8f87.mov


As can be seen, it correctly redirects to the WordPress log in then redirects back to the OAuth flow that had originally been started with the logged-in user.


**‼️ Note: I am putting out this PR as a replacement to https://github.com/woocommerce/woocommerce/pull/29977 which hasn't received any response in a while. The solution in the old PR had some problems with the way the $action was overridden, this PR addresses that by building the SSO URL with the appropriate action and performing the redirect directly** 

### How to test the changes in this Pull Request:

1. You'll need a site using the SSO method supplied by Jetpack
2. Visit https:/[YOUR SITE]/wc-auth/v1/authorize/?app_name=WooCommerce%20Integration&user_id=[USER ID]&return_url=[somewhere.com]&callback_url=[somewhereelse.com]&scope=read_write
3. Check that the redirect works

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ 0] Have you written new tests for your changes, as applicable? - WC_Auth isn't really covered by any tests from what I can see. Let me know if there's a requirement for tests.
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix - OAuth flows that use the wc-auth endpoint on sites that use SSO with a redirect for authentication.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
