### PR TITLE
Add filters to product attributes template

### DIFF
--- a/plugins/woocommerce/templates/single-product/product-attributes.php
+++ b/plugins/woocommerce/templates/single-product/product-attributes.php
@@ -26,8 +26,12 @@ if ( ! $product_attributes ) {
 <table class="woocommerce-product-attributes shop_attributes">
 	<?php foreach ( $product_attributes as $product_attribute_key => $product_attribute ) : ?>
 		<tr class="woocommerce-product-attributes-item woocommerce-product-attributes-item--<?php echo esc_attr( $product_attribute_key ); ?>">
-			<th class="woocommerce-product-attributes-item__label"><?php echo wp_kses_post( $product_attribute['label'] ); ?></th>
-			<td class="woocommerce-product-attributes-item__value"><?php echo wp_kses_post( $product_attribute['value'] ); ?></td>
+			<th class="woocommerce-product-attributes-item__label">
+				<?php echo wp_kses_post( apply_filters( 'woocommerce_product_attribute_label_html', wp_kses_post( $product_attribute['label'] ), $product_attribute, $product_attribute_key ) ); ?>
+			</th>
+			<td class="woocommerce-product-attributes-item__value">
+				<?php echo wp_kses_post( apply_filters( 'woocommerce_product_attribute_value_html', wp_kses_post( $product_attribute['value'] ), $product_attribute, $product_attribute_key ) ); ?>
+			</td>
 		</tr>
 	<?php endforeach; ?>
 </table>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add filters `woocommerce_product_attribute_label_html` and `woocommerce_product_attribute_value_html` for modifying product attribute labels and values on a single-product's 'additional information' tab.

Users may want to have more fine-grained control over the content that's displayed to give customers richer product information.

#### Here's one usage example (the added table):
![Example](https://i.imgur.com/IAZHz3n.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Added filters to single-product product attribute template

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
