### PR TITLE
Fix experiment 1 UI issues

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -64,6 +64,8 @@ export const Layout = ( {
 	query,
 	taskListComplete,
 	hasTaskList,
+	showingProgressHeader,
+	isLoadingTaskLists,
 	shouldShowWelcomeModal,
 	shouldShowWelcomeFromCalypsoModal,
 	isTaskListHidden,
@@ -141,7 +143,9 @@ export const Layout = ( {
 				<Column shouldStick={ shouldStickColumns }>
 					{ ! isLoadingExperimentAssignment &&
 						! isLoadingTwoColExperimentAssignment &&
-						! isRunningTaskListExperiment && (
+						! isRunningTaskListExperiment &&
+						! isLoadingTaskLists &&
+						! showingProgressHeader && (
 							<ActivityHeader
 								className="your-store-today"
 								title={ __(
@@ -286,7 +290,13 @@ export default compose(
 		const { getOption, hasFinishedResolution } = select(
 			OPTIONS_STORE_NAME
 		);
-		const { getTaskList } = select( ONBOARDING_STORE_NAME );
+		const {
+			getTaskList,
+			getTaskLists,
+			hasFinishedResolution: taskListFinishResolution,
+		} = select( ONBOARDING_STORE_NAME );
+		const taskLists = getTaskLists();
+		const isLoadingTaskLists = ! taskListFinishResolution( 'getTaskLists' );
 
 		const welcomeFromCalypsoModalDismissed =
 			getOption( WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME ) !==
@@ -336,8 +346,12 @@ export default compose(
 			isBatchUpdating: isNotesRequesting( 'batchUpdateNotes' ),
 			shouldShowWelcomeModal,
 			shouldShowWelcomeFromCalypsoModal,
+			isLoadingTaskLists,
 			isTaskListHidden: getTaskList( 'setup' )?.isHidden,
 			hasTaskList: getAdminSetting( 'visibleTaskListIds', [] ).length > 0,
+			showingProgressHeader: !! taskLists.find(
+				( list ) => list.isVisible && list.displayProgressHeader
+			),
 			taskListComplete: getTaskList( 'setup' )?.isComplete,
 			installTimestamp,
 			installTimestampHasResolved,

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -236,10 +236,6 @@
 		position: absolute;
 		z-index: 0;
 		right: 6%;
-		// top: 50%;
-		// bottom: 50%;
-		// margin-top: auto;
-		// margin-bottom: auto;
 
 		.admin-theme-color {
 			fill: var(--wp-admin-theme-color);

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -130,7 +130,7 @@
 		}
 
 		.woocommerce-task-header__contents {
-			max-width: calc( 60% - 2% );
+			max-width: calc(60% - 2%);
 		}
 
 		.svg-background {

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -19,10 +19,10 @@
 		flex: 1;
 	}
 
-	.woocommerce-ellipsis-menu.setup {
+	.woocommerce-ellipsis-menu {
 		position: absolute;
-		top: 20px;
-		right: 16px;
+		top: $gap;
+		right: $gap-large;
 	}
 
 	.woocommerce-task-card.is-loading {
@@ -130,17 +130,24 @@
 		}
 
 		.woocommerce-task-header__contents {
-			max-width: 380px;
+			max-width: calc( 60% - 2% );
 		}
 
 		.svg-background {
-			right: 0.5%;
+			right: 2%;
 			width: 40%;
 		}
 	}
 
 	&:not(.two-columns) {
 		@include single-column;
+	}
+
+	&.two-columns .svg-background {
+		top: 50%;
+		bottom: 50%;
+		margin-top: auto;
+		margin-bottom: auto;
 	}
 
 	ul {
@@ -229,10 +236,10 @@
 		position: absolute;
 		z-index: 0;
 		right: 6%;
-		top: 50%;
-		bottom: 50%;
-		margin-top: auto;
-		margin-bottom: auto;
+		// top: 50%;
+		// bottom: 50%;
+		// margin-top: auto;
+		// margin-bottom: auto;
 
 		.admin-theme-color {
 			fill: var(--wp-admin-theme-color);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update some minor CSS issues, and make sure the activity header doesn't show in the two column layout when the progressive header is shown.

Closes #32128 

<img width="1250" alt="Screen Shot 2022-04-06 at 2 04 04 PM" src="https://user-images.githubusercontent.com/2240960/162028984-9e621b5e-633a-46c4-9f0d-513d002152e8.png">

### How to test the changes in this Pull Request:

Use the latest version of [WooCommerce Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper) plugin to toggle features, toggle `tasklist-setup-experiment-1` to true.
Or edit the `includes/feature-config.php` file by enabling the `tasklist-setup-experiment-1` feature, you can also run an add_filter in your mu plugin, something like this:
```
add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) {
	$feature_config['tasklist-setup-experiment-1'] = true;
	return $feature_config;
} );
```


1. Finish the onboarding wizard
2. Go to **WooCommerce > Home** and toggle the display to two columns
3. Make sure the header text doesn't overlap into the image
4. Now run this in your console and refresh the home page:
```
localStorage.setItem('explat-experiment--woocommerce_tasklist_progression_headercard_2022_04', '{"experimentName":"woocommerce_tasklist_progression_headercard_2022_04","variationName":"treatment","retrievedTimestamp":' + Date.now() + ',"ttl":9600}');
```
5. You should see the old experiment that overlaps the two columns, make sure that still looks good.
6. Toggle back to the single column and check if the burger button (for hiding the task list) is spaced properly now (should align with the burger button of the notes panel.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
