### PR TITLE
Don't trigger beforeunload notice inappropriately.

### DIFF
--- a/plugins/woocommerce/legacy/js/admin/settings.js
+++ b/plugins/woocommerce/legacy/js/admin/settings.js
@@ -70,8 +70,14 @@
 		// Edit prompt
 		$( function() {
 			var changed = false;
+			let $check_column = $( '.wp-list-table .check-column' );
 
-			$( 'input, textarea, select, checkbox' ).on( 'change', function() {
+			$( 'input, textarea, select, checkbox' ).on( 'change', function( event ) {
+				// Toggling WP List Table checkboxes should not trigger navigation warnings.
+				if ( $check_column.length && $check_column.has( event.target ) ) {
+					return;
+				}
+
 				if ( ! changed ) {
 					window.onbeforeunload = function() {
 						return params.i18n_nav_warning;
@@ -80,7 +86,7 @@
 				}
 			});
 
-			$( '.submit :input' ).on( 'click', function() {
+			$( '.submit :input, input#search-submit' ).on( 'click', function() {
 				window.onbeforeunload = '';
 			});
 		});


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If a user adjusts settings on our legacy settings screen, then tries to navigate away without saving their changes, a warning will appear looking something like this:

<img width="475" alt="before-unload-nav-warning" src="https://user-images.githubusercontent.com/3594411/160900292-29a545f1-d258-4a60-ae9b-c60df2de2857.png">

This is useful, however in various admin screens we have embedded WP List Tables. Examples include **WooCommerce ▸ Settings ▸ Advanced ▸ Webhooks** and the new **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** screen: in these cases the warning is also being triggered, simply because a table row checkbox was checked and also when a search is performed.

As the linked issue makes clear, this isn't really optimal or desirable.

Closes #30102.

### How to test the changes in this Pull Request:

Webhooks checkboxes:

1. Visit **WooCommerce ▸ Settings ▸ Advanced ▸ Webhooks**.
2. Check one of the table row checkboxes (if you don't have any webhooks, create one first).
3. Now try navigating away (for example, to the main WP dashboard). 
    1. Without this fix, the nav warning will appear.
    2. With this fix, the nav warning should not appear.

Webhook search:

1. On the same admin screen, search for a webhook.
2. Enter your search term and click "Search Webhooks".
    1. Without this fix, the nav warning will appear.
    2. With this fix, the nav warning should not appear.

Other settings:

1. Visit **WooCommerce ▸ Settings ▸ General**.
4. Change one or more fields.
5. Now try navigating away without saving.
6. The nav warning should appear, with or without this change.

### Changelog entry

> Fix - Stop the unsaved changes warning from appearing at inappropriate moments in the settings area.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
