### PR TITLE
Replace i18n textdomain 'woocommerce-admin' with 'woocommerce'

### DIFF
--- a/packages/js/components/src/advanced-filters/README.md
+++ b/packages/js/components/src/advanced-filters/README.md
@@ -12,24 +12,24 @@ const config = {
 		// A sentence describing filters for Orders
 		// See screen shot for context: https://cloudup.com/cSsUY9VeCVJ
 		'Orders Match {{select /}} Filters',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	filters: {
 		status: {
 			labels: {
-				add: __( 'Order Status', 'woocommerce-admin' ),
-				remove: __( 'Remove order status filter', 'woocommerce-admin' ),
+				add: __( 'Order Status', 'woocommerce' ),
+				remove: __( 'Remove order status filter', 'woocommerce' ),
 				rule: __(
 					'Select an order status filter match',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				// A sentence describing an Order Status filter
 				// See screen shot for context: https://cloudup.com/cSsUY9VeCVJ
 				title: __(
 					'Order Status {{rule /}} {{filter /}}',
-					'woocommerce-admin'
+					'woocommerce'
 				),
-				filter: __( 'Select an order status', 'woocommerce-admin' ),
+				filter: __( 'Select an order status', 'woocommerce' ),
 			},
 			rules: [
 				{
@@ -37,14 +37,14 @@ const config = {
 					// Sentence fragment, logical, "Is"
 					// Refers to searching for orders matching a chosen order status
 					// Screenshot for context: https://cloudup.com/cSsUY9VeCVJ
-					label: _x( 'Is', 'order status', 'woocommerce-admin' ),
+					label: _x( 'Is', 'order status', 'woocommerce' ),
 				},
 				{
 					value: 'is_not',
 					// Sentence fragment, logical, "Is Not"
 					// Refers to searching for orders that don't match a chosen order status
 					// Screenshot for context: https://cloudup.com/cSsUY9VeCVJ
-					label: _x( 'Is Not', 'order status', 'woocommerce-admin' ),
+					label: _x( 'Is Not', 'order status', 'woocommerce' ),
 				},
 			],
 			input: {
@@ -139,15 +139,15 @@ const config = {
 			rules: [
 				{
 					value: 'before',
-					label: __( 'Before', 'woocommerce-admin' ),
+					label: __( 'Before', 'woocommerce' ),
 				},
 				{
 					value: 'after',
-					label: __( 'After', 'woocommerce-admin' ),
+					label: __( 'After', 'woocommerce' ),
 				},
 				{
 					value: 'between',
-					label: __( 'Between', 'woocommerce-admin' ),
+					label: __( 'Between', 'woocommerce' ),
 				},
 			],
 			input: {
@@ -172,15 +172,15 @@ const config = {
 			rules: [
 				{
 					value: 'lessthan',
-					label: __( 'Less Than', 'woocommerce-admin' ),
+					label: __( 'Less Than', 'woocommerce' ),
 				},
 				{
 					value: 'morethan',
-					label: __( 'More Than', 'woocommerce-admin' ),
+					label: __( 'More Than', 'woocommerce' ),
 				},
 				{
 					value: 'between',
-					label: __( 'Between', 'woocommerce-admin' ),
+					label: __( 'Between', 'woocommerce' ),
 				},
 			],
 			input: {

--- a/packages/js/components/src/advanced-filters/attribute-filter.js
+++ b/packages/js/components/src/advanced-filters/attribute-filter.js
@@ -59,7 +59,7 @@ const getScreenReaderText = ( {
 		/* translators: Sentence fragment describing a product attribute match. Example: "Color Is Not Blue" - attribute = Color, equals = Is Not, value = Blue */
 		mixedString: __(
 			'{{attribute /}} {{equals /}} {{value /}}',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		components: {
 			attribute: <Fragment>{ attributeName }</Fragment>,
@@ -202,14 +202,14 @@ const AttributeFilter = ( props ) => {
 										type="attributes"
 										placeholder={ __(
 											'Attribute name',
-											'woocommerce-admin'
+											'woocommerce'
 										) }
 										multiple={ false }
 										selected={ selectedAttribute }
 										inlineTags
 										aria-label={ __(
 											'Attribute name',
-											'woocommerce-admin'
+											'woocommerce'
 										) }
 									/>
 								) : (
@@ -225,7 +225,7 @@ const AttributeFilter = ( props ) => {
 												className="woocommerce-filters-advanced__input woocommerce-search"
 												placeholder={ __(
 													'Attribute value',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												inlineTags
 												isSearchable

--- a/packages/js/components/src/advanced-filters/date-filter.js
+++ b/packages/js/components/src/advanced-filters/date-filter.js
@@ -16,8 +16,8 @@ import moment from 'moment';
 import DatePicker from '../calendar/date-picker';
 import { textContent } from './utils';
 
-const dateStringFormat = __( 'MMM D, YYYY', 'woocommerce-admin' );
-const dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
+const dateStringFormat = __( 'MMM D, YYYY', 'woocommerce' );
+const dateFormat = __( 'MM/DD/YYYY', 'woocommerce' );
 
 class DateFilter extends Component {
 	constructor( { filter } ) {
@@ -48,7 +48,7 @@ class DateFilter extends Component {
 		return _x(
 			'{{after /}}{{span}} and {{/span}}{{before /}}',
 			'Date range inputs arranged on a single line',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 

--- a/packages/js/components/src/advanced-filters/index.js
+++ b/packages/js/components/src/advanced-filters/index.js
@@ -32,8 +32,8 @@ import AdvancedFilterItem from './item';
 import { Text } from '../experimental';
 
 const matches = [
-	{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
-	{ value: 'any', label: __( 'Any', 'woocommerce-admin' ) },
+	{ value: 'all', label: __( 'All', 'woocommerce' ) },
+	{ value: 'any', label: __( 'Any', 'woocommerce' ) },
 ];
 
 /**
@@ -154,7 +154,7 @@ class AdvancedFilters extends Component {
 						onChange={ this.onMatchChange }
 						aria-label={ __(
 							'Choose to apply any or all filters',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					/>
 				),
@@ -330,10 +330,7 @@ class AdvancedFilters extends Component {
 										aria-expanded={ isOpen }
 									>
 										<AddOutlineIcon />
-										{ __(
-											'Add a Filter',
-											'woocommerce-admin'
-										) }
+										{ __( 'Add a Filter', 'woocommerce' ) }
 									</Button>
 								) }
 								renderContent={ ( { onClose } ) => (
@@ -364,7 +361,7 @@ class AdvancedFilters extends Component {
 					<div className="woocommerce-filters-advanced__controls">
 						{ updateDisabled && (
 							<Button isPrimary disabled>
-								{ __( 'Filter', 'woocommerce-admin' ) }
+								{ __( 'Filter', 'woocommerce' ) }
 							</Button>
 						) }
 						{ ! updateDisabled && (
@@ -374,7 +371,7 @@ class AdvancedFilters extends Component {
 								href={ updateHref }
 								onClick={ this.onFilter }
 							>
-								{ __( 'Filter', 'woocommerce-admin' ) }
+								{ __( 'Filter', 'woocommerce' ) }
 							</Link>
 						) }
 						{ activeFilters.length > 0 && (
@@ -383,10 +380,7 @@ class AdvancedFilters extends Component {
 								href={ this.getUpdateHref( [] ) }
 								onClick={ this.clearFilters }
 							>
-								{ __(
-									'Clear all filters',
-									'woocommerce-admin'
-								) }
+								{ __( 'Clear all filters', 'woocommerce' ) }
 							</Link>
 						) }
 					</div>

--- a/packages/js/components/src/advanced-filters/number-filter.js
+++ b/packages/js/components/src/advanced-filters/number-filter.js
@@ -21,7 +21,7 @@ class NumberFilter extends Component {
 		return _x(
 			'{{rangeStart /}}{{span}} and {{/span}}{{rangeEnd /}}',
 			'Numerical range inputs arranged on a single line',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -151,7 +151,7 @@ class NumberFilter extends Component {
 			labelFormat = _x(
 				'%(field)s maximum amount',
 				'maximum value input',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		} else {
 			/* eslint-disable-next-line max-len */
@@ -159,7 +159,7 @@ class NumberFilter extends Component {
 			labelFormat = _x(
 				'%(field)s minimum amount',
 				'minimum value input',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
@@ -207,7 +207,7 @@ class NumberFilter extends Component {
 					label: sprintf(
 						/* eslint-disable-next-line max-len */
 						/* translators: Sentence fragment, "range start" refers to the first of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
-						__( '%(field)s range start', 'woocommerce-admin' ),
+						__( '%(field)s range start', 'woocommerce' ),
 						{ field: get( config, [ 'labels', 'add' ] ) }
 					),
 					onChange: rangeStartOnChange,
@@ -220,7 +220,7 @@ class NumberFilter extends Component {
 					label: sprintf(
 						/* eslint-disable-next-line max-len */
 						/* translators: Sentence fragment, "range end" refers to the second of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
-						__( '%(field)s range end', 'woocommerce-admin' ),
+						__( '%(field)s range end', 'woocommerce' ),
 						{ field: get( config, [ 'labels', 'add' ] ) }
 					),
 					onChange: rangeEndOnChange,

--- a/packages/js/components/src/calendar/date-picker.js
+++ b/packages/js/components/src/calendar/date-picker.js
@@ -96,12 +96,12 @@ class DatePicker extends Component {
 						onChange={ this.onInputChange }
 						onBlur={ partial( this.handleBlur, isOpen, onToggle ) }
 						dateFormat={ dateFormat }
-						label={ __( 'Choose a date', 'woocommerce-admin' ) }
+						label={ __( 'Choose a date', 'woocommerce' ) }
 						error={ error }
 						describedBy={ sprintf(
 							__(
 								'Date input describing a selected date in format %s',
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							dateFormat
 						) }
@@ -118,7 +118,7 @@ class DatePicker extends Component {
 				renderContent={ ( { onToggle } ) => (
 					<Section component={ false }>
 						<H className="woocommerce-calendar__date-picker-title">
-							{ __( 'select a date', 'woocommerce-admin' ) }
+							{ __( 'select a date', 'woocommerce' ) }
 						</H>
 						<div className="woocommerce-calendar__react-dates is-core-datepicker">
 							<WpDatePicker

--- a/packages/js/components/src/calendar/date-range.js
+++ b/packages/js/components/src/calendar/date-range.js
@@ -191,30 +191,30 @@ class DateRange extends Component {
 						value={ afterText }
 						onChange={ partial( this.onInputChange, 'after' ) }
 						dateFormat={ shortDateFormat }
-						label={ __( 'Start Date', 'woocommerce-admin' ) }
+						label={ __( 'Start Date', 'woocommerce' ) }
 						error={ afterError }
 						describedBy={ sprintf(
 							__(
 								"Date input describing a selected date range's start date in format %s",
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							shortDateFormat
 						) }
 						onFocus={ () => this.onFocusChange( 'startDate' ) }
 					/>
 					<div className="woocommerce-calendar__inputs-to">
-						{ __( 'to', 'woocommerce-admin' ) }
+						{ __( 'to', 'woocommerce' ) }
 					</div>
 					<DateInput
 						value={ beforeText }
 						onChange={ partial( this.onInputChange, 'before' ) }
 						dateFormat={ shortDateFormat }
-						label={ __( 'End Date', 'woocommerce-admin' ) }
+						label={ __( 'End Date', 'woocommerce' ) }
 						error={ beforeError }
 						describedBy={ sprintf(
 							__(
 								"Date input describing a selected date range's end date in format %s",
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							shortDateFormat
 						) }

--- a/packages/js/components/src/calendar/phrases.js
+++ b/packages/js/components/src/calendar/phrases.js
@@ -4,61 +4,55 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 export default {
-	calendarLabel: __( 'Calendar', 'woocommerce-admin' ),
-	closeDatePicker: __( 'Close', 'woocommerce-admin' ),
+	calendarLabel: __( 'Calendar', 'woocommerce' ),
+	closeDatePicker: __( 'Close', 'woocommerce' ),
 	focusStartDate: __(
 		'Interact with the calendar and select start and end dates.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	clearDate: __( 'Clear Date', 'woocommerce-admin' ),
-	clearDates: __( 'Clear Dates', 'woocommerce-admin' ),
+	clearDate: __( 'Clear Date', 'woocommerce' ),
+	clearDates: __( 'Clear Dates', 'woocommerce' ),
 	jumpToPrevMonth: __(
 		'Move backward to switch to the previous month.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	jumpToNextMonth: __(
 		'Move forward to switch to the next month.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	enterKey: __( 'Enter key', 'woocommerce-admin' ),
-	leftArrowRightArrow: __( 'Right and left arrow keys', 'woocommerce-admin' ),
-	upArrowDownArrow: __( 'up and down arrow keys', 'woocommerce-admin' ),
-	pageUpPageDown: __( 'page up and page down keys', 'woocommerce-admin' ),
-	homeEnd: __( 'Home and end keys', 'woocommerce-admin' ),
-	escape: __( 'Escape key', 'woocommerce-admin' ),
-	questionMark: __( 'Question mark', 'woocommerce-admin' ),
-	selectFocusedDate: __( 'Select the date in focus.', 'woocommerce-admin' ),
+	enterKey: __( 'Enter key', 'woocommerce' ),
+	leftArrowRightArrow: __( 'Right and left arrow keys', 'woocommerce' ),
+	upArrowDownArrow: __( 'up and down arrow keys', 'woocommerce' ),
+	pageUpPageDown: __( 'page up and page down keys', 'woocommerce' ),
+	homeEnd: __( 'Home and end keys', 'woocommerce' ),
+	escape: __( 'Escape key', 'woocommerce' ),
+	questionMark: __( 'Question mark', 'woocommerce' ),
+	selectFocusedDate: __( 'Select the date in focus.', 'woocommerce' ),
 	moveFocusByOneDay: __(
 		'Move backward (left) and forward (right) by one day.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	moveFocusByOneWeek: __(
 		'Move backward (up) and forward (down) by one week.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	moveFocusByOneMonth: __( 'Switch months.', 'woocommerce-admin' ),
+	moveFocusByOneMonth: __( 'Switch months.', 'woocommerce' ),
 	moveFocustoStartAndEndOfWeek: __(
 		'Go to the first or last day of a week.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	returnFocusToInput: __(
-		'Return to the date input field.',
-		'woocommerce-admin'
-	),
+	returnFocusToInput: __( 'Return to the date input field.', 'woocommerce' ),
 	keyboardNavigationInstructions: __(
 		'Press the down arrow key to interact with the calendar and select a date.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	chooseAvailableStartDate: ( { date } ) =>
-		sprintf(
-			__( 'Select %s as a start date.', 'woocommerce-admin' ),
-			date
-		),
+		sprintf( __( 'Select %s as a start date.', 'woocommerce' ), date ),
 	chooseAvailableEndDate: ( { date } ) =>
-		sprintf( __( 'Select %s as an end date.', 'woocommerce-admin' ), date ),
+		sprintf( __( 'Select %s as an end date.', 'woocommerce' ), date ),
 	chooseAvailableDate: ( { date } ) => date,
 	dateIsUnavailable: ( { date } ) =>
-		sprintf( __( '%s is not selectable.', 'woocommerce-admin' ), date ),
+		sprintf( __( '%s is not selectable.', 'woocommerce' ), date ),
 	dateIsSelected: ( { date } ) =>
-		sprintf( __( 'Selected. %s', 'woocommerce-admin' ), date ),
+		sprintf( __( 'Selected. %s', 'woocommerce' ), date ),
 };

--- a/packages/js/components/src/chart/d3chart/legend.js
+++ b/packages/js/components/src/chart/d3chart/legend.js
@@ -122,7 +122,7 @@ class D3Legend extends Component {
 										? sprintf(
 												__(
 													'You may select up to %d items.',
-													'woocommerce-admin'
+													'woocommerce'
 												),
 												selectionLimit
 										  )

--- a/packages/js/components/src/chart/index.js
+++ b/packages/js/components/src/chart/index.js
@@ -238,12 +238,12 @@ class Chart extends Component {
 		}
 
 		const intervalLabels = {
-			hour: __( 'By hour', 'woocommerce-admin' ),
-			day: __( 'By day', 'woocommerce-admin' ),
-			week: __( 'By week', 'woocommerce-admin' ),
-			month: __( 'By month', 'woocommerce-admin' ),
-			quarter: __( 'By quarter', 'woocommerce-admin' ),
-			year: __( 'By year', 'woocommerce-admin' ),
+			hour: __( 'By hour', 'woocommerce' ),
+			day: __( 'By day', 'woocommerce' ),
+			week: __( 'By week', 'woocommerce' ),
+			month: __( 'By month', 'woocommerce' ),
+			quarter: __( 'By quarter', 'woocommerce' ),
+			year: __( 'By year', 'woocommerce' ),
 		};
 
 		return (
@@ -390,10 +390,7 @@ class Chart extends Component {
 											chartType === 'line',
 									}
 								) }
-								title={ __(
-									'Line chart',
-									'woocommerce-admin'
-								) }
+								title={ __( 'Line chart', 'woocommerce' ) }
 								aria-checked={ chartType === 'line' }
 								role="menuitemradio"
 								tabIndex={ chartType === 'line' ? 0 : -1 }
@@ -412,7 +409,7 @@ class Chart extends Component {
 											chartType === 'bar',
 									}
 								) }
-								title={ __( 'Bar chart', 'woocommerce-admin' ) }
+								title={ __( 'Bar chart', 'woocommerce' ) }
 								aria-checked={ chartType === 'bar' }
 								role="menuitemradio"
 								tabIndex={ chartType === 'bar' ? 0 : -1 }
@@ -440,7 +437,7 @@ class Chart extends Component {
 								<span className="screen-reader-text">
 									{ __(
 										'Your requested data is loading',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</span>
 								<ChartPlaceholder height={ chartHeight } />

--- a/packages/js/components/src/compare-filter/index.js
+++ b/packages/js/components/src/compare-filter/index.js
@@ -126,7 +126,7 @@ export class CompareFilter extends Component {
 					</CompareButton>
 					{ selected.length > 0 && (
 						<Button isLink={ true } onClick={ this.clearQuery }>
-							{ __( 'Clear all', 'woocommerce-admin' ) }
+							{ __( 'Clear all', 'woocommerce' ) }
 						</Button>
 					) }
 				</CardFooter>

--- a/packages/js/components/src/date-range-filter-picker/compare-periods.js
+++ b/packages/js/components/src/date-range-filter-picker/compare-periods.js
@@ -21,7 +21,7 @@ class ComparePeriods extends Component {
 				selected={ compare }
 				onSelect={ onSelect }
 				name="compare"
-				legend={ __( 'compare to', 'woocommerce-admin' ) }
+				legend={ __( 'compare to', 'woocommerce' ) }
 			/>
 		);
 	}

--- a/packages/js/components/src/date-range-filter-picker/content.js
+++ b/packages/js/components/src/date-range-filter-picker/content.js
@@ -65,25 +65,22 @@ class DatePickerContent extends Component {
 		return (
 			<div>
 				<H className="screen-reader-text" tabIndex="0">
-					{ __(
-						'Select date range and comparison',
-						'woocommerce-admin'
-					) }
+					{ __( 'Select date range and comparison', 'woocommerce' ) }
 				</H>
 				<Section component={ false }>
 					<H className="woocommerce-filters-date__text">
-						{ __( 'select a date range', 'woocommerce-admin' ) }
+						{ __( 'select a date range', 'woocommerce' ) }
 					</H>
 					<TabPanel
 						tabs={ [
 							{
 								name: 'period',
-								title: __( 'Presets', 'woocommerce-admin' ),
+								title: __( 'Presets', 'woocommerce' ),
 								className: 'woocommerce-filters-date__tab',
 							},
 							{
 								name: 'custom',
-								title: __( 'Custom', 'woocommerce-admin' ),
+								title: __( 'Custom', 'woocommerce' ),
 								className: 'woocommerce-filters-date__tab',
 							},
 						] }
@@ -130,10 +127,7 @@ class DatePickerContent extends Component {
 									ref={ this.controlsRef }
 								>
 									<H className="woocommerce-filters-date__text">
-										{ __(
-											'compare to',
-											'woocommerce-admin'
-										) }
+										{ __( 'compare to', 'woocommerce' ) }
 									</H>
 									<ComparePeriods
 										onSelect={ onUpdate }
@@ -149,10 +143,7 @@ class DatePickerContent extends Component {
 													! ( after || before )
 												}
 											>
-												{ __(
-													'Reset',
-													'woocommerce-admin'
-												) }
+												{ __( 'Reset', 'woocommerce' ) }
 											</Button>
 										) }
 										{ isValidSelection( selected.name ) ? (
@@ -166,7 +157,7 @@ class DatePickerContent extends Component {
 											>
 												{ __(
 													'Update',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 											</Button>
 										) : (
@@ -177,7 +168,7 @@ class DatePickerContent extends Component {
 											>
 												{ __(
 													'Update',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 											</Button>
 										) }

--- a/packages/js/components/src/date-range-filter-picker/index.js
+++ b/packages/js/components/src/date-range-filter-picker/index.js
@@ -14,7 +14,7 @@ import classnames from 'classnames';
 import DatePickerContent from './content';
 import DropdownButton from '../dropdown-button';
 
-const shortDateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
+const shortDateFormat = __( 'MM/DD/YYYY', 'woocommerce' );
 
 /**
  * Select a range of dates or single dates.
@@ -86,7 +86,7 @@ class DateRangeFilterPicker extends Component {
 		const { primaryDate, secondaryDate } = this.props.dateQuery;
 		return [
 			`${ primaryDate.label } (${ primaryDate.range })`,
-			`${ __( 'vs.', 'woocommerce-admin' ) } ${ secondaryDate.label } (${
+			`${ __( 'vs.', 'woocommerce' ) } ${ secondaryDate.label } (${
 				secondaryDate.range
 			})`,
 		];
@@ -135,7 +135,7 @@ class DateRangeFilterPicker extends Component {
 		return (
 			<div className="woocommerce-filters-filter">
 				<span className="woocommerce-filters-label">
-					{ __( 'Date range', 'woocommerce-admin' ) }:
+					{ __( 'Date range', 'woocommerce' ) }:
 				</span>
 				<Dropdown
 					contentClassName={ contentClasses }

--- a/packages/js/components/src/date-range-filter-picker/preset-periods.js
+++ b/packages/js/components/src/date-range-filter-picker/preset-periods.js
@@ -25,7 +25,7 @@ class PresetPeriods extends Component {
 				selected={ period }
 				onSelect={ onSelect }
 				name="period"
-				legend={ __( 'select a preset period', 'woocommerce-admin' ) }
+				legend={ __( 'select a preset period', 'woocommerce' ) }
 			/>
 		);
 	}

--- a/packages/js/components/src/dynamic-form/dynamic-form.tsx
+++ b/packages/js/components/src/dynamic-form/dynamic-form.tsx
@@ -55,7 +55,7 @@ export const DynamicForm: React.FC< DynamicFormProps > = ( {
 	onSubmit = () => {},
 	onChange = () => {},
 	validate = () => ( {} ),
-	submitLabel = __( 'Proceed', 'woocommerce-admin' ),
+	submitLabel = __( 'Proceed', 'woocommerce' ),
 } ) => {
 	// Support accepting fields in the format provided by the API (object), but transform to Array
 	const fields =

--- a/packages/js/components/src/filter-picker/index.js
+++ b/packages/js/components/src/filter-picker/index.js
@@ -305,7 +305,7 @@ class FilterPicker extends Component {
 					expandOnMobile
 					headerTitle={ __(
 						'filter report to show:',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<DropdownButton

--- a/packages/js/components/src/filters/index.js
+++ b/packages/js/components/src/filters/index.js
@@ -121,7 +121,7 @@ class ReportFilters extends Component {
 		return (
 			<Fragment>
 				<H className="screen-reader-text">
-					{ __( 'Filters', 'woocommerce-admin' ) }
+					{ __( 'Filters', 'woocommerce' ) }
 				</H>
 				<Section component="div" className="woocommerce-filters">
 					<div className="woocommerce-filters__basic-filters">

--- a/packages/js/components/src/image-upload/index.js
+++ b/packages/js/components/src/image-upload/index.js
@@ -76,7 +76,7 @@ class ImageUpload extends Component {
 							className="woocommerce-image-upload__remove-image"
 							onClick={ this.removeImage }
 						>
-							{ __( 'Remove image', 'woocommerce-admin' ) }
+							{ __( 'Remove image', 'woocommerce' ) }
 						</Button>
 					</div>
 				) }
@@ -94,7 +94,7 @@ class ImageUpload extends Component {
 							isSecondary
 						>
 							<Icon icon={ upload } />
-							{ __( 'Add an image', 'woocommerce-admin' ) }
+							{ __( 'Add an image', 'woocommerce' ) }
 						</Button>
 					</div>
 				) }

--- a/packages/js/components/src/pagination/index.js
+++ b/packages/js/components/src/pagination/index.js
@@ -108,7 +108,7 @@ class Pagination extends Component {
 						aria-live="polite"
 					>
 						{ sprintf(
-							__( 'Page %d of %d', 'woocommerce-admin' ),
+							__( 'Page %d of %d', 'woocommerce' ),
 							page,
 							this.pageCount
 						) }
@@ -119,7 +119,7 @@ class Pagination extends Component {
 						className={ previousLinkClass }
 						disabled={ ! ( page > 1 ) }
 						onClick={ this.previousPage }
-						label={ __( 'Previous Page', 'woocommerce-admin' ) }
+						label={ __( 'Previous Page', 'woocommerce' ) }
 					>
 						<Icon icon={ chevronLeft } />
 					</Button>
@@ -127,7 +127,7 @@ class Pagination extends Component {
 						className={ nextLinkClass }
 						disabled={ ! ( page < this.pageCount ) }
 						onClick={ this.nextPage }
-						label={ __( 'Next Page', 'woocommerce-admin' ) }
+						label={ __( 'Next Page', 'woocommerce' ) }
 					>
 						<Icon icon={ chevronRight } />
 					</Button>
@@ -154,7 +154,7 @@ class Pagination extends Component {
 					htmlFor={ instanceId }
 					className="woocommerce-pagination__page-picker-label"
 				>
-					{ __( 'Go to page', 'woocommerce-admin' ) }
+					{ __( 'Go to page', 'woocommerce' ) }
 					<input
 						id={ instanceId }
 						className={ inputClass }
@@ -181,7 +181,7 @@ class Pagination extends Component {
 		return (
 			<div className="woocommerce-pagination__per-page-picker">
 				<SelectControl
-					label={ __( 'Rows per page', 'woocommerce-admin' ) }
+					label={ __( 'Rows per page', 'woocommerce' ) }
 					labelPosition="side"
 					value={ this.props.perPage }
 					onChange={ this.perPageChange }

--- a/packages/js/components/src/plugins/index.js
+++ b/packages/js/components/src/plugins/index.js
@@ -91,13 +91,10 @@ export class Plugins extends Component {
 						isBusy={ isRequesting }
 						onClick={ this.installAndActivate }
 					>
-						{ __( 'Retry', 'woocommerce-admin' ) }
+						{ __( 'Retry', 'woocommerce' ) }
 					</Button>
 					<Button onClick={ this.skipInstaller }>
-						{ __(
-							'Continue without installing',
-							'woocommerce-admin'
-						) }
+						{ __( 'Continue without installing', 'woocommerce' ) }
 					</Button>
 				</Fragment>
 			);
@@ -115,7 +112,7 @@ export class Plugins extends Component {
 						isBusy={ isRequesting }
 						onClick={ this.skipInstaller }
 					>
-						{ __( 'Continue', 'woocommerce-admin' ) }
+						{ __( 'Continue', 'woocommerce' ) }
 					</Button>
 				</Fragment>
 			);
@@ -128,14 +125,14 @@ export class Plugins extends Component {
 					isPrimary
 					onClick={ this.installAndActivate }
 				>
-					{ __( 'Install & enable', 'woocommerce-admin' ) }
+					{ __( 'Install & enable', 'woocommerce' ) }
 				</Button>
 				<Button isTertiary onClick={ this.skipInstaller }>
-					{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
+					{ skipText || __( 'No thanks', 'woocommerce' ) }
 				</Button>
 				{ onAbort && (
 					<Button isTertiary onClick={ onAbort }>
-						{ abortText || __( 'Abort', 'woocommerce-admin' ) }
+						{ abortText || __( 'Abort', 'woocommerce' ) }
 					</Button>
 				) }
 			</Fragment>

--- a/packages/js/components/src/rating/index.js
+++ b/packages/js/components/src/rating/index.js
@@ -38,7 +38,7 @@ class Rating extends Component {
 		};
 
 		const label = sprintf(
-			__( '%1$s out of %2$s stars.', 'woocommerce-admin' ),
+			__( '%1$s out of %2$s stars.', 'woocommerce' ),
 			rating,
 			totalStars
 		);

--- a/packages/js/components/src/search-list-control/index.js
+++ b/packages/js/components/src/search-list-control/index.js
@@ -28,22 +28,17 @@ import SearchListItem from './item';
 import Tag from '../tag';
 
 const defaultMessages = {
-	clear: __( 'Clear all selected items', 'woocommerce-admin' ),
-	noItems: __( 'No items found.', 'woocommerce-admin' ),
-	noResults: __( 'No results for %s', 'woocommerce-admin' ),
-	search: __( 'Search for items', 'woocommerce-admin' ),
+	clear: __( 'Clear all selected items', 'woocommerce' ),
+	noItems: __( 'No items found.', 'woocommerce' ),
+	noResults: __( 'No results for %s', 'woocommerce' ),
+	search: __( 'Search for items', 'woocommerce' ),
 	selected: ( n ) =>
 		sprintf(
 			/* translators: Number of items selected from list. */
-			_n(
-				'%d item selected',
-				'%d items selected',
-				n,
-				'woocommerce-admin'
-			),
+			_n( '%d item selected', '%d items selected', n, 'woocommerce' ),
 			n
 		),
-	updated: __( 'Search results updated.', 'woocommerce-admin' ),
+	updated: __( 'Search results updated.', 'woocommerce' ),
 };
 
 /**
@@ -201,7 +196,7 @@ export const SearchListControl = ( props ) => {
 							onClick={ onChange( [] ) }
 							aria-label={ messages.clear }
 						>
-							{ __( 'Clear all', 'woocommerce-admin' ) }
+							{ __( 'Clear all', 'woocommerce' ) }
 						</Button>
 					) : null }
 				</div>

--- a/packages/js/components/src/search/autocompleters/attributes.js
+++ b/packages/js/components/src/search/autocompleters/attributes.js
@@ -122,7 +122,7 @@ export default {
 				{ interpolateComponents( {
 					mixedString: __(
 						'All attributes with names that include {{query /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						query: (

--- a/packages/js/components/src/search/autocompleters/categories.js
+++ b/packages/js/components/src/search/autocompleters/categories.js
@@ -122,7 +122,7 @@ export default {
 				{ interpolateComponents( {
 					mixedString: __(
 						'All categories with titles that include {{query /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						query: (

--- a/packages/js/components/src/search/autocompleters/coupons.js
+++ b/packages/js/components/src/search/autocompleters/coupons.js
@@ -121,7 +121,7 @@ export default {
 				{ interpolateComponents( {
 					mixedString: __(
 						'All coupons with codes that include {{query /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						query: (

--- a/packages/js/components/src/search/autocompleters/customers.js
+++ b/packages/js/components/src/search/autocompleters/customers.js
@@ -122,7 +122,7 @@ export default {
 				{ interpolateComponents( {
 					mixedString: __(
 						'All customers with names that include {{query /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						query: (

--- a/packages/js/components/src/search/autocompleters/product.js
+++ b/packages/js/components/src/search/autocompleters/product.js
@@ -122,7 +122,7 @@ export default {
 				{ interpolateComponents( {
 					mixedString: __(
 						'All products with titles that include {{query /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						query: (

--- a/packages/js/components/src/search/autocompleters/taxes.js
+++ b/packages/js/components/src/search/autocompleters/taxes.js
@@ -121,7 +121,7 @@ export default {
 				{ interpolateComponents( {
 					mixedString: __(
 						'All taxes with codes that include {{query /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						query: (

--- a/packages/js/components/src/search/autocompleters/utils.js
+++ b/packages/js/components/src/search/autocompleters/utils.js
@@ -37,7 +37,7 @@ export function getTaxCode( tax ) {
 	return [
 		tax.country,
 		tax.state,
-		tax.name || __( 'TAX', 'woocommerce-admin' ),
+		tax.name || __( 'TAX', 'woocommerce' ),
 		tax.priority,
 	]
 		.filter( Boolean )

--- a/packages/js/components/src/select-control/control.js
+++ b/packages/js/components/src/select-control/control.js
@@ -252,7 +252,7 @@ class Control extends Component {
 						>
 							{ __(
 								'Move backward for selected items',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</span>
 					) }

--- a/packages/js/components/src/select-control/index.js
+++ b/packages/js/components/src/select-control/index.js
@@ -173,17 +173,14 @@ export class SelectControl extends Component {
 						'%d result found, use up and down arrow keys to navigate.',
 						'%d results found, use up and down arrow keys to navigate.',
 						searchOptions.length,
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					searchOptions.length
 				),
 				'assertive'
 			);
 		} else {
-			debouncedSpeak(
-				__( 'No results.', 'woocommerce-admin' ),
-				'assertive'
-			);
+			debouncedSpeak( __( 'No results.', 'woocommerce' ), 'assertive' );
 		}
 	}
 

--- a/packages/js/components/src/select-control/tags.js
+++ b/packages/js/components/src/select-control/tags.js
@@ -53,7 +53,7 @@ class Tags extends Component {
 							return null;
 						}
 						const screenReaderLabel = sprintf(
-							__( '%1$s (%2$s of %3$s)', 'woocommerce-admin' ),
+							__( '%1$s (%2$s of %3$s)', 'woocommerce' ),
 							item.label,
 							i + 1,
 							selected.length
@@ -80,7 +80,7 @@ class Tags extends Component {
 							className="clear-icon"
 						/>
 						<span className="screen-reader-text">
-							{ __( 'Clear all', 'woocommerce-admin' ) }
+							{ __( 'Clear all', 'woocommerce' ) }
 						</span>
 					</Button>
 				) }

--- a/packages/js/components/src/summary/README.md
+++ b/packages/js/components/src/summary/README.md
@@ -36,7 +36,7 @@ A container element for a list of SummaryNumbers. This component handles detecti
 Name | Type | Default | Description
 --- | --- | --- | ---
 `children` | Function | `null` | (required) A function returning a list of `<SummaryNumber />`s
-`label` | String | `__( 'Performance Indicators', 'woocommerce-admin' )` | An optional label of this group, read to screen reader users
+`label` | String | `__( 'Performance Indicators', 'woocommerce' )` | An optional label of this group, read to screen reader users
 
 
 SummaryNumber
@@ -57,7 +57,7 @@ Name | Type | Default | Description
 `isOpen` | Boolean | `false` | Boolean describing whether the menu list is open. Only applies in mobile view, and only applies to the toggle-able item (first in the list)
 `label` | String | `null` | (required) A string description of this value, ex "Revenue", or "New Customers"
 `onToggle` | Function | `null` | A function used to switch the given SummaryNumber to a button, and called on click
-`prevLabel` | String | `__( 'Previous period:', 'woocommerce-admin' )` | A string description of the previous value's timeframe, ex "Previous year:"
+`prevLabel` | String | `__( 'Previous period:', 'woocommerce' )` | A string description of the previous value's timeframe, ex "Previous year:"
 `prevValue` | One of type: number, string | `null` | A string or number value to display - a string is allowed so we can accept currency formatting. If omitted, this section won't display
 `reverseTrend` | Boolean | `false` | A boolean used to indicate that a negative delta is "good", and should be styled like a positive (and vice-versa)
 `selected` | Boolean | `false` | A boolean used to show a highlight style on this number

--- a/packages/js/components/src/summary/index.js
+++ b/packages/js/components/src/summary/index.js
@@ -78,7 +78,7 @@ SummaryList.propTypes = {
 };
 
 SummaryList.defaultProps = {
-	label: __( 'Performance Indicators', 'woocommerce-admin' ),
+	label: __( 'Performance Indicators', 'woocommerce' ),
 };
 
 export default withViewportMatch( {

--- a/packages/js/components/src/summary/menu.js
+++ b/packages/js/components/src/summary/menu.js
@@ -31,7 +31,7 @@ const Menu = ( { label, orientation, itemCount, items } ) => {
 				{ __(
 					'List of data points available for filtering. Use arrow keys to cycle through ' +
 						'the list. Click a data point for a detailed report.',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			</p>
 			<ul className={ classes }>{ items }</ul>

--- a/packages/js/components/src/summary/number.js
+++ b/packages/js/components/src/summary/number.js
@@ -65,18 +65,18 @@ const SummaryNumber = ( {
 	let screenReaderLabel =
 		delta > 0
 			? sprintf(
-					__( 'Up %f%% from %s', 'woocommerce-admin' ),
+					__( 'Up %f%% from %s', 'woocommerce' ),
 					delta,
 					prevLabel
 			  )
 			: sprintf(
-					__( 'Down %f%% from %s', 'woocommerce-admin' ),
+					__( 'Down %f%% from %s', 'woocommerce' ),
 					Math.abs( delta ),
 					prevLabel
 			  );
 	if ( ! delta ) {
 		screenReaderLabel = sprintf(
-			__( 'No change from %s', 'woocommerce-admin' ),
+			__( 'No change from %s', 'woocommerce' ),
 			prevLabel
 		);
 	}
@@ -131,7 +131,7 @@ const SummaryNumber = ( {
 						<Text variant="title.small" size="20" lineHeight="28px">
 							{ ! isNil( value )
 								? value
-								: __( 'N/A', 'woocommerce-admin' ) }
+								: __( 'N/A', 'woocommerce' ) }
 						</Text>
 					</div>
 
@@ -139,7 +139,7 @@ const SummaryNumber = ( {
 						text={
 							! isNil( prevValue )
 								? `${ prevLabel } ${ prevValue }`
-								: __( 'N/A', 'woocommerce-admin' )
+								: __( 'N/A', 'woocommerce' )
 						}
 						position="top center"
 					>
@@ -151,10 +151,10 @@ const SummaryNumber = ( {
 							<Text variant="caption" size="12" lineHeight="16px">
 								{ ! isNil( delta )
 									? sprintf(
-											__( '%f%%', 'woocommerce-admin' ),
+											__( '%f%%', 'woocommerce' ),
 											delta
 									  )
-									: __( 'N/A', 'woocommerce-admin' ) }
+									: __( 'N/A', 'woocommerce' ) }
 							</Text>
 						</div>
 					</Tooltip>
@@ -235,7 +235,7 @@ SummaryNumber.defaultProps = {
 	href: '',
 	hrefType: 'wc-admin',
 	isOpen: false,
-	prevLabel: __( 'Previous period:', 'woocommerce-admin' ),
+	prevLabel: __( 'Previous period:', 'woocommerce' ),
 	reverseTrend: false,
 	selected: false,
 	onLinkClickCallback: noop,

--- a/packages/js/components/src/table/index.js
+++ b/packages/js/components/src/table/index.js
@@ -177,15 +177,12 @@ class TableCard extends Component {
 						<EllipsisMenu
 							label={ __(
 								'Choose which values to display',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 							renderContent={ () => (
 								<Fragment>
 									<MenuTitle>
-										{ __(
-											'Columns:',
-											'woocommerce-admin'
-										) }
+										{ __( 'Columns:', 'woocommerce' ) }
 									</MenuTitle>
 									{ allHeaders.map(
 										( { key, label, required } ) => {
@@ -220,7 +217,7 @@ class TableCard extends Component {
 							<span className="screen-reader-text">
 								{ __(
 									'Your requested data is loading',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							</span>
 							<TablePlaceholder

--- a/packages/js/components/src/table/table.js
+++ b/packages/js/components/src/table/table.js
@@ -178,10 +178,7 @@ class Table extends Component {
 						{ caption }
 						{ tabIndex === '0' && (
 							<small>
-								{ __(
-									'(scroll to see more)',
-									'woocommerce-admin'
-								) }
+								{ __( '(scroll to see more)', 'woocommerce' ) }
 							</small>
 						) }
 					</caption>
@@ -226,14 +223,14 @@ class Table extends Component {
 										? sprintf(
 												__(
 													'Sort by %s in ascending order',
-													'woocommerce-admin'
+													'woocommerce'
 												),
 												screenReaderLabel || label
 										  )
 										: sprintf(
 												__(
 													'Sort by %s in descending order',
-													'woocommerce-admin'
+													'woocommerce'
 												),
 												screenReaderLabel || label
 										  );
@@ -349,7 +346,7 @@ class Table extends Component {
 								>
 									{ __(
 										'No data to display',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</td>
 							</tr>

--- a/packages/js/components/src/tag/index.js
+++ b/packages/js/components/src/tag/index.js
@@ -77,10 +77,7 @@ const Tag = ( {
 				<Button
 					className="woocommerce-tag__remove"
 					onClick={ remove( id ) }
-					label={ sprintf(
-						__( 'Remove %s', 'woocommerce-admin' ),
-						label
-					) }
+					label={ sprintf( __( 'Remove %s', 'woocommerce' ), label ) }
 					aria-describedby={ labelId }
 				>
 					<Icon

--- a/packages/js/components/src/timeline/index.js
+++ b/packages/js/components/src/timeline/index.js
@@ -29,7 +29,7 @@ const Timeline = ( props ) => {
 		return (
 			<div className={ timelineClassName }>
 				<p className={ 'timeline_no_events' }>
-					{ __( 'No data to display', 'woocommerce-admin' ) }
+					{ __( 'No data to display', 'woocommerce' ) }
 				</p>
 			</div>
 		);
@@ -123,9 +123,9 @@ Timeline.defaultProps = {
 	groupBy: 'day',
 	orderBy: 'desc',
 	/* translators: PHP date format string used to display dates, see php.net/date. */
-	dateFormat: __( 'F j, Y', 'woocommerce-admin' ),
+	dateFormat: __( 'F j, Y', 'woocommerce' ),
 	/* translators: PHP clock format string used to display times, see php.net/date. */
-	clockFormat: __( 'g:ia', 'woocommerce-admin' ),
+	clockFormat: __( 'g:ia', 'woocommerce' ),
 };
 
 export { orderByOptions, groupByOptions } from './util';

--- a/packages/js/components/src/view-more-list/index.js
+++ b/packages/js/components/src/view-more-list/index.js
@@ -22,7 +22,7 @@ const ViewMoreList = ( { items } ) => {
 		<Tag
 			className="woocommerce-view-more-list"
 			label={ sprintf(
-				__( '+%d more', 'woocommerce-admin' ),
+				__( '+%d more', 'woocommerce' ),
 				items.length - 1
 			) }
 			popoverContents={

--- a/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -36,23 +36,23 @@ function CustomerFeedbackModal( {
 } ): JSX.Element | null {
 	const options = [
 		{
-			label: __( 'Very difficult', 'woocommerce-admin' ),
+			label: __( 'Very difficult', 'woocommerce' ),
 			value: '1',
 		},
 		{
-			label: __( 'Somewhat difficult', 'woocommerce-admin' ),
+			label: __( 'Somewhat difficult', 'woocommerce' ),
 			value: '2',
 		},
 		{
-			label: __( 'Neutral', 'woocommerce-admin' ),
+			label: __( 'Neutral', 'woocommerce' ),
 			value: '3',
 		},
 		{
-			label: __( 'Somewhat easy', 'woocommerce-admin' ),
+			label: __( 'Somewhat easy', 'woocommerce' ),
 			value: '4',
 		},
 		{
-			label: __( 'Very easy', 'woocommerce-admin' ),
+			label: __( 'Very easy', 'woocommerce' ),
 			value: '5',
 		},
 	];
@@ -86,7 +86,7 @@ function CustomerFeedbackModal( {
 	return (
 		<Modal
 			className="woocommerce-customer-effort-score"
-			title={ __( 'Please share your feedback', 'woocommerce-admin' ) }
+			title={ __( 'Please share your feedback', 'woocommerce' ) }
 			onRequestClose={ closeModal }
 			shouldCloseOnClickOutside={ false }
 		>
@@ -111,13 +111,10 @@ function CustomerFeedbackModal( {
 			{ ( score === 1 || score === 2 ) && (
 				<div className="woocommerce-customer-effort-score__comments">
 					<TextareaControl
-						label={ __(
-							'Comments (Optional)',
-							'woocommerce-admin'
-						) }
+						label={ __( 'Comments (Optional)', 'woocommerce' ) }
 						help={ __(
 							'Your feedback will go to the WooCommerce development team',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 						value={ comments }
 						onChange={ ( value: string ) => setComments( value ) }
@@ -134,7 +131,7 @@ function CustomerFeedbackModal( {
 					<Text variant="body" as="p">
 						{ __(
 							'Please provide feedback by selecting an option above.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 				</div>
@@ -142,10 +139,10 @@ function CustomerFeedbackModal( {
 
 			<div className="woocommerce-customer-effort-score__buttons">
 				<Button isTertiary onClick={ closeModal } name="cancel">
-					{ __( 'Cancel', 'woocommerce-admin' ) }
+					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>
 				<Button isPrimary onClick={ sendScore } name="send">
-					{ __( 'Send', 'woocommerce-admin' ) }
+					{ __( 'Send', 'woocommerce' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/packages/js/customer-effort-score/src/index.js
+++ b/packages/js/customer-effort-score/src/index.js
@@ -49,7 +49,7 @@ export function CustomerEffortScore( {
 		createNotice( 'success', label, {
 			actions: [
 				{
-					label: __( 'Give feedback', 'woocommerce-admin' ),
+					label: __( 'Give feedback', 'woocommerce' ),
 					onClick: () => {
 						setVisible( true );
 						onModalShownCallback();

--- a/packages/js/data/src/import/reducer.js
+++ b/packages/js/data/src/import/reducer.js
@@ -17,7 +17,7 @@ const reducer = (
 		errors: {},
 		lastImportStartTimestamp: 0,
 		period: {
-			date: moment().format( __( 'MM/DD/YYYY', 'woocommerce-admin' ) ),
+			date: moment().format( __( 'MM/DD/YYYY', 'woocommerce' ) ),
 			label: 'all',
 		},
 		skipPrevious: true,

--- a/packages/js/data/src/notes/resolvers.js
+++ b/packages/js/data/src/notes/resolvers.js
@@ -40,7 +40,7 @@ export function* getNotes( query = {} ) {
 						/* translators: %s = link to developer blog */
 						__(
 							'WooCommerce Admin will soon limit inbox note contents to 320 characters. For more information, please visit %s. The following notes currently exceeds that limit:',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						'https://developer.woocommerce.com/?p=10749'
 					) +

--- a/packages/js/data/src/plugins/actions.ts
+++ b/packages/js/data/src/plugins/actions.ts
@@ -96,7 +96,7 @@ const formatErrorMessage = (
 			'Could not %(actionType)s %(pluginName)s plugin, %(error)s',
 			'Could not %(actionType)s the following plugins: %(pluginName)s with these Errors: %(error)s',
 			Object.keys( pluginErrors ).length || 1,
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		{
 			actionType,

--- a/packages/js/data/src/plugins/constants.ts
+++ b/packages/js/data/src/plugins/constants.ts
@@ -10,64 +10,49 @@ export const PAYPAL_NAMESPACE = '/wc-paypal/v1';
  * Plugin slugs and names as key/value pairs.
  */
 export const pluginNames = {
-	'facebook-for-woocommerce': __(
-		'Facebook for WooCommerce',
-		'woocommerce-admin'
-	),
-	jetpack: __( 'Jetpack', 'woocommerce-admin' ),
+	'facebook-for-woocommerce': __( 'Facebook for WooCommerce', 'woocommerce' ),
+	jetpack: __( 'Jetpack', 'woocommerce' ),
 	'klarna-checkout-for-woocommerce': __(
 		'Klarna Checkout for WooCommerce',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'klarna-payments-for-woocommerce': __(
 		'Klarna Payments for WooCommerce',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'mailchimp-for-woocommerce': __(
 		'Mailchimp for WooCommerce',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'creative-mail-by-constant-contact': __(
 		'Creative Mail for WooCommerce',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'woocommerce-gateway-paypal-express-checkout': __(
 		'WooCommerce PayPal',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	'woocommerce-gateway-stripe': __(
-		'WooCommerce Stripe',
-		'woocommerce-admin'
-	),
-	'woocommerce-payfast-gateway': __(
-		'WooCommerce PayFast',
-		'woocommerce-admin'
-	),
-	'woocommerce-payments': __( 'WooCommerce Payments', 'woocommerce-admin' ),
-	'woocommerce-services': __(
-		'WooCommerce Shipping & Tax',
-		'woocommerce-admin'
-	),
+	'woocommerce-gateway-stripe': __( 'WooCommerce Stripe', 'woocommerce' ),
+	'woocommerce-payfast-gateway': __( 'WooCommerce PayFast', 'woocommerce' ),
+	'woocommerce-payments': __( 'WooCommerce Payments', 'woocommerce' ),
+	'woocommerce-services': __( 'WooCommerce Shipping & Tax', 'woocommerce' ),
 	'woocommerce-services:shipping': __(
 		'WooCommerce Shipping & Tax',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'woocommerce-services:tax': __(
 		'WooCommerce Shipping & Tax',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'woocommerce-shipstation-integration': __(
 		'WooCommerce ShipStation Gateway',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	'woocommerce-mercadopago': __(
 		'Mercado Pago payments for WooCommerce',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	'google-listings-and-ads': __(
-		'Google Listings and Ads',
-		'woocommerce-admin'
-	),
-	'woo-razorpay': __( 'Razorpay', 'woocommerce-admin' ),
-	mailpoet: __( 'MailPoet', 'woocommerce-admin' ),
+	'google-listings-and-ads': __( 'Google Listings and Ads', 'woocommerce' ),
+	'woo-razorpay': __( 'Razorpay', 'woocommerce' ),
+	mailpoet: __( 'MailPoet', 'woocommerce' ),
 };

--- a/packages/js/data/src/settings/actions.js
+++ b/packages/js/data/src/settings/actions.js
@@ -98,7 +98,7 @@ export function* persistSettingsForGroup( group ) {
 			throw new Error(
 				__(
 					'There was a problem updating your settings.',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}

--- a/packages/js/date/src/index.js
+++ b/packages/js/date/src/index.js
@@ -31,27 +31,27 @@ export const defaultDateTimeFormat = 'YYYY-MM-DDTHH:mm:ss';
  */
 
 export const presetValues = [
-	{ value: 'today', label: __( 'Today', 'woocommerce-admin' ) },
-	{ value: 'yesterday', label: __( 'Yesterday', 'woocommerce-admin' ) },
-	{ value: 'week', label: __( 'Week to date', 'woocommerce-admin' ) },
-	{ value: 'last_week', label: __( 'Last week', 'woocommerce-admin' ) },
-	{ value: 'month', label: __( 'Month to date', 'woocommerce-admin' ) },
-	{ value: 'last_month', label: __( 'Last month', 'woocommerce-admin' ) },
-	{ value: 'quarter', label: __( 'Quarter to date', 'woocommerce-admin' ) },
-	{ value: 'last_quarter', label: __( 'Last quarter', 'woocommerce-admin' ) },
-	{ value: 'year', label: __( 'Year to date', 'woocommerce-admin' ) },
-	{ value: 'last_year', label: __( 'Last year', 'woocommerce-admin' ) },
-	{ value: 'custom', label: __( 'Custom', 'woocommerce-admin' ) },
+	{ value: 'today', label: __( 'Today', 'woocommerce' ) },
+	{ value: 'yesterday', label: __( 'Yesterday', 'woocommerce' ) },
+	{ value: 'week', label: __( 'Week to date', 'woocommerce' ) },
+	{ value: 'last_week', label: __( 'Last week', 'woocommerce' ) },
+	{ value: 'month', label: __( 'Month to date', 'woocommerce' ) },
+	{ value: 'last_month', label: __( 'Last month', 'woocommerce' ) },
+	{ value: 'quarter', label: __( 'Quarter to date', 'woocommerce' ) },
+	{ value: 'last_quarter', label: __( 'Last quarter', 'woocommerce' ) },
+	{ value: 'year', label: __( 'Year to date', 'woocommerce' ) },
+	{ value: 'last_year', label: __( 'Last year', 'woocommerce' ) },
+	{ value: 'custom', label: __( 'Custom', 'woocommerce' ) },
 ];
 
 export const periods = [
 	{
 		value: 'previous_period',
-		label: __( 'Previous period', 'woocommerce-admin' ),
+		label: __( 'Previous period', 'woocommerce' ),
 	},
 	{
 		value: 'previous_year',
-		label: __( 'Previous year', 'woocommerce-admin' ),
+		label: __( 'Previous year', 'woocommerce' ),
 	},
 ];
 
@@ -109,7 +109,7 @@ export function getRangeLabel( after, before ) {
 	const isSameMonth = isSameYear && after.month() === before.month();
 	const isSameDay =
 		isSameYear && isSameMonth && after.isSame( before, 'day' );
-	const fullDateFormat = __( 'MMM D, YYYY', 'woocommerce-admin' );
+	const fullDateFormat = __( 'MMM D, YYYY', 'woocommerce' );
 
 	if ( isSameDay ) {
 		return after.format( fullDateFormat );
@@ -119,7 +119,7 @@ export function getRangeLabel( after, before ) {
 			.format( fullDateFormat )
 			.replace( afterDate, `${ afterDate } - ${ before.date() }` );
 	} else if ( isSameYear ) {
-		const monthDayFormat = __( 'MMM D', 'woocommerce-admin' );
+		const monthDayFormat = __( 'MMM D', 'woocommerce' );
 		return `${ after.format( monthDayFormat ) } - ${ before.format(
 			fullDateFormat
 		) }`;
@@ -646,15 +646,9 @@ export function getDateFormatsForIntervalD3( interval, ticks = 0 ) {
 				x2Format = '%Y';
 			}
 			// eslint-disable-next-line @wordpress/i18n-translator-comments
-			screenReaderFormat = __(
-				'Week of %B %-d, %Y',
-				'woocommerce-admin'
-			);
+			screenReaderFormat = __( 'Week of %B %-d, %Y', 'woocommerce' );
 			// eslint-disable-next-line @wordpress/i18n-translator-comments
-			tooltipLabelFormat = __(
-				'Week of %B %-d, %Y',
-				'woocommerce-admin'
-			);
+			tooltipLabelFormat = __( 'Week of %B %-d, %Y', 'woocommerce' );
 			break;
 		case 'quarter':
 		case 'month':
@@ -720,10 +714,10 @@ export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
 			}
 
 			// Since some alphabet letters have php associated formats, we need to escape them first.
-			const escapedWeekOfStr = __(
-				'Week of',
-				'woocommerce-admin'
-			).replace( /(\w)/g, '\\$1' );
+			const escapedWeekOfStr = __( 'Week of', 'woocommerce' ).replace(
+				/(\w)/g,
+				'\\$1'
+			);
 
 			screenReaderFormat = `${ escapedWeekOfStr } F j, Y`;
 			tooltipLabelFormat = `${ escapedWeekOfStr } F j, Y`;
@@ -765,11 +759,11 @@ export function loadLocaleData( { userLocale, weekdaysShort } ) {
 	if ( moment.locale() !== 'en' ) {
 		moment.updateLocale( userLocale, {
 			longDateFormat: {
-				L: __( 'MM/DD/YYYY', 'woocommerce-admin' ),
-				LL: __( 'MMMM D, YYYY', 'woocommerce-admin' ),
-				LLL: __( 'D MMMM YYYY LT', 'woocommerce-admin' ),
-				LLLL: __( 'dddd, D MMMM YYYY LT', 'woocommerce-admin' ),
-				LT: __( 'HH:mm', 'woocommerce-admin' ),
+				L: __( 'MM/DD/YYYY', 'woocommerce' ),
+				LL: __( 'MMMM D, YYYY', 'woocommerce' ),
+				LLL: __( 'D MMMM YYYY LT', 'woocommerce' ),
+				LLLL: __( 'dddd, D MMMM YYYY LT', 'woocommerce' ),
+				LT: __( 'HH:mm', 'woocommerce' ),
 			},
 			weekdaysMin: weekdaysShort,
 		} );
@@ -777,16 +771,10 @@ export function loadLocaleData( { userLocale, weekdaysShort } ) {
 }
 
 export const dateValidationMessages = {
-	invalid: __( 'Invalid date', 'woocommerce-admin' ),
-	future: __( 'Select a date in the past', 'woocommerce-admin' ),
-	startAfterEnd: __(
-		'Start date must be before end date',
-		'woocommerce-admin'
-	),
-	endBeforeStart: __(
-		'Start date must be before end date',
-		'woocommerce-admin'
-	),
+	invalid: __( 'Invalid date', 'woocommerce' ),
+	future: __( 'Select a date in the past', 'woocommerce' ),
+	startAfterEnd: __( 'Start date must be before end date', 'woocommerce' ),
+	endBeforeStart: __( 'Start date must be before end date', 'woocommerce' ),
 };
 
 /**

--- a/packages/js/e2e-environment/bin/get-latest-docker-tag.js
+++ b/packages/js/e2e-environment/bin/get-latest-docker-tag.js
@@ -68,7 +68,7 @@ async function fetchLatestTagFromPage( image, nameSearch, page ) {
 			});
 			req.end();
 		}
-	)
+	);
 }
 
 /**

--- a/packages/js/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/js/experimental/src/experimental-list/task-item/index.tsx
@@ -69,12 +69,12 @@ const OptionalTaskTooltip: React.FC< {
 	if ( level === 1 && ! completed ) {
 		tooltip = __(
 			'This task is required to keep your store running',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	} else if ( level === 2 && ! completed ) {
 		tooltip = __(
 			'This task is required to set up your extension',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 	if ( tooltip === '' ) {
@@ -236,7 +236,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 			</div>
 			{ showEllipsisMenu && (
 				<EllipsisMenu
-					label={ __( 'Task Options', 'woocommerce-admin' ) }
+					label={ __( 'Task Options', 'woocommerce' ) }
 					className="woocommerce-task-list__item-after"
 					onToggle={ ( e: React.MouseEvent | React.KeyboardEvent ) =>
 						e.stopPropagation()
@@ -254,7 +254,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 										onDismiss();
 									} }
 								>
-									{ __( 'Dismiss', 'woocommerce-admin' ) }
+									{ __( 'Dismiss', 'woocommerce' ) }
 								</Button>
 							) }
 							{ onSnooze && ! completed && (
@@ -264,10 +264,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 										onSnooze();
 									} }
 								>
-									{ __(
-										'Remind me later',
-										'woocommerce-admin'
-									) }
+									{ __( 'Remind me later', 'woocommerce' ) }
 								</Button>
 							) }
 							{ onDelete && completed && (
@@ -281,7 +278,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 										onDelete();
 									} }
 								>
-									{ __( 'Delete', 'woocommerce-admin' ) }
+									{ __( 'Delete', 'woocommerce' ) }
 								</Button>
 							) }
 						</div>

--- a/packages/js/experimental/src/inbox-note/inbox-dismiss-confirmation-modal.tsx
+++ b/packages/js/experimental/src/inbox-note/inbox-dismiss-confirmation-modal.tsx
@@ -14,13 +14,13 @@ type ConfirmationModalProps = {
 export const InboxDismissConfirmationModal: React.FC< ConfirmationModalProps > = ( {
 	onClose,
 	onDismiss,
-	buttonLabel = __( "Yes, I'm sure", 'woocommerce-admin' ),
+	buttonLabel = __( "Yes, I'm sure", 'woocommerce' ),
 } ) => {
 	const [ inAction, setInAction ] = useState( false );
 
 	return (
 		<Modal
-			title={ __( 'Are you sure?', 'woocommerce-admin' ) }
+			title={ __( 'Are you sure?', 'woocommerce' ) }
 			onRequestClose={ () => onClose() }
 			className="woocommerce-inbox-dismiss-confirmation_modal"
 		>
@@ -28,12 +28,12 @@ export const InboxDismissConfirmationModal: React.FC< ConfirmationModalProps > =
 				<p>
 					{ __(
 						'Dismissed messages cannot be viewed again',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<div className="woocommerce-inbox-dismiss-confirmation_buttons">
 					<Button isSecondary onClick={ () => onClose() }>
-						{ __( 'Cancel', 'woocommerce-admin' ) }
+						{ __( 'Cancel', 'woocommerce' ) }
 					</Button>
 					<Button
 						isSecondary

--- a/packages/js/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/inbox-note.tsx
@@ -95,7 +95,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 				className="woocommerce-admin-dismiss-notification"
 				onClick={ () => onDismiss && onDismiss( note ) }
 			>
-				{ __( 'Dismiss', 'woocommerce-admin' ) }
+				{ __( 'Dismiss', 'woocommerce' ) }
 			</Button>
 		);
 	};

--- a/packages/js/js-tests/src/setup-globals.js
+++ b/packages/js/js-tests/src/setup-globals.js
@@ -115,8 +115,8 @@ if ( global.window ) {
 }
 
 setLocaleData(
-	{ '': { domain: 'woocommerce-admin', lang: 'en_US' } },
-	'woocommerce-admin'
+	{ '': { domain: 'woocommerce', lang: 'en_US' } },
+	'woocommerce'
 );
 
 // Mock core/notices store for components dispatching core notices

--- a/packages/js/onboarding/src/components/RecommendedRibbon/RecommendedRibbon.js
+++ b/packages/js/onboarding/src/components/RecommendedRibbon/RecommendedRibbon.js
@@ -6,8 +6,8 @@ import { createElement } from '@wordpress/element';
 
 export const RecommendedRibbon = ( { isLocalPartner = false } ) => {
 	const text = isLocalPartner
-		? __( 'Local Partner', 'woocommerce-admin' )
-		: __( 'Recommended', 'woocommerce-admin' );
+		? __( 'Local Partner', 'woocommerce' )
+		: __( 'Recommended', 'woocommerce' );
 
 	return (
 		<div className={ 'woocommerce-task-payment__recommended-ribbon' }>

--- a/packages/js/onboarding/src/components/SetupRequired.js
+++ b/packages/js/onboarding/src/components/SetupRequired.js
@@ -11,7 +11,7 @@ export const SetupRequired = () => {
 		<span className="woocommerce-task-payment__setup_required">
 			<NoticeOutlineIcon />
 			<Text variant="small" size="14" lineHeight="20px">
-				{ __( 'Setup required', 'woocommerce-admin' ) }
+				{ __( 'Setup required', 'woocommerce' ) }
 			</Text>
 		</span>
 	);

--- a/packages/js/onboarding/src/components/WCPayAcceptedMethods.js
+++ b/packages/js/onboarding/src/components/WCPayAcceptedMethods.js
@@ -22,7 +22,7 @@ import UnionPay from '../images/cards/unionpay.js';
 export const WCPayAcceptedMethods = () => (
 	<>
 		<Text as="h3" variant="label" weight="600" size="12" lineHeight="16px">
-			{ __( 'Accepted payment methods', 'woocommerce-admin' ) }
+			{ __( 'Accepted payment methods', 'woocommerce' ) }
 		</Text>
 
 		<div className="woocommerce-task-payment-wcpay__accepted">

--- a/packages/js/onboarding/src/components/WCPayCard/WCPayCard.js
+++ b/packages/js/onboarding/src/components/WCPayCard/WCPayCard.js
@@ -46,7 +46,7 @@ export const WCPayCardBody = ( {
 				href="https://woocommerce.com/payments/?utm_medium=product"
 				onClick={ onLinkClick }
 			>
-				{ __( 'Learn more', 'woocommerce-admin' ) }
+				{ __( 'Learn more', 'woocommerce' ) }
 			</Link>
 		</Text>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -98,4 +98,34 @@
 	<rule ref="Squiz.Commenting.FileComment.Missing">
 		<exclude-pattern>tests/php/</exclude-pattern>
 	</rule>
+
+	<!-- Temporary -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<exclude-pattern>src/Internal/Admin/</exclude-pattern>
+		<exclude-pattern>src/Admin/</exclude-pattern>
+	</rule>
+
+	<!-- Temporary -->
+	<rule ref="WooCommerce.Functions.InternalInjectionMethod.MissingFinal">
+		<exclude-pattern>src/Internal/Admin/</exclude-pattern>
+		<exclude-pattern>src/Admin/</exclude-pattern>
+	</rule>
+
+	<!-- Temporary -->
+	<rule ref="WooCommerce.Functions.InternalInjectionMethod.MissingInternalTag">
+		<exclude-pattern>src/Internal/Admin/</exclude-pattern>
+		<exclude-pattern>src/Admin/</exclude-pattern>
+	</rule>
+
+	<!-- Temporary -->
+	<rule ref="WooCommerce.Commenting.CommentHooks.MissingHooksComment">
+		<exclude-pattern>plugins/woocommerce/src/Internal/Admin/</exclude-pattern>
+		<exclude-pattern>src/Admin/</exclude-pattern>
+	</rule>
+
+	<!-- Temporary -->
+	<rule ref="WordPress.Security.NonceVerification.Recommended">
+		<exclude-pattern>src/Internal/Admin/</exclude-pattern>
+		<exclude-pattern>src/Admin/</exclude-pattern>
+	</rule>
 </ruleset>

--- a/plugins/woocommerce-admin/Gruntfile.js
+++ b/plugins/woocommerce-admin/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function( grunt ) {
 
 		checktextdomain: {
 			options: {
-				text_domain: 'woocommerce-admin',
+				text_domain: 'woocommerce',
 				keywords: [
 					'__:1,2d',
 					'_e:1,2d',

--- a/plugins/woocommerce-admin/bin/package-update-textdomain.js
+++ b/plugins/woocommerce-admin/bin/package-update-textdomain.js
@@ -1,0 +1,31 @@
+const wpTextdomain = require( 'wp-textdomain' );
+
+const dirs = process.argv.slice( 2 );
+
+for ( dir of dirs ) {
+	let path = dir + '/**/*.php';
+	console.log("Processing: " + dir);
+	wpTextdomain( path, {
+		domain: 'woocommerce',
+		fix: true,
+		missingDomain: true,
+		variableDomain: true,
+		keywords: [
+			'__:1,2d',
+			'_e:1,2d',
+			'_x:1,2c,3d',
+			'esc_html__:1,2d',
+			'esc_html_e:1,2d',
+			'esc_html_x:1,2c,3d',
+			'esc_attr__:1,2d',
+			'esc_attr_e:1,2d',
+			'esc_attr_x:1,2c,3d',
+			'_ex:1,2c,3d',
+			'_n:1,2,4d',
+			'_nx:1,2,4c,5d',
+			'_n_noop:1,2,3d',
+			'_nx_noop:1,2,3c,4d',
+			'wp_set_script_translations:1,2d,3',
+		],
+	} );
+}

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -224,7 +224,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const getTabs = () => {
 		const activity = {
 			name: 'activity',
-			title: __( 'Activity', 'woocommerce-admin' ),
+			title: __( 'Activity', 'woocommerce' ),
 			icon: <IconFlag />,
 			unread: hasUnreadNotes || hasAbbreviatedNotifications,
 			visible:
@@ -233,7 +233,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const setup = {
 			name: 'setup',
-			title: __( 'Finish setup', 'woocommerce-admin' ),
+			title: __( 'Finish setup', 'woocommerce' ),
 			icon: <SetupProgress />,
 			onClick: () => {
 				const currentLocation = window.location.href;
@@ -265,7 +265,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const help = {
 			name: 'help',
-			title: __( 'Help', 'woocommerce-admin' ),
+			title: __( 'Help', 'woocommerce' ),
 			icon: <Icon icon={ helpIcon } />,
 			visible:
 				currentUserCan( 'manage_woocommerce' ) &&
@@ -284,7 +284,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const previewSite = {
 			name: 'previewSite',
-			title: __( 'Preview site', 'woocommerce-admin' ),
+			title: __( 'Preview site', 'woocommerce' ),
 			icon: <Icon icon={ external } />,
 			visible: query.page === 'wc-admin' && query.task === 'appearance',
 			onClick: () => {
@@ -355,7 +355,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	return (
 		<div>
 			<H id={ headerId } className="screen-reader-text">
-				{ __( 'Store Activity', 'woocommerce-admin' ) }
+				{ __( 'Store Activity', 'woocommerce' ) }
 			</H>
 			<Section
 				component="aside"
@@ -390,12 +390,12 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 				<HighlightTooltip
 					delay={ 1000 }
 					useAnchor={ true }
-					title={ __( "We're here for help", 'woocommerce-admin' ) }
+					title={ __( "We're here for help", 'woocommerce' ) }
 					content={ __(
 						'If you have any questions, feel free to explore the WooCommerce docs listed here.',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
-					closeButtonText={ __( 'Got it', 'woocommerce-admin' ) }
+					closeButtonText={ __( 'Got it', 'woocommerce' ) }
 					id="activity-panel-tab-help"
 					onClose={ () => closedHelpPanelHighlight() }
 					onShow={ () => recordEvent( 'help_tooltip_view' ) }

--- a/plugins/woocommerce-admin/client/activity-panel/display-options/icons/display.js
+++ b/plugins/woocommerce-admin/client/activity-panel/display-options/icons/display.js
@@ -38,6 +38,6 @@ export const DisplayIcon = () => (
 				strokeLinejoin="round"
 			/>
 		</svg>
-		{ __( 'Display', 'woocommerce-admin' ) }
+		{ __( 'Display', 'woocommerce' ) }
 	</>
 );

--- a/plugins/woocommerce-admin/client/activity-panel/display-options/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/display-options/index.js
@@ -35,7 +35,7 @@ const LAYOUTS = [
 		label: (
 			<>
 				<SingleColumnIcon />
-				{ __( 'Single column', 'woocommerce-admin' ) }
+				{ __( 'Single column', 'woocommerce' ) }
 			</>
 		),
 	},
@@ -44,7 +44,7 @@ const LAYOUTS = [
 		label: (
 			<>
 				<TwoColumnsIcon />
-				{ __( 'Two columns', 'woocommerce-admin' ) }
+				{ __( 'Two columns', 'woocommerce' ) }
 			</>
 		),
 	},
@@ -88,7 +88,7 @@ export const DisplayOptions = () => {
 					<DropdownMenu
 						icon={ <DisplayIcon /> }
 						/* translators: button label text should, if possible, be under 16 characters. */
-						label={ __( 'Display options', 'woocommerce-admin' ) }
+						label={ __( 'Display options', 'woocommerce' ) }
 						toggleProps={ {
 							className:
 								'woocommerce-layout__activity-panel-tab display-options',
@@ -106,10 +106,7 @@ export const DisplayOptions = () => {
 								{ hasTwoColumnContent ? (
 									<MenuGroup
 										className="woocommerce-layout__homescreen-display-options"
-										label={ __(
-											'Layout',
-											'woocommerce-admin'
-										) }
+										label={ __( 'Layout', 'woocommerce' ) }
 									>
 										<MenuItemsChoice
 											choices={ LAYOUTS }

--- a/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/highlight-tooltip/index.js
@@ -169,7 +169,7 @@ function HighlightTooltip( {
 									onClick={ triggerClose }
 								>
 									{ closeButtonText ||
-										__( 'Close', 'woocommerce-admin' ) }
+										__( 'Close', 'woocommerce' ) }
 								</Button>
 							</CardFooter>
 						</Card>

--- a/plugins/woocommerce-admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/help.js
@@ -29,32 +29,32 @@ export const SETUP_TASK_HELP_ITEMS_FILTER =
 function getHomeItems() {
 	return [
 		{
-			title: __( 'Get Support', 'woocommerce-admin' ),
+			title: __( 'Get Support', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/my-account/create-a-ticket/?utm_medium=product',
 		},
 		{
-			title: __( 'Home Screen', 'woocommerce-admin' ),
+			title: __( 'Home Screen', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/home-screen/?utm_medium=product',
 		},
 		{
-			title: __( 'Inbox', 'woocommerce-admin' ),
+			title: __( 'Inbox', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/home-screen/?utm_medium=product#section-2',
 		},
 		{
-			title: __( 'Stats Overview', 'woocommerce-admin' ),
+			title: __( 'Stats Overview', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/home-screen/?utm_medium=product#section-4',
 		},
 		{
-			title: __( 'Store Management', 'woocommerce-admin' ),
+			title: __( 'Store Management', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/home-screen/?utm_medium=product#section-5',
 		},
 		{
-			title: __( 'Store Setup Checklist', 'woocommerce-admin' ),
+			title: __( 'Store Setup Checklist', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/woocommerce-setup-wizard?utm_medium=product#store-setup-checklist',
 		},
@@ -66,7 +66,7 @@ function getAppearanceItems() {
 		{
 			title: __(
 				'Showcase your products and tailor your shopping experience using Blocks',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/woocommerce-blocks/?utm_source=help_panel&utm_medium=product',
@@ -74,16 +74,13 @@ function getAppearanceItems() {
 		{
 			title: __(
 				'Manage Store Notice, Catalog View and Product Images',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/woocommerce-customizer/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __(
-				'How to choose and change a theme',
-				'woocommerce-admin'
-			),
+			title: __( 'How to choose and change a theme', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/choose-change-theme/?utm_source=help_panel&utm_medium=product',
 		},
@@ -95,27 +92,21 @@ function getMarketingItems( props ) {
 
 	return [
 		activePlugins.includes( 'mailpoet' ) && {
-			title: __( 'Get started with Mailpoet', 'woocommerce-admin' ),
+			title: __( 'Get started with Mailpoet', 'woocommerce' ),
 			link: 'https://kb.mailpoet.com/category/114-getting-started',
 		},
 		activePlugins.includes( 'google-listings-and-ads' ) && {
-			title: __( 'Set up Google Listing & Ads', 'woocommerce-admin' ),
+			title: __( 'Set up Google Listing & Ads', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/google-listings-and-ads/?utm_medium=product#get-started',
 		},
 		activePlugins.includes( 'mailchimp-for-woocommerce' ) && {
-			title: __(
-				'Connect Mailchimp for WooCommerce',
-				'woocommerce-admin'
-			),
+			title: __( 'Connect Mailchimp for WooCommerce', 'woocommerce' ),
 			link:
 				'https://mailchimp.com/help/connect-or-disconnect-mailchimp-for-woocommerce/',
 		},
 		activePlugins.includes( 'creative-mail-by-constant-contact' ) && {
-			title: __(
-				'Set up Creative Mail for WooCommerce',
-				'woocommerce-admin'
-			),
+			title: __( 'Set up Creative Mail for WooCommerce', 'woocommerce' ),
 			link: 'https://app.creativemail.com/kb/help/WooCommerce',
 		},
 	].filter( Boolean );
@@ -126,71 +117,65 @@ function getPaymentGatewaySuggestions( props ) {
 
 	return [
 		{
-			title: __(
-				'Which Payment Option is Right for Me?',
-				'woocommerce-admin'
-			),
+			title: __( 'Which Payment Option is Right for Me?', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/premium-payment-gateway-extensions/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.woocommerce_payments && {
-			title: __(
-				'WooCommerce Payments Start Up Guide',
-				'woocommerce-admin'
-			),
+			title: __( 'WooCommerce Payments Start Up Guide', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/payments/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.woocommerce_payments && {
-			title: __( 'WooCommerce Payments FAQs', 'woocommerce-admin' ),
+			title: __( 'WooCommerce Payments FAQs', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/documentation/woocommerce-payments/woocommerce-payments-faqs/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.stripe && {
-			title: __( 'Stripe Setup and Configuration', 'woocommerce-admin' ),
+			title: __( 'Stripe Setup and Configuration', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/stripe/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions[ 'ppcp-gateway' ] && {
 			title: __(
 				'PayPal Checkout Setup and Configuration',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/2-0/woocommerce-paypal-payments/?utm_medium=product#section-3',
 		},
 		paymentGatewaySuggestions.square_credit_card && {
-			title: __( 'Square - Get started', 'woocommerce-admin' ),
+			title: __( 'Square - Get started', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/woocommerce-square/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.kco && {
-			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
+			title: __( 'Klarna - Introduction', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/klarna-checkout/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.klarna_payments && {
-			title: __( 'Klarna - Introduction', 'woocommerce-admin' ),
+			title: __( 'Klarna - Introduction', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/klarna-payments/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.payfast && {
-			title: __( 'PayFast Setup and Configuration', 'woocommerce-admin' ),
+			title: __( 'PayFast Setup and Configuration', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/payfast-payment-gateway/?utm_source=help_panel&utm_medium=product',
 		},
 		paymentGatewaySuggestions.eway && {
-			title: __( 'Eway Setup and Configuration', 'woocommerce-admin' ),
+			title: __( 'Eway Setup and Configuration', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/eway/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __( 'Direct Bank Transfer (BACS)', 'woocommerce-admin' ),
+			title: __( 'Direct Bank Transfer (BACS)', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/bacs/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __( 'Cash on Delivery', 'woocommerce-admin' ),
+			title: __( 'Cash on Delivery', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/cash-on-delivery/?utm_source=help_panel&utm_medium=product',
 		},
@@ -200,31 +185,25 @@ function getPaymentGatewaySuggestions( props ) {
 function getProductsItems() {
 	return [
 		{
-			title: __( 'Adding and Managing Products', 'woocommerce-admin' ),
+			title: __( 'Adding and Managing Products', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product',
 		},
 		{
 			title: __(
 				'Import products using the CSV Importer and Exporter',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/product-csv-importer-exporter/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __(
-				'Migrate products using Cart2Cart',
-				'woocommerce-admin'
-			),
+			title: __( 'Migrate products using Cart2Cart', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/products/cart2cart/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __(
-				'Learn more about setting up products',
-				'woocommerce-admin'
-			),
+			title: __( 'Learn more about setting up products', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/documentation/plugins/woocommerce/getting-started/setup-products/?utm_source=help_panel&utm_medium=product',
 		},
@@ -237,24 +216,24 @@ function getShippingItems( { activePlugins, countryCode } ) {
 		! activePlugins.includes( 'woocommerce-services' );
 	return [
 		{
-			title: __( 'Setting up Shipping Zones', 'woocommerce-admin' ),
+			title: __( 'Setting up Shipping Zones', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/setting-up-shipping-zones/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __( 'Core Shipping Options', 'woocommerce-admin' ),
+			title: __( 'Core Shipping Options', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/documentation/plugins/woocommerce/getting-started/shipping/core-shipping-options/?utm_source=help_panel&utm_medium=product',
 		},
 		{
-			title: __( 'Product Shipping Classes', 'woocommerce-admin' ),
+			title: __( 'Product Shipping Classes', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/product-shipping-classes/?utm_source=help_panel&utm_medium=product',
 		},
 		showWCS && {
 			title: __(
 				'WooCommerce Shipping setup and configuration',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/woocommerce-shipping-and-tax/?utm_source=help_panel&utm_medium=product#section-3',
@@ -262,7 +241,7 @@ function getShippingItems( { activePlugins, countryCode } ) {
 		{
 			title: __(
 				'Learn more about configuring your shipping settings',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/plugins/woocommerce/getting-started/shipping/?utm_source=help_panel&utm_medium=product',
@@ -292,14 +271,14 @@ function getTaxItems( props ) {
 
 	return [
 		{
-			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce-admin' ),
+			title: __( 'Setting up Taxes in WooCommerce', 'woocommerce' ),
 			link:
 				'https://woocommerce.com/document/setting-up-taxes-in-woocommerce/?utm_source=help_panel&utm_medium=product',
 		},
 		showWCS && {
 			title: __(
 				'Automated Tax calculation using WooCommerce Tax',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			link:
 				'https://woocommerce.com/document/woocommerce-services/?utm_source=help_panel&utm_medium=product#section-10',
@@ -345,7 +324,7 @@ function handleOnItemClick( props, event ) {
 function getListItems( props ) {
 	const itemsByType = getItems( props );
 	const genericDocsLink = {
-		title: __( 'WooCommerce Docs', 'woocommerce-admin' ),
+		title: __( 'WooCommerce Docs', 'woocommerce' ),
 		link:
 			'https://woocommerce.com/documentation/?utm_source=help_panel&utm_medium=product',
 	};
@@ -413,9 +392,7 @@ export const HelpPanel = ( props ) => {
 
 	return (
 		<Fragment>
-			<ActivityHeader
-				title={ __( 'Documentation', 'woocommerce-admin' ) }
-			/>
+			<ActivityHeader title={ __( 'Documentation', 'woocommerce' ) } />
 			<Section>
 				<List
 					items={ listItems }

--- a/plugins/woocommerce-admin/client/activity-panel/panels/inbox/abbreviated-notifications-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/inbox/abbreviated-notifications-panel.js
@@ -71,7 +71,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 					type={ isWCAdminPage ? 'wc-admin' : 'wp-admin' }
 				>
 					<Text as="h3">
-						{ __( 'Things to do next', 'woocommerce-admin' ) }
+						{ __( 'Things to do next', 'woocommerce' ) }
 					</Text>
 					<Text as="p">
 						{ sprintf(
@@ -80,7 +80,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 								'You have %d new thing to do',
 								'You have %d new things to do',
 								thingsToDoNextCount,
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							thingsToDoNextCount
 						) }
@@ -98,7 +98,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 					type={ isWCAdminPage ? 'wc-admin' : 'wp-admin' }
 				>
 					<Text as="h3">
-						{ __( 'Orders to fulfill', 'woocommerce-admin' ) }
+						{ __( 'Orders to fulfill', 'woocommerce' ) }
 					</Text>
 					<Text>
 						{ sprintf(
@@ -107,7 +107,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 								'You have %d order to fulfill',
 								'You have %d orders to fulfill',
 								ordersToProcessCount,
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							ordersToProcessCount
 						) }
@@ -125,7 +125,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 					type={ isWCAdminPage ? 'wc-admin' : 'wp-admin' }
 				>
 					<Text as="h3">
-						{ __( 'Reviews to moderate', 'woocommerce-admin' ) }
+						{ __( 'Reviews to moderate', 'woocommerce' ) }
 					</Text>
 					<Text>
 						{ sprintf(
@@ -134,7 +134,7 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 								'You have %d review to moderate',
 								'You have %d reviews to moderate',
 								reviewsToModerateCount,
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							reviewsToModerateCount
 						) }
@@ -152,12 +152,12 @@ export const AbbreviatedNotificationsPanel = ( { thingsToDoNextCount } ) => {
 					type={ isWCAdminPage ? 'wc-admin' : 'wp-admin' }
 				>
 					<Text as="h3">
-						{ __( 'Inventory to review', 'woocommerce-admin' ) }
+						{ __( 'Inventory to review', 'woocommerce' ) }
 					</Text>
 					<Text>
 						{ __(
 							'You have inventory to review and update',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 				</AbbreviatedCard>

--- a/plugins/woocommerce-admin/client/activity-panel/tab/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/tab/index.js
@@ -37,7 +37,7 @@ export const Tab = ( {
 			{ title }{ ' ' }
 			{ unread && (
 				<span className="screen-reader-text">
-					{ __( 'unread activity', 'woocommerce-admin' ) }
+					{ __( 'unread activity', 'woocommerce' ) }
 				</span>
 			) }
 		</Button>

--- a/plugins/woocommerce-admin/client/analytics/components/leaderboard/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/leaderboard/index.js
@@ -80,7 +80,7 @@ export class Leaderboard extends Component {
 						<EmptyTable>
 							{ __(
 								'No data recorded for the selected time period.',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</EmptyTable>
 					</CardBody>

--- a/plugins/woocommerce-admin/client/analytics/components/report-chart/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-chart/index.js
@@ -169,8 +169,8 @@ export class ReportChart extends Component {
 			{ type: 'php' }
 		);
 		const emptyMessage = emptySearchResults
-			? __( 'No data for the current search', 'woocommerce-admin' )
-			: __( 'No data for the selected date range', 'woocommerce-admin' );
+			? __( 'No data for the current search', 'woocommerce' )
+			: __( 'No data for the selected date range', 'woocommerce' );
 		const { formatAmount, getCurrencyConfig } = this.context;
 		return (
 			<Chart

--- a/plugins/woocommerce-admin/client/analytics/components/report-error/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-error/index.js
@@ -15,9 +15,9 @@ import { EmptyContent } from '@woocommerce/components';
 function ReportError( { className } ) {
 	const title = __(
 		'There was an error getting your stats. Please try again.',
-		'woocommerce-admin'
+		'woocommerce'
 	);
-	const actionLabel = __( 'Reload', 'woocommerce-admin' );
+	const actionLabel = __( 'Reload', 'woocommerce' );
 	const actionCallback = () => {
 		// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 		window.location.reload();

--- a/plugins/woocommerce-admin/client/analytics/components/report-summary/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-summary/index.js
@@ -104,8 +104,8 @@ export class ReportSummary extends Component {
 						reverseTrend={ isReverseTrend }
 						prevLabel={
 							compare === 'previous_period'
-								? __( 'Previous period:', 'woocommerce-admin' )
-								: __( 'Previous year:', 'woocommerce-admin' )
+								? __( 'Previous period:', 'woocommerce' )
+								: __( 'Previous year:', 'woocommerce' )
 						}
 						prevValue={ prevValue }
 						selected={ isSelected }

--- a/plugins/woocommerce-admin/client/analytics/components/report-table/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-table/index.js
@@ -209,7 +209,7 @@ const ReportTable = ( props ) => {
 							/* translators: %s = type of report */
 							__(
 								'Your %s Report will be emailed to you.',
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							title
 						)
@@ -223,7 +223,7 @@ const ReportTable = ( props ) => {
 								/* translators: %s = type of report */
 								__(
 									'There was a problem exporting your %s Report. Please try again.',
-									'woocommerce-admin'
+									'woocommerce'
 								),
 								title
 							)
@@ -401,14 +401,14 @@ const ReportTable = ( props ) => {
 								labels.helpText ||
 								__(
 									'Check at least two items below to compare',
-									'woocommerce-admin'
+									'woocommerce'
 								)
 							}
 							onClick={ onCompare }
 							disabled={ ! downloadable }
 						>
 							{ labels.compareButton ||
-								__( 'Compare', 'woocommerce-admin' ) }
+								__( 'Compare', 'woocommerce' ) }
 						</CompareButton>
 					),
 					searchBy && (
@@ -419,7 +419,7 @@ const ReportTable = ( props ) => {
 							onChange={ onSearchChange }
 							placeholder={
 								labels.placeholder ||
-								__( 'Search by item name', 'woocommerce-admin' )
+								__( 'Search by item name', 'woocommerce' )
 							}
 							selected={ searchedLabels }
 							showClearButton={ true }
@@ -437,7 +437,7 @@ const ReportTable = ( props ) => {
 							<DownloadIcon />
 							<span className="woocommerce-table__download-button__label">
 								{ labels.downloadButton ||
-									__( 'Download', 'woocommerce-admin' ) }
+									__( 'Download', 'woocommerce' ) }
 							</span>
 						</Button>
 					),

--- a/plugins/woocommerce-admin/client/analytics/report/categories/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/categories/config.js
@@ -33,21 +33,21 @@ const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
 	{
 		key: 'items_sold',
-		label: __( 'Items sold', 'woocommerce-admin' ),
+		label: __( 'Items sold', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'items_sold',
 		type: 'number',
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net sales', 'woocommerce-admin' ),
+		label: __( 'Net sales', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',
@@ -69,18 +69,18 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Categories match {{select /}} filters',
 			'A sentence describing filters for Categories. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	}
 );
 
 const filterValues = [
 	{
-		label: __( 'All categories', 'woocommerce-admin' ),
+		label: __( 'All categories', 'woocommerce' ),
 		value: 'all',
 	},
 	{
-		label: __( 'Single category', 'woocommerce-admin' ),
+		label: __( 'Single category', 'woocommerce' ),
 		value: 'select_category',
 		chartMode: 'item-comparison',
 		subFilters: [
@@ -96,16 +96,16 @@ const filterValues = [
 					labels: {
 						placeholder: __(
 							'Type to search for a category',
-							'woocommerce-admin'
+							'woocommerce'
 						),
-						button: __( 'Single Category', 'woocommerce-admin' ),
+						button: __( 'Single Category', 'woocommerce' ),
 					},
 				},
 			},
 		],
 	},
 	{
-		label: __( 'Comparison', 'woocommerce-admin' ),
+		label: __( 'Comparison', 'woocommerce' ),
 		value: 'compare-categories',
 		chartMode: 'item-comparison',
 		settings: {
@@ -115,14 +115,14 @@ const filterValues = [
 			labels: {
 				helpText: __(
 					'Check at least two categories below to compare',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				placeholder: __(
 					'Search for categories to compare',
-					'woocommerce-admin'
+					'woocommerce'
 				),
-				title: __( 'Compare Categories', 'woocommerce-admin' ),
-				update: __( 'Compare', 'woocommerce-admin' ),
+				title: __( 'Compare Categories', 'woocommerce' ),
+				update: __( 'Compare', 'woocommerce' ),
 			},
 			onClick: addCesSurveyForAnalytics,
 		},
@@ -131,7 +131,7 @@ const filterValues = [
 
 if ( Object.keys( advancedFilters.filters ).length ) {
 	filterValues.push( {
-		label: __( 'Advanced filters', 'woocommerce-admin' ),
+		label: __( 'Advanced filters', 'woocommerce' ),
 		value: 'advanced',
 	} );
 }
@@ -148,7 +148,7 @@ if ( Object.keys( advancedFilters.filters ).length ) {
  */
 export const filters = applyFilters( CATEGORY_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,

--- a/plugins/woocommerce-admin/client/analytics/report/categories/index.js
+++ b/plugins/woocommerce-admin/client/analytics/report/categories/index.js
@@ -31,8 +31,8 @@ class CategoriesReport extends Component {
 				? 'item-comparison'
 				: 'time-comparison';
 		const itemsLabel = isSingleCategoryView
-			? __( '%d products', 'woocommerce-admin' )
-			: __( '%d categories', 'woocommerce-admin' );
+			? __( '%d products', 'woocommerce' )
+			: __( '%d categories', 'woocommerce' );
 
 		return {
 			isSingleCategoryView,

--- a/plugins/woocommerce-admin/client/analytics/report/categories/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/categories/table.js
@@ -29,14 +29,14 @@ class CategoriesReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Category', 'woocommerce-admin' ),
+				label: __( 'Category', 'woocommerce' ),
 				key: 'category',
 				required: true,
 				isSortable: true,
 				isLeftAligned: true,
 			},
 			{
-				label: __( 'Items sold', 'woocommerce-admin' ),
+				label: __( 'Items sold', 'woocommerce' ),
 				key: 'items_sold',
 				required: true,
 				defaultSort: true,
@@ -44,19 +44,19 @@ class CategoriesReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
 				key: 'net_revenue',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Products', 'woocommerce-admin' ),
+				label: __( 'Products', 'woocommerce' ),
 				key: 'products_count',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				isSortable: true,
 				isNumeric: true,
@@ -146,7 +146,7 @@ class CategoriesReportTable extends Component {
 					'Category',
 					'Categories',
 					totalResults,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', totalResults ),
 			},
@@ -155,21 +155,16 @@ class CategoriesReportTable extends Component {
 					'Item sold',
 					'Items sold',
 					itemsSold,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', itemsSold ),
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
 				value: formatAmount( netRevenue ),
 			},
 			{
-				label: _n(
-					'Order',
-					'Orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'Order', 'Orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 		];
@@ -181,9 +176,9 @@ class CategoriesReportTable extends Component {
 		const labels = {
 			helpText: __(
 				'Check at least two categories below to compare',
-				'woocommerce-admin'
+				'woocommerce'
 			),
-			placeholder: __( 'Search by category name', 'woocommerce-admin' ),
+			placeholder: __( 'Search by category name', 'woocommerce' ),
 		};
 
 		return (
@@ -208,7 +203,7 @@ class CategoriesReportTable extends Component {
 					order: query.order || 'desc',
 					extended_info: true,
 				} }
-				title={ __( 'Categories', 'woocommerce-admin' ) }
+				title={ __( 'Categories', 'woocommerce' ) }
 				columnPrefsKey="categories_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/coupons/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/coupons/config.js
@@ -31,14 +31,14 @@ const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 export const charts = applyFilters( COUPON_REPORT_CHARTS_FILTER, [
 	{
 		key: 'orders_count',
-		label: __( 'Discounted orders', 'woocommerce-admin' ),
+		label: __( 'Discounted orders', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',
 	},
 	{
 		key: 'amount',
-		label: __( 'Amount', 'woocommerce-admin' ),
+		label: __( 'Amount', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'amount',
 		type: 'currency',
@@ -60,15 +60,15 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Coupons match {{select /}} filters',
 			'A sentence describing filters for Coupons. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	}
 );
 
 const filterValues = [
-	{ label: __( 'All coupons', 'woocommerce-admin' ), value: 'all' },
+	{ label: __( 'All coupons', 'woocommerce' ), value: 'all' },
 	{
-		label: __( 'Single coupon', 'woocommerce-admin' ),
+		label: __( 'Single coupon', 'woocommerce' ),
 		value: 'select_coupon',
 		chartMode: 'item-comparison',
 		subFilters: [
@@ -84,27 +84,27 @@ const filterValues = [
 					labels: {
 						placeholder: __(
 							'Type to search for a coupon',
-							'woocommerce-admin'
+							'woocommerce'
 						),
-						button: __( 'Single Coupon', 'woocommerce-admin' ),
+						button: __( 'Single Coupon', 'woocommerce' ),
 					},
 				},
 			},
 		],
 	},
 	{
-		label: __( 'Comparison', 'woocommerce-admin' ),
+		label: __( 'Comparison', 'woocommerce' ),
 		value: 'compare-coupons',
 		settings: {
 			type: 'coupons',
 			param: 'coupons',
 			getLabels: getCouponLabels,
 			labels: {
-				title: __( 'Compare Coupon Codes', 'woocommerce-admin' ),
-				update: __( 'Compare', 'woocommerce-admin' ),
+				title: __( 'Compare Coupon Codes', 'woocommerce' ),
+				update: __( 'Compare', 'woocommerce' ),
 				helpText: __(
 					'Check at least two coupon codes below to compare',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 			},
 			onClick: addCesSurveyForAnalytics,
@@ -114,7 +114,7 @@ const filterValues = [
 
 if ( Object.keys( advancedFilters.filters ).length ) {
 	filterValues.push( {
-		label: __( 'Advanced filters', 'woocommerce-admin' ),
+		label: __( 'Advanced filters', 'woocommerce' ),
 		value: 'advanced',
 	} );
 }
@@ -131,7 +131,7 @@ if ( Object.keys( advancedFilters.filters ).length ) {
  */
 export const filters = applyFilters( COUPON_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,

--- a/plugins/woocommerce-admin/client/analytics/report/coupons/index.js
+++ b/plugins/woocommerce-admin/client/analytics/report/coupons/index.js
@@ -24,7 +24,7 @@ class CouponsReport extends Component {
 			query.coupons.split( ',' ).length > 1;
 
 		const mode = isCompareView ? 'item-comparison' : 'time-comparison';
-		const itemsLabel = __( '%d coupons', 'woocommerce-admin' );
+		const itemsLabel = __( '%d coupons', 'woocommerce' );
 
 		return {
 			itemsLabel,

--- a/plugins/woocommerce-admin/client/analytics/report/coupons/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/coupons/table.js
@@ -28,14 +28,14 @@ class CouponsReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Coupon code', 'woocommerce-admin' ),
+				label: __( 'Coupon code', 'woocommerce' ),
 				key: 'code',
 				required: true,
 				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				required: true,
 				defaultSort: true,
@@ -43,21 +43,21 @@ class CouponsReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Amount discounted', 'woocommerce-admin' ),
+				label: __( 'Amount discounted', 'woocommerce' ),
 				key: 'amount',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Created', 'woocommerce-admin' ),
+				label: __( 'Created', 'woocommerce' ),
 				key: 'created',
 			},
 			{
-				label: __( 'Expires', 'woocommerce-admin' ),
+				label: __( 'Expires', 'woocommerce' ),
 				key: 'expires',
 			},
 			{
-				label: __( 'Type', 'woocommerce-admin' ),
+				label: __( 'Type', 'woocommerce' ),
 				key: 'type',
 			},
 		];
@@ -147,7 +147,7 @@ class CouponsReportTable extends Component {
 							visibleFormat={ dateFormat }
 						/>
 					) : (
-						__( 'N/A', 'woocommerce-admin' )
+						__( 'N/A', 'woocommerce' )
 					),
 					value: dateCreated,
 				},
@@ -158,7 +158,7 @@ class CouponsReportTable extends Component {
 							visibleFormat={ dateFormat }
 						/>
 					) : (
-						__( 'N/A', 'woocommerce-admin' )
+						__( 'N/A', 'woocommerce' )
 					),
 					value: dateExpires,
 				},
@@ -180,25 +180,15 @@ class CouponsReportTable extends Component {
 		const currency = getCurrencyConfig();
 		return [
 			{
-				label: _n(
-					'Coupon',
-					'Coupons',
-					couponsCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'Coupon', 'Coupons', couponsCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', couponsCount ),
 			},
 			{
-				label: _n(
-					'Order',
-					'Orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'Order', 'Orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 			{
-				label: __( 'Amount discounted', 'woocommerce-admin' ),
+				label: __( 'Amount discounted', 'woocommerce' ),
 				value: formatAmount( amount ),
 			},
 		];
@@ -206,11 +196,11 @@ class CouponsReportTable extends Component {
 
 	getCouponType( discountType ) {
 		const couponTypes = {
-			percent: __( 'Percentage', 'woocommerce-admin' ),
-			fixed_cart: __( 'Fixed cart', 'woocommerce-admin' ),
-			fixed_product: __( 'Fixed product', 'woocommerce-admin' ),
+			percent: __( 'Percentage', 'woocommerce' ),
+			fixed_cart: __( 'Fixed cart', 'woocommerce' ),
+			fixed_product: __( 'Fixed product', 'woocommerce' ),
 		};
-		return couponTypes[ discountType ] || __( 'N/A', 'woocommerce-admin' );
+		return couponTypes[ discountType ] || __( 'N/A', 'woocommerce' );
 	}
 
 	render() {
@@ -233,7 +223,7 @@ class CouponsReportTable extends Component {
 					order: query.order || 'desc',
 					extended_info: true,
 				} }
-				title={ __( 'Coupons', 'woocommerce-admin' ) }
+				title={ __( 'Coupons', 'woocommerce' ) }
 				columnPrefsKey="coupons_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/customers/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/customers/config.js
@@ -32,14 +32,14 @@ const CUSTOMERS_REPORT_ADVANCED_FILTERS_FILTER =
  */
 export const filters = applyFilters( CUSTOMERS_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [
-			{ label: __( 'All Customers', 'woocommerce-admin' ), value: 'all' },
+			{ label: __( 'All Customers', 'woocommerce' ), value: 'all' },
 			{
-				label: __( 'Single Customer', 'woocommerce-admin' ),
+				label: __( 'Single Customer', 'woocommerce' ),
 				value: 'select_customer',
 				chartMode: 'item-comparison',
 				subFilters: [
@@ -55,19 +55,16 @@ export const filters = applyFilters( CUSTOMERS_REPORT_FILTERS_FILTER, [
 							labels: {
 								placeholder: __(
 									'Type to search for a customer',
-									'woocommerce-admin'
+									'woocommerce'
 								),
-								button: __(
-									'Single Customer',
-									'woocommerce-admin'
-								),
+								button: __( 'Single Customer', 'woocommerce' ),
 							},
 						},
 					},
 				],
 			},
 			{
-				label: __( 'Advanced filters', 'woocommerce-admin' ),
+				label: __( 'Advanced filters', 'woocommerce' ),
 				value: 'advanced',
 			},
 		],
@@ -89,27 +86,24 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Customers match {{select /}} filters',
 			'A sentence describing filters for Customers. See screen shot for context: https://cloudup.com/cCsm3GeXJbE',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		filters: {
 			name: {
 				labels: {
-					add: __( 'Name', 'woocommerce-admin' ),
-					placeholder: __( 'Search', 'woocommerce-admin' ),
-					remove: __(
-						'Remove customer name filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Name', 'woocommerce' ),
+					placeholder: __( 'Search', 'woocommerce' ),
+					remove: __( 'Remove customer name filter', 'woocommerce' ),
 					rule: __(
 						'Select a customer name filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 					title: __(
 						'{{title}}Name{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select customer name', 'woocommerce-admin' ),
+					filter: __( 'Select customer name', 'woocommerce' ),
 				},
 				rules: [
 					{
@@ -118,7 +112,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Includes',
 							'customer names',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -127,7 +121,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Excludes',
 							'customer names',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -145,44 +139,33 @@ export const advancedFilters = applyFilters(
 			},
 			country: {
 				labels: {
-					add: __( 'Country / Region', 'woocommerce-admin' ),
-					placeholder: __( 'Search', 'woocommerce-admin' ),
+					add: __( 'Country / Region', 'woocommerce' ),
+					placeholder: __( 'Search', 'woocommerce' ),
 					remove: __(
 						'Remove country / region filter',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					rule: __(
 						'Select a country / region filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 					title: __(
 						'{{title}}Country / Region{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __(
-						'Select country / region',
-						'woocommerce-admin'
-					),
+					filter: __( 'Select country / region', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to countries including a given country or countries. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x(
-							'Includes',
-							'countries',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'countries', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to countries excluding a given country or countries. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x(
-							'Excludes',
-							'countries',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'countries', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -207,28 +190,25 @@ export const advancedFilters = applyFilters(
 			},
 			username: {
 				labels: {
-					add: __( 'Username', 'woocommerce-admin' ),
+					add: __( 'Username', 'woocommerce' ),
 					placeholder: __(
 						'Search customer username',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					remove: __(
 						'Remove customer username filter',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					rule: __(
 						'Select a customer username filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 					title: __(
 						'{{title}}Username{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __(
-						'Select customer username',
-						'woocommerce-admin'
-					),
+					filter: __( 'Select customer username', 'woocommerce' ),
 				},
 				rules: [
 					{
@@ -237,7 +217,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Includes',
 							'customer usernames',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -246,7 +226,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Excludes',
 							'customer usernames',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -258,25 +238,19 @@ export const advancedFilters = applyFilters(
 			},
 			email: {
 				labels: {
-					add: __( 'Email', 'woocommerce-admin' ),
-					placeholder: __(
-						'Search customer email',
-						'woocommerce-admin'
-					),
-					remove: __(
-						'Remove customer email filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Email', 'woocommerce' ),
+					placeholder: __( 'Search customer email', 'woocommerce' ),
+					remove: __( 'Remove customer email filter', 'woocommerce' ),
 					rule: __(
 						'Select a customer email filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a customer email filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 					title: __(
 						'{{title}}Email{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select customer email', 'woocommerce-admin' ),
+					filter: __( 'Select customer email', 'woocommerce' ),
 				},
 				rules: [
 					{
@@ -285,7 +259,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Includes',
 							'customer emails',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -294,7 +268,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Excludes',
 							'customer emails',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -312,15 +286,15 @@ export const advancedFilters = applyFilters(
 			},
 			orders_count: {
 				labels: {
-					add: __( 'No. of Orders', 'woocommerce-admin' ),
-					remove: __( 'Remove order filter', 'woocommerce-admin' ),
+					add: __( 'No. of Orders', 'woocommerce' ),
+					remove: __( 'Remove order filter', 'woocommerce' ),
 					rule: __(
 						'Select an order count filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					title: __(
 						'{{title}}No. of Orders{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 				},
 				rules: [
@@ -330,7 +304,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Less Than',
 							'number of orders',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -339,7 +313,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'More Than',
 							'number of orders',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -348,7 +322,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Between',
 							'number of orders',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -358,18 +332,15 @@ export const advancedFilters = applyFilters(
 			},
 			total_spend: {
 				labels: {
-					add: __( 'Total Spend', 'woocommerce-admin' ),
-					remove: __(
-						'Remove total spend filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Total Spend', 'woocommerce' ),
+					remove: __( 'Remove total spend filter', 'woocommerce' ),
 					rule: __(
 						'Select a total spend filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					title: __(
 						'{{title}}Total Spend{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 				},
 				rules: [
@@ -379,7 +350,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Less Than',
 							'total spend by customer',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -388,7 +359,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'More Than',
 							'total spend by customer',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -397,7 +368,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Between',
 							'total spend by customer',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -407,18 +378,18 @@ export const advancedFilters = applyFilters(
 			},
 			avg_order_value: {
 				labels: {
-					add: __( 'AOV', 'woocommerce-admin' ),
+					add: __( 'AOV', 'woocommerce' ),
 					remove: __(
 						'Remove average order value filter',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					rule: __(
 						'Select an average order value filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					title: __(
 						'{{title}}AOV{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 				},
 				rules: [
@@ -428,7 +399,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Less Than',
 							'average order value of customer',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -438,7 +409,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'More Than',
 							'average order value of customer',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -447,7 +418,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Between',
 							'average order value of customer',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -457,37 +428,34 @@ export const advancedFilters = applyFilters(
 			},
 			registered: {
 				labels: {
-					add: __( 'Registered', 'woocommerce-admin' ),
-					remove: __(
-						'Remove registered filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Registered', 'woocommerce' ),
+					remove: __( 'Remove registered filter', 'woocommerce' ),
 					rule: __(
 						'Select a registered filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 					title: __(
 						'{{title}}Registered{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select registered date', 'woocommerce-admin' ),
+					filter: __( 'Select registered date', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'before',
 						/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x( 'Before', 'date', 'woocommerce-admin' ),
+						label: _x( 'Before', 'date', 'woocommerce' ),
 					},
 					{
 						value: 'after',
 						/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x( 'After', 'date', 'woocommerce-admin' ),
+						label: _x( 'After', 'date', 'woocommerce' ),
 					},
 					{
 						value: 'between',
 						/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x( 'Between', 'date', 'woocommerce-admin' ),
+						label: _x( 'Between', 'date', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -496,37 +464,34 @@ export const advancedFilters = applyFilters(
 			},
 			last_active: {
 				labels: {
-					add: __( 'Last active', 'woocommerce-admin' ),
-					remove: __(
-						'Remove last active filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Last active', 'woocommerce' ),
+					remove: __( 'Remove last active filter', 'woocommerce' ),
 					rule: __(
 						'Select a last active filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 					title: __(
 						'{{title}}Last active{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select registered date', 'woocommerce-admin' ),
+					filter: __( 'Select registered date', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'before',
 						/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x( 'Before', 'date', 'woocommerce-admin' ),
+						label: _x( 'Before', 'date', 'woocommerce' ),
 					},
 					{
 						value: 'after',
 						/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x( 'After', 'date', 'woocommerce-admin' ),
+						label: _x( 'After', 'date', 'woocommerce' ),
 					},
 					{
 						value: 'between',
 						/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-						label: _x( 'Between', 'date', 'woocommerce-admin' ),
+						label: _x( 'Between', 'date', 'woocommerce' ),
 					},
 				],
 				input: {

--- a/plugins/woocommerce-admin/client/analytics/report/customers/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/customers/table.js
@@ -38,72 +38,69 @@ function CustomersReportTable( {
 	const getHeadersContent = () => {
 		return [
 			{
-				label: __( 'Name', 'woocommerce-admin' ),
+				label: __( 'Name', 'woocommerce' ),
 				key: 'name',
 				required: true,
 				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Username', 'woocommerce-admin' ),
+				label: __( 'Username', 'woocommerce' ),
 				key: 'username',
 				hiddenByDefault: true,
 			},
 			{
-				label: __( 'Last active', 'woocommerce-admin' ),
+				label: __( 'Last active', 'woocommerce' ),
 				key: 'date_last_active',
 				defaultSort: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Date registered', 'woocommerce-admin' ),
+				label: __( 'Date registered', 'woocommerce' ),
 				key: 'date_registered',
 				isSortable: true,
 			},
 			{
-				label: __( 'Email', 'woocommerce-admin' ),
+				label: __( 'Email', 'woocommerce' ),
 				key: 'email',
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Total spend', 'woocommerce-admin' ),
+				label: __( 'Total spend', 'woocommerce' ),
 				key: 'total_spend',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'AOV', 'woocommerce-admin' ),
-				screenReaderLabel: __(
-					'Average order value',
-					'woocommerce-admin'
-				),
+				label: __( 'AOV', 'woocommerce' ),
+				screenReaderLabel: __( 'Average order value', 'woocommerce' ),
 				key: 'avg_order_value',
 				isNumeric: true,
 			},
 			{
-				label: __( 'Country / Region', 'woocommerce-admin' ),
+				label: __( 'Country / Region', 'woocommerce' ),
 				key: 'country',
 				isSortable: true,
 			},
 			{
-				label: __( 'City', 'woocommerce-admin' ),
+				label: __( 'City', 'woocommerce' ),
 				key: 'city',
 				hiddenByDefault: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Region', 'woocommerce-admin' ),
+				label: __( 'Region', 'woocommerce' ),
 				key: 'state',
 				hiddenByDefault: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Postal code', 'woocommerce-admin' ),
+				label: __( 'Postal code', 'woocommerce' ),
 				key: 'postcode',
 				hiddenByDefault: true,
 				isSortable: true,
@@ -250,7 +247,7 @@ function CustomersReportTable( {
 					'customer',
 					'customers',
 					customersCount,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', customersCount ),
 			},
@@ -259,16 +256,16 @@ function CustomersReportTable( {
 					'Average order',
 					'Average orders',
 					avgOrdersCount,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', avgOrdersCount ),
 			},
 			{
-				label: __( 'Average lifetime spend', 'woocommerce-admin' ),
+				label: __( 'Average lifetime spend', 'woocommerce' ),
 				value: formatAmount( avgTotalSpend ),
 			},
 			{
-				label: __( 'Average order value', 'woocommerce-admin' ),
+				label: __( 'Average order value', 'woocommerce' ),
 				value: formatAmount( avgAvgOrderValue ),
 			},
 		];
@@ -290,13 +287,10 @@ function CustomersReportTable( {
 			itemIdField="id"
 			query={ query }
 			labels={ {
-				placeholder: __(
-					'Search by customer name',
-					'woocommerce-admin'
-				),
+				placeholder: __( 'Search by customer name', 'woocommerce' ),
 			} }
 			searchBy="customers"
-			title={ __( 'Customers', 'woocommerce-admin' ) }
+			title={ __( 'Customers', 'woocommerce' ) }
 			columnPrefsKey="customers_report_columns"
 			filters={ filters }
 			advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/downloads/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/downloads/config.js
@@ -32,7 +32,7 @@ const DOWLOADS_REPORT_ADVANCED_FILTERS_FILTER =
 export const charts = applyFilters( DOWLOADS_REPORT_CHARTS_FILTER, [
 	{
 		key: 'download_count',
-		label: __( 'Downloads', 'woocommerce-admin' ),
+		label: __( 'Downloads', 'woocommerce' ),
 		type: 'number',
 	},
 ] );
@@ -49,14 +49,14 @@ export const charts = applyFilters( DOWLOADS_REPORT_CHARTS_FILTER, [
  */
 export const filters = applyFilters( DOWLOADS_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [
-			{ label: __( 'All downloads', 'woocommerce-admin' ), value: 'all' },
+			{ label: __( 'All downloads', 'woocommerce' ), value: 'all' },
 			{
-				label: __( 'Advanced filters', 'woocommerce-admin' ),
+				label: __( 'Advanced filters', 'woocommerce' ),
 				value: 'advanced',
 			},
 		],
@@ -79,43 +79,32 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Downloads match {{select /}} filters',
 			'A sentence describing filters for Downloads. See screen shot for context: https://cloudup.com/ccxhyH2mEDg',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		filters: {
 			product: {
 				labels: {
-					add: __( 'Product', 'woocommerce-admin' ),
-					placeholder: __( 'Search', 'woocommerce-admin' ),
-					remove: __( 'Remove product filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a product filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Product', 'woocommerce' ),
+					placeholder: __( 'Search', 'woocommerce' ),
+					remove: __( 'Remove product filter', 'woocommerce' ),
+					rule: __( 'Select a product filter match', 'woocommerce' ),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
 						'{{title}}Product{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select product', 'woocommerce-admin' ),
+					filter: __( 'Select product', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to products including a given product(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
-						label: _x(
-							'Includes',
-							'products',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'products', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to products excluding a products(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
-						label: _x(
-							'Excludes',
-							'products',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'products', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -126,28 +115,25 @@ export const advancedFilters = applyFilters(
 			},
 			customer: {
 				labels: {
-					add: __( 'Username', 'woocommerce-admin' ),
+					add: __( 'Username', 'woocommerce' ),
 					placeholder: __(
 						'Search customer username',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					remove: __(
 						'Remove customer username filter',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					rule: __(
 						'Select a customer username filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
 						'{{title}}Username{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __(
-						'Select customer username',
-						'woocommerce-admin'
-					),
+					filter: __( 'Select customer username', 'woocommerce' ),
 				},
 				rules: [
 					{
@@ -156,7 +142,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Includes',
 							'customer usernames',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 					{
@@ -165,7 +151,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Excludes',
 							'customer usernames',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -177,44 +163,30 @@ export const advancedFilters = applyFilters(
 			},
 			order: {
 				labels: {
-					add: __( 'Order #', 'woocommerce-admin' ),
-					placeholder: __(
-						'Search order number',
-						'woocommerce-admin'
-					),
-					remove: __(
-						'Remove order number filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Order #', 'woocommerce' ),
+					placeholder: __( 'Search order number', 'woocommerce' ),
+					remove: __( 'Remove order number filter', 'woocommerce' ),
 					rule: __(
 						'Select a order number filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
 						'{{title}}Order #{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select order number', 'woocommerce-admin' ),
+					filter: __( 'Select order number', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to order numbers including a given order(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
-						label: _x(
-							'Includes',
-							'order numbers',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'order numbers', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to order numbers excluding a given order(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
-						label: _x(
-							'Excludes',
-							'order numbers',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'order numbers', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -231,41 +203,30 @@ export const advancedFilters = applyFilters(
 			},
 			ip_address: {
 				labels: {
-					add: __( 'IP Address', 'woocommerce-admin' ),
-					placeholder: __( 'Search IP address', 'woocommerce-admin' ),
-					remove: __(
-						'Remove IP address filter',
-						'woocommerce-admin'
-					),
+					add: __( 'IP Address', 'woocommerce' ),
+					placeholder: __( 'Search IP address', 'woocommerce' ),
+					remove: __( 'Remove IP address filter', 'woocommerce' ),
 					rule: __(
 						'Select an IP address filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
 						'{{title}}IP Address{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select IP address', 'woocommerce-admin' ),
+					filter: __( 'Select IP address', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to IP addresses including a given address(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
-						label: _x(
-							'Includes',
-							'IP addresses',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'IP addresses', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to IP addresses excluding a given address(s). Screenshot for context: https://cloudup.com/ccxhyH2mEDg */
-						label: _x(
-							'Excludes',
-							'IP addresses',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'IP addresses', 'woocommerce' ),
 					},
 				],
 				input: {

--- a/plugins/woocommerce-admin/client/analytics/report/downloads/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/downloads/table.js
@@ -32,7 +32,7 @@ class DownloadsReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Date', 'woocommerce-admin' ),
+				label: __( 'Date', 'woocommerce' ),
 				key: 'date',
 				defaultSort: true,
 				required: true,
@@ -40,26 +40,26 @@ class DownloadsReportTable extends Component {
 				isSortable: true,
 			},
 			{
-				label: __( 'Product title', 'woocommerce-admin' ),
+				label: __( 'Product title', 'woocommerce' ),
 				key: 'product',
 				isSortable: true,
 				required: true,
 			},
 			{
-				label: __( 'File name', 'woocommerce-admin' ),
+				label: __( 'File name', 'woocommerce' ),
 				key: 'file_name',
 			},
 			{
-				label: __( 'Order #', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Order Number', 'woocommerce-admin' ),
+				label: __( 'Order #', 'woocommerce' ),
+				screenReaderLabel: __( 'Order Number', 'woocommerce' ),
 				key: 'order_number',
 			},
 			{
-				label: __( 'Username', 'woocommerce-admin' ),
+				label: __( 'Username', 'woocommerce' ),
 				key: 'user_id',
 			},
 			{
-				label: __( 'IP', 'woocommerce-admin' ),
+				label: __( 'IP', 'woocommerce' ),
 				key: 'ip_address',
 			},
 		];
@@ -94,8 +94,8 @@ class DownloadsReportTable extends Component {
 
 			// Handle deleted products.
 			if ( errorCode === 'woocommerce_rest_product_invalid_id' ) {
-				productDisplay = __( '(Deleted)', 'woocommerce-admin' );
-				productValue = __( '(Deleted)', 'woocommerce-admin' );
+				productDisplay = __( '(Deleted)', 'woocommerce' );
+				productValue = __( '(Deleted)', 'woocommerce' );
 			} else {
 				const productURL = getNewPath(
 					persistedQuery,
@@ -169,7 +169,7 @@ class DownloadsReportTable extends Component {
 
 		return [
 			{
-				label: _n( 'day', 'days', days, 'woocommerce-admin' ),
+				label: _n( 'day', 'days', days, 'woocommerce' ),
 				value: formatValue( currency, 'number', days ),
 			},
 			{
@@ -177,7 +177,7 @@ class DownloadsReportTable extends Component {
 					'Download',
 					'Downloads',
 					downloadCount,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', downloadCount ),
 			},
@@ -198,7 +198,7 @@ class DownloadsReportTable extends Component {
 				tableQuery={ {
 					_embed: true,
 				} }
-				title={ __( 'Downloads', 'woocommerce-admin' ) }
+				title={ __( 'Downloads', 'woocommerce' ) }
 				columnPrefsKey="downloads_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/get-reports.js
+++ b/plugins/woocommerce-admin/client/analytics/report/get-reports.js
@@ -51,7 +51,7 @@ export default () => {
 	const reports = [
 		{
 			report: 'revenue',
-			title: __( 'Revenue', 'woocommerce-admin' ),
+			title: __( 'Revenue', 'woocommerce' ),
 			component: RevenueReport,
 			navArgs: {
 				id: 'woocommerce-analytics-revenue',
@@ -59,7 +59,7 @@ export default () => {
 		},
 		{
 			report: 'products',
-			title: __( 'Products', 'woocommerce-admin' ),
+			title: __( 'Products', 'woocommerce' ),
 			component: ProductsReport,
 			navArgs: {
 				id: 'woocommerce-analytics-products',
@@ -67,7 +67,7 @@ export default () => {
 		},
 		{
 			report: 'variations',
-			title: __( 'Variations', 'woocommerce-admin' ),
+			title: __( 'Variations', 'woocommerce' ),
 			component: VariationsReport,
 			navArgs: {
 				id: 'woocommerce-analytics-variations',
@@ -75,7 +75,7 @@ export default () => {
 		},
 		{
 			report: 'orders',
-			title: __( 'Orders', 'woocommerce-admin' ),
+			title: __( 'Orders', 'woocommerce' ),
 			component: OrdersReport,
 			navArgs: {
 				id: 'woocommerce-analytics-orders',
@@ -83,7 +83,7 @@ export default () => {
 		},
 		{
 			report: 'categories',
-			title: __( 'Categories', 'woocommerce-admin' ),
+			title: __( 'Categories', 'woocommerce' ),
 			component: CategoriesReport,
 			navArgs: {
 				id: 'woocommerce-analytics-categories',
@@ -91,7 +91,7 @@ export default () => {
 		},
 		{
 			report: 'coupons',
-			title: __( 'Coupons', 'woocommerce-admin' ),
+			title: __( 'Coupons', 'woocommerce' ),
 			component: CouponsReport,
 			navArgs: {
 				id: 'woocommerce-analytics-coupons',
@@ -99,7 +99,7 @@ export default () => {
 		},
 		{
 			report: 'taxes',
-			title: __( 'Taxes', 'woocommerce-admin' ),
+			title: __( 'Taxes', 'woocommerce' ),
 			component: TaxesReport,
 			navArgs: {
 				id: 'woocommerce-analytics-taxes',
@@ -108,7 +108,7 @@ export default () => {
 		manageStock === 'yes'
 			? {
 					report: 'stock',
-					title: __( 'Stock', 'woocommerce-admin' ),
+					title: __( 'Stock', 'woocommerce' ),
 					component: StockReport,
 					navArgs: {
 						id: 'woocommerce-analytics-stock',
@@ -117,12 +117,12 @@ export default () => {
 			: null,
 		{
 			report: 'customers',
-			title: __( 'Customers', 'woocommerce-admin' ),
+			title: __( 'Customers', 'woocommerce' ),
 			component: CustomersReport,
 		},
 		{
 			report: 'downloads',
-			title: __( 'Downloads', 'woocommerce-admin' ),
+			title: __( 'Downloads', 'woocommerce' ),
 			component: DownloadsReport,
 			navArgs: {
 				id: 'woocommerce-analytics-downloads',

--- a/plugins/woocommerce-admin/client/analytics/report/orders/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/orders/config.js
@@ -33,24 +33,24 @@ const ORDERS_REPORT_ADVANCED_FILTERS_FILTER =
 export const charts = applyFilters( ORDERS_REPORT_CHARTS_FILTER, [
 	{
 		key: 'orders_count',
-		label: __( 'Orders', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce' ),
 		type: 'number',
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net sales', 'woocommerce-admin' ),
+		label: __( 'Net sales', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'net_total',
 		type: 'currency',
 	},
 	{
 		key: 'avg_order_value',
-		label: __( 'Average order value', 'woocommerce-admin' ),
+		label: __( 'Average order value', 'woocommerce' ),
 		type: 'currency',
 	},
 	{
 		key: 'avg_items_per_order',
-		label: __( 'Average items per order', 'woocommerce-admin' ),
+		label: __( 'Average items per order', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'num_items_sold',
 		type: 'average',
@@ -69,14 +69,14 @@ export const charts = applyFilters( ORDERS_REPORT_CHARTS_FILTER, [
  */
 export const filters = applyFilters( ORDERS_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,
 		filters: [
-			{ label: __( 'All orders', 'woocommerce-admin' ), value: 'all' },
+			{ label: __( 'All orders', 'woocommerce' ), value: 'all' },
 			{
-				label: __( 'Advanced filters', 'woocommerce-admin' ),
+				label: __( 'Advanced filters', 'woocommerce' ),
 				value: 'advanced',
 			},
 		],
@@ -99,41 +99,34 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Orders match {{select /}} filters',
 			'A sentence describing filters for Orders. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		filters: {
 			status: {
 				labels: {
-					add: __( 'Order Status', 'woocommerce-admin' ),
-					remove: __(
-						'Remove order status filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Order Status', 'woocommerce' ),
+					remove: __( 'Remove order status filter', 'woocommerce' ),
 					rule: __(
 						'Select an order status filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing an Order Status filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Order Status{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select an order status', 'woocommerce-admin' ),
+					filter: __( 'Select an order status', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'is',
 						/* translators: Sentence fragment, logical, "Is" refers to searching for orders matching a chosen order status. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x( 'Is', 'order status', 'woocommerce-admin' ),
+						label: _x( 'Is', 'order status', 'woocommerce' ),
 					},
 					{
 						value: 'is_not',
 						/* translators: Sentence fragment, logical, "Is Not" refers to searching for orders that don\'t match a chosen order status. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Is Not',
-							'order status',
-							'woocommerce-admin'
-						),
+						label: _x( 'Is Not', 'order status', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -146,38 +139,27 @@ export const advancedFilters = applyFilters(
 			},
 			product: {
 				labels: {
-					add: __( 'Products', 'woocommerce-admin' ),
-					placeholder: __( 'Search products', 'woocommerce-admin' ),
-					remove: __( 'Remove products filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a product filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Products', 'woocommerce' ),
+					placeholder: __( 'Search products', 'woocommerce' ),
+					remove: __( 'Remove products filter', 'woocommerce' ),
+					rule: __( 'Select a product filter match', 'woocommerce' ),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Product{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select products', 'woocommerce-admin' ),
+					filter: __( 'Select products', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Includes',
-							'products',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'products', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Excludes',
-							'products',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'products', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -188,41 +170,30 @@ export const advancedFilters = applyFilters(
 			},
 			variation: {
 				labels: {
-					add: __( 'Variations', 'woocommerce-admin' ),
-					placeholder: __( 'Search variations', 'woocommerce-admin' ),
-					remove: __(
-						'Remove variations filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Variations', 'woocommerce' ),
+					placeholder: __( 'Search variations', 'woocommerce' ),
+					remove: __( 'Remove variations filter', 'woocommerce' ),
 					rule: __(
 						'Select a variation filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Variation filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Variation{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select variation', 'woocommerce-admin' ),
+					filter: __( 'Select variation', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given variation(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Includes',
-							'variations',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'variations', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given variation(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Excludes',
-							'variations',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'variations', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -233,38 +204,27 @@ export const advancedFilters = applyFilters(
 			},
 			coupon: {
 				labels: {
-					add: __( 'Coupon Codes', 'woocommerce-admin' ),
-					placeholder: __( 'Search coupons', 'woocommerce-admin' ),
-					remove: __( 'Remove coupon filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a coupon filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Coupon Codes', 'woocommerce' ),
+					placeholder: __( 'Search coupons', 'woocommerce' ),
+					remove: __( 'Remove coupon filter', 'woocommerce' ),
+					rule: __( 'Select a coupon filter match', 'woocommerce' ),
 					/* translators: A sentence describing a Coupon filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Coupon code{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select coupon codes', 'woocommerce-admin' ),
+					filter: __( 'Select coupon codes', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given coupon code(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Includes',
-							'coupon code',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'coupon code', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given coupon code(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Excludes',
-							'coupon code',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'coupon code', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -275,29 +235,26 @@ export const advancedFilters = applyFilters(
 			},
 			customer_type: {
 				labels: {
-					add: __( 'Customer type', 'woocommerce-admin' ),
-					remove: __( 'Remove customer filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a customer filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Customer type', 'woocommerce' ),
+					remove: __( 'Remove customer filter', 'woocommerce' ),
+					rule: __( 'Select a customer filter match', 'woocommerce' ),
 					/* translators: A sentence describing a Customer filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Customer is{{/title}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select a customer type', 'woocommerce-admin' ),
+					filter: __( 'Select a customer type', 'woocommerce' ),
 				},
 				input: {
 					component: 'SelectControl',
 					options: [
 						{
 							value: 'new',
-							label: __( 'New', 'woocommerce-admin' ),
+							label: __( 'New', 'woocommerce' ),
 						},
 						{
 							value: 'returning',
-							label: __( 'Returning', 'woocommerce-admin' ),
+							label: __( 'Returning', 'woocommerce' ),
 						},
 					],
 					defaultOption: 'new',
@@ -305,39 +262,33 @@ export const advancedFilters = applyFilters(
 			},
 			refunds: {
 				labels: {
-					add: __( 'Refunds', 'woocommerce-admin' ),
-					remove: __( 'Remove refunds filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a refund filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Refunds', 'woocommerce' ),
+					remove: __( 'Remove refunds filter', 'woocommerce' ),
+					rule: __( 'Select a refund filter match', 'woocommerce' ),
 					title: __(
 						'{{title}}Refunds{{/title}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select a refund type', 'woocommerce-admin' ),
+					filter: __( 'Select a refund type', 'woocommerce' ),
 				},
 				input: {
 					component: 'SelectControl',
 					options: [
 						{
 							value: 'all',
-							label: __( 'All', 'woocommerce-admin' ),
+							label: __( 'All', 'woocommerce' ),
 						},
 						{
 							value: 'partial',
-							label: __(
-								'Partially refunded',
-								'woocommerce-admin'
-							),
+							label: __( 'Partially refunded', 'woocommerce' ),
 						},
 						{
 							value: 'full',
-							label: __( 'Fully refunded', 'woocommerce-admin' ),
+							label: __( 'Fully refunded', 'woocommerce' ),
 						},
 						{
 							value: 'none',
-							label: __( 'None', 'woocommerce-admin' ),
+							label: __( 'None', 'woocommerce' ),
 						},
 					],
 					defaultOption: 'all',
@@ -345,38 +296,27 @@ export const advancedFilters = applyFilters(
 			},
 			tax_rate: {
 				labels: {
-					add: __( 'Tax Rates', 'woocommerce-admin' ),
-					placeholder: __( 'Search tax rates', 'woocommerce-admin' ),
-					remove: __( 'Remove tax rate filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a tax rate filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Tax Rates', 'woocommerce' ),
+					placeholder: __( 'Search tax rates', 'woocommerce' ),
+					remove: __( 'Remove tax rate filter', 'woocommerce' ),
+					rule: __( 'Select a tax rate filter match', 'woocommerce' ),
 					/* translators: A sentence describing a tax rate filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Tax Rate{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select tax rates', 'woocommerce-admin' ),
+					filter: __( 'Select tax rates', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Includes',
-							'tax rate',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'tax rate', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Excludes',
-							'tax rate',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'tax rate', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -388,32 +328,25 @@ export const advancedFilters = applyFilters(
 			attribute: {
 				allowMultiple: true,
 				labels: {
-					add: __( 'Attribute', 'woocommerce-admin' ),
-					placeholder: __( 'Search attributes', 'woocommerce-admin' ),
-					remove: __(
-						'Remove attribute filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Attribute', 'woocommerce' ),
+					placeholder: __( 'Search attributes', 'woocommerce' ),
+					remove: __( 'Remove attribute filter', 'woocommerce' ),
 					rule: __(
 						'Select a product attribute filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Attribute{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select attributes', 'woocommerce-admin' ),
+					filter: __( 'Select attributes', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'is',
 						/* translators: Sentence fragment, logical, "Is" refers to searching for products matching a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Is',
-							'product attribute',
-							'woocommerce-admin'
-						),
+						label: _x( 'Is', 'product attribute', 'woocommerce' ),
 					},
 					{
 						value: 'is_not',
@@ -421,7 +354,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Is Not',
 							'product attribute',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],

--- a/plugins/woocommerce-admin/client/analytics/report/orders/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/orders/table.js
@@ -31,7 +31,7 @@ class OrdersReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Date', 'woocommerce-admin' ),
+				label: __( 'Date', 'woocommerce' ),
 				key: 'date',
 				required: true,
 				defaultSort: true,
@@ -39,53 +39,53 @@ class OrdersReportTable extends Component {
 				isSortable: true,
 			},
 			{
-				label: __( 'Order #', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Order Number', 'woocommerce-admin' ),
+				label: __( 'Order #', 'woocommerce' ),
+				screenReaderLabel: __( 'Order Number', 'woocommerce' ),
 				key: 'order_number',
 				required: true,
 			},
 			{
-				label: __( 'Status', 'woocommerce-admin' ),
+				label: __( 'Status', 'woocommerce' ),
 				key: 'status',
 				required: false,
 				isSortable: false,
 			},
 			{
-				label: __( 'Customer', 'woocommerce-admin' ),
+				label: __( 'Customer', 'woocommerce' ),
 				key: 'customer_id',
 				required: false,
 				isSortable: false,
 			},
 			{
-				label: __( 'Customer type', 'woocommerce-admin' ),
+				label: __( 'Customer type', 'woocommerce' ),
 				key: 'customer_type',
 				required: false,
 				isSortable: false,
 			},
 			{
-				label: __( 'Product(s)', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Products', 'woocommerce-admin' ),
+				label: __( 'Product(s)', 'woocommerce' ),
+				screenReaderLabel: __( 'Products', 'woocommerce' ),
 				key: 'products',
 				required: false,
 				isSortable: false,
 			},
 			{
-				label: __( 'Items sold', 'woocommerce-admin' ),
+				label: __( 'Items sold', 'woocommerce' ),
 				key: 'num_items_sold',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Coupon(s)', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Coupons', 'woocommerce-admin' ),
+				label: __( 'Coupon(s)', 'woocommerce' ),
+				screenReaderLabel: __( 'Coupons', 'woocommerce' ),
 				key: 'coupons',
 				required: false,
 				isSortable: false,
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
+				screenReaderLabel: __( 'Net sales', 'woocommerce' ),
 				key: 'net_total',
 				required: true,
 				isSortable: true,
@@ -202,7 +202,7 @@ class OrdersReportTable extends Component {
 							: [],
 						formattedProducts.map( ( product ) => ( {
 							label: sprintf(
-								__( '%s× %s', 'woocommerce-admin' ),
+								__( '%s× %s', 'woocommerce' ),
 								product.quantity,
 								product.label
 							),
@@ -212,7 +212,7 @@ class OrdersReportTable extends Component {
 					value: formattedProducts
 						.map( ( { quantity, label } ) =>
 							sprintf(
-								__( '%s× %s', 'woocommerce-admin' ),
+								__( '%s× %s', 'woocommerce' ),
 								quantity,
 								label
 							)
@@ -259,12 +259,7 @@ class OrdersReportTable extends Component {
 		const currency = getCurrencyConfig();
 		return [
 			{
-				label: _n(
-					'Order',
-					'Orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'Order', 'Orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 			{
@@ -272,17 +267,12 @@ class OrdersReportTable extends Component {
 					' Customer',
 					' Customers',
 					totalCustomers,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', totalCustomers ),
 			},
 			{
-				label: _n(
-					'Product',
-					'Products',
-					products,
-					'woocommerce-admin'
-				),
+				label: _n( 'Product', 'Products', products, 'woocommerce' ),
 				value: formatValue( currency, 'number', products ),
 			},
 			{
@@ -290,21 +280,16 @@ class OrdersReportTable extends Component {
 					'Item sold',
 					'Items sold',
 					numItemsSold,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', numItemsSold ),
 			},
 			{
-				label: _n(
-					'Coupon',
-					'Coupons',
-					couponsCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'Coupon', 'Coupons', couponsCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', couponsCount ),
 			},
 			{
-				label: __( 'net sales', 'woocommerce-admin' ),
+				label: __( 'net sales', 'woocommerce' ),
 				value: formatAmount( netRevenue ),
 			},
 		];
@@ -350,7 +335,7 @@ class OrdersReportTable extends Component {
 				tableQuery={ {
 					extended_info: true,
 				} }
-				title={ __( 'Orders', 'woocommerce-admin' ) }
+				title={ __( 'Orders', 'woocommerce' ) }
 				columnPrefsKey="orders_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/products/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/products/config.js
@@ -36,21 +36,21 @@ const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 	{
 		key: 'items_sold',
-		label: __( 'Items sold', 'woocommerce-admin' ),
+		label: __( 'Items sold', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'items_sold',
 		type: 'number',
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net sales', 'woocommerce-admin' ),
+		label: __( 'Net sales', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',
@@ -58,14 +58,14 @@ export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 ] );
 
 const filterConfig = {
-	label: __( 'Show', 'woocommerce-admin' ),
+	label: __( 'Show', 'woocommerce' ),
 	staticParams: [ 'chartType', 'paged', 'per_page' ],
 	param: 'filter',
 	showFilters: () => true,
 	filters: [
-		{ label: __( 'All products', 'woocommerce-admin' ), value: 'all' },
+		{ label: __( 'All products', 'woocommerce' ), value: 'all' },
 		{
-			label: __( 'Single product', 'woocommerce-admin' ),
+			label: __( 'Single product', 'woocommerce' ),
 			value: 'select_product',
 			chartMode: 'item-comparison',
 			subFilters: [
@@ -81,16 +81,16 @@ const filterConfig = {
 						labels: {
 							placeholder: __(
 								'Type to search for a product',
-								'woocommerce-admin'
+								'woocommerce'
 							),
-							button: __( 'Single product', 'woocommerce-admin' ),
+							button: __( 'Single product', 'woocommerce' ),
 						},
 					},
 				},
 			],
 		},
 		{
-			label: __( 'Comparison', 'woocommerce-admin' ),
+			label: __( 'Comparison', 'woocommerce' ),
 			value: 'compare-products',
 			chartMode: 'item-comparison',
 			settings: {
@@ -100,14 +100,14 @@ const filterConfig = {
 				labels: {
 					helpText: __(
 						'Check at least two products below to compare',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					placeholder: __(
 						'Search for products to compare',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					title: __( 'Compare Products', 'woocommerce-admin' ),
-					update: __( 'Compare', 'woocommerce-admin' ),
+					title: __( 'Compare Products', 'woocommerce' ),
+					update: __( 'Compare', 'woocommerce' ),
 				},
 				onClick: addCesSurveyForAnalytics,
 			},
@@ -124,12 +124,12 @@ const variationsConfig = {
 	param: 'filter-variations',
 	filters: [
 		{
-			label: __( 'All variations', 'woocommerce-admin' ),
+			label: __( 'All variations', 'woocommerce' ),
 			chartMode: 'item-comparison',
 			value: 'all',
 		},
 		{
-			label: __( 'Single variation', 'woocommerce-admin' ),
+			label: __( 'Single variation', 'woocommerce' ),
 			value: 'select_variation',
 			subFilters: [
 				{
@@ -143,19 +143,16 @@ const variationsConfig = {
 						labels: {
 							placeholder: __(
 								'Type to search for a variation',
-								'woocommerce-admin'
+								'woocommerce'
 							),
-							button: __(
-								'Single variation',
-								'woocommerce-admin'
-							),
+							button: __( 'Single variation', 'woocommerce' ),
 						},
 					},
 				},
 			],
 		},
 		{
-			label: __( 'Comparison', 'woocommerce-admin' ),
+			label: __( 'Comparison', 'woocommerce' ),
 			chartMode: 'item-comparison',
 			value: 'compare-variations',
 			settings: {
@@ -165,14 +162,14 @@ const variationsConfig = {
 				labels: {
 					helpText: __(
 						'Check at least two variations below to compare',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					placeholder: __(
 						'Search for variations to compare',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					title: __( 'Compare Variations', 'woocommerce-admin' ),
-					update: __( 'Compare', 'woocommerce-admin' ),
+					title: __( 'Compare Variations', 'woocommerce' ),
+					update: __( 'Compare', 'woocommerce' ),
 				},
 			},
 		},
@@ -194,18 +191,18 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Products Match {{select /}} Filters',
 			'A sentence describing filters for Products. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	}
 );
 
 if ( Object.keys( advancedFilters.filters ).length ) {
 	filterConfig.filters.push( {
-		label: __( 'Advanced Filters', 'woocommerce-admin' ),
+		label: __( 'Advanced Filters', 'woocommerce' ),
 		value: 'advanced',
 	} );
 	variationsConfig.filters.push( {
-		label: __( 'Advanced Filters', 'woocommerce-admin' ),
+		label: __( 'Advanced Filters', 'woocommerce' ),
 		value: 'advanced',
 	} );
 }

--- a/plugins/woocommerce-admin/client/analytics/report/products/index.js
+++ b/plugins/woocommerce-admin/client/analytics/report/products/index.js
@@ -42,8 +42,8 @@ class ProductsReport extends Component {
 				: 'products';
 		const label =
 			isSingleProductView && isSingleProductVariable
-				? __( '%d variations', 'woocommerce-admin' )
-				: __( '%d products', 'woocommerce-admin' );
+				? __( '%d variations', 'woocommerce' )
+				: __( '%d products', 'woocommerce' );
 
 		return {
 			compareObject,

--- a/plugins/woocommerce-admin/client/analytics/report/products/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/products/table.js
@@ -39,20 +39,20 @@ class ProductsReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Product title', 'woocommerce-admin' ),
+				label: __( 'Product title', 'woocommerce' ),
 				key: 'product_name',
 				required: true,
 				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'SKU', 'woocommerce-admin' ),
+				label: __( 'SKU', 'woocommerce' ),
 				key: 'sku',
 				hiddenByDefault: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Items sold', 'woocommerce-admin' ),
+				label: __( 'Items sold', 'woocommerce' ),
 				key: 'items_sold',
 				required: true,
 				defaultSort: true,
@@ -60,37 +60,37 @@ class ProductsReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
+				screenReaderLabel: __( 'Net sales', 'woocommerce' ),
 				key: 'net_revenue',
 				required: true,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Category', 'woocommerce-admin' ),
+				label: __( 'Category', 'woocommerce' ),
 				key: 'product_cat',
 			},
 			{
-				label: __( 'Variations', 'woocommerce-admin' ),
+				label: __( 'Variations', 'woocommerce' ),
 				key: 'variations',
 				isSortable: true,
 			},
 			manageStock === 'yes'
 				? {
-						label: __( 'Status', 'woocommerce-admin' ),
+						label: __( 'Status', 'woocommerce' ),
 						key: 'stock_status',
 				  }
 				: null,
 			manageStock === 'yes'
 				? {
-						label: __( 'Stock', 'woocommerce-admin' ),
+						label: __( 'Stock', 'woocommerce' ),
 						key: 'stock',
 						isNumeric: true,
 				  }
@@ -167,7 +167,7 @@ class ProductsReportTable extends Component {
 					{ _x(
 						'Low',
 						'Indication of a low quantity',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</Link>
 			) : (
@@ -218,7 +218,7 @@ class ProductsReportTable extends Component {
 										_x(
 											'+%d more',
 											'categories',
-											'woocommerce-admin'
+											'woocommerce'
 										),
 										productCategories.length - 1
 									) }
@@ -252,7 +252,7 @@ class ProductsReportTable extends Component {
 					? {
 							display: extendedInfoManageStock
 								? stockStatus
-								: __( 'N/A', 'woocommerce-admin' ),
+								: __( 'N/A', 'woocommerce' ),
 							value: extendedInfoManageStock
 								? stockStatuses[ extendedInfoStockStatus ]
 								: null,
@@ -266,7 +266,7 @@ class ProductsReportTable extends Component {
 										'number',
 										stockQuantity
 								  )
-								: __( 'N/A', 'woocommerce-admin' ),
+								: __( 'N/A', 'woocommerce' ),
 							value: stockQuantity,
 					  }
 					: null,
@@ -289,7 +289,7 @@ class ProductsReportTable extends Component {
 					'Product',
 					'Products',
 					productsCount,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', productsCount ),
 			},
@@ -298,21 +298,16 @@ class ProductsReportTable extends Component {
 					'Item sold',
 					'Items sold',
 					itemsSold,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', itemsSold ),
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
 				value: formatAmount( netRevenue ),
 			},
 			{
-				label: _n(
-					'Orders',
-					'Orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'Orders', 'Orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 		];
@@ -331,12 +326,9 @@ class ProductsReportTable extends Component {
 		const labels = {
 			helpText: __(
 				'Check at least two products below to compare',
-				'woocommerce-admin'
+				'woocommerce'
 			),
-			placeholder: __(
-				'Search by product name or SKU',
-				'woocommerce-admin'
-			),
+			placeholder: __( 'Search by product name or SKU', 'woocommerce' ),
 		};
 
 		return (
@@ -364,7 +356,7 @@ class ProductsReportTable extends Component {
 					extended_info: true,
 					segmentby: query.segmentby,
 				} }
-				title={ __( 'Products', 'woocommerce-admin' ) }
+				title={ __( 'Products', 'woocommerce' ) }
 				columnPrefsKey="products_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/revenue/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/revenue/config.js
@@ -23,7 +23,7 @@ const REVENUE_REPORT_ADVANCED_FILTERS_FILTER =
 export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 	{
 		key: 'gross_sales',
-		label: __( 'Gross sales', 'woocommerce-admin' ),
+		label: __( 'Gross sales', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'gross_sales',
 		type: 'currency',
@@ -31,7 +31,7 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'refunds',
-		label: __( 'Returns', 'woocommerce-admin' ),
+		label: __( 'Returns', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'refunds',
 		type: 'currency',
@@ -39,7 +39,7 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'coupons',
-		label: __( 'Coupons', 'woocommerce-admin' ),
+		label: __( 'Coupons', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'coupons',
 		type: 'currency',
@@ -47,37 +47,37 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net sales', 'woocommerce-admin' ),
+		label: __( 'Net sales', 'woocommerce' ),
 		orderby: 'net_revenue',
 		type: 'currency',
 		isReverseTrend: false,
 		labelTooltipText: __(
 			'Full refunds are not deducted from tax or net sales totals',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'taxes',
-		label: __( 'Taxes', 'woocommerce-admin' ),
+		label: __( 'Taxes', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'taxes',
 		type: 'currency',
 		isReverseTrend: false,
 		labelTooltipText: __(
 			'Full refunds are not deducted from tax or net sales totals',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'shipping',
-		label: __( 'Shipping', 'woocommerce-admin' ),
+		label: __( 'Shipping', 'woocommerce' ),
 		orderby: 'shipping',
 		type: 'currency',
 		isReverseTrend: false,
 	},
 	{
 		key: 'total_sales',
-		label: __( 'Total sales', 'woocommerce-admin' ),
+		label: __( 'Total sales', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'total_sales',
 		type: 'currency',
@@ -100,7 +100,7 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Revenue Matches {{select /}} Filters',
 			'A sentence describing filters for Revenue. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	}
 );
@@ -109,11 +109,11 @@ const filterValues = [];
 
 if ( Object.keys( advancedFilters.filters ).length ) {
 	filterValues.push( {
-		label: __( 'All Revenue', 'woocommerce-admin' ),
+		label: __( 'All Revenue', 'woocommerce' ),
 		value: 'all',
 	} );
 	filterValues.push( {
-		label: __( 'Advanced Filters', 'woocommerce-admin' ),
+		label: __( 'Advanced Filters', 'woocommerce' ),
 		value: 'advanced',
 	} );
 }
@@ -130,7 +130,7 @@ if ( Object.keys( advancedFilters.filters ).length ) {
  */
 export const filters = applyFilters( REVENUE_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => filterValues.length > 0,

--- a/plugins/woocommerce-admin/client/analytics/report/revenue/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/revenue/table.js
@@ -54,7 +54,7 @@ class RevenueReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Date', 'woocommerce-admin' ),
+				label: __( 'Date', 'woocommerce' ),
 				key: 'date',
 				required: true,
 				defaultSort: true,
@@ -62,56 +62,56 @@ class RevenueReportTable extends Component {
 				isSortable: true,
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Gross sales', 'woocommerce-admin' ),
+				label: __( 'Gross sales', 'woocommerce' ),
 				key: 'gross_sales',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Returns', 'woocommerce-admin' ),
+				label: __( 'Returns', 'woocommerce' ),
 				key: 'refunds',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Coupons', 'woocommerce-admin' ),
+				label: __( 'Coupons', 'woocommerce' ),
 				key: 'coupons',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
 				key: 'net_revenue',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Taxes', 'woocommerce-admin' ),
+				label: __( 'Taxes', 'woocommerce' ),
 				key: 'taxes',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Shipping', 'woocommerce-admin' ),
+				label: __( 'Shipping', 'woocommerce' ),
 				key: 'shipping',
 				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Total sales', 'woocommerce-admin' ),
+				label: __( 'Total sales', 'woocommerce' ),
 				key: 'total_sales',
 				required: false,
 				isSortable: true,
@@ -222,44 +222,39 @@ class RevenueReportTable extends Component {
 		const currency = getCurrencyConfig();
 		return [
 			{
-				label: _n( 'day', 'days', totalResults, 'woocommerce-admin' ),
+				label: _n( 'day', 'days', totalResults, 'woocommerce' ),
 				value: formatValue( currency, 'number', totalResults ),
 			},
 			{
-				label: _n(
-					'order',
-					'orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'order', 'orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 			{
-				label: __( 'Gross sales', 'woocommerce-admin' ),
+				label: __( 'Gross sales', 'woocommerce' ),
 				value: formatAmount( grossSales ),
 			},
 			{
-				label: __( 'Returns', 'woocommerce-admin' ),
+				label: __( 'Returns', 'woocommerce' ),
 				value: formatAmount( refunds ),
 			},
 			{
-				label: __( 'Coupons', 'woocommerce-admin' ),
+				label: __( 'Coupons', 'woocommerce' ),
 				value: formatAmount( coupons ),
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
 				value: formatAmount( netRevenue ),
 			},
 			{
-				label: __( 'Taxes', 'woocommerce-admin' ),
+				label: __( 'Taxes', 'woocommerce' ),
 				value: formatAmount( taxes ),
 			},
 			{
-				label: __( 'Shipping', 'woocommerce-admin' ),
+				label: __( 'Shipping', 'woocommerce' ),
 				value: formatAmount( shipping ),
 			},
 			{
-				label: __( 'Total sales', 'woocommerce-admin' ),
+				label: __( 'Total sales', 'woocommerce' ),
 				value: formatAmount( totalSales ),
 			},
 		];
@@ -277,7 +272,7 @@ class RevenueReportTable extends Component {
 				summaryFields={ summaryFields }
 				query={ query }
 				tableData={ tableData }
-				title={ __( 'Revenue', 'woocommerce-admin' ) }
+				title={ __( 'Revenue', 'woocommerce' ) }
 				columnPrefsKey="revenue_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/stock/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/stock/config.js
@@ -25,7 +25,7 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Products Match {{select /}} Filters',
 			'A sentence describing filters for Products. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	}
 );
@@ -42,36 +42,36 @@ export const advancedFilters = applyFilters(
  */
 export const filters = applyFilters( STOCK_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'paged', 'per_page' ],
 		param: 'type',
 		showFilters: () => true,
 		filters: [
-			{ label: __( 'All products', 'woocommerce-admin' ), value: 'all' },
+			{ label: __( 'All products', 'woocommerce' ), value: 'all' },
 			{
-				label: __( 'Out of stock', 'woocommerce-admin' ),
+				label: __( 'Out of stock', 'woocommerce' ),
 				value: 'outofstock',
 			},
 			{
-				label: __( 'Low stock', 'woocommerce-admin' ),
+				label: __( 'Low stock', 'woocommerce' ),
 				value: 'lowstock',
 			},
-			{ label: __( 'In stock', 'woocommerce-admin' ), value: 'instock' },
+			{ label: __( 'In stock', 'woocommerce' ), value: 'instock' },
 			{
-				label: __( 'On backorder', 'woocommerce-admin' ),
+				label: __( 'On backorder', 'woocommerce' ),
 				value: 'onbackorder',
 			},
 		],
 	},
 	{
-		label: __( 'Filter by', 'woocommerce-admin' ),
+		label: __( 'Filter by', 'woocommerce' ),
 		staticParams: [ 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => Object.keys( advancedFilters.filters ).length,
 		filters: [
-			{ label: __( 'All Products', 'woocommerce-admin' ), value: 'all' },
+			{ label: __( 'All Products', 'woocommerce' ), value: 'all' },
 			{
-				label: __( 'Advanced Filters', 'woocommerce-admin' ),
+				label: __( 'Advanced Filters', 'woocommerce' ),
 				value: 'advanced',
 			},
 		],

--- a/plugins/woocommerce-admin/client/analytics/report/stock/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/stock/table.js
@@ -31,25 +31,25 @@ class StockReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Product / Variation', 'woocommerce-admin' ),
+				label: __( 'Product / Variation', 'woocommerce' ),
 				key: 'title',
 				required: true,
 				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'SKU', 'woocommerce-admin' ),
+				label: __( 'SKU', 'woocommerce' ),
 				key: 'sku',
 				isSortable: true,
 			},
 			{
-				label: __( 'Status', 'woocommerce-admin' ),
+				label: __( 'Status', 'woocommerce' ),
 				key: 'stock_status',
 				isSortable: true,
 				defaultSort: true,
 			},
 			{
-				label: __( 'Stock', 'woocommerce-admin' ),
+				label: __( 'Stock', 'woocommerce' ),
 				key: 'stock_quantity',
 				isSortable: true,
 			},
@@ -100,7 +100,7 @@ class StockReportTable extends Component {
 					{ _x(
 						'Low',
 						'Indication of a low quantity',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</Link>
 			) : (
@@ -129,7 +129,7 @@ class StockReportTable extends Component {
 								'number',
 								stockQuantity
 						  )
-						: __( 'N/A', 'woocommerce-admin' ),
+						: __( 'N/A', 'woocommerce' ),
 					value: stockQuantity,
 				},
 			];
@@ -147,28 +147,23 @@ class StockReportTable extends Component {
 		const currency = this.context.getCurrencyConfig();
 		return [
 			{
-				label: _n(
-					'Product',
-					'Products',
-					products,
-					'woocommerce-admin'
-				),
+				label: _n( 'Product', 'Products', products, 'woocommerce' ),
 				value: formatValue( currency, 'number', products ),
 			},
 			{
-				label: __( 'Out of stock', 'woocommerce-admin' ),
+				label: __( 'Out of stock', 'woocommerce' ),
 				value: formatValue( currency, 'number', outofstock ),
 			},
 			{
-				label: __( 'Low stock', 'woocommerce-admin' ),
+				label: __( 'Low stock', 'woocommerce' ),
 				value: formatValue( currency, 'number', lowstock ),
 			},
 			{
-				label: __( 'On backorder', 'woocommerce-admin' ),
+				label: __( 'On backorder', 'woocommerce' ),
 				value: formatValue( currency, 'number', onbackorder ),
 			},
 			{
-				label: __( 'In stock', 'woocommerce-admin' ),
+				label: __( 'In stock', 'woocommerce' ),
 				value: formatValue( currency, 'number', instock ),
 			},
 		];
@@ -196,7 +191,7 @@ class StockReportTable extends Component {
 					order: query.order || 'asc',
 					type: query.type || 'all',
 				} }
-				title={ __( 'Stock', 'woocommerce-admin' ) }
+				title={ __( 'Stock', 'woocommerce' ) }
 				filters={ filters }
 				advancedFilters={ advancedFilters }
 			/>

--- a/plugins/woocommerce-admin/client/analytics/report/taxes/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/taxes/config.js
@@ -33,28 +33,28 @@ const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 export const charts = applyFilters( TAXES_REPORT_CHARTS_FILTER, [
 	{
 		key: 'total_tax',
-		label: __( 'Total tax', 'woocommerce-admin' ),
+		label: __( 'Total tax', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'total_tax',
 		type: 'currency',
 	},
 	{
 		key: 'order_tax',
-		label: __( 'Order tax', 'woocommerce-admin' ),
+		label: __( 'Order tax', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'order_tax',
 		type: 'currency',
 	},
 	{
 		key: 'shipping_tax',
-		label: __( 'Shipping tax', 'woocommerce-admin' ),
+		label: __( 'Shipping tax', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'shipping_tax',
 		type: 'currency',
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',
@@ -76,15 +76,15 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Taxes match {{select /}} filters',
 			'A sentence describing filters for Taxes. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	}
 );
 
 const filterValues = [
-	{ label: __( 'All taxes', 'woocommerce-admin' ), value: 'all' },
+	{ label: __( 'All taxes', 'woocommerce' ), value: 'all' },
 	{
-		label: __( 'Comparison', 'woocommerce-admin' ),
+		label: __( 'Comparison', 'woocommerce' ),
 		value: 'compare-taxes',
 		chartMode: 'item-comparison',
 		settings: {
@@ -101,14 +101,14 @@ const filterValues = [
 			labels: {
 				helpText: __(
 					'Check at least two tax codes below to compare',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				placeholder: __(
 					'Search for tax codes to compare',
-					'woocommerce-admin'
+					'woocommerce'
 				),
-				title: __( 'Compare Tax Codes', 'woocommerce-admin' ),
-				update: __( 'Compare', 'woocommerce-admin' ),
+				title: __( 'Compare Tax Codes', 'woocommerce' ),
+				update: __( 'Compare', 'woocommerce' ),
 			},
 			onClick: addCesSurveyForAnalytics,
 		},
@@ -117,7 +117,7 @@ const filterValues = [
 
 if ( Object.keys( advancedFilters.filters ).length ) {
 	filterValues.push( {
-		label: __( 'Advanced filters', 'woocommerce-admin' ),
+		label: __( 'Advanced filters', 'woocommerce' ),
 		value: 'advanced',
 	} );
 }
@@ -134,7 +134,7 @@ if ( Object.keys( advancedFilters.filters ).length ) {
  */
 export const filters = applyFilters( TAXES_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter',
 		showFilters: () => true,

--- a/plugins/woocommerce-admin/client/analytics/report/taxes/index.js
+++ b/plugins/woocommerce-admin/client/analytics/report/taxes/index.js
@@ -20,7 +20,7 @@ class TaxesReport extends Component {
 		const { query } = this.props;
 		const isCompareTaxView = query.filter === 'compare-taxes';
 		const mode = isCompareTaxView ? 'item-comparison' : 'time-comparison';
-		const itemsLabel = __( '%d taxes', 'woocommerce-admin' );
+		const itemsLabel = __( '%d taxes', 'woocommerce' );
 
 		return {
 			itemsLabel,

--- a/plugins/woocommerce-admin/client/analytics/report/taxes/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/taxes/table.js
@@ -27,35 +27,35 @@ class TaxesReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Tax code', 'woocommerce-admin' ),
+				label: __( 'Tax code', 'woocommerce' ),
 				key: 'tax_code',
 				required: true,
 				isLeftAligned: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Rate', 'woocommerce-admin' ),
+				label: __( 'Rate', 'woocommerce' ),
 				key: 'rate',
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Total tax', 'woocommerce-admin' ),
+				label: __( 'Total tax', 'woocommerce' ),
 				key: 'total_tax',
 				isSortable: true,
 			},
 			{
-				label: __( 'Order tax', 'woocommerce-admin' ),
+				label: __( 'Order tax', 'woocommerce' ),
 				key: 'order_tax',
 				isSortable: true,
 			},
 			{
-				label: __( 'Shipping tax', 'woocommerce-admin' ),
+				label: __( 'Shipping tax', 'woocommerce' ),
 				key: 'shipping_tax',
 				isSortable: true,
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				required: true,
 				defaultSort: true,
@@ -144,33 +144,23 @@ class TaxesReportTable extends Component {
 		const currency = getCurrencyConfig();
 		return [
 			{
-				label: _n(
-					'tax code',
-					'tax codes',
-					taxesCodes,
-					'woocommerce-admin'
-				),
+				label: _n( 'tax code', 'tax codes', taxesCodes, 'woocommerce' ),
 				value: formatValue( currency, 'number', taxesCodes ),
 			},
 			{
-				label: __( 'total tax', 'woocommerce-admin' ),
+				label: __( 'total tax', 'woocommerce' ),
 				value: formatAmount( totalTax ),
 			},
 			{
-				label: __( 'order tax', 'woocommerce-admin' ),
+				label: __( 'order tax', 'woocommerce' ),
 				value: formatAmount( orderTax ),
 			},
 			{
-				label: __( 'shipping tax', 'woocommerce-admin' ),
+				label: __( 'shipping tax', 'woocommerce' ),
 				value: formatAmount( shippingTax ),
 			},
 			{
-				label: _n(
-					'order',
-					'orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'order', 'orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 		];
@@ -200,7 +190,7 @@ class TaxesReportTable extends Component {
 				tableQuery={ {
 					orderby: query.orderby || 'tax_rate_id',
 				} }
-				title={ __( 'Taxes', 'woocommerce-admin' ) }
+				title={ __( 'Taxes', 'woocommerce' ) }
 				columnPrefsKey="taxes_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/plugins/woocommerce-admin/client/analytics/report/taxes/utils.js
+++ b/plugins/woocommerce-admin/client/analytics/report/taxes/utils.js
@@ -7,7 +7,7 @@ export function getTaxCode( tax ) {
 	return [
 		tax.country,
 		tax.state,
-		tax.name || __( 'TAX', 'woocommerce-admin' ),
+		tax.name || __( 'TAX', 'woocommerce' ),
 		tax.priority,
 	]
 		.map( ( item ) => item.toString().toUpperCase().trim() )

--- a/plugins/woocommerce-admin/client/analytics/report/variations/config.js
+++ b/plugins/woocommerce-admin/client/analytics/report/variations/config.js
@@ -37,21 +37,21 @@ const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 export const charts = applyFilters( VARIATIONS_REPORT_CHARTS_FILTER, [
 	{
 		key: 'items_sold',
-		label: __( 'Items sold', 'woocommerce-admin' ),
+		label: __( 'Items sold', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'items_sold',
 		type: 'number',
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net sales', 'woocommerce-admin' ),
+		label: __( 'Net sales', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',
@@ -70,18 +70,18 @@ export const charts = applyFilters( VARIATIONS_REPORT_CHARTS_FILTER, [
  */
 export const filters = applyFilters( VARIATIONS_REPORT_FILTERS_FILTER, [
 	{
-		label: __( 'Show', 'woocommerce-admin' ),
+		label: __( 'Show', 'woocommerce' ),
 		staticParams: [ 'chartType', 'paged', 'per_page' ],
 		param: 'filter-variations',
 		showFilters: () => true,
 		filters: [
 			{
-				label: __( 'All variations', 'woocommerce-admin' ),
+				label: __( 'All variations', 'woocommerce' ),
 				chartMode: 'item-comparison',
 				value: 'all',
 			},
 			{
-				label: __( 'Single variation', 'woocommerce-admin' ),
+				label: __( 'Single variation', 'woocommerce' ),
 				value: 'select_variation',
 				subFilters: [
 					{
@@ -95,19 +95,16 @@ export const filters = applyFilters( VARIATIONS_REPORT_FILTERS_FILTER, [
 							labels: {
 								placeholder: __(
 									'Type to search for a variation',
-									'woocommerce-admin'
+									'woocommerce'
 								),
-								button: __(
-									'Single variation',
-									'woocommerce-admin'
-								),
+								button: __( 'Single variation', 'woocommerce' ),
 							},
 						},
 					},
 				],
 			},
 			{
-				label: __( 'Comparison', 'woocommerce-admin' ),
+				label: __( 'Comparison', 'woocommerce' ),
 				chartMode: 'item-comparison',
 				value: 'compare-variations',
 				settings: {
@@ -117,20 +114,20 @@ export const filters = applyFilters( VARIATIONS_REPORT_FILTERS_FILTER, [
 					labels: {
 						helpText: __(
 							'Check at least two variations below to compare',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						placeholder: __(
 							'Search for variations to compare',
-							'woocommerce-admin'
+							'woocommerce'
 						),
-						title: __( 'Compare Variations', 'woocommerce-admin' ),
-						update: __( 'Compare', 'woocommerce-admin' ),
+						title: __( 'Compare Variations', 'woocommerce' ),
+						update: __( 'Compare', 'woocommerce' ),
 					},
 					onClick: addCesSurveyForAnalytics,
 				},
 			},
 			{
-				label: __( 'Advanced filters', 'woocommerce-admin' ),
+				label: __( 'Advanced filters', 'woocommerce' ),
 				value: 'advanced',
 			},
 		],
@@ -151,38 +148,31 @@ export const advancedFilters = applyFilters(
 		title: _x(
 			'Variations match {{select /}} filters',
 			'A sentence describing filters for Variations. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		filters: {
 			attribute: {
 				allowMultiple: true,
 				labels: {
-					add: __( 'Attribute', 'woocommerce-admin' ),
-					placeholder: __( 'Search attributes', 'woocommerce-admin' ),
-					remove: __(
-						'Remove attribute filter',
-						'woocommerce-admin'
-					),
+					add: __( 'Attribute', 'woocommerce' ),
+					placeholder: __( 'Search attributes', 'woocommerce' ),
+					remove: __( 'Remove attribute filter', 'woocommerce' ),
 					rule: __(
 						'Select a product attribute filter match',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Attribute{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select attributes', 'woocommerce-admin' ),
+					filter: __( 'Select attributes', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'is',
 						/* translators: Sentence fragment, logical, "Is" refers to searching for product variations matching a chosen attribute. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Is',
-							'product attribute',
-							'woocommerce-admin'
-						),
+						label: _x( 'Is', 'product attribute', 'woocommerce' ),
 					},
 					{
 						value: 'is_not',
@@ -190,7 +180,7 @@ export const advancedFilters = applyFilters(
 						label: _x(
 							'Is Not',
 							'product attribute',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					},
 				],
@@ -200,41 +190,27 @@ export const advancedFilters = applyFilters(
 			},
 			category: {
 				labels: {
-					add: __( 'Categories', 'woocommerce-admin' ),
-					placeholder: __( 'Search categories', 'woocommerce-admin' ),
-					remove: __(
-						'Remove categories filter',
-						'woocommerce-admin'
-					),
-					rule: __(
-						'Select a category filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Categories', 'woocommerce' ),
+					placeholder: __( 'Search categories', 'woocommerce' ),
+					remove: __( 'Remove categories filter', 'woocommerce' ),
+					rule: __( 'Select a category filter match', 'woocommerce' ),
 					/* translators: A sentence describing a Category filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Category{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select categories', 'woocommerce-admin' ),
+					filter: __( 'Select categories', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to variations including a given category. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Includes',
-							'categories',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'categories', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to variations excluding a given category. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Excludes',
-							'categories',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'categories', 'woocommerce' ),
 					},
 				],
 				input: {
@@ -245,38 +221,27 @@ export const advancedFilters = applyFilters(
 			},
 			product: {
 				labels: {
-					add: __( 'Products', 'woocommerce-admin' ),
-					placeholder: __( 'Search products', 'woocommerce-admin' ),
-					remove: __( 'Remove products filter', 'woocommerce-admin' ),
-					rule: __(
-						'Select a product filter match',
-						'woocommerce-admin'
-					),
+					add: __( 'Products', 'woocommerce' ),
+					placeholder: __( 'Search products', 'woocommerce' ),
+					remove: __( 'Remove products filter', 'woocommerce' ),
+					rule: __( 'Select a product filter match', 'woocommerce' ),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
 					title: __(
 						'{{title}}Product{{/title}} {{rule /}} {{filter /}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
-					filter: __( 'Select products', 'woocommerce-admin' ),
+					filter: __( 'Select products', 'woocommerce' ),
 				},
 				rules: [
 					{
 						value: 'includes',
 						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Includes',
-							'products',
-							'woocommerce-admin'
-						),
+						label: _x( 'Includes', 'products', 'woocommerce' ),
 					},
 					{
 						value: 'excludes',
 						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-						label: _x(
-							'Excludes',
-							'products',
-							'woocommerce-admin'
-						),
+						label: _x( 'Excludes', 'products', 'woocommerce' ),
 					},
 				],
 				input: {

--- a/plugins/woocommerce-admin/client/analytics/report/variations/index.js
+++ b/plugins/woocommerce-admin/client/analytics/report/variations/index.js
@@ -24,7 +24,7 @@ const getChartMeta = ( { query } ) => {
 
 	return {
 		compareObject: 'variations',
-		itemsLabel: __( '%d variations', 'woocommerce-admin' ),
+		itemsLabel: __( '%d variations', 'woocommerce' ),
 		mode: isCompareView ? 'item-comparison' : 'time-comparison',
 	};
 };

--- a/plugins/woocommerce-admin/client/analytics/report/variations/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/variations/table.js
@@ -42,19 +42,19 @@ class VariationsReportTable extends Component {
 	getHeadersContent() {
 		return [
 			{
-				label: __( 'Product / Variation title', 'woocommerce-admin' ),
+				label: __( 'Product / Variation title', 'woocommerce' ),
 				key: 'name',
 				required: true,
 				isLeftAligned: true,
 			},
 			{
-				label: __( 'SKU', 'woocommerce-admin' ),
+				label: __( 'SKU', 'woocommerce' ),
 				key: 'sku',
 				hiddenByDefault: true,
 				isSortable: true,
 			},
 			{
-				label: __( 'Items sold', 'woocommerce-admin' ),
+				label: __( 'Items sold', 'woocommerce' ),
 				key: 'items_sold',
 				required: true,
 				defaultSort: true,
@@ -62,28 +62,28 @@ class VariationsReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Net sales', 'woocommerce-admin' ),
-				screenReaderLabel: __( 'Net sales', 'woocommerce-admin' ),
+				label: __( 'Net sales', 'woocommerce' ),
+				screenReaderLabel: __( 'Net sales', 'woocommerce' ),
 				key: 'net_revenue',
 				required: true,
 				isSortable: true,
 				isNumeric: true,
 			},
 			{
-				label: __( 'Orders', 'woocommerce-admin' ),
+				label: __( 'Orders', 'woocommerce' ),
 				key: 'orders_count',
 				isSortable: true,
 				isNumeric: true,
 			},
 			manageStock === 'yes'
 				? {
-						label: __( 'Status', 'woocommerce-admin' ),
+						label: __( 'Status', 'woocommerce' ),
 						key: 'stock_status',
 				  }
 				: null,
 			manageStock === 'yes'
 				? {
-						label: __( 'Stock', 'woocommerce-admin' ),
+						label: __( 'Stock', 'woocommerce' ),
 						key: 'stock',
 						isNumeric: true,
 				  }
@@ -175,7 +175,7 @@ class VariationsReportTable extends Component {
 									{ _x(
 										'Low',
 										'Indication of a low quantity',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</Link>
 							) : (
@@ -221,7 +221,7 @@ class VariationsReportTable extends Component {
 						'variation sold',
 						'variations sold',
 						variationsCount,
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					variationsCount,
 					query
@@ -233,21 +233,16 @@ class VariationsReportTable extends Component {
 					'item sold',
 					'items sold',
 					itemsSold,
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				value: formatValue( currency, 'number', itemsSold ),
 			},
 			{
-				label: __( 'net sales', 'woocommerce-admin' ),
+				label: __( 'net sales', 'woocommerce' ),
 				value: formatAmount( netRevenue ),
 			},
 			{
-				label: _n(
-					'orders',
-					'orders',
-					ordersCount,
-					'woocommerce-admin'
-				),
+				label: _n( 'orders', 'orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 		];
@@ -265,12 +260,9 @@ class VariationsReportTable extends Component {
 		const labels = {
 			helpText: __(
 				'Check at least two variations below to compare',
-				'woocommerce-admin'
+				'woocommerce'
 			),
-			placeholder: __(
-				'Search by variation name or SKU',
-				'woocommerce-admin'
-			),
+			placeholder: __( 'Search by variation name or SKU', 'woocommerce' ),
 		};
 
 		return (
@@ -309,7 +301,7 @@ class VariationsReportTable extends Component {
 				 */
 				title={ applyFilters(
 					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER,
-					__( 'Variations', 'woocommerce-admin' ),
+					__( 'Variations', 'woocommerce' ),
 					query
 				) }
 				columnPrefsKey="variations_report_columns"

--- a/plugins/woocommerce-admin/client/analytics/settings/README.md
+++ b/plugins/woocommerce-admin/client/analytics/settings/README.md
@@ -13,7 +13,7 @@ addFilter( 'woocommerce_admin_analytics_settings', 'wc-example/my-setting', sett
 		...settings,
 		{
             name: 'custom_setting',
-            label: __( 'Custom setting:', 'woocommerce-admin' ),
+            label: __( 'Custom setting:', 'woocommerce' ),
             inputType: 'text',
             helpText: __( 'Help text to describe what the setting does.' ),
             defaultValue: 'Default value',

--- a/plugins/woocommerce-admin/client/analytics/settings/config.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/config.js
@@ -31,7 +31,7 @@ const filteredOrderStatuses = Object.keys( ORDER_STATUSES )
 			value: key,
 			label: ORDER_STATUSES[ key ],
 			description: sprintf(
-				__( 'Exclude the %s status from reports', 'woocommerce-admin' ),
+				__( 'Exclude the %s status from reports', 'woocommerce' ),
 				ORDER_STATUSES[ key ]
 			),
 		};
@@ -51,23 +51,20 @@ const orderStatusOptions = [
 	},
 	{
 		key: 'customStatuses',
-		label: __( 'Custom Statuses', 'woocommerce-admin' ),
+		label: __( 'Custom Statuses', 'woocommerce' ),
 		options: filteredOrderStatuses.filter(
 			( status ) => ! DEFAULT_ORDER_STATUSES.includes( status.value )
 		),
 	},
 	{
 		key: 'unregisteredStatuses',
-		label: __( 'Unregistered Statuses', 'woocommerce-admin' ),
+		label: __( 'Unregistered Statuses', 'woocommerce' ),
 		options: Object.keys( unregisteredOrderStatuses ).map( ( key ) => {
 			return {
 				value: key,
 				label: key,
 				description: sprintf(
-					__(
-						'Exclude the %s status from reports',
-						'woocommerce-admin'
-					),
+					__( 'Exclude the %s status from reports', 'woocommerce' ),
 					key
 				),
 			};
@@ -83,14 +80,14 @@ const orderStatusOptions = [
  */
 export const config = applyFilters( SETTINGS_FILTER, {
 	woocommerce_excluded_report_order_statuses: {
-		label: __( 'Excluded statuses:', 'woocommerce-admin' ),
+		label: __( 'Excluded statuses:', 'woocommerce' ),
 		inputType: 'checkboxGroup',
 		options: orderStatusOptions,
 		helpText: interpolateComponents( {
 			mixedString: __(
 				'Orders with these statuses are excluded from the totals in your reports. ' +
 					'The {{strong}}Refunded{{/strong}} status can not be excluded.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			components: {
 				strong: <strong />,
@@ -99,25 +96,25 @@ export const config = applyFilters( SETTINGS_FILTER, {
 		defaultValue: [ 'pending', 'cancelled', 'failed' ],
 	},
 	woocommerce_actionable_order_statuses: {
-		label: __( 'Actionable statuses:', 'woocommerce-admin' ),
+		label: __( 'Actionable statuses:', 'woocommerce' ),
 		inputType: 'checkboxGroup',
 		options: orderStatusOptions,
 		helpText: __(
 			'Orders with these statuses require action on behalf of the store admin. ' +
 				'These orders will show up in the Home Screen - Orders task.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		defaultValue: DEFAULT_ACTIONABLE_STATUSES,
 	},
 	woocommerce_default_date_range: {
 		name: 'woocommerce_default_date_range',
-		label: __( 'Default date range:', 'woocommerce-admin' ),
+		label: __( 'Default date range:', 'woocommerce' ),
 		inputType: 'component',
 		component: DefaultDate,
 		helpText: __(
 			'Select a default date range. When no range is selected, reports will be viewed by ' +
 				'the default date range.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		defaultValue: DEFAULT_DATE_RANGE,
 	},

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/actions.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/actions.js
@@ -35,7 +35,7 @@ function HistoricalDataActions( {
 		);
 		const errorMessage = __(
 			'There was a problem rebuilding your report data.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 
 		const importStarted = true;
@@ -48,7 +48,7 @@ function HistoricalDataActions( {
 		const path = '/wc-analytics/reports/import/cancel';
 		const errorMessage = __(
 			'There was a problem stopping your current import.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 		makeQuery( path, errorMessage );
 	};
@@ -77,7 +77,7 @@ function HistoricalDataActions( {
 		const path = '/wc-analytics/reports/import/delete';
 		const errorMessage = __(
 			'There was a problem deleting your previous data.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 		makeQuery( path, errorMessage );
 
@@ -106,17 +106,17 @@ function HistoricalDataActions( {
 						isPrimary
 						onClick={ onStopImport }
 					>
-						{ __( 'Stop Import', 'woocommerce-admin' ) }
+						{ __( 'Stop Import', 'woocommerce' ) }
 					</Button>
 					<div className="woocommerce-setting__help woocommerce-settings-historical-data__action-help">
 						{ __(
 							'Imported data will not be lost if the import is stopped.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 						<br />
 						{ __(
 							'Navigating away from this page will not affect the import.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</div>
 				</Fragment>
@@ -132,12 +132,12 @@ function HistoricalDataActions( {
 							onClick={ onStartImport }
 							disabled={ importDisabled }
 						>
-							{ __( 'Start', 'woocommerce-admin' ) }
+							{ __( 'Start', 'woocommerce' ) }
 						</Button>
 						<Button isSecondary onClick={ deletePreviousData }>
 							{ __(
 								'Delete Previously Imported Data',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</Button>
 					</Fragment>
@@ -151,7 +151,7 @@ function HistoricalDataActions( {
 						onClick={ onStartImport }
 						disabled={ importDisabled }
 					>
-						{ __( 'Start', 'woocommerce-admin' ) }
+						{ __( 'Start', 'woocommerce' ) }
 					</Button>
 				</Fragment>
 			);
@@ -162,7 +162,7 @@ function HistoricalDataActions( {
 				'error',
 				__(
 					'Something went wrong with the importation process.',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}
@@ -171,13 +171,10 @@ function HistoricalDataActions( {
 		return (
 			<Fragment>
 				<Button isSecondary onClick={ reimportData }>
-					{ __( 'Re-import Data', 'woocommerce-admin' ) }
+					{ __( 'Re-import Data', 'woocommerce' ) }
 				</Button>
 				<Button isSecondary onClick={ deletePreviousData }>
-					{ __(
-						'Delete Previously Imported Data',
-						'woocommerce-admin'
-					) }
+					{ __( 'Delete Previously Imported Data', 'woocommerce' ) }
 				</Button>
 			</Fragment>
 		);

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/index.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/index.js
@@ -23,7 +23,7 @@ class HistoricalData extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
+		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce' );
 		this.intervalId = -1;
 		this.lastImportStopTimestamp = 0;
 		this.cacheNeedsClearing = true;

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/layout.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/layout.js
@@ -41,10 +41,7 @@ class HistoricalDataLayout extends Component {
 		return (
 			<Fragment>
 				<SectionHeader
-					title={ __(
-						'Import historical data',
-						'woocommerce-admin'
-					) }
+					title={ __( 'Import historical data', 'woocommerce' ) }
 				/>
 				<div className="woocommerce-settings__wrapper">
 					<div className="woocommerce-setting">
@@ -53,7 +50,7 @@ class HistoricalDataLayout extends Component {
 								{ __(
 									'This tool populates historical analytics data by processing customers ' +
 										'and orders created prior to activating WooCommerce Admin.',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							</span>
 							{ status !== 'finished' && (
@@ -70,7 +67,7 @@ class HistoricalDataLayout extends Component {
 									<HistoricalDataProgress
 										label={ __(
 											'Registered Customers',
-											'woocommerce-admin'
+											'woocommerce'
 										) }
 										progress={ customersProgress }
 										total={ customersTotal }
@@ -78,7 +75,7 @@ class HistoricalDataLayout extends Component {
 									<HistoricalDataProgress
 										label={ __(
 											'Orders and Refunds',
-											'woocommerce-admin'
+											'woocommerce'
 										) }
 										progress={ ordersProgress }
 										total={ ordersTotal }

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/period-selector.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/period-selector.js
@@ -44,7 +44,7 @@ function HistoricalDataPeriodSelector( {
 		return (
 			<div className="woocommerce-settings-historical-data__column">
 				<div className="woocommerce-settings-historical-data__column-label">
-					{ __( 'Beginning on', 'woocommerce-admin' ) }
+					{ __( 'Beginning on', 'woocommerce' ) }
 				</div>
 				<DatePicker
 					date={ momentDate.isValid() ? momentDate.toDate() : null }
@@ -65,10 +65,7 @@ function HistoricalDataPeriodSelector( {
 		<div className="woocommerce-settings-historical-data__columns">
 			<div className="woocommerce-settings-historical-data__column">
 				<SelectControl
-					label={ __(
-						'Import historical data',
-						'woocommerce-admin'
-					) }
+					label={ __( 'Import historical data', 'woocommerce' ) }
 					value={ value.label }
 					disabled={ disabled }
 					onChange={ onSelectChange }

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/progress.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/progress.js
@@ -5,15 +5,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { isNil } from 'lodash';
 
 function HistoricalDataProgress( { label, progress, total } ) {
-	const labelText = sprintf(
-		__( 'Imported %(label)s', 'woocommerce-admin' ),
-		{
-			label,
-		}
-	);
+	const labelText = sprintf( __( 'Imported %(label)s', 'woocommerce' ), {
+		label,
+	} );
 
 	const labelCounters = ! isNil( total )
-		? sprintf( __( '%(progress)s of %(total)s', 'woocommerce-admin' ), {
+		? sprintf( __( '%(progress)s of %(total)s', 'woocommerce' ), {
 				progress: progress || 0,
 				total,
 		  } )

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/skip-checkbox.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/skip-checkbox.js
@@ -17,7 +17,7 @@ function HistoricalDataSkipCheckbox( { checked, disabled, setSkipPrevious } ) {
 			disabled={ disabled }
 			label={ __(
 				'Skip previously imported customers and orders',
-				'woocommerce-admin'
+				'woocommerce'
 			) }
 			onChange={ skipChange }
 		/>

--- a/plugins/woocommerce-admin/client/analytics/settings/historical-data/status.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/historical-data/status.js
@@ -24,31 +24,31 @@ function HistoricalDataStatus( { importDate, status } ) {
 	 * @param {string} statuses.finished     Message displayed after import.
 	 */
 	const statusLabels = applyFilters( HISTORICAL_DATA_STATUS_FILTER, {
-		nothing: __( 'Nothing To Import', 'woocommerce-admin' ),
-		ready: __( 'Ready To Import', 'woocommerce-admin' ),
+		nothing: __( 'Nothing To Import', 'woocommerce' ),
+		ready: __( 'Ready To Import', 'woocommerce' ),
 		initializing: [
-			__( 'Initializing', 'woocommerce-admin' ),
+			__( 'Initializing', 'woocommerce' ),
 			<Spinner key="spinner" />,
 		],
 		customers: [
-			__( 'Importing Customers', 'woocommerce-admin' ),
+			__( 'Importing Customers', 'woocommerce' ),
 			<Spinner key="spinner" />,
 		],
 		orders: [
-			__( 'Importing Orders', 'woocommerce-admin' ),
+			__( 'Importing Orders', 'woocommerce' ),
 			<Spinner key="spinner" />,
 		],
 		finalizing: [
-			__( 'Finalizing', 'woocommerce-admin' ),
+			__( 'Finalizing', 'woocommerce' ),
 			<Spinner key="spinner" />,
 		],
 		finished:
 			importDate === -1
-				? __( 'All historical data imported', 'woocommerce-admin' )
+				? __( 'All historical data imported', 'woocommerce' )
 				: sprintf(
 						__(
 							'Historical data from %s onward imported',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						// @todo The date formatting should be localized ( 'll' ), but this is currently broken in Gutenberg.
 						// See https://github.com/WordPress/gutenberg/issues/12626 for details.
@@ -58,7 +58,7 @@ function HistoricalDataStatus( { importDate, status } ) {
 
 	return (
 		<span className="woocommerce-settings-historical-data__status">
-			{ __( 'Status:', 'woocommerce-admin' ) + ' ' }
+			{ __( 'Status:', 'woocommerce' ) + ' ' }
 			{ statusLabels[ status ] }
 		</span>
 	);

--- a/plugins/woocommerce-admin/client/analytics/settings/index.js
+++ b/plugins/woocommerce-admin/client/analytics/settings/index.js
@@ -35,7 +35,7 @@ const Settings = ( { createNotice, query } ) => {
 			if ( isDirty ) {
 				event.returnValue = __(
 					'You have unsaved changes. If you proceed, they will be lost.',
-					'woocommerce-admin'
+					'woocommerce'
 				);
 				return event.returnValue;
 			}
@@ -56,7 +56,7 @@ const Settings = ( { createNotice, query } ) => {
 					'success',
 					__(
 						'Your settings have been successfully saved.',
-						'woocommerce-admin'
+						'woocommerce'
 					)
 				);
 			} else {
@@ -64,7 +64,7 @@ const Settings = ( { createNotice, query } ) => {
 					'error',
 					__(
 						'There was an error saving your settings. Please try again.',
-						'woocommerce-admin'
+						'woocommerce'
 					)
 				);
 			}
@@ -78,7 +78,7 @@ const Settings = ( { createNotice, query } ) => {
 			window.confirm(
 				__(
 					'Are you sure you want to reset all settings to default values?',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			)
 		) {
@@ -130,7 +130,7 @@ const Settings = ( { createNotice, query } ) => {
 	return (
 		<Fragment>
 			<SectionHeader
-				title={ __( 'Analytics settings', 'woocommerce-admin' ) }
+				title={ __( 'Analytics settings', 'woocommerce' ) }
 			/>
 			<div className="woocommerce-settings__wrapper">
 				{ Object.keys( config ).map( ( setting ) => (
@@ -144,14 +144,14 @@ const Settings = ( { createNotice, query } ) => {
 				) ) }
 				<div className="woocommerce-settings__actions">
 					<Button isSecondary onClick={ resetDefaults }>
-						{ __( 'Reset defaults', 'woocommerce-admin' ) }
+						{ __( 'Reset defaults', 'woocommerce' ) }
 					</Button>
 					<Button
 						isPrimary
 						isBusy={ isRequesting }
 						onClick={ saveChanges }
 					>
-						{ __( 'Save settings', 'woocommerce-admin' ) }
+						{ __( 'Save settings', 'woocommerce' ) }
 					</Button>
 				</div>
 			</div>

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -35,7 +35,7 @@ function CustomerEffortScoreTracks( {
 	action,
 	trackProps,
 	label,
-	onSubmitLabel = __( 'Thank you for your feedback!', 'woocommerce-admin' ),
+	onSubmitLabel = __( 'Thank you for your feedback!', 'woocommerce' ),
 	cesShownForActions,
 	allowTracking,
 	resolving,
@@ -126,7 +126,7 @@ function CustomerEffortScoreTracks( {
 				<span
 					style={ { height: 21, width: 21 } }
 					role="img"
-					aria-label={ __( 'Pencil icon', 'woocommerce-admin' ) }
+					aria-label={ __( 'Pencil icon', 'woocommerce' ) }
 				>
 					✏️
 				</span>

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/actions.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/actions.js
@@ -55,10 +55,7 @@ export function addCesSurvey(
 export function addCesSurveyForAnalytics() {
 	return addCesSurvey(
 		'analytics_filtered',
-		__(
-			'How easy was it to filter your store analytics?',
-			'woocommerce-admin'
-		),
+		__( 'How easy was it to filter your store analytics?', 'woocommerce' ),
 		'woocommerce_page_wc-admin',
 		'woocommerce_page_wc-admin'
 	);
@@ -70,7 +67,7 @@ export function addCesSurveyForAnalytics() {
 export function addCesSurveyForCustomerSearch() {
 	return addCesSurvey(
 		'ces_search',
-		__( 'How easy was it to use search?', 'woocommerce-admin' ),
+		__( 'How easy was it to use search?', 'woocommerce' ),
 		'woocommerce_page_wc-admin',
 		'woocommerce_page_wc-admin',
 		undefined,

--- a/plugins/woocommerce-admin/client/dashboard/components/cart-modal.js
+++ b/plugins/woocommerce-admin/client/dashboard/components/cart-modal.js
@@ -103,7 +103,7 @@ class CartModal extends Component {
 			if ( themeInfo ) {
 				listItems.push( {
 					title: sprintf(
-						__( '%s — %s per year', 'woocommerce-admin' ),
+						__( '%s — %s per year', 'woocommerce' ),
 						themeInfo.title,
 						decodeEntities( themeInfo.price )
 					),
@@ -127,7 +127,7 @@ class CartModal extends Component {
 			<Modal
 				title={ __(
 					'Would you like to add the following paid features to your store now?',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				onRequestClose={ () => this.onClose() }
 				className="woocommerce-cart-modal"
@@ -137,7 +137,7 @@ class CartModal extends Component {
 				<p className="woocommerce-cart-modal__help-text">
 					{ __(
 						"You won't have access to this functionality until the extensions have been purchased and installed.",
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 
@@ -147,7 +147,7 @@ class CartModal extends Component {
 						isBusy={ purchaseLaterButtonBusy }
 						onClick={ () => this.onClickPurchaseLater() }
 					>
-						{ __( "I'll do it later", 'woocommerce-admin' ) }
+						{ __( "I'll do it later", 'woocommerce' ) }
 					</Button>
 
 					<Button
@@ -155,7 +155,7 @@ class CartModal extends Component {
 						isBusy={ purchaseNowButtonBusy }
 						onClick={ () => this.onClickPurchaseNow() }
 					>
-						{ __( 'Buy now', 'woocommerce-admin' ) }
+						{ __( 'Buy now', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Modal>

--- a/plugins/woocommerce-admin/client/dashboard/components/connect/index.js
+++ b/plugins/woocommerce-admin/client/dashboard/components/connect/index.js
@@ -74,7 +74,7 @@ export class Connect extends Component {
 						isPrimary
 						onClick={ () => window.location.reload() }
 					>
-						{ __( 'Retry', 'woocommerce-admin' ) }
+						{ __( 'Retry', 'woocommerce' ) }
 					</Button>
 				) : (
 					<Button
@@ -83,17 +83,17 @@ export class Connect extends Component {
 						isPrimary
 						onClick={ this.connectJetpack }
 					>
-						{ __( 'Connect', 'woocommerce-admin' ) }
+						{ __( 'Connect', 'woocommerce' ) }
 					</Button>
 				) }
 				{ onSkip && (
 					<Button onClick={ onSkip }>
-						{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
+						{ skipText || __( 'No thanks', 'woocommerce' ) }
 					</Button>
 				) }
 				{ onAbort && (
 					<Button onClick={ onAbort }>
-						{ abortText || __( 'Abort', 'woocommerce-admin' ) }
+						{ abortText || __( 'Abort', 'woocommerce' ) }
 					</Button>
 				) }
 			</Fragment>

--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -69,31 +69,25 @@ export function getStoreAddressValidator( locale = {} ) {
 			isAddressFieldRequired( 'address_1', locale ) &&
 			! values.addressLine1.trim().length
 		) {
-			errors.addressLine1 = __(
-				'Please add an address',
-				'woocommerce-admin'
-			);
+			errors.addressLine1 = __( 'Please add an address', 'woocommerce' );
 		}
 		if ( ! values.countryState.trim().length ) {
 			errors.countryState = __(
 				'Please select a country / region',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 		if (
 			isAddressFieldRequired( 'city', locale ) &&
 			! values.city.trim().length
 		) {
-			errors.city = __( 'Please add a city', 'woocommerce-admin' );
+			errors.city = __( 'Please add a city', 'woocommerce' );
 		}
 		if (
 			isAddressFieldRequired( 'postcode', locale ) &&
 			! values.postCode.trim().length
 		) {
-			errors.postCode = __(
-				'Please add a post code',
-				'woocommerce-admin'
-			);
+			errors.postCode = __( 'Please add a post code', 'woocommerce' );
 		}
 
 		return errors;
@@ -390,7 +384,7 @@ export function StoreAddress( {
 				<TextControl
 					label={
 						locale?.address_1?.label ||
-						__( 'Address line 1', 'woocommerce-admin' )
+						__( 'Address line 1', 'woocommerce' )
 					}
 					required={ isAddressFieldRequired( 'address_1', locale ) }
 					autoComplete="address-line1"
@@ -402,7 +396,7 @@ export function StoreAddress( {
 				<TextControl
 					label={
 						locale?.address_2?.label ||
-						__( 'Address line 2 (optional)', 'woocommerce-admin' )
+						__( 'Address line 2 (optional)', 'woocommerce' )
 					}
 					required={ isAddressFieldRequired( 'address_2', locale ) }
 					autoComplete="address-line2"
@@ -411,7 +405,7 @@ export function StoreAddress( {
 			) }
 
 			<SelectControl
-				label={ __( 'Country / Region', 'woocommerce-admin' ) }
+				label={ __( 'Country / Region', 'woocommerce' ) }
 				required
 				autoComplete="new-password" // disable autocomplete and autofill
 				options={ countryStateOptions }
@@ -426,9 +420,7 @@ export function StoreAddress( {
 
 			{ ! locale?.city?.hidden && (
 				<TextControl
-					label={
-						locale?.city?.label || __( 'City', 'woocommerce-admin' )
-					}
+					label={ locale?.city?.label || __( 'City', 'woocommerce' ) }
 					required={ isAddressFieldRequired( 'city', locale ) }
 					{ ...getInputProps( 'city' ) }
 					autoComplete="address-level2"
@@ -439,7 +431,7 @@ export function StoreAddress( {
 				<TextControl
 					label={
 						locale?.postcode?.label ||
-						__( 'Post code', 'woocommerce-admin' )
+						__( 'Post code', 'woocommerce' )
 					}
 					required={ isAddressFieldRequired( 'postcode', locale ) }
 					autoComplete="postal-code"

--- a/plugins/woocommerce-admin/client/dashboard/customizable.js
+++ b/plugins/woocommerce-admin/client/dashboard/customizable.js
@@ -190,7 +190,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 				renderToggle={ ( { onToggle, isOpen } ) => (
 					<Button
 						onClick={ onToggle }
-						title={ __( 'Add more sections', 'woocommerce-admin' ) }
+						title={ __( 'Add more sections', 'woocommerce' ) }
 						aria-expanded={ isOpen }
 					>
 						<Icon icon={ plusCircleFilled } />
@@ -198,9 +198,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 				) }
 				renderContent={ ( { onToggle } ) => (
 					<>
-						<H>
-							{ __( 'Dashboard Sections', 'woocommerce-admin' ) }
-						</H>
+						<H>{ __( 'Dashboard Sections', 'woocommerce' ) }</H>
 						<div className="woocommerce-dashboard-section__add-more-choices">
 							{ hiddenSections.map( ( section ) => {
 								return (
@@ -214,7 +212,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 										title={ sprintf(
 											__(
 												'Add %s section',
-												'woocommerce-admin'
+												'woocommerce'
 											),
 											section.title
 										) }

--- a/plugins/woocommerce-admin/client/dashboard/dashboard-charts/block.js
+++ b/plugins/woocommerce-admin/client/dashboard/dashboard-charts/block.js
@@ -75,7 +75,7 @@ class ChartBlock extends Component {
 							{
 								/* translators: %s is the chart type */
 								sprintf(
-									__( '%s Report', 'woocommerce-admin' ),
+									__( '%s Report', 'woocommerce' ),
 									selectedChart.label
 								)
 							}

--- a/plugins/woocommerce-admin/client/dashboard/dashboard-charts/config.js
+++ b/plugins/woocommerce-admin/client/dashboard/dashboard-charts/config.js
@@ -27,67 +27,67 @@ const charts = {
 
 const defaultCharts = [
 	{
-		label: __( 'Total sales', 'woocommerce-admin' ),
+		label: __( 'Total sales', 'woocommerce' ),
 		report: 'revenue',
 		key: 'total_sales',
 	},
 	{
-		label: __( 'Net sales', 'woocommerce-admin' ),
+		label: __( 'Net sales', 'woocommerce' ),
 		report: 'revenue',
 		key: 'net_revenue',
 	},
 	{
-		label: __( 'Orders', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce' ),
 		report: 'orders',
 		key: 'orders_count',
 	},
 	{
-		label: __( 'Average order value', 'woocommerce-admin' ),
+		label: __( 'Average order value', 'woocommerce' ),
 		report: 'orders',
 		key: 'avg_order_value',
 	},
 	{
-		label: __( 'Items sold', 'woocommerce-admin' ),
+		label: __( 'Items sold', 'woocommerce' ),
 		report: 'products',
 		key: 'items_sold',
 	},
 	{
-		label: __( 'Returns', 'woocommerce-admin' ),
+		label: __( 'Returns', 'woocommerce' ),
 		report: 'revenue',
 		key: 'refunds',
 	},
 	{
-		label: __( 'Discounted orders', 'woocommerce-admin' ),
+		label: __( 'Discounted orders', 'woocommerce' ),
 		report: 'coupons',
 		key: 'orders_count',
 	},
 	{
-		label: __( 'Gross discounted', 'woocommerce-admin' ),
+		label: __( 'Gross discounted', 'woocommerce' ),
 		report: 'coupons',
 		key: 'amount',
 	},
 	{
-		label: __( 'Total tax', 'woocommerce-admin' ),
+		label: __( 'Total tax', 'woocommerce' ),
 		report: 'taxes',
 		key: 'total_tax',
 	},
 	{
-		label: __( 'Order tax', 'woocommerce-admin' ),
+		label: __( 'Order tax', 'woocommerce' ),
 		report: 'taxes',
 		key: 'order_tax',
 	},
 	{
-		label: __( 'Shipping tax', 'woocommerce-admin' ),
+		label: __( 'Shipping tax', 'woocommerce' ),
 		report: 'taxes',
 		key: 'shipping_tax',
 	},
 	{
-		label: __( 'Shipping', 'woocommerce-admin' ),
+		label: __( 'Shipping', 'woocommerce' ),
 		report: 'revenue',
 		key: 'shipping',
 	},
 	{
-		label: __( 'Downloads', 'woocommerce-admin' ),
+		label: __( 'Downloads', 'woocommerce' ),
 		report: 'downloads',
 		key: 'download_count',
 	},

--- a/plugins/woocommerce-admin/client/dashboard/dashboard-charts/index.js
+++ b/plugins/woocommerce-admin/client/dashboard/dashboard-charts/index.js
@@ -65,12 +65,12 @@ const renderIntervalSelector = ( {
 	}
 
 	const intervalLabels = {
-		hour: __( 'By hour', 'woocommerce-admin' ),
-		day: __( 'By day', 'woocommerce-admin' ),
-		week: __( 'By week', 'woocommerce-admin' ),
-		month: __( 'By month', 'woocommerce-admin' ),
-		quarter: __( 'By quarter', 'woocommerce-admin' ),
-		year: __( 'By year', 'woocommerce-admin' ),
+		hour: __( 'By hour', 'woocommerce' ),
+		day: __( 'By day', 'woocommerce' ),
+		week: __( 'By week', 'woocommerce' ),
+		month: __( 'By month', 'woocommerce' ),
+		quarter: __( 'By quarter', 'woocommerce' ),
+		year: __( 'By year', 'woocommerce' ),
 	};
 
 	return (
@@ -159,15 +159,10 @@ const DashboardCharts = ( props ) => {
 
 	const renderMenu = () => (
 		<EllipsisMenu
-			label={ __(
-				'Choose which charts to display',
-				'woocommerce-admin'
-			) }
+			label={ __( 'Choose which charts to display', 'woocommerce' ) }
 			renderContent={ ( { onToggle } ) => (
 				<Fragment>
-					<MenuTitle>
-						{ __( 'Charts', 'woocommerce-admin' ) }
-					</MenuTitle>
+					<MenuTitle>{ __( 'Charts', 'woocommerce' ) }</MenuTitle>
 					{ renderChartToggles( {
 						hiddenBlocks,
 						onToggleHiddenBlock,
@@ -199,7 +194,7 @@ const DashboardCharts = ( props ) => {
 	return (
 		<div className="woocommerce-dashboard__dashboard-charts">
 			<SectionHeader
-				title={ title || __( 'Charts', 'woocommerce-admin' ) }
+				title={ title || __( 'Charts', 'woocommerce' ) }
 				menu={ renderMenu() }
 				className={ 'has-interval-select' }
 			>
@@ -223,7 +218,7 @@ const DashboardCharts = ( props ) => {
 									query.chartType === 'line',
 							}
 						) }
-						title={ __( 'Line chart', 'woocommerce-admin' ) }
+						title={ __( 'Line chart', 'woocommerce' ) }
 						aria-checked={ query.chartType === 'line' }
 						role="menuitemradio"
 						tabIndex={ query.chartType === 'line' ? 0 : -1 }
@@ -239,7 +234,7 @@ const DashboardCharts = ( props ) => {
 									query.chartType === 'bar',
 							}
 						) }
-						title={ __( 'Bar chart', 'woocommerce-admin' ) }
+						title={ __( 'Bar chart', 'woocommerce' ) }
 						aria-checked={ query.chartType === 'bar' }
 						role="menuitemradio"
 						tabIndex={ query.chartType === 'bar' ? 0 : -1 }

--- a/plugins/woocommerce-admin/client/dashboard/default-sections.js
+++ b/plugins/woocommerce-admin/client/dashboard/default-sections.js
@@ -63,7 +63,7 @@ export default applyFilters( DEFAULT_SECTIONS_FILTER, [
 	{
 		key: 'store-performance',
 		component: StorePerformance,
-		title: __( 'Performance', 'woocommerce-admin' ),
+		title: __( 'Performance', 'woocommerce' ),
 		isVisible: true,
 		icon: arrowRight,
 		hiddenBlocks: [
@@ -82,7 +82,7 @@ export default applyFilters( DEFAULT_SECTIONS_FILTER, [
 	{
 		key: 'charts',
 		component: DashboardCharts,
-		title: __( 'Charts', 'woocommerce-admin' ),
+		title: __( 'Charts', 'woocommerce' ),
 		isVisible: true,
 		icon: chartBar,
 		hiddenBlocks: [
@@ -103,7 +103,7 @@ export default applyFilters( DEFAULT_SECTIONS_FILTER, [
 	{
 		key: 'leaderboards',
 		component: Leaderboards,
-		title: __( 'Leaderboards', 'woocommerce-admin' ),
+		title: __( 'Leaderboards', 'woocommerce' ),
 		isVisible: true,
 		icon: <ListOrdered />,
 		hiddenBlocks: [ 'coupons', 'customers' ],

--- a/plugins/woocommerce-admin/client/dashboard/leaderboards/index.js
+++ b/plugins/woocommerce-admin/client/dashboard/leaderboards/index.js
@@ -110,12 +110,12 @@ const Leaderboards = ( props ) => {
 		<EllipsisMenu
 			label={ __(
 				'Choose which leaderboards to display and other settings',
-				'woocommerce-admin'
+				'woocommerce'
 			) }
 			renderContent={ ( { onToggle } ) => (
 				<Fragment>
 					<MenuTitle>
-						{ __( 'Leaderboards', 'woocommerce-admin' ) }
+						{ __( 'Leaderboards', 'woocommerce' ) }
 					</MenuTitle>
 					{ renderLeaderboardToggles( {
 						allLeaderboards,
@@ -124,7 +124,7 @@ const Leaderboards = ( props ) => {
 					} ) }
 					<SelectControl
 						className="woocommerce-dashboard__dashboard-leaderboards__select"
-						label={ __( 'Rows per table', 'woocommerce-admin' ) }
+						label={ __( 'Rows per table', 'woocommerce' ) }
 						value={ rowsPerTable }
 						options={ Array.from( { length: 20 }, ( v, key ) => ( {
 							v: key + 1,
@@ -151,7 +151,7 @@ const Leaderboards = ( props ) => {
 		<Fragment>
 			<div className="woocommerce-dashboard__dashboard-leaderboards">
 				<SectionHeader
-					title={ title || __( 'Leaderboards', 'woocommerce-admin' ) }
+					title={ title || __( 'Leaderboards', 'woocommerce' ) }
 					menu={ renderMenu() }
 				/>
 				<div className="woocommerce-dashboard__columns">

--- a/plugins/woocommerce-admin/client/dashboard/section-controls.js
+++ b/plugins/woocommerce-admin/client/dashboard/section-controls.js
@@ -44,7 +44,7 @@ class SectionControls extends Component {
 			<Fragment>
 				<div className="woocommerce-ellipsis-menu__item">
 					<TextControl
-						label={ __( 'Section title', 'woocommerce-admin' ) }
+						label={ __( 'Section title', 'woocommerce' ) }
 						onBlur={ onTitleBlur }
 						onChange={ onTitleChange }
 						required
@@ -60,7 +60,7 @@ class SectionControls extends Component {
 								size={ 20 }
 								className="icon-control"
 							/>
-							{ __( 'Move up', 'woocommerce-admin' ) }
+							{ __( 'Move up', 'woocommerce' ) }
 						</MenuItem>
 					) }
 					{ ! isLast && (
@@ -71,7 +71,7 @@ class SectionControls extends Component {
 								label={ __( 'Move down' ) }
 								className="icon-control"
 							/>
-							{ __( 'Move down', 'woocommerce-admin' ) }
+							{ __( 'Move down', 'woocommerce' ) }
 						</MenuItem>
 					) }
 					<MenuItem isClickable onInvoke={ onRemove }>
@@ -81,7 +81,7 @@ class SectionControls extends Component {
 							label={ __( 'Remove block' ) }
 							className="icon-control"
 						/>
-						{ __( 'Remove section', 'woocommerce-admin' ) }
+						{ __( 'Remove section', 'woocommerce' ) }
 					</MenuItem>
 				</div>
 			</Fragment>

--- a/plugins/woocommerce-admin/client/dashboard/store-performance/index.js
+++ b/plugins/woocommerce-admin/client/dashboard/store-performance/index.js
@@ -52,12 +52,12 @@ class StorePerformance extends Component {
 			<EllipsisMenu
 				label={ __(
 					'Choose which analytics to display and the section name',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				renderContent={ ( { onToggle } ) => (
 					<Fragment>
 						<MenuTitle>
-							{ __( 'Display stats:', 'woocommerce-admin' ) }
+							{ __( 'Display stats:', 'woocommerce' ) }
 						</MenuTitle>
 						{ indicators.map( ( indicator, i ) => {
 							const checked = ! hiddenBlocks.includes(
@@ -126,8 +126,8 @@ class StorePerformance extends Component {
 		const { compare } = getDateParamsFromQuery( query, defaultDateRange );
 		const prevLabel =
 			compare === 'previous_period'
-				? __( 'Previous period:', 'woocommerce-admin' )
-				: __( 'Previous year:', 'woocommerce-admin' );
+				? __( 'Previous period:', 'woocommerce' )
+				: __( 'Previous year:', 'woocommerce' );
 		const { formatAmount, getCurrencyConfig } = this.context;
 		const currency = getCurrencyConfig();
 		return (
@@ -177,9 +177,7 @@ class StorePerformance extends Component {
 		return (
 			<Fragment>
 				<SectionHeader
-					title={
-						title || __( 'Store Performance', 'woocommerce-admin' )
-					}
+					title={ title || __( 'Store Performance', 'woocommerce' ) }
 					menu={ this.renderMenu() }
 				/>
 				{ userIndicators.length > 0 && (

--- a/plugins/woocommerce-admin/client/header/README.md
+++ b/plugins/woocommerce-admin/client/header/README.md
@@ -12,8 +12,8 @@ render: function() {
 	return (
 		<Header
 			sections={ [
-				[ '/analytics', __( 'Analytics', 'woocommerce-admin' ) ],
-				__( 'Report Title', 'woocommerce-admin' ),
+				[ '/analytics', __( 'Analytics', 'woocommerce' ) ],
+				__( 'Report Title', 'woocommerce' ),
 			] }
 		/>
   	);
@@ -22,7 +22,7 @@ render: function() {
 
 ## Props
 
-* `sections` (required): Used to generate breadcrumbs. Accepts a single items or an array of items. To make an item a link, wrap it in an array with a relative link (example: `[ '/analytics', __( 'Analytics', 'woocommerce-admin' ) ]` ).
+* `sections` (required): Used to generate breadcrumbs. Accepts a single items or an array of items. To make an item a link, wrap it in an array with a relative link (example: `[ '/analytics', __( 'Analytics', 'woocommerce' ) ]` ).
 * `isEmbedded`: Boolean describing if the header is embedded on an existing wp-admin page. False if rendered as part of a full react page.
 
 Activity Panel

--- a/plugins/woocommerce-admin/client/header/index.js
+++ b/plugins/woocommerce-admin/client/header/index.js
@@ -80,7 +80,7 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 					/* translators: 1: document title. 2: page title */
 					__(
 						'%1$s &lsaquo; %2$s &#8212; WooCommerce',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					documentTitle,
 					siteTitle

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/index.js
@@ -49,10 +49,7 @@ const renderEmptyCard = () => {
 					🎉
 				</span>
 				<H id="woocommerce-order-empty-message">
-					{ __(
-						'You’ve fulfilled all your orders',
-						'woocommerce-admin'
-					) }
+					{ __( 'You’ve fulfilled all your orders', 'woocommerce' ) }
 				</H>
 			</ActivityCard>
 			<Link
@@ -61,7 +58,7 @@ const renderEmptyCard = () => {
 				className="woocommerce-layout__activity-panel-outbound-link woocommerce-layout__activity-panel-empty"
 				type="wp-admin"
 			>
-				{ __( 'Manage all orders', 'woocommerce-admin' ) }
+				{ __( 'Manage all orders', 'woocommerce' ) }
 			</Link>
 		</>
 	);
@@ -104,7 +101,7 @@ function renderOrders( orders ) {
 					mixedString: sprintf(
 						__(
 							'{{orderLink}}Order #%(orderNumber)s{{/orderLink}} %(customerString)s',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						{
 							orderNumber,
@@ -178,7 +175,7 @@ function renderOrders( orders ) {
 									'%d product',
 									'%d products',
 									productsCount,
-									'woocommerce-admin'
+									'woocommerce'
 								),
 								productsCount
 							) }
@@ -203,7 +200,7 @@ function renderOrders( orders ) {
 				onClick={ () => recordOrderEvent( 'orders_manage' ) }
 				type="wp-admin"
 			>
-				{ __( 'Manage all orders', 'woocommerce-admin' ) }
+				{ __( 'Manage all orders', 'woocommerce' ) }
 			</Link>
 		</>
 	);
@@ -278,9 +275,9 @@ function OrdersPanel( { unreadOrdersCount, orderStatuses } ) {
 					title={ __(
 						"You currently don't have any actionable statuses. " +
 							'To display orders here, select orders that require further review in settings.',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
-					actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
+					actionLabel={ __( 'Settings', 'woocommerce' ) }
 					actionURL={ getAdminLink(
 						'admin.php?page=wc-admin&path=/analytics/settings'
 					) }
@@ -290,9 +287,9 @@ function OrdersPanel( { unreadOrdersCount, orderStatuses } ) {
 
 		const title = __(
 			'There was an error getting your orders. Please try again.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
-		const actionLabel = __( 'Reload', 'woocommerce-admin' );
+		const actionLabel = __( 'Reload', 'woocommerce' );
 		const actionCallback = () => {
 			// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 			window.location.reload();

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/panels.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/panels.js
@@ -38,7 +38,7 @@ export function getAllPanels( {
 					orderStatuses={ orderStatuses }
 				/>
 			),
-			title: __( 'Orders', 'woocommerce-admin' ),
+			title: __( 'Orders', 'woocommerce' ),
 		},
 		totalOrderCount > 0 &&
 			publishedProductCount > 0 &&
@@ -53,7 +53,7 @@ export function getAllPanels( {
 						lowStockProductsCount={ lowStockProductsCount }
 					/>
 				),
-				title: __( 'Stock', 'woocommerce-admin' ),
+				title: __( 'Stock', 'woocommerce' ),
 			},
 		publishedProductCount > 0 &&
 			unapprovedReviewsCount > 0 &&
@@ -68,7 +68,7 @@ export function getAllPanels( {
 						hasUnapprovedReviews={ unapprovedReviewsCount > 0 }
 					/>
 				),
-				title: __( 'Reviews', 'woocommerce-admin' ),
+				title: __( 'Reviews', 'woocommerce' ),
 			},
 		// Add another panel row here
 	].filter( Boolean );

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/index.js
@@ -61,14 +61,11 @@ class ReviewsPanel extends Component {
 					clearReviewsCache();
 					createNotice(
 						'success',
-						__(
-							'Review successfully deleted.',
-							'woocommerce-admin'
-						),
+						__( 'Review successfully deleted.', 'woocommerce' ),
 						{
 							actions: [
 								{
-									label: __( 'Undo', 'woocommerce-admin' ),
+									label: __( 'Undo', 'woocommerce' ),
 									onClick: () => {
 										updateReview(
 											reviewId,
@@ -88,10 +85,7 @@ class ReviewsPanel extends Component {
 				.catch( () => {
 					createNotice(
 						'error',
-						__(
-							'Review could not be deleted.',
-							'woocommerce-admin'
-						)
+						__( 'Review could not be deleted.', 'woocommerce' )
 					);
 				} );
 		}
@@ -105,14 +99,11 @@ class ReviewsPanel extends Component {
 					clearReviewsCache();
 					createNotice(
 						'success',
-						__(
-							'Review successfully updated.',
-							'woocommerce-admin'
-						),
+						__( 'Review successfully updated.', 'woocommerce' ),
 						{
 							actions: [
 								{
-									label: __( 'Undo', 'woocommerce-admin' ),
+									label: __( 'Undo', 'woocommerce' ),
 									onClick: () => {
 										updateReview(
 											reviewId,
@@ -132,10 +123,7 @@ class ReviewsPanel extends Component {
 				.catch( () => {
 					createNotice(
 						'error',
-						__(
-							'Review could not be updated.',
-							'woocommerce-admin'
-						)
+						__( 'Review could not be updated.', 'woocommerce' )
 					);
 				} );
 		}
@@ -168,7 +156,7 @@ class ReviewsPanel extends Component {
 			mixedString: sprintf(
 				__(
 					'{{authorLink}}%s{{/authorLink}}{{verifiedCustomerIcon/}} reviewed {{productLink}}%s{{/productLink}}',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				review.reviewer,
 				product.name
@@ -193,9 +181,7 @@ class ReviewsPanel extends Component {
 				),
 				verifiedCustomerIcon: review.verified ? (
 					<span className="woocommerce-review-activity-card__verified">
-						<Tooltip
-							text={ __( 'Verified owner', 'woocommerce-admin' ) }
-						>
+						<Tooltip text={ __( 'Verified owner', 'woocommerce' ) }>
 							<span>
 								<CheckmarkCircleIcon />
 							</span>
@@ -254,7 +240,7 @@ class ReviewsPanel extends Component {
 					);
 				} }
 			>
-				{ __( 'Approve', 'woocommerce-admin' ) }
+				{ __( 'Approve', 'woocommerce' ) }
 			</Button>,
 			<Button
 				key="spam-action"
@@ -264,7 +250,7 @@ class ReviewsPanel extends Component {
 					this.updateReviewStatus( review.id, 'spam', review.status );
 				} }
 			>
-				{ __( 'Mark as spam', 'woocommerce-admin' ) }
+				{ __( 'Mark as spam', 'woocommerce' ) }
 			</Button>,
 			<Button
 				key="delete-action"
@@ -275,7 +261,7 @@ class ReviewsPanel extends Component {
 					this.deleteReview( review.id );
 				} }
 			>
-				{ __( 'Delete', 'woocommerce-admin' ) }
+				{ __( 'Delete', 'woocommerce' ) }
 			</Button>,
 		];
 
@@ -314,7 +300,7 @@ class ReviewsPanel extends Component {
 					className="woocommerce-layout__activity-panel-outbound-link woocommerce-layout__activity-panel-empty"
 					type="wp-admin"
 				>
-					{ __( 'Manage all reviews', 'woocommerce-admin' ) }
+					{ __( 'Manage all reviews', 'woocommerce' ) }
 				</Link>
 			</>
 		);
@@ -326,9 +312,9 @@ class ReviewsPanel extends Component {
 		if ( isError ) {
 			const title = __(
 				'There was an error getting your reviews. Please try again.',
-				'woocommerce-admin'
+				'woocommerce'
 			);
-			const actionLabel = __( 'Reload', 'woocommerce-admin' );
+			const actionLabel = __( 'Reload', 'woocommerce' );
 			const actionCallback = () => {
 				// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 				window.location.reload();

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/card.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/card.js
@@ -93,13 +93,13 @@ export class ProductStockCard extends Component {
 				'success',
 				sprintf(
 					/* translators: %s = name of the product having stock updated */
-					__( '%s stock updated', 'woocommerce-admin' ),
+					__( '%s stock updated', 'woocommerce' ),
 					product.name
 				),
 				{
 					actions: [
 						{
-							label: __( 'Undo', 'woocommerce-admin' ),
+							label: __( 'Undo', 'woocommerce' ),
 							onClick: () => {
 								updateProductStock(
 									product,
@@ -117,7 +117,7 @@ export class ProductStockCard extends Component {
 				'error',
 				sprintf(
 					/* translators: %s = name of the product having stock updated */
-					__( '%s stock could not be updated', 'woocommerce-admin' ),
+					__( '%s stock could not be updated', 'woocommerce' ),
 					product.name
 				)
 			);
@@ -134,17 +134,17 @@ export class ProductStockCard extends Component {
 		if ( editing ) {
 			return [
 				<Button key="save" type="submit" isPrimary>
-					{ __( 'Save', 'woocommerce-admin' ) }
+					{ __( 'Save', 'woocommerce' ) }
 				</Button>,
 				<Button key="cancel" type="reset">
-					{ __( 'Cancel', 'woocommerce-admin' ) }
+					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>,
 			];
 		}
 
 		return [
 			<Button key="update" isSecondary onClick={ this.beginEdit }>
-				{ __( 'Update stock', 'woocommerce-admin' ) }
+				{ __( 'Update stock', 'woocommerce' ) }
 			</Button>,
 		];
 	}
@@ -168,7 +168,7 @@ export class ProductStockCard extends Component {
 							} }
 						/>
 					</BaseControl>
-					<span>{ __( 'in stock', 'woocommerce-admin' ) }</span>
+					<span>{ __( 'in stock', 'woocommerce' ) }</span>
 				</Fragment>
 			);
 		}
@@ -184,7 +184,7 @@ export class ProductStockCard extends Component {
 			>
 				{ sprintf(
 					/* translators: %d = stock quantity of the product being updated */
-					__( '%d in stock', 'woocommerce-admin' ),
+					__( '%d in stock', 'woocommerce' ),
 					product.stock_quantity
 				) }
 			</span>
@@ -205,7 +205,7 @@ export class ProductStockCard extends Component {
 		const lastOrderDate = product.last_order_date
 			? sprintf(
 					/* translators: %s = time since last product order. e.g.: "10 minutes ago" - translated. */
-					__( 'Last ordered %s', 'woocommerce-admin' ),
+					__( 'Last ordered %s', 'woocommerce' ),
 					moment.utc( product.last_order_date ).fromNow()
 			  )
 			: null;

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/index.js
@@ -90,9 +90,9 @@ export class StockPanel extends Component {
 		if ( isError ) {
 			const title = __(
 				'There was an error getting your low stock products. Please try again.',
-				'woocommerce-admin'
+				'woocommerce'
 			);
-			const actionLabel = __( 'Reload', 'woocommerce-admin' );
+			const actionLabel = __( 'Reload', 'woocommerce' );
 			const actionCallback = () => {
 				// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 				window.location.reload();

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -145,11 +145,11 @@ export const Layout = ( {
 								className="your-store-today"
 								title={ __(
 									'Your store today',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 								subtitle={ __(
 									"To do's, tips, and insights for your business",
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							/>
 						) }

--- a/plugins/woocommerce-admin/client/homescreen/stats-overview/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/stats-overview/index.js
@@ -67,7 +67,7 @@ export const StatsOverview = () => {
 
 	const HeaderText = (
 		<Text variant="title.small" size="20" lineHeight="28px">
-			{ __( 'Stats overview', 'woocommerce-admin' ) }
+			{ __( 'Stats overview', 'woocommerce' ) }
 		</Text>
 	);
 
@@ -86,12 +86,12 @@ export const StatsOverview = () => {
 				<EllipsisMenu
 					label={ __(
 						'Choose which values to display',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 					renderContent={ () => (
 						<Fragment>
 							<MenuTitle>
-								{ __( 'Display stats:', 'woocommerce-admin' ) }
+								{ __( 'Display stats:', 'woocommerce' ) }
 							</MenuTitle>
 							{ stats.map( ( item ) => {
 								const checked = ! hiddenStats.includes(
@@ -125,15 +125,15 @@ export const StatsOverview = () => {
 				} }
 				tabs={ [
 					{
-						title: __( 'Today', 'woocommerce-admin' ),
+						title: __( 'Today', 'woocommerce' ),
 						name: 'today',
 					},
 					{
-						title: __( 'Week to date', 'woocommerce-admin' ),
+						title: __( 'Week to date', 'woocommerce' ),
 						name: 'week',
 					},
 					{
-						title: __( 'Month to date', 'woocommerce-admin' ),
+						title: __( 'Month to date', 'woocommerce' ),
 						name: 'month',
 					},
 				] }
@@ -165,7 +165,7 @@ export const StatsOverview = () => {
 						} );
 					} }
 				>
-					{ __( 'View detailed stats', 'woocommerce-admin' ) }
+					{ __( 'View detailed stats', 'woocommerce' ) }
 				</Link>
 			</CardFooter>
 		</Card>

--- a/plugins/woocommerce-admin/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/plugins/woocommerce-admin/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -17,9 +17,9 @@ import { createErrorNotice } from '@woocommerce/data/src/plugins/actions';
 const getJetpackInstallText = ( jetpackInstallState ) => {
 	return (
 		{
-			unavailable: __( 'Get Jetpack', 'woocommerce-admin' ),
-			installed: __( 'Activate Jetpack', 'woocommerce-admin' ),
-			activated: __( 'Connect Jetpack', 'woocommerce-admin' ),
+			unavailable: __( 'Get Jetpack', 'woocommerce' ),
+			installed: __( 'Activate Jetpack', 'woocommerce' ),
+			activated: __( 'Connect Jetpack', 'woocommerce' ),
 		}[ jetpackInstallState ] || ''
 	);
 };
@@ -33,18 +33,13 @@ export const JetpackCTA = ( {
 	return (
 		<article className="woocommerce-stats-overview__install-jetpack-promo">
 			<div className="woocommerce-stats-overview__install-jetpack-promo__content">
-				<H>
-					{ __(
-						'Get traffic stats with Jetpack',
-						'woocommerce-admin'
-					) }
-				</H>
+				<H>{ __( 'Get traffic stats with Jetpack', 'woocommerce' ) }</H>
 				<p>
 					{ __(
 						'Keep an eye on your views and visitors metrics with ' +
 							'Jetpack. Requires Jetpack plugin and a WordPress.com ' +
 							'account.',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 			</div>
@@ -69,7 +64,7 @@ export const JetpackCTA = ( {
 					disabled={ isBusy }
 					isBusy={ isBusy }
 				>
-					{ __( 'No thanks', 'woocommerce-admin' ) }
+					{ __( 'No thanks', 'woocommerce' ) }
 				</Button>
 			</footer>
 		</article>

--- a/plugins/woocommerce-admin/client/homescreen/stats-overview/stats-list.js
+++ b/plugins/woocommerce-admin/client/homescreen/stats-overview/stats-list.js
@@ -72,10 +72,7 @@ export const StatsList = ( {
 						hrefType={ reportUrlType }
 						label={ item.label }
 						value={ primaryValue }
-						prevLabel={ __(
-							'Previous period:',
-							'woocommerce-admin'
-						) }
+						prevLabel={ __( 'Previous period:', 'woocommerce' ) }
 						prevValue={ secondaryValue }
 						delta={ delta }
 						onLinkClickCallback={ () => {

--- a/plugins/woocommerce-admin/client/homescreen/welcome-from-calypso-modal/welcome-from-calypso-modal.js
+++ b/plugins/woocommerce-admin/client/homescreen/welcome-from-calypso-modal/welcome-from-calypso-modal.js
@@ -22,12 +22,12 @@ const page = {
 		<PageContent
 			title={ __(
 				'Welcome to your new store management experience',
-				'woocommerce-admin'
+				'woocommerce'
 			) }
 			body={ interpolateComponents( {
 				mixedString: __(
 					"We've designed your navigation and home screen to help you focus on the things that matter most in managing your online store. {{link}}Learn more{{/link}} about these changes – or explore on your own.",
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				components: {
 					link: (
@@ -70,7 +70,7 @@ export default function WelcomeFromCalypsoModal( { onClose } ) {
 				recordEvent( 'welcome_from_calypso_modal_close' );
 			} }
 			className={ guideClassNames }
-			finishButtonText={ __( "Let's go", 'woocommerce-admin' ) }
+			finishButtonText={ __( "Let's go", 'woocommerce' ) }
 			pages={ [ page ] }
 		/>
 	);

--- a/plugins/woocommerce-admin/client/homescreen/welcome-modal/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/welcome-modal/index.js
@@ -22,11 +22,11 @@ const pages = [
 			<PageContent
 				title={ __(
 					'Welcome to your WooCommerce store’s online HQ!',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				body={ __(
 					"Here's where you’ll find setup suggestions, tips and tools, and key data on your store’s performance and earnings — all the basics for store management and growth.",
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			/>
 		),
@@ -37,11 +37,11 @@ const pages = [
 			<PageContent
 				title={ __(
 					'A personalized inbox full of relevant advice',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				body={ __(
 					'Check your inbox for helpful growth tips tailored to your store and notifications about key traffic and sales milestones. We look forward to celebrating them with you!',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			/>
 		),
@@ -52,11 +52,11 @@ const pages = [
 			<PageContent
 				title={ __(
 					'Good data leads to smart business decisions',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				body={ __(
 					'Monitor your stats to improve performance, increase sales, and track your progress toward revenue goals. The more you know, the better you can serve your customers and grow your store.',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			/>
 		),
@@ -80,7 +80,7 @@ export const WelcomeModal = ( { onClose } ) => {
 						recordEvent( 'task_list_welcome_modal_close' );
 					} }
 					className={ 'woocommerce__welcome-modal' }
-					finishButtonText={ __( "Let's go", 'woocommerce-admin' ) }
+					finishButtonText={ __( "Let's go", 'woocommerce' ) }
 					pages={ pages }
 				/>
 			) }

--- a/plugins/woocommerce-admin/client/inbox-panel/dismiss-all-modal.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/dismiss-all-modal.js
@@ -22,11 +22,11 @@ const DismissAllModal = ( { onClose } ) => {
 			} );
 			createNotice(
 				'success',
-				__( 'All messages dismissed', 'woocommerce-admin' ),
+				__( 'All messages dismissed', 'woocommerce' ),
 				{
 					actions: [
 						{
-							label: __( 'Undo', 'woocommerce-admin' ),
+							label: __( 'Undo', 'woocommerce' ),
 							onClick: () => {
 								batchUpdateNotes(
 									notesRemoved.map( ( note ) => note.id ),
@@ -42,7 +42,7 @@ const DismissAllModal = ( { onClose } ) => {
 		} catch ( e ) {
 			createNotice(
 				'error',
-				__( 'Messages could not be dismissed', 'woocommerce-admin' )
+				__( 'Messages could not be dismissed', 'woocommerce' )
 			);
 			onClose();
 		}
@@ -50,7 +50,7 @@ const DismissAllModal = ( { onClose } ) => {
 	return (
 		<>
 			<Modal
-				title={ __( 'Dismiss all messages', 'woocommerce-admin' ) }
+				title={ __( 'Dismiss all messages', 'woocommerce' ) }
 				className="woocommerce-inbox-dismiss-all-modal"
 				onRequestClose={ onClose }
 			>
@@ -58,12 +58,12 @@ const DismissAllModal = ( { onClose } ) => {
 					<div className="woocommerce-usage-modal__message">
 						{ __(
 							'Are you sure? Inbox messages will be dismissed forever.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</div>
 					<div className="woocommerce-usage-modal__actions">
 						<Button onClick={ onClose }>
-							{ __( 'Cancel', 'woocommerce-admin' ) }
+							{ __( 'Cancel', 'woocommerce' ) }
 						</Button>
 						<Button
 							isPrimary
@@ -72,7 +72,7 @@ const DismissAllModal = ( { onClose } ) => {
 								onClose();
 							} }
 						>
-							{ __( 'Yes, dismiss all', 'woocommerce-admin' ) }
+							{ __( 'Yes, dismiss all', 'woocommerce' ) }
 						</Button>
 					</div>
 				</div>

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -33,13 +33,13 @@ import './index.scss';
 const renderEmptyCard = () => (
 	<ActivityCard
 		className="woocommerce-empty-activity-card"
-		title={ __( 'Your inbox is empty', 'woocommerce-admin' ) }
+		title={ __( 'Your inbox is empty', 'woocommerce' ) }
 		icon={ false }
 	>
 		{ __(
 			'As things begin to happen in your store your inbox will start to fill up. ' +
 				"You'll see things like achievements, new feature announcements, extension recommendations and more!",
-			'woocommerce-admin'
+			'woocommerce'
 		) }
 	</ActivityCard>
 );
@@ -97,15 +97,12 @@ const renderNotes = ( {
 				<CardHeader size="medium">
 					<div className="wooocommerce-inbox-card__header">
 						<Text size="20" lineHeight="28px" variant="title.small">
-							{ __( 'Inbox', 'woocommerce-admin' ) }
+							{ __( 'Inbox', 'woocommerce' ) }
 						</Text>
 						<Badge count={ notesArray.length } />
 					</div>
 					<EllipsisMenu
-						label={ __(
-							'Inbox Notes Options',
-							'woocommerce-admin'
-						) }
+						label={ __( 'Inbox Notes Options', 'woocommerce' ) }
 						renderContent={ ( { onToggle } ) => (
 							<div className="woocommerce-inbox-card__section-controls">
 								<Button
@@ -114,7 +111,7 @@ const renderNotes = ( {
 										onToggle();
 									} }
 								>
-									{ __( 'Dismiss all', 'woocommerce-admin' ) }
+									{ __( 'Dismiss all', 'woocommerce' ) }
 								</Button>
 							</div>
 						) }
@@ -247,22 +244,18 @@ const InboxPanel = ( { showHeader = true } ) => {
 		const noteId = note.id;
 		try {
 			removeNote( noteId );
-			createNotice(
-				'success',
-				__( 'Message dismissed', 'woocommerce-admin' ),
-				{
-					actions: [
-						{
-							label: __( 'Undo', 'woocommerce-admin' ),
-							onClick: () => {
-								updateNote( noteId, {
-									is_deleted: 0,
-								} );
-							},
+			createNotice( 'success', __( 'Message dismissed', 'woocommerce' ), {
+				actions: [
+					{
+						label: __( 'Undo', 'woocommerce' ),
+						onClick: () => {
+							updateNote( noteId, {
+								is_deleted: 0,
+							} );
 						},
-					],
-				}
-			);
+					},
+				],
+			} );
 		} catch ( e ) {
 			createNotice(
 				'error',
@@ -270,7 +263,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 					'Message could not be dismissed',
 					'Messages could not be dismissed',
 					1,
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}
@@ -279,9 +272,9 @@ const InboxPanel = ( { showHeader = true } ) => {
 	if ( isError ) {
 		const title = __(
 			'There was an error getting your inbox. Please try again.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
-		const actionLabel = __( 'Reload', 'woocommerce-admin' );
+		const actionLabel = __( 'Reload', 'woocommerce' );
 		const actionCallback = () => {
 			// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
 			window.location.reload();

--- a/plugins/woocommerce-admin/client/layout/NoMatch.tsx
+++ b/plugins/woocommerce-admin/client/layout/NoMatch.tsx
@@ -13,7 +13,7 @@ const NoMatch: React.FC = () => {
 					<Text>
 						{ __(
 							'Sorry, you are not allowed to access this page.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 				</CardBody>

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -67,10 +67,7 @@ export const getPages = () => {
 	pages.push( {
 		container: Homescreen,
 		path: '/',
-		breadcrumbs: [
-			...initialBreadcrumbs,
-			__( 'Home', 'woocommerce-admin' ),
-		],
+		breadcrumbs: [ ...initialBreadcrumbs, __( 'Home', 'woocommerce' ) ],
 		wpOpenMenu: 'toplevel_page_woocommerce',
 		navArgs: {
 			id: 'woocommerce-home',
@@ -84,11 +81,8 @@ export const getPages = () => {
 			path: '/analytics/overview',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[
-					'/analytics/overview',
-					__( 'Analytics', 'woocommerce-admin' ),
-				],
-				__( 'Overview', 'woocommerce-admin' ),
+				[ '/analytics/overview', __( 'Analytics', 'woocommerce' ) ],
+				__( 'Overview', 'woocommerce' ),
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 			navArgs: {
@@ -101,11 +95,8 @@ export const getPages = () => {
 			path: '/analytics/settings',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[
-					'/analytics/revenue',
-					__( 'Analytics', 'woocommerce-admin' ),
-				],
-				__( 'Settings', 'woocommerce-admin' ),
+				[ '/analytics/revenue', __( 'Analytics', 'woocommerce' ) ],
+				__( 'Settings', 'woocommerce' ),
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 			navArgs: {
@@ -118,7 +109,7 @@ export const getPages = () => {
 			path: '/customers',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				__( 'Customers', 'woocommerce-admin' ),
+				__( 'Customers', 'woocommerce' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 			navArgs: {
@@ -138,10 +129,7 @@ export const getPages = () => {
 				}
 				return [
 					...initialBreadcrumbs,
-					[
-						'/analytics/revenue',
-						__( 'Analytics', 'woocommerce-admin' ),
-					],
+					[ '/analytics/revenue', __( 'Analytics', 'woocommerce' ) ],
 					report.title,
 				];
 			},
@@ -156,8 +144,8 @@ export const getPages = () => {
 			path: '/marketing',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				[ '/marketing', __( 'Marketing', 'woocommerce-admin' ) ],
-				__( 'Overview', 'woocommerce-admin' ),
+				[ '/marketing', __( 'Marketing', 'woocommerce' ) ],
+				__( 'Overview', 'woocommerce' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 			navArgs: {
@@ -173,7 +161,7 @@ export const getPages = () => {
 			path: '/setup-wizard',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				__( 'Setup Wizard', 'woocommerce-admin' ),
+				__( 'Setup Wizard', 'woocommerce' ),
 			],
 			capability: 'manage_woocommerce',
 		} );
@@ -198,7 +186,7 @@ export const getPages = () => {
 							: `/settings/${
 									Object.keys( settingsPages )[ 0 ]
 							  }`,
-						__( 'Settings', 'woocommerce-admin' ),
+						__( 'Settings', 'woocommerce' ),
 					],
 					page,
 				];
@@ -215,9 +203,9 @@ export const getPages = () => {
 			breadcrumbs: [
 				[
 					'/wc-pay-welcome-page',
-					__( 'WooCommerce Payments', 'woocommerce-admin' ),
+					__( 'WooCommerce Payments', 'woocommerce' ),
 				],
-				__( 'WooCommerce Payments', 'woocommerce-admin' ),
+				__( 'WooCommerce Payments', 'woocommerce' ),
 			],
 			navArgs: {
 				id: 'woocommerce-wc-pay-welcome-page',
@@ -240,7 +228,7 @@ export const getPages = () => {
 		path: '*',
 		breadcrumbs: [
 			...initialBreadcrumbs,
-			__( 'Not allowed', 'woocommerce-admin' ),
+			__( 'Not allowed', 'woocommerce' ),
 		],
 		wpOpenMenu: 'toplevel_page_woocommerce',
 	} );

--- a/plugins/woocommerce-admin/client/layout/navigation.js
+++ b/plugins/woocommerce-admin/client/layout/navigation.js
@@ -53,7 +53,7 @@ const NavigationPlugin = () => {
 			if ( page.path === '/analytics/settings' ) {
 				return {
 					...page,
-					breadcrumbs: [ __( 'Analytics', 'woocommerce-admin' ) ],
+					breadcrumbs: [ __( 'Analytics', 'woocommerce' ) ],
 				};
 			}
 			return page;

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -85,7 +85,7 @@ export class StoreAlerts extends Component {
 		const snoozeOptions = [
 			{
 				value: moment().add( 4, 'hours' ).unix().toString(),
-				label: __( 'Later Today', 'woocommerce-admin' ),
+				label: __( 'Later Today', 'woocommerce' ),
 			},
 			{
 				value: moment()
@@ -96,7 +96,7 @@ export class StoreAlerts extends Component {
 					.millisecond( 0 )
 					.unix()
 					.toString(),
-				label: __( 'Tomorrow', 'woocommerce-admin' ),
+				label: __( 'Tomorrow', 'woocommerce' ),
 			},
 			{
 				value: moment()
@@ -107,7 +107,7 @@ export class StoreAlerts extends Component {
 					.millisecond( 0 )
 					.unix()
 					.toString(),
-				label: __( 'Next Week', 'woocommerce-admin' ),
+				label: __( 'Next Week', 'woocommerce' ),
 			},
 			{
 				value: moment()
@@ -118,7 +118,7 @@ export class StoreAlerts extends Component {
 					.millisecond( 0 )
 					.unix()
 					.toString(),
-				label: __( 'Next Month', 'woocommerce-admin' ),
+				label: __( 'Next Month', 'woocommerce' ),
 			},
 		];
 
@@ -142,7 +142,7 @@ export class StoreAlerts extends Component {
 				className="woocommerce-store-alerts__snooze"
 				options={ [
 					{
-						label: __( 'Remind Me Later', 'woocommerce-admin' ),
+						label: __( 'Remind Me Later', 'woocommerce' ),
 						value: '0',
 					},
 					...snoozeOptions,
@@ -221,10 +221,7 @@ export class StoreAlerts extends Component {
 							<Button
 								onClick={ this.previousAlert }
 								disabled={ currentIndex === 0 }
-								label={ __(
-									'Previous Alert',
-									'woocommerce-admin'
-								) }
+								label={ __( 'Previous Alert', 'woocommerce' ) }
 							>
 								<Icon
 									icon={ chevronLeft }
@@ -239,7 +236,7 @@ export class StoreAlerts extends Component {
 								{ interpolateComponents( {
 									mixedString: __(
 										'{{current /}} of {{total /}}',
-										'woocommerce-admin'
+										'woocommerce'
 									),
 									components: {
 										current: (
@@ -258,10 +255,7 @@ export class StoreAlerts extends Component {
 							<Button
 								onClick={ this.nextAlert }
 								disabled={ numberOfAlerts - 1 === currentIndex }
-								label={ __(
-									'Next Alert',
-									'woocommerce-admin'
-								) }
+								label={ __( 'Next Alert', 'woocommerce' ) }
 							>
 								<Icon
 									icon={ chevronRight }

--- a/plugins/woocommerce-admin/client/marketing/components/button/README.md
+++ b/plugins/woocommerce-admin/client/marketing/components/button/README.md
@@ -11,7 +11,7 @@ This component creates simple reusable html `<button></button>` element.
 	onClick={ this.onActivateClick }
 	disabled={ isLoading }
 >
-	{ __( 'Activate', 'woocommerce-admin' ) }
+	{ __( 'Activate', 'woocommerce' ) }
 </Button>
 ```
 

--- a/plugins/woocommerce-admin/client/marketing/components/knowledge-base/ReadBlogMessage.js
+++ b/plugins/woocommerce-admin/client/marketing/components/knowledge-base/ReadBlogMessage.js
@@ -9,7 +9,7 @@ const ReadBlogMessage = () => {
 	return interpolateComponents( {
 		mixedString: __(
 			'Read {{link}}the WooCommerce blog{{/link}} for more tips on marketing your store',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		components: {
 			link: (

--- a/plugins/woocommerce-admin/client/marketing/components/knowledge-base/index.js
+++ b/plugins/woocommerce-admin/client/marketing/components/knowledge-base/index.js
@@ -89,7 +89,7 @@ const KnowledgeBase = ( {
 					<div className="woocommerce-marketing-knowledgebase-card__post-text">
 						<h3>{ post.title }</h3>
 						<p className="woocommerce-marketing-knowledgebase-card__post-meta">
-							{ __( 'By', 'woocommerce-admin' ) + ' ' }
+							{ __( 'By', 'woocommerce' ) + ' ' }
 							{ post.author_name }
 							{ post.author_avatar && (
 								<img
@@ -113,7 +113,7 @@ const KnowledgeBase = ( {
 	};
 
 	const renderEmpty = () => {
-		const emptyTitle = __( 'No posts yet', 'woocommerce-admin' );
+		const emptyTitle = __( 'No posts yet', 'woocommerce' );
 
 		return (
 			<EmptyContent
@@ -128,7 +128,7 @@ const KnowledgeBase = ( {
 	const renderError = () => {
 		const errorTitle = __(
 			"Oops, our posts aren't loading right now",
-			'woocommerce-admin'
+			'woocommerce'
 		);
 
 		return (
@@ -228,10 +228,10 @@ KnowledgeBase.propTypes = {
 };
 
 KnowledgeBase.defaultProps = {
-	title: __( 'WooCommerce knowledge base', 'woocommerce-admin' ),
+	title: __( 'WooCommerce knowledge base', 'woocommerce' ),
 	description: __(
 		'Learn the ins and outs of successful marketing from the experts at WooCommerce.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 };
 

--- a/plugins/woocommerce-admin/client/marketing/components/recommended-extensions/index.js
+++ b/plugins/woocommerce-admin/client/marketing/components/recommended-extensions/index.js
@@ -96,10 +96,10 @@ RecommendedExtensions.propTypes = {
 };
 
 RecommendedExtensions.defaultProps = {
-	title: __( 'Recommended extensions', 'woocommerce-admin' ),
+	title: __( 'Recommended extensions', 'woocommerce' ),
 	description: __(
 		'Great marketing requires the right tools. Take your marketing to the next level with our recommended marketing extensions.',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 };
 

--- a/plugins/woocommerce-admin/client/marketing/coupons/index.js
+++ b/plugins/woocommerce-admin/client/marketing/coupons/index.js
@@ -26,11 +26,11 @@ const CouponsOverview = () => {
 				<RecommendedExtensions
 					title={ __(
 						'Recommended coupon extensions',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 					description={ __(
 						'Take your coupon marketing to the next level with our recommended coupon extensions.',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 					category="coupons"
 				/>
@@ -39,7 +39,7 @@ const CouponsOverview = () => {
 				category="coupons"
 				description={ __(
 					'Learn the ins and outs of successful coupon marketing from the experts at WooCommerce.',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			/>
 		</div>

--- a/plugins/woocommerce-admin/client/marketing/data/actions.js
+++ b/plugins/woocommerce-admin/client/marketing/data/actions.js
@@ -80,7 +80,7 @@ export function* activateInstalledPlugin( pluginSlug ) {
 				'success',
 				__(
 					'The extension has been successfully activated.',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 			// Deliberately load the new plugin data in a new request.
@@ -93,7 +93,7 @@ export function* activateInstalledPlugin( pluginSlug ) {
 			error,
 			__(
 				'There was an error trying to activate the extension.',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 		yield removeActivatingPlugin( pluginSlug );
@@ -119,7 +119,7 @@ export function* loadInstalledPluginsAfterActivation( activatedPluginSlug ) {
 			error,
 			__(
 				'There was an error loading installed extensions.',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 	}

--- a/plugins/woocommerce-admin/client/marketing/data/resolvers.js
+++ b/plugins/woocommerce-admin/client/marketing/data/resolvers.js
@@ -32,7 +32,7 @@ export function* getRecommendedPlugins( category ) {
 			error,
 			__(
 				'There was an error loading recommended extensions.',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 	}

--- a/plugins/woocommerce-admin/client/marketing/overview/installed-extensions/index.js
+++ b/plugins/woocommerce-admin/client/marketing/overview/installed-extensions/index.js
@@ -34,10 +34,7 @@ class InstalledExtensions extends Component {
 			return null;
 		}
 
-		const title = __(
-			'Installed marketing extensions',
-			'woocommerce-admin'
-		);
+		const title = __( 'Installed marketing extensions', 'woocommerce' );
 
 		return (
 			<Card className="woocommerce-marketing-installed-extensions-card">

--- a/plugins/woocommerce-admin/client/marketing/overview/installed-extensions/row.js
+++ b/plugins/woocommerce-admin/client/marketing/overview/installed-extensions/row.js
@@ -28,28 +28,28 @@ class InstalledExtensionRow extends Component {
 			links.push( {
 				key: 'docs',
 				href: docsUrl,
-				text: __( 'Docs', 'woocommerce-admin' ),
+				text: __( 'Docs', 'woocommerce' ),
 			} );
 		}
 		if ( supportUrl ) {
 			links.push( {
 				key: 'support',
 				href: supportUrl,
-				text: __( 'Get support', 'woocommerce-admin' ),
+				text: __( 'Get support', 'woocommerce' ),
 			} );
 		}
 		if ( settingsUrl ) {
 			links.push( {
 				key: 'settings',
 				href: settingsUrl,
-				text: __( 'Settings', 'woocommerce-admin' ),
+				text: __( 'Settings', 'woocommerce' ),
 			} );
 		}
 		if ( dashboardUrl ) {
 			links.push( {
 				key: 'dashboard',
 				href: dashboardUrl,
-				text: __( 'Dashboard', 'woocommerce-admin' ),
+				text: __( 'Dashboard', 'woocommerce' ),
 			} );
 		}
 
@@ -97,7 +97,7 @@ class InstalledExtensionRow extends Component {
 				onClick={ this.onActivateClick }
 				disabled={ isLoading }
 			>
-				{ __( 'Activate', 'woocommerce-admin' ) }
+				{ __( 'Activate', 'woocommerce' ) }
 			</Button>
 		);
 	}
@@ -109,7 +109,7 @@ class InstalledExtensionRow extends Component {
 				href={ this.props.settingsUrl }
 				onClick={ this.onFinishSetupClick }
 			>
-				{ __( 'Finish setup', 'woocommerce-admin' ) }
+				{ __( 'Finish setup', 'woocommerce' ) }
 			</Button>
 		);
 	}

--- a/plugins/woocommerce-admin/client/marketing/overview/welcome-card/index.js
+++ b/plugins/woocommerce-admin/client/marketing/overview/welcome-card/index.js
@@ -32,7 +32,7 @@ const WelcomeCard = ( { isHidden, updateOptions } ) => {
 		<Card className="woocommerce-marketing-overview-welcome-card">
 			<CardBody>
 				<Button
-					label={ __( 'Hide', 'woocommerce-admin' ) }
+					label={ __( 'Hide', 'woocommerce' ) }
 					onClick={ hide }
 					className="woocommerce-marketing-overview-welcome-card__hide-button"
 				>
@@ -42,7 +42,7 @@ const WelcomeCard = ( { isHidden, updateOptions } ) => {
 				<h3>
 					{ __(
 						'Grow your customer base and increase your sales with marketing tools built for WooCommerce',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</h3>
 			</CardBody>

--- a/plugins/woocommerce-admin/client/mobile-banner/banner.js
+++ b/plugins/woocommerce-admin/client/mobile-banner/banner.js
@@ -60,16 +60,10 @@ export const Banner = ( { onInstall, onDismiss } ) => {
 			<AppIcon />
 			<div className="woocommerce-mobile-app-banner__description">
 				<p className="woocommerce-mobile-app-banner__description__text">
-					{ __(
-						'Run your store from anywhere',
-						'woocommerce-admin'
-					) }
+					{ __( 'Run your store from anywhere', 'woocommerce' ) }
 				</p>
 				<p className="woocommerce-mobile-app-banner__description__text">
-					{ __(
-						'Download the WooCommerce app',
-						'woocommerce-admin'
-					) }
+					{ __( 'Download the WooCommerce app', 'woocommerce' ) }
 				</p>
 			</div>
 
@@ -84,7 +78,7 @@ export const Banner = ( { onInstall, onDismiss } ) => {
 					} );
 				} }
 			>
-				{ __( 'Install', 'woocommerce-admin' ) }
+				{ __( 'Install', 'woocommerce' ) }
 			</Button>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/navigation/components/container/primary-menu.js
+++ b/plugins/woocommerce-admin/client/navigation/components/container/primary-menu.js
@@ -29,7 +29,7 @@ export const PrimaryMenu = ( {
 	 */
 	const rootBackLabel = applyFilters(
 		'woocommerce_navigation_root_back_label',
-		__( 'WordPress Dashboard', 'woocommerce-admin' )
+		__( 'WordPress Dashboard', 'woocommerce' )
 	);
 
 	/**
@@ -75,7 +75,7 @@ export const PrimaryMenu = ( {
 				<NavigationGroup
 					title={
 						category.id === 'woocommerce'
-							? __( 'Extensions', 'woocommerce-admin' )
+							? __( 'Extensions', 'woocommerce' )
 							: null
 					}
 				>

--- a/plugins/woocommerce-admin/client/navigation/components/favorite-button/index.js
+++ b/plugins/woocommerce-admin/client/navigation/components/favorite-button/index.js
@@ -50,13 +50,10 @@ export const FavoriteButton = ( { id } ) => {
 			onClick={ toggleFavorite }
 			aria-label={
 				isFavorited
-					? __(
-							'Add this item to your favorites.',
-							'woocommerce-admin'
-					  )
+					? __( 'Add this item to your favorites.', 'woocommerce' )
 					: __(
 							'Remove this item from your favorites.',
-							'woocommerce-admin'
+							'woocommerce'
 					  )
 			}
 		>

--- a/plugins/woocommerce-admin/client/navigation/components/favorites-tooltip/index.js
+++ b/plugins/woocommerce-admin/client/navigation/components/favorites-tooltip/index.js
@@ -43,12 +43,12 @@ export const FavoritesTooltip = () => {
 	return (
 		<HighlightTooltip
 			delay={ 1000 }
-			title={ __( 'Introducing favorites', 'woocommerce-admin' ) }
+			title={ __( 'Introducing favorites', 'woocommerce' ) }
 			content={ __(
 				'You can now favorite your extensions to pin them in the top level of the navigation.',
-				'woocommerce-admin'
+				'woocommerce'
 			) }
-			closeButtonText={ __( 'Got it', 'woocommerce-admin' ) }
+			closeButtonText={ __( 'Got it', 'woocommerce' ) }
 			id="woocommerce-navigation-favorite-button"
 			onClose={ () =>
 				updateOptions( {

--- a/plugins/woocommerce-admin/client/navigation/components/intro-modal/index.js
+++ b/plugins/woocommerce-admin/client/navigation/components/intro-modal/index.js
@@ -107,32 +107,29 @@ export const IntroModal = () => {
 			onFinish={ dismissModal }
 			pages={ [
 				getPage(
-					__(
-						'A new navigation for WooCommerce',
-						'woocommerce-admin'
-					),
+					__( 'A new navigation for WooCommerce', 'woocommerce' ),
 					__(
 						'All of your store management features in one place',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					NavInto1
 				),
 				getPage(
-					__( 'Focus on managing your store', 'woocommerce-admin' ),
+					__( 'Focus on managing your store', 'woocommerce' ),
 					__(
 						'Give your attention to key areas of WooCommerce with little distraction',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					NavInto2
 				),
 				getPage(
 					__(
 						'Easily find and favorite your extensions',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					__(
 						"They'll appear in the top level of the navigation for quick access",
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					NavInto3
 				),

--- a/plugins/woocommerce-admin/client/payments-welcome/strings.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/strings.tsx
@@ -6,42 +6,36 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 
 export default {
-	button: __( 'Install', 'woocommerce-admin' ),
-	nothanks: __( 'No thanks', 'woocommerce-admin' ),
-	limitedTimeOffer: __( 'Limited time offer', 'woocommerce-admin' ),
-	heading: __( 'WooCommerce Payments', 'woocommerce-admin' ),
-	bannerHeading: __(
-		'Save big with WooCommerce Payments',
-		'woocommerce-admin'
-	),
+	button: __( 'Install', 'woocommerce' ),
+	nothanks: __( 'No thanks', 'woocommerce' ),
+	limitedTimeOffer: __( 'Limited time offer', 'woocommerce' ),
+	heading: __( 'WooCommerce Payments', 'woocommerce' ),
+	bannerHeading: __( 'Save big with WooCommerce Payments', 'woocommerce' ),
 	bannerCopy: __(
 		'No card transaction fees for up to 3 months (or $25,000 in payments)',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 	discountCopy: __(
 		'Discount will be applied upon install and completed setup of WooCommerce Payments',
-		'woocommerce-admin'
+		'woocommerce'
 	),
-	learnMore: __( 'Learn more', 'woocommerce-admin' ),
+	learnMore: __( 'Learn more', 'woocommerce' ),
 
 	onboarding: {
 		description: __(
 			"Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store's dashboard - with no setup costs or monthly fees.",
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 
-	paymentMethodsHeading: __(
-		'Accepted payment methods',
-		'woocommerce-admin'
-	),
-	surveyTitle: __( 'Remove WooCommerce Payments', 'woocommerce-admin' ),
+	paymentMethodsHeading: __( 'Accepted payment methods', 'woocommerce' ),
+	surveyTitle: __( 'Remove WooCommerce Payments', 'woocommerce' ),
 
 	surveyIntro: createInterpolateElement(
 		// Note: \xa0 is used to create a non-breaking space.
 		__(
 			'Please take a moment to tell us why you’d like to remove WooCommerce Payments. This will remove WooCommerce\xa0Payments from the navigation. You can enable it again in <strong>WooCommerce\xa0Settings\xa0>\xa0Payments</strong>, however the promotion will not apply.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		{
 			strong: <strong />,
@@ -50,47 +44,44 @@ export default {
 
 	surveyQuestion: __(
 		'What made you disable the new payments experience?',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 
 	surveyHappyLabel: __(
 		'I’m already happy with my payments setup',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 
 	surveyInstallLabel: __(
 		'I don’t want to install another plugin',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 
 	surveyMoreInfoLabel: __(
 		'I need more information about WooCommerce Payments',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 
 	surveyAnotherTimeLabel: __(
 		'I’m open to installing it another time',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 
 	surveySomethingElseLabel: __(
 		'It’s something else (Please share below)',
-		'woocommerce-admin'
+		'woocommerce'
 	),
 
-	surveyCommentsLabel: __( 'Comments (Optional)', 'woocommerce-admin' ),
+	surveyCommentsLabel: __( 'Comments (Optional)', 'woocommerce' ),
 
-	surveyCancelButton: __(
-		'Just remove WooCommerce Payments',
-		'woocommerce-admin'
-	),
+	surveyCancelButton: __( 'Just remove WooCommerce Payments', 'woocommerce' ),
 
-	surveySubmitButton: __( 'Remove and send feedback', 'woocommerce-admin' ),
+	surveySubmitButton: __( 'Remove and send feedback', 'woocommerce' ),
 
 	terms: createInterpolateElement(
 		__(
 			'By clicking "Install", you agree to the <a>Terms of Service</a>',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		{
 			a: (
@@ -105,83 +96,83 @@ export default {
 	),
 
 	faq: {
-		faqHeader: __( 'Frequently asked questions', 'woocommerce-admin' ),
+		faqHeader: __( 'Frequently asked questions', 'woocommerce' ),
 
-		question1: __( 'What is WooCommerce Payments?', 'woocommerce-admin' ),
+		question1: __( 'What is WooCommerce Payments?', 'woocommerce' ),
 
 		question1Answer1: __(
 			'WooCommerce Payments is an integrated payment solution, built by WooCommerce, for WooCommerce. Use WooCommerce Payments to manage your payments, track cash flow, and manage revenue from your dashboard.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question1Answer2: __(
 			'You can securely accept credit and debit card payments, Apple Pay, bank transfers, recurring revenue, accelerated checkout, and more - in over 100+ currencies with WooCommerce Payments.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question2: __(
 			'Can I use WooCommerce Payments alongside other payment gateways?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question2Answer1: __(
 			'Yes. WooCommerce Payments works alongside other payment service providers, including Stripe, PayPal, and all others. We’ve built it with this flexibility in mind so that you can ensure your store is working to meet your business needs.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question3: __(
 			'Why should I choose WCPay over other payment gateways?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question3Answer1: __(
 			"Native dashboard: track cash flow from the same WordPress dashboard you're already using to manage product catalogue, inventory, orders, fulfilment, and otherwise run your online storefront.",
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question3Answer2: __(
 			'In-person payments: the only payment method that helps you sell online and offline with the official WooCommerce mobile app instead of a paid POS solution.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question3Answer3: __(
 			'Subscription functionality: offer customers a recurring option for your inventory without purchasing an additional extension.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question3Answer4: __(
 			'Native multi-currency: increase sales by making it easier for customers outside your country to purchase from your store, without an extension.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question4: __(
 			'How will I save money using WooCommerce Payments?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		// eslint-disable-next-line @wordpress/i18n-translator-comments
 		question4Answer1: __(
 			'Stores accepted into the promotional program will receive a 100% discount on transaction fees (excluding currency conversion fees) for the first $25,000 in payments, or 3 months, whichever comes first. Simply install the extension and if eligible you’ll be entered into the promotional offer.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question4Answer2: __(
 			'To be eligible for this promotional offer, your store must: (1) meet the WooCommerce Payments usage requirements; (2) be a U.S.-based business; (3) not have processed payments through WooCommerce Payments before; and (4) be accepted into the promotional program.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question5: __(
 			'What are the fees for WooCommerce Payments?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question5Answer1: __(
 			'WooCommerce Payments uses a pay-as-you-go pricing model. You pay only for activity on the account. No setup fee or monthly fee. Fees differ based on the country of your account and country of your customer’s card.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question5Answer2: createInterpolateElement(
-			__( '<a>View all fees</a>', 'woocommerce-admin' ),
+			__( '<a>View all fees</a>', 'woocommerce' ),
 			{
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -198,7 +189,7 @@ export default {
 			// eslint-disable-next-line @wordpress/i18n-translator-comments
 			__(
 				'1.5% fee on the payout amount for <a>instant deposits</a>',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -213,7 +204,7 @@ export default {
 		),
 
 		question5Answer8: createInterpolateElement(
-			__( '<a>View all fees</a>', 'woocommerce-admin' ),
+			__( '<a>View all fees</a>', 'woocommerce' ),
 			{
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -228,13 +219,13 @@ export default {
 
 		question6: __(
 			'When will I receive deposits for my WooCommerce Payments account balance?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question6Answer1: createInterpolateElement(
 			__(
 				'For most accounts, <a>WooCommerce Payments</a> automatically pays out your available account balance into your nominated account daily after a standard pending period.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -250,21 +241,21 @@ export default {
 
 		question6Answer2: __(
 			'Payments received each day become part of the pending balance. That pending balance will become available after a pending period. On the day it becomes available, it will be automatically paid out to your bank account. The pending period is based on the country of the account.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question6Answer3: __(
 			'For example, a business based in New Zealand has a pending period of 4 business days. Payments made to this account on Wednesday will be paid out on the next Tuesday.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question6Answer4: __(
 			'Most banks will reflect the deposit in your account as soon as they receive the transfer from WooCommerce Payments. Some may take a few extra days to make the balance available to you.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question6Answer5: createInterpolateElement(
-			__( '<a>All deposits details</a>', 'woocommerce-admin' ),
+			__( '<a>All deposits details</a>', 'woocommerce' ),
 			{
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -279,51 +270,48 @@ export default {
 
 		question7: __(
 			'What products are not permitted on my store when accepting payments with WooCommerce Payments?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question7Answer1: __(
 			'Due to restrictions from card networks, our payment service providers, and their financial service providers, some businesses and product types that are not allowed to transact using WooCommerce Payments, including but not limited to:',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question7Answer2: __(
 			'Virtual currency, including video game or virtual world credits',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
-		question7Answer3: __( 'Counterfeit goods', 'woocommerce-admin' ),
+		question7Answer3: __( 'Counterfeit goods', 'woocommerce' ),
 
-		question7Answer4: __(
-			'Adult content and services',
-			'woocommerce-admin'
-		),
+		question7Answer4: __( 'Adult content and services', 'woocommerce' ),
 
 		question7Answer5: __(
 			'Drug paraphernalia (including e-cigarette, vapes and nutraceuticals)',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
-		question7Answer6: __( 'Multi-level marketing', 'woocommerce-admin' ),
+		question7Answer6: __( 'Multi-level marketing', 'woocommerce' ),
 
-		question7Answer7: __( 'Pseudo pharmaceuticals', 'woocommerce-admin' ),
+		question7Answer7: __( 'Pseudo pharmaceuticals', 'woocommerce' ),
 
 		question7Answer8: __(
 			'Social media activity, like Twitter followers, Facebook likes, YouTube views',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question7Answer9: __(
 			'Substances designed to mimic illegal drugs',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
-		question7Answer10: __( 'Firearms, ammunition', 'woocommerce-admin' ),
+		question7Answer10: __( 'Firearms, ammunition', 'woocommerce' ),
 
 		question7Answer11: createInterpolateElement(
 			__(
 				'The full list of these businesses can be found in <a>Stripe’s Restricted Businesses list</a>.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -339,23 +327,23 @@ export default {
 
 		question7Answer12: __(
 			'By signing up to use WooCommerce Payments, you agree not to accept payments in connection with these restricted activities, practices or products. We also work to ensure that no prohibited activity is conducted on WooCommerce Payments.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question7Answer13: __(
 			'If we become aware of prohibited activity, we may restrict or shutdown the account responsible.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question8: __(
 			'Can WooCommerce Payments support Subscriptions and recurring payment options?',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question8Answer1: createInterpolateElement(
 			__(
 				'WooCommerce Payments supports charging automatic recurring payments via the <a>WooCommerce Subscriptions</a> plugin.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -371,36 +359,30 @@ export default {
 
 		question8Answer2: __(
 			'WooCommerce Payments offers full compatibility with WooCommerce Subscriptions’ features, including:',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
-		question8Answer3: __( 'Subscription suspension', 'woocommerce-admin' ),
+		question8Answer3: __( 'Subscription suspension', 'woocommerce' ),
 
-		question8Answer4: __(
-			'Subscription cancellation',
-			'woocommerce-admin'
-		),
+		question8Answer4: __( 'Subscription cancellation', 'woocommerce' ),
 
-		question8Answer5: __(
-			'Subscription reactivation',
-			'woocommerce-admin'
-		),
+		question8Answer5: __( 'Subscription reactivation', 'woocommerce' ),
 
-		question8Answer6: __( 'Multiple subscriptions', 'woocommerce-admin' ),
+		question8Answer6: __( 'Multiple subscriptions', 'woocommerce' ),
 
-		question8Answer7: __( 'Recurring total changes', 'woocommerce-admin' ),
+		question8Answer7: __( 'Recurring total changes', 'woocommerce' ),
 
-		question8Answer8: __( 'Payment date changes', 'woocommerce-admin' ),
+		question8Answer8: __( 'Payment date changes', 'woocommerce' ),
 
 		question8Answer9: __(
 			'Customer & Store Manager payment method changes',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 
 		question8Answer10: createInterpolateElement(
 			__(
 				'For more details on the subscription features that WooCommerce Payments offers, refer to the <a>subscription section of the WooCommerce Payments start up guide</a>.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -414,8 +396,8 @@ export default {
 			}
 		),
 
-		haveMoreQuestions: __( 'Have more questions?', 'woocommerce-admin' ),
+		haveMoreQuestions: __( 'Have more questions?', 'woocommerce' ),
 
-		getInTouch: __( 'Get in touch', 'woocommerce-admin' ),
+		getInTouch: __( 'Get in touch', 'woocommerce' ),
 	},
 };

--- a/plugins/woocommerce-admin/client/payments/payment-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/payments/payment-recommendations.tsx
@@ -134,7 +134,7 @@ const PaymentRecommendations: React.FC = () => {
 				'error',
 				__(
 					'There was a problem hiding the "Additional ways to get paid" card.',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}
@@ -174,9 +174,7 @@ const PaymentRecommendations: React.FC = () => {
 					<>
 						{ plugin.title }
 						{ plugin.recommended && (
-							<Pill>
-								{ __( 'Recommended', 'woocommerce-admin' ) }
-							</Pill>
+							<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
 						) }
 					</>
 				),
@@ -189,7 +187,7 @@ const PaymentRecommendations: React.FC = () => {
 						disabled={ !! installingPlugin }
 					>
 						{ plugin.actionText ||
-							__( 'Get started', 'woocommerce-admin' ) }
+							__( 'Get started', 'woocommerce' ) }
 					</Button>
 				),
 				before: (
@@ -208,10 +206,7 @@ const PaymentRecommendations: React.FC = () => {
 						size="20"
 						lineHeight="28px"
 					>
-						{ __(
-							'Additional ways to get paid',
-							'woocommerce-admin'
-						) }
+						{ __( 'Additional ways to get paid', 'woocommerce' ) }
 					</Text>
 					<Text
 						className={
@@ -224,19 +219,19 @@ const PaymentRecommendations: React.FC = () => {
 					>
 						{ __(
 							'We recommend adding one of the following payment extensions to your store. The extension will be installed and activated for you when you click "Get started".',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 				</div>
 				<div className="woocommerce-card__menu woocommerce-card__header-item">
 					<EllipsisMenu
-						label={ __( 'Task List Options', 'woocommerce-admin' ) }
+						label={ __( 'Task List Options', 'woocommerce' ) }
 						renderContent={ () => (
 							<div className="woocommerce-review-activity-card__section-controls">
 								<Button
 									onClick={ dismissPaymentRecommendations }
 								>
-									{ __( 'Hide this', 'woocommerce-admin' ) }
+									{ __( 'Hide this', 'woocommerce' ) }
 								</Button>
 							</div>
 						) }
@@ -246,7 +241,7 @@ const PaymentRecommendations: React.FC = () => {
 			<List items={ pluginsList } />
 			<CardFooter>
 				<Button href={ SEE_MORE_LINK } target="_blank" isTertiary>
-					{ __( 'See more options', 'woocommerce-admin' ) }
+					{ __( 'See more options', 'woocommerce' ) }
 					<ExternalIcon size={ 18 } />
 				</Button>
 			</CardFooter>

--- a/plugins/woocommerce-admin/client/profile-wizard/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/index.js
@@ -65,7 +65,7 @@ class ProfileWizard extends Component {
 				'error',
 				__(
 					'There was a problem finishing the setup wizard',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}
@@ -135,7 +135,7 @@ class ProfileWizard extends Component {
 		steps.push( {
 			key: 'store-details',
 			container: StoreDetails,
-			label: __( 'Store Details', 'woocommerce-admin' ),
+			label: __( 'Store Details', 'woocommerce' ),
 			isComplete:
 				profileItems.hasOwnProperty( 'setup_client' ) &&
 				profileItems.setup_client !== null,
@@ -143,7 +143,7 @@ class ProfileWizard extends Component {
 		steps.push( {
 			key: 'industry',
 			container: Industry,
-			label: __( 'Industry', 'woocommerce-admin' ),
+			label: __( 'Industry', 'woocommerce' ),
 			isComplete:
 				profileItems.hasOwnProperty( 'industry' ) &&
 				profileItems.industry !== null,
@@ -151,7 +151,7 @@ class ProfileWizard extends Component {
 		steps.push( {
 			key: 'product-types',
 			container: ProductTypes,
-			label: __( 'Product Types', 'woocommerce-admin' ),
+			label: __( 'Product Types', 'woocommerce' ),
 			isComplete:
 				profileItems.hasOwnProperty( 'product_types' ) &&
 				profileItems.product_types !== null,
@@ -159,7 +159,7 @@ class ProfileWizard extends Component {
 		steps.push( {
 			key: 'business-details',
 			container: BusinessDetailsStep,
-			label: __( 'Business Details', 'woocommerce-admin' ),
+			label: __( 'Business Details', 'woocommerce' ),
 			isComplete:
 				profileItems.hasOwnProperty( 'product_count' ) &&
 				profileItems.product_count !== null,
@@ -167,7 +167,7 @@ class ProfileWizard extends Component {
 		steps.push( {
 			key: 'theme',
 			container: Theme,
-			label: __( 'Theme', 'woocommerce-admin' ),
+			label: __( 'Theme', 'woocommerce' ),
 			isComplete:
 				profileItems.hasOwnProperty( 'theme' ) &&
 				profileItems.theme !== null,
@@ -274,7 +274,7 @@ class ProfileWizard extends Component {
 					'error',
 					__(
 						'There was a problem skipping the setup wizard',
-						'woocommerce-admin'
+						'woocommerce'
 					)
 				);
 			} );

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/employee-options.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/employee-options.js
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 export const employeeOptions = [
 	{
 		key: '1',
-		label: __( "It's just me", 'woocommerce-admin' ),
+		label: __( "It's just me", 'woocommerce' ),
 	},
 	{
 		key: '<10',
-		label: __( '< 10', 'woocommerce-admin' ),
+		label: __( '< 10', 'woocommerce' ),
 	},
 	{
 		key: '10-50',
@@ -22,10 +22,10 @@ export const employeeOptions = [
 	},
 	{
 		key: '+250',
-		label: __( '+250', 'woocommerce-admin' ),
+		label: __( '+250', 'woocommerce' ),
 	},
 	{
 		key: 'not specified',
-		label: __( "I'd rather not say", 'woocommerce-admin' ),
+		label: __( "I'd rather not say", 'woocommerce' ),
 	},
 ];

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/platform-options.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/platform-options.js
@@ -6,38 +6,38 @@ import { __ } from '@wordpress/i18n';
 export const platformOptions = [
 	{
 		key: 'shopify',
-		label: __( 'Shopify', 'woocommerce-admin' ),
+		label: __( 'Shopify', 'woocommerce' ),
 	},
 	{
 		key: 'bigcommerce',
-		label: __( 'BigCommerce', 'woocommerce-admin' ),
+		label: __( 'BigCommerce', 'woocommerce' ),
 	},
 	{
 		key: 'magento',
-		label: __( 'Magento', 'woocommerce-admin' ),
+		label: __( 'Magento', 'woocommerce' ),
 	},
 	{
 		key: 'wix',
-		label: __( 'Wix', 'woocommerce-admin' ),
+		label: __( 'Wix', 'woocommerce' ),
 	},
 	{
 		key: 'amazon',
-		label: __( 'Amazon', 'woocommerce-admin' ),
+		label: __( 'Amazon', 'woocommerce' ),
 	},
 	{
 		key: 'ebay',
-		label: __( 'eBay', 'woocommerce-admin' ),
+		label: __( 'eBay', 'woocommerce' ),
 	},
 	{
 		key: 'etsy',
-		label: __( 'Etsy', 'woocommerce-admin' ),
+		label: __( 'Etsy', 'woocommerce' ),
 	},
 	{
 		key: 'squarespace',
-		label: __( 'Squarespace', 'woocommerce-admin' ),
+		label: __( 'Squarespace', 'woocommerce' ),
 	},
 	{
 		key: 'other',
-		label: __( 'Other', 'woocommerce-admin' ),
+		label: __( 'Other', 'woocommerce' ),
 	},
 ];

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/product-options.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/product-options.js
@@ -16,7 +16,7 @@ export const getNumberRangeString = (
 ) => {
 	if ( ! max ) {
 		return sprintf(
-			_x( '%s+', 'store product count or revenue', 'woocommerce-admin' ),
+			_x( '%s+', 'store product count or revenue', 'woocommerce' ),
 			formatAmount( numberConfig, min )
 		);
 	}
@@ -25,7 +25,7 @@ export const getNumberRangeString = (
 		_x(
 			'%1$s - %2$s',
 			'store product count or revenue range',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		formatAmount( numberConfig, min ),
 		formatAmount( numberConfig, max )
@@ -35,7 +35,7 @@ export const getNumberRangeString = (
 export const getProductCountOptions = ( numberConfig ) => [
 	{
 		key: '0',
-		label: __( "I don't have any products yet.", 'woocommerce-admin' ),
+		label: __( "I don't have any products yet.", 'woocommerce' ),
 	},
 	{
 		key: '1-10',

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/revenue-options.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/revenue-options.js
@@ -46,7 +46,7 @@ export const getRevenueOptions = ( numberConfig, country, formatAmount ) => [
 		key: 'none',
 		label: sprintf(
 			/* translators: %s: $0 revenue amount */
-			__( "%s (I'm just getting started)", 'woocommerce-admin' ),
+			__( "%s (I'm just getting started)", 'woocommerce' ),
 			formatAmount( 0 )
 		),
 	},
@@ -54,7 +54,7 @@ export const getRevenueOptions = ( numberConfig, country, formatAmount ) => [
 		key: 'up-to-2500',
 		label: sprintf(
 			/* translators: %s: A given revenue amount, e.g., $2500 */
-			__( 'Up to %s', 'woocommerce-admin' ),
+			__( 'Up to %s', 'woocommerce' ),
 			formatAmount( convertCurrency( 2500, country ) )
 		),
 	},
@@ -89,12 +89,12 @@ export const getRevenueOptions = ( numberConfig, country, formatAmount ) => [
 		key: 'more-than-250000',
 		label: sprintf(
 			/* translators: %s: A given revenue amount, e.g., $250000 */
-			__( 'More than %s', 'woocommerce-admin' ),
+			__( 'More than %s', 'woocommerce' ),
 			formatAmount( convertCurrency( 250000, country ) )
 		),
 	},
 	{
 		key: 'rather-not-say',
-		label: __( "I'd rather not say", 'woocommerce-admin' ),
+		label: __( "I'd rather not say", 'woocommerce' ),
 	},
 ];

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/selling-venue-options.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/data/selling-venue-options.js
@@ -6,31 +6,31 @@ import { __ } from '@wordpress/i18n';
 export const sellingVenueOptions = [
 	{
 		key: 'no',
-		label: __( 'No', 'woocommerce-admin' ),
+		label: __( 'No', 'woocommerce' ),
 	},
 	{
 		key: 'other',
-		label: __( 'Yes, on another platform', 'woocommerce-admin' ),
+		label: __( 'Yes, on another platform', 'woocommerce' ),
 	},
 	{
 		key: 'other-woocommerce',
 		label: __(
 			'Yes, I own a different store powered by WooCommerce',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'brick-mortar',
 		label: __(
 			'Yes, in person at physical stores and/or events',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'brick-mortar-other',
 		label: __(
 			'Yes, on another platform and in person at physical stores and/or events',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 ];

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -254,7 +254,7 @@ class BusinessDetails extends Component {
 					'error',
 					__(
 						'There was a problem updating your business details',
-						'woocommerce-admin'
+						'woocommerce'
 					)
 				);
 			} );
@@ -302,7 +302,7 @@ class BusinessDetails extends Component {
 				'error',
 				__(
 					'There was a problem updating your business details',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		} );
@@ -314,14 +314,14 @@ class BusinessDetails extends Component {
 		if ( ! values.product_count.length ) {
 			errors.product_count = __(
 				'This field is required',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
 		if ( ! values.selling_venues.length ) {
 			errors.selling_venues = __(
 				'This field is required',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
@@ -331,7 +331,7 @@ class BusinessDetails extends Component {
 		) {
 			errors.other_platform = __(
 				'This field is required',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 		if (
@@ -341,7 +341,7 @@ class BusinessDetails extends Component {
 		) {
 			errors.other_platform_name = __(
 				'This field is required',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
@@ -351,7 +351,7 @@ class BusinessDetails extends Component {
 		) {
 			errors.number_employees = __(
 				'This field is required',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
@@ -359,10 +359,7 @@ class BusinessDetails extends Component {
 			! values.revenue.length &&
 			isSellingElsewhere( values.selling_venues )
 		) {
-			errors.revenue = __(
-				'This field is required',
-				'woocommerce-admin'
-			);
+			errors.revenue = __( 'This field is required', 'woocommerce' );
 		}
 
 		if ( Object.keys( errors ).length === 0 ) {
@@ -461,13 +458,13 @@ class BusinessDetails extends Component {
 								>
 									{ __(
 										'Tell us about your business',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</Text>
 								<Text variant="body" as="p">
 									{ __(
 										"We'd love to know if you are just getting started or you already have a business in place.",
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</Text>
 							</div>
@@ -477,7 +474,7 @@ class BusinessDetails extends Component {
 										excludeSelectedOptions={ false }
 										label={ __(
 											'How many products do you plan to display?',
-											'woocommerce-admin'
+											'woocommerce'
 										) }
 										options={ productCountOptions }
 										required
@@ -491,7 +488,7 @@ class BusinessDetails extends Component {
 										excludeSelectedOptions={ false }
 										label={ __(
 											'Currently selling elsewhere?',
-											'woocommerce-admin'
+											'woocommerce'
 										) }
 										options={ sellingVenueOptions }
 										required
@@ -508,7 +505,7 @@ class BusinessDetails extends Component {
 											excludeSelectedOptions={ false }
 											label={ __(
 												'How many employees do you have?',
-												'woocommerce-admin'
+												'woocommerce'
 											) }
 											options={ employeeOptions }
 											required
@@ -526,7 +523,7 @@ class BusinessDetails extends Component {
 											excludeSelectedOptions={ false }
 											label={ __(
 												"What's your current annual revenue?",
-												'woocommerce-admin'
+												'woocommerce'
 											) }
 											options={ getRevenueOptions(
 												getCurrencyConfig(),
@@ -553,7 +550,7 @@ class BusinessDetails extends Component {
 													}
 													label={ __(
 														'Which platform is the store using?',
-														'woocommerce-admin'
+														'woocommerce'
 													) }
 													options={ platformOptions }
 													required
@@ -567,7 +564,7 @@ class BusinessDetails extends Component {
 													<TextControl
 														label={ __(
 															'What is the platform name?',
-															'woocommerce-admin'
+															'woocommerce'
 														) }
 														required
 														{ ...this.getSelectControlProps(
@@ -586,7 +583,7 @@ class BusinessDetails extends Component {
 											<CheckboxControl
 												label={ __(
 													"I'm setting up a store for a client",
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												{ ...getInputProps(
 													'setup_client'
@@ -606,14 +603,8 @@ class BusinessDetails extends Component {
 										isBusy={ isInstallingActivating }
 									>
 										{ ! hasInstallActivateError
-											? __(
-													'Continue',
-													'woocommerce-admin'
-											  )
-											: __(
-													'Retry',
-													'woocommerce-admin'
-											  ) }
+											? __( 'Continue', 'woocommerce' )
+											: __( 'Retry', 'woocommerce' ) }
 									</Button>
 									{ hasInstallActivateError && (
 										<Button
@@ -626,7 +617,7 @@ class BusinessDetails extends Component {
 										>
 											{ __(
 												'Continue without installing',
-												'woocommerce-admin'
+												'woocommerce'
 											) }
 										</Button>
 									) }
@@ -654,21 +645,18 @@ class BusinessDetails extends Component {
 						size="20"
 						lineHeight="28px"
 					>
-						{ __(
-							'Included business features',
-							'woocommerce-admin'
-						) }
+						{ __( 'Included business features', 'woocommerce' ) }
 					</Text>
 					<Text variant="body" as="p">
 						{ __(
 							'We recommend enhancing your store with these free extensions',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 					<Text variant="body" as="p">
 						{ __(
 							'No commitment required - you can remove them at any time.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 				</div>
@@ -715,7 +703,7 @@ class BusinessDetails extends Component {
 								? 'current-tab'
 								: BUSINESS_DETAILS_TAB_NAME,
 						id: BUSINESS_DETAILS_TAB_NAME,
-						title: __( 'Business details', 'woocommerce-admin' ),
+						title: __( 'Business details', 'woocommerce' ),
 					},
 					{
 						name:
@@ -723,7 +711,7 @@ class BusinessDetails extends Component {
 								? 'current-tab'
 								: BUSINESS_FEATURES_TAB_NAME,
 						id: BUSINESS_FEATURES_TAB_NAME,
-						title: __( 'Free features', 'woocommerce-admin' ),
+						title: __( 'Free features', 'woocommerce' ),
 						className: this.state.isValid ? '' : 'is-disabled',
 					},
 				] }

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -26,7 +26,7 @@ const ALLOWED_PLUGIN_CATEGORIES = [ 'obw/basics', 'obw/grow' ];
 const FreeBadge = () => {
 	return (
 		<div className="woocommerce-admin__business-details__free-badge">
-			{ __( 'Free', 'woocommerce-admin' ) }
+			{ __( 'Free', 'woocommerce' ) }
 		</div>
 	);
 };
@@ -59,7 +59,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 							'Installing the following plugin: %s',
 							'Installing the following plugins: %s',
 							extensions.length,
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						extensionsList
 					) }
@@ -70,7 +70,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 
 	const accountRequiredText = __(
 		'User accounts are required to use these features.',
-		'woocommerce-admin'
+		'woocommerce'
 	);
 
 	const extensionsWithToS = extensions.filter(
@@ -94,7 +94,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 			'By installing %s plugin for free you agree to our {{link}}Terms of Service{{/link}}.',
 			'By installing %s plugins for free you agree to our {{link}}Terms of Service{{/link}}.',
 			extensionsWithToS.length,
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		extensionsListText
 	);
@@ -108,7 +108,7 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 						'The following plugin will be installed for free: %1$s. %2$s',
 						'The following plugins will be installed for free: %1$s. %2$s',
 						extensions.length,
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					extensionsList,
 					accountRequiredText
@@ -343,7 +343,7 @@ export const SelectiveExtensionsBundle = ( {
 						<p className="woocommerce-admin__business-details__selective-extensions-bundle__description">
 							{ __(
 								'Add recommended business features to my site',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</p>
 						<Button
@@ -399,7 +399,7 @@ export const SelectiveExtensionsBundle = ( {
 						disabled={ isInstallingActivating || isResolving }
 						isPrimary
 					>
-						{ __( 'Continue', 'woocommerce-admin' ) }
+						{ __( 'Continue', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Card>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -114,7 +114,7 @@ class Industry extends Component {
 				'error',
 				__(
 					'There was a problem updating your industries',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 
@@ -127,7 +127,7 @@ class Industry extends Component {
 	async validateField() {
 		const error = this.state.selected.length
 			? null
-			: __( 'Please select at least one industry', 'woocommerce-admin' );
+			: __( 'Please select at least one industry', 'woocommerce' );
 		this.setState( { error } );
 	}
 
@@ -225,11 +225,11 @@ class Industry extends Component {
 					>
 						{ __(
 							'In which industry does the store operate?',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 					<Text variant="body" as="p">
-						{ __( 'Choose any that apply', 'woocommerce-admin' ) }
+						{ __( 'Choose any that apply', 'woocommerce' ) }
 					</Text>
 				</div>
 				<Card>
@@ -276,7 +276,7 @@ class Industry extends Component {
 								! selected.length || isProfileItemsRequesting
 							}
 						>
-							{ __( 'Continue', 'woocommerce-admin' ) }
+							{ __( 'Continue', 'woocommerce' ) }
 						</Button>
 					</CardFooter>
 				</Card>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
@@ -94,10 +94,7 @@ export class ProductTypes extends Component {
 	validateField() {
 		const error = this.state.selected.length
 			? null
-			: __(
-					'Please select at least one product type',
-					'woocommerce-admin'
-			  );
+			: __( 'Please select at least one product type', 'woocommerce' );
 		this.setState( { error } );
 		return ! error;
 	}
@@ -172,7 +169,7 @@ export class ProductTypes extends Component {
 					'error',
 					__(
 						'There was a problem updating your product types',
-						'woocommerce-admin'
+						'woocommerce'
 					)
 				)
 			);
@@ -233,11 +230,11 @@ export class ProductTypes extends Component {
 					>
 						{ __(
 							'What type of products will be listed?',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 					<Text variant="body" as="p">
-						{ __( 'Choose any that apply', 'woocommerce-admin' ) }
+						{ __( 'Choose any that apply', 'woocommerce' ) }
 					</Text>
 				</div>
 
@@ -294,7 +291,7 @@ export class ProductTypes extends Component {
 								isInstallingActivating
 							}
 						>
-							{ __( 'Continue', 'woocommerce-admin' ) }
+							{ __( 'Continue', 'woocommerce' ) }
 						</Button>
 					</CardFooter>
 				</Card>
@@ -304,7 +301,7 @@ export class ProductTypes extends Component {
 							<Text variant="body" as="p">
 								{ __(
 									'Display monthly prices',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							</Text>
 							<FormToggle
@@ -321,7 +318,7 @@ export class ProductTypes extends Component {
 					<Text variant="caption" size="12" lineHeight="16px">
 						{ __(
 							'Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.',
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 					{ window.wcAdminFeatures &&
@@ -339,7 +336,7 @@ export class ProductTypes extends Component {
 							>
 								{ __(
 									'The following extensions will be added to your site for free: WooCommerce Payments. An account is required to use this feature.',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							</Text>
 						) }

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/label.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/label.js
@@ -25,7 +25,7 @@ export default function ProductTypeLabel( {
 	/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 	const toolTipText = __(
 		"This product type requires a paid extension.\nWe'll add this to a cart so that\nyou can purchase and install it later.",
-		'woocommerce-admin'
+		'woocommerce'
 	);
 	/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 
@@ -38,7 +38,7 @@ export default function ProductTypeLabel( {
 				isTertiary
 				label={ __(
 					'Learn more about recommended free business features',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				onClick={ () => {
 					setIsPopoverVisible( true );
@@ -70,7 +70,7 @@ export default function ProductTypeLabel( {
 										)
 									}
 								>
-									{ __( 'Learn more', 'woocommerce-admin' ) }
+									{ __( 'Learn more', 'woocommerce' ) }
 								</Link>
 							) : (
 								''
@@ -85,12 +85,12 @@ export default function ProductTypeLabel( {
 					{ isMonthlyPricing
 						? sprintf(
 								/* translators: Dollar amount (example: $4.08 ) */
-								__( '$%f per month', 'woocommerce-admin' ),
+								__( '$%f per month', 'woocommerce' ),
 								( annualPrice / 12.0 ).toFixed( 2 )
 						  )
 						: sprintf(
 								/* translators: Dollar amount (example: $49.00 ) */
-								__( '$%f per year', 'woocommerce-admin' ),
+								__( '$%f per year', 'woocommerce' ),
 								annualPrice
 						  ) }
 				</Pill>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/product-type.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/product-type.js
@@ -25,7 +25,7 @@ export default function ProductType( {
 	/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 	const toolTipText = __(
 		"This product type requires a paid extension.\nWe'll add this to a cart so that\nyou can purchase and install it later.",
-		'woocommerce-admin'
+		'woocommerce'
 	);
 	/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 
@@ -36,7 +36,7 @@ export default function ProductType( {
 				isTertiary
 				label={ __(
 					'Learn more about recommended free business features',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				onClick={ () => {
 					setIsPopoverVisible( true );
@@ -68,7 +68,7 @@ export default function ProductType( {
 										)
 									}
 								>
-									{ __( 'Learn more', 'woocommerce-admin' ) }
+									{ __( 'Learn more', 'woocommerce' ) }
 								</Link>
 							) : (
 								''
@@ -83,12 +83,12 @@ export default function ProductType( {
 					{ isMonthlyPricing
 						? sprintf(
 								/* translators: Dollar amount (example: $4.08 ) */
-								__( '$%f per month', 'woocommerce-admin' ),
+								__( '$%f per month', 'woocommerce' ),
 								( annualPrice / 12.0 ).toFixed( 2 )
 						  )
 						: sprintf(
 								/* translators: Dollar amount (example: $49.00 ) */
-								__( '$%f per year', 'woocommerce-admin' ),
+								__( '$%f per year', 'woocommerce' ),
 								annualPrice
 						  ) }
 				</Pill>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -213,10 +213,7 @@ export class StoreDetails extends Component {
 		}
 		createNotice(
 			'error',
-			__(
-				'There was a problem saving your store details',
-				'woocommerce-admin'
-			)
+			__( 'There was a problem saving your store details', 'woocommerce' )
 		);
 
 		errorMessages.forEach( ( message ) =>
@@ -231,10 +228,7 @@ export class StoreDetails extends Component {
 		const errors = validateAddress( values );
 
 		if ( values.storeEmail && ! isEmail( values.storeEmail ) ) {
-			errors.storeEmail = __(
-				'Invalid email address',
-				'woocommerce-admin'
-			);
+			errors.storeEmail = __( 'Invalid email address', 'woocommerce' );
 		}
 
 		return errors;
@@ -258,12 +252,12 @@ export class StoreDetails extends Component {
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 		const skipSetupText = __(
 			'Manual setup is only recommended for\n experienced WooCommerce users or developers.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 
 		const configureCurrencyText = __(
 			'Your store address will help us configure currency\n options and shipping rules automatically.\n This information will not be publicly visible and can\n easily be changed later.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 		/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 
@@ -284,19 +278,19 @@ export class StoreDetails extends Component {
 						size="20"
 						lineHeight="28px"
 					>
-						{ __( 'Welcome to WooCommerce', 'woocommerce-admin' ) }
+						{ __( 'Welcome to WooCommerce', 'woocommerce' ) }
 					</Text>
 					<Text variant="body" as="p">
 						{ __(
 							"Tell us about your store and we'll get you set up in no time",
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 
 						<Button
 							isTertiary
 							label={ __(
 								'Learn more about store details',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 							onClick={ () =>
 								this.setState( {
@@ -368,11 +362,11 @@ export class StoreDetails extends Component {
 										values.isAgreeMarketing
 											? __(
 													'Email address',
-													'woocommerce-admin'
+													'woocommerce'
 											  )
 											: __(
 													'Email address (Optional)',
-													'woocommerce-admin'
+													'woocommerce'
 											  )
 									}
 									required={ values.isAgreeMarketing }
@@ -385,7 +379,7 @@ export class StoreDetails extends Component {
 										<div className="woocommerce-profile-wizard__store-details-error">
 											{ __(
 												'Please enter your email address to subscribe',
-												'woocommerce-admin'
+												'woocommerce'
 											) }
 										</div>
 									) }
@@ -396,12 +390,12 @@ export class StoreDetails extends Component {
 												<>
 													{ __(
 														'Get tips, product updates and inspiration straight to your mailbox.',
-														'woocommerce-admin'
+														'woocommerce'
 													) }{ ' ' }
 													<span className="woocommerce-profile-wizard__powered-by-mailchimp">
 														{ __(
 															'Powered by Mailchimp',
-															'woocommerce-admin'
+															'woocommerce'
 														) }
 													</span>
 												</>
@@ -421,7 +415,7 @@ export class StoreDetails extends Component {
 									isBusy={ isBusy }
 									disabled={ ! isValidForm || isBusy }
 								>
-									{ __( 'Continue', 'woocommerce-admin' ) }
+									{ __( 'Continue', 'woocommerce' ) }
 								</Button>
 							</CardFooter>
 						</Card>
@@ -442,10 +436,7 @@ export class StoreDetails extends Component {
 							return false;
 						} }
 					>
-						{ __(
-							'Skip setup store details',
-							'woocommerce-admin'
-						) }
+						{ __( 'Skip setup store details', 'woocommerce' ) }
 					</Button>
 					<Button
 						isTertiary

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/theme/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/theme/index.js
@@ -75,7 +75,7 @@ class Theme extends Component {
 				'error',
 				__(
 					'There was a problem selecting your store theme',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}
@@ -131,7 +131,7 @@ class Theme extends Component {
 						/* translators: The name of the theme that was installed and activated */
 						__(
 							'%s was installed and activated on your site',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						response.name
 					)
@@ -201,7 +201,7 @@ class Theme extends Component {
 							<Tooltip
 								text={ __(
 									'This theme does not support WooCommerce.',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							>
 								<span>
@@ -228,7 +228,7 @@ class Theme extends Component {
 						>
 							{ __(
 								'Continue with my active theme',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</Button>
 					) : (
@@ -238,7 +238,7 @@ class Theme extends Component {
 							isBusy={ chosen === slug }
 							disabled={ chosen === slug }
 						>
-							{ __( 'Choose', 'woocommerce-admin' ) }
+							{ __( 'Choose', 'woocommerce' ) }
 						</Button>
 					) }
 					{ demoUrl && (
@@ -246,7 +246,7 @@ class Theme extends Component {
 							isTertiary
 							onClick={ () => this.openDemo( theme ) }
 						>
-							{ __( 'Live demo', 'woocommerce-admin' ) }
+							{ __( 'Live demo', 'woocommerce' ) }
 						</Button>
 					) }
 				</CardFooter>
@@ -259,16 +259,16 @@ class Theme extends Component {
 		const { activeTheme = '' } = getAdminSetting( 'onboarding', {} );
 
 		if ( activeTheme === slug ) {
-			return __( 'Currently active theme', 'woocommerce-admin' );
+			return __( 'Currently active theme', 'woocommerce' );
 		}
 		if ( isInstalled ) {
-			return __( 'Installed', 'woocommerce-admin' );
+			return __( 'Installed', 'woocommerce' );
 		} else if ( getPriceValue( price ) <= 0 ) {
-			return __( 'Free', 'woocommerce-admin' );
+			return __( 'Free', 'woocommerce' );
 		}
 
 		return sprintf(
-			__( '%s per year', 'woocommerce-admin' ),
+			__( '%s per year', 'woocommerce' ),
 			decodeEntities( price )
 		);
 	}
@@ -353,12 +353,12 @@ class Theme extends Component {
 						size="20"
 						lineHeight="28px"
 					>
-						{ __( 'Choose a theme', 'woocommerce-admin' ) }
+						{ __( 'Choose a theme', 'woocommerce' ) }
 					</Text>
 					<Text variant="body" as="p">
 						{ __(
 							"Choose how your store appears to customers. And don't worry, you can always switch themes and edit them later.",
-							'woocommerce-admin'
+							'woocommerce'
 						) }
 					</Text>
 				</div>
@@ -369,15 +369,15 @@ class Theme extends Component {
 					tabs={ [
 						{
 							name: 'all',
-							title: __( 'All themes', 'woocommerce-admin' ),
+							title: __( 'All themes', 'woocommerce' ),
 						},
 						{
 							name: 'paid',
-							title: __( 'Paid themes', 'woocommerce-admin' ),
+							title: __( 'Paid themes', 'woocommerce' ),
 						},
 						{
 							name: 'free',
-							title: __( 'Free themes', 'woocommerce-admin' ),
+							title: __( 'Free themes', 'woocommerce' ),
 						},
 					] }
 				>
@@ -408,7 +408,7 @@ class Theme extends Component {
 							className="woocommerce-profile-wizard__skip"
 							onClick={ () => this.skipStep() }
 						>
-							{ __( 'Skip this step', 'woocommerce-admin' ) }
+							{ __( 'Skip this step', 'woocommerce' ) }
 						</Button>
 					</p>
 				) }

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/theme/preview.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/theme/preview.js
@@ -72,7 +72,7 @@ class ThemePreview extends Component {
 							mixedString: sprintf(
 								__(
 									'{{strong}}%s{{/strong}} developed by WooCommerce',
-									'woocommerce-admin'
+									'woocommerce'
 								),
 								title
 							),
@@ -108,7 +108,7 @@ class ThemePreview extends Component {
 						onClick={ () => onChoose( slug, 'preview' ) }
 						isBusy={ isBusy }
 					>
-						{ __( 'Choose', 'woocommerce-admin' ) }
+						{ __( 'Choose', 'woocommerce' ) }
 					</Button>
 				</div>
 				<WebPreview

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/theme/uploader.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/theme/uploader.js
@@ -101,22 +101,19 @@ class ThemeUploader extends Component {
 							>
 								<CloudUploadIcon />
 								<H className="woocommerce-theme-uploader__title">
-									{ __(
-										'Upload a theme',
-										'woocommerce-admin'
-									) }
+									{ __( 'Upload a theme', 'woocommerce' ) }
 								</H>
 								<p>
 									{ __(
 										'Drop a theme zip file here to upload',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</p>
 							</FormFileUpload>
 							<DropZone
 								label={ __(
 									'Drop your theme zip file here',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 								onFilesDrop={ this.handleFilesDrop }
 							/>
@@ -125,12 +122,12 @@ class ThemeUploader extends Component {
 						<Fragment>
 							<Spinner />
 							<H className="woocommerce-theme-uploader__title">
-								{ __( 'Uploading theme', 'woocommerce-admin' ) }
+								{ __( 'Uploading theme', 'woocommerce' ) }
 							</H>
 							<p>
 								{ __(
 									'Your theme is being uploaded',
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							</p>
 						</Fragment>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
@@ -53,7 +53,7 @@ class UsageModal extends Component {
 				'error',
 				__(
 					'There was a problem updating your preferences',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 			onClose();
@@ -110,12 +110,12 @@ class UsageModal extends Component {
 
 		const {
 			isRequesting,
-			title = __( 'Build a better WooCommerce', 'woocommerce-admin' ),
+			title = __( 'Build a better WooCommerce', 'woocommerce' ),
 			message = interpolateComponents( {
 				mixedString: __(
 					'Get improved features and faster fixes by sharing non-sensitive data via {{link}}usage tracking{{/link}} ' +
 						'that shows us how WooCommerce is used. No personal data is tracked or stored.',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				components: {
 					link: (
@@ -127,8 +127,8 @@ class UsageModal extends Component {
 					),
 				},
 			} ),
-			dismissActionText = __( 'No thanks', 'woocommerce-admin' ),
-			acceptActionText = __( 'Yes, count me in!', 'woocommerce-admin' ),
+			dismissActionText = __( 'No thanks', 'woocommerce' ),
+			acceptActionText = __( 'Yes, count me in!', 'woocommerce' ),
 		} = this.props;
 
 		const { isRequestStarted } = this.state;

--- a/plugins/woocommerce-admin/client/profile-wizard/unsaved-changes-modal.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/unsaved-changes-modal.js
@@ -5,13 +5,13 @@ import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const UnsavedChangesModal = ( { onClose, onSave } ) => {
-	const title = __( 'Save changes?', 'woocommerce-admin' );
+	const title = __( 'Save changes?', 'woocommerce' );
 	const message = __(
 		"You're about to go to a different step. Do you want to save the changes you've made here so far?",
-		'woocommerce-admin'
+		'woocommerce'
 	);
-	const discardText = __( 'Discard', 'woocommerce-admin' );
-	const saveText = __( 'Save', 'woocommerce-admin' );
+	const discardText = __( 'Discard', 'woocommerce' );
+	const saveText = __( 'Save', 'woocommerce' );
 	return (
 		<>
 			<Modal

--- a/plugins/woocommerce-admin/client/settings-recommendations/dismissable-list.tsx
+++ b/plugins/woocommerce-admin/client/settings-recommendations/dismissable-list.tsx
@@ -37,11 +37,11 @@ export const DismissableListHeading: React.FC< {
 			</div>
 			<div>
 				<EllipsisMenu
-					label={ __( 'Task List Options', 'woocommerce-admin' ) }
+					label={ __( 'Task List Options', 'woocommerce' ) }
 					renderContent={ () => (
 						<div className="woocommerce-dismissable-list__controls">
 							<Button onClick={ handleDismissClick }>
-								{ __( 'Hide this', 'woocommerce-admin' ) }
+								{ __( 'Hide this', 'woocommerce' ) }
 							</Button>
 						</div>
 					) }

--- a/plugins/woocommerce-admin/client/shipping/shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/shipping-recommendations.tsx
@@ -59,7 +59,7 @@ const ShippingRecommendationsList: React.FC = ( { children } ) => (
 	>
 		<DismissableListHeading>
 			<Text variant="title.small" as="p" size="20" lineHeight="28px">
-				{ __( 'Recommended shipping solutions', 'woocommerce-admin' ) }
+				{ __( 'Recommended shipping solutions', 'woocommerce' ) }
 			</Text>
 			<Text
 				className="woocommerce-recommended-shipping__header-heading"
@@ -70,7 +70,7 @@ const ShippingRecommendationsList: React.FC = ( { children } ) => (
 			>
 				{ __(
 					'We recommend adding one of the following shipping extensions to your store. The extension will be installed and activated for you when you click "Get started".',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			</Text>
 		</DismissableListHeading>
@@ -86,9 +86,9 @@ const ShippingRecommendationsList: React.FC = ( { children } ) => (
 				target="_blank"
 				isTertiary
 			>
-				{ __( 'See more options', 'woocommerce-admin' ) }
+				{ __( 'See more options', 'woocommerce' ) }
 				<VisuallyHidden>
-					{ __( '(opens in a new tab)', 'woocommerce-admin' ) }
+					{ __( '(opens in a new tab)', 'woocommerce' ) }
 				</VisuallyHidden>
 				<ExternalIcon size={ 18 } />
 			</Button>

--- a/plugins/woocommerce-admin/client/shipping/woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/woocommerce-services-item.tsx
@@ -34,16 +34,13 @@ const WooCommerceServicesItem: React.FC< {
 					url: getAdminLink( 'plugins.php' ),
 					label: __(
 						'Finish the setup by connecting your store to Jetpack.',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 				} );
 			}
 
 			createSuccessNotice(
-				__(
-					'🎉 WooCommerce Shipping is installed!',
-					'woocommerce-admin'
-				),
+				__( '🎉 WooCommerce Shipping is installed!', 'woocommerce' ),
 				{
 					actions,
 				}
@@ -62,17 +59,17 @@ const WooCommerceServicesItem: React.FC< {
 			</div>
 			<div className="woocommerce-list__item-text">
 				<span className="woocommerce-list__item-title">
-					{ __( 'Woocommerce Shipping', 'woocommerce-admin' ) }
-					<Pill>{ __( 'Recommended', 'woocommerce-admin' ) }</Pill>
+					{ __( 'Woocommerce Shipping', 'woocommerce' ) }
+					<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
 				</span>
 				<span className="woocommerce-list__item-content">
 					{ __(
 						'Print USPS and DHL Express labels straight from your WooCommerce dashboard and save on shipping.',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 					<br />
 					<ExternalLink href="https://woocommerce.com/woocommerce-shipping/">
-						{ __( 'Learn more', 'woocommerce-admin' ) }
+						{ __( 'Learn more', 'woocommerce' ) }
 					</ExternalLink>
 				</span>
 			</div>
@@ -85,7 +82,7 @@ const WooCommerceServicesItem: React.FC< {
 					) }
 					disabled={ pluginsBeingSetup.length > 0 }
 				>
-					{ __( 'Get started', 'woocommerce-admin' ) }
+					{ __( 'Get started', 'woocommerce' ) }
 				</Button>
 			</div>
 		</div>

--- a/plugins/woocommerce-admin/client/store-management-links/index.js
+++ b/plugins/woocommerce-admin/client/store-management-links/index.js
@@ -28,10 +28,10 @@ import { getAdminSetting } from '~/utils/admin-settings';
 export function getItemsByCategory( shopUrl ) {
 	return [
 		{
-			title: __( 'Marketing & Merchandising', 'woocommerce-admin' ),
+			title: __( 'Marketing & Merchandising', 'woocommerce' ),
 			items: [
 				{
-					title: __( 'Marketing', 'woocommerce-admin' ),
+					title: __( 'Marketing', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wc-admin',
 						path: 'marketing',
@@ -40,7 +40,7 @@ export function getItemsByCategory( shopUrl ) {
 					listItemTag: 'marketing',
 				},
 				{
-					title: __( 'Add products', 'woocommerce-admin' ),
+					title: __( 'Add products', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wp-admin',
 						path: 'post-new.php?post_type=product',
@@ -49,7 +49,7 @@ export function getItemsByCategory( shopUrl ) {
 					listItemTag: 'add-products',
 				},
 				{
-					title: __( 'Personalize my store', 'woocommerce-admin' ),
+					title: __( 'Personalize my store', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wp-admin',
 						path: 'customize.php',
@@ -58,7 +58,7 @@ export function getItemsByCategory( shopUrl ) {
 					listItemTag: 'personalize-store',
 				},
 				{
-					title: __( 'View my store', 'woocommerce-admin' ),
+					title: __( 'View my store', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'external',
 						href: shopUrl,
@@ -69,10 +69,10 @@ export function getItemsByCategory( shopUrl ) {
 			],
 		},
 		{
-			title: __( 'Settings', 'woocommerce-admin' ),
+			title: __( 'Settings', 'woocommerce' ),
 			items: [
 				{
-					title: __( 'Store details', 'woocommerce-admin' ),
+					title: __( 'Store details', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wc-settings',
 						tab: 'general',
@@ -81,7 +81,7 @@ export function getItemsByCategory( shopUrl ) {
 					listItemTag: 'edit-store-details',
 				},
 				{
-					title: __( 'Payments', 'woocommerce-admin' ),
+					title: __( 'Payments', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wc-settings',
 						tab: 'checkout',
@@ -90,7 +90,7 @@ export function getItemsByCategory( shopUrl ) {
 					listItemTag: 'payment-settings',
 				},
 				{
-					title: __( 'Tax', 'woocommerce-admin' ),
+					title: __( 'Tax', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wc-settings',
 						tab: 'tax',
@@ -99,7 +99,7 @@ export function getItemsByCategory( shopUrl ) {
 					listItemTag: 'tax-settings',
 				},
 				{
-					title: __( 'Shipping', 'woocommerce-admin' ),
+					title: __( 'Shipping', 'woocommerce' ),
 					link: getLinkTypeAndHref( {
 						type: 'wc-settings',
 						tab: 'shipping',
@@ -180,7 +180,7 @@ export const StoreManagementLinks = () => {
 	const itemCategories = getItemsByCategory( shopUrl );
 
 	const extensionCategory = {
-		title: __( 'Extensions', 'woocommerce-admin' ),
+		title: __( 'Extensions', 'woocommerce' ),
 		items: extensionQuickLinks,
 	};
 
@@ -192,7 +192,7 @@ export const StoreManagementLinks = () => {
 		<Card size="medium">
 			<CardHeader size="medium">
 				<Text variant="title.small" size="20" lineHeight="28px">
-					{ __( 'Store management', 'woocommerce-admin' ) }
+					{ __( 'Store management', 'woocommerce' ) }
 				</Text>
 			</CardHeader>
 			<CardBody

--- a/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx
@@ -57,18 +57,18 @@ export const ProgressHeader: React.FC< ProgressHeaderProps > = ( {
 			return siteTitle
 				? sprintf(
 						/* translators: %s = site title */
-						__( 'Welcome to %s', 'woocommerce-admin' ),
+						__( 'Welcome to %s', 'woocommerce' ),
 						siteTitle
 				  )
-				: __( 'Welcome', 'woocommerce-admin' );
+				: __( 'Welcome', 'woocommerce' );
 		}
 		if ( completedCount > 0 && completedCount < 4 ) {
-			return __( "Let's get you started", 'woocommerce-admin' ) + '   🚀';
+			return __( "Let's get you started", 'woocommerce' ) + '   🚀';
 		}
 		if ( completedCount > 3 && completedCount < 6 ) {
-			return __( 'You are on the right track', 'woocommerce-admin' );
+			return __( 'You are on the right track', 'woocommerce' );
 		}
-		return __( 'You are almost there', 'woocommerce-admin' );
+		return __( 'You are almost there', 'woocommerce' );
 	}, [ completedCount, hasVisitedTasks ] );
 
 	if ( loading || completedCount === tasksCount ) {
@@ -79,10 +79,7 @@ export const ProgressHeader: React.FC< ProgressHeaderProps > = ( {
 		<div className="woocommerce-task-progress-header">
 			<TaskListMenu
 				id={ taskListId }
-				hideTaskListText={ __(
-					'Hide setup list',
-					'woocommerce-admin'
-				) }
+				hideTaskListText={ __( 'Hide setup list', 'woocommerce' ) }
 			/>
 			<div className="woocommerce-task-progress-header__contents">
 				<h1 className="woocommerce-task-progress-header__title">
@@ -93,7 +90,7 @@ export const ProgressHeader: React.FC< ProgressHeaderProps > = ( {
 						/* translators: 1: completed tasks, 2: total tasks */
 						__(
 							'Follow these steps to start selling quickly. %1$d out of %2$d complete.',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						completedCount,
 						tasksCount

--- a/plugins/woocommerce-admin/client/tasks/back-button.tsx
+++ b/plugins/woocommerce-admin/client/tasks/back-button.tsx
@@ -18,7 +18,7 @@ export type BackButtonProps = {
 };
 
 export const BackButton: React.FC< BackButtonProps > = ( { title } ) => {
-	const homeText = __( 'WooCommerce Home', 'woocommerce-admin' );
+	const homeText = __( 'WooCommerce Home', 'woocommerce' );
 
 	const navigateHome = () => {
 		recordEvent( 'topbar_back_button', {

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
@@ -48,7 +48,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 						src={ imageUrl }
 						alt={ sprintf(
 							/* translators: %s = name of the plugin */
-							__( '%s logo', 'woocommerce-admin' ),
+							__( '%s logo', 'woocommerce' ),
 							name
 						) }
 					/>
@@ -59,10 +59,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 					{ name }
 					{ isBuiltByWC && (
 						<Pill>
-							{ __(
-								'Built by WooCommerce',
-								'woocommerce-admin'
-							) }
+							{ __( 'Built by WooCommerce', 'woocommerce' ) }
 						</Pill>
 					) }
 				</Text>

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
@@ -186,7 +186,7 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 						>
 							{ __(
 								'Installed marketing extensions',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</Text>
 					</CardHeader>
@@ -207,13 +207,13 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 						>
 							{ __(
 								'Recommended marketing extensions',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</Text>
 						<Text as="span">
 							{ __(
 								'We recommend adding one of the following marketing tools for your store. The extension will be installed and activated for you when you click "Get started".',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</Text>
 					</CardHeader>

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/Action.js
@@ -24,7 +24,7 @@ export const Action = ( {
 	markConfigured,
 	onSetUp = () => {},
 	onSetupCallback,
-	setupButtonText = __( 'Set up', 'woocommerce-admin' ),
+	setupButtonText = __( 'Set up', 'woocommerce' ),
 } ) => {
 	const [ isBusy, setIsBusy ] = useState( false );
 
@@ -67,7 +67,7 @@ export const Action = ( {
 			href={ manageUrl }
 			onClick={ () => recordEvent( 'tasklist_payment_manage', { id } ) }
 		>
-			{ __( 'Manage', 'woocommerce-admin' ) }
+			{ __( 'Manage', 'woocommerce' ) }
 		</Button>
 	);
 
@@ -92,7 +92,7 @@ export const Action = ( {
 					isSecondary
 					onClick={ () => markConfigured( id ) }
 				>
-					{ __( 'Enable', 'woocommerce-admin' ) }
+					{ __( 'Enable', 'woocommerce' ) }
 				</Button>
 			);
 		}
@@ -123,7 +123,7 @@ export const Action = ( {
 				disabled={ isBusy }
 				onClick={ () => handleClick() }
 			>
-				{ __( 'Finish setup', 'woocommerce-admin' ) }
+				{ __( 'Finish setup', 'woocommerce' ) }
 			</Button>
 		);
 	}

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/Setup/Configure.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/Setup/Configure.js
@@ -72,10 +72,7 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 						'success',
 						sprintf(
 							/* translators: %s = title of the payment gateway */
-							__(
-								'%s configured successfully',
-								'woocommerce-admin'
-							),
+							__( '%s configured successfully', 'woocommerce' ),
 							title
 						)
 					);
@@ -86,7 +83,7 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 					'error',
 					__(
 						'There was a problem saving your payment settings',
-						'woocommerce-admin'
+						'woocommerce'
 					)
 				);
 			} );
@@ -100,7 +97,7 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 			fields={ fields }
 			isBusy={ isUpdating }
 			onSubmit={ handleSubmit }
-			submitLabel={ __( 'Proceed', 'woocommerce-admin' ) }
+			submitLabel={ __( 'Proceed', 'woocommerce' ) }
 			validate={ ( values ) => validateFields( values, fields ) }
 		/>
 	);
@@ -133,7 +130,7 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 					}
 					href={ connectionUrl }
 				>
-					{ __( 'Connect', 'woocommerce-admin' ) }
+					{ __( 'Connect', 'woocommerce' ) }
 				</Button>
 			</>
 		);
@@ -154,12 +151,12 @@ export const Configure = ( { markConfigured, paymentGateway } ) => {
 				<p>
 					{ __(
 						"You can manage this payment gateway's settings by clicking the button below",
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 			) }
 			<Button isPrimary href={ settingsUrl }>
-				{ __( 'Set up', 'woocommerce-admin' ) }
+				{ __( 'Set up', 'woocommerce' ) }
 			</Button>
 		</>
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/Setup/Setup.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/Setup/Setup.js
@@ -88,7 +88,7 @@ export const Setup = ( { markConfigured, paymentGateway } ) => {
 					key: 'install',
 					label: sprintf(
 						/* translators: %s = title of the payment gateway to install */
-						__( 'Install %s', 'woocommerce-admin' ),
+						__( 'Install %s', 'woocommerce' ),
 						title
 					),
 					content: (
@@ -120,7 +120,7 @@ export const Setup = ( { markConfigured, paymentGateway } ) => {
 		() => ( {
 			key: 'configure',
 			label: sprintf(
-				__( 'Configure your %(title)s account', 'woocommerce-admin' ),
+				__( 'Configure your %(title)s account', 'woocommerce' ),
 				{
 					title,
 				}

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/Suggestion.js
@@ -26,7 +26,7 @@ const TosPrompt = () =>
 	interpolateComponents( {
 		mixedString: __(
 			'Upon clicking "Get started", you agree to the {{link}}Terms of service{{/link}}. Next we’ll ask you to share a few details about your business to create your account.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		components: {
 			link: (
@@ -67,7 +67,7 @@ export const Suggestion = ( { paymentGateway, onSetupCallback = null } ) => {
 				{ installed && needsSetup ? (
 					<SetupRequired />
 				) : (
-					<Pill>{ __( 'Recommended', 'woocommerce-admin' ) }</Pill>
+					<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
 				) }
 			</WCPayCardHeader>
 
@@ -91,10 +91,7 @@ export const Suggestion = ( { paymentGateway, onSetupCallback = null } ) => {
 						isRecommended={ true }
 						isInstalled={ isInstalled }
 						hasPlugins={ true }
-						setupButtonText={ __(
-							'Get started',
-							'woocommerce-admin'
-						) }
+						setupButtonText={ __( 'Get started', 'woocommerce' ) }
 						onSetupCallback={ onSetupCallback }
 					/>
 				</>

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/UsageModal.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/UsageModal.js
@@ -28,12 +28,12 @@ export const UsageModal = () => {
 
 	const title = __(
 		'Help us build a better WooCommerce Payments experience',
-		'woocommerce-admin'
+		'woocommerce'
 	);
 	const trackingMessage = interpolateComponents( {
 		mixedString: __(
 			'By agreeing to share non-sensitive {{link}}usage data{{/link}}, you’ll help us improve features and optimize the WooCommerce Payments experience. You can opt out at any time.',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		components: {
 			link: (
@@ -51,8 +51,8 @@ export const UsageModal = () => {
 			isDismissible={ false }
 			title={ title }
 			message={ trackingMessage }
-			acceptActionText={ __( 'I agree', 'woocommerce-admin' ) }
-			dismissActionText={ __( 'No thanks', 'woocommerce-admin' ) }
+			acceptActionText={ __( 'I agree', 'woocommerce' ) }
+			dismissActionText={ __( 'No thanks', 'woocommerce' ) }
 			onContinue={ closeModal }
 			onClose={ closeModal }
 		/>

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/utils.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/utils.js
@@ -14,7 +14,7 @@ import { createNoticesFromResponse } from '~/lib/notices';
 export function connectWcpay( createNotice, onCatch ) {
 	const errorMessage = __(
 		'There was an error connecting to WooCommerce Payments. Please try again or connect later in store settings.',
-		'woocommerce-admin'
+		'woocommerce'
 	);
 	apiFetch( {
 		path: WC_ADMIN_NAMESPACE + '/plugins/connect-wcpay',

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -241,10 +241,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 
 			{ !! enabledGateways.length && (
 				<List
-					heading={ __(
-						'Enabled payment gateways',
-						'woocommerce-admin'
-					) }
+					heading={ __( 'Enabled payment gateways', 'woocommerce' ) }
 					recommendation={ recommendation }
 					paymentGateways={ enabledGateways }
 				/>
@@ -254,7 +251,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 				<List
 					heading={ __(
 						'Additional payment gateways',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 					recommendation={ recommendation }
 					paymentGateways={ additionalGateways }

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/plugins/Bacs.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/plugins/Bacs.js
@@ -31,7 +31,7 @@ const BacsPaymentGatewaySetup = () => {
 		if ( ! values.account_number && ! values.iban ) {
 			errors.account_number = errors.iban = __(
 				'Please enter an account number or IBAN',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
@@ -52,7 +52,7 @@ const BacsPaymentGatewaySetup = () => {
 				'success',
 				__(
 					'Direct bank transfer details added successfully',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 			return;
@@ -62,7 +62,7 @@ const BacsPaymentGatewaySetup = () => {
 			'error',
 			__(
 				'There was a problem saving your payment settings',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 	};
@@ -85,20 +85,20 @@ const BacsPaymentGatewaySetup = () => {
 										<H>
 											{ __(
 												'Add your bank details',
-												'woocommerce-admin'
+												'woocommerce'
 											) }
 										</H>
 										<p>
 											{ __(
 												'These details are required to receive payments via bank transfer',
-												'woocommerce-admin'
+												'woocommerce'
 											) }
 										</p>
 										<div className="woocommerce-task-payment-method__fields">
 											<TextControl
 												label={ __(
 													'Account name',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												required
 												{ ...getInputProps(
@@ -108,7 +108,7 @@ const BacsPaymentGatewaySetup = () => {
 											<TextControl
 												label={ __(
 													'Account number',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												required
 												{ ...getInputProps(
@@ -118,7 +118,7 @@ const BacsPaymentGatewaySetup = () => {
 											<TextControl
 												label={ __(
 													'Bank name',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												required
 												{ ...getInputProps(
@@ -128,7 +128,7 @@ const BacsPaymentGatewaySetup = () => {
 											<TextControl
 												label={ __(
 													'Sort code',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												required
 												{ ...getInputProps(
@@ -138,7 +138,7 @@ const BacsPaymentGatewaySetup = () => {
 											<TextControl
 												label={ __(
 													'IBAN',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												required
 												{ ...getInputProps( 'iban' ) }
@@ -146,7 +146,7 @@ const BacsPaymentGatewaySetup = () => {
 											<TextControl
 												label={ __(
 													'BIC / Swift',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 												required
 												{ ...getInputProps( 'bic' ) }
@@ -157,10 +157,7 @@ const BacsPaymentGatewaySetup = () => {
 											isBusy={ isUpdating }
 											onClick={ handleSubmit }
 										>
-											{ __(
-												'Save',
-												'woocommerce-admin'
-											) }
+											{ __( 'Save', 'woocommerce' ) }
 										</Button>
 									</>
 								);

--- a/plugins/woocommerce-admin/client/tasks/fills/appearance.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/appearance.js
@@ -121,7 +121,7 @@ class Appearance extends Component {
 						'error',
 						__(
 							'There was an error importing some of the sample products',
-							'woocommerce-admin'
+							'woocommerce'
 						)
 					);
 				} else {
@@ -129,7 +129,7 @@ class Appearance extends Component {
 						'success',
 						__(
 							'All sample products have been imported',
-							'woocommerce-admin'
+							'woocommerce'
 						)
 					);
 				}
@@ -143,7 +143,7 @@ class Appearance extends Component {
 					message ||
 						__(
 							'There was an error importing the sample products',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 					{ __unstableHTML: true }
 				);
@@ -168,10 +168,7 @@ class Appearance extends Component {
 					actions: response.edit_post_link
 						? [
 								{
-									label: __(
-										'Customize',
-										'woocommerce-admin'
-									),
+									label: __( 'Customize', 'woocommerce' ),
 									onClick: () => {
 										queueRecordEvent(
 											'tasklist_appearance_customize_homepage',
@@ -213,7 +210,7 @@ class Appearance extends Component {
 			this.setState( { isUpdatingLogo: false } );
 			createNotice(
 				'success',
-				__( 'Store logo updated sucessfully', 'woocommerce-admin' )
+				__( 'Store logo updated sucessfully', 'woocommerce' )
 			);
 			this.completeStep();
 		} else {
@@ -241,7 +238,7 @@ class Appearance extends Component {
 				'success',
 				__(
 					"🎨 Your store is looking great! Don't forget to continue personalizing it",
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 			this.completeStep();
@@ -262,10 +259,10 @@ class Appearance extends Component {
 		const steps = [
 			{
 				key: 'import',
-				label: __( 'Import sample products', 'woocommerce-admin' ),
+				label: __( 'Import sample products', 'woocommerce' ),
 				description: __(
 					'We’ll add some products that will make it easier to see what your store looks like',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: (
 					<Fragment>
@@ -274,10 +271,10 @@ class Appearance extends Component {
 							isBusy={ isPending }
 							isPrimary
 						>
-							{ __( 'Import products', 'woocommerce-admin' ) }
+							{ __( 'Import products', 'woocommerce' ) }
 						</Button>
 						<Button onClick={ () => this.completeStep() }>
-							{ __( 'Skip', 'woocommerce-admin' ) }
+							{ __( 'Skip', 'woocommerce' ) }
 						</Button>
 					</Fragment>
 				),
@@ -285,10 +282,10 @@ class Appearance extends Component {
 			},
 			{
 				key: 'homepage',
-				label: __( 'Create a custom homepage', 'woocommerce-admin' ),
+				label: __( 'Create a custom homepage', 'woocommerce' ),
 				description: __(
 					'Create a new homepage and customize it to suit your needs',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: (
 					<Fragment>
@@ -297,7 +294,7 @@ class Appearance extends Component {
 							isBusy={ isPending }
 							onClick={ this.createHomepage }
 						>
-							{ __( 'Create homepage', 'woocommerce-admin' ) }
+							{ __( 'Create homepage', 'woocommerce' ) }
 						</Button>
 						<Button
 							isTertiary
@@ -309,7 +306,7 @@ class Appearance extends Component {
 								this.completeStep();
 							} }
 						>
-							{ __( 'Skip', 'woocommerce-admin' ) }
+							{ __( 'Skip', 'woocommerce' ) }
 						</Button>
 					</Fragment>
 				),
@@ -317,10 +314,10 @@ class Appearance extends Component {
 			},
 			{
 				key: 'logo',
-				label: __( 'Upload a logo', 'woocommerce-admin' ),
+				label: __( 'Upload a logo', 'woocommerce' ),
 				description: __(
 					'Ensure your store is on-brand by adding your logo',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: isPending ? null : (
 					<Fragment>
@@ -336,13 +333,13 @@ class Appearance extends Component {
 							isBusy={ isUpdatingLogo }
 							isPrimary
 						>
-							{ __( 'Proceed', 'woocommerce-admin' ) }
+							{ __( 'Proceed', 'woocommerce' ) }
 						</Button>
 						<Button
 							isTertiary
 							onClick={ () => this.completeStep() }
 						>
-							{ __( 'Skip', 'woocommerce-admin' ) }
+							{ __( 'Skip', 'woocommerce' ) }
 						</Button>
 					</Fragment>
 				),
@@ -350,21 +347,18 @@ class Appearance extends Component {
 			},
 			{
 				key: 'notice',
-				label: __( 'Set a store notice', 'woocommerce-admin' ),
+				label: __( 'Set a store notice', 'woocommerce' ),
 				description: __(
 					'Optionally display a prominent notice across all pages of your store',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: (
 					<Fragment>
 						<TextControl
-							label={ __(
-								'Store notice text',
-								'woocommerce-admin'
-							) }
+							label={ __( 'Store notice text', 'woocommerce' ) }
 							placeholder={ __(
 								'Store notice text',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 							value={ storeNoticeText }
 							onChange={ ( value ) =>
@@ -372,7 +366,7 @@ class Appearance extends Component {
 							}
 						/>
 						<Button onClick={ this.updateNotice } isPrimary>
-							{ __( 'Complete task', 'woocommerce-admin' ) }
+							{ __( 'Complete task', 'woocommerce' ) }
 						</Button>
 					</Fragment>
 				),

--- a/plugins/woocommerce-admin/client/tasks/fills/connect.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/connect.js
@@ -21,7 +21,7 @@ class Connect extends Component {
 			this.errorMessage(
 				__(
 					'You must click approve to install your extensions and connect to WooCommerce.com',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 			return;
@@ -48,7 +48,7 @@ class Connect extends Component {
 	errorMessage(
 		message = __(
 			'There was an error connecting to WooCommerce.com. Please try again',
-			'woocommerce-admin'
+			'woocommerce'
 		)
 	) {
 		document.body.classList.remove( 'woocommerce-admin-is-loading' );
@@ -91,7 +91,7 @@ class Connect extends Component {
 						'success',
 						__(
 							'Store connected to WooCommerce.com and extensions are being installed',
-							'woocommerce-admin'
+							'woocommerce'
 						)
 					);
 

--- a/plugins/woocommerce-admin/client/tasks/fills/products/product-template-modal.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/product-template-modal.js
@@ -28,34 +28,34 @@ export const ONBOARDING_PRODUCT_TEMPLATES_FILTER =
 const getProductTemplates = () => [
 	{
 		key: 'physical',
-		title: __( 'Physical product', 'woocommerce-admin' ),
+		title: __( 'Physical product', 'woocommerce' ),
 		subtitle: __(
 			'Tangible items that get delivered to customers',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'digital',
-		title: __( 'Digital product', 'woocommerce-admin' ),
+		title: __( 'Digital product', 'woocommerce' ),
 		subtitle: __(
 			'Items that customers download or access through your website',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'variable',
-		title: __( 'Variable product', 'woocommerce-admin' ),
+		title: __( 'Variable product', 'woocommerce' ),
 		subtitle: __(
 			'Products with several versions that customers can choose from',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 	{
 		key: 'subscription',
-		title: __( 'Subscription product', 'woocommerce-admin' ),
+		title: __( 'Subscription product', 'woocommerce' ),
 		subtitle: __(
 			'Products that customers receive or gain access to regularly by paying in advance',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 	},
 ];

--- a/plugins/woocommerce-admin/client/tasks/fills/products/products.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/products.js
@@ -35,13 +35,13 @@ const getSubTasks = () => [
 		key: 'addProductTemplate',
 		title: (
 			<>
-				{ __( 'Start with a template', 'woocommerce-admin' ) }
-				<Pill>{ __( 'Recommended', 'woocommerce-admin' ) }</Pill>
+				{ __( 'Start with a template', 'woocommerce' ) }
+				<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
 			</>
 		),
 		content: __(
 			'Use a template to add physical, digital, and variable products',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		before: <Icon icon={ sidebar }></Icon>,
 		after: <Icon icon={ chevronRight } />,
@@ -52,10 +52,10 @@ const getSubTasks = () => [
 	},
 	{
 		key: 'addProductManually',
-		title: __( 'Add manually', 'woocommerce-admin' ),
+		title: __( 'Add manually', 'woocommerce' ),
 		content: __(
 			'For small stores we recommend adding products manually',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		before: <Icon icon={ plusCircle } />,
 		after: <Icon icon={ chevronRight } />,
@@ -67,10 +67,10 @@ const getSubTasks = () => [
 	},
 	{
 		key: 'importProducts',
-		title: __( 'Import via CSV', 'woocommerce-admin' ),
+		title: __( 'Import via CSV', 'woocommerce' ),
 		content: __(
 			'For larger stores we recommend importing all products at once via CSV file',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		before: <Icon icon={ archive } />,
 		after: <Icon icon={ chevronRight } />,
@@ -82,10 +82,10 @@ const getSubTasks = () => [
 	},
 	{
 		key: 'migrateProducts',
-		title: __( 'Import from another service', 'woocommerce-admin' ),
+		title: __( 'Import from another service', 'woocommerce' ),
 		content: __(
 			'For stores currently selling elsewhere we suggest using a product migration service',
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		before: <Icon icon={ download } />,
 		after: <Icon icon={ chevronRight } />,
@@ -131,7 +131,7 @@ const Products = () => {
 		);
 		task.content = __(
 			'Use a template to add physical, digital, variable, and subscription products',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 

--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
@@ -72,7 +72,7 @@ export class Shipping extends Component {
 					zone.methods = await apiFetch( {
 						path: `/wc/v3/shipping/zones/${ zone.id }/methods`,
 					} );
-					zone.name = __( 'Rest of the world', 'woocommerce-admin' );
+					zone.name = __( 'Rest of the world', 'woocommerce' );
 					zone.toggleable = true;
 					shippingZones.push( zone );
 					return;
@@ -159,7 +159,7 @@ export class Shipping extends Component {
 				'success',
 				__(
 					"📦 Shipping is done! Don't worry, you can always change it later",
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 			onComplete();
@@ -198,10 +198,10 @@ export class Shipping extends Component {
 		const steps = [
 			{
 				key: 'store_location',
-				label: __( 'Set store location', 'woocommerce-admin' ),
+				label: __( 'Set store location', 'woocommerce' ),
 				description: __(
 					'The address from which your business operates',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: (
 					<StoreLocation
@@ -225,18 +225,18 @@ export class Shipping extends Component {
 			},
 			{
 				key: 'rates',
-				label: __( 'Set shipping costs', 'woocommerce-admin' ),
+				label: __( 'Set shipping costs', 'woocommerce' ),
 				description: __(
 					'Define how much customers pay to ship to different destinations',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: (
 					<ShippingRates
 						buttonText={
 							pluginsToActivate.length ||
 							requiresJetpackConnection
-								? __( 'Proceed', 'woocommerce-admin' )
-								: __( 'Complete task', 'woocommerce-admin' )
+								? __( 'Proceed', 'woocommerce' )
+								: __( 'Complete task', 'woocommerce' )
 						}
 						shippingZones={ this.state.shippingZones }
 						onComplete={ () => {
@@ -255,10 +255,7 @@ export class Shipping extends Component {
 			},
 			{
 				key: 'label_printing',
-				label: __(
-					'Enable shipping label printing',
-					'woocommerce-admin'
-				),
+				label: __( 'Enable shipping label printing', 'woocommerce' ),
 				description: pluginsToActivate.includes(
 					'woocommerce-shipstation-integration'
 				)
@@ -266,7 +263,7 @@ export class Shipping extends Component {
 							mixedString: __(
 								'We recommend using ShipStation to save time at the post office by printing your shipping ' +
 									'labels at home. Try ShipStation free for 30 days. {{link}}Learn more{{/link}}.',
-								'woocommerce-admin'
+								'woocommerce'
 							),
 							components: {
 								link: (
@@ -281,7 +278,7 @@ export class Shipping extends Component {
 					: __(
 							'With WooCommerce Shipping you can save time ' +
 								'by printing your USPS and DHL Express shipping labels at home',
-							'woocommerce-admin'
+							'woocommerce'
 					  ),
 				content: (
 					<Plugins
@@ -311,10 +308,10 @@ export class Shipping extends Component {
 			},
 			{
 				key: 'connect',
-				label: __( 'Connect your store', 'woocommerce-admin' ),
+				label: __( 'Connect your store', 'woocommerce' ),
 				description: __(
 					'Connect your store to WordPress.com to enable label printing',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				content: (
 					<Connect

--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/rates.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/rates.js
@@ -70,7 +70,7 @@ const ShippingRateInput = ( {
 			) }
 			{ ( ! zone.toggleable || values[ `${ zone.id }_enabled` ] ) && (
 				<TextControlWithAffixes
-					label={ __( 'Shipping cost', 'woocommerce-admin' ) }
+					label={ __( 'Shipping cost', 'woocommerce' ) }
 					required
 					className={ textControlClassName }
 					{ ...restInputProps }
@@ -192,7 +192,7 @@ class ShippingRates extends Component {
 
 		createNotice(
 			'success',
-			__( 'Your shipping rates have been updated', 'woocommerce-admin' )
+			__( 'Your shipping rates have been updated', 'woocommerce' )
 		);
 
 		this.props.onComplete();
@@ -222,7 +222,7 @@ class ShippingRates extends Component {
 
 		return parseFloat( rate ) === parseFloat( 0 ) ? (
 			<span className="woocommerce-shipping-rate__control-suffix">
-				{ __( 'Free shipping', 'woocommerce-admin' ) }
+				{ __( 'Free shipping', 'woocommerce' ) }
 			</span>
 		) : null;
 	}
@@ -272,7 +272,7 @@ class ShippingRates extends Component {
 			if ( values[ rate ] < 0 ) {
 				errors[ rate ] = __(
 					'Shipping rates can not be negative numbers.',
-					'woocommerce-admin'
+					'woocommerce'
 				);
 			}
 		} );
@@ -341,8 +341,7 @@ class ShippingRates extends Component {
 							</div>
 
 							<Button isPrimary onClick={ handleSubmit }>
-								{ buttonText ||
-									__( 'Update', 'woocommerce-admin' ) }
+								{ buttonText || __( 'Update', 'woocommerce' ) }
 							</Button>
 						</Fragment>
 					);

--- a/plugins/woocommerce-admin/client/tasks/fills/steps/location.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/steps/location.js
@@ -54,7 +54,7 @@ const StoreLocation = ( {
 				'error',
 				__(
 					'There was a problem saving your store location',
-					'woocommerce-admin'
+					'woocommerce'
 				)
 			);
 		}
@@ -101,7 +101,7 @@ const StoreLocation = ( {
 						setValue={ setValue }
 					/>
 					<Button isPrimary onClick={ handleSubmit }>
-						{ __( 'Continue', 'woocommerce-admin' ) }
+						{ __( 'Continue', 'woocommerce' ) }
 					</Button>
 				</Fragment>
 			) }

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/avalara/card.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/avalara/card.tsx
@@ -17,18 +17,15 @@ export const Card = ( { task } ) => {
 
 	return (
 		<PartnerCard
-			name={ __( 'Avalara', 'woocommerce-admin' ) }
+			name={ __( 'Avalara', 'woocommerce' ) }
 			logo={ logo }
-			description={ __(
-				'Powerful all-in-one tax tool',
-				'woocommerce-admin'
-			) }
+			description={ __( 'Powerful all-in-one tax tool', 'woocommerce' ) }
 			benefits={ [
-				__( 'Real-time sales tax calculation', 'woocommerce-admin' ),
+				__( 'Real-time sales tax calculation', 'woocommerce' ),
 				interpolateComponents( {
 					mixedString: __(
 						'{{strong}}Multi{{/strong}}-economic nexus compliance',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						strong: <strong />,
@@ -36,22 +33,22 @@ export const Card = ( { task } ) => {
 				} ),
 				__(
 					'Cross-border and multi-channel compliance',
-					'woocommerce-admin'
+					'woocommerce'
 				),
-				__( 'Automate filing & remittance', 'woocommerce-admin' ),
+				__( 'Automate filing & remittance', 'woocommerce' ),
 				__(
 					'Return-ready, jurisdiction-level reporting.',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 			] }
 			terms={ __(
 				'30-day free trial. No credit card needed.',
-				'woocommerce-admin'
+				'woocommerce'
 			) }
 			actionText={
 				avalaraActivated
-					? __( 'Continue setup', 'woocommerce-admin' )
-					: __( 'Enable & set up', 'woocommerce-admin' )
+					? __( 'Continue setup', 'woocommerce' )
+					: __( 'Enable & set up', 'woocommerce' )
 			}
 			onClick={ () => {
 				recordEvent( 'tasklist_tax_select_option', {

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/components/partners.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/components/partners.tsx
@@ -28,7 +28,7 @@ export const Partners: React.FC< TaxChildProps > = ( {
 	return (
 		<Card className={ classes }>
 			<CardHeader>
-				{ __( 'Choose a tax partner', 'woocommerce-admin' ) }
+				{ __( 'Choose a tax partner', 'woocommerce' ) }
 			</CardHeader>
 			<CardBody>
 				<div className="woocommerce-tax-partners__partners">
@@ -44,10 +44,7 @@ export const Partners: React.FC< TaxChildProps > = ( {
 								onManual();
 							} }
 						>
-							{ __(
-								'Set up taxes manually',
-								'woocommerce-admin'
-							) }
+							{ __( 'Set up taxes manually', 'woocommerce' ) }
 						</Button>
 					</li>
 					<li>
@@ -59,10 +56,7 @@ export const Partners: React.FC< TaxChildProps > = ( {
 								onDisable();
 							} }
 						>
-							{ __(
-								"I don't charge sales tax",
-								'woocommerce-admin'
-							) }
+							{ __( "I don't charge sales tax", 'woocommerce' ) }
 						</Button>
 					</li>
 				</ul>

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/index.tsx
@@ -112,7 +112,7 @@ const Tax = ( { onComplete, query, task } ) => {
 			'success',
 			__(
 				"You're awesome! One less item on your to-do list ✅",
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 		onComplete();

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/manual-configuration/configure.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/manual-configuration/configure.tsx
@@ -39,7 +39,7 @@ export const Configure: React.FC< TaxChildProps > = ( {
 					onManual();
 				} }
 			>
-				{ __( 'Configure', 'woocommerce-admin' ) }
+				{ __( 'Configure', 'woocommerce' ) }
 			</Button>
 			<p>
 				{ generalSettings.woocommerce_calc_taxes !== 'yes' &&
@@ -47,8 +47,7 @@ export const Configure: React.FC< TaxChildProps > = ( {
 						mixedString: __(
 							/*eslint-disable max-len*/
 							'By clicking "Configure" you\'re enabling tax rates and calculations. More info {{link}}here{{/link}}.',
-							/*eslint-enable max-len*/
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						components: {
 							link: (

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/manual-configuration/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/manual-configuration/index.tsx
@@ -42,19 +42,19 @@ export const ManualConfiguration: React.FC< ManualConfigurationProps > = ( {
 	const steps = [
 		{
 			key: 'store_location',
-			label: __( 'Set store location', 'woocommerce-admin' ),
+			label: __( 'Set store location', 'woocommerce' ),
 			description: __(
 				'The address from which your business operates',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			content: <StoreLocation { ...stepProps } />,
 		},
 		{
 			key: 'manual_configuration',
-			label: __( 'Configure tax rates', 'woocommerce-admin' ),
+			label: __( 'Configure tax rates', 'woocommerce' ),
 			description: __(
 				'Head over to the tax rate settings screen to configure your tax rates',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			content: <Configure { ...stepProps } />,
 		},

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/automated-taxes.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/automated-taxes.tsx
@@ -28,14 +28,14 @@ export const AutomatedTaxes: React.FC< SetupStepProps > = ( {
 				🎊
 			</span>
 			<H id="woocommerce-task-tax__success-message">
-				{ __( 'Good news!', 'woocommerce-admin' ) }
+				{ __( 'Good news!', 'woocommerce' ) }
 			</H>
 			<p>
 				{ interpolateComponents( {
 					mixedString: __(
 						'{{strong}}Jetpack{{/strong}} and {{strong}}WooCommerce Tax{{/strong}} ' +
 							'can automate your sales tax calculations for you.',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						strong: <strong />,
@@ -52,7 +52,7 @@ export const AutomatedTaxes: React.FC< SetupStepProps > = ( {
 					onAutomate();
 				} }
 			>
-				{ __( 'Yes please', 'woocommerce-admin' ) }
+				{ __( 'Yes please', 'woocommerce' ) }
 			</Button>
 			<Button
 				disabled={ isPending }
@@ -64,10 +64,10 @@ export const AutomatedTaxes: React.FC< SetupStepProps > = ( {
 					onManual();
 				} }
 			>
-				{ __( "No thanks, I'll set up manually", 'woocommerce-admin' ) }
+				{ __( "No thanks, I'll set up manually", 'woocommerce' ) }
 			</Button>
 			<Button disabled={ isPending } isTertiary onClick={ onDisable }>
-				{ __( "I don't charge sales tax", 'woocommerce-admin' ) }
+				{ __( "I don't charge sales tax", 'woocommerce' ) }
 			</Button>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/card.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/card.tsx
@@ -17,15 +17,15 @@ import { TaxChildProps } from '../utils';
 export const Card: React.FC< TaxChildProps > = () => {
 	return (
 		<PartnerCard
-			name={ __( 'WooCommerce Tax', 'woocommerce-admin' ) }
+			name={ __( 'WooCommerce Tax', 'woocommerce' ) }
 			logo={ logo }
-			description={ __( 'Best for new stores', 'woocommerce-admin' ) }
+			description={ __( 'Best for new stores', 'woocommerce' ) }
 			benefits={ [
-				__( 'Real-time sales tax calculation', 'woocommerce-admin' ),
+				__( 'Real-time sales tax calculation', 'woocommerce' ),
 				interpolateComponents( {
 					mixedString: __(
 						'{{strong}}Single{{/strong}} economic nexus compliance',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						strong: <strong />,
@@ -34,7 +34,7 @@ export const Card: React.FC< TaxChildProps > = () => {
 				interpolateComponents( {
 					mixedString: __(
 						'Powered by {{link}}Jetpack{{/link}}',
-						'woocommerce-admin'
+						'woocommerce'
 					),
 					components: {
 						link: (
@@ -47,12 +47,12 @@ export const Card: React.FC< TaxChildProps > = () => {
 					},
 				} ),
 				// eslint-disable-next-line @wordpress/i18n-translator-comments
-				__( '100% free', 'woocommerce-admin' ),
+				__( '100% free', 'woocommerce' ),
 			] }
 			terms={ interpolateComponents( {
 				mixedString: __(
 					'By installing WooCommerce Tax and Jetpack you agree to the {{link}}Terms of Service{{/link}}.',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				components: {
 					link: (
@@ -64,7 +64,7 @@ export const Card: React.FC< TaxChildProps > = () => {
 					),
 				},
 			} ) }
-			actionText={ __( 'Continue setup', 'woocommerce-admin' ) }
+			actionText={ __( 'Continue setup', 'woocommerce' ) }
 			onClick={ () => {
 				recordEvent( 'tasklist_tax_select_option', {
 					selected_option: 'woocommerce-tax',

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/connect.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/connect.tsx
@@ -29,11 +29,11 @@ export const Connect: React.FC< SetupStepProps > = ( {
 				} );
 				onManual();
 			} }
-			skipText={ __( 'Set up tax rates manually', 'woocommerce-admin' ) }
+			skipText={ __( 'Set up tax rates manually', 'woocommerce' ) }
 			onAbort={ () => onDisable() }
 			abortText={ __(
 				"My business doesn't charge sales tax",
-				'woocommerce-admin'
+				'woocommerce'
 			) }
 		/>
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/plugins.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/plugins.tsx
@@ -54,11 +54,11 @@ export const Plugins: React.FC< SetupStepProps > = ( {
 	const agreementText = pluginsToActivate.includes( 'woocommerce-services' )
 		? __(
 				'By installing Jetpack and WooCommerce Tax you agree to the {{link}}Terms of Service{{/link}}.',
-				'woocommerce-admin'
+				'woocommerce'
 		  )
 		: __(
 				'By installing Jetpack you agree to the {{link}}Terms of Service{{/link}}.',
-				'woocommerce-admin'
+				'woocommerce'
 		  );
 
 	if ( isResolving ) {
@@ -87,12 +87,9 @@ export const Plugins: React.FC< SetupStepProps > = ( {
 					} );
 					onManual();
 				} }
-				skipText={ __( 'Set up manually', 'woocommerce-admin' ) }
+				skipText={ __( 'Set up manually', 'woocommerce' ) }
 				onAbort={ () => onDisable() }
-				abortText={ __(
-					"I don't charge sales tax",
-					'woocommerce-admin'
-				) }
+				abortText={ __( "I don't charge sales tax", 'woocommerce' ) }
 			/>
 			{ ! tosAccepted && (
 				<Text

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/setup.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/woocommerce-tax/setup.tsx
@@ -96,33 +96,30 @@ export const Setup: React.FC< SetupProps > = ( {
 	const steps = [
 		{
 			key: 'store_location',
-			label: __( 'Set store location', 'woocommerce-admin' ),
+			label: __( 'Set store location', 'woocommerce' ),
 			description: __(
 				'The address from which your business operates',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			content: <StoreLocation { ...stepProps } />,
 		},
 		{
 			key: 'plugins',
 			label: pluginsToActivate.includes( 'woocommerce-services' )
-				? __(
-						'Install Jetpack and WooCommerce Tax',
-						'woocommerce-admin'
-				  )
-				: __( 'Install Jetpack', 'woocommerce-admin' ),
+				? __( 'Install Jetpack and WooCommerce Tax', 'woocommerce' )
+				: __( 'Install Jetpack', 'woocommerce' ),
 			description: __(
 				'Jetpack and WooCommerce Tax allow you to automate sales tax calculations',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			content: <Plugins { ...stepProps } />,
 		},
 		{
 			key: 'connect',
-			label: __( 'Connect your store', 'woocommerce-admin' ),
+			label: __( 'Connect your store', 'woocommerce' ),
 			description: __(
 				'Connect your store to WordPress.com to enable automated sales tax calculations',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			content: <Connect { ...stepProps } />,
 		},

--- a/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
@@ -38,12 +38,12 @@ const ReminderText: React.FC< ReminderTextProps > = ( { remainingCount } ) => {
 			? /* translators: 1: remaining tasks count */
 			  __(
 					'🎉 Almost there. Only {{strongText}}%1$d step left{{/strongText}} get your store up and running. {{setupLink}}Finish setup{{/setupLink}}',
-					'woocommerce-admin'
+					'woocommerce'
 			  )
 			: /* translators: 1: remaining tasks count */
 			  __(
 					"🚀 You're doing great! {{strongText}}%1$d steps left{{/strongText}} to get your store up and running. {{setupLink}}Continue setup{{/setupLink}}",
-					'woocommerce-admin'
+					'woocommerce'
 			  );
 
 	return (

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -69,7 +69,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
 				{
-					label: __( 'Undo', 'woocommerce-admin' ),
+					label: __( 'Undo', 'woocommerce' ),
 					onClick: () => undoDismissTask( id ),
 				},
 			],
@@ -80,11 +80,11 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		snoozeTask( id );
 		createNotice(
 			'success',
-			__( 'Task postponed until tomorrow', 'woocommerce-admin' ),
+			__( 'Task postponed until tomorrow', 'woocommerce' ),
 			{
 				actions: [
 					{
-						label: __( 'Undo', 'woocommerce-admin' ),
+						label: __( 'Undo', 'woocommerce' ),
 						onClick: () => undoSnoozeTask( id ),
 					},
 				],

--- a/plugins/woocommerce-admin/client/tasks/task-list-menu.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-menu.tsx
@@ -21,12 +21,12 @@ export const TaskListMenu: React.FC< TaskListMenuProps > = ( {
 	return (
 		<div className="woocommerce-card__menu woocommerce-card__header-item">
 			<EllipsisMenu
-				label={ __( 'Task List Options', 'woocommerce-admin' ) }
+				label={ __( 'Task List Options', 'woocommerce' ) }
 				renderContent={ () => (
 					<div className="woocommerce-task-card__section-controls">
 						<Button onClick={ () => hideTaskList( id ) }>
 							{ hideTaskListText ||
-								__( 'Hide this', 'woocommerce-admin' ) }
+								__( 'Hide this', 'woocommerce' ) }
 						</Button>
 					</div>
 				) }

--- a/plugins/woocommerce-admin/client/tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list.tsx
@@ -91,11 +91,11 @@ export const TaskList: React.FC< TaskListProps > = ( {
 			'Show %d more task.',
 			'Show %d more tasks.',
 			visibleTasks.length - 2,
-			'woocommerce-admin'
+			'woocommerce'
 		),
 		visibleTasks.length - 2
 	);
-	const collapseLabel = __( 'Show less', 'woocommerce-admin' );
+	const collapseLabel = __( 'Show less', 'woocommerce' );
 	const ListComp = isCollapsible ? CollapsibleList : List;
 
 	const listProps = isCollapsible

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -171,7 +171,7 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 						<DisplayOption>
 							<MenuGroup
 								className="woocommerce-layout__homescreen-display-options"
-								label={ __( 'Display', 'woocommerce-admin' ) }
+								label={ __( 'Display', 'woocommerce' ) }
 							>
 								<MenuItem
 									className="woocommerce-layout__homescreen-extension-tasklist-toggle"
@@ -182,7 +182,7 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 								>
 									{ __(
 										'Show things to do next',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 								</MenuItem>
 							</MenuGroup>

--- a/plugins/woocommerce-admin/client/two-column-tasks/completed.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/completed.js
@@ -30,14 +30,14 @@ export const TaskListCompleted = ( { twoColumns, hideTasks, keepTasks } ) => {
 							<h2>
 								{ __(
 									"You've completed store setup",
-									'woocommerce-admin'
+									'woocommerce'
 								) }
 							</h2>
 							<Button isSecondary onClick={ keepTasks }>
-								{ __( 'Keep list', 'woocommerce-admin' ) }
+								{ __( 'Keep list', 'woocommerce' ) }
 							</Button>
 							<Button isPrimary onClick={ hideTasks }>
-								{ __( 'Hide this list', 'woocommerce-admin' ) }
+								{ __( 'Hide this list', 'woocommerce' ) }
 							</Button>
 						</div>
 					</CardHeader>

--- a/plugins/woocommerce-admin/client/two-column-tasks/dismiss-modal.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/dismiss-modal.js
@@ -10,16 +10,13 @@ const DismissModal = ( {
 	hideTasks,
 } ) => {
 	const closeModal = () => setShowDismissModal( false );
-	const title = __( 'Hide store setup tasks', 'woocommerce-admin' );
+	const title = __( 'Hide store setup tasks', 'woocommerce' );
 	const message = __(
 		'Are you sure? These tasks are required for all stores.',
-		'woocommerce-admin'
+		'woocommerce'
 	);
-	const dismissActionText = __( 'Cancel', 'woocommerce-admin' );
-	const acceptActionText = __(
-		'Yes, hide store setup tasks',
-		'woocommerce-admin'
-	);
+	const dismissActionText = __( 'Cancel', 'woocommerce' );
+	const acceptActionText = __( 'Yes, hide store setup tasks', 'woocommerce' );
 	return (
 		<>
 			{ showDismissModal && (

--- a/plugins/woocommerce-admin/client/two-column-tasks/extended-task.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/extended-task.tsx
@@ -108,7 +108,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 				<DisplayOption>
 					<MenuGroup
 						className="woocommerce-layout__homescreen-display-options"
-						label={ __( 'Display', 'woocommerce-admin' ) }
+						label={ __( 'Display', 'woocommerce' ) }
 					>
 						<MenuItem
 							className="woocommerce-layout__homescreen-extension-tasklist-toggle"
@@ -117,10 +117,7 @@ const ExtendedTask: React.FC< TasksProps > = ( { query } ) => {
 							role="menuitemcheckbox"
 							onClick={ () => toggleTaskList( extendedTaskList ) }
 						>
-							{ __(
-								'Show things to do next',
-								'woocommerce-admin'
-							) }
+							{ __( 'Show things to do next', 'woocommerce' ) }
 						</MenuItem>
 					</MenuGroup>
 				</DisplayOption>

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/appearance.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/appearance.js
@@ -15,11 +15,11 @@ const AppearanceHeader = ( { task, goToTask } ) => {
 		<div className="woocommerce-task-header__contents-container">
 			<PersonalizeMyStore className="svg-background" />
 			<div className="woocommerce-task-header__contents">
-				<h1>{ __( 'Personalize my store', 'woocommerce-admin' ) }</h1>
+				<h1>{ __( 'Personalize my store', 'woocommerce' ) }</h1>
 				<p>
 					{ __(
 						'Add your logo, create a homepage, and start designing your store',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<Button
@@ -28,8 +28,8 @@ const AppearanceHeader = ( { task, goToTask } ) => {
 					onClick={ goToTask }
 				>
 					{ task.isComplete
-						? __( 'Modify choices', 'woocommerce-admin' )
-						: __( 'Personalize', 'woocommerce-admin' ) }
+						? __( 'Modify choices', 'woocommerce' )
+						: __( 'Personalize', 'woocommerce' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/marketing.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/marketing.js
@@ -15,11 +15,11 @@ const MarketingHeader = ( { task, goToTask } ) => {
 		<div className="woocommerce-task-header__contents-container">
 			<GetMoreSales className="svg-background" />
 			<div className="woocommerce-task-header__contents">
-				<h1>{ __( 'Get more sales', 'woocommerce-admin' ) }</h1>
+				<h1>{ __( 'Get more sales', 'woocommerce' ) }</h1>
 				<p>
 					{ __(
 						'Add tools to grow your store such as email, social, and in-person selling',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<Button
@@ -27,7 +27,7 @@ const MarketingHeader = ( { task, goToTask } ) => {
 					isPrimary={ ! task.isComplete }
 					onClick={ goToTask }
 				>
-					{ __( 'Add selling tools', 'woocommerce-admin' ) }
+					{ __( 'Add selling tools', 'woocommerce' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/payments.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/payments.js
@@ -15,11 +15,11 @@ const PaymentsHeader = ( { task, goToTask } ) => {
 		<div className="woocommerce-task-header__contents-container">
 			<GetPaid className="svg-background" />
 			<div className="woocommerce-task-header__contents">
-				<h1>{ __( 'Choose payment methods', 'woocommerce-admin' ) }</h1>
+				<h1>{ __( 'Choose payment methods', 'woocommerce' ) }</h1>
 				<p>
 					{ __(
 						'Choose payment providers and enable payment methods at checkout',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<Button
@@ -27,7 +27,7 @@ const PaymentsHeader = ( { task, goToTask } ) => {
 					isPrimary={ ! task.isComplete }
 					onClick={ goToTask }
 				>
-					{ __( 'Set up payments', 'woocommerce-admin' ) }
+					{ __( 'Set up payments', 'woocommerce' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/products.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/products.js
@@ -26,7 +26,7 @@ const ProductsHeader = ( { task, goToTask } ) => {
 					isPrimary={ ! task.isComplete }
 					onClick={ goToTask }
 				>
-					{ __( 'Add products', 'woocommerce-admin' ) }
+					{ __( 'Add products', 'woocommerce' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/shipping.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/shipping.js
@@ -16,15 +16,12 @@ const ShippingHeader = ( { task, goToTask } ) => {
 			<Shipping className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>
-					{ __(
-						'Set up shipping for your store',
-						'woocommerce-admin'
-					) }
+					{ __( 'Set up shipping for your store', 'woocommerce' ) }
 				</h1>
 				<p>
 					{ __(
 						'Configure shipping zones and rates',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<Button
@@ -32,7 +29,7 @@ const ShippingHeader = ( { task, goToTask } ) => {
 					isPrimary={ ! task.isComplete }
 					onClick={ goToTask }
 				>
-					{ __( 'Add shipping zones', 'woocommerce-admin' ) }
+					{ __( 'Add shipping zones', 'woocommerce' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/tax.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/tax.js
@@ -15,9 +15,7 @@ const TaxHeader = ( { task, goToTask } ) => {
 		<div className="woocommerce-task-header__contents-container">
 			<AddTaxRates className="svg-background" />
 			<div className="woocommerce-task-header__contents">
-				<h1>
-					{ __( 'Next up, add your tax rates', 'woocommerce-admin' ) }
-				</h1>
+				<h1>{ __( 'Next up, add your tax rates', 'woocommerce' ) }</h1>
 				<p>{ task.content }</p>
 				<Button
 					isSecondary={ task.isComplete }

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/woocommerce-payments.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/woocommerce-payments.js
@@ -19,7 +19,7 @@ import GetPaid from './illustrations/get-paid';
 const connect = ( createNotice, setIsBusy ) => {
 	const errorMessage = __(
 		'There was an error connecting to WooCommerce Payments. Please try again or connect later in store settings.',
-		'woocommerce-admin'
+		'woocommerce'
 	);
 	setIsBusy( true );
 	apiFetch( {
@@ -47,18 +47,18 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 		<div className="woocommerce-task-header__contents-container">
 			<GetPaid className="svg-background" />
 			<div className="woocommerce-task-header__contents">
-				<h1>{ __( "It's time to get paid", 'woocommerce-admin' ) }</h1>
+				<h1>{ __( "It's time to get paid", 'woocommerce' ) }</h1>
 				<p>
 					{ __(
 						"You're only one step away from getting paid. Verify your business details to start managing transactions with WooCommerce Payments.",
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<p>
 					{ interpolateComponents( {
 						mixedString: __(
 							'By clicking "Verify Details", you agree to the {{link}}Terms of Service{{/link}}',
-							'woocommerce-admin'
+							'woocommerce'
 						),
 						components: {
 							link: (
@@ -79,7 +79,7 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 					disabled={ isBusy }
 					onClick={ onClick }
 				>
-					{ __( 'Verify details', 'woocommerce-admin' ) }
+					{ __( 'Verify details', 'woocommerce' ) }
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }

--- a/plugins/woocommerce-admin/client/two-column-tasks/index.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/index.js
@@ -109,10 +109,7 @@ const TaskDashboard = ( { query, twoColumns } ) => {
 					isComplete={ isTaskListComplete }
 					query={ query }
 					tasks={ setupTasks }
-					title={ __(
-						'Get ready to start selling',
-						'woocommerce-admin'
-					) }
+					title={ __( 'Get ready to start selling', 'woocommerce' ) }
 				/>
 			) }
 		</>

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -104,7 +104,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		createNotice( 'success', __( 'Task dismissed' ), {
 			actions: [
 				{
-					label: __( 'Undo', 'woocommerce-admin' ),
+					label: __( 'Undo', 'woocommerce' ),
 					onClick: () => undoDismissTask( taskId ),
 				},
 			],
@@ -134,7 +134,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 			<div className="woocommerce-card__menu woocommerce-card__header-item">
 				<EllipsisMenu
 					className={ id }
-					label={ __( 'Task List Options', 'woocommerce-admin' ) }
+					label={ __( 'Task List Options', 'woocommerce' ) }
 					renderContent={ ( {
 						onToggle,
 					}: {
@@ -151,7 +151,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 									}
 								} }
 							>
-								{ __( 'Hide this', 'woocommerce-admin' ) }
+								{ __( 'Hide this', 'woocommerce' ) }
 							</Button>
 						</div>
 					) }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -65,21 +65,21 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 
 	return (
 		<Modal
-			title={ __( 'Build a Better WooCommerce', 'woocommerce-admin' ) }
+			title={ __( 'Build a Better WooCommerce', 'woocommerce' ) }
 			onRequestClose={ () => setIsModalOpen( false ) }
 			className="woocommerce-beta-features-tracking-modal"
 		>
 			<p>
 				{ __(
 					'Testing new features requires sharing non-sensitive data via ',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 				<a href="https://woocommerce.com/usage-tracking?utm_medium=product">
-					{ __( 'usage tracking', 'woocommerce-admin' ) }
+					{ __( 'usage tracking', 'woocommerce' ) }
 				</a>
 				{ __(
 					'. Gathering usage data allows us to make WooCommerce better — your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. No personal data is tracked or stored and you can opt-out at any time.',
-					'woocommerce-admin'
+					'woocommerce'
 				) }
 			</p>
 			<div className="woocommerce-beta-features-tracking-modal__checkbox">
@@ -102,7 +102,7 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 						setIsModalOpen( false );
 					} }
 				>
-					{ __( 'Save', 'woocommerce-admin' ) }
+					{ __( 'Save', 'woocommerce' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/navigation-opt-out/container.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/navigation-opt-out/container.js
@@ -25,14 +25,14 @@ export class NavigationOptOutContainer extends Component {
 
 		return (
 			<Modal
-				title={ __( 'Help us improve', 'woocommerce-admin' ) }
+				title={ __( 'Help us improve', 'woocommerce' ) }
 				onRequestClose={ () => this.setState( { isModalOpen: false } ) }
 				className="woocommerce-navigation-opt-out-modal"
 			>
 				<p>
 					{ __(
 						"Take this 2-minute survey to share why you're opting out of the new navigation",
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 
@@ -43,7 +43,7 @@ export class NavigationOptOutContainer extends Component {
 							this.setState( { isModalOpen: false } )
 						}
 					>
-						{ __( 'No thanks', 'woocommerce-admin' ) }
+						{ __( 'No thanks', 'woocommerce' ) }
 					</Button>
 
 					<Button
@@ -54,7 +54,7 @@ export class NavigationOptOutContainer extends Component {
 							this.setState( { isModalOpen: false } )
 						}
 					>
-						{ __( 'Share feedback', 'woocommerce-admin' ) }
+						{ __( 'Share feedback', 'woocommerce' ) }
 					</Button>
 				</div>
 			</Modal>

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -70,16 +70,13 @@ const onboardingHomepageNotice = () => {
 
 		dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
 		dispatch( 'core/notices' ).createSuccessNotice(
-			__(
-				"🏠 Nice work creating your store's homepage!",
-				'woocommerce-admin'
-			),
+			__( "🏠 Nice work creating your store's homepage!", 'woocommerce' ),
 			{
 				id: 'WOOCOMMERCE_ONBOARDING_HOME_PAGE_NOTICE',
 				type: notificationType,
 				actions: [
 					{
-						label: __( 'Continue setup.', 'woocommerce-admin' ),
+						label: __( 'Continue setup.', 'woocommerce' ),
 						onClick: () => {
 							queueRecordEvent(
 								'tasklist_appearance_continue_setup',

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-product-import-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-product-import-notice/index.js
@@ -23,7 +23,7 @@ domReady( () => {
 			'href',
 			getAdminLink( 'admin.php?page=wc-admin' )
 		);
-		continueButton.innerText = __( 'Continue setup', 'woocommerce-admin' );
+		continueButton.innerText = __( 'Continue setup', 'woocommerce' );
 
 		actionButtons.appendChild( continueButton );
 	}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-product-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-product-notice/index.js
@@ -11,13 +11,13 @@ import { getAdminLink } from '@woocommerce/settings';
  */
 const showProductCompletionNotice = () => {
 	dispatch( 'core/notices' ).createSuccessNotice(
-		__( '🎉 Congrats on adding your first product!', 'woocommerce-admin' ),
+		__( '🎉 Congrats on adding your first product!', 'woocommerce' ),
 		{
 			id: 'WOOCOMMERCE_ONBOARDING_PRODUCT_NOTICE',
 			actions: [
 				{
 					url: getAdminLink( 'admin.php?page=wc-admin' ),
-					label: __( 'Continue setup.', 'woocommerce-admin' ),
+					label: __( 'Continue setup.', 'woocommerce' ),
 				},
 			],
 		}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-tax-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-tax-notice/index.js
@@ -41,13 +41,13 @@ const showTaxCompletionNotice = () => {
 
 		saveButton.classList.add( 'has-tax' );
 		dispatch( 'core/notices' ).createSuccessNotice(
-			__( "You've added your first tax rate!", 'woocommerce-admin' ),
+			__( "You've added your first tax rate!", 'woocommerce' ),
 			{
 				id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
 				actions: [
 					{
 						url: getAdminLink( 'admin.php?page=wc-admin' ),
-						label: __( 'Continue setup.', 'woocommerce-admin' ),
+						label: __( 'Continue setup.', 'woocommerce' ),
 					},
 				],
 			}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/payment-method-promotions/payment-promotion-row.tsx
@@ -164,7 +164,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 								<EllipsisMenu
 									label={ __(
 										'Payment Promotion Options',
-										'woocommerce-admin'
+										'woocommerce'
 									) }
 									className="pre-install-payment-gateway__actions-menu"
 									onToggle={ (
@@ -177,7 +177,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 											<Button onClick={ onDismiss }>
 												{ __(
 													'Dismiss',
-													'woocommerce-admin'
+													'woocommerce'
 												) }
 											</Button>
 										</div>
@@ -190,7 +190,7 @@ export const PaymentPromotionRow: React.FC< PaymentPromotionRowProps > = ( {
 									isBusy={ installing }
 									aria-disabled={ installing }
 								>
-									{ __( 'Install', 'woocommerce-admin' ) }
+									{ __( 'Install', 'woocommerce' ) }
 								</Button>
 							</div>
 						</td>

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
@@ -51,22 +51,22 @@ export class DismissModal extends Component {
 
 		return (
 			<Modal
-				title={ __( 'Are you sure?', 'woocommerce-admin' ) }
+				title={ __( 'Are you sure?', 'woocommerce' ) }
 				onRequestClose={ onClose }
 				className="wc-admin-shipping-banner__dismiss-modal"
 			>
 				<p className="wc-admin-shipping-banner__dismiss-modal-help-text">
 					{ __(
 						'With WooCommerce Shipping you can Print shipping labels from your WooCommerce dashboard at the lowest USPS rates.',
-						'woocommerce-admin'
+						'woocommerce'
 					) }
 				</p>
 				<div className="wc-admin-shipping-banner__dismiss-modal-actions">
 					<Button isSecondary onClick={ this.remindMeLaterClicked }>
-						{ __( 'Remind me later', 'woocommerce-admin' ) }
+						{ __( 'Remind me later', 'woocommerce' ) }
 					</Button>
 					<Button isPrimary onClick={ this.closeForeverClicked }>
-						{ __( "I don't need this", 'woocommerce-admin' ) }
+						{ __( "I don't need this", 'woocommerce' ) }
 					</Button>
 				</div>
 			</Modal>

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/setup-notice/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/setup-notice/index.js
@@ -13,11 +13,11 @@ export const setupErrorTypes = {
 };
 
 const setupErrorDescriptions = {
-	[ setupErrorTypes.DOWNLOAD ]: __( 'download', 'woocommerce-admin' ),
-	[ setupErrorTypes.INSTALL ]: __( 'install', 'woocommerce-admin' ),
-	[ setupErrorTypes.ACTIVATE ]: __( 'activate', 'woocommerce-admin' ),
-	[ setupErrorTypes.SETUP ]: __( 'set up', 'woocommerce-admin' ),
-	[ setupErrorTypes.START ]: __( 'start', 'woocommerce-admin' ),
+	[ setupErrorTypes.DOWNLOAD ]: __( 'download', 'woocommerce' ),
+	[ setupErrorTypes.INSTALL ]: __( 'install', 'woocommerce' ),
+	[ setupErrorTypes.ACTIVATE ]: __( 'activate', 'woocommerce' ),
+	[ setupErrorTypes.SETUP ]: __( 'set up', 'woocommerce' ),
+	[ setupErrorTypes.START ]: __( 'start', 'woocommerce' ),
 };
 
 export default function SetupNotice( { isSetupError, errorReason } ) {
@@ -31,7 +31,7 @@ export default function SetupNotice( { isSetupError, errorReason } ) {
 		return sprintf(
 			__(
 				'Unable to %s the plugin. Refresh the page and try again.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			description
 		);

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -145,7 +145,7 @@ export class ShippingBanner extends Component {
 	generateMetaBoxHtml( nodeId, title, args ) {
 		const argsJsonString = JSON.stringify( args ).replace( /"/g, '&quot;' ); // JS has no native html_entities so we just replace.
 
-		const togglePanelText = __( 'Toggle panel:', 'woocommerce-admin' );
+		const togglePanelText = __( 'Toggle panel:', 'woocommerce' );
 
 		return `
 <div id="${ nodeId }" class="postbox">
@@ -190,7 +190,7 @@ export class ShippingBanner extends Component {
 
 		const shippingLabelContainerHtml = this.generateMetaBoxHtml(
 			'woocommerce-order-label',
-			__( 'Shipping Label', 'woocommerce-admin' ),
+			__( 'Shipping Label', 'woocommerce' ),
 			{
 				order: { id: orderId },
 				context: 'shipping_label',
@@ -204,7 +204,7 @@ export class ShippingBanner extends Component {
 
 		const shipmentTrackingHtml = this.generateMetaBoxHtml(
 			'woocommerce-order-shipment-tracking',
-			__( 'Shipment Tracking', 'woocommerce-admin' ),
+			__( 'Shipment Tracking', 'woocommerce' ),
 			{
 				order: { id: orderId },
 				context: 'shipment_tracking',
@@ -264,12 +264,12 @@ export class ShippingBanner extends Component {
 			// If WCS is active, then the only remaining step is to agree to the ToS.
 			return __(
 				'You\'ve already installed WooCommerce Shipping. By clicking "Create shipping label", you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 		return __(
 			'By clicking "Create shipping label", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	};
 
@@ -360,7 +360,7 @@ export class ShippingBanner extends Component {
 										status: 'is-success',
 										text: __(
 											'Plugin installed and activated',
-											'woocommerce-admin'
+											'woocommerce'
 										),
 									},
 								} );
@@ -400,13 +400,13 @@ export class ShippingBanner extends Component {
 					<img
 						className="wc-admin-shipping-banner-illustration"
 						src={ wcAdminAssetUrl + '/shippingillustration.svg' }
-						alt={ __( 'Shipping ', 'woocommerce-admin' ) }
+						alt={ __( 'Shipping ', 'woocommerce' ) }
 					/>
 					<div className="wc-admin-shipping-banner-blob">
 						<h3>
 							{ __(
 								'Print discounted shipping labels with a click.',
-								'woocommerce-admin'
+								'woocommerce'
 							) }
 						</h3>
 						<p>
@@ -445,7 +445,7 @@ export class ShippingBanner extends Component {
 						isBusy={ isShippingLabelButtonBusy }
 						onClick={ this.createShippingLabelClicked }
 					>
-						{ __( 'Create shipping label', 'woocommerce-admin' ) }
+						{ __( 'Create shipping label', 'woocommerce' ) }
 					</Button>
 
 					<button
@@ -455,10 +455,7 @@ export class ShippingBanner extends Component {
 						disabled={ this.state.isShippingLabelButtonBusy }
 					>
 						<span className="screen-reader-text">
-							{ __(
-								'Close Print Label Banner.',
-								'woocommerce-admin'
-							) }
+							{ __( 'Close Print Label Banner.', 'woocommerce' ) }
 						</span>
 					</button>
 				</div>

--- a/plugins/woocommerce-admin/docs/features/onboarding-tasks.md
+++ b/plugins/woocommerce-admin/docs/features/onboarding-tasks.md
@@ -26,7 +26,7 @@ $args = array(
   'id'              => 'my-task', // A unique task ID.
   'title'           => 'My Task', // Task title.
   'content'         => 'Task explanation and instructions', // Content shown in the task list item.
-  'action_label'    => __( "Do the task!", 'woocommerce-admin' ), // Text used for the action button.
+  'action_label'    => __( "Do the task!", 'woocommerce' ), // Text used for the action button.
   'action_url'      => 'http://wordpress.com/my/task', // URL used when clicking the task item in lieu of SlotFill.
   'is_complete'     => get_option( 'my-task-option', false ), // Determine if the task is complete.
   'can_view'        => 'US:CA' === wc_get_base_location(),

--- a/plugins/woocommerce-admin/docs/page-controller.md
+++ b/plugins/woocommerce-admin/docs/page-controller.md
@@ -25,8 +25,8 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-settings',
 		'screen_id' => 'woocommerce_page_wc-settings-general',
 		'title'     => array(
-			__( 'Settings', 'woocommerce-admin' ),
-			__( 'General', 'woocommerce-admin' ),
+			__( 'Settings', 'woocommerce' ),
+			__( 'General', 'woocommerce' ),
 		),
 		'path'      => add_query_arg( 'page', 'wc-settings', 'admin.php' ),
 	)
@@ -42,7 +42,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-settings-payments',
 		'parent'    => 'woocommerce-settings',
 		'screen_id' => 'woocommerce_page_wc-settings-checkout',
-		'title'     => __( 'Payments', 'woocommerce-admin' ),
+		'title'     => __( 'Payments', 'woocommerce' ),
 		'path'      => add_query_arg(
 			array(
 				'page' => 'wc-settings',
@@ -58,7 +58,7 @@ wc_admin_connect_page(
 	array(
 		'id'        => 'woocommerce-orders',
 		'screen_id' => 'edit-shop_order',
-		'title'     => __( 'Orders', 'woocommerce-admin' ),
+		'title'     => __( 'Orders', 'woocommerce' ),
 		'path'      => add_query_arg( 'post_type', 'shop_order', 'edit.php' ),
 	)
 );

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -21,6 +21,7 @@
 		"preinstall": "npx only-allow pnpm",
 		"prebuild": "pnpm run install-if-deps-outdated",
 		"run:packages": "pnpm run --filter ../../packages/js/",
+		"packages:fix:textdomain": "node ./bin/package-update-textdomain.js",
 		"build": "pnpm run build:feature-config && cross-env NODE_ENV=production webpack",
 		"analyze": "cross-env NODE_ENV=production ANALYZE=true webpack",
 		"postbuild": "pnpm run -s i18n:pot && pnpm run -s i18n:build",

--- a/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
+++ b/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
@@ -23,25 +23,25 @@ function wc_admin_get_core_pages_to_connect() {
 
 	return array(
 		'wc-addons'   => array(
-			'title' => __( 'Extensions', 'woocommerce-admin' ),
+			'title' => __( 'Extensions', 'woocommerce' ),
 			'tabs'  => array(),
 		),
 		'wc-reports'  => array(
-			'title' => __( 'Reports', 'woocommerce-admin' ),
+			'title' => __( 'Reports', 'woocommerce' ),
 			'tabs'  => $report_tabs,
 		),
 		'wc-settings' => array(
-			'title' => __( 'Settings', 'woocommerce-admin' ),
+			'title' => __( 'Settings', 'woocommerce' ),
 			'tabs'  => apply_filters( 'woocommerce_settings_tabs_array', array() ),
 		),
 		'wc-status'   => array(
-			'title' => __( 'Status', 'woocommerce-admin' ),
+			'title' => __( 'Status', 'woocommerce' ),
 			'tabs'  => apply_filters(
 				'woocommerce_admin_status_tabs',
 				array(
-					'status' => __( 'System status', 'woocommerce-admin' ),
-					'tools'  => __( 'Tools', 'woocommerce-admin' ),
-					'logs'   => __( 'Logs', 'woocommerce-admin' ),
+					'status' => __( 'System status', 'woocommerce' ),
+					'tools'  => __( 'Tools', 'woocommerce' ),
+					'logs'   => __( 'Logs', 'woocommerce' ),
 				)
 			),
 		),
@@ -59,7 +59,7 @@ function wc_admin_filter_core_page_breadcrumbs( $breadcrumbs ) {
 	$pages_to_connect       = wc_admin_get_core_pages_to_connect();
 	$woocommerce_breadcrumb = array(
 		'admin.php?page=wc-admin',
-		__( 'WooCommerce', 'woocommerce-admin' ),
+		__( 'WooCommerce', 'woocommerce' ),
 	);
 
 	foreach ( $pages_to_connect as $page_id => $page_data ) {
@@ -129,7 +129,7 @@ wc_admin_connect_page(
 	array(
 		'id'        => 'woocommerce-orders',
 		'screen_id' => 'edit-shop_order',
-		'title'     => __( 'Orders', 'woocommerce-admin' ),
+		'title'     => __( 'Orders', 'woocommerce' ),
 		'path'      => add_query_arg( 'post_type', 'shop_order', $posttype_list_base ),
 	)
 );
@@ -140,7 +140,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-add-order',
 		'parent'    => 'woocommerce-orders',
 		'screen_id' => 'shop_order-add',
-		'title'     => __( 'Add New', 'woocommerce-admin' ),
+		'title'     => __( 'Add New', 'woocommerce' ),
 	)
 );
 
@@ -150,7 +150,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-edit-order',
 		'parent'    => 'woocommerce-orders',
 		'screen_id' => 'shop_order',
-		'title'     => __( 'Edit Order', 'woocommerce-admin' ),
+		'title'     => __( 'Edit Order', 'woocommerce' ),
 	)
 );
 
@@ -160,7 +160,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-coupons',
 		'parent'    => Features::is_enabled( 'coupons' ) ? 'woocommerce-marketing' : null,
 		'screen_id' => 'edit-shop_coupon',
-		'title'     => __( 'Coupons', 'woocommerce-admin' ),
+		'title'     => __( 'Coupons', 'woocommerce' ),
 		'path'      => add_query_arg( 'post_type', 'shop_coupon', $posttype_list_base ),
 	)
 );
@@ -171,7 +171,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-add-coupon',
 		'parent'    => 'woocommerce-coupons',
 		'screen_id' => 'shop_coupon-add',
-		'title'     => __( 'Add New', 'woocommerce-admin' ),
+		'title'     => __( 'Add New', 'woocommerce' ),
 	)
 );
 
@@ -181,7 +181,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-edit-coupon',
 		'parent'    => 'woocommerce-coupons',
 		'screen_id' => 'shop_coupon',
-		'title'     => __( 'Edit Coupon', 'woocommerce-admin' ),
+		'title'     => __( 'Edit Coupon', 'woocommerce' ),
 	)
 );
 
@@ -190,7 +190,7 @@ wc_admin_connect_page(
 	array(
 		'id'        => 'woocommerce-products',
 		'screen_id' => 'edit-product',
-		'title'     => __( 'Products', 'woocommerce-admin' ),
+		'title'     => __( 'Products', 'woocommerce' ),
 		'path'      => add_query_arg( 'post_type', 'product', $posttype_list_base ),
 	)
 );
@@ -201,7 +201,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-add-product',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product-add',
-		'title'     => __( 'Add New', 'woocommerce-admin' ),
+		'title'     => __( 'Add New', 'woocommerce' ),
 	)
 );
 
@@ -211,7 +211,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-edit-product',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product',
-		'title'     => __( 'Edit Product', 'woocommerce-admin' ),
+		'title'     => __( 'Edit Product', 'woocommerce' ),
 	)
 );
 
@@ -221,7 +221,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-import-products',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_page_product_importer',
-		'title'     => __( 'Import Products', 'woocommerce-admin' ),
+		'title'     => __( 'Import Products', 'woocommerce' ),
 	)
 );
 
@@ -231,7 +231,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-export-products',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_page_product_exporter',
-		'title'     => __( 'Export Products', 'woocommerce-admin' ),
+		'title'     => __( 'Export Products', 'woocommerce' ),
 	)
 );
 
@@ -241,7 +241,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-product-categories',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'edit-product_cat',
-		'title'     => __( 'Product categories', 'woocommerce-admin' ),
+		'title'     => __( 'Product categories', 'woocommerce' ),
 	)
 );
 
@@ -251,7 +251,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-product-edit-category',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_cat',
-		'title'     => __( 'Edit category', 'woocommerce-admin' ),
+		'title'     => __( 'Edit category', 'woocommerce' ),
 	)
 );
 
@@ -261,7 +261,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-product-tags',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'edit-product_tag',
-		'title'     => __( 'Product tags', 'woocommerce-admin' ),
+		'title'     => __( 'Product tags', 'woocommerce' ),
 	)
 );
 
@@ -271,7 +271,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-product-edit-tag',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_tag',
-		'title'     => __( 'Edit tag', 'woocommerce-admin' ),
+		'title'     => __( 'Edit tag', 'woocommerce' ),
 	)
 );
 
@@ -281,7 +281,7 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-product-attributes',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_page_product_attributes',
-		'title'     => __( 'Attributes', 'woocommerce-admin' ),
+		'title'     => __( 'Attributes', 'woocommerce' ),
 	)
 );
 
@@ -291,6 +291,6 @@ wc_admin_connect_page(
 		'id'        => 'woocommerce-product-edit-attribute',
 		'parent'    => 'woocommerce-products',
 		'screen_id' => 'product_page_product_attribute-edit',
-		'title'     => __( 'Edit attribute', 'woocommerce-admin' ),
+		'title'     => __( 'Edit attribute', 'woocommerce' ),
 	)
 );

--- a/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/html-admin-report-export-download.php
@@ -16,7 +16,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email );
 <a href="<?php echo esc_url( $download_url ); ?>">
 	<?php
 		/* translators: %s: report name */
-		echo esc_html( sprintf( __( 'Download your %s Report', 'woocommerce-admin' ), $report_name ) );
+		echo esc_html( sprintf( __( 'Download your %s Report', 'woocommerce' ), $report_name ) );
 	?>
 </a>
 <?php

--- a/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
+++ b/plugins/woocommerce/includes/react-admin/emails/plain-admin-report-export-download.php
@@ -12,7 +12,7 @@ echo esc_html( wp_strip_all_tags( $email_heading ) );
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /* translators: %1$s: report name, %2$s: download URL */
-echo wp_kses_post( sprintf( __( 'Download your %1$s Report: %2$s', 'woocommerce-admin' ), $report_name, $download_url ) );
+echo wp_kses_post( sprintf( __( 'Download your %1$s Report: %2$s', 'woocommerce' ), $report_name, $download_url ) );
 
 echo "\n\n----------------------------------------\n\n";
 

--- a/plugins/woocommerce/includes/react-admin/emails/plain-merchant-notification.php
+++ b/plugins/woocommerce/includes/react-admin/emails/plain-merchant-notification.php
@@ -16,7 +16,7 @@ echo wp_kses_post( $email_content );
 foreach ( $email_actions as $an_action ) {
 	echo "\n";
 	/* translators: %1$s: action label, %2$s: action URL */
-	echo wp_kses_post( sprintf( __( '%1$s: %2$s', 'woocommerce-admin' ), $an_action->label, $trigger_note_action_url . $an_action->id ) );
+	echo wp_kses_post( sprintf( __( '%1$s: %2$s', 'woocommerce' ), $an_action->label, $trigger_note_action_url . $an_action->id ) );
 }
 echo "\n\n----------------------------------------\n\n";
 

--- a/plugins/woocommerce/src/Admin/API/Coupons.php
+++ b/plugins/woocommerce/src/Admin/API/Coupons.php
@@ -32,7 +32,7 @@ class Coupons extends \WC_REST_Coupons_Controller {
 	public function get_collection_params() {
 		$params           = parent::get_collection_params();
 		$params['search'] = array(
-			'description'       => __( 'Limit results to coupons with codes matching a given string.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit results to coupons with codes matching a given string.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/src/Admin/API/CustomAttributeTraits.php
+++ b/plugins/woocommerce/src/Admin/API/CustomAttributeTraits.php
@@ -26,7 +26,7 @@ trait CustomAttributeTraits {
 		if ( empty( $matching_attributes ) ) {
 			return new \WP_Error(
 				'woocommerce_rest_product_attribute_not_found',
-				__( 'No product attribute with that slug was found.', 'woocommerce-admin' ),
+				__( 'No product attribute with that slug was found.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/Customers.php
+++ b/plugins/woocommerce/src/Admin/API/Customers.php
@@ -48,7 +48,7 @@ class Customers extends \Automattic\WooCommerce\Admin\API\Reports\Customers\Cont
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'Unique ID for the resource.', 'woocommerce-admin' ),
+						'description' => __( 'Unique ID for the resource.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 				),

--- a/plugins/woocommerce/src/Admin/API/Data.php
+++ b/plugins/woocommerce/src/Admin/API/Data.php
@@ -36,7 +36,7 @@ class Data extends \WC_REST_Data_Controller {
 			$this->prepare_item_for_response(
 				(object) array(
 					'slug'        => 'download-ips',
-					'description' => __( 'An endpoint used for searching download logs for a specific IP address.', 'woocommerce-admin' ),
+					'description' => __( 'An endpoint used for searching download logs for a specific IP address.', 'woocommerce' ),
 				),
 				$request
 			)

--- a/plugins/woocommerce/src/Admin/API/DataDownloadIPs.php
+++ b/plugins/woocommerce/src/Admin/API/DataDownloadIPs.php
@@ -70,7 +70,7 @@ class DataDownloadIPs extends \WC_REST_Data_Controller {
 				)
 			);
 		} else {
-			return new \WP_Error( 'woocommerce_rest_data_download_ips_invalid_request', __( 'Invalid request. Please pass the match parameter.', 'woocommerce-admin' ), array( 'status' => 400 ) );
+			return new \WP_Error( 'woocommerce_rest_data_download_ips_invalid_request', __( 'Invalid request. Please pass the match parameter.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		$data = array();
@@ -134,7 +134,7 @@ class DataDownloadIPs extends \WC_REST_Data_Controller {
 		$params            = array();
 		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['match']   = array(
-			'description'       => __( 'A partial IP address can be passed and matching results will be returned.', 'woocommerce-admin' ),
+			'description'       => __( 'A partial IP address can be passed and matching results will be returned.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -155,7 +155,7 @@ class DataDownloadIPs extends \WC_REST_Data_Controller {
 			'properties' => array(
 				'user_ip_address' => array(
 					'type'        => 'string',
-					'description' => __( 'IP address.', 'woocommerce-admin' ),
+					'description' => __( 'IP address.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),

--- a/plugins/woocommerce/src/Admin/API/Experiments.php
+++ b/plugins/woocommerce/src/Admin/API/Experiments.php
@@ -62,7 +62,7 @@ class Experiments extends \WC_REST_Data_Controller {
 		if ( ! isset( $args['experiment_name'] ) ) {
 			return new \WP_Error(
 				'woocommerce_rest_experiment_name_required',
-				__( 'Sorry, experiment_name is required.', 'woocommerce-admin' ),
+				__( 'Sorry, experiment_name is required.', 'woocommerce' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/Features.php
+++ b/plugins/woocommerce/src/Admin/API/Features.php
@@ -59,7 +59,7 @@ class Features extends \WC_REST_Data_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Admin/API/Leaderboards.php
+++ b/plugins/woocommerce/src/Admin/API/Leaderboards.php
@@ -120,16 +120,16 @@ class Leaderboards extends \WC_REST_Data_Controller {
 
 		return array(
 			'id'      => 'coupons',
-			'label'   => __( 'Top Coupons - Number of Orders', 'woocommerce-admin' ),
+			'label'   => __( 'Top Coupons - Number of Orders', 'woocommerce' ),
 			'headers' => array(
 				array(
-					'label' => __( 'Coupon code', 'woocommerce-admin' ),
+					'label' => __( 'Coupon code', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Orders', 'woocommerce-admin' ),
+					'label' => __( 'Orders', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Amount discounted', 'woocommerce-admin' ),
+					'label' => __( 'Amount discounted', 'woocommerce' ),
 				),
 			),
 			'rows'    => $rows,
@@ -189,16 +189,16 @@ class Leaderboards extends \WC_REST_Data_Controller {
 
 		return array(
 			'id'      => 'categories',
-			'label'   => __( 'Top categories - Items sold', 'woocommerce-admin' ),
+			'label'   => __( 'Top categories - Items sold', 'woocommerce' ),
 			'headers' => array(
 				array(
-					'label' => __( 'Category', 'woocommerce-admin' ),
+					'label' => __( 'Category', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Items sold', 'woocommerce-admin' ),
+					'label' => __( 'Items sold', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Net sales', 'woocommerce-admin' ),
+					'label' => __( 'Net sales', 'woocommerce' ),
 				),
 			),
 			'rows'    => $rows,
@@ -256,16 +256,16 @@ class Leaderboards extends \WC_REST_Data_Controller {
 
 		return array(
 			'id'      => 'customers',
-			'label'   => __( 'Top Customers - Total Spend', 'woocommerce-admin' ),
+			'label'   => __( 'Top Customers - Total Spend', 'woocommerce' ),
 			'headers' => array(
 				array(
-					'label' => __( 'Customer Name', 'woocommerce-admin' ),
+					'label' => __( 'Customer Name', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Orders', 'woocommerce-admin' ),
+					'label' => __( 'Orders', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Total Spend', 'woocommerce-admin' ),
+					'label' => __( 'Total Spend', 'woocommerce' ),
 				),
 			),
 			'rows'    => $rows,
@@ -325,16 +325,16 @@ class Leaderboards extends \WC_REST_Data_Controller {
 
 		return array(
 			'id'      => 'products',
-			'label'   => __( 'Top products - Items sold', 'woocommerce-admin' ),
+			'label'   => __( 'Top products - Items sold', 'woocommerce' ),
 			'headers' => array(
 				array(
-					'label' => __( 'Product', 'woocommerce-admin' ),
+					'label' => __( 'Product', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Items sold', 'woocommerce-admin' ),
+					'label' => __( 'Items sold', 'woocommerce' ),
 				),
 				array(
-					'label' => __( 'Net sales', 'woocommerce-admin' ),
+					'label' => __( 'Net sales', 'woocommerce' ),
 				),
 			),
 			'rows'    => $rows,
@@ -445,7 +445,7 @@ class Leaderboards extends \WC_REST_Data_Controller {
 	public function get_collection_params() {
 		$params                    = array();
 		$params['page']            = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -453,7 +453,7 @@ class Leaderboards extends \WC_REST_Data_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']        = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 5,
 			'minimum'           => 1,
@@ -462,19 +462,19 @@ class Leaderboards extends \WC_REST_Data_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']           = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']          = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['persisted_query'] = array(
-			'description'       => __( 'URL query to persist across links.', 'woocommerce-admin' ),
+			'description'       => __( 'URL query to persist across links.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -494,26 +494,26 @@ class Leaderboards extends \WC_REST_Data_Controller {
 			'properties' => array(
 				'id'      => array(
 					'type'        => 'string',
-					'description' => __( 'Leaderboard ID.', 'woocommerce-admin' ),
+					'description' => __( 'Leaderboard ID.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'label'   => array(
 					'type'        => 'string',
-					'description' => __( 'Displayed title for the leaderboard.', 'woocommerce-admin' ),
+					'description' => __( 'Displayed title for the leaderboard.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'headers' => array(
 					'type'        => 'array',
-					'description' => __( 'Table headers.', 'woocommerce-admin' ),
+					'description' => __( 'Table headers.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
 						'type'       => 'array',
 						'properties' => array(
 							'label' => array(
-								'description' => __( 'Table column header.', 'woocommerce-admin' ),
+								'description' => __( 'Table column header.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -523,20 +523,20 @@ class Leaderboards extends \WC_REST_Data_Controller {
 				),
 				'rows'    => array(
 					'type'        => 'array',
-					'description' => __( 'Table rows.', 'woocommerce-admin' ),
+					'description' => __( 'Table rows.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 					'items'       => array(
 						'type'       => 'array',
 						'properties' => array(
 							'display' => array(
-								'description' => __( 'Table cell display.', 'woocommerce-admin' ),
+								'description' => __( 'Table cell display.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'value'   => array(
-								'description' => __( 'Table cell value.', 'woocommerce-admin' ),
+								'description' => __( 'Table cell value.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/Marketing.php
+++ b/plugins/woocommerce/src/Admin/API/Marketing.php
@@ -88,7 +88,7 @@ class Marketing extends \WC_REST_Data_Controller {
 	 */
 	public function get_recommended_plugins_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Admin/API/MarketingOverview.php
+++ b/plugins/woocommerce/src/Admin/API/MarketingOverview.php
@@ -84,13 +84,13 @@ class MarketingOverview extends \WC_REST_Data_Controller {
 		$plugin_slug = $request->get_param( 'plugin' );
 
 		if ( ! PluginsHelper::is_plugin_installed( $plugin_slug ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'Invalid plugin.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'Invalid plugin.', 'woocommerce' ), 404 );
 		}
 
 		$result = activate_plugin( PluginsHelper::get_plugin_path_from_slug( $plugin_slug ) );
 
 		if ( ! is_null( $result ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'The plugin could not be activated.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'The plugin could not be activated.', 'woocommerce' ), 500 );
 		}
 
 		// IMPORTANT - Don't return the active plugins data here.
@@ -111,7 +111,7 @@ class MarketingOverview extends \WC_REST_Data_Controller {
 	 */
 	public function install_plugins_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Admin/API/NavigationFavorites.php
+++ b/plugins/woocommerce/src/Admin/API/NavigationFavorites.php
@@ -118,7 +118,7 @@ class NavigationFavorites extends \WC_REST_Data_Controller {
 			return $this->prepare_error(
 				new \WP_Error(
 					'woocommerce_favorites_invalid_user',
-					__( 'Invalid user_id provided', 'woocommerce-admin' )
+					__( 'Invalid user_id provided', 'woocommerce' )
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/NoteActions.php
+++ b/plugins/woocommerce/src/Admin/API/NoteActions.php
@@ -30,11 +30,11 @@ class NoteActions extends Notes {
 			array(
 				'args'   => array(
 					'note_id'   => array(
-						'description' => __( 'Unique ID for the Note.', 'woocommerce-admin' ),
+						'description' => __( 'Unique ID for the Note.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 					'action_id' => array(
-						'description' => __( 'Unique ID for the Note Action.', 'woocommerce-admin' ),
+						'description' => __( 'Unique ID for the Note Action.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 				),
@@ -61,7 +61,7 @@ class NoteActions extends Notes {
 		if ( ! $note ) {
 			return new \WP_Error(
 				'woocommerce_note_invalid_id',
-				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -74,7 +74,7 @@ class NoteActions extends Notes {
 		if ( ! $triggered_action ) {
 			return new \WP_Error(
 				'woocommerce_note_action_invalid_id',
-				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/Notes.php
+++ b/plugins/woocommerce/src/Admin/API/Notes.php
@@ -67,7 +67,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'Unique ID for the resource.', 'woocommerce-admin' ),
+						'description' => __( 'Unique ID for the resource.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 				),
@@ -108,7 +108,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 					'permission_callback' => array( $this, 'update_items_permissions_check' ),
 					'args'                => array(
 						'status' => array(
-							'description'       => __( 'Status of note.', 'woocommerce-admin' ),
+							'description'       => __( 'Status of note.', 'woocommerce' ),
 							'type'              => 'array',
 							'sanitize_callback' => 'wp_parse_slug_list',
 							'validate_callback' => 'rest_validate_request_arg',
@@ -175,7 +175,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new \WP_Error(
 				'woocommerce_note_invalid_id',
-				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -295,7 +295,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -309,7 +309,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'system_status', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -327,7 +327,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new \WP_Error(
 				'woocommerce_note_invalid_id',
-				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -348,7 +348,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new \WP_Error(
 				'woocommerce_note_invalid_id',
-				__( 'Sorry, there is no note with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no note with that ID.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -434,7 +434,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		if ( ! isset( $note_ids ) || ! is_array( $note_ids ) ) {
 			return new \WP_Error(
 				'woocommerce_note_invalid_ids',
-				__( 'Please provide an array of IDs through the noteIds param.', 'woocommerce-admin' ),
+				__( 'Please provide an array of IDs through the noteIds param.', 'woocommerce' ),
 				array( 'status' => 422 )
 			);
 		}
@@ -464,7 +464,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		if ( ! in_array( $promo_note_name, $this->allowed_promo_notes, true ) ) {
 			return new \WP_Error(
 				'woocommerce_note_invalid_promo_note_name',
-				__( 'Please provide a valid promo note name.', 'woocommerce-admin' ),
+				__( 'Please provide a valid promo note name.', 'woocommerce' ),
 				array( 'status' => 422 )
 			);
 		}
@@ -505,7 +505,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 	 */
 	public function update_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -634,14 +634,14 @@ class Notes extends \WC_REST_CRUD_Controller {
 		$params             = array();
 		$params['context']  = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['order']    = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']  = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -654,7 +654,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['page']     = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -662,7 +662,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page'] = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -671,7 +671,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['type']     = array(
-			'description'       => __( 'Type of note.', 'woocommerce-admin' ),
+			'description'       => __( 'Type of note.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -681,7 +681,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			),
 		);
 		$params['status']   = array(
-			'description'       => __( 'Status of note.', 'woocommerce-admin' ),
+			'description'       => __( 'Status of note.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -691,7 +691,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 			),
 		);
 		$params['source']   = array(
-			'description'       => __( 'Source of note.', 'woocommerce-admin' ),
+			'description'       => __( 'Source of note.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -714,108 +714,108 @@ class Notes extends \WC_REST_CRUD_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'id'                => array(
-					'description' => __( 'ID of the note record.', 'woocommerce-admin' ),
+					'description' => __( 'ID of the note record.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'name'              => array(
-					'description' => __( 'Name of the note.', 'woocommerce-admin' ),
+					'description' => __( 'Name of the note.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'type'              => array(
-					'description' => __( 'The type of the note (e.g. error, warning, etc.).', 'woocommerce-admin' ),
+					'description' => __( 'The type of the note (e.g. error, warning, etc.).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'locale'            => array(
-					'description' => __( 'Locale used for the note title and content.', 'woocommerce-admin' ),
+					'description' => __( 'Locale used for the note title and content.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'title'             => array(
-					'description' => __( 'Title of the note.', 'woocommerce-admin' ),
+					'description' => __( 'Title of the note.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'content'           => array(
-					'description' => __( 'Content of the note.', 'woocommerce-admin' ),
+					'description' => __( 'Content of the note.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'content_data'      => array(
-					'description' => __( 'Content data for the note. JSON string. Available for re-localization.', 'woocommerce-admin' ),
+					'description' => __( 'Content data for the note. JSON string. Available for re-localization.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'status'            => array(
-					'description' => __( 'The status of the note (e.g. unactioned, actioned).', 'woocommerce-admin' ),
+					'description' => __( 'The status of the note (e.g. unactioned, actioned).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'source'            => array(
-					'description' => __( 'Source of the note.', 'woocommerce-admin' ),
+					'description' => __( 'Source of the note.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_created'      => array(
-					'description' => __( 'Date the note was created.', 'woocommerce-admin' ),
+					'description' => __( 'Date the note was created.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_created_gmt'  => array(
-					'description' => __( 'Date the note was created (GMT).', 'woocommerce-admin' ),
+					'description' => __( 'Date the note was created (GMT).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_reminder'     => array(
-					'description' => __( 'Date after which the user should be reminded of the note, if any.', 'woocommerce-admin' ),
+					'description' => __( 'Date after which the user should be reminded of the note, if any.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true, // @todo Allow date_reminder to be updated.
 				),
 				'date_reminder_gmt' => array(
-					'description' => __( 'Date after which the user should be reminded of the note, if any (GMT).', 'woocommerce-admin' ),
+					'description' => __( 'Date after which the user should be reminded of the note, if any (GMT).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'is_snoozable'      => array(
-					'description' => __( 'Whether or not a user can request to be reminded about the note.', 'woocommerce-admin' ),
+					'description' => __( 'Whether or not a user can request to be reminded about the note.', 'woocommerce' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'actions'           => array(
-					'description' => __( 'An array of actions, if any, for the note.', 'woocommerce-admin' ),
+					'description' => __( 'An array of actions, if any, for the note.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'layout'            => array(
-					'description' => __( 'The layout of the note (e.g. banner, thumbnail, plain).', 'woocommerce-admin' ),
+					'description' => __( 'The layout of the note (e.g. banner, thumbnail, plain).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'image'             => array(
-					'description' => __( 'The image of the note, if any.', 'woocommerce-admin' ),
+					'description' => __( 'The image of the note, if any.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'is_deleted'        => array(
-					'description' => __( 'Registers whether the note is deleted or not', 'woocommerce-admin' ),
+					'description' => __( 'Registers whether the note is deleted or not', 'woocommerce' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -59,7 +59,7 @@ class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Admin/API/OnboardingProductTypes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProductTypes.php
@@ -59,7 +59,7 @@ class OnboardingProductTypes extends \WC_REST_Data_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -87,7 +87,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -101,7 +101,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	 */
 	public function update_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot edit this resource.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -162,7 +162,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 
 		$result = array(
 			'status'  => 'success',
-			'message' => __( 'Onboarding profile data has been updated.', 'woocommerce-admin' ),
+			'message' => __( 'Onboarding profile data has been updated.', 'woocommerce' ),
 		);
 
 		$response = $this->prepare_item_for_response( $result, $request );
@@ -263,21 +263,21 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		$properties = array(
 			'completed'           => array(
 				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce-admin' ),
+				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'skipped'             => array(
 				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce-admin' ),
+				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'industry'            => array(
 				'type'              => 'array',
-				'description'       => __( 'Industry.', 'woocommerce-admin' ),
+				'description'       => __( 'Industry.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
@@ -287,7 +287,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'product_types'       => array(
 				'type'              => 'array',
-				'description'       => __( 'Types of products sold.', 'woocommerce-admin' ),
+				'description'       => __( 'Types of products sold.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'sanitize_callback' => 'wp_parse_slug_list',
@@ -299,7 +299,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'product_count'       => array(
 				'type'              => 'string',
-				'description'       => __( 'Number of products to be added.', 'woocommerce-admin' ),
+				'description'       => __( 'Number of products to be added.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
@@ -313,7 +313,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'selling_venues'      => array(
 				'type'              => 'string',
-				'description'       => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
+				'description'       => __( 'Other places the store is selling products.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
@@ -327,7 +327,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'number_employees'    => array(
 				'type'              => 'string',
-				'description'       => __( 'Number of employees of the store.', 'woocommerce-admin' ),
+				'description'       => __( 'Number of employees of the store.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
@@ -342,7 +342,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'revenue'             => array(
 				'type'              => 'string',
-				'description'       => __( 'Current annual revenue of the store.', 'woocommerce-admin' ),
+				'description'       => __( 'Current annual revenue of the store.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
@@ -358,7 +358,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'other_platform'      => array(
 				'type'              => 'string',
-				'description'       => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
+				'description'       => __( 'Name of other platform used to sell.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
@@ -376,14 +376,14 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'other_platform_name' => array(
 				'type'              => 'string',
-				'description'       => __( 'Name of other platform used to sell (not listed).', 'woocommerce-admin' ),
+				'description'       => __( 'Name of other platform used to sell (not listed).', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'business_extensions' => array(
 				'type'              => 'array',
-				'description'       => __( 'Extra business extensions to install.', 'woocommerce-admin' ),
+				'description'       => __( 'Extra business extensions to install.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'sanitize_callback' => 'wp_parse_slug_list',
@@ -404,7 +404,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'theme'               => array(
 				'type'              => 'string',
-				'description'       => __( 'Selected store theme.', 'woocommerce-admin' ),
+				'description'       => __( 'Selected store theme.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'sanitize_callback' => 'sanitize_title_with_dashes',
@@ -412,28 +412,28 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 			'setup_client'        => array(
 				'type'              => 'boolean',
-				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce-admin' ),
+				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'wccom_connected'     => array(
 				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce-admin' ),
+				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'is_agree_marketing'  => array(
 				'type'              => 'boolean',
-				'description'       => __( 'Whether or not this store agreed to receiving marketing contents from WooCommerce.com.', 'woocommerce-admin' ),
+				'description'       => __( 'Whether or not this store agreed to receiving marketing contents from WooCommerce.com.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'store_email'         => array(
 				'type'              => 'string',
-				'description'       => __( 'Store email address.', 'woocommerce-admin' ),
+				'description'       => __( 'Store email address.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => array( __CLASS__, 'rest_validate_marketing_email' ),
@@ -456,7 +456,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		if (
 			( $is_agree_marketing || ! empty( $value ) ) &&
 			! is_email( $value ) ) {
-			return new \WP_Error( 'rest_invalid_email', __( 'Invalid email address', 'woocommerce-admin' ) );
+			return new \WP_Error( 'rest_invalid_email', __( 'Invalid email address', 'woocommerce' ) );
 		};
 		return true;
 	}

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -91,7 +91,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 							'template_name' => array(
 								'required'    => true,
 								'type'        => 'string',
-								'description' => __( 'Product template name.', 'woocommerce-admin' ),
+								'description' => __( 'Product template name.', 'woocommerce' ),
 							),
 						)
 					),
@@ -110,7 +110,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 					'permission_callback' => array( $this, 'get_tasks_permission_check' ),
 					'args'                => array(
 						'ids' => array(
-							'description'       => __( 'Optional parameter to get only specific task lists by id.', 'woocommerce-admin' ),
+							'description'       => __( 'Optional parameter to get only specific task lists by id.', 'woocommerce' ),
 							'type'              => 'array',
 							'sanitize_callback' => 'wp_parse_slug_list',
 							'validate_callback' => 'rest_validate_request_arg',
@@ -189,14 +189,14 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			array(
 				'args'   => array(
 					'duration'     => array(
-						'description'       => __( 'Time period to snooze the task.', 'woocommerce-admin' ),
+						'description'       => __( 'Time period to snooze the task.', 'woocommerce' ),
 						'type'              => 'string',
 						'validate_callback' => function( $param, $request, $key ) {
 							return in_array( $param, array_keys( $this->duration_to_ms ), true );
 						},
 					),
 					'task_list_id' => array(
-						'description' => __( 'Optional parameter to query specific task list.', 'woocommerce-admin' ),
+						'description' => __( 'Optional parameter to query specific task list.', 'woocommerce' ),
 						'type'        => 'string',
 					),
 				),
@@ -244,7 +244,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function create_products_permission_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( 'product', 'create' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -258,7 +258,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function create_pages_permission_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( 'page', 'create' ) || ! current_user_can( 'manage_options' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create new pages.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create new pages.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -272,7 +272,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function get_tasks_permission_check( $request ) {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to retrieve onboarding tasks.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to retrieve onboarding tasks.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -286,7 +286,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function hide_task_list_permission_check( $request ) {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you are not allowed to hide task lists.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you are not allowed to hide task lists.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -300,7 +300,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function snooze_task_permissions_check( $request ) {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to snooze onboarding tasks.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to snooze onboarding tasks.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -329,7 +329,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			$import   = $importer->import();
 			return $import;
 		} else {
-			return new \WP_Error( 'woocommerce_rest_import_error', __( 'Sorry, the sample products data file was not found.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'woocommerce_rest_import_error', __( 'Sorry, the sample products data file was not found.', 'woocommerce' ) );
 		}
 	}
 
@@ -365,7 +365,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			return new \WP_Error(
 				'woocommerce_rest_product_creation_error',
 				/* translators: %s is template name */
-				__( 'Sorry, creating the product with template failed.', 'woocommerce-admin' ),
+				__( 'Sorry, creating the product with template failed.', 'woocommerce' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -439,31 +439,31 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$shop_url = get_permalink( wc_get_page_id( 'shop' ) );
 		if ( ! empty( $image['url'] ) && ! empty( $image['id'] ) ) {
 			return '<!-- wp:cover {"url":"' . esc_url( $image['url'] ) . '","id":' . intval( $image['id'] ) . ',"dimRatio":0} -->
-			<div class="wp-block-cover" style="background-image:url(' . esc_url( $image['url'] ) . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce-admin' ) . '","textColor":"white","fontSize":"large"} -->
-			<p class="has-text-align-center has-large-font-size">' . __( 'Welcome to the store', 'woocommerce-admin' ) . '</p>
+			<div class="wp-block-cover" style="background-image:url(' . esc_url( $image['url'] ) . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce' ) . '","textColor":"white","fontSize":"large"} -->
+			<p class="has-text-align-center has-large-font-size">' . __( 'Welcome to the store', 'woocommerce' ) . '</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"align":"center","textColor":"white"} -->
-			<p class="has-text-color has-text-align-center">' . __( 'Write a short welcome message here', 'woocommerce-admin' ) . '</p>
+			<p class="has-text-color has-text-align-center">' . __( 'Write a short welcome message here', 'woocommerce' ) . '</p>
 			<!-- /wp:paragraph -->
 
 			<!-- wp:button {"align":"center"} -->
-			<div class="wp-block-button aligncenter"><a href="' . esc_url( $shop_url ) . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
+			<div class="wp-block-button aligncenter"><a href="' . esc_url( $shop_url ) . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce' ) . '</a></div>
 			<!-- /wp:button --></div></div>
 			<!-- /wp:cover -->';
 		}
 
 		return '<!-- wp:cover {"dimRatio":0} -->
-		<div class="wp-block-cover"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce-admin' ) . '","textColor":"white","fontSize":"large"} -->
-		<p class="has-text-color has-text-align-center has-large-font-size">' . __( 'Welcome to the store', 'woocommerce-admin' ) . '</p>
+		<div class="wp-block-cover"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce' ) . '","textColor":"white","fontSize":"large"} -->
+		<p class="has-text-color has-text-align-center has-large-font-size">' . __( 'Welcome to the store', 'woocommerce' ) . '</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"align":"center","textColor":"white"} -->
-		<p class="has-text-color has-text-align-center">' . __( 'Write a short welcome message here', 'woocommerce-admin' ) . '</p>
+		<p class="has-text-color has-text-align-center">' . __( 'Write a short welcome message here', 'woocommerce' ) . '</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:button {"align":"center"} -->
-		<div class="wp-block-button aligncenter"><a href="' . esc_url( $shop_url ) . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
+		<div class="wp-block-button aligncenter"><a href="' . esc_url( $shop_url ) . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce' ) . '</a></div>
 		<!-- /wp:button --></div></div>
 		<!-- /wp:cover -->';
 	}
@@ -482,14 +482,14 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! empty( $image['url'] ) && ! empty( $image['id'] ) ) {
 			return '<!-- wp:media-text {' . $media_position . '"mediaId":' . intval( $image['id'] ) . ',"mediaType":"image"} -->
-			<div class="wp-block-media-text alignwide' . $css_class . '""><figure class="wp-block-media-text__media"><img src="' . esc_url( $image['url'] ) . '" alt="" class="wp-image-' . intval( $image['id'] ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"' . __( 'Content…', 'woocommerce-admin' ) . '","fontSize":"large"} -->
+			<div class="wp-block-media-text alignwide' . $css_class . '""><figure class="wp-block-media-text__media"><img src="' . esc_url( $image['url'] ) . '" alt="" class="wp-image-' . intval( $image['id'] ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"' . __( 'Content…', 'woocommerce' ) . '","fontSize":"large"} -->
 			<p class="has-large-font-size"></p>
 			<!-- /wp:paragraph --></div></div>
 			<!-- /wp:media-text -->';
 		}
 
 		return '<!-- wp:media-text {' . $media_position . '} -->
-		<div class="wp-block-media-text alignwide' . $css_class . '"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"' . __( 'Content…', 'woocommerce-admin' ) . '","fontSize":"large"} -->
+		<div class="wp-block-media-text alignwide' . $css_class . '"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"' . __( 'Content…', 'woocommerce' ) . '","fontSize":"large"} -->
 		<p class="has-large-font-size"></p>
 		<!-- /wp:paragraph --></div></div>
 		<!-- /wp:media-text -->';
@@ -509,25 +509,25 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			$image_1  = ! empty( $images[0] ) ? $images[0] : '';
 			$template = self::get_homepage_cover_block( $image_1 ) . '
 				<!-- wp:heading {"align":"center"} -->
-				<h2 style="text-align:center">' . __( 'Shop by Category', 'woocommerce-admin' ) . '</h2>
+				<h2 style="text-align:center">' . __( 'Shop by Category', 'woocommerce' ) . '</h2>
 				<!-- /wp:heading -->
 				<!-- wp:shortcode -->
 				[product_categories number="0" parent="0"]
 				<!-- /wp:shortcode -->
 				<!-- wp:heading {"align":"center"} -->
-				<h2 style="text-align:center">' . __( 'New In', 'woocommerce-admin' ) . '</h2>
+				<h2 style="text-align:center">' . __( 'New In', 'woocommerce' ) . '</h2>
 				<!-- /wp:heading -->
 				<!-- wp:woocommerce/product-new {"columns":4} /-->
 				<!-- wp:heading {"align":"center"} -->
-				<h2 style="text-align:center">' . __( 'Fan Favorites', 'woocommerce-admin' ) . '</h2>
+				<h2 style="text-align:center">' . __( 'Fan Favorites', 'woocommerce' ) . '</h2>
 				<!-- /wp:heading -->
 				<!-- wp:woocommerce/product-top-rated {"columns":4} /-->
 				<!-- wp:heading {"align":"center"} -->
-				<h2 style="text-align:center">' . __( 'On Sale', 'woocommerce-admin' ) . '</h2>
+				<h2 style="text-align:center">' . __( 'On Sale', 'woocommerce' ) . '</h2>
 				<!-- /wp:heading -->
 				<!-- wp:woocommerce/product-on-sale {"columns":4} /-->
 				<!-- wp:heading {"align":"center"} -->
-				<h2 style="text-align:center">' . __( 'Best Sellers', 'woocommerce-admin' ) . '</h2>
+				<h2 style="text-align:center">' . __( 'Best Sellers', 'woocommerce' ) . '</h2>
 				<!-- /wp:heading -->
 				<!-- wp:woocommerce/product-best-sellers {"columns":4} /-->
 			';
@@ -546,7 +546,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$image_3  = ! empty( $images[2] ) ? $images[2] : '';
 		$template = self::get_homepage_cover_block( $image_1 ) . '
 		<!-- wp:heading {"align":"center"} -->
-		<h2 style="text-align:center">' . __( 'New Products', 'woocommerce-admin' ) . '</h2>
+		<h2 style="text-align:center">' . __( 'New Products', 'woocommerce' ) . '</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:woocommerce/product-new /--> ' .
@@ -648,7 +648,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public static function create_homepage() {
 		$post_id = wp_insert_post(
 			array(
-				'post_title'   => __( 'Homepage', 'woocommerce-admin' ),
+				'post_title'   => __( 'Homepage', 'woocommerce' ),
 				'post_type'    => 'page',
 				'post_status'  => 'publish',
 				'post_content' => '', // Template content is updated below, so images can be attached to the post.
@@ -676,7 +676,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 			return array(
 				'status'         => 'success',
-				'message'        => __( 'Homepage created', 'woocommerce-admin' ),
+				'message'        => __( 'Homepage created', 'woocommerce' ),
 				'post_id'        => $post_id,
 				'edit_post_link' => htmlspecialchars_decode( get_edit_post_link( $post_id ) ),
 			);
@@ -693,7 +693,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function get_task_list_params() {
 		$params                   = array();
 		$params['ids']            = array(
-			'description'       => __( 'Optional parameter to get only specific task lists by id.', 'woocommerce-admin' ),
+			'description'       => __( 'Optional parameter to get only specific task lists by id.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -703,7 +703,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			),
 		);
 		$params['extended_tasks'] = array(
-			'description'       => __( 'List of extended deprecated tasks from the client side filter.', 'woocommerce-admin' ),
+			'description'       => __( 'List of extended deprecated tasks from the client side filter.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => function( $param, $request, $key ) {
 				$has_valid_keys = true;
@@ -764,7 +764,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task || ! $task->is_dismissable() ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
-				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
+				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)
@@ -797,7 +797,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task || ! $task->is_dismissable() ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
-				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
+				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)
@@ -835,7 +835,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task || ! $task->is_snoozeable() ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
-				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
+				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)
@@ -868,7 +868,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task || ! $task->is_snoozeable() ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
-				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
+				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)
@@ -893,7 +893,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task_list ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task_list',
-				__( 'Sorry, that task list was not found', 'woocommerce-admin' ),
+				__( 'Sorry, that task list was not found', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)
@@ -920,7 +920,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task_list ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task_list',
-				__( 'Sorry, that task list was not found', 'woocommerce-admin' ),
+				__( 'Sorry, that task list was not found', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)
@@ -954,7 +954,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( ! $task ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
-				__( 'Sorry, no task with that ID was found.', 'woocommerce-admin' ),
+				__( 'Sorry, no task with that ID was found.', 'woocommerce' ),
 				array(
 					'status' => 404,
 				)

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -71,7 +71,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 	 */
 	public function update_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'switch_themes' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage themes.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage themes.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -87,7 +87,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 		$theme          = sanitize_text_field( $request['theme'] );
 
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce' ), 404 );
 		}
 
 		$installed_themes = wp_get_themes();
@@ -121,7 +121,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 				'woocommerce_rest_theme_install',
 				sprintf(
 					/* translators: %s: theme slug (example: woocommerce-services) */
-					__( 'The requested theme `%s` could not be installed. Theme API call failed.', 'woocommerce-admin' ),
+					__( 'The requested theme `%s` could not be installed. Theme API call failed.', 'woocommerce' ),
 					$theme
 				),
 				500
@@ -136,7 +136,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 				'woocommerce_rest_theme_install',
 				sprintf(
 					/* translators: %s: theme slug (example: woocommerce-services) */
-					__( 'The requested theme `%s` could not be installed.', 'woocommerce-admin' ),
+					__( 'The requested theme `%s` could not be installed.', 'woocommerce' ),
 					$theme
 				),
 				500
@@ -160,7 +160,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 		$allowed_themes = Themes::get_allowed_themes();
 		$theme          = sanitize_text_field( $request['theme'] );
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce' ), 404 );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/theme.php';
@@ -169,12 +169,12 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 
 		if ( ! in_array( $theme, array_keys( $installed_themes ), true ) ) {
 			/* translators: %s: theme slug (example: woocommerce-services) */
-			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce-admin' ), $theme ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce' ), $theme ), 404 );
 		}
 
 		$result = switch_theme( $theme );
 		if ( ! is_null( $result ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'The requested theme could not be activated.', 'woocommerce-admin' ), $theme ), 500 );
+			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'The requested theme could not be activated.', 'woocommerce' ), $theme ), 500 );
 		}
 
 		return( array(
@@ -196,19 +196,19 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'slug'   => array(
-					'description' => __( 'Theme slug.', 'woocommerce-admin' ),
+					'description' => __( 'Theme slug.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'   => array(
-					'description' => __( 'Theme name.', 'woocommerce-admin' ),
+					'description' => __( 'Theme name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'status' => array(
-					'description' => __( 'Theme status.', 'woocommerce-admin' ),
+					'description' => __( 'Theme status.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -72,12 +72,12 @@ class Options extends \WC_REST_Data_Controller {
 		$params = explode( ',', $request['options'] );
 
 		if ( ! isset( $request['options'] ) || ! is_array( $params ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of options.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of options.', 'woocommerce' ), 500 );
 		}
 
 		foreach ( $params as $option ) {
 			if ( ! $this->user_has_permission( $option, $request ) ) {
-				return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view these options.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+				return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view these options.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
 
@@ -113,12 +113,12 @@ class Options extends \WC_REST_Data_Controller {
 		$params = $request->get_json_params();
 
 		if ( ! is_array( $params ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'You must supply an array of options and values.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'You must supply an array of options and values.', 'woocommerce' ), 500 );
 		}
 
 		foreach ( $params as $option_name => $option_value ) {
 			if ( ! $this->user_has_permission( $option_name, $request, true ) ) {
-				return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage these options.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+				return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage these options.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
 
@@ -248,7 +248,7 @@ class Options extends \WC_REST_Data_Controller {
 			'properties' => array(
 				'options' => array(
 					'type'        => 'array',
-					'description' => __( 'Array of options with associated values.', 'woocommerce-admin' ),
+					'description' => __( 'Array of options with associated values.', 'woocommerce' ),
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),

--- a/plugins/woocommerce/src/Admin/API/Orders.php
+++ b/plugins/woocommerce/src/Admin/API/Orders.php
@@ -34,7 +34,7 @@ class Orders extends \WC_REST_Orders_Controller {
 		$params = parent::get_collection_params();
 		// This needs to remain a string to support extensions that filter Order Number.
 		$params['number'] = array(
-			'description'       => __( 'Limit result set to orders matching part of an order number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders matching part of an order number.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/src/Admin/API/PaymentGatewaySuggestions.php
+++ b/plugins/woocommerce/src/Admin/API/PaymentGatewaySuggestions.php
@@ -73,7 +73,7 @@ class PaymentGatewaySuggestions extends \WC_REST_Data_Controller {
 	 */
 	public function get_permission_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -114,43 +114,43 @@ class PaymentGatewaySuggestions extends \WC_REST_Data_Controller {
 			'type'       => 'array',
 			'properties' => array(
 				'content'                 => array(
-					'description' => __( 'Suggestion description.', 'woocommerce-admin' ),
+					'description' => __( 'Suggestion description.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'id'                      => array(
-					'description' => __( 'Suggestion ID.', 'woocommerce-admin' ),
+					'description' => __( 'Suggestion ID.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'image'                   => array(
-					'description' => __( 'Gateway image.', 'woocommerce-admin' ),
+					'description' => __( 'Gateway image.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'is_visible'              => array(
-					'description' => __( 'Suggestion visibility.', 'woocommerce-admin' ),
+					'description' => __( 'Suggestion visibility.', 'woocommerce' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'plugins'                 => array(
-					'description' => __( 'Array of plugin slugs.', 'woocommerce-admin' ),
+					'description' => __( 'Array of plugin slugs.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'recommendation_priority' => array(
-					'description' => __( 'Priority of recommendation.', 'woocommerce-admin' ),
+					'description' => __( 'Priority of recommendation.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'title'                   => array(
-					'description' => __( 'Gateway title.', 'woocommerce-admin' ),
+					'description' => __( 'Gateway title.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -217,7 +217,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function update_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage plugins.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -245,7 +245,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		$plugins = explode( ',', $request['plugins'] );
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );
 		}
 
 		if ( isset( $request['async'] ) && $request['async'] ) {
@@ -256,7 +256,7 @@ class Plugins extends \WC_REST_Data_Controller {
 					'job_id'  => $job_id,
 					'plugins' => $plugins,
 				),
-				'message' => __( 'Plugin installation has been scheduled.', 'woocommerce-admin' ),
+				'message' => __( 'Plugin installation has been scheduled.', 'woocommerce' ),
 			);
 		}
 
@@ -271,8 +271,8 @@ class Plugins extends \WC_REST_Data_Controller {
 			'errors'  => $data['errors'],
 			'success' => count( $data['errors']->errors ) === 0,
 			'message' => count( $data['errors']->errors ) === 0
-				? __( 'Plugins were successfully installed.', 'woocommerce-admin' )
-				: __( 'There was a problem installing some of the requested plugins.', 'woocommerce-admin' ),
+				? __( 'Plugins were successfully installed.', 'woocommerce' )
+				: __( 'There was a problem installing some of the requested plugins.', 'woocommerce' ),
 		);
 	}
 
@@ -340,7 +340,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		$plugins = explode( ',', $request['plugins'] );
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );
 		}
 
 		if ( isset( $request['async'] ) && $request['async'] ) {
@@ -351,7 +351,7 @@ class Plugins extends \WC_REST_Data_Controller {
 					'job_id'  => $job_id,
 					'plugins' => $plugins,
 				),
-				'message' => __( 'Plugin activation has been scheduled.', 'woocommerce-admin' ),
+				'message' => __( 'Plugin activation has been scheduled.', 'woocommerce' ),
 			);
 		}
 
@@ -365,8 +365,8 @@ class Plugins extends \WC_REST_Data_Controller {
 			'errors'  => $data['errors'],
 			'success' => count( $data['errors']->errors ) === 0,
 			'message' => count( $data['errors']->errors ) === 0
-				? __( 'Plugins were successfully activated.', 'woocommerce-admin' )
-				: __( 'There was a problem activating some of the requested plugins.', 'woocommerce-admin' ),
+				? __( 'Plugins were successfully activated.', 'woocommerce' )
+				: __( 'There was a problem activating some of the requested plugins.', 'woocommerce' ),
 		) );
 	}
 
@@ -400,7 +400,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function connect_jetpack( $request ) {
 		if ( ! class_exists( '\Jetpack' ) ) {
-			return new \WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce' ), 404 );
 		}
 
 		$redirect_url = apply_filters( 'woocommerce_admin_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
@@ -411,7 +411,7 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		return( array(
 			'slug'          => 'jetpack',
-			'name'          => __( 'Jetpack', 'woocommerce-admin' ),
+			'name'          => __( 'Jetpack', 'woocommerce' ),
 			'connectAction' => $connect_url,
 		) );
 	}
@@ -424,7 +424,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	public function request_wccom_connect() {
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php';
 		if ( ! class_exists( 'WC_Helper_API' ) ) {
-			return new \WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce' ), 404 );
 		}
 
 		$redirect_uri = wc_admin_url( '&task=connect&wccom-connected=1' );
@@ -441,12 +441,12 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		$code = wp_remote_retrieve_response_code( $request );
 		if ( 200 !== $code ) {
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce' ), 500 );
 		}
 
 		$secret = json_decode( wp_remote_retrieve_body( $request ) );
 		if ( empty( $secret ) ) {
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce' ), 500 );
 		}
 
 		do_action( 'woocommerce_helper_connect_start' );
@@ -487,7 +487,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-updater.php';
 		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
 		if ( ! class_exists( 'WC_Helper_API' ) ) {
-			return new \WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce' ), 404 );
 		}
 
 		// Obtain an access token.
@@ -503,12 +503,12 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		$code = wp_remote_retrieve_response_code( $request );
 		if ( 200 !== $code ) {
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce' ), 500 );
 		}
 
 		$access_token = json_decode( wp_remote_retrieve_body( $request ), true );
 		if ( ! $access_token ) {
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce' ), 500 );
 		}
 
 		\WC_Helper_Options::update(
@@ -524,7 +524,7 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		if ( ! \WC_Helper::_flush_authentication_cache() ) {
 			\WC_Helper_Options::update( 'auth', array() );
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce' ), 500 );
 		}
 
 		delete_transient( '_woocommerce_helper_subscriptions' );
@@ -545,7 +545,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function connect_square() {
 		if ( ! class_exists( '\WooCommerce\Square\Handlers\Connection' ) ) {
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to Square.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to Square.', 'woocommerce' ), 500 );
 		}
 
 		if ( 'US' === WC()->countries->get_base_country() ) {
@@ -597,7 +597,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function connect_wcpay() {
 		if ( ! class_exists( 'WC_Payments_Account' ) ) {
-			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error communicating with the WooCommerce Payments plugin.', 'woocommerce-admin' ), 500 );
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error communicating with the WooCommerce Payments plugin.', 'woocommerce' ), 500 );
 		}
 
 		$connect_url = add_query_arg(
@@ -625,19 +625,19 @@ class Plugins extends \WC_REST_Data_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'slug'   => array(
-					'description' => __( 'Plugin slug.', 'woocommerce-admin' ),
+					'description' => __( 'Plugin slug.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'   => array(
-					'description' => __( 'Plugin name.', 'woocommerce-admin' ),
+					'description' => __( 'Plugin name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'status' => array(
-					'description' => __( 'Plugin status.', 'woocommerce-admin' ),
+					'description' => __( 'Plugin status.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -657,7 +657,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		$schema = $this->get_item_schema();
 		unset( $schema['properties']['status'] );
 		$schema['properties']['connectAction'] = array(
-			'description' => __( 'Action that should be completed to connect Jetpack.', 'woocommerce-admin' ),
+			'description' => __( 'Action that should be completed to connect Jetpack.', 'woocommerce' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/ProductAttributeTerms.php
+++ b/plugins/woocommerce/src/Admin/API/ProductAttributeTerms.php
@@ -38,7 +38,7 @@ class ProductAttributeTerms extends \WC_REST_Product_Attribute_Terms_Controller 
 			array(
 				'args'   => array(
 					'slug' => array(
-						'description' => __( 'Slug identifier for the resource.', 'woocommerce-admin' ),
+						'description' => __( 'Slug identifier for the resource.', 'woocommerce' ),
 						'type'        => 'string',
 					),
 				),
@@ -63,7 +63,7 @@ class ProductAttributeTerms extends \WC_REST_Product_Attribute_Terms_Controller 
 		if ( ! wc_rest_check_manager_permissions( 'attributes', 'read' ) ) {
 			return new WP_Error(
 				'woocommerce_rest_cannot_view',
-				__( 'Sorry, you cannot view this resource.', 'woocommerce-admin' ),
+				__( 'Sorry, you cannot view this resource.', 'woocommerce' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)

--- a/plugins/woocommerce/src/Admin/API/ProductAttributes.php
+++ b/plugins/woocommerce/src/Admin/API/ProductAttributes.php
@@ -37,7 +37,7 @@ class ProductAttributes extends \WC_REST_Product_Attributes_Controller {
 			array(
 				'args'   => array(
 					'slug' => array(
-						'description' => __( 'Slug identifier for the resource.', 'woocommerce-admin' ),
+						'description' => __( 'Slug identifier for the resource.', 'woocommerce' ),
 						'type'        => 'string',
 					),
 				),
@@ -59,7 +59,7 @@ class ProductAttributes extends \WC_REST_Product_Attributes_Controller {
 	public function get_collection_params() {
 		$params           = parent::get_collection_params();
 		$params['search'] = array(
-			'description'       => __( 'Search by similar attribute name.', 'woocommerce-admin' ),
+			'description'       => __( 'Search by similar attribute name.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/src/Admin/API/ProductVariations.php
+++ b/plugins/woocommerce/src/Admin/API/ProductVariations.php
@@ -53,7 +53,7 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 	public function get_collection_params() {
 		$params           = parent::get_collection_params();
 		$params['search'] = array(
-			'description'       => __( 'Search by similar product name, sku, or attribute value.', 'woocommerce-admin' ),
+			'description'       => __( 'Search by similar product name, sku, or attribute value.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -163,19 +163,19 @@ class ProductVariations extends \WC_REST_Product_Variations_Controller {
 		$schema = parent::get_item_schema();
 
 		$schema['properties']['name']      = array(
-			'description' => __( 'Product parent name.', 'woocommerce-admin' ),
+			'description' => __( 'Product parent name.', 'woocommerce' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit' ),
 		);
 		$schema['properties']['type']      = array(
-			'description' => __( 'Product type.', 'woocommerce-admin' ),
+			'description' => __( 'Product type.', 'woocommerce' ),
 			'type'        => 'string',
 			'default'     => 'variation',
 			'enum'        => array( 'variation' ),
 			'context'     => array( 'view', 'edit' ),
 		);
 		$schema['properties']['parent_id'] = array(
-			'description' => __( 'Product parent ID.', 'woocommerce-admin' ),
+			'description' => __( 'Product parent ID.', 'woocommerce' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 		);

--- a/plugins/woocommerce/src/Admin/API/Products.php
+++ b/plugins/woocommerce/src/Admin/API/Products.php
@@ -54,7 +54,7 @@ class Products extends \WC_REST_Products_Controller {
 		}
 
 		$schema['properties']['last_order_date'] = array(
-			'description' => __( "The date the last order for this product was placed, in the site's timezone.", 'woocommerce-admin' ),
+			'description' => __( "The date the last order for this product was placed, in the site's timezone.", 'woocommerce' ),
 			'type'        => 'date-time',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
@@ -71,13 +71,13 @@ class Products extends \WC_REST_Products_Controller {
 	public function get_collection_params() {
 		$params                 = parent::get_collection_params();
 		$params['low_in_stock'] = array(
-			'description'       => __( 'Limit result set to products that are low or out of stock. (Deprecated)', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to products that are low or out of stock. (Deprecated)', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
 		);
 		$params['search']       = array(
-			'description'       => __( 'Search by similar product name or sku.', 'woocommerce-admin' ),
+			'description'       => __( 'Search by similar product name or sku.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -288,7 +288,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$params['context']['default'] = 'view';
 
 		$params['page']     = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -296,7 +296,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page'] = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -307,7 +307,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 
 		$params['status'] = array(
 			'default'           => 'publish',
-			'description'       => __( 'Limit result set to products assigned a specific status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to products assigned a specific status.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array_merge( array_keys( get_post_statuses() ), array( 'future' ) ),
 			'sanitize_callback' => 'sanitize_key',

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -73,7 +73,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		}
 
 		if ( ! isset( $report_data->data ) || ! isset( $report_data->page_no ) || ! isset( $report_data->pages ) ) {
-			return new \WP_Error( 'woocommerce_rest_reports_categories_invalid_response', __( 'Invalid response from data store.', 'woocommerce-admin' ), array( 'status' => 500 ) );
+			return new \WP_Error( 'woocommerce_rest_reports_categories_invalid_response', __( 'Invalid response from data store.', 'woocommerce' ), array( 'status' => 500 ) );
 		}
 
 		$out_data = array();
@@ -165,31 +165,31 @@ class Controller extends ReportsController implements ExportableInterface {
 			'type'       => 'object',
 			'properties' => array(
 				'category_id'    => array(
-					'description' => __( 'Category ID.', 'woocommerce-admin' ),
+					'description' => __( 'Category ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'items_sold'     => array(
-					'description' => __( 'Amount of items sold.', 'woocommerce-admin' ),
+					'description' => __( 'Amount of items sold.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'net_revenue'    => array(
-					'description' => __( 'Total sales.', 'woocommerce-admin' ),
+					'description' => __( 'Total sales.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'orders_count'   => array(
-					'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'products_count' => array(
-					'description' => __( 'Amount of products.', 'woocommerce-admin' ),
+					'description' => __( 'Amount of products.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -199,7 +199,7 @@ class Controller extends ReportsController implements ExportableInterface {
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Category name.', 'woocommerce-admin' ),
+						'description' => __( 'Category name.', 'woocommerce' ),
 					),
 				),
 			),
@@ -217,7 +217,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		$params                  = array();
 		$params['context']       = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']          = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -225,7 +225,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'minimum'           => 1,
 		);
 		$params['per_page']      = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -234,26 +234,26 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']         = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']        = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']         = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']       = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'category_id',
 			'enum'              => array(
@@ -267,7 +267,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']      = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -281,7 +281,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['status_is']     = array(
-			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -291,7 +291,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['status_is_not'] = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -301,7 +301,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['categories']    = array(
-			'description'       => __( 'Limit result set to all items that have the specified term assigned in the categories taxonomy.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to all items that have the specified term assigned in the categories taxonomy.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -310,7 +310,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['extended_info'] = array(
-			'description'       => __( 'Add additional piece of info about each category to the report.', 'woocommerce-admin' ),
+			'description'       => __( 'Add additional piece of info about each category to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
@@ -327,11 +327,11 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'category'       => __( 'Category', 'woocommerce-admin' ),
-			'items_sold'     => __( 'Items sold', 'woocommerce-admin' ),
-			'net_revenue'    => __( 'Net Revenue', 'woocommerce-admin' ),
-			'products_count' => __( 'Products', 'woocommerce-admin' ),
-			'orders_count'   => __( 'Orders', 'woocommerce-admin' ),
+			'category'       => __( 'Category', 'woocommerce' ),
+			'items_sold'     => __( 'Items sold', 'woocommerce' ),
+			'net_revenue'    => __( 'Net Revenue', 'woocommerce' ),
+			'products_count' => __( 'Products', 'woocommerce' ),
+			'orders_count'   => __( 'Orders', 'woocommerce' ),
 		);
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php
@@ -272,7 +272,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			);
 
 			if ( null === $categories_data ) {
-				return new \WP_Error( 'woocommerce_analytics_categories_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ), array( 'status' => 500 ) );
+				return new \WP_Error( 'woocommerce_analytics_categories_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ), array( 'status' => 500 ) );
 			}
 
 			$record_count = count( $categories_data );

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -58,7 +58,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'reports', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -76,71 +76,71 @@ class Controller extends \WC_REST_Reports_Controller {
 		$reports = array(
 			array(
 				'slug'        => 'performance-indicators',
-				'description' => __( 'Batch endpoint for getting specific performance indicators from `stats` endpoints.', 'woocommerce-admin' ),
+				'description' => __( 'Batch endpoint for getting specific performance indicators from `stats` endpoints.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'revenue/stats',
-				'description' => __( 'Stats about revenue.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about revenue.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'orders/stats',
-				'description' => __( 'Stats about orders.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about orders.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'products',
-				'description' => __( 'Products detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Products detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'products/stats',
-				'description' => __( 'Stats about products.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about products.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'variations',
-				'description' => __( 'Variations detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Variations detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'variations/stats',
-				'description' => __( 'Stats about variations.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about variations.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'categories',
-				'description' => __( 'Product categories detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Product categories detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'categories/stats',
-				'description' => __( 'Stats about product categories.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about product categories.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'coupons',
-				'description' => __( 'Coupons detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Coupons detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'coupons/stats',
-				'description' => __( 'Stats about coupons.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about coupons.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'taxes',
-				'description' => __( 'Taxes detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Taxes detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'taxes/stats',
-				'description' => __( 'Stats about taxes.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about taxes.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'downloads',
-				'description' => __( 'Product downloads detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Product downloads detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'downloads/files',
-				'description' => __( 'Product download files detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Product download files detailed reports.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'downloads/stats',
-				'description' => __( 'Stats about product downloads.', 'woocommerce-admin' ),
+				'description' => __( 'Stats about product downloads.', 'woocommerce' ),
 			),
 			array(
 				'slug'        => 'customers',
-				'description' => __( 'Customers detailed reports.', 'woocommerce-admin' ),
+				'description' => __( 'Customers detailed reports.', 'woocommerce' ),
 			),
 		);
 
@@ -285,19 +285,19 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'slug'        => array(
-					'description' => __( 'An alphanumeric identifier for the resource.', 'woocommerce-admin' ),
+					'description' => __( 'An alphanumeric identifier for the resource.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'description' => array(
-					'description' => __( 'A human-readable description of the resource.', 'woocommerce-admin' ),
+					'description' => __( 'A human-readable description of the resource.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
 				'path'        => array(
-					'description' => __( 'API path.', 'woocommerce-admin' ),
+					'description' => __( 'API path.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view' ),
 					'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -152,19 +152,19 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'type'       => 'object',
 			'properties' => array(
 				'coupon_id'     => array(
-					'description' => __( 'Coupon ID.', 'woocommerce-admin' ),
+					'description' => __( 'Coupon ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'amount'        => array(
-					'description' => __( 'Net discount amount.', 'woocommerce-admin' ),
+					'description' => __( 'Net discount amount.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'orders_count'  => array(
-					'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -174,38 +174,38 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Coupon code.', 'woocommerce-admin' ),
+						'description' => __( 'Coupon code.', 'woocommerce' ),
 					),
 					'date_created'     => array(
 						'type'        => 'date-time',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Coupon creation date.', 'woocommerce-admin' ),
+						'description' => __( 'Coupon creation date.', 'woocommerce' ),
 					),
 					'date_created_gmt' => array(
 						'type'        => 'date-time',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Coupon creation date in GMT.', 'woocommerce-admin' ),
+						'description' => __( 'Coupon creation date in GMT.', 'woocommerce' ),
 					),
 					'date_expires'     => array(
 						'type'        => 'date-time',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Coupon expiration date.', 'woocommerce-admin' ),
+						'description' => __( 'Coupon expiration date.', 'woocommerce' ),
 					),
 					'date_expires_gmt' => array(
 						'type'        => 'date-time',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Coupon expiration date in GMT.', 'woocommerce-admin' ),
+						'description' => __( 'Coupon expiration date in GMT.', 'woocommerce' ),
 					),
 					'discount_type'    => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
 						'enum'        => array_keys( wc_get_coupon_types() ),
-						'description' => __( 'Coupon discount type.', 'woocommerce-admin' ),
+						'description' => __( 'Coupon discount type.', 'woocommerce' ),
 					),
 				),
 			),
@@ -223,7 +223,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$params                  = array();
 		$params['context']       = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']          = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -231,7 +231,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'minimum'           => 1,
 		);
 		$params['per_page']      = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -240,26 +240,26 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']         = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']        = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']         = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']       = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'coupon_id',
 			'enum'              => array(
@@ -271,7 +271,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['coupons']       = array(
-			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -280,7 +280,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['extended_info'] = array(
-			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce-admin' ),
+			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
@@ -297,12 +297,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'code'         => __( 'Coupon code', 'woocommerce-admin' ),
-			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
-			'amount'       => __( 'Amount discounted', 'woocommerce-admin' ),
-			'created'      => __( 'Created', 'woocommerce-admin' ),
-			'expires'      => __( 'Expires', 'woocommerce-admin' ),
-			'type'         => __( 'Type', 'woocommerce-admin' ),
+			'code'         => __( 'Coupon code', 'woocommerce' ),
+			'orders_count' => __( 'Orders', 'woocommerce' ),
+			'amount'       => __( 'Amount discounted', 'woocommerce' ),
+			'created'      => __( 'Created', 'woocommerce' ),
+			'expires'      => __( 'Expires', 'woocommerce' ),
+			'type'         => __( 'Type', 'woocommerce' ),
 		);
 
 		/**
@@ -325,7 +325,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function prepare_item_for_export( $item ) {
 		$date_expires = empty( $item['extended_info']['date_expires'] )
-			? __( 'N/A', 'woocommerce-admin' )
+			? __( 'N/A', 'woocommerce' )
 			: $item['extended_info']['date_expires'];
 
 		$export_item = array(

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/DataStore.php
@@ -170,12 +170,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				if ( 0 === $coupon->get_id() ) {
 					// Deleted or otherwise invalid coupon.
 					$extended_info = array(
-						'code'             => __( '(Deleted)', 'woocommerce-admin' ),
+						'code'             => __( '(Deleted)', 'woocommerce' ),
 						'date_created'     => '',
 						'date_created_gmt' => '',
 						'date_expires'     => '',
 						'date_expires_gmt' => '',
-						'discount_type'    => __( 'N/A', 'woocommerce-admin' ),
+						'discount_type'    => __( 'N/A', 'woocommerce' ),
 					);
 				} else {
 					$gmt_timzone = new \DateTimeZone( 'UTC' );

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -142,7 +142,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'amount'        => array(
-				'description' => __( 'Net discount amount.', 'woocommerce-admin' ),
+				'description' => __( 'Net discount amount.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -150,14 +150,14 @@ class Controller extends \WC_REST_Reports_Controller {
 				'format'      => 'currency',
 			),
 			'coupons_count' => array(
-				'description' => __( 'Number of coupons.', 'woocommerce-admin' ),
+				'description' => __( 'Number of coupons.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'orders_count'  => array(
-				'title'       => __( 'Discounted orders', 'woocommerce-admin' ),
-				'description' => __( 'Number of discounted orders.', 'woocommerce-admin' ),
+				'title'       => __( 'Discounted orders', 'woocommerce' ),
+				'description' => __( 'Number of discounted orders.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -167,7 +167,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$segments = array(
 			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce-admin' ),
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -175,13 +175,13 @@ class Controller extends \WC_REST_Reports_Controller {
 					'type'       => 'object',
 					'properties' => array(
 						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce-admin' ),
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
 							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -200,14 +200,14 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -215,38 +215,38 @@ class Controller extends \WC_REST_Reports_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -270,7 +270,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params              = array();
 		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']      = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -278,7 +278,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']  = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -287,26 +287,26 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']     = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']    = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']     = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']   = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -318,7 +318,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']  = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -332,7 +332,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['coupons']   = array(
-			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -341,7 +341,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['segmentby'] = array(
-			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
+			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'product',
@@ -352,7 +352,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['fields']    = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Segmenter.php
@@ -280,7 +280,7 @@ class Segmenter extends ReportsSegmenter {
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
 			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
-				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce-admin' ) );
+				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 
 			$product_level_columns     = $this->get_segment_selections_product_level( $product_segmenting_table );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -222,91 +222,91 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'type'       => 'object',
 			'properties' => array(
 				'id'                   => array(
-					'description' => __( 'Customer ID.', 'woocommerce-admin' ),
+					'description' => __( 'Customer ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'user_id'              => array(
-					'description' => __( 'User ID.', 'woocommerce-admin' ),
+					'description' => __( 'User ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'                 => array(
-					'description' => __( 'Name.', 'woocommerce-admin' ),
+					'description' => __( 'Name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'username'             => array(
-					'description' => __( 'Username.', 'woocommerce-admin' ),
+					'description' => __( 'Username.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'country'              => array(
-					'description' => __( 'Country / Region.', 'woocommerce-admin' ),
+					'description' => __( 'Country / Region.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'city'                 => array(
-					'description' => __( 'City.', 'woocommerce-admin' ),
+					'description' => __( 'City.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'state'                => array(
-					'description' => __( 'Region.', 'woocommerce-admin' ),
+					'description' => __( 'Region.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'postcode'             => array(
-					'description' => __( 'Postal code.', 'woocommerce-admin' ),
+					'description' => __( 'Postal code.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_registered'      => array(
-					'description' => __( 'Date registered.', 'woocommerce-admin' ),
+					'description' => __( 'Date registered.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_registered_gmt'  => array(
-					'description' => __( 'Date registered GMT.', 'woocommerce-admin' ),
+					'description' => __( 'Date registered GMT.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_last_active'     => array(
-					'description' => __( 'Date last active.', 'woocommerce-admin' ),
+					'description' => __( 'Date last active.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_last_active_gmt' => array(
-					'description' => __( 'Date last active GMT.', 'woocommerce-admin' ),
+					'description' => __( 'Date last active GMT.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'orders_count'         => array(
-					'description' => __( 'Order count.', 'woocommerce-admin' ),
+					'description' => __( 'Order count.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'total_spend'          => array(
-					'description' => __( 'Total spend.', 'woocommerce-admin' ),
+					'description' => __( 'Total spend.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'avg_order_value'      => array(
-					'description' => __( 'Avg order value.', 'woocommerce-admin' ),
+					'description' => __( 'Avg order value.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -325,31 +325,31 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$params                            = array();
 		$params['context']                 = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['registered_before']       = array(
-			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['registered_after']        = array(
-			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']                   = array(
-			'description'       => __( 'Limit response to resources with orders published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources with orders published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']                  = array(
-			'description'       => __( 'Limit response to resources with orders published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources with orders published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['page']                    = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -357,7 +357,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'minimum'           => 1,
 		);
 		$params['per_page']                = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -366,14 +366,14 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']                   = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']                 = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date_registered',
 			'enum'              => array(
@@ -392,7 +392,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']                   = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -402,7 +402,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['search']                  = array(
-			'description'       => __( 'Limit response to objects with a customer field containing the search term. Searches the field provided by `searchby`.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a customer field containing the search term. Searches the field provided by `searchby`.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -417,59 +417,59 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['name_includes']           = array(
-			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['name_excludes']           = array(
-			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['username_includes']       = array(
-			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['username_excludes']       = array(
-			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['email_includes']          = array(
-			'description'       => __( 'Limit response to objects including emails.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects including emails.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['email_excludes']          = array(
-			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['country_includes']        = array(
-			'description'       => __( 'Limit response to objects with specfic countries.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with specfic countries.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['country_excludes']        = array(
-			'description'       => __( 'Limit response to objects excluding specfic countries.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding specfic countries.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_active_before']      = array(
-			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_active_after']       = array(
-			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_active_between']     = array(
-			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
 			'items'             => array(
@@ -477,19 +477,19 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['registered_before']       = array(
-			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['registered_after']        = array(
-			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['registered_between']      = array(
-			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
 			'items'             => array(
@@ -497,19 +497,19 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['orders_count_min']        = array(
-			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orders_count_max']        = array(
-			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orders_count_between']    = array(
-			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
 			'items'             => array(
@@ -517,17 +517,17 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['total_spend_min']         = array(
-			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['total_spend_max']         = array(
-			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['total_spend_between']     = array(
-			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
 			'items'             => array(
@@ -535,17 +535,17 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['avg_order_value_min']     = array(
-			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['avg_order_value_max']     = array(
-			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['avg_order_value_between'] = array(
-			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
 			'items'             => array(
@@ -553,19 +553,19 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['last_order_before']       = array(
-			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_order_after']        = array(
-			'description'       => __( 'Limit response to objects with last order after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with last order after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['customers']               = array(
-			'description'       => __( 'Limit result to items with specified customer ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified customer ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -584,18 +584,18 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'name'            => __( 'Name', 'woocommerce-admin' ),
-			'username'        => __( 'Username', 'woocommerce-admin' ),
-			'last_active'     => __( 'Last Active', 'woocommerce-admin' ),
-			'registered'      => __( 'Sign Up', 'woocommerce-admin' ),
-			'email'           => __( 'Email', 'woocommerce-admin' ),
-			'orders_count'    => __( 'Orders', 'woocommerce-admin' ),
-			'total_spend'     => __( 'Total Spend', 'woocommerce-admin' ),
-			'avg_order_value' => __( 'AOV', 'woocommerce-admin' ),
-			'country'         => __( 'Country / Region', 'woocommerce-admin' ),
-			'city'            => __( 'City', 'woocommerce-admin' ),
-			'region'          => __( 'Region', 'woocommerce-admin' ),
-			'postcode'        => __( 'Postal Code', 'woocommerce-admin' ),
+			'name'            => __( 'Name', 'woocommerce' ),
+			'username'        => __( 'Username', 'woocommerce' ),
+			'last_active'     => __( 'Last Active', 'woocommerce' ),
+			'registered'      => __( 'Sign Up', 'woocommerce' ),
+			'email'           => __( 'Email', 'woocommerce' ),
+			'orders_count'    => __( 'Orders', 'woocommerce' ),
+			'total_spend'     => __( 'Total Spend', 'woocommerce' ),
+			'avg_order_value' => __( 'AOV', 'woocommerce' ),
+			'country'         => __( 'Country / Region', 'woocommerce' ),
+			'city'            => __( 'City', 'woocommerce' ),
+			'region'          => __( 'Region', 'woocommerce' ),
+			'postcode'        => __( 'Postal Code', 'woocommerce' ),
 		);
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
@@ -129,26 +129,26 @@ class Controller extends \WC_REST_Reports_Controller {
 		// @todo Should any of these be 'indicator's?
 		$totals = array(
 			'customers_count'     => array(
-				'description' => __( 'Number of customers.', 'woocommerce-admin' ),
+				'description' => __( 'Number of customers.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'avg_orders_count'    => array(
-				'description' => __( 'Average number of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Average number of orders.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'avg_total_spend'     => array(
-				'description' => __( 'Average total spend per customer.', 'woocommerce-admin' ),
+				'description' => __( 'Average total spend per customer.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'format'      => 'currency',
 			),
 			'avg_avg_order_value' => array(
-				'description' => __( 'Average AOV per customer.', 'woocommerce-admin' ),
+				'description' => __( 'Average AOV per customer.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -162,7 +162,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals' => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -183,19 +183,19 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params                            = array();
 		$params['context']                 = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['registered_before']       = array(
-			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['registered_after']        = array(
-			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']                   = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -205,7 +205,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['search']                  = array(
-			'description'       => __( 'Limit response to objects with a customer field containing the search term. Searches the field provided by `searchby`.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a customer field containing the search term. Searches the field provided by `searchby`.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -220,59 +220,59 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['name_includes']           = array(
-			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with specfic names.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['name_excludes']           = array(
-			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding specfic names.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['username_includes']       = array(
-			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with specfic usernames.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['username_excludes']       = array(
-			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding specfic usernames.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['email_includes']          = array(
-			'description'       => __( 'Limit response to objects including emails.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects including emails.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['email_excludes']          = array(
-			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding emails.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['country_includes']        = array(
-			'description'       => __( 'Limit response to objects with specfic countries.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with specfic countries.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['country_excludes']        = array(
-			'description'       => __( 'Limit response to objects excluding specfic countries.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects excluding specfic countries.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_active_before']      = array(
-			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_active_after']       = array(
-			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_active_between']     = array(
-			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
 			'items'             => array(
@@ -280,19 +280,19 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['registered_before']       = array(
-			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['registered_after']        = array(
-			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects registered after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['registered_between']      = array(
-			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
 			'items'             => array(
@@ -300,19 +300,19 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['orders_count_min']        = array(
-			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orders_count_max']        = array(
-			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an order count less than or equal to given integer.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orders_count_between']    = array(
-			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
 			'items'             => array(
@@ -320,17 +320,17 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['total_spend_min']         = array(
-			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['total_spend_max']         = array(
-			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a total order spend less than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['total_spend_between']     = array(
-			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
 			'items'             => array(
@@ -338,17 +338,17 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['avg_order_value_min']     = array(
-			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['avg_order_value_max']     = array(
-			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an average order spend less than or equal to given number.', 'woocommerce' ),
 			'type'              => 'number',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['avg_order_value_between'] = array(
-			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
 			'items'             => array(
@@ -356,19 +356,19 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['last_order_before']       = array(
-			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['last_order_after']        = array(
-			'description'       => __( 'Limit response to objects with last order after (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects with last order after (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['customers']               = array(
-			'description'       => __( 'Limit result to items with specified customer ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified customer ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -377,7 +377,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['fields']                  = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
@@ -167,22 +167,22 @@ class Controller extends ReportsController implements ExportableInterface {
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'ID.', 'woocommerce-admin' ),
+					'description' => __( 'ID.', 'woocommerce' ),
 				),
 				'product_id'   => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Product ID.', 'woocommerce-admin' ),
+					'description' => __( 'Product ID.', 'woocommerce' ),
 				),
 				'date'         => array(
-					'description' => __( "The date of the download, in the site's timezone.", 'woocommerce-admin' ),
+					'description' => __( "The date of the download, in the site's timezone.", 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_gmt'     => array(
-					'description' => __( 'The date of the download, as GMT.', 'woocommerce-admin' ),
+					'description' => __( 'The date of the download, as GMT.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -191,49 +191,49 @@ class Controller extends ReportsController implements ExportableInterface {
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Download ID.', 'woocommerce-admin' ),
+					'description' => __( 'Download ID.', 'woocommerce' ),
 				),
 				'file_name'    => array(
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'File name.', 'woocommerce-admin' ),
+					'description' => __( 'File name.', 'woocommerce' ),
 				),
 				'file_path'    => array(
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'File URL.', 'woocommerce-admin' ),
+					'description' => __( 'File URL.', 'woocommerce' ),
 				),
 				'order_id'     => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Order ID.', 'woocommerce-admin' ),
+					'description' => __( 'Order ID.', 'woocommerce' ),
 				),
 				'order_number' => array(
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Order Number.', 'woocommerce-admin' ),
+					'description' => __( 'Order Number.', 'woocommerce' ),
 				),
 				'user_id'      => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'User ID for the downloader.', 'woocommerce-admin' ),
+					'description' => __( 'User ID for the downloader.', 'woocommerce' ),
 				),
 				'username'     => array(
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'User name of the downloader.', 'woocommerce-admin' ),
+					'description' => __( 'User name of the downloader.', 'woocommerce' ),
 				),
 				'ip_address'   => array(
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'IP address for the downloader.', 'woocommerce-admin' ),
+					'description' => __( 'IP address for the downloader.', 'woocommerce' ),
 				),
 			),
 		);
@@ -250,7 +250,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		$params                        = array();
 		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']                = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -258,7 +258,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'minimum'           => 1,
 		);
 		$params['per_page']            = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -267,26 +267,26 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']               = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']              = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']               = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']             = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -296,7 +296,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']               = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: products, orders, username, ip_address.', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: products, orders, username, ip_address.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -306,7 +306,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_includes']    = array(
-			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -316,7 +316,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_excludes']    = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -326,7 +326,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['order_includes']      = array(
-			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -335,7 +335,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['order_excludes']      = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -344,7 +344,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['customer_includes']   = array(
-			'description'       => __( 'Limit response to objects that have the specified user ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that have the specified user ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -353,7 +353,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['customer_excludes']   = array(
-			'description'       => __( 'Limit response to objects that don\'t have the specified user ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that don\'t have the specified user ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -362,7 +362,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['ip_address_includes'] = array(
-			'description'       => __( 'Limit response to objects that have a specified ip address.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that have a specified ip address.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
@@ -371,7 +371,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		);
 
 		$params['ip_address_excludes'] = array(
-			'description'       => __( 'Limit response to objects that don\'t have a specified ip address.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that don\'t have a specified ip address.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
@@ -389,12 +389,12 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'date'         => __( 'Date', 'woocommerce-admin' ),
-			'product'      => __( 'Product title', 'woocommerce-admin' ),
-			'file_name'    => __( 'File name', 'woocommerce-admin' ),
-			'order_number' => __( 'Order #', 'woocommerce-admin' ),
-			'user_id'      => __( 'User Name', 'woocommerce-admin' ),
-			'ip_address'   => __( 'IP', 'woocommerce-admin' ),
+			'date'         => __( 'Date', 'woocommerce' ),
+			'product'      => __( 'Product title', 'woocommerce' ),
+			'file_name'    => __( 'File name', 'woocommerce' ),
+			'order_number' => __( 'Order #', 'woocommerce' ),
+			'user_id'      => __( 'User Name', 'woocommerce' ),
+			'ip_address'   => __( 'IP', 'woocommerce' ),
 		);
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -142,8 +142,8 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$totals = array(
 			'download_count' => array(
-				'title'       => __( 'Downloads', 'woocommerce-admin' ),
-				'description' => __( 'Number of downloads.', 'woocommerce-admin' ),
+				'title'       => __( 'Downloads', 'woocommerce' ),
+				'description' => __( 'Number of downloads.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -157,14 +157,14 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -172,38 +172,38 @@ class Controller extends \WC_REST_Reports_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -227,7 +227,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params                     = array();
 		$params['context']          = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']             = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -235,7 +235,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']         = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -244,26 +244,26 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']            = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']           = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']            = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']          = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -273,7 +273,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']         = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -287,7 +287,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']            = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -297,7 +297,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_includes'] = array(
-			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -307,7 +307,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		);
 		$params['product_excludes']    = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -316,7 +316,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['order_includes']      = array(
-			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -325,7 +325,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['order_excludes']      = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -334,7 +334,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['customer_includes']   = array(
-			'description'       => __( 'Limit response to objects that have the specified customer ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that have the specified customer ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -343,7 +343,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['customer_excludes']   = array(
-			'description'       => __( 'Limit response to objects that don\'t have the specified customer ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that don\'t have the specified customer ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -352,7 +352,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['ip_address_includes'] = array(
-			'description'       => __( 'Limit response to objects that have a specified ip address.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that have a specified ip address.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
@@ -361,7 +361,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		);
 
 		$params['ip_address_excludes'] = array(
-			'description'       => __( 'Limit response to objects that don\'t have a specified ip address.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to objects that don\'t have a specified ip address.', 'woocommerce' ),
 			'type'              => 'array',
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
@@ -369,7 +369,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['fields']              = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/DataStore.php
@@ -117,7 +117,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 				ARRAY_A
 			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce' ) );
 			}
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
@@ -133,7 +133,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/plugins/woocommerce/src/Admin/API/Reports/Export/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Export/Controller.php
@@ -74,12 +74,12 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	protected function get_export_collection_params() {
 		$params                = array();
 		$params['report_args'] = array(
-			'description'       => __( 'Parameters to pass on to the exported report.', 'woocommerce-admin' ),
+			'description'       => __( 'Parameters to pass on to the exported report.', 'woocommerce' ),
 			'type'              => 'object',
 			'validate_callback' => 'rest_validate_request_arg', // @todo: use each controller's schema?
 		);
 		$params['email']       = array(
-			'description'       => __( 'When true, email a link to download the export to the requesting user.', 'woocommerce-admin' ),
+			'description'       => __( 'When true, email a link to download the export to the requesting user.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
@@ -98,19 +98,19 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'status'    => array(
-					'description' => __( 'Export status.', 'woocommerce-admin' ),
+					'description' => __( 'Export status.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'message'   => array(
-					'description' => __( 'Export status message.', 'woocommerce-admin' ),
+					'description' => __( 'Export status message.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'export_id' => array(
-					'description' => __( 'Export ID.', 'woocommerce-admin' ),
+					'description' => __( 'Export ID.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -133,13 +133,13 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'percent_complete' => array(
-					'description' => __( 'Percentage complete.', 'woocommerce-admin' ),
+					'description' => __( 'Percentage complete.', 'woocommerce' ),
 					'type'        => 'int',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'download_url'     => array(
-					'description' => __( 'Export download URL.', 'woocommerce-admin' ),
+					'description' => __( 'Export download URL.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -170,7 +170,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		if ( 0 === $total_rows ) {
 			return rest_ensure_response(
 				array(
-					'message' => __( 'There is no data to export for the given request.', 'woocommerce-admin' ),
+					'message' => __( 'There is no data to export for the given request.', 'woocommerce' ),
 				)
 			);
 		}
@@ -179,7 +179,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 
 		$response = rest_ensure_response(
 			array(
-				'message'   => __( 'Your report file is being generated.', 'woocommerce-admin' ),
+				'message'   => __( 'Your report file is being generated.', 'woocommerce' ),
 				'export_id' => $export_id,
 			)
 		);
@@ -212,7 +212,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		if ( false === $percentage ) {
 			return new \WP_Error(
 				'woocommerce_admin_reports_export_invalid_id',
-				__( 'Sorry, there is no export with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no export with that ID.', 'woocommerce' ),
 				array( 'status' => 404 )
 			);
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Import/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Import/Controller.php
@@ -108,7 +108,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	 */
 	public function import_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 		return true;
 	}
@@ -185,14 +185,14 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	public function get_import_collection_params() {
 		$params                  = array();
 		$params['days']          = array(
-			'description'       => __( 'Number of days to import.', 'woocommerce-admin' ),
+			'description'       => __( 'Number of days to import.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 0,
 		);
 		$params['skip_existing'] = array(
-			'description'       => __( 'Skip importing existing order data.', 'woocommerce-admin' ),
+			'description'       => __( 'Skip importing existing order data.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
@@ -213,13 +213,13 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'status'  => array(
-					'description' => __( 'Regeneration status.', 'woocommerce-admin' ),
+					'description' => __( 'Regeneration status.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'message' => array(
-					'description' => __( 'Regenerate data message.', 'woocommerce-admin' ),
+					'description' => __( 'Regenerate data message.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -241,7 +241,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 
 		$result = array(
 			'status'  => 'success',
-			'message' => __( 'All pending and in-progress import actions have been cancelled.', 'woocommerce-admin' ),
+			'message' => __( 'All pending and in-progress import actions have been cancelled.', 'woocommerce' ),
 		);
 
 		$response = $this->prepare_item_for_response( $result, $request );

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -172,61 +172,61 @@ class Controller extends ReportsController implements ExportableInterface {
 			'type'       => 'object',
 			'properties' => array(
 				'order_id'         => array(
-					'description' => __( 'Order ID.', 'woocommerce-admin' ),
+					'description' => __( 'Order ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'order_number'     => array(
-					'description' => __( 'Order Number.', 'woocommerce-admin' ),
+					'description' => __( 'Order Number.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_created'     => array(
-					'description' => __( "Date the order was created, in the site's timezone.", 'woocommerce-admin' ),
+					'description' => __( "Date the order was created, in the site's timezone.", 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'date_created_gmt' => array(
-					'description' => __( 'Date the order was created, as GMT.', 'woocommerce-admin' ),
+					'description' => __( 'Date the order was created, as GMT.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'status'           => array(
-					'description' => __( 'Order status.', 'woocommerce-admin' ),
+					'description' => __( 'Order status.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'customer_id'      => array(
-					'description' => __( 'Customer ID.', 'woocommerce-admin' ),
+					'description' => __( 'Customer ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'num_items_sold'   => array(
-					'description' => __( 'Number of items sold.', 'woocommerce-admin' ),
+					'description' => __( 'Number of items sold.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'net_total'        => array(
-					'description' => __( 'Net total revenue.', 'woocommerce-admin' ),
+					'description' => __( 'Net total revenue.', 'woocommerce' ),
 					'type'        => 'float',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'total_formatted'  => array(
-					'description' => __( 'Net total revenue (formatted).', 'woocommerce-admin' ),
+					'description' => __( 'Net total revenue (formatted).', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'customer_type'    => array(
-					'description' => __( 'Returning or new customer.', 'woocommerce-admin' ),
+					'description' => __( 'Returning or new customer.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -236,19 +236,19 @@ class Controller extends ReportsController implements ExportableInterface {
 						'type'        => 'array',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'List of order product IDs, names, quantities.', 'woocommerce-admin' ),
+						'description' => __( 'List of order product IDs, names, quantities.', 'woocommerce' ),
 					),
 					'coupons'  => array(
 						'type'        => 'array',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'List of order coupons.', 'woocommerce-admin' ),
+						'description' => __( 'List of order coupons.', 'woocommerce' ),
 					),
 					'customer' => array(
 						'type'        => 'object',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Order customer information.', 'woocommerce-admin' ),
+						'description' => __( 'Order customer information.', 'woocommerce' ),
 					),
 				),
 			),
@@ -266,7 +266,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		$params                       = array();
 		$params['context']            = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']               = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -274,7 +274,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'minimum'           => 1,
 		);
 		$params['per_page']           = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 0,
@@ -283,26 +283,26 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']              = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']             = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']              = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']            = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -313,7 +313,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_includes']   = array(
-			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -323,7 +323,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_excludes']   = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -333,7 +333,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['variation_includes'] = array(
-			'description'       => __( 'Limit result set to items that have the specified variation(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -343,7 +343,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['variation_excludes'] = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified variation(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -353,7 +353,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['coupon_includes']    = array(
-			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -363,7 +363,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['coupon_excludes']    = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -373,7 +373,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['tax_rate_includes']  = array(
-			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -383,7 +383,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['tax_rate_excludes']  = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -393,7 +393,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['status_is']          = array(
-			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -403,7 +403,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['status_is_not']      = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -413,7 +413,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['customer_type']      = array(
-			'description'       => __( 'Limit result set to returning or new customers.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to returning or new customers.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => '',
 			'enum'              => array(
@@ -424,7 +424,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['refunds']            = array(
-			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => '',
 			'enum'              => array(
@@ -437,14 +437,14 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['extended_info']      = array(
-			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce-admin' ),
+			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order_includes']     = array(
-			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -453,7 +453,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['order_excludes']     = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -462,7 +462,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['attribute_is']       = array(
-			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -471,7 +471,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attribute_is_not']   = array(
-			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -505,7 +505,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		foreach ( $products as $product ) {
 			$products_list[] = sprintf(
 				/* translators: 1: numeric product quantity, 2: name of product */
-				__( '%1$s× %2$s', 'woocommerce-admin' ),
+				__( '%1$s× %2$s', 'woocommerce' ),
 				$product['quantity'],
 				$product['name']
 			);
@@ -531,16 +531,16 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'date_created'    => __( 'Date', 'woocommerce-admin' ),
-			'order_number'    => __( 'Order #', 'woocommerce-admin' ),
-			'total_formatted' => __( 'N. Revenue (formatted)', 'woocommerce-admin' ),
-			'status'          => __( 'Status', 'woocommerce-admin' ),
-			'customer_name'   => __( 'Customer', 'woocommerce-admin' ),
-			'customer_type'   => __( 'Customer type', 'woocommerce-admin' ),
-			'products'        => __( 'Product(s)', 'woocommerce-admin' ),
-			'num_items_sold'  => __( 'Items sold', 'woocommerce-admin' ),
-			'coupons'         => __( 'Coupon(s)', 'woocommerce-admin' ),
-			'net_total'       => __( 'N. Revenue', 'woocommerce-admin' ),
+			'date_created'    => __( 'Date', 'woocommerce' ),
+			'order_number'    => __( 'Order #', 'woocommerce' ),
+			'total_formatted' => __( 'N. Revenue (formatted)', 'woocommerce' ),
+			'status'          => __( 'Status', 'woocommerce' ),
+			'customer_name'   => __( 'Customer', 'woocommerce' ),
+			'customer_type'   => __( 'Customer type', 'woocommerce' ),
+			'products'        => __( 'Product(s)', 'woocommerce' ),
+			'num_items_sold'  => __( 'Items sold', 'woocommerce' ),
+			'coupons'         => __( 'Coupon(s)', 'woocommerce' ),
+			'net_total'       => __( 'N. Revenue', 'woocommerce' ),
 		);
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -161,22 +161,22 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'net_revenue'         => array(
-				'description' => __( 'Net sales.', 'woocommerce-admin' ),
+				'description' => __( 'Net sales.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'format'      => 'currency',
 			),
 			'orders_count'        => array(
-				'title'       => __( 'Orders', 'woocommerce-admin' ),
-				'description' => __( 'Number of orders', 'woocommerce-admin' ),
+				'title'       => __( 'Orders', 'woocommerce' ),
+				'description' => __( 'Number of orders', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'indicator'   => true,
 			),
 			'avg_order_value'     => array(
-				'description' => __( 'Average order value.', 'woocommerce-admin' ),
+				'description' => __( 'Average order value.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -184,37 +184,37 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 				'format'      => 'currency',
 			),
 			'avg_items_per_order' => array(
-				'description' => __( 'Average items per order', 'woocommerce-admin' ),
+				'description' => __( 'Average items per order', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'num_items_sold'      => array(
-				'description' => __( 'Number of items sold', 'woocommerce-admin' ),
+				'description' => __( 'Number of items sold', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'coupons'             => array(
-				'description' => __( 'Amount discounted by coupons.', 'woocommerce-admin' ),
+				'description' => __( 'Amount discounted by coupons.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'coupons_count'       => array(
-				'description' => __( 'Unique coupons count.', 'woocommerce-admin' ),
+				'description' => __( 'Unique coupons count.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'total_customers'     => array(
-				'description' => __( 'Total distinct customers.', 'woocommerce-admin' ),
+				'description' => __( 'Total distinct customers.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'products'            => array(
-				'description' => __( 'Number of distinct products sold.', 'woocommerce-admin' ),
+				'description' => __( 'Number of distinct products sold.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -223,7 +223,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 
 		$segments = array(
 			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce-admin' ),
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -231,13 +231,13 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 					'type'       => 'object',
 					'properties' => array(
 						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce-admin' ),
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
 							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -261,14 +261,14 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -276,38 +276,38 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -331,7 +331,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		$params                     = array();
 		$params['context']          = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']             = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -339,7 +339,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']         = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -348,26 +348,26 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']            = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']           = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']            = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']          = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -379,7 +379,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']         = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -393,7 +393,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']            = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -403,7 +403,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['status_is']        = array(
-			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -414,7 +414,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 		);
 		$params['status_is_not']    = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -424,7 +424,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 		);
 		$params['product_includes'] = array(
-			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -434,7 +434,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 
 		);
 		$params['product_excludes']   = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -443,7 +443,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['variation_includes'] = array(
-			'description'       => __( 'Limit result set to items that have the specified variation(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -453,7 +453,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['variation_excludes'] = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified variation(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -463,7 +463,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['coupon_includes']    = array(
-			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -472,7 +472,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['coupon_excludes']    = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -481,7 +481,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['tax_rate_includes']  = array(
-			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -491,7 +491,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['tax_rate_excludes']  = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -501,7 +501,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['customer']           = array(
-			'description'       => __( 'Alias for customer_type (deprecated).', 'woocommerce-admin' ),
+			'description'       => __( 'Alias for customer_type (deprecated).', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'new',
@@ -510,7 +510,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['customer_type']      = array(
-			'description'       => __( 'Limit result set to orders that have the specified customer_type', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that have the specified customer_type', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'new',
@@ -519,7 +519,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['refunds']            = array(
-			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => '',
 			'enum'              => array(
@@ -532,7 +532,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attribute_is']       = array(
-			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -541,7 +541,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attribute_is_not']   = array(
-			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -550,7 +550,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['segmentby']          = array(
-			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
+			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'product',
@@ -562,7 +562,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['fields']             = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -332,7 +332,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				ARRAY_A
 			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_analytics_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			// @todo Remove these assignements when refactoring segmenter classes to use query objects.
@@ -385,7 +385,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_analytics_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			if ( isset( $intervals[0] ) ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Segmenter.php
@@ -375,7 +375,7 @@ class Segmenter extends ReportsSegmenter {
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
 			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
-				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce-admin' ) );
+				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 
 			$product_level_columns     = $this->get_segment_selections_product_level( $product_segmenting_table );

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -141,7 +141,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		}
 
 		if ( 200 !== $response->get_status() ) {
-			return new \WP_Error( 'woocommerce_analytics_performance_indicators_result_failed', __( 'Sorry, fetching performance indicators failed.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'woocommerce_analytics_performance_indicators_result_failed', __( 'Sorry, fetching performance indicators failed.', 'woocommerce' ) );
 		}
 
 		$endpoints = $response->get_data();
@@ -223,13 +223,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			'woocommerce_rest_performance_indicators_jetpack_items',
 			array(
 				'stats/visitors' => array(
-					'label'      => __( 'Visitors', 'woocommerce-admin' ),
+					'label'      => __( 'Visitors', 'woocommerce' ),
 					'permission' => 'view_stats',
 					'format'     => 'number',
 					'module'     => 'stats',
 				),
 				'stats/views'    => array(
-					'label'      => __( 'Views', 'woocommerce-admin' ),
+					'label'      => __( 'Views', 'woocommerce' ),
 					'permission' => 'view_stats',
 					'format'     => 'number',
 					'module'     => 'stats',
@@ -405,7 +405,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$query_args = $this->prepare_reports_query( $request );
 		if ( empty( $query_args['stats'] ) ) {
-			return new \WP_Error( 'woocommerce_analytics_performance_indicators_empty_query', __( 'A list of stats to query must be provided.', 'woocommerce-admin' ), 400 );
+			return new \WP_Error( 'woocommerce_analytics_performance_indicators_empty_query', __( 'A list of stats to query must be provided.', 'woocommerce' ), 400 );
 		}
 
 		$stats = array();
@@ -594,33 +594,33 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'stat'   => array(
-					'description' => __( 'Unique identifier for the resource.', 'woocommerce-admin' ),
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'enum'        => $allowed_stats,
 				),
 				'chart'  => array(
-					'description' => __( 'The specific chart this stat referrers to.', 'woocommerce-admin' ),
+					'description' => __( 'The specific chart this stat referrers to.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'label'  => array(
-					'description' => __( 'Human readable label for the stat.', 'woocommerce-admin' ),
+					'description' => __( 'Human readable label for the stat.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'format' => array(
-					'description' => __( 'Format of the stat.', 'woocommerce-admin' ),
+					'description' => __( 'Format of the stat.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'enum'        => array( 'number', 'currency' ),
 				),
 				'value'  => array(
-					'description' => __( 'Value of the stat. Returns null if the stat does not exist or cannot be loaded.', 'woocommerce-admin' ),
+					'description' => __( 'Value of the stat. Returns null if the stat does not exist or cannot be loaded.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -651,7 +651,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_collection_params() {
 		$indicator_data = $this->get_indicator_data();
 		if ( is_wp_error( $indicator_data ) ) {
-			$allowed_stats = __( 'There was an issue loading the report endpoints', 'woocommerce-admin' );
+			$allowed_stats = __( 'There was an issue loading the report endpoints', 'woocommerce' );
 		} else {
 			$allowed_stats = implode( ', ', $this->allowed_stats );
 		}
@@ -661,7 +661,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params['stats']   = array(
 			'description'       => sprintf(
 				/* translators: Allowed values is a list of stat endpoints. */
-				__( 'Limit response to specific report stats. Allowed values: %s.', 'woocommerce-admin' ),
+				__( 'Limit response to specific report stats. Allowed values: %s.', 'woocommerce' ),
 				$allowed_stats
 			),
 			'type'              => 'array',
@@ -673,13 +673,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			'default'           => $this->allowed_stats,
 		);
 		$params['after']   = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']  = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -162,86 +162,86 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Product ID.', 'woocommerce-admin' ),
+					'description' => __( 'Product ID.', 'woocommerce' ),
 				),
 				'items_sold'    => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Number of items sold.', 'woocommerce-admin' ),
+					'description' => __( 'Number of items sold.', 'woocommerce' ),
 				),
 				'net_revenue'   => array(
 					'type'        => 'number',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Total Net sales of all items sold.', 'woocommerce-admin' ),
+					'description' => __( 'Total Net sales of all items sold.', 'woocommerce' ),
 				),
 				'orders_count'  => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Number of orders product appeared in.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders product appeared in.', 'woocommerce' ),
 				),
 				'extended_info' => array(
 					'name'             => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product name.', 'woocommerce-admin' ),
+						'description' => __( 'Product name.', 'woocommerce' ),
 					),
 					'price'            => array(
 						'type'        => 'number',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product price.', 'woocommerce-admin' ),
+						'description' => __( 'Product price.', 'woocommerce' ),
 					),
 					'image'            => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product image.', 'woocommerce-admin' ),
+						'description' => __( 'Product image.', 'woocommerce' ),
 					),
 					'permalink'        => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product link.', 'woocommerce-admin' ),
+						'description' => __( 'Product link.', 'woocommerce' ),
 					),
 					'category_ids'     => array(
 						'type'        => 'array',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product category IDs.', 'woocommerce-admin' ),
+						'description' => __( 'Product category IDs.', 'woocommerce' ),
 					),
 					'stock_status'     => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product inventory status.', 'woocommerce-admin' ),
+						'description' => __( 'Product inventory status.', 'woocommerce' ),
 					),
 					'stock_quantity'   => array(
 						'type'        => 'integer',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product inventory quantity.', 'woocommerce-admin' ),
+						'description' => __( 'Product inventory quantity.', 'woocommerce' ),
 					),
 					'low_stock_amount' => array(
 						'type'        => 'integer',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product inventory threshold for low stock.', 'woocommerce-admin' ),
+						'description' => __( 'Product inventory threshold for low stock.', 'woocommerce' ),
 					),
 					'variations'       => array(
 						'type'        => 'array',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product variations IDs.', 'woocommerce-admin' ),
+						'description' => __( 'Product variations IDs.', 'woocommerce' ),
 					),
 					'sku'              => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product SKU.', 'woocommerce-admin' ),
+						'description' => __( 'Product SKU.', 'woocommerce' ),
 					),
 				),
 			),
@@ -259,7 +259,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$params               = array();
 		$params['context']    = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']       = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -267,7 +267,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'minimum'           => 1,
 		);
 		$params['per_page']   = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -276,26 +276,26 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']      = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']     = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']      = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']    = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -310,7 +310,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['categories'] = array(
-			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -319,7 +319,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			),
 		);
 		$params['match']      = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -329,7 +329,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['products']   = array(
-			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -339,7 +339,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 
 		);
 		$params['extended_info'] = array(
-			'description'       => __( 'Add additional piece of info about each product to the report.', 'woocommerce-admin' ),
+			'description'       => __( 'Add additional piece of info about each product to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
@@ -386,18 +386,18 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'product_name' => __( 'Product title', 'woocommerce-admin' ),
-			'sku'          => __( 'SKU', 'woocommerce-admin' ),
-			'items_sold'   => __( 'Items sold', 'woocommerce-admin' ),
-			'net_revenue'  => __( 'N. Revenue', 'woocommerce-admin' ),
-			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
-			'product_cat'  => __( 'Category', 'woocommerce-admin' ),
-			'variations'   => __( 'Variations', 'woocommerce-admin' ),
+			'product_name' => __( 'Product title', 'woocommerce' ),
+			'sku'          => __( 'SKU', 'woocommerce' ),
+			'items_sold'   => __( 'Items sold', 'woocommerce' ),
+			'net_revenue'  => __( 'N. Revenue', 'woocommerce' ),
+			'orders_count' => __( 'Orders', 'woocommerce' ),
+			'product_cat'  => __( 'Category', 'woocommerce' ),
+			'variations'   => __( 'Variations', 'woocommerce' ),
 		);
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
-			$export_columns['stock_status'] = __( 'Status', 'woocommerce-admin' );
-			$export_columns['stock']        = __( 'Stock', 'woocommerce-admin' );
+			$export_columns['stock_status'] = __( 'Status', 'woocommerce' );
+			$export_columns['stock']        = __( 'Stock', 'woocommerce' );
 		}
 
 		/**
@@ -434,8 +434,8 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				$export_item['stock_status'] = $this->get_stock_status( $item['extended_info']['stock_status'] );
 				$export_item['stock']        = $item['extended_info']['stock_quantity'];
 			} else {
-				$export_item['stock_status'] = __( 'N/A', 'woocommerce-admin' );
-				$export_item['stock']        = __( 'N/A', 'woocommerce-admin' );
+				$export_item['stock_status'] = __( 'N/A', 'woocommerce' );
+				$export_item['stock']        = __( 'N/A', 'woocommerce' );
 			}
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/DataStore.php
@@ -224,7 +224,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 					}
 
 					/* translators: %s is product name */
-					$products_data[ $key ]['extended_info']['name'] = $product_names[ $product_id ] ? sprintf( __( '%s (Deleted)', 'woocommerce-admin' ), $product_names[ $product_id ] ) : __( '(Deleted)', 'woocommerce-admin' );
+					$products_data[ $key ]['extended_info']['name'] = $product_names[ $product_id ] ? sprintf( __( '%s (Deleted)', 'woocommerce' ), $product_names[ $product_id ] ) : __( '(Deleted)', 'woocommerce' );
 					continue;
 				}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -157,22 +157,22 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
-				'title'       => __( 'Products sold', 'woocommerce-admin' ),
-				'description' => __( 'Number of product items sold.', 'woocommerce-admin' ),
+				'title'       => __( 'Products sold', 'woocommerce' ),
+				'description' => __( 'Number of product items sold.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'indicator'   => true,
 			),
 			'net_revenue'  => array(
-				'description' => __( 'Net sales.', 'woocommerce-admin' ),
+				'description' => __( 'Net sales.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'format'      => 'currency',
 			),
 			'orders_count' => array(
-				'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -181,7 +181,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$segments = array(
 			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce-admin' ),
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -189,20 +189,20 @@ class Controller extends \WC_REST_Reports_Controller {
 					'type'       => 'object',
 					'properties' => array(
 						'segment_id'    => array(
-							'description' => __( 'Segment identificator.', 'woocommerce-admin' ),
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'segment_label' => array(
-							'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce-admin' ),
+							'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'enum'        => array( 'day', 'week', 'month', 'year' ),
 						),
 						'subtotals'     => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
 							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -221,14 +221,14 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -236,38 +236,38 @@ class Controller extends \WC_REST_Reports_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -313,7 +313,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params               = array();
 		$params['context']    = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']       = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -321,7 +321,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']   = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -330,26 +330,26 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']      = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']     = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']      = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']    = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -366,7 +366,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']   = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -380,7 +380,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['categories'] = array(
-			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -389,7 +389,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['products']   = array(
-			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -398,7 +398,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['variations'] = array(
-			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -407,7 +407,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['segmentby']  = array(
-			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
+			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'product',
@@ -417,7 +417,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['fields']     = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
@@ -183,7 +183,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 			$totals[0]['segments'] = $segmenter->get_totals_segments( $totals_query, $table_name );
 
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_analytics_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
@@ -199,7 +199,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_analytics_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Segmenter.php
@@ -166,7 +166,7 @@ class Segmenter extends ReportsSegmenter {
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		} elseif ( 'variation' === $this->query_args['segmentby'] ) {
 			if ( ! isset( $this->query_args['product_includes'] ) || count( $this->query_args['product_includes'] ) !== 1 ) {
-				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce-admin' ) );
+				throw new ParameterException( 'wc_admin_reports_invalid_segmenting_variation', __( 'product_includes parameter need to specify exactly one product when segmenting by variation.', 'woocommerce' ) );
 			}
 
 			$product_level_columns     = $this->get_segment_selections_product_level( $product_segmenting_table );

--- a/plugins/woocommerce/src/Admin/API/Reports/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Query.php
@@ -19,6 +19,6 @@ abstract class Query extends \WC_Object_Query {
 	 */
 	public function get_data() {
 		/* translators: %s: Method name */
-		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be overridden in subclass.", 'woocommerce-admin' ), __METHOD__ ), array( 'status' => 405 ) );
+		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be overridden in subclass.", 'woocommerce' ), __METHOD__ ), array( 'status' => 405 ) );
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -165,7 +165,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	public function get_item_schema() {
 		$data_values = array(
 			'total_sales'    => array(
-				'description' => __( 'Total sales.', 'woocommerce-admin' ),
+				'description' => __( 'Total sales.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -173,7 +173,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				'format'      => 'currency',
 			),
 			'net_revenue'    => array(
-				'description' => __( 'Net sales.', 'woocommerce-admin' ),
+				'description' => __( 'Net sales.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -181,21 +181,21 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				'format'      => 'currency',
 			),
 			'coupons'        => array(
-				'description' => __( 'Amount discounted by coupons.', 'woocommerce-admin' ),
+				'description' => __( 'Amount discounted by coupons.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'coupons_count'  => array(
-				'description' => __( 'Unique coupons count.', 'woocommerce-admin' ),
+				'description' => __( 'Unique coupons count.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'format'      => 'currency',
 			),
 			'shipping'       => array(
-				'title'       => __( 'Shipping', 'woocommerce-admin' ),
-				'description' => __( 'Total of shipping.', 'woocommerce-admin' ),
+				'title'       => __( 'Shipping', 'woocommerce' ),
+				'description' => __( 'Total of shipping.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -203,15 +203,15 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				'format'      => 'currency',
 			),
 			'taxes'          => array(
-				'description' => __( 'Total of taxes.', 'woocommerce-admin' ),
+				'description' => __( 'Total of taxes.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'format'      => 'currency',
 			),
 			'refunds'        => array(
-				'title'       => __( 'Returns', 'woocommerce-admin' ),
-				'description' => __( 'Total of returns.', 'woocommerce-admin' ),
+				'title'       => __( 'Returns', 'woocommerce' ),
+				'description' => __( 'Total of returns.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -219,25 +219,25 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				'format'      => 'currency',
 			),
 			'orders_count'   => array(
-				'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'num_items_sold' => array(
-				'description' => __( 'Items sold.', 'woocommerce-admin' ),
+				'description' => __( 'Items sold.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'products'       => array(
-				'description' => __( 'Products sold.', 'woocommerce-admin' ),
+				'description' => __( 'Products sold.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'gross_sales'    => array(
-				'description' => __( 'Gross sales.', 'woocommerce-admin' ),
+				'description' => __( 'Gross sales.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -248,7 +248,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 
 		$segments = array(
 			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce-admin' ),
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -256,13 +256,13 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 					'type'       => 'object',
 					'properties' => array(
 						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce-admin' ),
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
 							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -286,14 +286,14 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -301,38 +301,38 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -356,7 +356,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$params              = array();
 		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']      = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -364,7 +364,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'minimum'           => 1,
 		);
 		$params['per_page']  = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -373,26 +373,26 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']     = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']    = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']     = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']   = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -410,7 +410,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']  = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -424,7 +424,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['segmentby'] = array(
-			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
+			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'product',
@@ -446,15 +446,15 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function get_export_columns() {
 		return array(
-			'date'         => __( 'Date', 'woocommerce-admin' ),
-			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
-			'gross_sales'  => __( 'Gross sales', 'woocommerce-admin' ),
-			'total_sales'  => __( 'Total sales', 'woocommerce-admin' ),
-			'refunds'      => __( 'Returns', 'woocommerce-admin' ),
-			'coupons'      => __( 'Coupons', 'woocommerce-admin' ),
-			'taxes'        => __( 'Taxes', 'woocommerce-admin' ),
-			'shipping'     => __( 'Shipping', 'woocommerce-admin' ),
-			'net_revenue'  => __( 'Net Revenue', 'woocommerce-admin' ),
+			'date'         => __( 'Date', 'woocommerce' ),
+			'orders_count' => __( 'Orders', 'woocommerce' ),
+			'gross_sales'  => __( 'Gross sales', 'woocommerce' ),
+			'total_sales'  => __( 'Total sales', 'woocommerce' ),
+			'refunds'      => __( 'Returns', 'woocommerce' ),
+			'coupons'      => __( 'Coupons', 'woocommerce' ),
+			'taxes'        => __( 'Taxes', 'woocommerce' ),
+			'shipping'     => __( 'Shipping', 'woocommerce' ),
+			'net_revenue'  => __( 'Net Revenue', 'woocommerce' ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -387,44 +387,44 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'type'       => 'object',
 			'properties' => array(
 				'id'             => array(
-					'description' => __( 'Unique identifier for the resource.', 'woocommerce-admin' ),
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'parent_id'      => array(
-					'description' => __( 'Product parent ID.', 'woocommerce-admin' ),
+					'description' => __( 'Product parent ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'           => array(
-					'description' => __( 'Product name.', 'woocommerce-admin' ),
+					'description' => __( 'Product name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'sku'            => array(
-					'description' => __( 'Unique identifier.', 'woocommerce-admin' ),
+					'description' => __( 'Unique identifier.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'stock_status'   => array(
-					'description' => __( 'Stock status.', 'woocommerce-admin' ),
+					'description' => __( 'Stock status.', 'woocommerce' ),
 					'type'        => 'string',
 					'enum'        => array_keys( wc_get_product_stock_status_options() ),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'stock_quantity' => array(
-					'description' => __( 'Stock quantity.', 'woocommerce-admin' ),
+					'description' => __( 'Stock quantity.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'manage_stock'   => array(
-					'description' => __( 'Manage stock.', 'woocommerce-admin' ),
+					'description' => __( 'Manage stock.', 'woocommerce' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -444,7 +444,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$params                   = array();
 		$params['context']        = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']           = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -452,7 +452,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'minimum'           => 1,
 		);
 		$params['per_page']       = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -461,7 +461,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['exclude']        = array(
-			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce-admin' ),
+			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -470,7 +470,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['include']        = array(
-			'description'       => __( 'Limit result set to specific ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to specific ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -479,20 +479,20 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['offset']         = array(
-			'description'       => __( 'Offset the result set by a specific number of items.', 'woocommerce-admin' ),
+			'description'       => __( 'Offset the result set by a specific number of items.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']          = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'asc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']        = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'stock_status',
 			'enum'              => array(
@@ -507,7 +507,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['parent']         = array(
-			'description'       => __( 'Limit result set to those of particular parent IDs.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to those of particular parent IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -516,7 +516,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'default'           => array(),
 		);
 		$params['parent_exclude'] = array(
-			'description'       => __( 'Limit result set to all items except those of a particular parent ID.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to all items except those of a particular parent ID.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -525,7 +525,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'default'           => array(),
 		);
 		$params['type']           = array(
-			'description' => __( 'Limit result set to items assigned a stock report type.', 'woocommerce-admin' ),
+			'description' => __( 'Limit result set to items assigned a stock report type.', 'woocommerce' ),
 			'type'        => 'string',
 			'default'     => 'all',
 			'enum'        => array_merge( array( 'all', 'lowstock' ), array_keys( wc_get_product_stock_status_options() ) ),
@@ -541,10 +541,10 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'title'          => __( 'Product / Variation', 'woocommerce-admin' ),
-			'sku'            => __( 'SKU', 'woocommerce-admin' ),
-			'stock_status'   => __( 'Status', 'woocommerce-admin' ),
-			'stock_quantity' => __( 'Stock', 'woocommerce-admin' ),
+			'title'          => __( 'Product / Variation', 'woocommerce' ),
+			'sku'            => __( 'SKU', 'woocommerce' ),
+			'stock_status'   => __( 'Status', 'woocommerce' ),
+			'stock_quantity' => __( 'Stock', 'woocommerce' ),
 		);
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
@@ -83,13 +83,13 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$totals = array(
 			'products' => array(
-				'description' => __( 'Number of products.', 'woocommerce-admin' ),
+				'description' => __( 'Number of products.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'lowstock' => array(
-				'description' => __( 'Number of low stock products.', 'woocommerce-admin' ),
+				'description' => __( 'Number of low stock products.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -100,7 +100,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		foreach ( $status_options as $status => $label ) {
 			$totals[ $status ] = array(
 				/* translators: Stock status. Example: "Number of low stock products */
-				'description' => sprintf( __( 'Number of %s products.', 'woocommerce-admin' ), $label ),
+				'description' => sprintf( __( 'Number of %s products.', 'woocommerce' ), $label ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -113,7 +113,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals' => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -155,61 +155,61 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'type'       => 'object',
 			'properties' => array(
 				'tax_rate_id'  => array(
-					'description' => __( 'Tax rate ID.', 'woocommerce-admin' ),
+					'description' => __( 'Tax rate ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'name'         => array(
-					'description' => __( 'Tax rate name.', 'woocommerce-admin' ),
+					'description' => __( 'Tax rate name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'tax_rate'     => array(
-					'description' => __( 'Tax rate.', 'woocommerce-admin' ),
+					'description' => __( 'Tax rate.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'country'      => array(
-					'description' => __( 'Country / Region.', 'woocommerce-admin' ),
+					'description' => __( 'Country / Region.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'state'        => array(
-					'description' => __( 'State.', 'woocommerce-admin' ),
+					'description' => __( 'State.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'priority'     => array(
-					'description' => __( 'Priority.', 'woocommerce-admin' ),
+					'description' => __( 'Priority.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'total_tax'    => array(
-					'description' => __( 'Total tax.', 'woocommerce-admin' ),
+					'description' => __( 'Total tax.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'order_tax'    => array(
-					'description' => __( 'Order tax.', 'woocommerce-admin' ),
+					'description' => __( 'Order tax.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'shipping_tax' => array(
-					'description' => __( 'Shipping tax.', 'woocommerce-admin' ),
+					'description' => __( 'Shipping tax.', 'woocommerce' ),
 					'type'        => 'number',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'orders_count' => array(
-					'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -229,7 +229,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$params             = array();
 		$params['context']  = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']     = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -237,7 +237,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'minimum'           => 1,
 		);
 		$params['per_page'] = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -246,26 +246,26 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']    = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']   = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']    = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']  = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'tax_rate_id',
 			'enum'              => array(
@@ -281,7 +281,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['taxes']    = array(
-			'description'       => __( 'Limit result set to items assigned one or more tax rates.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items assigned one or more tax rates.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -300,12 +300,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 */
 	public function get_export_columns() {
 		return array(
-			'tax_code'     => __( 'Tax code', 'woocommerce-admin' ),
-			'rate'         => __( 'Rate', 'woocommerce-admin' ),
-			'total_tax'    => __( 'Total tax', 'woocommerce-admin' ),
-			'order_tax'    => __( 'Order tax', 'woocommerce-admin' ),
-			'shipping_tax' => __( 'Shipping tax', 'woocommerce-admin' ),
-			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
+			'tax_code'     => __( 'Tax code', 'woocommerce' ),
+			'rate'         => __( 'Rate', 'woocommerce' ),
+			'total_tax'    => __( 'Total tax', 'woocommerce' ),
+			'order_tax'    => __( 'Order tax', 'woocommerce' ),
+			'shipping_tax' => __( 'Shipping tax', 'woocommerce' ),
+			'orders_count' => __( 'Orders', 'woocommerce' ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -166,7 +166,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'total_tax'    => array(
-				'description' => __( 'Total tax.', 'woocommerce-admin' ),
+				'description' => __( 'Total tax.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -174,7 +174,7 @@ class Controller extends \WC_REST_Reports_Controller {
 				'format'      => 'currency',
 			),
 			'order_tax'    => array(
-				'description' => __( 'Order tax.', 'woocommerce-admin' ),
+				'description' => __( 'Order tax.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -182,7 +182,7 @@ class Controller extends \WC_REST_Reports_Controller {
 				'format'      => 'currency',
 			),
 			'shipping_tax' => array(
-				'description' => __( 'Shipping tax.', 'woocommerce-admin' ),
+				'description' => __( 'Shipping tax.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -190,13 +190,13 @@ class Controller extends \WC_REST_Reports_Controller {
 				'format'      => 'currency',
 			),
 			'orders_count' => array(
-				'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'tax_codes'    => array(
-				'description' => __( 'Amount of tax codes.', 'woocommerce-admin' ),
+				'description' => __( 'Amount of tax codes.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -205,7 +205,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$segments = array(
 			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce-admin' ),
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -213,13 +213,13 @@ class Controller extends \WC_REST_Reports_Controller {
 					'type'       => 'object',
 					'properties' => array(
 						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce-admin' ),
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
 							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -238,14 +238,14 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -253,38 +253,38 @@ class Controller extends \WC_REST_Reports_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -308,7 +308,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params              = array();
 		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']      = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -316,7 +316,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']  = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -325,26 +325,26 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']     = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']    = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']     = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']   = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -357,7 +357,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']  = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -371,7 +371,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['taxes']     = array(
-			'description'       => __( 'Limit result set to all items that have the specified term assigned in the taxes taxonomy.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to all items that have the specified term assigned in the taxes taxonomy.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -380,7 +380,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['segmentby'] = array(
-			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
+			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'tax_rate_id',
@@ -388,7 +388,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['fields']    = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/DataStore.php
@@ -192,7 +192,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_analytics_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			// @todo remove these assignements when refactoring segmenter classes to use query objects.
@@ -226,7 +226,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_analytics_taxes_stats_result_failed', __( 'Sorry, fetching tax data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_taxes_stats_result_failed', __( 'Sorry, fetching tax data failed.', 'woocommerce' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -573,7 +573,7 @@ class TimeInterval {
 			return new \WP_Error(
 				'rest_invalid_param',
 				/* translators: 1: parameter name */
-				sprintf( __( '%1$s is not a numerically indexed array.', 'woocommerce-admin' ), $param )
+				sprintf( __( '%1$s is not a numerically indexed array.', 'woocommerce' ), $param )
 			);
 		}
 
@@ -585,7 +585,7 @@ class TimeInterval {
 			return new \WP_Error(
 				'rest_invalid_param',
 				/* translators: %s: parameter name */
-				sprintf( __( '%s must contain 2 numbers.', 'woocommerce-admin' ), $param )
+				sprintf( __( '%s must contain 2 numbers.', 'woocommerce' ), $param )
 			);
 		}
 
@@ -605,7 +605,7 @@ class TimeInterval {
 			return new \WP_Error(
 				'rest_invalid_param',
 				/* translators: 1: parameter name */
-				sprintf( __( '%1$s is not a numerically indexed array.', 'woocommerce-admin' ), $param )
+				sprintf( __( '%1$s is not a numerically indexed array.', 'woocommerce' ), $param )
 			);
 		}
 
@@ -617,7 +617,7 @@ class TimeInterval {
 			return new \WP_Error(
 				'rest_invalid_param',
 				/* translators: %s: parameter name */
-				sprintf( __( '%s must contain 2 valid dates.', 'woocommerce-admin' ), $param )
+				sprintf( __( '%s must contain 2 valid dates.', 'woocommerce' ), $param )
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -177,80 +177,80 @@ class Controller extends ReportsController implements ExportableInterface {
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Product ID.', 'woocommerce-admin' ),
+					'description' => __( 'Product ID.', 'woocommerce' ),
 				),
 				'variation_id'  => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Product ID.', 'woocommerce-admin' ),
+					'description' => __( 'Product ID.', 'woocommerce' ),
 				),
 				'items_sold'    => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Number of items sold.', 'woocommerce-admin' ),
+					'description' => __( 'Number of items sold.', 'woocommerce' ),
 				),
 				'net_revenue'   => array(
 					'type'        => 'number',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Total Net sales of all items sold.', 'woocommerce-admin' ),
+					'description' => __( 'Total Net sales of all items sold.', 'woocommerce' ),
 				),
 				'orders_count'  => array(
 					'type'        => 'integer',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Number of orders product appeared in.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders product appeared in.', 'woocommerce' ),
 				),
 				'extended_info' => array(
 					'name'             => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product name.', 'woocommerce-admin' ),
+						'description' => __( 'Product name.', 'woocommerce' ),
 					),
 					'price'            => array(
 						'type'        => 'number',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product price.', 'woocommerce-admin' ),
+						'description' => __( 'Product price.', 'woocommerce' ),
 					),
 					'image'            => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product image.', 'woocommerce-admin' ),
+						'description' => __( 'Product image.', 'woocommerce' ),
 					),
 					'permalink'        => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product link.', 'woocommerce-admin' ),
+						'description' => __( 'Product link.', 'woocommerce' ),
 					),
 					'attributes'       => array(
 						'type'        => 'array',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product attributes.', 'woocommerce-admin' ),
+						'description' => __( 'Product attributes.', 'woocommerce' ),
 					),
 					'stock_status'     => array(
 						'type'        => 'string',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product inventory status.', 'woocommerce-admin' ),
+						'description' => __( 'Product inventory status.', 'woocommerce' ),
 					),
 					'stock_quantity'   => array(
 						'type'        => 'integer',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product inventory quantity.', 'woocommerce-admin' ),
+						'description' => __( 'Product inventory quantity.', 'woocommerce' ),
 					),
 					'low_stock_amount' => array(
 						'type'        => 'integer',
 						'readonly'    => true,
 						'context'     => array( 'view', 'edit' ),
-						'description' => __( 'Product inventory threshold for low stock.', 'woocommerce-admin' ),
+						'description' => __( 'Product inventory threshold for low stock.', 'woocommerce' ),
 					),
 				),
 			),
@@ -268,7 +268,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		$params                      = array();
 		$params['context']           = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']              = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -276,7 +276,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'minimum'           => 1,
 		);
 		$params['per_page']          = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -285,19 +285,19 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']             = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']            = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']             = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -307,14 +307,14 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']             = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']           = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -327,7 +327,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_includes']  = array(
-			'description'       => __( 'Limit result set to items that have the specified parent product(s).', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified parent product(s).', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -337,7 +337,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_excludes']  = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified parent product(s).', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified parent product(s).', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -347,7 +347,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['variations']        = array(
-			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -356,14 +356,14 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['extended_info']     = array(
-			'description'       => __( 'Add additional piece of info about each variation to the report.', 'woocommerce-admin' ),
+			'description'       => __( 'Add additional piece of info about each variation to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attribute_is']      = array(
-			'description'       => __( 'Limit result set to variations that include the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to variations that include the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -372,7 +372,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attribute_is_not']  = array(
-			'description'       => __( 'Limit result set to variations that don\'t include the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to variations that don\'t include the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -381,7 +381,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['category_includes'] = array(
-			'description'       => __( 'Limit result set to variations in the specified categories.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to variations in the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -390,7 +390,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 		);
 		$params['category_excludes'] = array(
-			'description'       => __( 'Limit result set to variations not in the specified categories.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to variations not in the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -421,16 +421,16 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'product_name' => __( 'Product / Variation title', 'woocommerce-admin' ),
-			'sku'          => __( 'SKU', 'woocommerce-admin' ),
-			'items_sold'   => __( 'Items sold', 'woocommerce-admin' ),
-			'net_revenue'  => __( 'N. Revenue', 'woocommerce-admin' ),
-			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
+			'product_name' => __( 'Product / Variation title', 'woocommerce' ),
+			'sku'          => __( 'SKU', 'woocommerce' ),
+			'items_sold'   => __( 'Items sold', 'woocommerce' ),
+			'net_revenue'  => __( 'N. Revenue', 'woocommerce' ),
+			'orders_count' => __( 'Orders', 'woocommerce' ),
 		);
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
-			$export_columns['stock_status'] = __( 'Status', 'woocommerce-admin' );
-			$export_columns['stock']        = __( 'Stock', 'woocommerce-admin' );
+			$export_columns['stock_status'] = __( 'Status', 'woocommerce' );
+			$export_columns['stock']        = __( 'Stock', 'woocommerce' );
 		}
 
 		return $export_columns;

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -161,22 +161,22 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
-				'title'       => __( 'Variations Sold', 'woocommerce-admin' ),
-				'description' => __( 'Number of variation items sold.', 'woocommerce-admin' ),
+				'title'       => __( 'Variations Sold', 'woocommerce' ),
+				'description' => __( 'Number of variation items sold.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'indicator'   => true,
 			),
 			'net_revenue'  => array(
-				'description' => __( 'Net sales.', 'woocommerce-admin' ),
+				'description' => __( 'Net sales.', 'woocommerce' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'format'      => 'currency',
 			),
 			'orders_count' => array(
-				'description' => __( 'Number of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders.', 'woocommerce' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -185,7 +185,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$segments = array(
 			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce-admin' ),
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
 				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
@@ -193,20 +193,20 @@ class Controller extends \WC_REST_Reports_Controller {
 					'type'       => 'object',
 					'properties' => array(
 						'segment_id'    => array(
-							'description' => __( 'Segment identificator.', 'woocommerce-admin' ),
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 						),
 						'segment_label' => array(
-							'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce-admin' ),
+							'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
 							'enum'        => array( 'day', 'week', 'month', 'year' ),
 						),
 						'subtotals'     => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
 							'type'        => 'object',
 							'context'     => array( 'view', 'edit' ),
 							'readonly'    => true,
@@ -225,14 +225,14 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce-admin' ),
+					'description' => __( 'Totals data.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'properties'  => $totals,
 				),
 				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce-admin' ),
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -240,38 +240,38 @@ class Controller extends \WC_REST_Reports_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce-admin' ),
+								'description' => __( 'Type of interval.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'enum'        => array( 'day', 'week', 'month', 'year' ),
 							),
 							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce-admin' ),
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce-admin' ),
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
 								'type'        => 'date-time',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce-admin' ),
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
 								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
@@ -316,7 +316,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$params                      = array();
 		$params['context']           = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['page']              = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
 			'sanitize_callback' => 'absint',
@@ -324,7 +324,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'minimum'           => 1,
 		);
 		$params['per_page']          = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
 			'minimum'           => 1,
@@ -333,19 +333,19 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['after']             = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['before']            = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']             = array(
-			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce-admin' ),
+			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
 			'enum'              => array(
@@ -355,14 +355,14 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order']             = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['orderby']           = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
 			'enum'              => array(
@@ -379,7 +379,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['interval']          = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce-admin' ),
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
 			'enum'              => array(
@@ -393,7 +393,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['category_includes'] = array(
-			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -402,7 +402,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['category_excludes'] = array(
-			'description'       => __( 'Limit result set to variations not in the specified categories.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to variations not in the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -411,7 +411,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['product_includes']  = array(
-			'description'       => __( 'Limit result set to items that have the specified parent product(s).', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified parent product(s).', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -421,7 +421,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['product_excludes']  = array(
-			'description'       => __( 'Limit result set to items that don\'t have the specified parent product(s).', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that don\'t have the specified parent product(s).', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',
@@ -431,7 +431,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 		$params['variations']        = array(
-			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -440,7 +440,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['segmentby']         = array(
-			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
+			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
 				'product',
@@ -450,7 +450,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['fields']            = array(
-			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -459,7 +459,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 		$params['attribute_is']      = array(
-			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',
@@ -468,7 +468,7 @@ class Controller extends \WC_REST_Reports_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attribute_is_not']  = array(
-			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'array',

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
@@ -221,7 +221,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 			$totals[0]['segments'] = $segmenter->get_totals_segments( $totals_query, $table_name );
 
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_analytics_variations_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_variations_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
@@ -239,7 +239,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 			/* phpcs:enable */
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_analytics_variations_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_variations_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/plugins/woocommerce/src/Admin/API/Taxes.php
+++ b/plugins/woocommerce/src/Admin/API/Taxes.php
@@ -32,12 +32,12 @@ class Taxes extends \WC_REST_Taxes_Controller {
 	public function get_collection_params() {
 		$params            = parent::get_collection_params();
 		$params['search']  = array(
-			'description'       => __( 'Search by similar tax code.', 'woocommerce-admin' ),
+			'description'       => __( 'Search by similar tax code.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['include'] = array(
-			'description'       => __( 'Limit result set to items that have the specified rate ID(s) assigned.', 'woocommerce-admin' ),
+			'description'       => __( 'Limit result set to items that have the specified rate ID(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',

--- a/plugins/woocommerce/src/Admin/API/Themes.php
+++ b/plugins/woocommerce/src/Admin/API/Themes.php
@@ -60,7 +60,7 @@ class Themes extends \WC_REST_Data_Controller {
 	 */
 	public function upload_theme_permissions_check( $request ) {
 		if ( ! current_user_can( 'upload_themes' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you are not allowed to install themes on this site.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you are not allowed to install themes on this site.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -75,7 +75,7 @@ class Themes extends \WC_REST_Data_Controller {
 	public function upload_theme( $request ) {
 		if (
 			! isset( $_FILES['pluginzip'] ) || ! isset( $_FILES['pluginzip']['tmp_name'] ) || ! is_uploaded_file( $_FILES['pluginzip']['tmp_name'] ) || ! is_file( $_FILES['pluginzip']['tmp_name'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,  WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			return new \WP_Error( 'woocommerce_rest_invalid_file', __( 'Specified file failed upload test.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'woocommerce_rest_invalid_file', __( 'Specified file failed upload test.', 'woocommerce' ) );
 		}
 
 		include_once ABSPATH . 'wp-admin/includes/file.php';
@@ -163,19 +163,19 @@ class Themes extends \WC_REST_Data_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'status'  => array(
-					'description' => __( 'Theme installation status.', 'woocommerce-admin' ),
+					'description' => __( 'Theme installation status.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'message' => array(
-					'description' => __( 'Theme installation message.', 'woocommerce-admin' ),
+					'description' => __( 'Theme installation message.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'theme'   => array(
-					'description' => __( 'Uploaded theme.', 'woocommerce-admin' ),
+					'description' => __( 'Uploaded theme.', 'woocommerce' ),
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -194,7 +194,7 @@ class Themes extends \WC_REST_Data_Controller {
 	public function get_collection_params() {
 		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
 		$params['pluginzip'] = array(
-			'description'       => __( 'A zip file of the theme to be uploaded.', 'woocommerce-admin' ),
+			'description'       => __( 'A zip file of the theme to be uploaded.', 'woocommerce' ),
 			'type'              => 'file',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -261,7 +261,7 @@ class Features {
 			return $sections;
 		}
 
-		$sections['features'] = __( 'Features', 'woocommerce-admin' );
+		$sections['features'] = __( 'Features', 'woocommerce' );
 		return $sections;
 	}
 
@@ -288,8 +288,8 @@ class Features {
 			return $settings;
 		}
 
-		$desc          = __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' );
-		$disabled_desc = __( 'WooCommerce features have been disabled.', 'woocommerce-admin' );
+		$desc          = __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce' );
+		$disabled_desc = __( 'WooCommerce features have been disabled.', 'woocommerce' );
 
 		if ( $features_disabled ) {
 			$GLOBALS['hide_save_button'] = true;
@@ -298,7 +298,7 @@ class Features {
 		return array_merge(
 			array(
 				array(
-					'title' => __( 'Features', 'woocommerce-admin' ),
+					'title' => __( 'Features', 'woocommerce' ),
 					'type'  => 'title',
 					'desc'  => $features_disabled ? $disabled_desc : $desc,
 					'id'    => 'features_options',

--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -92,43 +92,43 @@ class CoreMenu {
 		$analytics_enabled = Features::is_enabled( 'analytics' );
 		return array(
 			array(
-				'title' => __( 'Orders', 'woocommerce-admin' ),
+				'title' => __( 'Orders', 'woocommerce' ),
 				'id'    => 'woocommerce-orders',
 				'badge' => self::get_shop_order_count(),
 				'order' => 10,
 			),
 			array(
-				'title' => __( 'Products', 'woocommerce-admin' ),
+				'title' => __( 'Products', 'woocommerce' ),
 				'id'    => 'woocommerce-products',
 				'order' => 20,
 			),
 			$analytics_enabled ?
 			array(
-				'title' => __( 'Analytics', 'woocommerce-admin' ),
+				'title' => __( 'Analytics', 'woocommerce' ),
 				'id'    => 'woocommerce-analytics',
 				'order' => 30,
 			) : null,
 			$analytics_enabled ?
 			array(
-				'title'  => __( 'Reports', 'woocommerce-admin' ),
+				'title'  => __( 'Reports', 'woocommerce' ),
 				'id'     => 'woocommerce-reports',
 				'parent' => 'woocommerce-analytics',
 				'order'  => 200,
 			) : null,
 			array(
-				'title' => __( 'Marketing', 'woocommerce-admin' ),
+				'title' => __( 'Marketing', 'woocommerce' ),
 				'id'    => 'woocommerce-marketing',
 				'order' => 40,
 			),
 			array(
-				'title'  => __( 'Settings', 'woocommerce-admin' ),
+				'title'  => __( 'Settings', 'woocommerce' ),
 				'id'     => 'woocommerce-settings',
 				'menuId' => 'secondary',
 				'order'  => 20,
 				'url'    => 'admin.php?page=wc-settings',
 			),
 			array(
-				'title'  => __( 'Tools', 'woocommerce-admin' ),
+				'title'  => __( 'Tools', 'woocommerce' ),
 				'id'     => 'woocommerce-tools',
 				'menuId' => 'secondary',
 				'order'  => 30,
@@ -192,7 +192,7 @@ class CoreMenu {
 		if ( defined( '\Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG' ) ) {
 			$home_item = array(
 				'id'              => 'woocommerce-home',
-				'title'           => __( 'Home', 'woocommerce-admin' ),
+				'title'           => __( 'Home', 'woocommerce' ),
 				'url'             => \Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG,
 				'order'           => 0,
 				'matchExpression' => 'page=wc-admin((?!path=).)*$',
@@ -203,7 +203,7 @@ class CoreMenu {
 		if ( Features::is_enabled( 'analytics' ) ) {
 			$customers_item = array(
 				'id'    => 'woocommerce-analytics-customers',
-				'title' => __( 'Customers', 'woocommerce-admin' ),
+				'title' => __( 'Customers', 'woocommerce' ),
 				'url'   => 'wc-admin&path=/customers',
 				'order' => 50,
 			);
@@ -220,7 +220,7 @@ class CoreMenu {
 				$product_tag_items['default'],
 				array(
 					'id'              => 'woocommerce-product-attributes',
-					'title'           => __( 'Attributes', 'woocommerce-admin' ),
+					'title'           => __( 'Attributes', 'woocommerce' ),
 					'url'             => 'edit.php?post_type=product&page=product_attributes',
 					'capability'      => 'manage_product_terms',
 					'order'           => 40,
@@ -231,7 +231,7 @@ class CoreMenu {
 				$coupon_items['default'],
 				// Marketplace category.
 				array(
-					'title'      => __( 'Marketplace', 'woocommerce-admin' ),
+					'title'      => __( 'Marketplace', 'woocommerce' ),
 					'capability' => 'manage_woocommerce',
 					'id'         => 'woocommerce-marketplace',
 					'url'        => 'wc-addons',
@@ -257,9 +257,9 @@ class CoreMenu {
 	 */
 	public static function get_tool_items() {
 		$tabs = array(
-			'status' => __( 'System status', 'woocommerce-admin' ),
-			'tools'  => __( 'Utilities', 'woocommerce-admin' ),
-			'logs'   => __( 'Logs', 'woocommerce-admin' ),
+			'status' => __( 'System status', 'woocommerce' ),
+			'tools'  => __( 'Utilities', 'woocommerce' ),
+			'logs'   => __( 'Logs', 'woocommerce' ),
 		);
 		$tabs = apply_filters( 'woocommerce_admin_status_tabs', $tabs );
 
@@ -267,7 +267,7 @@ class CoreMenu {
 		$items = array(
 			array(
 				'parent'     => 'woocommerce-tools',
-				'title'      => __( 'Import / Export', 'woocommerce-admin' ),
+				'title'      => __( 'Import / Export', 'woocommerce' ),
 				'capability' => 'import',
 				'id'         => 'tools-import-export',
 				'url'        => 'import.php',

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Favorites.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Favorites.php
@@ -55,7 +55,7 @@ class Favorites {
 		if ( in_array( $item_id, $all_favorites, true ) ) {
 			return new \WP_Error(
 				'woocommerce_favorites_already_exists',
-				__( 'Favorite already exists', 'woocommerce-admin' )
+				__( 'Favorite already exists', 'woocommerce' )
 			);
 		}
 
@@ -79,7 +79,7 @@ class Favorites {
 		if ( ! in_array( $item_id, $all_favorites, true ) ) {
 			return new \WP_Error(
 				'woocommerce_favorites_does_not_exist',
-				__( 'Favorite item not found', 'woocommerce-admin' )
+				__( 'Favorite item not found', 'woocommerce' )
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
@@ -47,14 +47,14 @@ class Init {
 	public static function add_feature_toggle( $features ) {
 		$description  = __(
 			'Adds the new WooCommerce navigation experience to the dashboard',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 		$update_text  = '';
 		$needs_update = version_compare( get_bloginfo( 'version' ), '5.6', '<' );
 		if ( $needs_update && current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
 			$update_text = sprintf(
 				/* translators: 1: line break tag, 2: open link to WordPress update link, 3: close link tag. */
-				__( '%1$s %2$sUpdate WordPress to enable the new navigation%3$s', 'woocommerce-admin' ),
+				__( '%1$s %2$sUpdate WordPress to enable the new navigation%3$s', 'woocommerce' ),
 				'<br/>',
 				'<a href="' . self_admin_url( 'update-core.php' ) . '" target="_blank">',
 				'</a>'
@@ -62,7 +62,7 @@ class Init {
 		}
 
 		$features[] = array(
-			'title' => __( 'Navigation', 'woocommerce-admin' ),
+			'title' => __( 'Navigation', 'woocommerce' ),
 			'desc'  => $description . $update_text,
 			'id'    => self::TOGGLE_OPTION_NAME,
 			'type'  => 'checkbox',

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Menu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Menu.php
@@ -188,7 +188,7 @@ class Menu {
 			$menu_item['parent']          = 'woocommerce';
 			$menu_item['backButtonLabel'] = __(
 				'WooCommerce Home',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 		}
 
@@ -226,7 +226,7 @@ class Menu {
 			error_log(  // phpcs:ignore
 				sprintf(
 					/* translators: 1: Duplicate menu item path. */
-					esc_html__( 'You have attempted to register a duplicate item with WooCommerce Navigation: %1$s', 'woocommerce-admin' ),
+					esc_html__( 'You have attempted to register a duplicate item with WooCommerce Navigation: %1$s', 'woocommerce' ),
 					'`' . $args['id'] . '`'
 				)
 			);
@@ -371,7 +371,7 @@ class Menu {
 			error_log(  // phpcs:ignore
 				sprintf(
 					/* translators: 1: Duplicate menu item path. */
-					esc_html__( 'The item ID %1$s attempted to register using an invalid option. The arguments `menuId` and `parent` are not allowed for add_setting_item()', 'woocommerce-admin' ),
+					esc_html__( 'The item ID %1$s attempted to register using an invalid option. The arguments `menuId` and `parent` are not allowed for add_setting_item()', 'woocommerce' ),
 					'`' . $args['id'] . '`'
 				)
 			);

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -190,7 +190,7 @@ abstract class Task {
 	 * @return string
 	 */
 	public function get_action_label() {
-		return __( "Let's go", 'woocommerce-admin' );
+		return __( "Let's go", 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -236,7 +236,7 @@ class TaskList {
 		if ( ! is_subclass_of( $task, 'Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task' ) ) {
 			return new \WP_Error(
 				'woocommerce_task_list_invalid_task',
-				__( 'Task is not a subclass of `Task`', 'woocommerce-admin' )
+				__( 'Task is not a subclass of `Task`', 'woocommerce' )
 			);
 		}
 		if ( array_search( $task, $this->tasks, true ) ) {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -79,7 +79,7 @@ class TaskLists {
 		self::add_list(
 			array(
 				'id'           => 'setup',
-				'title'        => __( 'Get ready to start selling', 'woocommerce-admin' ),
+				'title'        => __( 'Get ready to start selling', 'woocommerce' ),
 				'tasks'        => array(
 					'StoreDetails',
 					'Purchase',
@@ -100,7 +100,7 @@ class TaskLists {
 			array(
 				'id'                      => 'setup_experiment_1',
 				'hidden_id'               => 'setup',
-				'title'                   => __( 'Get ready to start selling', 'woocommerce-admin' ),
+				'title'                   => __( 'Get ready to start selling', 'woocommerce' ),
 				'tasks'                   => array(
 					'StoreDetails',
 					'Products',
@@ -123,7 +123,7 @@ class TaskLists {
 		self::add_list(
 			array(
 				'id'      => 'extended',
-				'title'   => __( 'Things to do next', 'woocommerce-admin' ),
+				'title'   => __( 'Things to do next', 'woocommerce' ),
 				'sort_by' => array(
 					array(
 						'key'   => 'is_complete',
@@ -143,7 +143,7 @@ class TaskLists {
 			array(
 				'id'           => 'setup_two_column',
 				'hidden_id'    => 'setup',
-				'title'        => __( 'Get ready to start selling', 'woocommerce-admin' ),
+				'title'        => __( 'Get ready to start selling', 'woocommerce' ),
 				'tasks'        => array(
 					'Products',
 					'WooCommercePayments',
@@ -160,7 +160,7 @@ class TaskLists {
 			array(
 				'id'           => 'extended_two_column',
 				'hidden_id'    => 'extended',
-				'title'        => __( 'Things to do next', 'woocommerce-admin' ),
+				'title'        => __( 'Things to do next', 'woocommerce' ),
 				'sort_by'      => array(
 					array(
 						'key'   => 'is_complete',
@@ -227,7 +227,7 @@ class TaskLists {
 		if ( isset( self::$lists[ $args['id'] ] ) ) {
 			return new \WP_Error(
 				'woocommerce_task_list_exists',
-				__( 'Task list ID already exists', 'woocommerce-admin' )
+				__( 'Task list ID already exists', 'woocommerce' )
 			);
 		}
 
@@ -246,7 +246,7 @@ class TaskLists {
 		if ( ! isset( self::$lists[ $list_id ] ) ) {
 			return new \WP_Error(
 				'woocommerce_task_list_invalid_list',
-				__( 'Task list ID does not exist', 'woocommerce-admin' )
+				__( 'Task list ID does not exist', 'woocommerce' )
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -27,7 +27,7 @@ class AdditionalPayments extends Payments {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Set up additional payment providers', 'woocommerce-admin' );
+		return __( 'Set up additional payment providers', 'woocommerce' );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class AdditionalPayments extends Payments {
 	public function get_content() {
 		return __(
 			'Choose payment providers and enable payment methods at checkout.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -48,7 +48,7 @@ class AdditionalPayments extends Payments {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '2 minutes', 'woocommerce-admin' );
+		return __( '2 minutes', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
@@ -41,11 +41,11 @@ class Appearance extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You personalized your store', 'woocommerce-admin' );
+				return __( 'You personalized your store', 'woocommerce' );
 			}
-			return __( 'Personalize your store', 'woocommerce-admin' );
+			return __( 'Personalize your store', 'woocommerce' );
 		}
-		return __( 'Personalize my store', 'woocommerce-admin' );
+		return __( 'Personalize my store', 'woocommerce' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class Appearance extends Task {
 	public function get_content() {
 		return __(
 			'Add your logo, create a homepage, and start designing your store.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -66,7 +66,7 @@ class Appearance extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '2 minutes', 'woocommerce-admin' );
+		return __( '2 minutes', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -27,11 +27,11 @@ class Marketing extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You added sales channels', 'woocommerce-admin' );
+				return __( 'You added sales channels', 'woocommerce' );
 			}
-			return __( 'Get more sales', 'woocommerce-admin' );
+			return __( 'Get more sales', 'woocommerce' );
 		}
-		return __( 'Set up marketing tools', 'woocommerce-admin' );
+		return __( 'Set up marketing tools', 'woocommerce' );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class Marketing extends Task {
 	public function get_content() {
 		return __(
 			'Add recommended marketing tools to reach new customers and grow your business',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -52,7 +52,7 @@ class Marketing extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '1 minute', 'woocommerce-admin' );
+		return __( '1 minute', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -27,11 +27,11 @@ class Payments extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You set up payments', 'woocommerce-admin' );
+				return __( 'You set up payments', 'woocommerce' );
 			}
-			return __( 'Set up payments', 'woocommerce-admin' );
+			return __( 'Set up payments', 'woocommerce' );
 		}
-		return __( 'Set up payments', 'woocommerce-admin' );
+		return __( 'Set up payments', 'woocommerce' );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class Payments extends Task {
 	public function get_content() {
 		return __(
 			'Choose payment providers and enable payment methods at checkout.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -52,7 +52,7 @@ class Payments extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '2 minutes', 'woocommerce-admin' );
+		return __( '2 minutes', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -38,11 +38,11 @@ class Products extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You added products', 'woocommerce-admin' );
+				return __( 'You added products', 'woocommerce' );
 			}
-			return __( 'Add products', 'woocommerce-admin' );
+			return __( 'Add products', 'woocommerce' );
 		}
-		return __( 'Add my products', 'woocommerce-admin' );
+		return __( 'Add my products', 'woocommerce' );
 	}
 
 	/**
@@ -53,7 +53,7 @@ class Products extends Task {
 	public function get_content() {
 		return __(
 			'Start by adding the first product to your store. You can add your products manually, via CSV, or import them from another service.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -63,7 +63,7 @@ class Products extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '1 minute per product', 'woocommerce-admin' );
+		return __( '1 minute per product', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Purchase.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Purchase.php
@@ -61,13 +61,13 @@ class Purchase extends Task {
 				/* translators: %1$s: list of product names comma separated, %2%s the last product name */
 				__(
 					'Add %s to my store',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				$products['remaining'][0]
 			)
 			: __(
 				'Add paid extensions to my store',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 	}
 
@@ -86,7 +86,7 @@ class Purchase extends Task {
 		/* translators: %1$s: list of product names comma separated, %2%s the last product name */
 			__(
 				'Good choice! You chose to add %1$s and %2$s to your store.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			implode( ', ', array_slice( $products['remaining'], 0, -1 ) ) . ( count( $products['remaining'] ) > 2 ? ',' : '' ),
 			end( $products['remaining'] )
@@ -99,7 +99,7 @@ class Purchase extends Task {
 	 * @return string
 	 */
 	public function get_action_label() {
-		return __( 'Purchase & install now', 'woocommerce-admin' );
+		return __( 'Purchase & install now', 'woocommerce' );
 	}
 
 
@@ -109,7 +109,7 @@ class Purchase extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '2 minutes', 'woocommerce-admin' );
+		return __( '2 minutes', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -26,11 +26,11 @@ class Shipping extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You added shipping costs', 'woocommerce-admin' );
+				return __( 'You added shipping costs', 'woocommerce' );
 			}
-			return __( 'Add shipping costs', 'woocommerce-admin' );
+			return __( 'Add shipping costs', 'woocommerce' );
 		}
-		return __( 'Set up shipping', 'woocommerce-admin' );
+		return __( 'Set up shipping', 'woocommerce' );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class Shipping extends Task {
 	public function get_content() {
 		return __(
 			"Set your store location and where you'll ship to.",
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -51,7 +51,7 @@ class Shipping extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '1 minute', 'woocommerce-admin' );
+		return __( '1 minute', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -26,11 +26,11 @@ class StoreDetails extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You added store details', 'woocommerce-admin' );
+				return __( 'You added store details', 'woocommerce' );
 			}
-			return __( 'Add store details', 'woocommerce-admin' );
+			return __( 'Add store details', 'woocommerce' );
 		}
-		return __( 'Store details', 'woocommerce-admin' );
+		return __( 'Store details', 'woocommerce' );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class StoreDetails extends Task {
 	public function get_content() {
 		return __(
 			'Your store address is required to set the origin country for shipping, currencies, and payment options.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -51,7 +51,7 @@ class StoreDetails extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '4 minutes', 'woocommerce-admin' );
+		return __( '4 minutes', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -67,11 +67,11 @@ class Tax extends Task {
 	public function get_title() {
 		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
 			if ( $this->is_complete() ) {
-				return __( 'You added tax rates', 'woocommerce-admin' );
+				return __( 'You added tax rates', 'woocommerce' );
 			}
-			return __( 'Add tax rates', 'woocommerce-admin' );
+			return __( 'Add tax rates', 'woocommerce' );
 		}
-		return __( 'Set up tax', 'woocommerce-admin' );
+		return __( 'Set up tax', 'woocommerce' );
 	}
 
 	/**
@@ -83,11 +83,11 @@ class Tax extends Task {
 		return self::can_use_automated_taxes()
 			? __(
 				'Good news! WooCommerce Services and Jetpack can automate your sales tax calculations for you.',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 			: __(
 				'Set your store location and configure tax rate settings.',
-				'woocommerce-admin'
+				'woocommerce'
 			);
 	}
 
@@ -97,7 +97,7 @@ class Tax extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '1 minute', 'woocommerce-admin' );
+		return __( '1 minute', 'woocommerce' );
 	}
 
 	/**
@@ -107,8 +107,8 @@ class Tax extends Task {
 	 */
 	public function get_action_label() {
 		return self::can_use_automated_taxes()
-			? __( 'Yes please', 'woocommerce-admin' )
-			: __( "Let's go", 'woocommerce-admin' );
+			? __( 'Yes please', 'woocommerce' )
+			: __( "Let's go", 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -34,7 +34,7 @@ class WooCommercePayments extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Get paid with WooCommerce Payments', 'woocommerce-admin' );
+		return __( 'Get paid with WooCommerce Payments', 'woocommerce' );
 	}
 
 	/**
@@ -45,7 +45,7 @@ class WooCommercePayments extends Task {
 	public function get_content() {
 		return __(
 			"You're only one step away from getting paid. Verify your business details to start managing transactions with WooCommerce Payments.",
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 
@@ -55,7 +55,7 @@ class WooCommercePayments extends Task {
 	 * @return string
 	 */
 	public function get_time() {
-		return __( '2 minutes', 'woocommerce-admin' );
+		return __( '2 minutes', 'woocommerce' );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class WooCommercePayments extends Task {
 	 * @return string
 	 */
 	public function get_action_label() {
-		return __( 'Finish setup', 'woocommerce-admin' );
+		return __( 'Finish setup', 'woocommerce' );
 	}
 
 	/**
@@ -75,7 +75,7 @@ class WooCommercePayments extends Task {
 	public function get_additional_info() {
 		return __(
 			'By setting up, you are agreeing to the <a href="https://wordpress.com/tos/" target="_blank">Terms of Service</a>',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -23,8 +23,8 @@ class DefaultPaymentGateways {
 		return array(
 			array(
 				'id'         => 'payfast',
-				'title'      => __( 'PayFast', 'woocommerce-admin' ),
-				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs. Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce-admin' ),
+				'title'      => __( 'PayFast', 'woocommerce' ),
+				'content'    => __( 'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs. Selecting this extension will configure your store to use South African rands as the selected currency.', 'woocommerce' ),
 				'image'      => WC()->plugin_url() . '/assets/images/payfast.png',
 				'plugins'    => array( 'woocommerce-payfast-gateway' ),
 				'is_visible' => array(
@@ -38,8 +38,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'                      => 'stripe',
-				'title'                   => __( ' Stripe', 'woocommerce-admin' ),
-				'content'                 => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-admin' ),
+				'title'                   => __( ' Stripe', 'woocommerce' ),
+				'content'                 => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce' ),
 				'image'                   => WC()->plugin_url() . '/assets/images/stripe.png',
 				'plugins'                 => array( 'woocommerce-gateway-stripe' ),
 				'is_visible'              => array(
@@ -94,8 +94,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'paystack',
-				'title'      => __( 'Paystack', 'woocommerce-admin' ),
-				'content'    => __( 'Paystack helps African merchants accept one-time and recurring payments online with a modern, safe, and secure payment gateway.', 'woocommerce-admin' ),
+				'title'      => __( 'Paystack', 'woocommerce' ),
+				'content'    => __( 'Paystack helps African merchants accept one-time and recurring payments online with a modern, safe, and secure payment gateway.', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/paystack.png',
 				'plugins'    => array( 'woo-paystack' ),
 				'is_visible' => array(
@@ -105,8 +105,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'kco',
-				'title'      => __( 'Klarna Checkout', 'woocommerce-admin' ),
-				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce-admin' ),
+				'title'      => __( 'Klarna Checkout', 'woocommerce' ),
+				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce' ),
 				'image'      => WC()->plugin_url() . '/assets/images/klarna-black.png',
 				'plugins'    => array( 'klarna-checkout-for-woocommerce' ),
 				'is_visible' => array(
@@ -116,8 +116,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'klarna_payments',
-				'title'      => __( 'Klarna Payments', 'woocommerce-admin' ),
-				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce-admin' ),
+				'title'      => __( 'Klarna Payments', 'woocommerce' ),
+				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce' ),
 				'image'      => WC()->plugin_url() . '/assets/images/klarna-black.png',
 				'plugins'    => array( 'klarna-payments-for-woocommerce' ),
 				'is_visible' => array(
@@ -141,8 +141,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'mollie_wc_gateway_banktransfer',
-				'title'      => __( 'Mollie', 'woocommerce-admin' ),
-				'content'    => __( 'Effortless payments by Mollie: Offer global and local payment methods, get onboarded in minutes, and supported in your language.', 'woocommerce-admin' ),
+				'title'      => __( 'Mollie', 'woocommerce' ),
+				'content'    => __( 'Effortless payments by Mollie: Offer global and local payment methods, get onboarded in minutes, and supported in your language.', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/mollie.svg',
 				'plugins'    => array( 'mollie-payments-for-woocommerce' ),
 				'is_visible' => array(
@@ -165,8 +165,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'                      => 'woo-mercado-pago-custom',
-				'title'                   => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce-admin' ),
-				'content'                 => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce-admin' ),
+				'title'                   => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce' ),
+				'content'                 => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce' ),
 				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/mercadopago.png',
 				'plugins'                 => array( 'woocommerce-mercadopago' ),
 				'is_visible'              => array(
@@ -177,8 +177,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'ppcp-gateway',
-				'title'      => __( 'PayPal Payments', 'woocommerce-admin' ),
-				'content'    => __( "Safe and secure payments using credit cards or your customer's PayPal account.", 'woocommerce-admin' ),
+				'title'      => __( 'PayPal Payments', 'woocommerce' ),
+				'content'    => __( "Safe and secure payments using credit cards or your customer's PayPal account.", 'woocommerce' ),
 				'image'      => WC()->plugin_url() . '/assets/images/paypal.png',
 				'plugins'    => array( 'woocommerce-paypal-payments' ),
 				'is_visible' => array(
@@ -192,8 +192,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'cod',
-				'title'      => __( 'Cash on delivery', 'woocommerce-admin' ),
-				'content'    => __( 'Take payments in cash upon delivery.', 'woocommerce-admin' ),
+				'title'      => __( 'Cash on delivery', 'woocommerce' ),
+				'content'    => __( 'Take payments in cash upon delivery.', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/cod.svg',
 				'is_visible' => array(
 					self::get_rules_for_cbd( false ),
@@ -201,8 +201,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'bacs',
-				'title'      => __( 'Direct bank transfer', 'woocommerce-admin' ),
-				'content'    => __( 'Take payments via bank transfer.', 'woocommerce-admin' ),
+				'title'      => __( 'Direct bank transfer', 'woocommerce' ),
+				'content'    => __( 'Take payments via bank transfer.', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/bacs.svg',
 				'is_visible' => array(
 					self::get_rules_for_cbd( false ),
@@ -210,10 +210,10 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'                      => 'woocommerce_payments',
-				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'title'                   => __( 'WooCommerce Payments', 'woocommerce' ),
 				'content'                 => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
 				'plugins'                 => array( 'woocommerce-payments' ),
@@ -252,10 +252,10 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'                      => 'woocommerce_payments:non-us',
-				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'title'                   => __( 'WooCommerce Payments', 'woocommerce' ),
 				'content'                 => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
 				'plugins'                 => array( 'woocommerce-payments' ),
@@ -286,10 +286,10 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'                      => 'woocommerce_payments:us',
-				'title'                   => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'title'                   => __( 'WooCommerce Payments', 'woocommerce' ),
 				'content'                 => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
 				'plugins'                 => array( 'woocommerce-payments' ),
@@ -320,8 +320,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'razorpay',
-				'title'      => __( 'Razorpay', 'woocommerce-admin' ),
-				'content'    => __( 'The official Razorpay extension for WooCommerce allows you to accept credit cards, debit cards, netbanking, wallet, and UPI payments.', 'woocommerce-admin' ),
+				'title'      => __( 'Razorpay', 'woocommerce' ),
+				'content'    => __( 'The official Razorpay extension for WooCommerce allows you to accept credit cards, debit cards, netbanking, wallet, and UPI payments.', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/razorpay.svg',
 				'plugins'    => array( 'woo-razorpay' ),
 				'is_visible' => array(
@@ -335,8 +335,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'payubiz',
-				'title'      => __( 'PayU for WooCommerce', 'woocommerce-admin' ),
-				'content'    => __( 'Enable PayU’s exclusive plugin for WooCommerce to start accepting payments in 100+ payment methods available in India including credit cards, debit cards, UPI, & more!', 'woocommerce-admin' ),
+				'title'      => __( 'PayU for WooCommerce', 'woocommerce' ),
+				'content'    => __( 'Enable PayU’s exclusive plugin for WooCommerce to start accepting payments in 100+ payment methods available in India including credit cards, debit cards, UPI, & more!', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/payu.svg',
 				'plugins'    => array( 'payu-india' ),
 				'is_visible' => array(
@@ -350,8 +350,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'eway',
-				'title'      => __( 'Eway', 'woocommerce-admin' ),
-				'content'    => __( 'The Eway extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.', 'woocommerce-admin' ),
+				'title'      => __( 'Eway', 'woocommerce' ),
+				'content'    => __( 'The Eway extension for WooCommerce allows you to take credit card payments directly on your store without redirecting your customers to a third party site to make payment.', 'woocommerce' ),
 				'image'      => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/eway.png',
 				'plugins'    => array( 'woocommerce-gateway-eway' ),
 				'is_visible' => array(
@@ -361,8 +361,8 @@ class DefaultPaymentGateways {
 			),
 			array(
 				'id'         => 'square_credit_card',
-				'title'      => __( 'Square', 'woocommerce-admin' ),
-				'content'    => __( 'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). Sell online and in store and track sales and inventory in one place.', 'woocommerce-admin' ),
+				'title'      => __( 'Square', 'woocommerce' ),
+				'content'    => __( 'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). Sell online and in store and track sales and inventory in one place.', 'woocommerce' ),
 				'image'      => WC()->plugin_url() . '/assets/images/square-black.png',
 				'plugins'    => array( 'woocommerce-square' ),
 				'is_visible' => array(

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/PaymentGatewaysController.php
@@ -130,7 +130,7 @@ class PaymentGatewaysController {
 				'status'  => 'success',
 				'content' => sprintf(
 					/* translators: the title of the payment gateway */
-					__( '%s connected successfully', 'woocommerce-admin' ),
+					__( '%s connected successfully', 'woocommerce' ),
 					$payment_gateway->method_title
 				),
 			)

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -121,7 +121,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			 */
 			do_action( 'woocommerce_note_loaded', $note );
 		} else {
-			throw new \Exception( __( 'Invalid admin note', 'woocommerce-admin' ) );
+			throw new \Exception( __( 'Invalid admin note', 'woocommerce' ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -374,7 +374,7 @@ class Note extends \WC_Data {
 	public function set_name( $name ) {
 		// Don't allow empty names.
 		if ( empty( $name ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note name prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note name prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		$this->set_prop( 'name', $name );
@@ -387,7 +387,7 @@ class Note extends \WC_Data {
 	 */
 	public function set_type( $type ) {
 		if ( empty( $type ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note type prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note type prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		if ( ! in_array( $type, self::get_allowed_types(), true ) ) {
@@ -395,7 +395,7 @@ class Note extends \WC_Data {
 				'admin_note_invalid_data',
 				sprintf(
 					/* translators: %s: admin note type. */
-					__( 'The admin note type prop (%s) is not one of the supported types.', 'woocommerce-admin' ),
+					__( 'The admin note type prop (%s) is not one of the supported types.', 'woocommerce' ),
 					$type
 				)
 			);
@@ -411,7 +411,7 @@ class Note extends \WC_Data {
 	 */
 	public function set_locale( $locale ) {
 		if ( empty( $locale ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note locale prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note locale prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		$this->set_prop( 'locale', $locale );
@@ -424,7 +424,7 @@ class Note extends \WC_Data {
 	 */
 	public function set_title( $title ) {
 		if ( empty( $title ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note title prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note title prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		$this->set_prop( 'title', $title );
@@ -464,7 +464,7 @@ class Note extends \WC_Data {
 		$content = wp_kses( $content, $allowed_html );
 
 		if ( empty( $content ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note content prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note content prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		$this->set_prop( 'content', $content );
@@ -481,7 +481,7 @@ class Note extends \WC_Data {
 
 		// Make sure $content_data is stdClass Object or an array.
 		if ( ! ( $content_data instanceof \stdClass ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note content_data prop must be an instance of stdClass.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note content_data prop must be an instance of stdClass.', 'woocommerce' ) );
 		}
 
 		$this->set_prop( 'content_data', $content_data );
@@ -494,7 +494,7 @@ class Note extends \WC_Data {
 	 */
 	public function set_status( $status ) {
 		if ( empty( $status ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note status prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note status prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		if ( ! in_array( $status, self::get_allowed_statuses(), true ) ) {
@@ -502,7 +502,7 @@ class Note extends \WC_Data {
 				'admin_note_invalid_data',
 				sprintf(
 					/* translators: %s: admin note status property. */
-					__( 'The admin note status prop (%s) is not one of the supported statuses.', 'woocommerce-admin' ),
+					__( 'The admin note status prop (%s) is not one of the supported statuses.', 'woocommerce' ),
 					$status
 				)
 			);
@@ -518,7 +518,7 @@ class Note extends \WC_Data {
 	 */
 	public function set_source( $source ) {
 		if ( empty( $source ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note source prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note source prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		$this->set_prop( 'source', $source );
@@ -531,7 +531,7 @@ class Note extends \WC_Data {
 	 */
 	public function set_date_created( $date ) {
 		if ( empty( $date ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note date prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note date prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		if ( is_string( $date ) ) {
@@ -582,7 +582,7 @@ class Note extends \WC_Data {
 		if ( in_array( $layout, $valid_layouts, true ) ) {
 			$this->set_prop( 'layout', $layout );
 		} else {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note layout has a wrong prop value.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note layout has a wrong prop value.', 'woocommerce' ) );
 		}
 	}
 
@@ -638,11 +638,11 @@ class Note extends \WC_Data {
 		$actioned_text = wc_clean( $actioned_text );
 
 		if ( empty( $name ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note action name prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note action name prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		if ( empty( $label ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note action label prop cannot be empty.', 'woocommerce-admin' ) );
+			$this->error( 'admin_note_invalid_data', __( 'The admin note action label prop cannot be empty.', 'woocommerce' ) );
 		}
 
 		$action = array(

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -616,12 +616,12 @@ class Note extends \WC_Data {
 	/**
 	 * Add an action to the note
 	 *
-	 * @param string $name           Action name (not presented to user).
-	 * @param string $label          Action label (presented as button label).
-	 * @param string $url            Action URL, if navigation needed. Optional.
-	 * @param string $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
+	 * @param string  $name           Action name (not presented to user).
+	 * @param string  $label          Action label (presented as button label).
+	 * @param string  $url            Action URL, if navigation needed. Optional.
+	 * @param string  $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
 	 * @param boolean $primary        Deprecated since version 3.4.0.
-	 * @param string $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
+	 * @param string  $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
 	 */
 	public function add_action(
 		$name,

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -465,7 +465,7 @@ class Notes {
 		} catch ( \Exception $e ) {
 			throw new NotesUnavailableException(
 				'woocommerce_admin_notes_unavailable',
-				__( 'Notes are unavailable because the "admin-note" data store cannot be loaded.', 'woocommerce-admin' )
+				__( 'Notes are unavailable because the "admin-note" data store cannot be loaded.', 'woocommerce' )
 			);
 		}
 	}

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -198,7 +198,7 @@ class PageController {
 			}
 		}
 
-		$woocommerce_breadcrumb = array( 'admin.php?page=' . self::PAGE_ROOT, __( 'WooCommerce', 'woocommerce-admin' ) );
+		$woocommerce_breadcrumb = array( 'admin.php?page=' . self::PAGE_ROOT, __( 'WooCommerce', 'woocommerce' ) );
 
 		array_unshift( $breadcrumbs, $woocommerce_breadcrumb );
 
@@ -220,7 +220,7 @@ class PageController {
 		// If 'current_screen' hasn't fired yet, the current page calculation
 		// will fail which causes `false` to be returned for all subsquent calls.
 		if ( ! did_action( 'current_screen' ) ) {
-			_doing_it_wrong( __FUNCTION__, esc_html__( 'Current page retrieval should be called on or after the `current_screen` hook.', 'woocommerce-admin' ), '0.16.0' );
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'Current page retrieval should be called on or after the `current_screen` hook.', 'woocommerce' ), '0.16.0' );
 		}
 
 		if ( is_null( $this->current_page ) ) {
@@ -507,7 +507,7 @@ class PageController {
 	public function register_store_details_page() {
 		wc_admin_register_page(
 			array(
-				'title'  => __( 'Setup Wizard', 'woocommerce-admin' ),
+				'title'  => __( 'Setup Wizard', 'woocommerce' ),
 				'parent' => '',
 				'path'   => '/setup-wizard',
 			)

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -154,7 +154,7 @@ class PluginsHelper {
 		$plugins = apply_filters( 'woocommerce_admin_plugins_pre_install', $plugins );
 
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
-			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ) );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -193,7 +193,7 @@ class PluginsHelper {
 			if ( is_wp_error( $api ) ) {
 				$properties = array(
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					'error_message' => __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce-admin' ),
+					'error_message' => __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce' ),
 					'api'           => $api,
 					'slug'          => $slug,
 				);
@@ -205,7 +205,7 @@ class PluginsHelper {
 					$plugin,
 					sprintf(
 						/* translators: %s: plugin slug (example: woocommerce-services) */
-						__( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce-admin' ),
+						__( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce' ),
 						$slug
 					)
 				);
@@ -221,7 +221,7 @@ class PluginsHelper {
 			if ( is_wp_error( $result ) || is_null( $result ) ) {
 				$properties = array(
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					'error_message' => __( 'The requested plugin `%s` could not be installed.', 'woocommerce-admin' ),
+					'error_message' => __( 'The requested plugin `%s` could not be installed.', 'woocommerce' ),
 					'slug'          => $slug,
 					'api'           => $api,
 					'upgrader'      => $upgrader,
@@ -235,7 +235,7 @@ class PluginsHelper {
 					$plugin,
 					sprintf(
 						/* translators: %s: plugin slug (example: woocommerce-services) */
-						__( 'The requested plugin `%s` could not be installed. Upgrader install failed.', 'woocommerce-admin' ),
+						__( 'The requested plugin `%s` could not be installed. Upgrader install failed.', 'woocommerce' ),
 						$slug
 					)
 				);
@@ -263,7 +263,7 @@ class PluginsHelper {
 	 */
 	public static function schedule_install_plugins( $plugins ) {
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
-			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );
 		}
 
 		$job_id = uniqid();
@@ -280,7 +280,7 @@ class PluginsHelper {
 	 */
 	public static function activate_plugins( $plugins ) {
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
-			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -307,7 +307,7 @@ class PluginsHelper {
 				$errors->add(
 					$plugin,
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					sprintf( __( 'The requested plugin `%s`. is not yet installed.', 'woocommerce-admin' ), $slug )
+					sprintf( __( 'The requested plugin `%s`. is not yet installed.', 'woocommerce' ), $slug )
 				);
 				continue;
 			}
@@ -319,7 +319,7 @@ class PluginsHelper {
 				$errors->add(
 					$plugin,
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					sprintf( __( 'The requested plugin `%s` could not be activated.', 'woocommerce-admin' ), $slug )
+					sprintf( __( 'The requested plugin `%s` could not be activated.', 'woocommerce' ), $slug )
 				);
 				continue;
 			}
@@ -344,7 +344,7 @@ class PluginsHelper {
 	 */
 	public static function schedule_activate_plugins( $plugins ) {
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
-			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );
 		}
 
 		$job_id = uniqid();

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -29,16 +29,16 @@ class ReportCSVEmail extends \WC_Email {
 		$this->template_html  = 'html-admin-report-export-download.php';
 		$this->template_plain = 'plain-admin-report-export-download.php';
 		$this->report_labels  = array(
-			'categories' => __( 'Categories', 'woocommerce-admin' ),
-			'coupons'    => __( 'Coupons', 'woocommerce-admin' ),
-			'customers'  => __( 'Customers', 'woocommerce-admin' ),
-			'downloads'  => __( 'Downloads', 'woocommerce-admin' ),
-			'orders'     => __( 'Orders', 'woocommerce-admin' ),
-			'products'   => __( 'Products', 'woocommerce-admin' ),
-			'revenue'    => __( 'Revenue', 'woocommerce-admin' ),
-			'stock'      => __( 'Stock', 'woocommerce-admin' ),
-			'taxes'      => __( 'Taxes', 'woocommerce-admin' ),
-			'variations' => __( 'Variations', 'woocommerce-admin' ),
+			'categories' => __( 'Categories', 'woocommerce' ),
+			'coupons'    => __( 'Coupons', 'woocommerce' ),
+			'customers'  => __( 'Customers', 'woocommerce' ),
+			'downloads'  => __( 'Downloads', 'woocommerce' ),
+			'orders'     => __( 'Orders', 'woocommerce' ),
+			'products'   => __( 'Products', 'woocommerce' ),
+			'revenue'    => __( 'Revenue', 'woocommerce' ),
+			'stock'      => __( 'Stock', 'woocommerce' ),
+			'taxes'      => __( 'Taxes', 'woocommerce' ),
+			'variations' => __( 'Variations', 'woocommerce' ),
 		);
 
 		// Call parent constructor.
@@ -70,7 +70,7 @@ class ReportCSVEmail extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_heading() {
-		return __( 'Your Report Download', 'woocommerce-admin' );
+		return __( 'Your Report Download', 'woocommerce' );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class ReportCSVEmail extends \WC_Email {
 	 * @return string
 	 */
 	public function get_default_subject() {
-		return __( '[{site_title}]: Your {report_name} Report download is ready', 'woocommerce-admin' );
+		return __( '[{site_title}]: Your {report_name} Report download is ready', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/ReportsSync.php
+++ b/plugins/woocommerce/src/Admin/ReportsSync.php
@@ -46,7 +46,7 @@ class ReportsSync {
 
 		foreach ( $schedulers as $scheduler ) {
 			if ( ! is_subclass_of( $scheduler, 'Automattic\WooCommerce\Internal\Admin\Schedulers\ImportScheduler' ) ) {
-				throw new \Exception( __( 'Report sync schedulers should be derived from the Automattic\WooCommerce\Internal\Admin\Schedulers\ImportScheduler class.', 'woocommerce-admin' ) );
+				throw new \Exception( __( 'Report sync schedulers should be derived from the Automattic\WooCommerce\Internal\Admin\Schedulers\ImportScheduler class.', 'woocommerce' ) );
 			}
 		}
 
@@ -76,7 +76,7 @@ class ReportsSync {
 	 */
 	public static function regenerate_report_data( $days, $skip_existing ) {
 		if ( self::is_importing() ) {
-			return new \WP_Error( 'wc_admin_import_in_progress', __( 'An import is already in progress. Please allow the previous import to complete before beginning a new one.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'wc_admin_import_in_progress', __( 'An import is already in progress. Please allow the previous import to complete before beginning a new one.', 'woocommerce' ) );
 		}
 
 		self::reset_import_stats( $days, $skip_existing );
@@ -92,7 +92,7 @@ class ReportsSync {
 		 */
 		do_action( 'woocommerce_analytics_regenerate_init', $days, $skip_existing );
 
-		return __( 'Report table data is being rebuilt. Please allow some time for data to fully populate.', 'woocommerce-admin' );
+		return __( 'Report table data is being rebuilt. Please allow some time for data to fully populate.', 'woocommerce' );
 	}
 
 	/**
@@ -176,7 +176,7 @@ class ReportsSync {
 		// Delete import options.
 		delete_option( ImportScheduler::IMPORT_STATS_OPTION );
 
-		return __( 'Report table data is being deleted.', 'woocommerce-admin' );
+		return __( 'Report table data is being deleted.', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Analytics.php
+++ b/plugins/woocommerce/src/Internal/Admin/Analytics.php
@@ -65,11 +65,11 @@ class Analytics {
 	public static function add_feature_toggle( $features ) {
 		$description = __(
 			'Enables WooCommerce Analytics',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 
 		$features[] = array(
-			'title'   => __( 'Analytics', 'woocommerce-admin' ),
+			'title'   => __( 'Analytics', 'woocommerce' ),
 			'desc'    => $description,
 			'id'      => self::TOGGLE_OPTION_NAME,
 			'type'    => 'checkbox',
@@ -151,11 +151,11 @@ class Analytics {
 		);
 
 		$debug_tools[ self::CACHE_TOOL_ID ] = array(
-			'name'     => __( 'Clear analytics cache', 'woocommerce-admin' ),
-			'button'   => __( 'Clear', 'woocommerce-admin' ),
+			'name'     => __( 'Clear analytics cache', 'woocommerce' ),
+			'button'   => __( 'Clear', 'woocommerce' ),
 			'desc'     => sprintf(
 				/* translators: 1: opening link tag, 2: closing tag */
-				__( 'This tool will reset the cached values used in WooCommerce Analytics. If numbers still look off, try %1$sReimporting Historical Data%2$s.', 'woocommerce-admin' ),
+				__( 'This tool will reset the cached values used in WooCommerce Analytics. If numbers still look off, try %1$sReimporting Historical Data%2$s.', 'woocommerce' ),
 				'<a href="' . esc_url( $settings_url ) . '">',
 				'</a>'
 			),
@@ -183,7 +183,7 @@ class Analytics {
 	public static function get_report_pages() {
 		$overview_page = array(
 			'id'       => 'woocommerce-analytics',
-			'title'    => __( 'Analytics', 'woocommerce-admin' ),
+			'title'    => __( 'Analytics', 'woocommerce' ),
 			'path'     => '/analytics/overview',
 			'icon'     => 'dashicons-chart-bar',
 			'position' => 57, // After WooCommerce & Product menu items.
@@ -193,7 +193,7 @@ class Analytics {
 			$overview_page,
 			array(
 				'id'       => 'woocommerce-analytics-overview',
-				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'title'    => __( 'Overview', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/overview',
 				'nav_args' => array(
@@ -203,7 +203,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-products',
-				'title'    => __( 'Products', 'woocommerce-admin' ),
+				'title'    => __( 'Products', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/products',
 				'nav_args' => array(
@@ -213,7 +213,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-revenue',
-				'title'    => __( 'Revenue', 'woocommerce-admin' ),
+				'title'    => __( 'Revenue', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/revenue',
 				'nav_args' => array(
@@ -223,7 +223,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-orders',
-				'title'    => __( 'Orders', 'woocommerce-admin' ),
+				'title'    => __( 'Orders', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/orders',
 				'nav_args' => array(
@@ -233,7 +233,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-variations',
-				'title'    => __( 'Variations', 'woocommerce-admin' ),
+				'title'    => __( 'Variations', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/variations',
 				'nav_args' => array(
@@ -243,7 +243,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-categories',
-				'title'    => __( 'Categories', 'woocommerce-admin' ),
+				'title'    => __( 'Categories', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/categories',
 				'nav_args' => array(
@@ -253,7 +253,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-coupons',
-				'title'    => __( 'Coupons', 'woocommerce-admin' ),
+				'title'    => __( 'Coupons', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/coupons',
 				'nav_args' => array(
@@ -263,7 +263,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-taxes',
-				'title'    => __( 'Taxes', 'woocommerce-admin' ),
+				'title'    => __( 'Taxes', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/taxes',
 				'nav_args' => array(
@@ -273,7 +273,7 @@ class Analytics {
 			),
 			array(
 				'id'       => 'woocommerce-analytics-downloads',
-				'title'    => __( 'Downloads', 'woocommerce-admin' ),
+				'title'    => __( 'Downloads', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/downloads',
 				'nav_args' => array(
@@ -283,7 +283,7 @@ class Analytics {
 			),
 			'yes' === get_option( 'woocommerce_manage_stock' ) ? array(
 				'id'       => 'woocommerce-analytics-stock',
-				'title'    => __( 'Stock', 'woocommerce-admin' ),
+				'title'    => __( 'Stock', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/stock',
 				'nav_args' => array(
@@ -293,17 +293,17 @@ class Analytics {
 			) : null,
 			array(
 				'id'     => 'woocommerce-analytics-customers',
-				'title'  => __( 'Customers', 'woocommerce-admin' ),
+				'title'  => __( 'Customers', 'woocommerce' ),
 				'parent' => 'woocommerce',
 				'path'   => '/customers',
 			),
 			array(
 				'id'       => 'woocommerce-analytics-settings',
-				'title'    => __( 'Settings', 'woocommerce-admin' ),
+				'title'    => __( 'Settings', 'woocommerce' ),
 				'parent'   => 'woocommerce-analytics',
 				'path'     => '/analytics/settings',
 				'nav_args' => array(
-					'title'  => __( 'Analytics', 'woocommerce-admin' ),
+					'title'  => __( 'Analytics', 'woocommerce' ),
 					'parent' => 'woocommerce-settings',
 				),
 			),
@@ -318,6 +318,6 @@ class Analytics {
 	public function run_clear_cache_tool() {
 		Cache::invalidate();
 
-		return __( 'Analytics cache cleared.', 'woocommerce-admin' );
+		return __( 'Analytics cache cleared.', 'woocommerce' );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Coupons.php
+++ b/plugins/woocommerce/src/Internal/Admin/Coupons.php
@@ -71,8 +71,8 @@ class Coupons {
 
 		add_submenu_page(
 			'woocommerce',
-			__( 'Coupons', 'woocommerce-admin' ),
-			__( 'Coupons', 'woocommerce-admin' ),
+			__( 'Coupons', 'woocommerce' ),
+			__( 'Coupons', 'woocommerce' ),
 			'manage_options',
 			'coupons-moved',
 			[ $this, 'coupon_menu_moved' ]

--- a/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
+++ b/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
@@ -129,7 +129,7 @@ class CustomerEffortScoreTracks {
 				3
 			);
 		}
-		$this->onsubmit_label = __( 'Thank you for your feedback!', 'woocommerce-admin' );
+		$this->onsubmit_label = __( 'Thank you for your feedback!', 'woocommerce' );
 	}
 
 	/**
@@ -273,7 +273,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::SEARCH_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to use search?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => $page_now,
@@ -339,7 +339,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::PRODUCT_ADD_PUBLISH_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to add a product?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'product',
@@ -364,7 +364,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::PRODUCT_UPDATE_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to edit your product?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'product',
@@ -389,7 +389,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::SHOP_ORDER_UPDATE_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to update an order?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'shop_order',
@@ -447,7 +447,7 @@ class CustomerEffortScoreTracks {
 		wc_enqueue_js(
 			$this->get_script_track_edit_php(
 				self::ADD_PRODUCT_CATEGORIES_ACTION_NAME,
-				__( 'How easy was it to add product category?', 'woocommerce-admin' )
+				__( 'How easy was it to add product category?', 'woocommerce' )
 			)
 		);
 	}
@@ -463,7 +463,7 @@ class CustomerEffortScoreTracks {
 		wc_enqueue_js(
 			$this->get_script_track_edit_php(
 				self::ADD_PRODUCT_TAGS_ACTION_NAME,
-				__( 'How easy was it to add a product tag?', 'woocommerce-admin' )
+				__( 'How easy was it to add a product tag?', 'woocommerce' )
 			)
 		);
 	}
@@ -486,7 +486,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::IMPORT_PRODUCTS_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to import products?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'product_page_product_importer',
@@ -521,7 +521,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::SETTINGS_CHANGE_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to update your settings?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'woocommerce_page_wc-settings',
@@ -544,7 +544,7 @@ class CustomerEffortScoreTracks {
 				'action'         => self::ADD_PRODUCT_ATTRIBUTES_ACTION_NAME,
 				'label'          => __(
 					'How easy was it to add a product attribute?',
-					'woocommerce-admin'
+					'woocommerce'
 				),
 				'onsubmit_label' => $this->onsubmit_label,
 				'pagenow'        => 'product_page_product_attributes',

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -245,7 +245,7 @@ class FeaturePlugin {
 		if ( ! $woocommerce_minimum_met ) {
 			$errors[] = sprintf(
 				/* translators: 1: URL of WooCommerce plugin, 2: The minimum WooCommerce version number */
-				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WooCommerce</a> %2$s or greater to be installed and active.', 'woocommerce-admin' ),
+				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WooCommerce</a> %2$s or greater to be installed and active.', 'woocommerce' ),
 				'https://wordpress.org/plugins/woocommerce/',
 				$minimum_woocommerce_version
 			);
@@ -254,7 +254,7 @@ class FeaturePlugin {
 		if ( ! $wordpress_minimum_met ) {
 			$errors[] = sprintf(
 				/* translators: 1: URL of WordPress.org, 2: The minimum WordPress version number */
-				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WordPress</a> %2$s or greater to be installed and active.', 'woocommerce-admin' ),
+				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WordPress</a> %2$s or greater to be installed and active.', 'woocommerce' ),
 				'https://wordpress.org/',
 				$minimum_wordpress_version
 			);

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -81,7 +81,7 @@ class Homescreen {
 			wc_admin_register_page(
 				array(
 					'id'         => 'woocommerce-home',
-					'title'      => __( 'WooCommerce', 'woocommerce-admin' ),
+					'title'      => __( 'WooCommerce', 'woocommerce' ),
 					'path'       => self::MENU_SLUG,
 					'capability' => 'read',
 				)
@@ -92,7 +92,7 @@ class Homescreen {
 		wc_admin_register_page(
 			array(
 				'id'         => 'woocommerce-home',
-				'title'      => __( 'Home', 'woocommerce-admin' ),
+				'title'      => __( 'Home', 'woocommerce' ),
 				'parent'     => 'woocommerce',
 				'path'       => self::MENU_SLUG,
 				'order'      => 0,

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -101,7 +101,7 @@ class Loader {
 						echo '<div class="error"><p>';
 						printf(
 							/* translators: %s: is referring to the plugin's name. */
-							esc_html__( 'You have the %s plugin activated but it is not being used.', 'woocommerce-admin' ),
+							esc_html__( 'You have the %s plugin activated but it is not being used.', 'woocommerce' ),
 							'<code>WooCommerce Admin</code>'
 						);
 						echo '</p></div>';
@@ -274,7 +274,7 @@ class Loader {
 		$title  = implode( ' &lsaquo; ', $pieces );
 
 		/* translators: %1$s: updated title, %2$s: blog info name */
-		return sprintf( __( '%1$s &lsaquo; %2$s', 'woocommerce-admin' ), $title, get_bloginfo( 'name' ) );
+		return sprintf( __( '%1$s &lsaquo; %2$s', 'woocommerce' ), $title, get_bloginfo( 'name' ) );
 	}
 
 	/**
@@ -376,7 +376,7 @@ class Loader {
 		// Plugins that depend on changing the translation work on the server but not the client -
 		// WooCommerce Branding is an example of this - so pass through the translation of
 		// 'WooCommerce' to wcSettings.
-		$settings['woocommerceTranslation'] = __( 'WooCommerce', 'woocommerce-admin' );
+		$settings['woocommerceTranslation'] = __( 'WooCommerce', 'woocommerce' );
 		// We may have synced orders with a now-unregistered status.
 		// E.g An extension that added statuses is now inactive or removed.
 		$settings['unregisteredOrderStatuses'] = self::get_unregistered_order_statuses();
@@ -447,8 +447,8 @@ class Loader {
 	public static function add_settings_group( $groups ) {
 		$groups[] = array(
 			'id'          => 'wc_admin',
-			'label'       => __( 'WooCommerce Admin', 'woocommerce-admin' ),
-			'description' => __( 'Settings for WooCommerce admin reporting.', 'woocommerce-admin' ),
+			'label'       => __( 'WooCommerce Admin', 'woocommerce' ),
+			'description' => __( 'Settings for WooCommerce admin reporting.', 'woocommerce' ),
 		);
 		return $groups;
 	}
@@ -467,8 +467,8 @@ class Loader {
 		$settings[] = array(
 			'id'          => 'woocommerce_excluded_report_order_statuses',
 			'option_key'  => 'woocommerce_excluded_report_order_statuses',
-			'label'       => __( 'Excluded report order statuses', 'woocommerce-admin' ),
-			'description' => __( 'Statuses that should not be included when calculating report totals.', 'woocommerce-admin' ),
+			'label'       => __( 'Excluded report order statuses', 'woocommerce' ),
+			'description' => __( 'Statuses that should not be included when calculating report totals.', 'woocommerce' ),
 			'default'     => array( 'pending', 'cancelled', 'failed' ),
 			'type'        => 'multiselect',
 			'options'     => $all_statuses,
@@ -476,8 +476,8 @@ class Loader {
 		$settings[] = array(
 			'id'          => 'woocommerce_actionable_order_statuses',
 			'option_key'  => 'woocommerce_actionable_order_statuses',
-			'label'       => __( 'Actionable order statuses', 'woocommerce-admin' ),
-			'description' => __( 'Statuses that require extra action on behalf of the store admin.', 'woocommerce-admin' ),
+			'label'       => __( 'Actionable order statuses', 'woocommerce' ),
+			'description' => __( 'Statuses that require extra action on behalf of the store admin.', 'woocommerce' ),
 			'default'     => array( 'processing', 'on-hold' ),
 			'type'        => 'multiselect',
 			'options'     => $all_statuses,
@@ -485,8 +485,8 @@ class Loader {
 		$settings[] = array(
 			'id'          => 'woocommerce_default_date_range',
 			'option_key'  => 'woocommerce_default_date_range',
-			'label'       => __( 'Default Date Range', 'woocommerce-admin' ),
-			'description' => __( 'Default Date Range', 'woocommerce-admin' ),
+			'label'       => __( 'Default Date Range', 'woocommerce' ),
+			'description' => __( 'Default Date Range', 'woocommerce' ),
 			'default'     => 'period=month&compare=previous_year',
 			'type'        => 'text',
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -72,8 +72,8 @@ class Marketing {
 	public function add_parent_menu_item() {
 		if ( ! Features::is_enabled( 'navigation' ) ) {
 			add_menu_page(
-				__( 'Marketing', 'woocommerce-admin' ),
-				__( 'Marketing', 'woocommerce-admin' ),
+				__( 'Marketing', 'woocommerce' ),
+				__( 'Marketing', 'woocommerce' ),
 				'manage_woocommerce',
 				'woocommerce-marketing',
 				null,
@@ -134,7 +134,7 @@ class Marketing {
 		PageController::get_instance()->register_page(
 			[
 				'id'       => 'woocommerce-marketing-overview',
-				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'title'    => __( 'Overview', 'woocommerce' ),
 				'path'     => 'wc-admin&path=/marketing',
 				'parent'   => 'woocommerce-marketing',
 				'nav_args' => array(

--- a/plugins/woocommerce/src/Internal/Admin/Notes/AddFirstProduct.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/AddFirstProduct.php
@@ -64,10 +64,10 @@ class AddFirstProduct {
 		$content_lines = array(
 			'{greetings}<br/><br/>',
 			/* translators: %s: line break */
-			sprintf( __( 'Nice one; you\'ve created a WooCommerce store! Now it\'s time to add your first product and get ready to start selling.%s', 'woocommerce-admin' ), '<br/><br/>' ),
-			__( 'There are three ways to add your products: you can <strong>create products manually, import them at once via CSV file</strong>, or <strong>migrate them from another service</strong>.<br/><br/>', 'woocommerce-admin' ),
+			sprintf( __( 'Nice one; you\'ve created a WooCommerce store! Now it\'s time to add your first product and get ready to start selling.%s', 'woocommerce' ), '<br/><br/>' ),
+			__( 'There are three ways to add your products: you can <strong>create products manually, import them at once via CSV file</strong>, or <strong>migrate them from another service</strong>.<br/><br/>', 'woocommerce' ),
 			/* translators: %1$s is an open anchor tag (<a>) and %2$s is a close link tag (</a>). */
-			sprintf( __( '%1$1sExplore our docs%2$2s for more information, or just get started!', 'woocommerce-admin' ), '<a href="https://woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product">', '</a>' ),
+			sprintf( __( '%1$1sExplore our docs%2$2s for more information, or just get started!', 'woocommerce' ), '<a href="https://woocommerce.com/document/managing-products/?utm_source=help_panel&utm_medium=product">', '</a>' ),
 		);
 
 		$additional_data = array(
@@ -75,7 +75,7 @@ class AddFirstProduct {
 		);
 
 		$note = new Note();
-		$note->set_title( __( 'Add your first product', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Add your first product', 'woocommerce' ) );
 		$note->set_content( implode( '', $content_lines ) );
 		$note->set_content_data( (object) $additional_data );
 		$note->set_image(
@@ -87,7 +87,7 @@ class AddFirstProduct {
 		$note->set_type( Note::E_WC_ADMIN_NOTE_EMAIL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'add-first-product', __( 'Add a product', 'woocommerce-admin' ), admin_url( 'admin.php?page=wc-admin&task=products' ) );
+		$note->add_action( 'add-first-product', __( 'Add a product', 'woocommerce' ), admin_url( 'admin.php?page=wc-admin&task=products' ) );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/AddingAndManangingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/AddingAndManangingProducts.php
@@ -58,11 +58,11 @@ class AddingAndManangingProducts {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Adding and Managing Products', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Adding and Managing Products', 'woocommerce' ) );
 		$note->set_content(
 			__(
 				'Learn more about how to set up products in WooCommerce through our useful documentation about adding and managing products.',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 		$note->set_content_data( (object) array() );
@@ -71,7 +71,7 @@ class AddingAndManangingProducts {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/document/managing-products/?utm_source=inbox&utm_medium=product'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ChoosingTheme.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ChoosingTheme.php
@@ -39,15 +39,15 @@ class ChoosingTheme {
 
 		// Otherwise, create our new note.
 		$note = new Note();
-		$note->set_title( __( 'Choosing a theme?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Check out the themes that are compatible with WooCommerce and choose one aligned with your brand and business needs.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Choosing a theme?', 'woocommerce' ) );
+		$note->set_content( __( 'Check out the themes that are compatible with WooCommerce and choose one aligned with your brand and business needs.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'visit-the-theme-marketplace',
-			__( 'Visit the theme marketplace', 'woocommerce-admin' ),
+			__( 'Visit the theme marketplace', 'woocommerce' ),
 			'https://woocommerce.com/product-category/themes/?utm_source=inbox&utm_medium=product'
 		);
 		return $note;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/CompleteStoreDetails.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/CompleteStoreDetails.php
@@ -48,15 +48,15 @@ class CompleteStoreDetails {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Add your store details to complete store setup', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Complete your store details with important information for setup such as your store’s base address', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Add your store details to complete store setup', 'woocommerce' ) );
+		$note->set_content( __( 'Complete your store details with important information for setup such as your store’s base address', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'add-store-details',
-			__( 'Add store details', 'woocommerce-admin' ),
+			__( 'Add store details', 'woocommerce' ),
 			wc_admin_url( '&path=/setup-wizard' )
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/CouponPageMoved.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/CouponPageMoved.php
@@ -73,15 +73,15 @@ class CouponPageMoved {
 	 */
 	public static function get_note() {
 		$note = new Note();
-		$note->set_title( __( 'Coupon management has moved!', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Coupons can now be managed from Marketing > Coupons. Click the button below to remove the legacy WooCommerce > Coupons menu item.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Coupon management has moved!', 'woocommerce' ) );
+		$note->set_content( __( 'Coupons can now be managed from Marketing > Coupons. Click the button below to remove the legacy WooCommerce > Coupons menu item.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_UPDATE );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( new stdClass() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'remove-legacy-coupon-menu',
-			__( 'Remove legacy coupon menu', 'woocommerce-admin' ),
+			__( 'Remove legacy coupon menu', 'woocommerce' ),
 			wc_admin_url( '&action=remove-coupon-menu' ),
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/CustomizeStoreWithBlocks.php
@@ -69,15 +69,15 @@ class CustomizeStoreWithBlocks {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Customize your online store with WooCommerce blocks', 'woocommerce-admin' ) );
-		$note->set_content( __( 'With our blocks, you can select and display products, categories, filters, and more virtually anywhere on your site — no need to use shortcodes or edit lines of code. Learn more about how to use each one of them.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Customize your online store with WooCommerce blocks', 'woocommerce' ) );
+		$note->set_content( __( 'With our blocks, you can select and display products, categories, filters, and more virtually anywhere on your site — no need to use shortcodes or edit lines of code. Learn more about how to use each one of them.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'customize-store-with-blocks',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/posts/how-to-customize-your-online-store-with-woocommerce-blocks/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/CustomizingProductCatalog.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/CustomizingProductCatalog.php
@@ -66,15 +66,15 @@ class CustomizingProductCatalog {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'How to customize your product catalog', 'woocommerce-admin' ) );
-		$note->set_content( __( 'You want your product catalog and images to look great and align with your brand. This guide will give you all the tips you need to get your products looking great in your store.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'How to customize your product catalog', 'woocommerce' ) );
+		$note->set_content( __( 'You want your product catalog and images to look great and align with your brand. This guide will give you all the tips you need to get your products looking great in your store.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'day-after-first-product',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/document/woocommerce-customizer/?utm_source=inbox&utm_medium=product'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/DeactivatePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/DeactivatePlugin.php
@@ -41,15 +41,15 @@ class DeactivatePlugin {
 	 */
 	public static function get_note() {
 		$note = new Note();
-		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce. We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce' ) );
+		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce. We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'deactivate-feature-plugin',
-			__( 'Deactivate', 'woocommerce-admin' ),
+			__( 'Deactivate', 'woocommerce' ),
 			wc_admin_url( '&action=deactivate-feature-plugin' ),
 			Note::E_WC_ADMIN_NOTE_UNACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/EUVATNumber.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/EUVATNumber.php
@@ -42,10 +42,10 @@ class EUVATNumber {
 			return;
 		}
 
-		$content = __( "If your store is based in the EU, we recommend using the EU VAT Number extension in addition to automated taxes. It provides your checkout with a field to collect and validate a customer's EU VAT number, if they have one.", 'woocommerce-admin' );
+		$content = __( "If your store is based in the EU, we recommend using the EU VAT Number extension in addition to automated taxes. It provides your checkout with a field to collect and validate a customer's EU VAT number, if they have one.", 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Collect and validate EU VAT numbers at checkout', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Collect and validate EU VAT numbers at checkout', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
@@ -53,7 +53,7 @@ class EUVATNumber {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/products/eu-vat-number/?utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/EditProductsOnTheMove.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/EditProductsOnTheMove.php
@@ -54,15 +54,15 @@ class EditProductsOnTheMove {
 
 		$note = new Note();
 
-		$note->set_title( __( 'Edit products on the move', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Edit and create new products from your mobile devices with the Woo app', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Edit products on the move', 'woocommerce' ) );
+		$note->set_content( __( 'Edit and create new products from your mobile devices with the Woo app', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/mobile/?utm_source=inbox&utm_medium=product'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/EmailNotification.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/EmailNotification.php
@@ -32,7 +32,7 @@ class EmailNotification extends \WC_Email {
 		$this->id            = 'merchant_notification';
 		$this->template_base = WC_ADMIN_ABSPATH . 'includes/react-admin/emails/';
 		$this->placeholders  = array(
-			'{greetings}' => __( 'Hi there,', 'woocommerce-admin' ),
+			'{greetings}' => __( 'Hi there,', 'woocommerce' ),
 		);
 
 		// Call parent constructor.
@@ -206,7 +206,7 @@ class EmailNotification extends \WC_Email {
 
 		if ( $user_name ) {
 			/* translators: %s = merchant name */
-			$this->placeholders['{greetings}'] = sprintf( __( 'Hi %s,', 'woocommerce-admin' ), $user_name );
+			$this->placeholders['{greetings}'] = sprintf( __( 'Hi %s,', 'woocommerce' ), $user_name );
 		}
 
 		$this->send(

--- a/plugins/woocommerce/src/Internal/Admin/Notes/FirstDownlaodableProduct.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/FirstDownlaodableProduct.php
@@ -49,11 +49,11 @@ class FirstDownlaodableProduct {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Learn more about digital/downloadable products', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Learn more about digital/downloadable products', 'woocommerce' ) );
 		$note->set_content(
 			__(
 				'Congrats on adding your first digital product! You can learn more about how to handle digital or downloadable products in our documentation.',
-				'woocommerce-admin'
+				'woocommerce'
 			)
 		);
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
@@ -62,7 +62,7 @@ class FirstDownlaodableProduct {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'first-downloadable-product-handling',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/document/digital-downloadable-product-handling/?utm_source=inbox&utm_medium=product'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/FirstProduct.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/FirstProduct.php
@@ -69,15 +69,15 @@ class FirstProduct {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Do you need help with adding your first product?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'This video tutorial will help you go through the process of adding your first product in WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Do you need help with adding your first product?', 'woocommerce' ) );
+		$note->set_content( __( 'This video tutorial will help you go through the process of adding your first product in WooCommerce.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'first-product-watch-tutorial',
-			__( 'Watch tutorial', 'woocommerce-admin' ),
+			__( 'Watch tutorial', 'woocommerce' ),
 			'https://www.youtube.com/watch?v=sFtXa00Jf_o&list=PLHdG8zvZd0E575Ia8Mu3w1h750YLXNfsC&index=24'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/GivingFeedbackNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/GivingFeedbackNotes.php
@@ -39,15 +39,15 @@ class GivingFeedbackNotes {
 
 		// Otherwise, create our new note.
 		$note = new Note();
-		$note->set_title( __( 'You\'re invited to share your experience', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Now that you’ve chosen us as a partner, our goal is to make sure we\'re providing the right tools to meet your needs. We\'re looking forward to having your feedback on the store setup experience so we can improve it in the future.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'You\'re invited to share your experience', 'woocommerce' ) );
+		$note->set_content( __( 'Now that you’ve chosen us as a partner, our goal is to make sure we\'re providing the right tools to meet your needs. We\'re looking forward to having your feedback on the store setup experience so we can improve it in the future.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'share-feedback',
-			__( 'Share feedback', 'woocommerce-admin' ),
+			__( 'Share feedback', 'woocommerce' ),
 			Survey::get_url( '/store-setup-survey' )
 		);
 		return $note;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstProductAndPayment.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstProductAndPayment.php
@@ -40,28 +40,28 @@ class InsightFirstProductAndPayment {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Insight', 'woocommerce-admin' ) );
-		$note->set_content( __( 'More than 80% of new merchants add the first product and have at least one payment method set up during the first week.<br><br>Do you find this type of insight useful?', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Insight', 'woocommerce' ) );
+		$note->set_content( __( 'More than 80% of new merchants add the first product and have at least one payment method set up during the first week.<br><br>Do you find this type of insight useful?', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_SURVEY );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'affirm-insight-first-product-and-payment',
-			__( 'Yes', 'woocommerce-admin' ),
+			__( 'Yes', 'woocommerce' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false,
-			__( 'Thanks for your feedback', 'woocommerce-admin' )
+			__( 'Thanks for your feedback', 'woocommerce' )
 		);
 
 		$note->add_action(
 			'affirm-insight-first-product-and-payment',
-			__( 'No', 'woocommerce-admin' ),
+			__( 'No', 'woocommerce' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false,
-			__( 'Thanks for your feedback', 'woocommerce-admin' )
+			__( 'Thanks for your feedback', 'woocommerce' )
 		);
 
 		return $note;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstSale.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InsightFirstSale.php
@@ -39,8 +39,8 @@ class InsightFirstSale {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Did you know?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'A WooCommerce powered store needs on average 31 days to get the first sale. You\'re on the right track! Do you find this type of insight useful?', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Did you know?', 'woocommerce' ) );
+		$note->set_content( __( 'A WooCommerce powered store needs on average 31 days to get the first sale. You\'re on the right track! Do you find this type of insight useful?', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_SURVEY );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
@@ -51,19 +51,19 @@ class InsightFirstSale {
 		// sent in NoteActions.
 		$note->add_action(
 			'affirm-insight-first-sale',
-			__( 'Yes', 'woocommerce-admin' ),
+			__( 'Yes', 'woocommerce' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false,
-			__( 'Thanks for your feedback', 'woocommerce-admin' )
+			__( 'Thanks for your feedback', 'woocommerce' )
 		);
 		$note->add_action(
 			'deny-insight-first-sale',
-			__( 'No', 'woocommerce-admin' ),
+			__( 'No', 'woocommerce' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false,
-			__( 'Thanks for your feedback', 'woocommerce-admin' )
+			__( 'Thanks for your feedback', 'woocommerce' )
 		);
 
 		return $note;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -47,10 +47,10 @@ class InstallJPAndWCSPlugins {
 	 * @return Note
 	 */
 	public static function get_note() {
-		$content = __( 'We noticed that there was a problem during the Jetpack and WooCommerce Shipping & Tax install. Please try again and enjoy all the advantages of having the plugins connected to your store! Sorry for the inconvenience. The "Jetpack" and "WooCommerce Shipping & Tax" plugins will be installed & activated for free.', 'woocommerce-admin' );
+		$content = __( 'We noticed that there was a problem during the Jetpack and WooCommerce Shipping & Tax install. Please try again and enjoy all the advantages of having the plugins connected to your store! Sorry for the inconvenience. The "Jetpack" and "WooCommerce Shipping & Tax" plugins will be installed & activated for free.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Uh oh... There was a problem during the Jetpack and WooCommerce Shipping & Tax install. Please try again.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Uh oh... There was a problem during the Jetpack and WooCommerce Shipping & Tax install. Please try again.', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
@@ -58,7 +58,7 @@ class InstallJPAndWCSPlugins {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'install-jp-and-wcs-plugins',
-			__( 'Install plugins', 'woocommerce-admin' ),
+			__( 'Install plugins', 'woocommerce' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/LaunchChecklist.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/LaunchChecklist.php
@@ -45,16 +45,16 @@ class LaunchChecklist {
 			return;
 		}
 
-		$content = __( 'To make sure you never get that sinking "what did I forget" feeling, we\'ve put together the essential pre-launch checklist.', 'woocommerce-admin' );
+		$content = __( 'To make sure you never get that sinking "what did I forget" feeling, we\'ve put together the essential pre-launch checklist.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Ready to launch your store?', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Ready to launch your store?', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/posts/pre-launch-checklist-the-essentials/?utm_source=inbox&utm_medium=product' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce' ), 'https://woocommerce.com/posts/pre-launch-checklist-the-essentials/?utm_source=inbox&utm_medium=product' );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/MagentoMigration.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/MagentoMigration.php
@@ -83,15 +83,15 @@ class MagentoMigration {
 	public static function get_note() {
 		$note = new Note();
 
-		$note->set_title( __( 'How to Migrate from Magento to WooCommerce', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Changing platforms might seem like a big hurdle to overcome, but it is easier than you might think to move your products, customers, and orders to WooCommerce. This article will help you with going through this process.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'How to Migrate from Magento to WooCommerce', 'woocommerce' ) );
+		$note->set_content( __( 'Changing platforms might seem like a big hurdle to overcome, but it is easier than you might think to move your products, customers, and orders to WooCommerce. This article will help you with going through this process.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/posts/how-migrate-from-magento-to-woocommerce/?utm_source=inbox'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ManageOrdersOnTheGo.php
@@ -47,15 +47,15 @@ class ManageOrdersOnTheGo {
 
 		$note = new Note();
 
-		$note->set_title( __( 'Manage your orders on the go', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Look for orders, customer info, and process refunds in one click with the Woo app.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Manage your orders on the go', 'woocommerce' ) );
+		$note->set_content( __( 'Look for orders, customer info, and process refunds in one click with the Woo app.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/mobile/?utm_source=inbox&utm_medium=product'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ManageStoreActivityFromHomeScreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ManageStoreActivityFromHomeScreen.php
@@ -51,14 +51,14 @@ class ManageStoreActivityFromHomeScreen {
 
 		$note = new Note();
 
-		$note->set_title( __( 'New! Manage your store activity from the Home screen', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Start your day knowing the next steps you need to take with your orders, products, and customer feedback.<br/><br/>Read more about how to use the activity panels on the Home screen.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'New! Manage your store activity from the Home screen', 'woocommerce' ) );
+		$note->set_content( __( 'Start your day knowing the next steps you need to take with your orders, products, and customer feedback.<br/><br/>Read more about how to use the activity panels on the Home screen.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/document/home-screen/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/MarketingJetpack.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/MarketingJetpack.php
@@ -101,8 +101,8 @@ class MarketingJetpack {
 	 */
 	public static function get_note() {
 		$note = new Note();
-		$note->set_title( __( 'Protect your WooCommerce Store with Jetpack Backup.', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Store downtime means lost sales. One-click restores get you back online quickly if something goes wrong.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Protect your WooCommerce Store with Jetpack Backup.', 'woocommerce' ) );
+		$note->set_content( __( 'Store downtime means lost sales. One-click restores get you back online quickly if something goes wrong.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_layout( 'thumbnail' );
@@ -113,7 +113,7 @@ class MarketingJetpack {
 		$note->set_source( 'woocommerce-admin-notes' );
 		$note->add_action(
 			'jetpack-backup-woocommerce',
-			__( 'Get backups', 'woocommerce-admin' ),
+			__( 'Get backups', 'woocommerce' ),
 			esc_url( 'https://jetpack.com/upgrade/backup-woocommerce/?utm_source=inbox&utm_medium=automattic_referred&utm_campaign=jp_backup_to_woo' ),
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/MigrateFromShopify.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/MigrateFromShopify.php
@@ -62,15 +62,15 @@ class MigrateFromShopify {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Do you want to migrate from Shopify to WooCommerce?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Changing eCommerce platforms might seem like a big hurdle to overcome, but it is easier than you might think to move your products, customers, and orders to WooCommerce. This article will help you with going through this process.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Do you want to migrate from Shopify to WooCommerce?', 'woocommerce' ) );
+		$note->set_content( __( 'Changing eCommerce platforms might seem like a big hurdle to overcome, but it is easier than you might think to move your products, customers, and orders to WooCommerce. This article will help you with going through this process.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'migrate-from-shopify',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/posts/migrate-from-shopify-to-woocommerce/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/MobileApp.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/MobileApp.php
@@ -38,16 +38,16 @@ class MobileApp {
 			return;
 		}
 
-		$content = __( 'Install the WooCommerce mobile app to manage orders, receive sales notifications, and view key metrics — wherever you are.', 'woocommerce-admin' );
+		$content = __( 'Install the WooCommerce mobile app to manage orders, receive sales notifications, and view key metrics — wherever you are.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Install Woo mobile app', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Install Woo mobile app', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/mobile/?utm_medium=product' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce' ), 'https://woocommerce.com/mobile/?utm_medium=product' );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/NavigationNudge.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/NavigationNudge.php
@@ -54,14 +54,14 @@ class NavigationNudge {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'You now have access to the WooCommerce navigation', 'woocommerce-admin' ) );
-		$note->set_content( __( 'We’re introducing a new navigation for a more intuitive and improved user experience. You can enable the beta version of the new experience in the Advanced Settings. Enable it now for your store.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'You now have access to the WooCommerce navigation', 'woocommerce' ) );
+		$note->set_content( __( 'We’re introducing a new navigation for a more intuitive and improved user experience. You can enable the beta version of the new experience in the Advanced Settings. Enable it now for your store.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'enable-navigation',
-			__( 'Enable in Settings', 'woocommerce-admin' ),
+			__( 'Enable in Settings', 'woocommerce' ),
 			admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' )
 		);
 		return $note;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/NewSalesRecord.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/NewSalesRecord.php
@@ -110,7 +110,7 @@ class NewSalesRecord {
 
 			$content = sprintf(
 				/* translators: 1 and 4: Date (e.g. October 16th), 2 and 3: Amount (e.g. $160.00) */
-				__( 'Woohoo, %1$s was your record day for sales! Net sales was %2$s beating the previous record of %3$s set on %4$s.', 'woocommerce-admin' ),
+				__( 'Woohoo, %1$s was your record day for sales! Net sales was %2$s beating the previous record of %3$s set on %4$s.', 'woocommerce' ),
 				$formatted_yesterday,
 				$formatted_total,
 				$formatted_record_amt,
@@ -131,13 +131,13 @@ class NewSalesRecord {
 
 			// And now, create our new note.
 			$note = new Note();
-			$note->set_title( __( 'New sales record!', 'woocommerce-admin' ) );
+			$note->set_title( __( 'New sales record!', 'woocommerce' ) );
 			$note->set_content( $content );
 			$note->set_content_data( $content_data );
 			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 			$note->set_name( self::NOTE_NAME );
 			$note->set_source( 'woocommerce-admin' );
-			$note->add_action( 'view-report', __( 'View report', 'woocommerce-admin' ), $report_url );
+			$note->add_action( 'view-report', __( 'View report', 'woocommerce' ), $report_url );
 			$note->save();
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OnboardingPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OnboardingPayments.php
@@ -50,15 +50,15 @@ class OnboardingPayments {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Start accepting payments on your store!', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Take payments with the provider that’s right for you - choose from 100+ payment gateways for WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Start accepting payments on your store!', 'woocommerce' ) );
+		$note->set_content( __( 'Take payments with the provider that’s right for you - choose from 100+ payment gateways for WooCommerce.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'view-payment-gateways',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OnlineClothingStore.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OnlineClothingStore.php
@@ -81,15 +81,15 @@ class OnlineClothingStore {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Start your online clothing store', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Starting a fashion website is exciting but it may seem overwhelming as well. In this article, we\'ll walk you through the setup process, teach you to create successful product listings, and show you how to market to your ideal audience.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Start your online clothing store', 'woocommerce' ) );
+		$note->set_content( __( 'Starting a fashion website is exciting but it may seem overwhelming as well. In this article, we\'ll walk you through the setup process, teach you to create successful product listings, and show you how to market to your ideal audience.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'online-clothing-store',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/posts/starting-an-online-clothing-store/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
@@ -182,7 +182,7 @@ class OrderMilestones {
 	public function get_note_title_for_milestone( $milestone ) {
 		switch ( $milestone ) {
 			case 1:
-				return __( 'First order received', 'woocommerce-admin' );
+				return __( 'First order received', 'woocommerce' );
 			case 10:
 			case 100:
 			case 250:
@@ -194,7 +194,7 @@ class OrderMilestones {
 			case 1000000:
 				return sprintf(
 					/* translators: Number of orders processed. */
-					__( 'Congratulations on processing %s orders!', 'woocommerce-admin' ),
+					__( 'Congratulations on processing %s orders!', 'woocommerce' ),
 					wc_format_decimal( $milestone )
 				);
 			default:
@@ -211,9 +211,9 @@ class OrderMilestones {
 	public function get_note_content_for_milestone( $milestone ) {
 		switch ( $milestone ) {
 			case 1:
-				return __( 'Congratulations on getting your first order! Now is a great time to learn how to manage your orders.', 'woocommerce-admin' );
+				return __( 'Congratulations on getting your first order! Now is a great time to learn how to manage your orders.', 'woocommerce' );
 			case 10:
-				return __( "You've hit the 10 orders milestone! Look at you go. Browse some WooCommerce success stories for inspiration.", 'woocommerce-admin' );
+				return __( "You've hit the 10 orders milestone! Look at you go. Browse some WooCommerce success stories for inspiration.", 'woocommerce' );
 			case 100:
 			case 250:
 			case 500:
@@ -222,7 +222,7 @@ class OrderMilestones {
 			case 10000:
 			case 500000:
 			case 1000000:
-				return __( 'Another order milestone! Take a look at your Orders Report to review your orders to date.', 'woocommerce-admin' );
+				return __( 'Another order milestone! Take a look at your Orders Report to review your orders to date.', 'woocommerce' );
 			default:
 				return '';
 		}
@@ -239,13 +239,13 @@ class OrderMilestones {
 			case 1:
 				return array(
 					'name'  => 'learn-more',
-					'label' => __( 'Learn more', 'woocommerce-admin' ),
+					'label' => __( 'Learn more', 'woocommerce' ),
 					'query' => 'https://woocommerce.com/document/managing-orders/?utm_source=inbox&utm_medium=product',
 				);
 			case 10:
 				return array(
 					'name'  => 'browse',
-					'label' => __( 'Browse', 'woocommerce-admin' ),
+					'label' => __( 'Browse', 'woocommerce' ),
 					'query' => 'https://woocommerce.com/success-stories/?utm_source=inbox&utm_medium=product',
 				);
 			case 100:
@@ -258,7 +258,7 @@ class OrderMilestones {
 			case 1000000:
 				return array(
 					'name'  => 'review-orders',
-					'label' => __( 'Review your orders', 'woocommerce-admin' ),
+					'label' => __( 'Review your orders', 'woocommerce' ),
 					'query' => '?page=wc-admin&path=/analytics/orders',
 				);
 			default:

--- a/plugins/woocommerce/src/Internal/Admin/Notes/PaymentsRemindMeLater.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/PaymentsRemindMeLater.php
@@ -68,16 +68,16 @@ class PaymentsRemindMeLater {
 		if ( ! self::should_display_note() ) {
 			return;
 		}
-		$content = __( 'Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'woocommerce-admin' );
+		$content = __( 'Save up to $800 in fees by managing transactions with WooCommerce Payments. With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Save big with WooCommerce Payments', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Save big with WooCommerce Payments', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), admin_url( 'admin.php?page=wc-admin&path=/wc-pay-welcome-page' ) );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce' ), admin_url( 'admin.php?page=wc-admin&path=/wc-pay-welcome-page' ) );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/PerformanceOnMobile.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/PerformanceOnMobile.php
@@ -51,15 +51,15 @@ class PerformanceOnMobile {
 
 		$note = new Note();
 
-		$note->set_title( __( 'Track your store performance on mobile', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Monitor your sales and high performing products with the Woo app.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Track your store performance on mobile', 'woocommerce' ) );
+		$note->set_content( __( 'Monitor your sales and high performing products with the Woo app.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/mobile/?utm_source=inbox&utm_medium=product'
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/PersonalizeStore.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/PersonalizeStore.php
@@ -48,16 +48,16 @@ class PersonalizeStore {
 			return;
 		}
 
-		$content = __( 'The homepage is one of the most important entry points in your store. When done right it can lead to higher conversions and engagement. Don\'t forget to personalize the homepage that we created for your store during the onboarding.', 'woocommerce-admin' );
+		$content = __( 'The homepage is one of the most important entry points in your store. When done right it can lead to higher conversions and engagement. Don\'t forget to personalize the homepage that we created for your store during the onboarding.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Personalize your store\'s homepage', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Personalize your store\'s homepage', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce-admin' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), Note::E_WC_ADMIN_NOTE_ACTIONED );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/RealTimeOrderAlerts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/RealTimeOrderAlerts.php
@@ -42,16 +42,16 @@ class RealTimeOrderAlerts {
 			return;
 		}
 
-		$content = __( 'Get notifications about store activity, including new orders and product reviews directly on your mobile devices with the Woo app.', 'woocommerce-admin' );
+		$content = __( 'Get notifications about store activity, including new orders and product reviews directly on your mobile devices with the Woo app.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Get real-time order alerts anywhere', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Get real-time order alerts anywhere', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/mobile/?utm_source=inbox&utm_medium=product' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce' ), 'https://woocommerce.com/mobile/?utm_source=inbox&utm_medium=product' );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/SellingOnlineCourses.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/SellingOnlineCourses.php
@@ -67,15 +67,15 @@ class SellingOnlineCourses {
 	public static function get_note() {
 		$note = new Note();
 
-		$note->set_title( __( 'Do you want to sell online courses?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Online courses are a great solution for any business that can teach a new skill. Since courses don’t require physical product development or shipping, they’re affordable, fast to create, and can generate passive income for years to come. In this article, we provide you more information about selling courses using WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Do you want to sell online courses?', 'woocommerce' ) );
+		$note->set_content( __( 'Online courses are a great solution for any business that can teach a new skill. Since courses don’t require physical product development or shipping, they’re affordable, fast to create, and can generate passive income for years to come. In this article, we provide you more information about selling courses using WooCommerce.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://woocommerce.com/posts/how-to-sell-online-courses-wordpress/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Notes/SetUpAdditionalPaymentTypes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/SetUpAdditionalPaymentTypes.php
@@ -91,11 +91,11 @@ class SetUpAdditionalPaymentTypes {
 	 * @return Note
 	 */
 	public static function get_note() {
-		$content = __( 'Set up additional payment providers, using third-party services or other methods.', 'woocommerce-admin' );
+		$content = __( 'Set up additional payment providers, using third-party services or other methods.', 'woocommerce' );
 
 		$note = new Note();
 
-		$note->set_title( __( 'Set up additional payment providers', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Set up additional payment providers', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
@@ -103,7 +103,7 @@ class SetUpAdditionalPaymentTypes {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'set-up-payments',
-			__( 'Set up payments', 'woocommerce-admin' ),
+			__( 'Set up payments', 'woocommerce' ),
 			wc_admin_url( '&task=payments' ),
 			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true

--- a/plugins/woocommerce/src/Internal/Admin/Notes/TestCheckout.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/TestCheckout.php
@@ -89,16 +89,16 @@ class TestCheckout {
 			return;
 		}
 
-		$content = __( 'Make sure that your checkout is working properly before you launch your store. Go through your checkout process in its entirety: from adding a product to your cart, choosing a shipping location, and making a payment.', 'woocommerce-admin' );
+		$content = __( 'Make sure that your checkout is working properly before you launch your store. Go through your checkout process in its entirety: from adding a product to your cart, choosing a shipping location, and making a payment.', 'woocommerce' );
 
 		$note = new Note();
-		$note->set_title( __( 'Don\'t forget to test your checkout', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Don\'t forget to test your checkout', 'woocommerce' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'test-checkout', __( 'Test checkout', 'woocommerce-admin' ), wc_get_page_permalink( 'shop' ) );
+		$note->add_action( 'test-checkout', __( 'Test checkout', 'woocommerce' ), wc_get_page_permalink( 'shop' ) );
 		return $note;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/TrackingOptIn.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/TrackingOptIn.php
@@ -52,7 +52,7 @@ class TrackingOptIn {
 		/* translators: 1: open link to WooCommerce.com settings, 2: open link to WooCommerce.com tracking documentation, 3: close link tag. */
 		$content_format = __(
 			'Gathering usage data allows us to improve WooCommerce. Your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. You can always visit the %1$sSettings%3$s and choose to stop sharing data. %2$sRead more%3$s about what data we collect.',
-			'woocommerce-admin'
+			'woocommerce'
 		);
 
 		$note_content = sprintf(
@@ -63,13 +63,13 @@ class TrackingOptIn {
 		);
 
 		$note = new Note();
-		$note->set_title( __( 'Help WooCommerce improve with usage tracking', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Help WooCommerce improve with usage tracking', 'woocommerce' ) );
 		$note->set_content( $note_content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'tracking-opt-in', __( 'Activate usage tracking', 'woocommerce-admin' ), false, Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+		$note->add_action( 'tracking-opt-in', __( 'Activate usage tracking', 'woocommerce' ), false, Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 		return $note;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/UnsecuredReportFiles.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/UnsecuredReportFiles.php
@@ -32,11 +32,11 @@ class UnsecuredReportFiles {
 	 */
 	public static function get_note() {
 		$note = new Note();
-		$note->set_title( __( 'Potentially unsecured files were found in your uploads directory', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Potentially unsecured files were found in your uploads directory', 'woocommerce' ) );
 		$note->set_content(
 			sprintf(
 				/* translators: 1: opening analytics docs link tag. 2: closing link tag */
-				__( 'Files that may contain %1$sstore analytics%2$s reports were found in your uploads directory - we recommend assessing and deleting any such files.', 'woocommerce-admin' ),
+				__( 'Files that may contain %1$sstore analytics%2$s reports were found in your uploads directory - we recommend assessing and deleting any such files.', 'woocommerce' ),
 				'<a href="https://woocommerce.com/document/woocommerce-analytics/" target="_blank">',
 				'</a>'
 			)
@@ -47,14 +47,14 @@ class UnsecuredReportFiles {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://developer.woocommerce.com/?p=10410',
 			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 		$note->add_action(
 			'dismiss',
-			__( 'Dismiss', 'woocommerce-admin' ),
+			__( 'Dismiss', 'woocommerce' ),
 			wc_admin_url(),
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			false

--- a/plugins/woocommerce/src/Internal/Admin/Notes/UpdateStoreDetails.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/UpdateStoreDetails.php
@@ -43,15 +43,15 @@ class UpdateStoreDetails {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Edit your store details if you need to', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Nice work completing your store profile! You can always go back and edit the details you just shared, as needed.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Edit your store details if you need to', 'woocommerce' ) );
+		$note->set_content( __( 'Nice work completing your store profile! You can always go back and edit the details you just shared, as needed.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'update-store-details',
-			__( 'Update store details', 'woocommerce-admin' ),
+			__( 'Update store details', 'woocommerce' ),
 			wc_admin_url( '&path=/setup-wizard' )
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WelcomeToWooCommerceForStoreUsers.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WelcomeToWooCommerceForStoreUsers.php
@@ -43,14 +43,14 @@ class WelcomeToWooCommerceForStoreUsers {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Welcome to your new store management experience', 'woocommerce-admin' ) );
-		$note->set_content( __( "We've designed your navigation and home screen to help you focus on the things that matter most in managing your online store.", 'woocommerce-admin' ) );
+		$note->set_title( __( 'Welcome to your new store management experience', 'woocommerce' ) );
+		$note->set_content( __( "We've designed your navigation and home screen to help you focus on the things that matter most in managing your online store.", 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce' ),
 			'https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"',
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooCommercePayments.php
@@ -103,13 +103,13 @@ class WooCommercePayments {
 	 */
 	public static function get_note() {
 		$note = new Note();
-		$note->set_title( __( 'Try the new way to get paid', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Try the new way to get paid', 'woocommerce' ) );
 		$note->set_content(
-			__( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with <strong>WooCommerce Payments</strong>.', 'woocommerce-admin' ) .
+			__( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with <strong>WooCommerce Payments</strong>.', 'woocommerce' ) .
 			'<br><br>' .
 			sprintf(
 				/* translators: 1: opening link tag, 2: closing tag */
-				__( 'By clicking "Get started", you agree to our %1$sTerms of Service%2$s', 'woocommerce-admin' ),
+				__( 'By clicking "Get started", you agree to our %1$sTerms of Service%2$s', 'woocommerce' ),
 				'<a href="https://wordpress.com/tos/" target="_blank">',
 				'</a>'
 			)
@@ -118,8 +118,8 @@ class WooCommercePayments {
 		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/payments/?utm_medium=product', Note::E_WC_ADMIN_NOTE_UNACTIONED );
-		$note->add_action( 'get-started', __( 'Get started', 'woocommerce-admin' ), wc_admin_url( '&action=setup-woocommerce-payments' ), Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce' ), 'https://woocommerce.com/payments/?utm_medium=product', Note::E_WC_ADMIN_NOTE_UNACTIONED );
+		$note->add_action( 'get-started', __( 'Get started', 'woocommerce' ), wc_admin_url( '&action=setup-woocommerce-payments' ), Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 		$note->add_nonce_to_action( 'get-started', 'setup-woocommerce-payments', '' );
 
 		// Create the note as "actioned" if the plugin is already installed.

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooCommerceSubscriptions.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooCommerceSubscriptions.php
@@ -44,15 +44,15 @@ class WooCommerceSubscriptions {
 		}
 
 		$note = new Note();
-		$note->set_title( __( 'Do you need more info about WooCommerce Subscriptions?', 'woocommerce-admin' ) );
-		$note->set_content( __( 'WooCommerce Subscriptions allows you to introduce a variety of subscriptions for physical or virtual products and services. Create product-of-the-month clubs, weekly service subscriptions or even yearly software billing packages. Add sign-up fees, offer free trials, or set expiration periods.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Do you need more info about WooCommerce Subscriptions?', 'woocommerce' ) );
+		$note->set_content( __( 'WooCommerce Subscriptions allows you to introduce a variety of subscriptions for physical or virtual products and services. Create product-of-the-month clubs, weekly service subscriptions or even yearly software billing packages. Add sign-up fees, offer free trials, or set expiration periods.', 'woocommerce' ) );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn More', 'woocommerce-admin' ),
+			__( 'Learn More', 'woocommerce' ),
 			'https://woocommerce.com/products/woocommerce-subscriptions/?utm_source=inbox&utm_medium=product',
 			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
@@ -182,15 +182,15 @@ class WooSubscriptionsNotes {
 	 */
 	public function add_no_connection_note() {
 		$note = new Note();
-		$note->set_title( __( 'Connect to WooCommerce.com', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Connect to get important product notifications and updates.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Connect to WooCommerce.com', 'woocommerce' ) );
+		$note->set_content( __( 'Connect to get important product notifications and updates.', 'woocommerce' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::CONNECTION_NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'connect',
-			__( 'Connect', 'woocommerce-admin' ),
+			__( 'Connect', 'woocommerce' ),
 			'?page=wc-addons&section=helper',
 			Note::E_WC_ADMIN_NOTE_UNACTIONED
 		);
@@ -311,13 +311,13 @@ class WooSubscriptionsNotes {
 
 		$note_title = sprintf(
 			/* translators: name of the extension subscription expiring soon */
-			__( '%s subscription expiring soon', 'woocommerce-admin' ),
+			__( '%s subscription expiring soon', 'woocommerce' ),
 			$product_name
 		);
 
 		$note_content = sprintf(
 			/* translators: number of days until the subscription expires */
-			__( 'Your subscription expires in %d days. Enable autorenew to avoid losing updates and access to support.', 'woocommerce-admin' ),
+			__( 'Your subscription expires in %d days. Enable autorenew to avoid losing updates and access to support.', 'woocommerce' ),
 			$days_until_expiration
 		);
 
@@ -340,7 +340,7 @@ class WooSubscriptionsNotes {
 		$note->clear_actions();
 		$note->add_action(
 			'enable-autorenew',
-			__( 'Enable Autorenew', 'woocommerce-admin' ),
+			__( 'Enable Autorenew', 'woocommerce' ),
 			'https://woocommerce.com/my-account/my-subscriptions/?utm_medium=product'
 		);
 		$note->set_content( $note_content );
@@ -372,13 +372,13 @@ class WooSubscriptionsNotes {
 
 		$note_title = sprintf(
 			/* translators: name of the extension subscription that expired */
-			__( '%s subscription expired', 'woocommerce-admin' ),
+			__( '%s subscription expired', 'woocommerce' ),
 			$product_name
 		);
 
 		$note_content = sprintf(
 			/* translators: date the subscription expired, e.g. Jun 7th 2018 */
-			__( 'Your subscription expired on %s. Get a new subscription to continue receiving updates and access to support.', 'woocommerce-admin' ),
+			__( 'Your subscription expired on %s. Get a new subscription to continue receiving updates and access to support.', 'woocommerce' ),
 			$expires_date
 		);
 
@@ -403,7 +403,7 @@ class WooSubscriptionsNotes {
 		$note->clear_actions();
 		$note->add_action(
 			'renew-subscription',
-			__( 'Renew Subscription', 'woocommerce-admin' ),
+			__( 'Renew Subscription', 'woocommerce' ),
 			$product_page
 		);
 		$note->save();

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingHelper.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingHelper.php
@@ -70,7 +70,7 @@ class OnboardingHelper {
 
 		// Add the new help tab.
 		$help_tab = array(
-			'title' => __( 'Setup wizard', 'woocommerce-admin' ),
+			'title' => __( 'Setup wizard', 'woocommerce' ),
 			'id'    => 'woocommerce_onboard_tab',
 		);
 
@@ -78,26 +78,26 @@ class OnboardingHelper {
 		$extended_list = TaskLists::get_list( 'extended' );
 
 		if ( $setup_list ) {
-			$help_tab['content'] = '<h2>' . __( 'WooCommerce Onboarding', 'woocommerce-admin' ) . '</h2>';
+			$help_tab['content'] = '<h2>' . __( 'WooCommerce Onboarding', 'woocommerce' ) . '</h2>';
 
-			$help_tab['content'] .= '<h3>' . __( 'Profile Setup Wizard', 'woocommerce-admin' ) . '</h3>';
-			$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-				'<p><a href="' . wc_admin_url( '&path=/setup-wizard' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
+			$help_tab['content'] .= '<h3>' . __( 'Profile Setup Wizard', 'woocommerce' ) . '</h3>';
+			$help_tab['content'] .= '<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce' ) . '</p>' .
+				'<p><a href="' . wc_admin_url( '&path=/setup-wizard' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce' ) . '</a></p>';
 
-			$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce-admin' ) . '</h3>';
-			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task lists, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
+			$help_tab['content'] .= '<h3>' . __( 'Task List', 'woocommerce' ) . '</h3>';
+			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the task lists, please click on the button below.', 'woocommerce' ) . '</p>' .
 			( $setup_list->is_hidden()
-				? '<p><a href="' . wc_admin_url( '&reset_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
-				: '<p><a href="' . wc_admin_url( '&reset_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
+				? '<p><a href="' . wc_admin_url( '&reset_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce' ) . '</a></p>'
+				: '<p><a href="' . wc_admin_url( '&reset_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce' ) . '</a></p>'
 			);
 		}
 
 		if ( $extended_list ) {
-			$help_tab['content'] .= '<h3>' . __( 'Extended task List', 'woocommerce-admin' ) . '</h3>';
-			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the extended task lists, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
+			$help_tab['content'] .= '<h3>' . __( 'Extended task List', 'woocommerce' ) . '</h3>';
+			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the extended task lists, please click on the button below.', 'woocommerce' ) . '</p>' .
 			( $extended_list->is_hidden()
-				? '<p><a href="' . wc_admin_url( '&reset_extended_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
-				: '<p><a href="' . wc_admin_url( '&reset_extended_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
+				? '<p><a href="' . wc_admin_url( '&reset_extended_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce' ) . '</a></p>'
+				: '<p><a href="' . wc_admin_url( '&reset_extended_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce' ) . '</a></p>'
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingIndustries.php
@@ -28,44 +28,44 @@ class OnboardingIndustries {
 			'woocommerce_admin_onboarding_industries',
 			array(
 				'fashion-apparel-accessories'     => array(
-					'label'             => __( 'Fashion, apparel, and accessories', 'woocommerce-admin' ),
+					'label'             => __( 'Fashion, apparel, and accessories', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'health-beauty'                   => array(
-					'label'             => __( 'Health and beauty', 'woocommerce-admin' ),
+					'label'             => __( 'Health and beauty', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'electronics-computers'           => array(
-					'label'             => __( 'Electronics and computers', 'woocommerce-admin' ),
+					'label'             => __( 'Electronics and computers', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'food-drink'                      => array(
-					'label'             => __( 'Food and drink', 'woocommerce-admin' ),
+					'label'             => __( 'Food and drink', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'home-furniture-garden'           => array(
-					'label'             => __( 'Home, furniture, and garden', 'woocommerce-admin' ),
+					'label'             => __( 'Home, furniture, and garden', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'cbd-other-hemp-derived-products' => array(
-					'label'             => __( 'CBD and other hemp-derived products', 'woocommerce-admin' ),
+					'label'             => __( 'CBD and other hemp-derived products', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'education-and-learning'          => array(
-					'label'             => __( 'Education and learning', 'woocommerce-admin' ),
+					'label'             => __( 'Education and learning', 'woocommerce' ),
 					'use_description'   => false,
 					'description_label' => '',
 				),
 				'other'                           => array(
-					'label'             => __( 'Other', 'woocommerce-admin' ),
+					'label'             => __( 'Other', 'woocommerce' ),
 					'use_description'   => true,
-					'description_label' => __( 'Description', 'woocommerce-admin' ),
+					'description_label' => __( 'Description', 'woocommerce' ),
 				),
 			)
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -31,29 +31,29 @@ class OnboardingProducts {
 	public static function get_allowed_product_types() {
 		$products         = array(
 			'physical'        => array(
-				'label'   => __( 'Physical products', 'woocommerce-admin' ),
+				'label'   => __( 'Physical products', 'woocommerce' ),
 				'default' => true,
 			),
 			'downloads'       => array(
-				'label' => __( 'Downloads', 'woocommerce-admin' ),
+				'label' => __( 'Downloads', 'woocommerce' ),
 			),
 			'subscriptions'   => array(
-				'label' => __( 'Subscriptions', 'woocommerce-admin' ),
+				'label' => __( 'Subscriptions', 'woocommerce' ),
 			),
 			'memberships'     => array(
-				'label'   => __( 'Memberships', 'woocommerce-admin' ),
+				'label'   => __( 'Memberships', 'woocommerce' ),
 				'product' => 958589,
 			),
 			'bookings'        => array(
-				'label'   => __( 'Bookings', 'woocommerce-admin' ),
+				'label'   => __( 'Bookings', 'woocommerce' ),
 				'product' => 390890,
 			),
 			'product-bundles' => array(
-				'label'   => __( 'Bundles', 'woocommerce-admin' ),
+				'label'   => __( 'Bundles', 'woocommerce' ),
 				'product' => 18716,
 			),
 			'product-add-ons' => array(
-				'label'   => __( 'Customizable products', 'woocommerce-admin' ),
+				'label'   => __( 'Customizable products', 'woocommerce' ),
 				'product' => 18618,
 			),
 		);
@@ -116,7 +116,7 @@ class OnboardingProducts {
 				$product_data[ $key ]['slug']         = strtolower( preg_replace( '~[^\pL\d]+~u', '-', $products[ $product_type['product'] ]->slug ) );
 			} elseif ( isset( $product_type['product'] ) ) {
 				/* translators: site currency symbol (used to show that the product costs money) */
-				$product_data[ $key ]['label'] .= sprintf( __( ' — %s', 'woocommerce-admin' ), html_entity_decode( get_woocommerce_currency_symbol() ) );
+				$product_data[ $key ]['label'] .= sprintf( __( ' — %s', 'woocommerce' ), html_entity_decode( get_woocommerce_currency_symbol() ) );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -22,7 +22,7 @@ class DefaultFreeExtensions {
 		$bundles = [
 			[
 				'key'     => 'obw/basics',
-				'title'   => __( 'Get the basics', 'woocommerce-admin' ),
+				'title'   => __( 'Get the basics', 'woocommerce' ),
 				'plugins' => [
 					self::get_plugin( 'woocommerce-payments' ),
 					self::get_plugin( 'woocommerce-services:shipping' ),
@@ -32,7 +32,7 @@ class DefaultFreeExtensions {
 			],
 			[
 				'key'     => 'obw/grow',
-				'title'   => __( 'Grow your store', 'woocommerce-admin' ),
+				'title'   => __( 'Grow your store', 'woocommerce' ),
 				'plugins' => [
 					self::get_plugin( 'mailpoet' ),
 					self::get_plugin( 'google-listings-and-ads' ),
@@ -40,7 +40,7 @@ class DefaultFreeExtensions {
 			],
 			[
 				'key'     => 'task-list/reach',
-				'title'   => __( 'Reach out to customers', 'woocommerce-admin' ),
+				'title'   => __( 'Reach out to customers', 'woocommerce' ),
 				'plugins' => [
 					self::get_plugin( 'mailpoet:alt' ),
 					self::get_plugin( 'mailchimp-for-woocommerce' ),
@@ -49,7 +49,7 @@ class DefaultFreeExtensions {
 			],
 			[
 				'key'     => 'task-list/grow',
-				'title'   => __( 'Grow your store', 'woocommerce-admin' ),
+				'title'   => __( 'Grow your store', 'woocommerce' ),
 				'plugins' => [
 					self::get_plugin( 'google-listings-and-ads:alt' ),
 				],
@@ -69,10 +69,10 @@ class DefaultFreeExtensions {
 	public static function get_plugin( $slug ) {
 		$plugins = array(
 			'google-listings-and-ads'           => [
-				'name'           => __( 'Google Listings & Ads', 'woocommerce-admin' ),
+				'name'           => __( 'Google Listings & Ads', 'woocommerce' ),
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Drive sales with %1$sGoogle Listings and Ads%2$s', 'woocommerce-admin' ),
+					__( 'Drive sales with %1$sGoogle Listings and Ads%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/google-listings-and-ads" target="_blank">',
 					'</a>'
 				),
@@ -92,29 +92,29 @@ class DefaultFreeExtensions {
 				],
 			],
 			'google-listings-and-ads:alt'       => [
-				'name'           => __( 'Google Listings & Ads', 'woocommerce-admin' ),
-				'description'    => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce-admin' ),
+				'name'           => __( 'Google Listings & Ads', 'woocommerce' ),
+				'description'    => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce' ),
 				'image_url'      => plugins_url( 'images/onboarding/google-listings-and-ads.png', WC_ADMIN_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc' => true,
 			],
 			'mailpoet'                          => [
-				'name'           => __( 'MailPoet', 'woocommerce-admin' ),
-				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
+				'name'           => __( 'MailPoet', 'woocommerce' ),
+				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce' ),
 				'image_url'      => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,
 			],
 			'mailchimp-for-woocommerce'         => [
-				'name'           => __( 'Mailchimp', 'woocommerce-admin' ),
-				'description'    => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce-admin' ),
+				'name'           => __( 'Mailchimp', 'woocommerce' ),
+				'description'    => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce' ),
 				'image_url'      => plugins_url( 'images/onboarding/mailchimp-for-woocommerce.png', WC_ADMIN_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailchimp-woocommerce',
 				'is_built_by_wc' => false,
 			],
 			'creative-mail-by-constant-contact' => [
-				'name'           => __( 'Creative Mail for WooCommerce', 'woocommerce-admin' ),
-				'description'    => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce-admin' ),
+				'name'           => __( 'Creative Mail for WooCommerce', 'woocommerce' ),
+				'description'    => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce' ),
 				'image_url'      => plugins_url( 'images/onboarding/creative-mail-by-constant-contact.png', WC_ADMIN_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=creativemail',
 				'is_built_by_wc' => false,
@@ -122,7 +122,7 @@ class DefaultFreeExtensions {
 			'woocommerce-payments'              => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Accept credit cards and other popular payment methods with %1$sWooCommerce Payments%2$s', 'woocommerce-admin' ),
+					__( 'Accept credit cards and other popular payment methods with %1$sWooCommerce Payments%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
 					'</a>'
 				),
@@ -260,7 +260,7 @@ class DefaultFreeExtensions {
 			'woocommerce-services:shipping'     => [
 				'description'    => sprintf(
 				/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce-admin' ),
+					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/shipping" target="_blank">',
 					'</a>'
 				),
@@ -327,7 +327,7 @@ class DefaultFreeExtensions {
 			'woocommerce-services:tax'          => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce-admin' ),
+					__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/tax" target="_blank">',
 					'</a>'
 				),
@@ -407,7 +407,7 @@ class DefaultFreeExtensions {
 			'jetpack'                           => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce-admin' ),
+					__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
 					'</a>'
 				),
@@ -425,10 +425,10 @@ class DefaultFreeExtensions {
 				'is_built_by_wc' => false,
 			],
 			'mailpoet'                          => [
-				'name'           => __( 'MailPoet', 'woocommerce-admin' ),
+				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Level up your email marketing with %1$sMailPoet%2$s', 'woocommerce-admin' ),
+					__( 'Level up your email marketing with %1$sMailPoet%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/mailpoet" target="_blank">',
 					'</a>'
 				),
@@ -447,8 +447,8 @@ class DefaultFreeExtensions {
 				'is_built_by_wc' => true,
 			],
 			'mailpoet:alt'                      => [
-				'name'           => __( 'MailPoet', 'woocommerce-admin' ),
-				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce-admin' ),
+				'name'           => __( 'MailPoet', 'woocommerce' ),
+				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce' ),
 				'image_url'      => plugins_url( 'images/onboarding/mailpoet.png', WC_ADMIN_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -240,7 +240,7 @@ class CustomersScheduler extends ImportScheduler {
 		}
 
 		// Long form query because $wpdb->update rejects [deleted].
-		$deleted_text = __( '[deleted]', 'woocommerce-admin' );
+		$deleted_text = __( '[deleted]', 'woocommerce' );
 		$updated      = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->prefix}wc_customer_lookup

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -192,7 +192,7 @@ class Settings {
 		// Plugins that depend on changing the translation work on the server but not the client -
 		// WooCommerce Branding is an example of this - so pass through the translation of
 		// 'WooCommerce' to wcSettings.
-		$settings['woocommerceTranslation'] = __( 'WooCommerce', 'woocommerce-admin' );
+		$settings['woocommerceTranslation'] = __( 'WooCommerce', 'woocommerce' );
 		// We may have synced orders with a now-unregistered status.
 		// E.g An extension that added statuses is now inactive or removed.
 		$settings['unregisteredOrderStatuses'] = $this->get_unregistered_order_statuses();
@@ -233,8 +233,8 @@ class Settings {
 	public function add_settings_group( $groups ) {
 		$groups[] = array(
 			'id'          => 'wc_admin',
-			'label'       => __( 'WooCommerce Admin', 'woocommerce-admin' ),
-			'description' => __( 'Settings for WooCommerce admin reporting.', 'woocommerce-admin' ),
+			'label'       => __( 'WooCommerce Admin', 'woocommerce' ),
+			'description' => __( 'Settings for WooCommerce admin reporting.', 'woocommerce' ),
 		);
 		return $groups;
 	}
@@ -253,8 +253,8 @@ class Settings {
 		$settings[] = array(
 			'id'          => 'woocommerce_excluded_report_order_statuses',
 			'option_key'  => 'woocommerce_excluded_report_order_statuses',
-			'label'       => __( 'Excluded report order statuses', 'woocommerce-admin' ),
-			'description' => __( 'Statuses that should not be included when calculating report totals.', 'woocommerce-admin' ),
+			'label'       => __( 'Excluded report order statuses', 'woocommerce' ),
+			'description' => __( 'Statuses that should not be included when calculating report totals.', 'woocommerce' ),
 			'default'     => array( 'pending', 'cancelled', 'failed' ),
 			'type'        => 'multiselect',
 			'options'     => $all_statuses,
@@ -262,8 +262,8 @@ class Settings {
 		$settings[] = array(
 			'id'          => 'woocommerce_actionable_order_statuses',
 			'option_key'  => 'woocommerce_actionable_order_statuses',
-			'label'       => __( 'Actionable order statuses', 'woocommerce-admin' ),
-			'description' => __( 'Statuses that require extra action on behalf of the store admin.', 'woocommerce-admin' ),
+			'label'       => __( 'Actionable order statuses', 'woocommerce' ),
+			'description' => __( 'Statuses that require extra action on behalf of the store admin.', 'woocommerce' ),
 			'default'     => array( 'processing', 'on-hold' ),
 			'type'        => 'multiselect',
 			'options'     => $all_statuses,
@@ -271,8 +271,8 @@ class Settings {
 		$settings[] = array(
 			'id'          => 'woocommerce_default_date_range',
 			'option_key'  => 'woocommerce_default_date_range',
-			'label'       => __( 'Default Date Range', 'woocommerce-admin' ),
-			'description' => __( 'Default Date Range', 'woocommerce-admin' ),
+			'label'       => __( 'Default Date Range', 'woocommerce' ),
+			'description' => __( 'Default Date Range', 'woocommerce' ),
 			'default'     => 'period=month&compare=previous_year',
 			'type'        => 'text',
 		);

--- a/plugins/woocommerce/src/Internal/Admin/SettingsNavigationFeature.php
+++ b/plugins/woocommerce/src/Internal/Admin/SettingsNavigationFeature.php
@@ -84,10 +84,10 @@ class SettingsNavigationFeature {
 	 */
 	public static function add_feature_toggle( $features ) {
 		$features[] = array(
-			'title' => __( 'Settings', 'woocommerce-admin' ),
+			'title' => __( 'Settings', 'woocommerce' ),
 			'desc'  => __(
 				'Adds the new WooCommerce settings UI.',
-				'woocommerce-admin'
+				'woocommerce'
 			),
 			'id'    => 'woocommerce_settings_enabled',
 			'type'  => 'checkbox',

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -87,7 +87,7 @@ class ShippingLabelBanner {
 		if ( $this->should_show_meta_box() ) {
 			add_meta_box(
 				'woocommerce-admin-print-label',
-				__( 'Shipping Label', 'woocommerce-admin' ),
+				__( 'Shipping Label', 'woocommerce' ),
 				array( $this, 'meta_box' ),
 				null,
 				'normal',

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -295,7 +295,7 @@ class WCAdminAssets {
 				);
 
 				if ( in_array( $script, $translated_scripts, true ) ) {
-					wp_set_script_translations( $script, 'woocommerce-admin' );
+					wp_set_script_translations( $script, 'woocommerce' );
 				}
 			} catch ( \Exception $e ) {
 				// Avoid crashing WordPress if an asset file could not be loaded.

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/WCPaymentGatewayPreInstallWCPayPromotion.php
@@ -50,9 +50,9 @@ class WCPaymentGatewayPreInstallWCPayPromotion extends \WC_Payment_Gateway {
 	public function init_form_fields() {
 		$this->form_fields = array(
 			'is_dismissed' => array(
-				'title'   => __( 'Dismiss', 'woocommerce-admin' ),
+				'title'   => __( 'Dismiss', 'woocommerce' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Dismiss the gateway', 'woocommerce-admin' ),
+				'label'   => __( 'Dismiss the gateway', 'woocommerce' ),
 				'default' => 'no',
 			),
 		);

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -46,11 +46,11 @@ class WcPayWelcomePage {
 
 		$menu_data = array(
 			'id'       => 'wc-calypso-bridge-payments-welcome-page',
-			'title'    => __( 'Payments', 'woocommerce-admin' ),
+			'title'    => __( 'Payments', 'woocommerce' ),
 			'path'     => '/wc-pay-welcome-page',
 			'position' => '56',
 			'nav_args' => [
-				'title'        => __( 'WooCommerce Payments', 'woocommerce-admin' ),
+				'title'        => __( 'WooCommerce Payments', 'woocommerce' ),
 				'is_category'  => false,
 				'menuId'       => 'plugins',
 				'is_top_level' => true,
@@ -66,8 +66,8 @@ class WcPayWelcomePage {
 		// WooCommerce menu.
 		if ( 'yes' === get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
 			$menu_with_nav_data = array(
-				__( 'Payments', 'woocommerce-admin' ),
-				__( 'Payments', 'woocommerce-admin' ),
+				__( 'Payments', 'woocommerce' ),
+				__( 'Payments', 'woocommerce' ),
 				'view_woocommerce_reports',
 				'admin.php?page=wc-admin&path=/wc-pay-welcome-page',
 				null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1597,6 +1597,7 @@ importers:
       '@types/node': ^16.9.4
       eslint: ^7.32.0
       globby: ^11
+      jscodeshift: ^0.13.1
       oclif: ^2
       shx: ^0.3.3
       ts-node: ^10.2.1
@@ -1611,6 +1612,7 @@ importers:
       '@types/node': 16.10.3
       eslint: 7.32.0
       globby: 11.0.4
+      jscodeshift: 0.13.1
       oclif: 2.4.5
       shx: 0.3.4
       ts-node: 10.5.0_e0d88945dfc7787883e9c330c9196a96
@@ -2469,7 +2471,7 @@ packages:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.16.0
+      '@babel/types': 7.17.0
 
   /@babel/helper-split-export-declaration/7.16.0:
     resolution: {integrity: sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==}
@@ -3810,7 +3812,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.0
-      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.16.12:
@@ -3819,7 +3821,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-plugin-utils': 7.16.7
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.17.8:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -3827,7 +3829,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-plugin-utils': 7.16.7
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.9:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -3942,7 +3944,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.0
-      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.16.12:
@@ -3951,7 +3953,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-plugin-utils': 7.16.7
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.17.8:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -3959,7 +3961,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-plugin-utils': 7.16.7
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5_@babel+core@7.16.0:
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -6172,6 +6174,20 @@ packages:
       lodash: 4.17.21
       make-dir: 2.1.0
       pirates: 4.0.1
+      source-map-support: 0.5.20
+    dev: true
+
+  /@babel/register/7.17.7_@babel+core@7.17.8:
+    resolution: {integrity: sha512-fg56SwvXRifootQEDQAu1mKdjh5uthPzdO0N6t358FktfL4XjAVXuH58ULoiW8mesxiOgNIrxiImqEwv0+hRRA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.8
+      clone-deep: 4.0.1
+      find-cache-dir: 2.1.0
+      make-dir: 2.1.0
+      pirates: 4.0.5
       source-map-support: 0.5.20
     dev: true
 
@@ -16120,6 +16136,14 @@ packages:
       '@babel/core': 7.16.0
     dev: true
 
+  /babel-core/7.0.0-bridge.0_@babel+core@7.17.8:
+    resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.17.8
+    dev: true
+
   /babel-eslint/10.1.0_eslint@6.8.0:
     resolution: {integrity: sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==}
     engines: {node: '>=6'}
@@ -21936,7 +21960,7 @@ packages:
       is-stream: 1.1.0
       npm-run-path: 2.0.2
       p-finally: 1.0.0
-      signal-exit: 3.0.5
+      signal-exit: 3.0.7
       strip-eof: 1.0.0
     dev: true
 
@@ -22006,7 +22030,7 @@ packages:
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
-      signal-exit: 3.0.5
+      signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
 
@@ -22021,7 +22045,7 @@ packages:
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
-      signal-exit: 3.0.5
+      signal-exit: 3.0.7
       strip-final-newline: 2.0.0
     dev: true
 
@@ -22679,6 +22703,11 @@ packages:
 
   /flatted/3.2.4:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
+    dev: true
+
+  /flow-parser/0.174.1:
+    resolution: {integrity: sha512-nDMOvlFR+4doLpB3OJpseHZ7uEr3ENptlF6qMas/kzQmNcLzMwfQeFX0gGJ/+em7UdldB/nGsk55tDTOvjbCuw==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /flush-write-stream/1.1.1:
@@ -24708,7 +24737,7 @@ packages:
     resolution: {integrity: sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==}
     engines: {node: '>=10'}
     dependencies:
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: true
 
   /ignore/4.0.6:
@@ -27939,6 +27968,35 @@ packages:
   /jsbn/0.1.1:
     resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}
 
+  /jscodeshift/0.13.1:
+    resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
+    hasBin: true
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/parser': 7.17.8
+      '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.17.8
+      '@babel/plugin-transform-modules-commonjs': 7.17.7_@babel+core@7.17.8
+      '@babel/preset-flow': 7.16.7_@babel+core@7.17.8
+      '@babel/preset-typescript': 7.16.7_@babel+core@7.17.8
+      '@babel/register': 7.17.7_@babel+core@7.17.8
+      babel-core: 7.0.0-bridge.0_@babel+core@7.17.8
+      chalk: 4.1.2
+      flow-parser: 0.174.1
+      graceful-fs: 4.2.9
+      micromatch: 3.1.10
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.20.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /jsdoc-type-pratt-parser/2.2.5:
     resolution: {integrity: sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==}
     engines: {node: '>=12.0.0'}
@@ -28607,7 +28665,7 @@ packages:
     resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
     engines: {node: '>=8'}
     dependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       parse-json: 5.2.0
       strip-bom: 4.0.0
       type-fest: 0.6.0
@@ -29275,7 +29333,7 @@ packages:
       globby: 11.0.4
       isbinaryfile: 4.0.8
       mem-fs: 2.2.1
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       multimatch: 5.0.0
       normalize-path: 3.0.0
       textextensions: 5.14.0
@@ -29870,7 +29928,7 @@ packages:
       array-differ: 3.0.0
       array-union: 2.1.0
       arrify: 2.0.1
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: true
 
   /mute-stream/0.0.7:
@@ -34262,6 +34320,16 @@ packages:
     resolution: {integrity: sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==}
     engines: {node: '>=8'}
 
+  /recast/0.20.5:
+    resolution: {integrity: sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==}
+    engines: {node: '>= 4'}
+    dependencies:
+      ast-types: 0.14.2
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tslib: 2.3.1
+    dev: true
+
   /rechoir/0.6.2:
     resolution: {integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=}
     engines: {node: '>= 0.10'}
@@ -36847,6 +36915,13 @@ packages:
       isobject: 4.0.0
       lodash: 4.17.21
       memoizerific: 1.11.3
+    dev: true
+
+  /temp/0.8.4:
+    resolution: {integrity: sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      rimraf: 2.6.3
     dev: true
 
   /term-size/1.2.0:
@@ -39474,7 +39549,7 @@ packages:
     dependencies:
       imurmurhash: 0.1.4
       is-typedarray: 1.0.0
-      signal-exit: 3.0.5
+      signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
   /write-file-atomic/4.0.1:
@@ -39490,7 +39565,7 @@ packages:
     engines: {node: '>=8.3'}
     dependencies:
       detect-indent: 6.1.0
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.9
       is-plain-obj: 2.1.0
       make-dir: 3.1.0
       sort-keys: 4.2.0

--- a/tools/monorepo-merge/codemods/rename-intl-domain.js
+++ b/tools/monorepo-merge/codemods/rename-intl-domain.js
@@ -1,0 +1,26 @@
+export const parser = 'tsx';
+
+const i18nFunctionsToRename = [
+    '__',
+    '_n',
+    '_x'
+]
+
+
+const isFunctionNamed = ( path, names ) => {
+	return names.includes(path.value.callee.name);
+};
+
+export default function transformer( file, api ) {
+	const j = api.jscodeshift;
+
+	return j( file.source )
+		.find( j.CallExpression )
+		.filter( ( p ) => isFunctionNamed( p, i18nFunctionsToRename ) )
+		.forEach( ( path ) => {
+			j( path ) // Descend into each call expression to find any strings literal 'woocommerce-admin'
+				.find( j.StringLiteral, { value: 'woocommerce-admin' } )
+				.replaceWith( j.stringLiteral( 'woocommerce' ) );
+		} )
+		.toSource();
+}

--- a/tools/monorepo-merge/package.json
+++ b/tools/monorepo-merge/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^16.9.4",
     "eslint": "^7.32.0",
     "globby": "^11",
+    "jscodeshift": "^0.13.1",
     "oclif": "^2",
     "shx": "^0.3.3",
     "ts-node": "^10.2.1",


### PR DESCRIPTION
### Description

This PR fixes #32175 by changing the text-domain strings across:

- JS/TS Files in:
  - ./packages/js/
  - ./plugins/woocommerce-admin/client/

- PHP Files in:
  - ./plugins/woocommerce/src/Admin/
  - ./plugins/woocommerce/src/Internal/
  - ./plugins/woocommerce/includes/react-admin/

- Markdown files for related documentation and examples in the above folders

#### JS
The JS/TS files were modified by using jscodeshift, with the transformation codified in https://github.com/woocommerce/woocommerce/blob/6f23a5ae68323f4457d644502aabe87391a4c9eb/tools/monorepo-merge/codemods/rename-intl-domain.js

These commands were ran from the monorepo-merge folder:

```sh
pnpx jscodeshift ../../packages/js/ -t codemods/rename-intl-domain.js --extensions=js,jsx,ts,tsx
pnpm run lint -- --fix
```
```sh
pnpx jscodeshift ../../plugins/woocommerce-admin/client -t codemods/rename-intl-domain.js --extensions=js,jsx,ts,tsx
pnpm run --filter "@woocommerce/admin-library" lint:js -- --fix
```

The lint-fix was necessary as there were some lint corrections applied by jscodeshift which violated our lint rules - it doesn't localise to the repo's lint rules.


#### PHP
The PHP files were modified using the existing script for wp-textdomain https://github.com/woocommerce/woocommerce/blob/6e8d620f00109b9c37083c778d30e6357d32a05f/plugins/woocommerce-admin/bin/package-update-textdomain.js

The existing script was copied over to woocommerce-admin and modified to take multiple folders. As I understand it, the original copy of this script was used to correct the text-domain during the build process for woocommerce-core.

This command was ran from the root of the repository:

```sh
pnpm run --filter "@woocommerce/admin-library" packages:fix:textdomain ../woocommerce/src/Admin/ ../woocommerce/src/Internal/ ../woocommerce/includes/react-admin/
```

#### Markdown
The .md files were modified by hand, by doing a find-in-folder of "woocommerce-admin" and inspecting if they were relevant. (There was the option to use jscodeshift + remark to do this too but remark ended up including a whole bunch of lint formatting that it thought it knew best 😠 ) 



### How to test the changes in this Pull Request:

1. Do the usual repo setup, i.e install and build 
2. Check that tests all still run
3. Check that i18n works correctly by changing the language in a running copy


### Changelog entry

i18n text domain strings were changed from 'woocommerce-admin' to 'woocommerce' in the files that were moved over from woocommerce-admin repo


### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
