### PR TITLE
Add/payment failed action hook

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -31,8 +31,6 @@ defined( 'ABSPATH' ) || exit;
 				'description' => __( 'This text will be shown on the button linking to the external product.', 'woocommerce' ),
 			)
 		);
-		
-		do_action( 'woocommerce_product_options_external' );
 		?>
 	</div>
 

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -980,6 +980,8 @@ class WC_Checkout {
 			}
 
 			wp_send_json( $result );
+		}else{
+			do_action( 'woocommerce_payment_failed', $result, $order_id );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The new hook will be fired in case of failed payment, this would provide the ability to add extra security procedures in case of multiple failed payment.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->



<!-- Mark completed items with an [x] -->

### Changelog entry

> Add woocommerce_payment_failed action hook, will be fired in case of failed payment attempt.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
