### PR TITLE
Execute Unit Tests in `wp-env`

### DIFF
--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Run Tests With Code Coverage
         run: |
           cd plugins/woocommerce
-          echo "{ \"phpVersion\": \"7.4\", \"core\": null }" > .wp-env.override.json
+          composer require "wp-phpunit/wp-phpunit" "^5.9" --dev --no-scripts
+          echo "{ \"phpVersion\": \"7.4\", \"core\": \"WordPress/WordPress#5.9\" }" > .wp-env.override.json
           npm -g install @wordpress/env
           wp-env start
           pnpm nx test-code-coverage woocommerce

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -47,10 +47,8 @@ jobs:
         run: |
           cd plugins/woocommerce
           composer require "wp-phpunit/wp-phpunit" "^5.9" --dev --no-scripts
-          echo "{ \"phpVersion\": \"7.4\", \"core\": \"WordPress/WordPress#5.9\" }" > .wp-env.override.json
-          npm -g install @wordpress/env
-          wp-env start
-          wp-env run tests-wordpress "chmod 755 wp-content wp-content/plugins wp-content/uploads"
+          WP_ENV_CORE="WordPress/WordPress#5.9" WP_ENV_PHP_VERSION="7.4" pnpm wp-env start
+          pnpm wp-env run tests-wordpress chmod 755 wp-content wp-content/plugins wp-content/uploads
           pnpm nx test-code-coverage woocommerce || true
       
       - name: Send code coverage to Codecov.

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run Tests With Code Coverage
         run: |
+          cd plugins/woocommerce
           echo "{ \"phpVersion\": \"7.4\", \"core\": null }" > .wp-env.override.json
           npm -g install @wordpress/env
           wp-env start

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -13,14 +13,6 @@ jobs:
     name: Code coverage (PHP 7.4, WP Latest)
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    services:
-      database:
-        image: mysql:5.6
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,11 +43,11 @@ jobs:
         run: |
           pnpm nx build:feature-config woocommerce
 
-      - name: Init DB and WP
-        run: pnpm nx install-unit-test-db woocommerce
-
-      - name: Run unit tests with code coverage. Allow to fail.
+      - name: Run Tests With Code Coverage
         run: |
+          echo "{ \"phpVersion\": \"7.4\", \"core\": null }" > .wp-env.override.json
+          npm -g install @wordpress/env
+          wp-env start
           pnpm nx test-code-coverage woocommerce
           exit 0
       

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -50,8 +50,8 @@ jobs:
           echo "{ \"phpVersion\": \"7.4\", \"core\": \"WordPress/WordPress#5.9\" }" > .wp-env.override.json
           npm -g install @wordpress/env
           wp-env start
-          pnpm nx test-code-coverage woocommerce
-          exit 0
+          wp-env run tests-wordpress "chmod 755 wp-content wp-content/plugins wp-content/uploads"
+          pnpm nx test-code-coverage woocommerce || true
       
       - name: Send code coverage to Codecov.
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -90,4 +90,3 @@ jobs:
           npm -g install @wordpress/env
           wp-env start
           pnpm nx test-unit woocommerce
-          wp-env logs tests --no-watch

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -26,14 +26,6 @@ jobs:
             php: 7.2
           - wp: '5.8'
             php: 7.2
-    services:
-      database:
-        image: mysql:5.6
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v2
 
@@ -75,9 +67,20 @@ jobs:
              pnpm nx composer-dump-autoload woocommerce
            fi
 
-      - name: Init DB and WP
-        working-directory: plugins/woocommerce
-        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
+      - name: Prepare Test Environment
+        run: |
+          WP_VERSION="${{ matrix.wp }}"
+          if [[ $WP_VERSION == 'latest' ]]; then
+            WP_VERSION="null"
+          elif [[ $WP_VERSION == 'nightly' ]]; then
+            WP_VERSION="\"WordPress/WordPress#master\""
+          else
+            WP_VERSION="\"WordPress/WordPress#$WP_VERSION\""
+          fi
+          echo "{ \"phpVersion\": \"${{ matrix.php }}\", \"core\": $WP_VERSION }" > .wp-env.override.json
 
-      - name: Run tests
-        run: pnpm nx test-unit woocommerce
+      - name: Run Tests
+        run: |
+          npm -g install @wordpress/env
+          wp-env start
+          pnpm nx test-unit woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -67,6 +67,23 @@ jobs:
              pnpm nx composer-dump-autoload woocommerce
            fi
 
+      - name: Prepare Test Environment
+        run: |
+          cd plugins/woocommerce
+          WP_VERSION="${{ matrix.wp }}"
+          if [[ $WP_VERSION == 'latest' ]]; then
+            WP_VERSION="\"https://wordpress.org/latest.zip\""
+          elif [[ $WP_VERSION == 'nightly' ]]; then
+            WP_VERSION="\"https://wordpress.org/nightly-builds/wordpress-latest.zip\""
+          elif [[ $WP_VERSION == '5.8' ]]; then
+            WP_VERSION="\"https://wordpress.org/wordpress-5.8.4.zip\""
+          elif [[ $WP_VERSION == '5.7' ]]; then
+            WP_VERSION="\"https://wordpress.org/wordpress-5.7.6.zip\""
+          else
+            WP_VERSION="\"WordPress/WordPress#$WP_VERSION\""
+          fi
+          echo "{ \"phpVersion\": \"${{ matrix.php }}\", \"core\": $WP_VERSION }" > .wp-env.override.json
+
       - name: Run Tests
         run: |
           cd plugins/woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -72,13 +72,14 @@ jobs:
           cd plugins/woocommerce
           WP_VERSION="${{ matrix.wp }}"
           if [[ $WP_VERSION == 'latest' ]]; then
