### PR TITLE
Removed separate WCA entry in issue template contact_link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,6 @@ contact_links:
   - name: ❓ Support Question
     url: https://woocommerce.com/document/woocommerce-self-service-guide/
     about: If you have a question please see our docs or use our forums, helpdesk, or Slack community!
-  - name: WooCommerce Admin
-    url: https://github.com/woocommerce/woocommerce-admin
-    about: Please report issues for WooCommerce Admin (such as Analytics and Onboarding) directly to it's repository.
   - name: WooCommerce Blocks
     url: https://github.com/woocommerce/woocommerce-gutenberg-products-block
     about: Please report issues for WooCommerce Blocks directly to it's repository.


### PR DESCRIPTION
Misleading, now that WCA is in this repo

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
