### PR TITLE
Deprecate WC_ADMIN_VERSION_NUMBER constant

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "3.4.0-dev",
+	"version": "3.3.0",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/plugins/woocommerce-admin/woocommerce-admin.php
+++ b/plugins/woocommerce-admin/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 3.4.0-dev
+ * Version: 3.3.0
  * Requires at least: 5.6
  * Requires PHP: 7.0
  *

--- a/plugins/woocommerce/src/Admin/Composer/Package.php
+++ b/plugins/woocommerce/src/Admin/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '3.4.0-dev';
+	const VERSION = '3.3.0';
 
 	/**
 	 * Package active.

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -156,12 +156,12 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_IMAGES_FOLDER_URL', plugins_url( 'assets/images', WC_PLUGIN_FILE ) );
 
 		/**
-		 * Define the current WV Admin version.
+		 * Define the current WC Admin version.
 		 *
 		 * @deprecated 3.3.0
 		 * @var string
 		 */
-		define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );		
+		define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -155,9 +155,13 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_PLUGIN_FILE );
 		$this->define( 'WC_ADMIN_IMAGES_FOLDER_URL', plugins_url( 'assets/images', WC_PLUGIN_FILE ) );
 
-		// WARNING: Do not directly edit this version number constant.
-		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.4.0-dev' );
+		/**
+		 * Define the current WV Admin version.
+		 *
+		 * @deprecated 3.3.0
+		 * @var string
+		 */
+		define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );		
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR deprecate `WC_ADMIN_VERSION_NUMBER` constant as a part of The Merge. 


Closes #32177  .

### How to test the changes in this Pull Request:

Not much to test as it's just adding `@deprecated` comment, but please navigate WooCommerce Admin pages and make sure no errors are displayed.

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
