### PR TITLE
Support shortcode-based downloadable files (as used by S3 Downloads e…

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-download.php
+++ b/plugins/woocommerce/includes/class-wc-product-download.php
@@ -201,7 +201,17 @@ class WC_Product_Download implements ArrayAccess {
 			return;
 		}
 
-		$download_file           = $this->get_file();
+		$download_file = $this->get_file();
+
+		/**
+		 * Controls whether shortcodes should be resolved and validated using the Approved Download Directory feature.
+		 *
+		 * @param bool $should_validate
+		 */
+		if ( apply_filters( 'woocommerce_product_downloads_approved_directory_validation_for_shortcodes', true ) && 'shortcode' === $this->get_type_of_file_path() ) {
+			$download_file = do_shortcode( $download_file );
+		}
+
 		$is_site_administrator   = is_multisite() ? current_user_can( 'manage_sites' ) : current_user_can( 'manage_options' );
 		$valid_storage_directory = $download_directories->is_valid_path( $download_file );
 

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -219,7 +219,18 @@ class Synchronize {
 			$parent_url = _x( 'invalid URL', 'Approved product download URLs migration', 'woocommerce' );
 
 			try {
-				$parent_url = ( new URL( $downloadable->get_file() ) )->get_parent_url();
+				$download_file = $downloadable->get_file();
+
+				/**
+				 * Controls whether shortcodes should be resolved and validated using the Approved Download Directory feature.
+				 *
+				 * @param bool $should_validate
+				 */
+				if ( apply_filters( 'woocommerce_product_downloads_approved_directory_validation_for_shortcodes', true ) && 'shortcode' === $downloadable->get_type_of_file_path() ) {
+					$download_file = do_shortcode( $download_file );
+				}
+
+				$parent_url = ( new URL( $download_file ) )->get_parent_url();
 				$this->register->add_approved_directory( $parent_url, false );
 			} catch ( Exception $e ) {
 				wc_get_logger()->log(


### PR DESCRIPTION
:bulb: Marking as a draft (though please do still review) until https://github.com/woocommerce/woocommerce/pull/32350 is merged, as it builds on work performed there.

### Changes proposed in this Pull Request:

Some extensions such as [Amazon S3 Storage](https://woocommerce.com/document/amazon-s3-storage/) require that users express the download location using a shortcode rather than an actual filepath or URL. Example:

```
[amazon_s3 bucket=bucketname object=filename.pdf]
```

To make these work with the new Approved Download Directory system (when that is enabled), we need to add extra steps where we resolve the shortcode earlier in the process.

### How to test the changes in this Pull Request:

**Part 1**

1. Enable the Approved Download Directory feature.
    1. Visit **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories**
    2. If you see a button reading `Stop Enforcing Rules` you are all set, otherwise click on `Start Enforcing Rules`
    3. (Optional) to make it easier to assess this change, I recommend visiting **WooCommerce ▸ Status ▸ Tools** and locate the *"Empty the approved download directories list"* tool: click the `Clear` button.
2. Install and activate [Amazon S3 Storage](https://woocommerce.com/document/amazon-s3-storage/).
    1. Internal testers, note that we have a test account and details of a testing bucket in the Secret Store.
    2. Go through the necessary setup procedure by adding the necessary information within **WooCommerce ▸ Amazon S3 Storage ▸ Security Credentials**.
3. As a lower-level user such as a shop manager, create a downloadable product or edit an existing one.
    1. Add a downloadable file using an S3 shortcode such as `[amazon_s3 bucket=bucketname object=filename.pdf]` (use an actual bucket and file, not a fake one).
    2. It will not be accepted (note that you should see an warning message, however that seems to be missing at present: I plan on investigating that separately).
    3. Switch to a full admin user and reload the **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** screen. You should see an entry for `https://<BUCKETNAME>.s3.amazonaws.com/` but *it should be disabled*.
    4. Enable it!
4. Now purchase the product (you may wish to do this from a logged-in customer account).
    1. As an admin user, mark the order as completed.
    2. As the customer, visit **My Account ▸ Downloads** (frontend).
    3. Assuming the shortcode 'pointed' to an actual file in storage, you should be able to download the expected file.
    4. As an admin user, deactivate the Amazon S3 Storage plugin.
    5. As the customer, try downloading it again. This time it should fail with a `File not found` error.

**Part 2**

1. Reactivate Amazon S3 Downloads.
2. Visit **WooCommerce ▸ Status ▸ Tools** and trigger a fresh sync:
    1. Locate the *"Empty the approved download directories list"* tool: click the `Clear` button.
    2. Locate the *"Synchronize approved download directories"* tool: click the `Update` button.
3. Give time for synchronization to complete.
    1. This happens via Action Scheduler.
    2. You may wish to run `wp action-scheduler run` multiple times to clear waiting queue items.
    3. Or, manually do this from the **Tools ▸ Scheduled Actions** screen (look for `woocommerce_download_dir_sync` which you can then run manually — you may need to refresh and repeat a few times).
4. Ultimately, within the **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** screen, you should see the relevant Amazon S3 URL has been added to the list.
 
### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Not needed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
