### PR TITLE
Define `NumberConfig` data type, export type declarations from `@woo…/currency`

### DIFF
--- a/packages/js/currency/README.md
+++ b/packages/js/currency/README.md
@@ -25,7 +25,7 @@ const total = storeCurrency.formatAmount( 20.923 ); // '$20.92'
 
 // Get the rounded decimal value of a number at the precision used for the current currency,
 // from the settings api. Defaults to 2.
-const total = storeCurrency.formatDecimal( '6.2892' ); // 6.29 https://google.com/?q=test
+const total = storeCurrency.formatDecimal( '6.2892' ); // 6.29
 
 // Get the string representation of a floating point number to the precision used by the current
 // currency. This is different from `formatAmount` by not returning the currency symbol.

--- a/packages/js/currency/src/index.js
+++ b/packages/js/currency/src/index.js
@@ -7,6 +7,22 @@ import { sprintf } from '@wordpress/i18n';
 import { numberFormat } from '@woocommerce/number';
 import deprecated from '@wordpress/deprecated';
 
+/**
+ * @typedef {import('@woocommerce/number').NumberConfig} NumberConfig
+ */
+/**
+ * @typedef {Object} CurrencyProps
+ * @property {string} code           Currency ISO code.
+ * @property {string} symbol         Symbol, can be multi-character.
+ * @property {string} symbolPosition Where the symbol should be relative to the amount. One of `'left' | 'right' | 'left_space | 'right_space'`.
+ * @typedef {NumberConfig & CurrencyProps} CurrencyConfig
+ */
+
+/**
+ *
+ * @param {CurrencyConfig} currencySetting
+ * @return {Object} currency object
+ */
 const CurrencyFactory = function ( currencySetting ) {
 	let currency;
 
@@ -63,7 +79,6 @@ const CurrencyFactory = function ( currencySetting ) {
 	 * Formats money value.
 	 *
 	 * @deprecated
-	 *
 	 * @param {number|string} number number to format
 	 * @return {?string} A formatted string.
 	 */
@@ -80,7 +95,7 @@ const CurrencyFactory = function ( currencySetting ) {
 	/**
 	 * Get the default price format from a currency.
 	 *
-	 * @param {Object} config Currency configuration.
+	 * @param {CurrencyConfig} config Currency configuration.
 	 * @return {string} Price format.
 	 */
 	function getPriceFormat( config ) {
@@ -108,7 +123,7 @@ const CurrencyFactory = function ( currencySetting ) {
 	 * @param {string} countryCode     Country code.
 	 * @param {Object} localeInfo      Locale info by country code.
 	 * @param {Object} currencySymbols Currency symbols by symbol code.
-	 * @return {Object} Formatted currency data for country.
+	 * @return {CurrencyConfig | {}} Formatted currency data for country.
 	 */
 	function getDataForCountry(
 		countryCode,
@@ -211,7 +226,6 @@ export default CurrencyFactory;
  * Dev Note: When adding new currencies below, the exchange rate array should also be updated in WooCommerce Admin's `business-details.js`.
  *
  * @deprecated
- *
  * @return {Object} Curreny data.
  */
 export function getCurrencyData() {

--- a/packages/js/currency/tsconfig-cjs.json
+++ b/packages/js/currency/tsconfig-cjs.json
@@ -1,6 +1,7 @@
 {
     "extends": "../tsconfig-cjs",
     "compilerOptions": {
+        "declaration": true,
         "outDir": "build"
     }
 }

--- a/packages/js/currency/tsconfig.json
+++ b/packages/js/currency/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../tsconfig",
 	"compilerOptions": {
+		"declaration": true,
 		"rootDir": "src",
 		"outDir": "build-module"
 	}


### PR DESCRIPTION
:warning: This PR is based on/requires https://github.com/woocommerce/woocommerce/pull/32325
And served the same purpose

It's also a redo of https://github.com/woocommerce/woocommerce-admin/pull/7848

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Removes unrelated Google Search link form README
- Defines `CurrencyConfig` type, exports declarations
  So they could be referenced in the other packages.

### How to test the changes in this Pull Request:


-   `npm install @woocommerce/currency`
-   Somewhere in your codebase's JSDoc use `{import('@woocommerce/currency').CurrencyConfig}`


### Screenshots

![image](https://user-images.githubusercontent.com/17435/138910465-5955d449-e3ef-4a94-a870-d9d61b1597bd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [n/a] Have you written new tests for your changes, as applicable?
* [n/a] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Export data types from `@woocommerce/currency`.

### Additional notes:
1. Preferable I'd not define `CurrencyProps` type, just do
	  ```js
	  /**
	   * @typedef {NumberConfig} CurrencyConfig
	   * @property {string} code Currency ISO code.
	   * …
	  ```
	  or at least
	  ```js
	  /**
	   * @typedef {NumberConfig & {code: string}} CurrencyConfig
	   * @property {string} code Currency ISO code.
	   * …
	  ```
	  But unfortunately, it's not supported by TypeScript yet https://github.com/microsoft/TypeScript/issues/20077
 
2. The type of the object returned by `CurrencyFactory` is still not defined, and the individual methods of that object are lost as well. I'd solve that in a separate PR, as I believe we could do a small refactoring by the way. The current code base makes it hard to document and test it. At least that makes this PR shorter and less controversial.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.