### PR TITLE
Add additional checks for a label and targeting trunk

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -30,7 +30,10 @@ jobs:
         with:
           php-version: '7.4'
       - name: "Run the script to assign a milestone"
-        if: "!github.event.pull_request.milestone"
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'plugin: woocommerce') &&
+          !github.event.pull_request.milestone &&
+          github.event.pull_request.base.ref == 'trunk'
         run: php assign-milestone-to-merged-pr.php
         env:
           PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
Closes [{36}-gh-{woocommerce}/{platform-private}](https://github.com/woocommerce/platform-private/issues/36)

This PR adds additional checks to make sure the PR being merged is targeting trunk and that it has the label `plugin: woocommerce` before assigning a milestone. This prevents milestone from being applied to PRs that are merged into branches.

**Test**

* Fork this repo.
* Enable actions.
* Create a label named `plugin: woocommerce`.
* Create a milestone named `12.0.0`. 
* Checkout this branch locally and merge into trunk and push it up to your fork.
* Create a new PR and push up to your fork.
* Add the label `plugin: woocommerce`.
* Merge the PR.
* Ensure the action runs and that the milestone was added successfully.
* Do the same test but this time don't add the label `plugin: woocommerce`.
* Ensure the action is skipped because it doesn't match conditions.
* Finally create a new branch named `branch-1`. Commit some code and push it up to GH.
* Now create another branch named it `branch-1`. Commit some code and push it up but this time target it to `branch-1` instead of `trunk`.
* Add the label `plugin: woocommerce` to the PR `branch-2`.
* Merge this PR.
* Ensure the action is skipped because it doesn't match the conditions (not targeting trunk).