### PR TITLE
Fix WooCommerce Payments task not showing up in some supported countries

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcpay_task
+++ b/plugins/woocommerce/changelog/fix-wcpay_task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WooCommerce Payments task not showing up in some supported countries. #32496

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as Suggestions;
 
 /**
  * WooCommercePayments Task
@@ -146,22 +147,14 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_supported() {
-		return in_array(
-			WC()->countries->get_base_country(),
-			array(
-				'US',
-				'PR',
-				'AU',
-				'CA',
-				'DE',
-				'ES',
-				'FR',
-				'GB',
-				'IE',
-				'IT',
-				'NZ',
-			),
-			true
-		);
+		$suggestions = Suggestions::get_suggestions();
+		$suggestion_plugins = array_merge( ...array_filter( array_column( $suggestions, 'plugins' ), function( $plugins ) {
+			return is_array( $plugins );
+		} ) );
+		$woocommerce_payments_ids = array_search( 'woocommerce-payments', $suggestion_plugins, true );
+		if ( false !== $woocommerce_payments_ids ) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -147,10 +147,15 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_supported() {
-		$suggestions = Suggestions::get_suggestions();
-		$suggestion_plugins = array_merge( ...array_filter( array_column( $suggestions, 'plugins' ), function( $plugins ) {
-			return is_array( $plugins );
-		} ) );
+		$suggestions              = Suggestions::get_suggestions();
+		$suggestion_plugins       = array_merge(
+			...array_filter(
+				array_column( $suggestions, 'plugins' ),
+				function( $plugins ) {
+					return is_array( $plugins );
+				}
+			)
+		);
 		$woocommerce_payments_ids = array_search( 'woocommerce-payments', $suggestion_plugins, true );
 		if ( false !== $woocommerce_payments_ids ) {
 			return true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

- Create a brand new store (e.g.: using JN).
- Start the Onboarding flow and make sure to set the country to Portugal
- During the Business Details, install WCPayments.
- After finishing the OBW the task `Get paid with WooCommerce Payments` should appear instead of the `Set up payments` task.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix WooCommerce Payments task not showing up in some supported countries.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
