### PR TITLE
Add "Build Admin feature config" step to "Run CI" action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Setup and install composer
         run: pnpm nx composer-install woocommerce
 
+      - name: Build Admin feature config
+        working-directory: ./
+        run: pnpm nx build:feature-config woocommerce-admin
+
       - name: Add PHP8 Compatibility.
         run: |
           if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We've removed the feature config from the repo in https://github.com/woocommerce/woocommerce/pull/32304 and added a build script for other action files.

To run the [ci tests](https://github.com/woocommerce/woocommerce/actions/workflows/ci.yml) successfully, add the build admin feature config step.

### How to test the changes in this Pull Request:

Check if action pass in the test branch.

https://github.com/woocommerce/woocommerce/actions/runs/2032559021

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
