### PR TITLE
Change is_file_valid_csv to wc_is_file_valid_csv

### DIFF
--- a/plugins/woocommerce/changelog/changelog-32460
+++ b/plugins/woocommerce/changelog/changelog-32460
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+WC_Product_CSV_Importer_Controller::is_file_valid_csv now just invokes wc_is_file_valid_csv. #32460

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -86,7 +86,6 @@ class WC_Product_CSV_Importer_Controller {
 	/**
 	 * Check whether a file is a valid CSV file.
 	 *
-	 * @todo Replace this method with wc_is_file_valid_csv() function.
 	 * @param string $file File path.
 	 * @param bool   $check_path Whether to also check the file is located in a valid location (Default: true).
 	 * @return bool
@@ -98,17 +97,7 @@ class WC_Product_CSV_Importer_Controller {
 		 * @param bool   $check_import_file_path If the import file path should be checked.
 		 * @param string $file                   Path of the file to be checked.
 		 */
-		if ( $check_path && apply_filters( 'woocommerce_product_csv_importer_check_import_file_path', true, $file ) && false !== stripos( $file, '://' ) ) {
-			return false;
-		}
-
-		$valid_filetypes = self::get_valid_csv_filetypes();
-		$filetype        = wp_check_filetype( $file, $valid_filetypes );
-		if ( in_array( $filetype['type'], $valid_filetypes, true ) ) {
-			return true;
-		}
-
-		return false;
+		return wc_is_file_valid_csv($file, $check_path);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -97,7 +97,7 @@ class WC_Product_CSV_Importer_Controller {
 		 * @param bool   $check_import_file_path If the import file path should be checked.
 		 * @param string $file                   Path of the file to be checked.
 		 */
-		return wc_is_file_valid_csv($file, $check_path);
+		return wc_is_file_valid_csv( $file, $check_path );
 	}
 
 	/**


### PR DESCRIPTION
This pull request replaces the class-specific is_file_valid_csv() function with the global wc_is_file_valid_csv() function as requested by the todo that was previously above the is_file_valid_csv() function on the previous line 89.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request replaces the class-specific is_file_valid_csv() function with the global wc_is_file_valid_csv() function as requested by the todo that was previously above the is_file_valid_csv() function on the previous line 89.

### How to test the changes in this Pull Request:

1. Go to Products -> All Products -> Import.
2. Follow the steps to import a CSV file, and make sure that the upload completes successfully.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak: WC_Product_CSV_Importer_Controller::is_file_valid_csv now just invokes wc_is_file_valid_csv.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