-            composer require "wp-phpunit/wp-phpunit" "dev-master" --dev --no-scripts
-            WP_VERSION="null"
+            WP_VERSION="\"https://wordpress.org/latest.zip\""
           elif [[ $WP_VERSION == 'nightly' ]]; then
-            composer require "wp-phpunit/wp-phpunit" "dev-master" --dev --no-scripts
-            WP_VERSION="\"WordPress/WordPress#master\""
+            WP_VERSION="\"https://wordpress.org/nightly-builds/wordpress-latest.zip\""
+          elif [[ $WP_VERSION == '5.8' ]]; then
+            WP_VERSION="\"https://wordpress.org/wordpress-5.8.4.zip\""
+          elif [[ $WP_VERSION == '5.7' ]]; then
+            WP_VERSION="\"https://wordpress.org/wordpress-5.7.6.zip\""
           else
-            composer require "wp-phpunit/wp-phpunit" "dev-tree-$WP_VERSION" --dev --no-scripts
             WP_VERSION="\"WordPress/WordPress#$WP_VERSION\""
           fi
           echo "{ \"phpVersion\": \"${{ matrix.php }}\", \"core\": $WP_VERSION }" > .wp-env.override.json

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,7 +88,6 @@ jobs:
         run: |
           cd plugins/woocommerce
           npm -g install @wordpress/env
-          WP_ENV_HOME="$HOME/.wp-env"
           wp-env start
-          pnpm nx test-unit woocommerce || true
-          wp-env logs all --no-watch
+          pnpm nx test-unit woocommerce
+          wp-env logs tests --no-watch

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -69,7 +69,6 @@ jobs:
 
       - name: Prepare Test Environment
         run: |
-          pwd
           cd plugins/woocommerce
           WP_VERSION="${{ matrix.wp }}"
           if [[ $WP_VERSION == 'latest' ]]; then
@@ -89,6 +88,7 @@ jobs:
         run: |
           cd plugins/woocommerce
           npm -g install @wordpress/env
+          echo $HOME
           WP_ENV_HOME="$HOME/.wp-env"
           wp-env start
           pnpm nx test-unit woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           cd plugins/woocommerce
           npm -g install @wordpress/env
-          echo $HOME
           WP_ENV_HOME="$HOME/.wp-env"
           wp-env start
           pnpm nx test-unit woocommerce
+          wp-env logs tests --no-watch

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Prepare Test Environment
         run: |
+          pwd
           cd plugins/woocommerce
           WP_VERSION="${{ matrix.wp }}"
           if [[ $WP_VERSION == 'latest' ]]; then
@@ -88,5 +89,6 @@ jobs:
         run: |
           cd plugins/woocommerce
           npm -g install @wordpress/env
+          WP_ENV_HOME="$HOME/.wp-env"
           wp-env start
           pnpm nx test-unit woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -89,5 +89,6 @@ jobs:
           cd plugins/woocommerce
           npm -g install @wordpress/env
           wp-env start
+          wp-env run tests-wordpress "chmod 755 wp-content wp-content/plugins wp-content/uploads"
           pnpm nx test-unit woocommerce
           wp-env logs tests --no-watch

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -67,23 +67,6 @@ jobs:
              pnpm nx composer-dump-autoload woocommerce
            fi
 
-      - name: Prepare Test Environment
-        run: |
-          cd plugins/woocommerce
-          WP_VERSION="${{ matrix.wp }}"
-          if [[ $WP_VERSION == 'latest' ]]; then
-            WP_VERSION="\"https://wordpress.org/latest.zip\""
-          elif [[ $WP_VERSION == 'nightly' ]]; then
-            WP_VERSION="\"https://wordpress.org/nightly-builds/wordpress-latest.zip\""
-          elif [[ $WP_VERSION == '5.8' ]]; then
-            WP_VERSION="\"https://wordpress.org/wordpress-5.8.4.zip\""
-          elif [[ $WP_VERSION == '5.7' ]]; then
-            WP_VERSION="\"https://wordpress.org/wordpress-5.7.6.zip\""
-          else
-            WP_VERSION="\"WordPress/WordPress#$WP_VERSION\""
-          fi
-          echo "{ \"phpVersion\": \"${{ matrix.php }}\", \"core\": $WP_VERSION }" > .wp-env.override.json
-
       - name: Run Tests
         run: |
           cd plugins/woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Prepare Test Environment
         run: |
+          cd plugins/woocommerce
           WP_VERSION="${{ matrix.wp }}"
           if [[ $WP_VERSION == 'latest' ]]; then
             WP_VERSION="null"
@@ -81,6 +82,7 @@ jobs:
 
       - name: Run Tests
         run: |
+          cd plugins/woocommerce
           npm -g install @wordpress/env
           wp-env start
           pnpm nx test-unit woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -67,26 +67,20 @@ jobs:
              pnpm nx composer-dump-autoload woocommerce
            fi
 
-      - name: Prepare Test Environment
-        run: |
-          cd plugins/woocommerce
-          WP_VERSION="${{ matrix.wp }}"
-          if [[ $WP_VERSION == 'latest' ]]; then
-            WP_VERSION="\"https://wordpress.org/latest.zip\""
-          elif [[ $WP_VERSION == 'nightly' ]]; then
-            WP_VERSION="\"https://wordpress.org/nightly-builds/wordpress-latest.zip\""
-          elif [[ $WP_VERSION == '5.8' ]]; then
-            WP_VERSION="\"https://wordpress.org/wordpress-5.8.4.zip\""
-          elif [[ $WP_VERSION == '5.7' ]]; then
-            WP_VERSION="\"https://wordpress.org/wordpress-5.7.6.zip\""
-          else
-            WP_VERSION="\"WordPress/WordPress#$WP_VERSION\""
-          fi
-          echo "{ \"phpVersion\": \"${{ matrix.php }}\", \"core\": $WP_VERSION }" > .wp-env.override.json
-
       - name: Run Tests
         run: |
           cd plugins/woocommerce
