### PR TITLE
Fix continue setup prompt for adding first product appeared too early

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -98,7 +98,7 @@ class Products extends Task {
 			return;
 		}
 
-		if ( ! $this->is_active() || $this->is_complete() ) {
+		if ( ! $this->is_active() || ! $this->is_complete() ) {
 			return;
 		}
 
@@ -112,6 +112,9 @@ class Products extends Task {
 			WC_VERSION,
 			true
 		);
+
+		// Clear the active task transient to only show notice once per active session.
+		delete_transient( self::ACTIVE_TASK_TRANSIENT );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32136.

Fix the notice logic to show the prompt after a product is published on adding the first product.

![Screen Shot 2022-04-05 at 16 08 11](https://user-images.githubusercontent.com/4344253/161720332-79b289e8-943c-494e-821e-cbbc30fac852.png)


### How to test the changes in this Pull Request:

1. In WooCommerce > Home, click on **Add my products**
2. Select start with a template
3. Select physical product
4. Wait until the product page is populated
5. Observe continue setup popup should NOT appear before the product is saved
6. Publish the product. 
7. Should see the "continue setup" prompt
8.  The "continue setup" prompt should not appear again when reloading the page or creating another product

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix: continue setup prompt for adding first product appeared too early

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
