### PR TITLE
Track completion of non visible tasks as well

### DIFF
--- a/plugins/woocommerce/changelog/fix-32140_wcpay_completion_task
+++ b/plugins/woocommerce/changelog/fix-32140_wcpay_completion_task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue where some tasks where not being tracked as completed, when tracking is enabled. #32493

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -358,10 +358,6 @@ abstract class Task {
 	 * Track task completion if task is viewable.
 	 */
 	public function possibly_track_completion() {
-		if ( ! $this->can_view() ) {
-			return;
-		}
-
 		if ( ! $this->is_complete() ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -350,6 +350,13 @@ class TaskList {
 	 */
 	public function get_json() {
 		$this->possibly_track_completion();
+		// Track completion of non viewable tasks.
+		foreach ( $this->tasks as $task ) {
+			if ( ! $task->can_view() ) {
+				$task->possibly_track_completion();
+			}
+		}
+
 		return array(
 			'id'                    => $this->get_list_id(),
 			'title'                 => $this->title,

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -350,10 +350,11 @@ class TaskList {
 	 */
 	public function get_json() {
 		$this->possibly_track_completion();
-		// Track completion of non viewable tasks.
+		$tasks_json = array();
 		foreach ( $this->tasks as $task ) {
-			if ( ! $task->can_view() ) {
-				$task->possibly_track_completion();
+			$json = $task->get_json();
+			if ( $json['canView'] ) {
+				$tasks_json[] = $json;
 			}
 		}
 
@@ -363,12 +364,7 @@ class TaskList {
 			'isHidden'              => $this->is_hidden(),
 			'isVisible'             => $this->is_visible(),
 			'isComplete'            => $this->is_complete(),
-			'tasks'                 => array_map(
-				function( $task ) {
-					return $task->get_json();
-				},
-				$this->get_viewable_tasks()
-			),
+			'tasks'                 => $tasks_json,
 			'eventPrefix'           => $this->prefix_event( '' ),
 			'displayProgressHeader' => $this->display_progress_header,
 		);

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -73,8 +73,11 @@ class AdditionalPayments extends Payments {
 
 		$woocommerce_payments = new WooCommercePayments();
 
-		if ( ! $woocommerce_payments->is_requested() || ( $woocommerce_payments->is_supported() && ! $woocommerce_payments->is_connected() ) ) {
-			// Hide task if WC Pay is installed via OBW, in supported country, but not connected.
+		if ( ! $woocommerce_payments->is_requested() || ! $woocommerce_payments->is_supported() || ! $woocommerce_payments->is_connected() ) {
+			// Hide task if WC Pay is not installed via OBW, or is not connected, or the store is located in a country that is not supported by WC Pay.
+			return false;
+		}
+		if ( $this->get_parent_id() === 'extended_two_column' && WooCommercePayments::is_connected() ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -121,7 +121,6 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_connected() {
-		return true;
 		if ( class_exists( '\WC_Payments' ) ) {
 			$wc_payments_gateway = \WC_Payments::get_gateway();
 			return method_exists( $wc_payments_gateway, 'is_connected' )

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -20,15 +20,6 @@ class WooCommercePayments extends Task {
 	}
 
 	/**
-	 * Parent ID.
-	 *
-	 * @return string
-	 */
-	public function get_parent_id() {
-		return 'setup';
-	}
-
-	/**
 	 * Title.
 	 *
 	 * @return string
@@ -130,6 +121,7 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_connected() {
+		return true;
 		if ( class_exists( '\WC_Payments' ) ) {
 			$wc_payments_gateway = \WC_Payments::get_gateway();
 			return method_exists( $wc_payments_gateway, 'is_connected' )

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test the Task class.
+ * Class for testing the Task class.
  *
  * @package WooCommerce\Admin\Tests\OnboardingTasks
  */

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task.php
@@ -5,10 +5,10 @@
  * @package WooCommerce\Admin\Tests\OnboardingTasks
  */
 
-require_once __DIR__ . '/test-task.php';
-
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
+
+require_once __DIR__ . '/test-task.php';
 
 /**
  * class WC_Admin_Tests_OnboardingTasks_Task

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task.php
@@ -394,7 +394,7 @@ class WC_Admin_Tests_OnboardingTasks_Task extends WC_Unit_Test_Case {
 	 */
 	public function test_get_list_id() {
 		$task = new TestTask(
-			new TaskList( array( 'id' => 'setup' ) ),
+			new TaskList( array( 'id' => 'extended' ) ),
 			array(
 				'id' => 'wc-unit-test-task',
 			)

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/test-task.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/test-task.php
@@ -97,15 +97,6 @@ class TestTask extends Task {
 	}
 
 	/**
-	 * Parent ID.
-	 *
-	 * @return string
-	 */
-	public function get_parent_id() {
-		return 'extended';
-	}
-
-	/**
 	 * Level.
 	 *
 	 * @return int


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure we also track completion of non visible tasks and fix parent id in WooCommercePayments task

Closes #32140 

### How to test the changes in this Pull Request:

1. Run `pnpm nx build woocommerce` which will generate a zip
2. Load a Jurassic site with the zip, the [WooCommerce Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper), and [WooCommerce Payments Dev Tools](https://github.com/Automattic/woocommerce-payments-dev-tools) (you probably want to disable the **Proxy WPCOM requests** setting in the WC Pay Dev Tools
3. Finish the onboarding wizard, installing WC Pay as part of the free business features
4. Enable the `progression_headercard` experiment under **WCA Test Helper > Experiments** enable the header card and the 2 col one to `treatment`
5. Go to **WooCommerce > Home** and finish the WooCommerce Payments task
6. Once connected The experiment task list won't show the Payments task anymore, but there should be a `wcadmin_tasklist_task_completed` generated to view this go to **WooCommerce > Status > Logs** and look for the `tracks-__current_date.log` log.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Track completion of non visible tasks within the task list.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