-          npm -g install @wordpress/env
-          wp-env start
+          WP_ENV_CORE="${{ matrix.wp }}"
+          if [[ WP_ENV_CORE == 'latest' ]]; then
+            WP_ENV_CORE="\"https://wordpress.org/latest.zip\""
+          elif [[ WP_ENV_CORE == 'nightly' ]]; then
+            WP_ENV_CORE="\"https://wordpress.org/nightly-builds/wordpress-latest.zip\""
+          elif [[ WP_ENV_CORE == '5.8' ]]; then
+            WP_ENV_CORE="\"https://wordpress.org/wordpress-5.8.4.zip\""
+          elif [[ WP_ENV_CORE == '5.7' ]]; then
+            WP_ENV_CORE="\"https://wordpress.org/wordpress-5.7.6.zip\""
+          else
+            WP_ENV_CORE="\"WordPress/WordPress#WP_ENV_CORE\""
+          fi
+          WP_ENV_PHP_VERSION="${{ matrix.php }}" pnpm wp-env start
           pnpm nx test-unit woocommerce

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -89,6 +89,5 @@ jobs:
           cd plugins/woocommerce
           npm -g install @wordpress/env
           wp-env start
-          wp-env run tests-wordpress "chmod 755 wp-content wp-content/plugins wp-content/uploads"
           pnpm nx test-unit woocommerce
           wp-env logs tests --no-watch

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -90,5 +90,5 @@ jobs:
           npm -g install @wordpress/env
           WP_ENV_HOME="$HOME/.wp-env"
           wp-env start
-          pnpm nx test-unit woocommerce
+          pnpm nx test-unit woocommerce || true
           wp-env logs tests --no-watch

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -72,10 +72,13 @@ jobs:
           cd plugins/woocommerce
           WP_VERSION="${{ matrix.wp }}"
           if [[ $WP_VERSION == 'latest' ]]; then
+            composer require "wp-phpunit/wp-phpunit" "dev-master" --dev --no-scripts
             WP_VERSION="null"
           elif [[ $WP_VERSION == 'nightly' ]]; then
+            composer require "wp-phpunit/wp-phpunit" "dev-master" --dev --no-scripts
             WP_VERSION="\"WordPress/WordPress#master\""
           else
+            composer require "wp-phpunit/wp-phpunit" "dev-tree-$WP_VERSION" --dev --no-scripts
             WP_VERSION="\"WordPress/WordPress#$WP_VERSION\""
           fi
           echo "{ \"phpVersion\": \"${{ matrix.php }}\", \"core\": $WP_VERSION }" > .wp-env.override.json

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -91,4 +91,4 @@ jobs:
           WP_ENV_HOME="$HOME/.wp-env"
           wp-env start
           pnpm nx test-unit woocommerce || true
