### PR TITLE
Fix daily e2e tests for WooCommerce Shipping & Tax

### DIFF
--- a/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
@@ -35,12 +35,11 @@ export async function deletePlugin( pluginName: string ) {
 }
 
 export async function deactivatePlugin( pluginName: string ) {
-	const response = await httpClient.post(
-		wpPluginsEndpoint + '/' + pluginName,
-		{
-			status: 'inactive',
-		}
-	);
+	const pluginSlug = pluginName.split( '/' )[ 1 ];
+	const response = await httpClient.post( wpPluginsEndpoint, {
+		slug: pluginSlug || pluginName,
+		status: 'inactive',
+	} );
 	expect( response.statusCode ).toEqual( 200 );
 }
 

--- a/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
@@ -35,11 +35,12 @@ export async function deletePlugin( pluginName: string ) {
 }
 
 export async function deactivatePlugin( pluginName: string ) {
-	const pluginSlug = pluginName.split( '/' )[ 1 ];
-	const response = await httpClient.post( wpPluginsEndpoint, {
-		slug: pluginSlug || pluginName,
-		status: 'inactive',
-	} );
+	const response = await httpClient.post(
+		wpPluginsEndpoint + '/' + pluginName,
+		{
+			status: 'inactive',
+		}
+	);
 	expect( response.statusCode ).toEqual( 200 );
 }
 

--- a/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
@@ -3,6 +3,9 @@
  */
 import { httpClient } from './http-client';
 
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { utils } = require( '@woocommerce/e2e-utils' );
+
 const wpPluginsEndpoint = '/wp/v2/plugins';
 
 type Plugin = {
@@ -52,7 +55,10 @@ export async function deactivateAndDeleteAllPlugins( except: string[] = [] ) {
 	for ( const plugin of plugins ) {
 		const splitPluginName = plugin.plugin.split( '/' );
 		const slug = splitPluginName[ 1 ] || splitPluginName[ 0 ];
-		if ( ! except.includes( slug ) ) {
+		const slugFromName = utils.getSlug(
+			plugin.name.replace( ' &amp;', '' )
+		);
+		if ( ! except.includes( slug ) && ! except.includes( slugFromName ) ) {
 			promises.push( deactivateAndDeletePlugin( plugin.plugin ) );
 		} else {
 			skippedPlugins.push( slug );

--- a/packages/js/e2e-environment/CHANGELOG.md
+++ b/packages/js/e2e-environment/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Updated `resolveSingleE2EPath` 
   - it resolves the full path if the filePath is valid
   - otherwise, it removes `tests/e2e` from the given filePath before resolving a full path.
+- Updated `getLatestReleaseZipUrl` to make use of the assets download url over the archive zip.
+
 
 ## Added
 

--- a/packages/js/e2e-environment/utils/get-plugin-zip.js
+++ b/packages/js/e2e-environment/utils/get-plugin-zip.js
@@ -77,11 +77,20 @@ const getLatestReleaseZipUrl = async (
 					}
 				} );
 			} else if ( authorizationToken ) {
-				// If it's a private repo, we need to download the archive this way
-				const tagName = body.tag_name;
-				resolve(
-					`https://github.com/${ repository }/archive/${ tagName }.zip`
-				);
+				// If it's a private repo, we need to download the archive this way.
+				// Use uploaded assets over downloading the zip archive.
+				if (
+					body.assets &&
+					body.assets.length > 0 &&
+					body.assets[ 0 ].browser_download_url
+				) {
+					resolve( body.assets[ 0 ].browser_download_url );
+				} else {
+					const tagName = body.tag_name;
+					resolve(
+						`https://github.com/${ repository }/archive/${ tagName }.zip`
+					);
+				}
 			} else {
 				resolve( body.assets[ 0 ].browser_download_url );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some of the smoke tests make use of a `PLUGIN_NAME` environment variable, that is used to install a plugin that should be kept during the duration of tests. The reset plugin was attempting to delete this.
I updated the reset logic so it takes the `PLUGIN_NAME` in account.

Closes #32364  .

### How to test the changes in this Pull Request:

**One thing to note:**
When I run my E2E tests locally sometimes they immediately fail with a **Target closed** error. Usually trying a second time does the trick, I am not sure why that is.

1. Run a build and set up your E2E tests by following these steps: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md
2. You also need a Github personal access token for this test to work -> https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
3. You first want to run the `upload-plugin.js` test with several environment variables like this -> `WC_E2E_SCREENSHOTS=1 PLUGIN_REPOSITORY="automattic/woocommerce-services" PLUGIN_NAME="WooCommerce Shipping & Tax" GITHUB_TOKEN="YOUR_GITHUB_TOKEN" pnpm exec wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/upload-plugin.js` 
replacing `YOUR_GITHUB_TOKEN` with your token from step 2
4. Those tests should succeed
5. Now run the onboarding wizard tests (these previously failed) using the same env tokens, just like this -> `WC_E2E_SCREENSHOTS=1 PLUGIN_REPOSITORY="automattic/woocommerce-services" PLUGIN_NAME="WooCommerce Shipping & Tax" GITHUB_TOKEN="YOUR_GITHUB_TOKEN" pnpm exec wc-e2e test:e2e ./tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js`
6. Those should all pass now
7. Now run tests normally on the same instance ( WooCommerce services should still be installed, you can check by visiting localhost:8084/wp-admin  -> `pnpm exec wc-e2e test:e2e ./tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js`
8. These should all pass now, previously they didn't because the reset plugin failed to delete the shipping & tax plugin, as the folder name contains the version (ex: `woocommerce-services.2.5.2`, it should now just be `woocommerce-services` )

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev: Fix smoke tests for Shipping and Tax plugin, and the downloading of plugin zips.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
