### PR TITLE
Add a custom build_step for use with Woorelease

### DIFF
--- a/plugins/woocommerce/changelog/add-woorelease-custom-build
+++ b/plugins/woocommerce/changelog/add-woorelease-custom-build
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: No changelog entry is necessary as this change only affects the tooling for building and releasing.
+
+

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -9,7 +9,8 @@
   },
   "license": "GPL-3.0+",
   "config": {
-    "wp_org_slug": "woocommerce"
+    "wp_org_slug": "woocommerce",
+    "build_step": "pnpm install && pnpm nx build-zip woocommerce"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a `build_step` configuration to the `package.json` file for properly building WooCommerce with Woorelease

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Verify that the `build_step` command is correct and works with a version of Woorelease supporting `build_step`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
