### PR TITLE
Update documentation links.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-product-download.php
+++ b/plugins/woocommerce/includes/class-wc-product-download.php
@@ -216,7 +216,7 @@ class WC_Product_Download implements ArrayAccess {
 						/* translators: %1$s is the downloadable file path, %2$s is an opening link tag, %3%s is a closing link tag. */
 						__( 'The downloadable file %1$s cannot be used: it is not located in an approved directory. Please contact a site administrator and request their approval. %2$sLearn more.%3$s', 'woocommerce' ),
 						'<code>' . $download_file . '</code>',
-						'<a href="https://woocommerce.com/documentation/approved-download-directories">', // @todo update to working link (see https://github.com/Automattic/woocommerce/issues/181)
+						'<a href="https://woocommerce.com/document/approved-download-directories">',
 						'</a>'
 					)
 				);
@@ -229,7 +229,7 @@ class WC_Product_Download implements ArrayAccess {
 					/* translators: %1$s is the downloadable file path, %2$s is an opening link tag, %3%s is a closing link tag. */
 					__( 'The downloadable file %1$s cannot be used: it is not located in an approved directory. Please contact a site administrator for help. %2$sLearn more.%3$s', 'woocommerce' ),
 					'<code>' . $download_file . '</code>',
-					'<a href="https://woocommerce.com/documentation/approved-download-directories">', // @todo update to working link (see https://github.com/Automattic/woocommerce/issues/181)
+					'<a href="https://woocommerce.com/document/approved-download-directories">',
 					'</a>'
 				)
 			);


### PR DESCRIPTION
Minor change, addresses two `@todo` items relating to documentation. Note the referenced doc is not live yet, but we anticipate making it live upon release.

### Changelog entry

Not needed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
