### PR TITLE
Add build-watch command for woocommerce-admin

### DIFF
--- a/packages/js/admin-e2e-tests/package.json
+++ b/packages/js/admin-e2e-tests/package.json
@@ -49,6 +49,7 @@
 	},
 	"scripts": {
 		"build": "tsc --build",
+	  	"start": "tsc --build --watch",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"prepack": "pnpm run clean && pnpm run build"
 	}

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -30,6 +30,8 @@
 		"clean": "rimraf ./dist && pnpm run:packages -- clean --parallel",
 		"predev": "pnpm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"dev": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development pnpm run build:packages && cross-env WC_ADMIN_PHASE=development webpack",
+		"client:watch": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development webpack --watch",
+		"packages:watch": "cross-env WC_ADMIN_PHASE=development pnpm run build:packages && cross-env WC_ADMIN_PHASE=development pnpm run:packages -- start --parallel",
 		"docs": "./bin/import-wp-css-storybook.sh && BABEL_ENV=storybook STORYBOOK=true pnpm exec build-storybook -c storybook/.storybook -o ./docs/components/storybook",
 		"i18n": "pnpm run -s i18n:js && pnpm run -s i18n:check && pnpm run -s i18n:pot && pnpm run -s i18n:build",
 		"i18n:build": "php bin/combine-pot-files.php languages/woocommerce-admin.po languages/woocommerce-admin.pot",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -31,7 +31,7 @@
 		"predev": "pnpm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"dev": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development pnpm run build:packages && cross-env WC_ADMIN_PHASE=development webpack",
 		"client:watch": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development webpack --watch",
-		"packages:watch": "cross-env WC_ADMIN_PHASE=development pnpm run build:packages && cross-env WC_ADMIN_PHASE=development pnpm run:packages -- start --parallel",
+		"packages:watch": "cross-env WC_ADMIN_PHASE=development pnpm run:packages -- start --parallel",
 		"docs": "./bin/import-wp-css-storybook.sh && BABEL_ENV=storybook STORYBOOK=true pnpm exec build-storybook -c storybook/.storybook -o ./docs/components/storybook",
 		"i18n": "pnpm run -s i18n:js && pnpm run -s i18n:check && pnpm run -s i18n:pot && pnpm run -s i18n:build",
 		"i18n:build": "php bin/combine-pot-files.php languages/woocommerce-admin.po languages/woocommerce-admin.pot",

--- a/plugins/woocommerce-admin/project.json
+++ b/plugins/woocommerce-admin/project.json
@@ -20,8 +20,18 @@
 			"executor": "@nrwl/workspace:run-commands",
 			"options": {
 				"commands": [
-					"pnpm nx client:watch woocommerce-admin",
-					"pnpm nx packages:watch woocommerce-admin"
+					"WC_ADMIN_PHASE=development pnpm nx dev woocommerce-admin",
+					"pnpm nx watch woocommerce-admin"
+				],
+				"parallel": false
+			}
+		},
+		"watch": {
+			"executor": "@nrwl/workspace:run-commands",
+			"options": {
+				"commands": [
+					"pnpm nx packages:watch woocommerce-admin",
+					"pnpm nx client:watch woocommerce-admin"
 				],
 				"parallel": true
 			}

--- a/plugins/woocommerce-admin/project.json
+++ b/plugins/woocommerce-admin/project.json
@@ -15,6 +15,16 @@
 			"options": {
 				"script": "build"
 			}
+		},
+		"build-watch": {
+			"executor": "@nrwl/workspace:run-commands",
+			"options": {
+				"commands": [
+					"pnpm nx client:watch woocommerce-admin",
+					"pnpm nx packages:watch woocommerce-admin"
+				],
+				"parallel": true
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/project.json
+++ b/plugins/woocommerce/project.json
@@ -2,9 +2,9 @@
 	"root": "plugins/woocommerce/",
 	"sourceRoot": "plugins/woocommerce",
 	"projectType": "application",
-	"implicitDependencies": [ 
+	"implicitDependencies": [
 		"woocommerce-legacy-assets",
-		"woocommerce-admin" 
+		"woocommerce-admin"
 	],
 	"targets": {
 		"changelog": {
@@ -54,6 +54,15 @@
 			}
 		},
 		"build-watch": {
+			"executor": "@nrwl/workspace:run-commands",
+			"options": {
+				"commands": [
+					"pnpm nx build:feature-config woocommerce-admin",
+					"pnpm nx watch-assets woocommerce"
+				]
+			}
+		},
+		"watch-assets": {
 			"executor": "@nrwl/workspace:run-commands",
 			"options": {
 				"command": "pnpx grunt watch",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added a `nx build-watch` command for the `woocommerce-admin` project. This actually watches changes in all the `js` packages and the client code.
This PR also modifies the current `build-watch` command for `woocommerce` to include the `build:feature-config` script that `woocommerce-admin` requires.

Closes # .

### How to test the changes in this Pull Request:

1. Run `pnpm nx build-watch woocommerce` and make sure it runs correctly
2. Run `pnpm nx build-watch woocommerce-admin` and make sure it runs correctly
3. While the above command is running, update files in both the `client` code or any of the `js` packages and see if it updates correctly.

### Changelog entry

> Dev: add `build-watch` command for the new WooCommerce Admin project.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
