### PR TITLE
Enhance directory traversal handling/resolution.

### DIFF
--- a/plugins/woocommerce/src/Internal/Utilities/URL.php
+++ b/plugins/woocommerce/src/Internal/Utilities/URL.php
@@ -161,7 +161,8 @@ class URL {
 			 * Consider allowing directory traversals to be resolved (ie, the process that converts 'foo/bar/../baz' to
 			 * 'foo/baz').
 			 *
-			 * 1. We are only concerned with file URLs, for all other types unwinding of traversals is already allowed.
+			 * 1. For this decision point, we are only concerned with relative filepaths (in all other cases,
+			 *    $resolve_traversals will already be true).
 			 * 2. This is a 'one time' and unidirectional operation. We only wish to flip from false to true, and we
 			 *    never wish to do this more than once.
 			 * 3. We only flip the switch after we have examined all leading '..' traversal segments.
@@ -170,7 +171,10 @@ class URL {
 				$resolve_traversals = true;
 			}
 
-			// At this point, if we are committing a traversal to the path then we will wish to retain the next traversal, too.
+			/*
+			 * Set a flag indicating that traversals should be retained. This is done to ensure we don't prematurely
+			 * discard traversals at the start of the path.
+			 */
 			$retain_traversals = $resolve_traversals && '..' === $part;
 
 			// Retain this part of the path.

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
@@ -198,7 +198,7 @@ class URLTest extends WC_Unit_Test_Case {
 				'file://./',
 			),
 			( new URL( 'relative/to/abspath' ) )->get_all_parent_urls(),
-			'When obtaining all parent URLs for a relative filepath, we never return the root directory and never return a URL containing traversals. '
+			'When obtaining all parent URLs for a relative filepath, we never return the root directory and never return a URL containing traversals if there were none to begin with.'
 		);
 
 		$this->assertEquals(

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
@@ -133,7 +133,12 @@ class URLTest extends WC_Unit_Test_Case {
 	public function test_can_obtain_parent_url() {
 		$this->assertFalse(
 			( new URL( '/' ) )->get_parent_url(),
-			'Root directory "/" is considered to have no parent.'
+			'Root directory "/" is considered to have no parent (scenario #1).'
+		);
+
+		$this->assertFalse(
+			( new URL( '/' ) )->get_parent_url( 2 ),
+			'Root directory "/" is considered to have no parent (scenario #2).'
 		);
 
 		$this->assertEquals(
@@ -194,6 +199,38 @@ class URLTest extends WC_Unit_Test_Case {
 			),
 			( new URL( 'relative/to/abspath' ) )->get_all_parent_urls(),
 			'When obtaining all parent URLs for a relative filepath, we never return the root directory and never return a URL containing traversals. '
+		);
+
+		$this->assertEquals(
+			array(
+				'file://../../'
+			),
+			( new URL( '../../some.file' ) )->get_all_parent_urls(),
+			'When obtaining all parent URLs for a path that begins with directory traversals, we only go up one more level.'
+		);
+
+		$this->assertEquals(
+			'file://../../',
+			( new URL( '../' ) )->get_parent_url(),
+			'If a relative *directory* beginning with a traversal is provided, we can successfully derive its parent (scenario #1).'
+		);
+
+		$this->assertEquals(
+			'file://../../../',
+			( new URL( '../' ) )->get_parent_url( 2 ),
+			'If a relative *directory* beginning with a traversal is provided, we can successfully derive its parent (scenario #2).'
+		);
+
+		$this->assertEquals(
+			'file://../../../',
+			( new URL( '../../some.file' ) )->get_parent_url( 2 ),
+			'If the grandparent of a relative path that begins with one or more traversals is requested, we should receive the expected result (scenario #1).'
+		);
+
+		$this->assertEquals(
+			'file://../../../../',
+			( new URL( '../../some.file' ) )->get_parent_url( 3 ),
+			'If the grandparent of a relative path that begins with one or more traversals is requested, we should receive the expected result (scenario #2).'
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This set of changes is a necessary precursor to some other changes that are required to support shortcodes as a means of supplying a downloadable file URL (as is the case with the S3 downloads add-on).

Specifically, it guards against tricky issues that might occur if a plugin like S3 is disabled and/or other scenarios where a disused shortcode is supplied to represent a downloadable filepath or URL (because in those cases, the shortcode is  unparseable and essentially represents a relative filepath.

Additionally, it improves logic relating to handling of filepaths and URLs that contain directory traversals from within our internally-facing URL utility class.

### How to test the changes in this Pull Request:

There is no UI-driven way to assess this set of changes. Instead, please review the newly added tests, and revisions to the existing tests. Those are probably the best indication of the scenarios I wanted to touch on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Not needed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
