### PR TITLE
WCPayments task is not visible after installing the plugin

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -201,7 +201,10 @@ class BusinessDetails extends Component {
 
 		const promises = [
 			this.persistProfileItems( {
-				business_extensions: businessExtensions,
+				business_extensions: [
+					...businessExtensions,
+					...alreadyActivatedExtensions,
+				],
 			} ),
 		];
 

--- a/plugins/woocommerce/changelog/fix-hidden_wcpay_task
+++ b/plugins/woocommerce/changelog/fix-hidden_wcpay_task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+WCPayments task is not visible after installing the plugin #32506


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR aims to fix the problem mentioned in [this comment](https://github.com/woocommerce/woocommerce/issues/32330#issuecomment-1082928199). After installing WCPayments during the profiler, the WCPayments task should be visible instead of the task `Set up payments`.

Closes #32330.

![screenshot-medieval-mantis jurassic ninja-2022 03 30-16_45_06](https://user-images.githubusercontent.com/1314156/160928161-2c8c7efe-0922-49dc-8c1d-f2a124ccf2cb.png)

Ref [WC-Admin 8514](https://github.com/woocommerce/woocommerce-admin/pull/8514)

### How to test the changes in this Pull Request:

1. Create a brand new store (e.g.: using JN).
2. Create a zip (using `npm run test:zip`), install it, and activate it.
3. In the OBW, during the Business Details, install WCPayments.
4. After finishing the OBW the task `Get paid with WooCommerce Payments` should appear instead of the `Set up payments` task.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> WCPayments task is not visible after installing the plugin #32506

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