-          wp-env logs tests --no-watch
+          wp-env logs all --no-watch

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,7 +1,10 @@
 {
 	"phpVersion": "7.4",
 	"core": "WordPress/WordPress#5.9",
-	"plugins": [ "." ],
+	"plugins": [ 
+		".",
+		"https://downloads.wordpress.org/plugin/akismet.zip"
+	 ],
 	"config": {
 		"JETPACK_AUTOLOAD_DEV": true,
 		"WP_DEBUG_LOG": true,

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,6 +1,6 @@
 {
-	"phpVersion": "7.4",
-	"core": "WordPress/WordPress#5.9",
+	"phpVersion": "7.2",
+	"core": null,
 	"plugins": [ 
 		".",
 		"https://downloads.wordpress.org/plugin/akismet.zip"

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"phpVersion": "7.4",
-	"core": null,
+	"core": "WordPress/WordPress#5.9",
 	"plugins": [ "." ],
 	"config": {
 		"JETPACK_AUTOLOAD_DEV": true,

--- a/plugins/woocommerce/changelog/add-wp-env-phpunit
+++ b/plugins/woocommerce/changelog/add-wp-env-phpunit
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This only changes test execution infrastructure that is present in the repository.
+
+

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -25,10 +25,11 @@
 		"woocommerce/woocommerce-blocks": "7.6.0"
 	},
 	"require-dev": {
+		"automattic/jetpack-changelogger": "3.0.2",
 		"bamarni/composer-bin-plugin": "^1.4",
-		"yoast/phpunit-polyfills": "^1.0",
 		"phpunit/phpunit": "7.5.20",
-		"automattic/jetpack-changelogger": "3.0.2"
+		"wp-phpunit/wp-phpunit": "^5.9",
+		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"config": {
 		"optimize-autoloader": true,

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -2948,6 +2948,54 @@
             "time": "2018-10-10T15:39:06+00:00"
         },
         {
+            "name": "wp-phpunit/wp-phpunit",
+            "version": "5.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-phpunit/wp-phpunit.git",
+                "reference": "ceece1ed4f2d0732c4a4f2603f4376d85547a50f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/ceece1ed4f2d0732c4a4f2603f4376d85547a50f",
+                "reference": "ceece1ed4f2d0732c4a4f2603f4376d85547a50f",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "__loaded.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Evan Mattson",
+                    "email": "me@aaemnnost.tv"
+                },
+                {
+                    "name": "WordPress Community",
+                    "homepage": "https://wordpress.org/about/"
+                }
+            ],
+            "description": "WordPress core PHPUnit library",
+            "homepage": "https://github.com/wp-phpunit",
+            "keywords": [
+                "phpunit",
+                "test",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://github.com/wp-phpunit/docs",
+                "issues": "https://github.com/wp-phpunit/issues",
+                "source": "https://github.com/wp-phpunit/wp-phpunit"
+            },
+            "time": "2022-02-22T20:53:17+00:00"
+        },
+        {
             "name": "yoast/phpunit-polyfills",
             "version": "1.0.3",
             "source": {

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -32,7 +32,7 @@
 		"test:e2e": "pnpm exec wc-e2e test:e2e",
 		"test:e2e-debug": "pnpm exec wc-e2e test:e2e-debug",
 		"test:e2e-dev": "pnpm exec wc-e2e test:e2e-dev",
-		"test:unit": "./vendor/bin/phpunit -c ./phpunit.xml",
+		"test:unit": "wp-env run tests-cli \"/var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml\"",
 		"makepot": "composer run-script makepot",
 		"packages:fix:textdomain": "node ./bin/package-update-textdomain.js"
 	},

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -32,8 +32,8 @@
 		"test:e2e": "pnpm exec wc-e2e test:e2e",
 		"test:e2e-debug": "pnpm exec wc-e2e test:e2e-debug",
 		"test:e2e-dev": "pnpm exec wc-e2e test:e2e-dev",
-		"test:unit": "wp-env run tests-cli \"/var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml\"",
-		"test:unit-coverage": "wp-env run tests-cli \"phpdbg -qrr /var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -d memory_limit=-1 -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml --coverage-clover=coverage.clover --exclude-group=timeout --exclude-group=run-in-separate-process\"",
+		"test:unit": "wp-env run tests-cli /var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml",
+		"test:unit-coverage": "wp-env run tests-cli phpdbg -qrr /var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -d memory_limit=-1 -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml --coverage-clover=coverage.clover --exclude-group=timeout --exclude-group=run-in-separate-process",
 		"makepot": "composer run-script makepot",
 		"packages:fix:textdomain": "node ./bin/package-update-textdomain.js"
 	},
@@ -56,6 +56,7 @@
 		"@woocommerce/woocommerce-rest-api": "^1.0.1",
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
 		"@wordpress/babel-preset-default": "3.0.2",
+		"@wordpress/env": "^4.8.0",
 		"@wordpress/stylelint-config": "19.1.0",
 		"allure-commandline": "^2.17.2",
 		"allure-playwright": "^2.0.0-beta.16",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -33,6 +33,7 @@
 		"test:e2e-debug": "pnpm exec wc-e2e test:e2e-debug",
 		"test:e2e-dev": "pnpm exec wc-e2e test:e2e-dev",
 		"test:unit": "wp-env run tests-cli \"/var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml\"",
+		"test:unit-coverage": "wp-env run tests-cli \"phpdbg -qrr /var/www/html/wp-content/plugins/woocommerce/vendor/bin/phpunit -d memory_limit=-1 -c /var/www/html/wp-content/plugins/woocommerce/phpunit.xml --coverage-clover=coverage.clover --exclude-group=timeout --exclude-group=run-in-separate-process\"",
 		"makepot": "composer run-script makepot",
 		"packages:fix:textdomain": "node ./bin/package-update-textdomain.js"
 	},

--- a/plugins/woocommerce/project.json
+++ b/plugins/woocommerce/project.json
@@ -150,10 +150,9 @@
 			}
 		},
 		"test-code-coverage": {
-			"executor": "@nrwl/workspace:run-commands",
+			"executor": "@nrwl/workspace:run-script",
 			"options": {
-				"command": "RUN_CODE_COVERAGE=1 bash tests/bin/phpunit.sh",
-				"cwd": "plugins/woocommerce"
+				"script": "test:unit-coverage"
 			}
 		}
 	}

--- a/plugins/woocommerce/tests/legacy/bootstrap.php
+++ b/plugins/woocommerce/tests/legacy/bootstrap.php
@@ -37,6 +37,12 @@ class WC_Unit_Tests_Bootstrap {
 	 * @since 2.2
 	 */
 	public function __construct() {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
+		putenv( 'WP_PHPUNIT__TESTS_CONFIG=' . __DIR__ . '/wp-config.php' );
+
+		// Load the dependencies first so that we have the unit test autoloader.
+		require_once __DIR__ . '/../../vendor/autoload.php';
+
 		$this->tests_dir  = dirname( __FILE__ );
 		$this->plugin_dir = dirname( dirname( $this->tests_dir ) );
 
@@ -57,7 +63,7 @@ class WC_Unit_Tests_Bootstrap {
 		}
 		// phpcs:enable WordPress.VIP.SuperGlobalInputUsage.AccessDetected
 
-		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : sys_get_temp_dir() . '/wordpress-tests-lib';
+		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : getenv( 'WP_PHPUNIT__DIR' );
 
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/template-cache.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/template-cache.php
@@ -33,7 +33,8 @@ class WC_Template_Cache extends WC_Unit_Test_Case {
 					)
 				)
 			);
