### PR TITLE
Add missing Admin e2e tests 

### DIFF
--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -449,10 +449,6 @@ const testSubscriptionsInclusion = () => {
 			await resetWooCommerceState();
 		} );
 
-		afterAll( async () => {
-			await login.logout();
-		} );
-
 		it( 'can complete the store details section', async () => {
 			await profileWizard.navigate();
 			await profileWizard.storeDetails.completeStoreDetailsSection( {
@@ -533,7 +529,6 @@ const testBusinessDetailsForm = () => {
 		const login = new Login( page );
 
 		beforeAll( async () => {
-			await login.login();
 			await resetWooCommerceState();
 		} );
 

--- a/plugins/woocommerce/tests/e2e/config/default.json
+++ b/plugins/woocommerce/tests/e2e/config/default.json
@@ -195,7 +195,11 @@
   "onboardingwizard": {
     "industry": "Test industry",
     "numberofproducts": "1 - 10",
-    "sellingelsewhere": "No"
+    "sellingelsewhere": "No",
+    "sellingOnAnotherPlatform": "Yes, on another platform",
+    "number_employees": "< 10",
+    "revenue": "Up to $2,500.00",
+    "other_platform_name": "Etsy"
   },
   "settings": {
     "shipping": {

--- a/plugins/woocommerce/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
+++ b/plugins/woocommerce/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
@@ -1,11 +1,11 @@
 const {
 	testAdminOnboardingWizard,
 	testSelectiveBundleWCPay,
+	testDifferentStoreCurrenciesWCPay,
+	testSubscriptionsInclusion,
+	testBusinessDetailsForm,
 } = require( '@woocommerce/admin-e2e-tests' );
-const {
-	withRestApi,
-	IS_RETEST_MODE,
-} = require( '@woocommerce/e2e-utils' );
+const { withRestApi, IS_RETEST_MODE } = require( '@woocommerce/e2e-utils' );
 
 // Reset onboarding profile when re-running tests on a site
 if ( IS_RETEST_MODE ) {
@@ -14,3 +14,6 @@ if ( IS_RETEST_MODE ) {
 
 testAdminOnboardingWizard();
 testSelectiveBundleWCPay();
+testDifferentStoreCurrenciesWCPay();
+testSubscriptionsInclusion();
+testBusinessDetailsForm();

--- a/plugins/woocommerce/tests/e2e/specs/admin-homescreen/activity-panel.test.js
+++ b/plugins/woocommerce/tests/e2e/specs/admin-homescreen/activity-panel.test.js
@@ -1,0 +1,3 @@
+const { testAdminHomescreenActivityPanel } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminHomescreenActivityPanel();

--- a/plugins/woocommerce/tests/e2e/specs/admin-homescreen/task-list.test.js
+++ b/plugins/woocommerce/tests/e2e/specs/admin-homescreen/task-list.test.js
@@ -1,0 +1,3 @@
+const { testAdminHomescreenTasklist } = require( '@woocommerce/admin-e2e-tests' );
+
+testAdminHomescreenTasklist();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The following e2e tests were copied from `plugins/woocommerce-admin` to `plugins/woocommerce`
1 - [activate-and-setup](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.tsx#L11-L13)
- testDifferentStoreCurrenciesWCPay
- testSubscriptionsInclusion
- testBusinessDetailsForm

2.. [homescreen](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-admin/tests/e2e/specs/homescreen)
- testAdminHomescreenActivityPanel
- testAdminHomescreenTasklist

Closes #32407.

As a follow-up PR we should delete the old e2e tests placed in `plugins/woocommerce-admin`.


### How to test the changes in this Pull Request:

1. Check out this branch.
2. Run E2E tests

### Changelog entry

> Add missing Admin e2e tests

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
