### PR TITLE
Add default woocommerce file for quality of life.

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: WooCommerce
+ * Plugin URI: https://woocommerce.com/
+ * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
+ * Version: development
+ * Author: Automattic
+ * Author URI: https://woocommerce.com
+ * Text Domain: woocommerce
+ * Domain Path: /i18n/languages/
+ * Requires at least: 5.7
+ * Requires PHP: 7.0
+ *
+ * @package WooCommerce
+ */
+
+require_once __DIR__ . '/plugins/woocommerce/woocommerce.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a default woocommerce load file to monorepo so that the plugin can be loaded after a git clone without having to symlink anything.

### How to test the changes in this Pull Request:

1. Checkout this branch, and place the repo in `wp-content/plugins` folder (like before monorepo setup).
2. Go to `/wp-admin/plugins.php` and activate the `WooCommerce` plugin with version set to `development`.
3. See if WooCommerce is loaded like it should.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