-			$templates[ $cache_key ] = $template;
+			// Tokenize the path since it is expected to be.
+			$templates[ $cache_key ] = wc_tokenize_path( $template, wc_get_path_define_tokens() );
 			wc_get_template_part( 'content', $name );
 		}
 		remove_filter( 'wc_get_template_part', '__return_false' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -174,7 +174,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_server_file() {
-		self::file_copy( $this->csv_file, ABSPATH . '/sample.csv' );
+		self::file_copy( $this->csv_file, ABSPATH . 'sample.csv' );
 		$_POST['file_url'] = 'sample.csv';
 		$import_controller = new WC_Product_CSV_Importer_Controller();
 		$this->assertEquals( ABSPATH . 'sample.csv', $import_controller->handle_upload() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -700,8 +700,6 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 * Test that directory traversal is prevented.
 	 */
 	public function test_server_path_traversal() {
-		self::file_copy( $this->csv_file, ABSPATH . '../sample.csv' );
-
 		$_POST['file_url'] = '../sample.csv';
 		$import_controller = new WC_Product_CSV_Importer_Controller();
 		$import_result     = $import_controller->handle_upload();

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -174,10 +174,13 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_server_file() {
-		self::file_copy( $this->csv_file, ABSPATH . 'sample.csv' );
-		$_POST['file_url'] = 'sample.csv';
+		$uploads = wp_upload_dir();
+
+		self::file_copy( $this->csv_file, $uploads['basedir'] . '/sample.csv' );
+		$_POST['file_url'] = str_replace( ABSPATH, '', $uploads['basedir'] ) . '/sample.csv';
 		$import_controller = new WC_Product_CSV_Importer_Controller();
-		$this->assertEquals( ABSPATH . 'sample.csv', $import_controller->handle_upload() );
+
+		$this->assertEquals( $uploads['basedir'] . '/sample.csv', $import_controller->handle_upload() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -108,7 +108,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	public function test_import_for_admin_users() {
 		// In most cases, an admin user will run the import.
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		$results  = $this->sut->import();
+		$results = $this->sut->import();
 
 		$this->assertEquals( 0, count( $results['failed'] ) );
 		$this->assertEquals( 0, count( $results['updated'] ) );
@@ -126,7 +126,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	public function test_import_for_shop_managers() {
 		// In some cases, a shop manager may run the import.
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'shop_manager' ) ) );
-		$results  = $this->sut->import();
+		$results = $this->sut->import();
 
 		$this->assertEquals( 0, count( $results['updated'] ) );
 		$this->assertEquals( 0, count( $results['skipped'] ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-themes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-themes.php
@@ -57,6 +57,7 @@ class WC_Admin_Tests_API_Onboarding_Themes extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 		$themes   = wp_get_themes();
 
+		print_r( $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'storefront', $data['slug'] );
 		$this->assertEquals( 'success', $data['status'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-themes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-themes.php
@@ -57,9 +57,6 @@ class WC_Admin_Tests_API_Onboarding_Themes extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 		$themes   = wp_get_themes();
 
-		echo 'Test';
-		echo print_r( $response, true ); // phpcs:ignore
-
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'storefront', $data['slug'] );
 		$this->assertEquals( 'success', $data['status'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-themes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-themes.php
@@ -57,7 +57,9 @@ class WC_Admin_Tests_API_Onboarding_Themes extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 		$themes   = wp_get_themes();
 
-		print_r( $response->get_data() );
+		echo 'Test';
+		echo print_r( $response, true ); // phpcs:ignore
+
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'storefront', $data['slug'] );
 		$this->assertEquals( 'success', $data['status'] );

--- a/plugins/woocommerce/tests/legacy/wp-config.php
+++ b/plugins/woocommerce/tests/legacy/wp-config.php
@@ -1,0 +1,70 @@
+<?php
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+define( 'ABSPATH', __DIR__ . '/../../../../../' );
+
+/*
+ * Path to the theme to test with.
+ *
+ * The 'default' theme is symlinked from test/phpunit/data/themedir1/default into
+ * the themes directory of the WordPress installation defined above.
+ */
+define( 'WP_DEFAULT_THEME', 'default' );
+
+/*
+ * Test with multisite enabled.
+ * Alternatively, use the tests/phpunit/multisite.xml configuration file.
+ */
+// define( 'WP_TESTS_MULTISITE', true );
+
+/*
+ * Force known bugs to be run.
+ * Tests with an associated Trac ticket that is still open are normally skipped.
+ */
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// ** MySQL settings ** //
+
+/*
+ * This configuration file will be used by the copy of WordPress being tested.
+ * wordpress/wp-config.php will be ignored.
+ *
+ * WARNING WARNING WARNING!
+ * These tests will DROP ALL TABLES in the database with the prefix named below.
+ * DO NOT use a production database or one that is shared with something else.
+ */
+
+define( 'DB_NAME', 'tests-wordpress' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', 'password' );
+define( 'DB_HOST', 'tests-mysql' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ */
+define( 'AUTH_KEY',         'unique' );
+define( 'SECURE_AUTH_KEY',  'unique' );
+define( 'LOGGED_IN_KEY',    'unique' );
+define( 'NONCE_KEY',        'unique' );
+define( 'AUTH_SALT',        'unique' );
+define( 'SECURE_AUTH_SALT', 'unique' );
+define( 'LOGGED_IN_SALT',   'unique' );
+define( 'NONCE_SALT',       'unique' );
+
+$table_prefix = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'WooCommerce Unit Tests' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );

--- a/plugins/woocommerce/tests/legacy/wp-config.php
+++ b/plugins/woocommerce/tests/legacy/wp-config.php
@@ -67,4 +67,4 @@ define( 'WP_TESTS_TITLE', 'WooCommerce Unit Tests' );
 
 define( 'WP_PHP_BINARY', 'php' );
 
-define( 'WPLANG', '' );
+define( 'WPLANG', 'en_US' );

--- a/plugins/woocommerce/tests/legacy/wp-config.php
+++ b/plugins/woocommerce/tests/legacy/wp-config.php
@@ -1,7 +1,7 @@
 <?php
 
 /* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
-define( 'ABSPATH', __DIR__ . '/../../../../../' );
+define( 'ABSPATH', realpath( __DIR__ . '/../../../../..' ) . '/' );
 
 /*
  * Path to the theme to test with.

--- a/plugins/woocommerce/tests/legacy/wp-config.php
+++ b/plugins/woocommerce/tests/legacy/wp-config.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable
 
 /* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
 define( 'ABSPATH', realpath( __DIR__ . '/../../../../..' ) . '/' );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -973,37 +973,6 @@ importers:
       ts-jest: 27.1.3_b64eba0a9f1c7068f7f3a75addda5ccd
       typescript: 4.6.2
 
-  packages/js/notices:
-    specifiers:
-      '@automattic/data-stores': ^2.0.1
-      '@babel/core': ^7.17.5
-      '@woocommerce/eslint-plugin': workspace:*
-      '@wordpress/a11y': ^3.5.0
-      '@wordpress/data': ^6.3.0
-      '@wordpress/notices': ^3.3.2
-      eslint: ^8.12.0
-      jest: ^27.5.1
-      jest-cli: ^27.5.1
-      redux: ^4.2.0
-      rimraf: ^3.0.2
-      ts-jest: ^27.1.3
-      typescript: ^4.6.2
-    dependencies:
-      '@wordpress/a11y': 3.5.0
-      '@wordpress/data': 6.4.1
-      '@wordpress/notices': 3.4.1
-    devDependencies:
-      '@automattic/data-stores': 2.0.1_@wordpress+data@6.4.1
-      '@babel/core': 7.17.8
-      '@woocommerce/eslint-plugin': link:../eslint-plugin
-      eslint: 8.12.0
-      jest: 27.5.1
-      jest-cli: 27.5.1
-      redux: 4.2.0
-      rimraf: 3.0.2
-      ts-jest: 27.1.3_b64eba0a9f1c7068f7f3a75addda5ccd
-      typescript: 4.6.2
-
   packages/js/internal-style-build:
     specifiers:
       '@automattic/color-studio': ^2.5.0
@@ -1082,6 +1051,37 @@ importers:
       eslint: 8.12.0
       jest: 27.5.1
       jest-cli: 27.5.1
+      rimraf: 3.0.2
+      ts-jest: 27.1.3_b64eba0a9f1c7068f7f3a75addda5ccd
+      typescript: 4.6.2
+
+  packages/js/notices:
+    specifiers:
+      '@automattic/data-stores': ^2.0.1
+      '@babel/core': ^7.17.5
+      '@woocommerce/eslint-plugin': workspace:*
+      '@wordpress/a11y': ^3.5.0
+      '@wordpress/data': ^6.3.0
+      '@wordpress/notices': ^3.3.2
+      eslint: ^8.12.0
+      jest: ^27.5.1
+      jest-cli: ^27.5.1
+      redux: ^4.2.0
+      rimraf: ^3.0.2
+      ts-jest: ^27.1.3
+      typescript: ^4.6.2
+    dependencies:
+      '@wordpress/a11y': 3.5.0
+      '@wordpress/data': 6.4.1
+      '@wordpress/notices': 3.4.1
+    devDependencies:
+      '@automattic/data-stores': 2.0.1_@wordpress+data@6.4.1
+      '@babel/core': 7.17.8
+      '@woocommerce/eslint-plugin': link:../eslint-plugin
+      eslint: 8.12.0
+      jest: 27.5.1
+      jest-cli: 27.5.1
+      redux: 4.2.0
       rimraf: 3.0.2
       ts-jest: 27.1.3_b64eba0a9f1c7068f7f3a75addda5ccd
       typescript: 4.6.2
@@ -1213,6 +1213,7 @@ importers:
       '@woocommerce/woocommerce-rest-api': ^1.0.1
       '@wordpress/babel-plugin-import-jsx-pragma': 1.1.3
       '@wordpress/babel-preset-default': 3.0.2
+      '@wordpress/env': ^4.8.0
       '@wordpress/stylelint-config': 19.1.0
       allure-commandline: ^2.17.2
       allure-playwright: ^2.0.0-beta.16
@@ -1254,6 +1255,7 @@ importers:
       '@woocommerce/woocommerce-rest-api': 1.0.1
       '@wordpress/babel-plugin-import-jsx-pragma': 1.1.3_@babel+core@7.12.9
       '@wordpress/babel-preset-default': 3.0.2
+      '@wordpress/env': 4.8.0
       '@wordpress/stylelint-config': 19.1.0_stylelint@13.13.1
       allure-commandline: 2.17.2
       allure-playwright: 2.0.0-beta.16
@@ -1332,9 +1334,9 @@ importers:
       '@woocommerce/experimental': workspace:*
       '@woocommerce/explat': workspace:*
       '@woocommerce/internal-js-tests': workspace:*
-      '@woocommerce/notices': workspace:*
       '@woocommerce/internal-style-build': workspace:*
       '@woocommerce/navigation': workspace:*
+      '@woocommerce/notices': workspace:*
       '@woocommerce/number': workspace:*
       '@woocommerce/onboarding': workspace:*
       '@woocommerce/tracks': workspace:*
@@ -1536,9 +1538,9 @@ importers:
       '@woocommerce/experimental': link:../../packages/js/experimental
       '@woocommerce/explat': link:../../packages/js/explat
       '@woocommerce/internal-js-tests': link:../../packages/js/internal-js-tests
-      '@woocommerce/notices': link:../../packages/js/notices
       '@woocommerce/internal-style-build': link:../../packages/js/internal-style-build
       '@woocommerce/navigation': link:../../packages/js/navigation
+      '@woocommerce/notices': link:../../packages/js/notices
       '@woocommerce/number': link:../../packages/js/number
       '@woocommerce/onboarding': link:../../packages/js/onboarding
       '@woocommerce/tracks': link:../../packages/js/tracks
@@ -9271,6 +9273,18 @@ packages:
       '@jridgewell/resolve-uri': 3.0.5
       '@jridgewell/sourcemap-codec': 1.4.11
 
+  /@kwsites/file-exists/1.1.1:
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@kwsites/promise-deferred/1.1.1:
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+    dev: true
+
   /@mdx-js/loader/1.6.22:
     resolution: {integrity: sha512-9CjGwy595NaxAYp0hF9B/A0lH6C8Rms97e2JS9d3jVUtILn6pT5i5IV965ra3lIWc7Rs1GG1tBdVF7dCowYe6Q==}
     dependencies:
@@ -10422,6 +10436,11 @@ packages:
     dependencies:
       lodash.merge: 4.6.2
       postcss: 5.2.18
+
+  /@sindresorhus/is/2.1.1:
+    resolution: {integrity: sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==}
+    engines: {node: '>=10'}
+    dev: true
 
   /@sindresorhus/is/4.6.0:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -13073,7 +13092,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       defer-to-connect: 2.0.1
-    dev: false
 
   /@tannin/compile/1.1.0:
     resolution: {integrity: sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==}
@@ -13270,7 +13288,6 @@ packages:
       '@types/keyv': 3.1.4
       '@types/node': 17.0.21
       '@types/responselike': 1.0.0
-    dev: false
 
   /@types/cheerio/0.22.30:
     resolution: {integrity: sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==}
@@ -13392,7 +13409,6 @@ packages:
 
   /@types/http-cache-semantics/4.0.1:
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
-    dev: false
 
   /@types/http-proxy/1.17.7:
     resolution: {integrity: sha512-9hdj6iXH64tHSLTY+Vt2eYOGzSogC+JQ2H7bdPWkuh7KXP5qLllWx++t+K9Wk556c3dkDdPws/SpMRi0sdCT1w==}
@@ -13456,7 +13472,6 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 17.0.21
-    dev: false
 
   /@types/lodash/4.14.180:
     resolution: {integrity: sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==}
@@ -13636,7 +13651,6 @@ packages:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
       '@types/node': 17.0.21
-    dev: false
 
   /@types/retry/0.12.1:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
@@ -15809,6 +15823,26 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
 
+  /@wordpress/env/4.8.0:
+    resolution: {integrity: sha512-PiXP4z0txUdjmhW+8/43efa8gajWHr+LIO6OQt1LEM413TBFSjcjQtV4Q1Y/VaOkp7IqQ/XOveFBAVyi2NxkBA==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      copy-dir: 1.3.0
+      docker-compose: 0.22.2
+      extract-zip: 1.7.0
+      got: 10.7.0
+      inquirer: 7.3.3
+      js-yaml: 3.14.1
+      ora: 4.1.1
+      rimraf: 3.0.2
+      simple-git: 3.7.1
+      terminal-link: 2.1.1
+      yargs: 17.5.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@wordpress/escape-html/1.12.2:
     resolution: {integrity: sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==}
     dependencies:
@@ -17652,7 +17686,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0
     dev: true
 
   /babel-loader/8.2.3_d3f6fe5812216e437b67a6bf164a056c:
@@ -17682,7 +17716,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.70.0_webpack-cli@4.9.2
+      webpack: 5.70.0
     dev: true
 
   /babel-messages/6.23.0:
@@ -18795,6 +18829,14 @@ packages:
       union-value: 1.0.1
       unset-value: 1.0.0
 
+  /cacheable-lookup/2.0.1:
+    resolution: {integrity: sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/keyv': 3.1.4
+      keyv: 4.1.1
+    dev: true
+
   /cacheable-lookup/5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
@@ -18811,7 +18853,6 @@ packages:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.0
-    dev: false
 
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
@@ -19394,17 +19435,16 @@ packages:
     dev: true
 
   /clone-response/1.0.2:
-    resolution: {integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=}
+    resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
     dependencies:
       mimic-response: 1.0.1
-    dev: false
 
   /clone-stats/1.0.0:
     resolution: {integrity: sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=}
     dev: true
 
   /clone/1.0.4:
-    resolution: {integrity: sha1-2jCcwmPfFZlMaIypAheco8fNfH4=}
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
   /clone/2.1.2:
@@ -19797,6 +19837,10 @@ packages:
     resolution: {integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=}
     engines: {node: '>=0.10.0'}
 
+  /copy-dir/1.3.0:
+    resolution: {integrity: sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==}
+    dev: true
+
   /copy-to-clipboard/3.3.1:
     resolution: {integrity: sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==}
     dependencies:
@@ -20104,7 +20148,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0
     dev: true
 
   /css-loader/3.6.0_webpack@5.70.0:
@@ -20692,6 +20736,13 @@ packages:
     resolution: {integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=}
     engines: {node: '>=0.10'}
 
+  /decompress-response/5.0.0:
+    resolution: {integrity: sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==}
+    engines: {node: '>=10'}
+    dependencies:
+      mimic-response: 2.1.0
+    dev: true
+
   /decompress-response/6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -20761,14 +20812,13 @@ packages:
     dev: true
 
   /defaults/1.0.3:
-    resolution: {integrity: sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=}
+    resolution: {integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==}
     dependencies:
       clone: 1.0.4
 
   /defer-to-connect/2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
-    dev: false
 
   /define-lazy-prop/2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
@@ -20993,6 +21043,11 @@ packages:
       buffer-indexof: 1.1.1
     dev: true
 
+  /docker-compose/0.22.2:
+    resolution: {integrity: sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==}
+    engines: {node: '>= 6.0.0'}
+    dev: true
+
   /doctrine/2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -21177,7 +21232,7 @@ packages:
     dev: true
 
   /duplexer3/0.1.4:
-    resolution: {integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=}
+    resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
     dev: true
 
   /duplexify/3.7.1:
@@ -23292,7 +23347,7 @@ packages:
     dev: true
 
   /fd-slicer/1.1.0:
-    resolution: {integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=}
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
       pend: 1.2.0
 
@@ -24551,6 +24606,27 @@ packages:
     dependencies:
       delegate: 3.2.0
 
+  /got/10.7.0:
+    resolution: {integrity: sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@sindresorhus/is': 2.1.1
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.2
+      cacheable-lookup: 2.0.1
+      cacheable-request: 7.0.2
+      decompress-response: 5.0.0
+      duplexer3: 0.1.4
+      get-stream: 5.2.0
+      lowercase-keys: 2.0.0
+      mimic-response: 2.1.0
+      p-cancelable: 2.1.1
+      p-event: 4.2.0
+      responselike: 2.0.0
+      to-readable-stream: 2.1.0
+      type-fest: 0.10.0
+    dev: true
+
   /got/11.8.3:
     resolution: {integrity: sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==}
     engines: {node: '>=10.19.0'}
@@ -25575,7 +25651,7 @@ packages:
     engines: {node: '>= 4'}
 
   /image-size/0.5.5:
-    resolution: {integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=}
+    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
@@ -28910,7 +28986,6 @@ packages:
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: false
 
   /json-parse-better-errors/1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -29017,7 +29092,6 @@ packages:
     resolution: {integrity: sha512-tGv1yP6snQVDSM4X6yxrv2zzq/EvpW+oYiUz6aueW1u9CtS8RzUQYxxmFwgZlO2jSgCxQbchhxaqXXp2hnKGpQ==}
     dependencies:
       json-buffer: 3.0.1
-    dev: false
 
   /kind-of/2.0.1:
     resolution: {integrity: sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=}
@@ -29568,7 +29642,6 @@ packages:
   /lowercase-keys/2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
-    dev: false
 
   /lowlight/1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -30168,7 +30241,11 @@ packages:
   /mimic-response/1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
-    dev: false
+
+  /mimic-response/2.1.0:
+    resolution: {integrity: sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==}
+    engines: {node: '>=8'}
+    dev: true
 
   /mimic-response/3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -31258,6 +31335,20 @@ packages:
       word-wrap: 1.2.3
     dev: true
 
+  /ora/4.1.1:
+    resolution: {integrity: sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==}
+    engines: {node: '>=8'}
+    dependencies:
+      chalk: 3.0.0
+      cli-cursor: 3.1.0
+      cli-spinners: 2.6.1
+      is-interactive: 1.0.0
+      log-symbols: 3.0.0
+      mute-stream: 0.0.8
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+    dev: true
+
   /ora/5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -31289,7 +31380,7 @@ packages:
     dev: true
 
   /os-tmpdir/1.0.2:
-    resolution: {integrity: sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=}
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
   /osenv/0.1.5:
@@ -31313,7 +31404,6 @@ packages:
   /p-cancelable/2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
-    dev: false
 
   /p-defer/1.0.0:
     resolution: {integrity: sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=}
@@ -31773,7 +31863,7 @@ packages:
     dev: true
 
   /pend/1.2.0:
-    resolution: {integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=}
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   /performance-now/2.1.0:
     resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
@@ -33653,7 +33743,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.70.0_webpack-cli@4.9.2
+      webpack: 5.70.0
     dev: true
 
   /rc/1.2.8:
@@ -35103,7 +35193,6 @@ packages:
     resolution: {integrity: sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==}
     dependencies:
       lowercase-keys: 2.0.0
-    dev: false
 
   /restore-cursor/2.0.0:
     resolution: {integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=}
@@ -35783,6 +35872,16 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  /simple-git/3.7.1:
+    resolution: {integrity: sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==}
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /simple-html-tokenizer/0.5.11:
     resolution: {integrity: sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==}
@@ -37144,7 +37243,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -37228,7 +37327,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0_acorn@8.7.0
-      webpack: 5.70.0_webpack-cli@3.3.12
+      webpack: 5.70.0
     transitivePeerDependencies:
       - acorn
     dev: true
@@ -37476,6 +37575,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       kind-of: 3.2.2
+
+  /to-readable-stream/2.1.0:
+    resolution: {integrity: sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==}
+    engines: {node: '>=8'}
+    dev: true
 
   /to-regex-range/2.1.1:
     resolution: {integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=}
@@ -37943,6 +38047,11 @@ packages:
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
+
+  /type-fest/0.10.0:
+    resolution: {integrity: sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==}
+    engines: {node: '>=8'}
+    dev: true
 
   /type-fest/0.12.0:
     resolution: {integrity: sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==}
@@ -39760,6 +39869,11 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
+  /yargs-parser/21.0.1:
+    resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
+    engines: {node: '>=12'}
+    dev: true
+
   /yargs-unparser/1.6.0:
     resolution: {integrity: sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==}
     engines: {node: '>=6'}
@@ -39826,6 +39940,19 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+
+  /yargs/17.5.1:
+    resolution: {integrity: sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.0.1
+    dev: true
 
   /yargs/4.8.1:
     resolution: {integrity: sha1-wMQpJMpKqmsObaFznfshZDn53cA=}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request makes changes to the unit test suite in order to support executing the tests within the `wp-env` environment. This will make it easier for people to start developing locally since they won't need to do anything special to run the test suite anymore.

Closes #32436.

### How to test the changes in this Pull Request:

1. Run `wp-env start`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
