### PR TITLE
Isolate `wp-env` Environments

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"phpVersion": "7.4",
 	"core": null,
-	"plugins": [ "./plugins/woocommerce" ],
+	"plugins": [ "." ],
 	"config": {
 		"JETPACK_AUTOLOAD_DEV": true,
 		"WP_DEBUG_LOG": true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While working on https://github.com/woocommerce/woocommerce/pull/32456 I realized that there is a large potential for plugin conflicts when using a central `wp-env` configuration. Plugins like the beta tester make changes to `wp-content/plugins/woocommerce`, which in that case would be very problematic. In order to avoid conflicts between plugins in the monorepo we should instead treat each as an isolated development environment. This pull request moves the `wp-env` configuration into `plugins/woocommerce` in pursuit of that.

Closes #32430.

### How to test the changes in this Pull Request:

1. [Make sure `wp-env` is installed](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/).
2. Make sure `pnpm` is installed and run `pnpm install` on the monorepo.
3. Run `pnpm nx composer-install woocommerce` to make sure WooCommerce is installed.4. 
4. Run `pnpm nx build woocommerce-admin` to make sure the React admin is built.
5. Run `wp-env start` from inside of the `plugins/woocommerce` directory and test out the environment. It should have a working WooCommerce plugin installed that maps to the local directory.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
