### PR TITLE
Remove the admin notice about the upcoming PHP 7.2 requirement

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -54,13 +54,7 @@ class WC_Admin_Notices {
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
-		add_action(
-			'admin_init',
-			function() {
-				self::maybe_remove_php72_required_notice();
-			},
-			20
-		);
+
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
 		// to avoid.
@@ -122,41 +116,6 @@ class WC_Admin_Notices {
 		self::add_notice( 'template_files' );
 		self::add_min_version_notice();
 		self::add_maxmind_missing_license_key_notice();
-		self::maybe_add_php72_required_notice();
-	}
-
-	/**
-	 * Add an admin notice about the bump of the required PHP version in WooCommerce 6.5
-	 * if the current PHP version is too old.
-	 *
-	 * TODO: Remove this method in WooCommerce 6.5.
-	 */
-	private static function maybe_add_php72_required_notice() {
-		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
-			return;
-		}
-
-		self::add_custom_notice(
-			'php72_required_in_woo_65',
-			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 6.5, scheduled for <b>May 2022</b>, will require PHP 7.2 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 7.4 is recommended. <b><a href="https://developer.woocommerce.com/2022/01/05/new-requirement-for-woocommerce-6-5-php-7-2/">Learn more about this change.</a></b></p>', 'woocommerce' )
-		);
-
-		$wp_version_is_ok = version_compare( get_bloginfo( 'version' ), WC_NOTICE_MIN_WP_VERSION, '>=' );
-		if ( $wp_version_is_ok ) {
-			self::hide_notice( WC_PHP_MIN_REQUIREMENTS_NOTICE );
-		}
-	}
-
-	/**
-	 * Remove the admin notice about the bump of the required PHP version in WooCommerce 6.5
-	 * if the current PHP version is good.
-	 *
-	 * TODO: Remove this method in WooCommerce 6.5.
-	 */
-	private static function maybe_remove_php72_required_notice() {
-		if ( version_compare( phpversion(), '7.2', '>=' ) && self::has_notice( 'php72_required_in_woo_65' ) ) {
-			self::remove_notice( 'php72_required_in_woo_65' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the admin notice introduced in https://github.com/woocommerce/woocommerce/pull/31557 about the requirement for PHP 7.2 introduced in WooCommerce 6.5. This pull request complements https://github.com/woocommerce/woocommerce/pull/32112 but isn't blocked by it.

### How to test the changes in this Pull Request:

Nothing special other than loading the admin area and verifying that nothing is broken.

There's an edge case, though: if a user was in PHP 7.0 or PHP 7.1, got the notice, and didn't dismiss it, the notice will still be there even after upgrading to Woo 6.5 (and even with the changes of this pull request in place).  This shouldn't affect a lot of users and isn't a big issue anyway.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove - Admin notice warning about the upcoming minimum PHP version bump

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
