### PR TITLE
Support protocol-less URLs from the URL util.

### DIFF
--- a/plugins/woocommerce/changelog/fix-protocol-agnostic-urls
+++ b/plugins/woocommerce/changelog/fix-protocol-agnostic-urls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Changelog entry not needed, because this is an adjustment to unreleased code.
+
+

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
@@ -88,6 +88,8 @@ class URLTest extends WC_Unit_Test_Case {
 			array( 'https://foo.bar/parent/%2E%2e/asset.txt', 'https://foo.bar/asset.txt' ),
 			array( 'https://foo.bar/parent/%2E.%2fasset.txt', 'https://foo.bar/parent/%2E.%2fasset.txt' ),
 			array( 'http://localhost?../../bar',              'http://localhost/?../../bar' ),
+			array( '//http.or.https/',                        '//http.or.https/' ),
+			array( '//schemaless/with-path',                  '//schemaless/with-path' ),
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/URLTest.php
@@ -9,9 +9,13 @@ use WC_Unit_Test_Case;
  * A collection of tests for the filepath utility class.
  */
 class URLTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Test if it can be determined whether a URL is absolute or relative.
+	 */
 	public function test_if_absolute_or_relative() {
 		$this->assertTrue(
-			( new URL( '/etc/foo/bar' ) )->is_absolute() ,
+			( new URL( '/etc/foo/bar' ) )->is_absolute(),
 			'Correctly determines if a Unix-style path is absolute.'
 		);
 
@@ -29,8 +33,8 @@ class URLTest extends WC_Unit_Test_Case {
 	/**
 	 * @dataProvider path_expectations
 	 *
-	 * @param string $source_path
-	 * @param string $expected_resolution
+	 * @param string $source_path Source path to test.
+	 * @param string $expected_resolution Expected result of the test.
 	 */
 	public function test_path_resolution( $source_path, $expected_resolution ) {
 		$this->assertEquals( $expected_resolution, ( new URL( $source_path ) )->get_path() );
@@ -43,22 +47,22 @@ class URLTest extends WC_Unit_Test_Case {
 	 */
 	public function path_expectations(): array {
 		return array(
-			array( '/var/foo/bar/baz/../../foobar',            '/var/foo/foobar' ),
-			array( '/var/foo/../../../../bazbar',              '/bazbar' ),
-			array( '././././.',                                './' ),
-			array( 'empty/segments//are/stripped',             'empty/segments/are/stripped' ),
-			array( '///nonempty/  /whitespace/   /is//kept',   '/nonempty/  /whitespace/   /is/kept' ),
-			array( 'relative/../../should/remain/relative',    '../should/remain/relative' ),
+			array( '/var/foo/bar/baz/../../foobar', '/var/foo/foobar' ),
+			array( '/var/foo/../../../../bazbar', '/bazbar' ),
+			array( '././././.', './' ),
+			array( 'empty/segments//are/stripped', 'empty/segments/are/stripped' ),
+			array( '///nonempty/  /whitespace/   /is//kept', '/nonempty/  /whitespace/   /is/kept' ),
+			array( 'relative/../../should/remain/relative', '../should/remain/relative' ),
 			array( 'relative/../../../should/remain/relative', '../../should/remain/relative' ),
-			array( 'c:\\Windows\Server\HTTP\dump.xml',         'c:/Windows/Server/HTTP/dump.xml')
+			array( 'c:\\Windows\Server\HTTP\dump.xml', 'c:/Windows/Server/HTTP/dump.xml' ),
 		);
 	}
 
 	/**
 	 * @dataProvider url_expectations
 	 *
-	 * @param string $source_url
-	 * @param string $expected_resolution
+	 * @param string $source_url URL to test.
+	 * @param string $expected_resolution Expected result of the test.
 	 */
 	public function test_url_resolution( $source_url, $expected_resolution ) {
 		$this->assertEquals( $expected_resolution, ( new URL( $source_url ) )->get_url() );
@@ -71,34 +75,34 @@ class URLTest extends WC_Unit_Test_Case {
 	 */
 	public function url_expectations(): array {
 		return array(
-			array( '/../foo/bar/baz/bazooka/../../baz',       'file:///foo/bar/baz' ),
-			array( './a/b/c/./../././../b/c',                 'file://a/b/c' ),
-			array( 'relative/path',                           'file://relative/path' ),
-			array( '/absolute/path',                          'file:///absolute/path' ),
-			array( '/var/www/network/%2econfig',              'file:///var/www/network/%2econfig' ),
-			array( '///foo',                                  'file:///foo' ),
-			array( '~/foo.txt',                               'file://~/foo.txt' ),
-			array( 'baz///foo',                               'file://baz/foo' ),
-			array( 'file:///etc/foo/bar',                     'file:///etc/foo/bar' ),
-			array( 'foo://bar',                               'foo://bar/' ),
-			array( 'foo://bar/baz-file',                      'foo://bar/baz-file' ),
-			array( 'foo://bar/baz-dir/',                      'foo://bar/baz-dir/' ),
-			array( 'https://foo.bar/parent/.%2e/asset.txt',   'https://foo.bar/asset.txt' ),
-			array( 'https://foo.bar/parent/%2E./asset.txt',   'https://foo.bar/asset.txt' ),
+			array( '/../foo/bar/baz/bazooka/../../baz', 'file:///foo/bar/baz' ),
+			array( './a/b/c/./../././../b/c', 'file://a/b/c' ),
+			array( 'relative/path', 'file://relative/path' ),
+			array( '/absolute/path', 'file:///absolute/path' ),
+			array( '/var/www/network/%2econfig', 'file:///var/www/network/%2econfig' ),
+			array( '///foo', 'file:///foo' ),
+			array( '~/foo.txt', 'file://~/foo.txt' ),
+			array( 'baz///foo', 'file://baz/foo' ),
+			array( 'file:///etc/foo/bar', 'file:///etc/foo/bar' ),
+			array( 'foo://bar', 'foo://bar/' ),
+			array( 'foo://bar/baz-file', 'foo://bar/baz-file' ),
+			array( 'foo://bar/baz-dir/', 'foo://bar/baz-dir/' ),
+			array( 'https://foo.bar/parent/.%2e/asset.txt', 'https://foo.bar/asset.txt' ),
+			array( 'https://foo.bar/parent/%2E./asset.txt', 'https://foo.bar/asset.txt' ),
 			array( 'https://foo.bar/parent/%2E%2e/asset.txt', 'https://foo.bar/asset.txt' ),
 			array( 'https://foo.bar/parent/%2E.%2fasset.txt', 'https://foo.bar/parent/%2E.%2fasset.txt' ),
-			array( 'http://localhost?../../bar',              'http://localhost/?../../bar' ),
-			array( '//http.or.https/',                        '//http.or.https/' ),
-			array( '//schemaless/with-path',                  '//schemaless/with-path' ),
+			array( 'http://localhost?../../bar', 'http://localhost/?../../bar' ),
+			array( '//http.or.https/', '//http.or.https/' ),
+			array( '//schemaless/with-path', '//schemaless/with-path' ),
 		);
 	}
 
 	/**
 	 * @dataProvider parent_url_expectations
 	 *
-	 * @param string       $source_path
-	 * @param int          $parent_level
-	 * @param string|false $expectation
+	 * @param string       $source_path Path to test.
+	 * @param int          $parent_level Parent level to use for the test.
+	 * @param string|false $expectation Expected result of the test.
 	 */
 	public function test_can_obtain_parent_url( string $source_path, int $parent_level, $expectation ) {
 		$this->assertEquals( $expectation, ( new URL( $source_path ) )->get_parent_url( $parent_level ) );
@@ -111,32 +115,32 @@ class URLTest extends WC_Unit_Test_Case {
 	 */
 	public function parent_url_expectations(): array {
 		return array(
-			array( '/',                                           1, false ),
-			array( '/',                                           2, false ),
-			array( './',                                          1, 'file://../' ),
-			array( '../',                                         1, 'file://../../' ),
-			array( 'relative-file.png',                           1, 'file://./' ),
-			array( 'relative-file.png',                           2, 'file://../' ),
-			array( '/var/dev/',                                   1, 'file:///var/' ),
-			array( '/var/../dev/./../foo/bar',                    1, 'file:///foo/' ),
-			array( 'https://example.com',                         1, false ),
-			array( 'https://example.com/foo',                     1, 'https://example.com/' ),
-			array( 'https://example.com/foo/bar/baz/../cat/',     2, 'https://example.com/foo/' ),
+			array( '/', 1, false ),
+			array( '/', 2, false ),
+			array( './', 1, 'file://../' ),
+			array( '../', 1, 'file://../../' ),
+			array( 'relative-file.png', 1, 'file://./' ),
+			array( 'relative-file.png', 2, 'file://../' ),
+			array( '/var/dev/', 1, 'file:///var/' ),
+			array( '/var/../dev/./../foo/bar', 1, 'file:///foo/' ),
+			array( 'https://example.com', 1, false ),
+			array( 'https://example.com/foo', 1, 'https://example.com/' ),
+			array( 'https://example.com/foo/bar/baz/../cat/', 2, 'https://example.com/foo/' ),
 			array( 'https://example.com/foo/bar/baz/%2E%2E/dog/', 2, 'https://example.com/foo/' ),
-			array( 'file://./',                                   1, 'file://../' ),
-			array( 'file://./',                                   2, 'file://../../' ),
-			array( 'file://../../foo',                            1, 'file://../../' ),
-			array( 'file://../../foo',                            2, 'file://../../../' ),
-			array( 'file://../../',                               1, 'file://../../../' ),
-			array( 'file://./../',                                2, 'file://../../../' ),
+			array( 'file://./', 1, 'file://../' ),
+			array( 'file://./', 2, 'file://../../' ),
+			array( 'file://../../foo', 1, 'file://../../' ),
+			array( 'file://../../foo', 2, 'file://../../../' ),
+			array( 'file://../../', 1, 'file://../../../' ),
+			array( 'file://./../', 2, 'file://../../../' ),
 		);
 	}
 
 	/**
 	 * @dataProvider all_parent_url_expectations
 	 *
-	 * @param string $source_path
-	 * @param array  $expectation
+	 * @param string $source_path Path to test.
+	 * @param array  $expectation Expected result of the test.
 	 */
 	public function test_can_obtain_all_parent_urls( string $source_path, array $expectation ) {
 		$this->assertEquals( $expectation, ( new URL( $source_path ) )->get_all_parent_urls() );
@@ -193,7 +197,7 @@ class URLTest extends WC_Unit_Test_Case {
 			array(
 				'../../some.file',
 				array(
-					'file://../../'
+					'file://../../',
 				),
 			),
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

"Protocol-agnostic" URLs such as `//some.domain/foo/bar.png` are already supported by the [product downloads handler](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/class-wc-download-handler.php#L277-L283) and have been for some time, but we were missing support for this in the internal URL utility (which viewed these as filepaths).

This corrects that oversight, and will improve other safeguards around download handling. *Note that there actually was no functional problem falling out of this oversight, it was mostly just a source of potential confusion (and, perhaps, in the future could lead to problems if other logic was built on top of it).*

> **Note** :bulb:
>
> Base-branch is set to `fix/relative-directory-handling` even though this fix is not *directly* related to that change. My intent was just to minimize the potential for conflicts when/if [PR 32350](https://github.com/woocommerce/woocommerce/pull/32350) is merged, since that is touching a number of the same files.
>
> To that end, if you are happy with this change, **please do not merge** — I'll handle that after the above PR is merged.

### How to test the changes in this Pull Request:

1. Visit **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** and enable the feature (click on `Start Enforcing Rules`, unless of course it is already enabled).
2. Edit a downloadable product or create a new one. Add a downloadable file with a URL like `//some.domain/foo/bar.png` (it's important it does not have a scheme/protocol).
3. Return to the above admin screen, reload. You should be able to locate a matching rule (something like `//some.domain/foo/`).

Further check:

1. As a customer, buy the product you used for the above tests.
2. Ensure you can download the file (if necessary, correct the download filepath to an actual live remote file ... otherwise there is a good chance you will hit a 'File not found' error or similar).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Not required, as it touches functionality that has not yet entered production.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
