### PR TITLE
Fix PHP warning of missing default value in spec

### DIFF
--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -42,7 +42,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		}
 
 		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
-			$option_value = TransformerService::apply( $option_value, $rule->transformers, $rule->default );
+			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
 		}
 
 		return ComparisonOperation::compare(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make use of `$default` value when passing it into the Transformer service.

Closes #32154 

### How to test the changes in this Pull Request:

1. On a fresh site, or make sure this transient is deleted `woocommerce_admin_payment_gateway_suggestions_specs`
2. Click on the `Set up payments` task
3. Open up your `debug.log` and make sure there are no new warnings displayed, specifically this warning:
```
Undefined property: stdClass::$default
 Type: PHP Notice Line: 45
 File: /wp-content/plugins/woocommerce-admin/src/RemoteInboxNotifications/OptionRuleProcessor.php
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix PHP warning when default param is missing in payments spec.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
