### PR TITLE
Add archive E2E screenshots step for E2E tests task

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -80,9 +80,9 @@ jobs:
               run: pnpx wc-e2e test:e2e
 
             - name: Archive E2E test screenshots
+              uses: actions/upload-artifact@v2
               working-directory: package/woocommerce/plugins/woocommerce
               if: always()
-              uses: actions/upload-artifact@v2
               with:
                   name: E2E Screenshots
                   path: tests/e2e/screenshots

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -78,7 +78,17 @@ jobs:
                   E2E_SLACK_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
                   E2E_SLACK_CHANNEL: ${{ secrets.E2E_SLACK_CHANNEL }}
               run: pnpx wc-e2e test:e2e
-                  
+
+            - name: Archive E2E test screenshots
+              working-directory: package/woocommerce/plugins/woocommerce
+              if: ${{ always() }}
+              uses: actions/upload-artifact@v2
+              with:
+                  name: E2E Screenshots
+                  path: tests/e2e/screenshots
+                  if-no-files-found: ignore
+                  retention-days: 5
+
     api-tests-run:
         name: Runs API tests.
         runs-on: ubuntu-18.04
@@ -136,65 +146,65 @@ jobs:
               run: pnpx wc-api-tests test api
 
     k6-tests-run:
-      name: Runs k6 Performance tests
-      runs-on: ubuntu-18.04
-      needs: [build]
-      steps:
-          - name: Create dirs.
-            run: |
-                mkdir -p code/woocommerce
-                mkdir -p package/woocommerce
-                mkdir -p tmp/woocommerce
-                mkdir -p node_modules
-          - name: Checkout code.
-            uses: actions/checkout@v2
-            with:
-                path: package/woocommerce
+        name: Runs k6 Performance tests
+        runs-on: ubuntu-18.04
+        needs: [build]
+        steps:
+            - name: Create dirs.
+              run: |
+                  mkdir -p code/woocommerce
+                  mkdir -p package/woocommerce
+                  mkdir -p tmp/woocommerce
+                  mkdir -p node_modules
+            - name: Checkout code.
+              uses: actions/checkout@v2
+              with:
+                  path: package/woocommerce
 
-          - name: Install PNPM and install dependencies
-            working-directory: package/woocommerce
-            run: |
-                npm install -g pnpm
-                pnpm install
+            - name: Install PNPM and install dependencies
+              working-directory: package/woocommerce
+              run: |
+                  npm install -g pnpm
+                  pnpm install
 
-          - name: Workaround to use initialization file with prepopulated data.
-            working-directory: package/woocommerce/plugins/woocommerce/tests/e2e/docker
-            run: |
-                cp init-sample-products.sh initialize.sh
+            - name: Workaround to use initialization file with prepopulated data.
+              working-directory: package/woocommerce/plugins/woocommerce/tests/e2e/docker
+              run: |
+                  cp init-sample-products.sh initialize.sh
 
-          - name: Load docker images and start containers.
-            working-directory: package/woocommerce/plugins/woocommerce
-            run: pnpx wc-e2e docker:up 
+            - name: Load docker images and start containers.
+              working-directory: package/woocommerce/plugins/woocommerce
+              run: pnpx wc-e2e docker:up
 
-          - name: Move current directory to code. We will install zip file in this dir later.
-            run: mv ./package/woocommerce/plugins/woocommerce/* ./code/woocommerce
+            - name: Move current directory to code. We will install zip file in this dir later.
+              run: mv ./package/woocommerce/plugins/woocommerce/* ./code/woocommerce
 
-          - name: Download WooCommerce ZIP.
-            uses: actions/download-artifact@v2
-            with:
-                name: woocommerce
-                path: tmp
+            - name: Download WooCommerce ZIP.
+              uses: actions/download-artifact@v2
+              with:
+                  name: woocommerce
+                  path: tmp
 
-          - name: Extract and replace WooCommerce zip.
-            working-directory: tmp
-            run: |
-                unzip woocommerce.zip -d woocommerce
-                mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+            - name: Extract and replace WooCommerce zip.
+              working-directory: tmp
+              run: |
+                  unzip woocommerce.zip -d woocommerce
+                  mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
 
-          - name: Install dependencies again
-            working-directory: package/woocommerce
-            run: |
-                npm install -g pnpm
-                pnpm install
+            - name: Install dependencies again
+              working-directory: package/woocommerce
+              run: |
+                  npm install -g pnpm
+                  pnpm install
 
-          - name: Wait for the Docker container to be built
-            working-directory: package/woocommerce/plugins/woocommerce
-            run: pnpx wc-e2e docker:wait
+            - name: Wait for the Docker container to be built
+              working-directory: package/woocommerce/plugins/woocommerce
+              run: pnpx wc-e2e docker:wait
 
-          - name: Install k6
-            run: |
-                curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
-      
-          - name: Run k6 tests
-            run: |
-              ./k6 run package/woocommerce/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+            - name: Install k6
+              run: |
+                  curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
+
+            - name: Run k6 tests
+              run: |
+                  ./k6 run package/woocommerce/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -81,7 +81,7 @@ jobs:
 
             - name: Archive E2E test screenshots
               working-directory: package/woocommerce/plugins/woocommerce
-              if: ${{ always() }}
+              if: always()
               uses: actions/upload-artifact@v2
               with:
                   name: E2E Screenshots

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -81,11 +81,10 @@ jobs:
 
             - name: Archive E2E test screenshots
               uses: actions/upload-artifact@v2
-              working-directory: package/woocommerce/plugins/woocommerce
               if: always()
               with:
                   name: E2E Screenshots
-                  path: tests/e2e/screenshots
+                  path: package/woocommerce/plugins/woocommerce/tests/e2e/screenshots
                   if-no-files-found: ignore
                   retention-days: 5
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds extra step to the E2E tests run on each PR to archive the screenshots generated by E2E tests. This would be helpful for debugging why a test might of failed.

Addresses #32355  .

### How to test the changes in this Pull Request:

1. Check the **Build Zip for PR** > **Runs E2E tests** action to make sure it passes
2. Check if it contains an E2E screenshots artifact (after it has finished running) in the summary screen (https://github.com/woocommerce/woocommerce/actions/runs/2053602822)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev: Add E2E screenshots artifact to Github action.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
