### PR TITLE
Skip deletion of PLUGIN_NAME when used by environment variables

### DIFF
--- a/packages/js/admin-e2e-tests/src/fixtures/reset.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/reset.ts
@@ -4,14 +4,23 @@
 import { httpClient } from './http-client';
 import { deactivateAndDeleteAllPlugins } from './plugins';
 
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { utils } = require( '@woocommerce/e2e-utils' );
+
+const { PLUGIN_NAME } = process.env;
+
 const resetEndpoint = '/woocommerce-reset/v1/state';
+
+const pluginName = PLUGIN_NAME ? PLUGIN_NAME : 'WooCommerce';
+const pluginNameSlug = utils.getSlug( pluginName );
 
 const skippedPlugins = [
 	'woocommerce',
 	'woocommerce-admin',
 	'woocommerce-reset',
 	'basic-auth',
-	'wp-mail-logging'
+	'wp-mail-logging',
+	pluginNameSlug,
 ];
 
 export async function resetWooCommerceState() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some of the smoke tests make use of a `PLUGIN_NAME` environment variable, that is used to install a plugin that should be kept during the duration of tests. The reset plugin was attempting to delete this.
I updated the reset logic so it takes the `PLUGIN_NAME` in account.

Closes #32364  .

### How to test the changes in this Pull Request:

**One thing to note:**
When I run my E2E tests locally sometimes they immediately fail with a **Target closed** error. Usually trying a second time does the trick, I am not sure why that is.

1. Run a build and set up your E2E tests by following these steps: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md
2. You also need a Github personal access token for this test to work -> https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
3. You first want to run the `upload-plugin.js` test with several environment variables like this -> `WC_E2E_SCREENSHOTS=1 PLUGIN_REPOSITORY="automattic/woocommerce-payments" PLUGIN_NAME="WooCommerce Payments" GITHUB_TOKEN="YOUR_GITHUB_TOKEN" pnpm exec wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/upload-plugin.js` 
replacing `YOUR_GITHUB_TOKEN` with your token from step 2
4. Those tests should succeed
5. Now run the onboarding wizard tests (these previously failed) using the same env tokens, just like this -> `WC_E2E_SCREENSHOTS=1 PLUGIN_REPOSITORY="automattic/woocommerce-payments" PLUGIN_NAME="WooCommerce Payments" GITHUB_TOKEN="YOUR_GITHUB_TOKEN" pnpm exec wc-e2e test:e2e ./tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js`
6. Those should all pass now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix smoke E2E tests that made use of a specific plugin being installed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
