### PR TITLE
Update @wordpress/* dependencies

### DIFF
--- a/packages/js/components/CHANGELOG.md
+++ b/packages/js/components/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+-   Update dependency `@wordpress/hooks` to ^3.5.0
+-   Update dependency `@wordpress/icons` to ^8.1.0
+
 # 10.0.0
 -   Replace deprecated wp.compose.withState with wp.element.useState. #8338
 -   Add missing dependencies. #8349

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -39,7 +39,7 @@
 		"@wordpress/deprecated": "^3.3.1",
 		"@wordpress/dom": "^3.3.2",
 		"@wordpress/element": "^4.1.1",
-		"@wordpress/hooks": "^2.12.3",
+		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/html-entities": "^3.3.1",
 		"@wordpress/i18n": "^4.3.1",
 		"@wordpress/icons": "^6.3.0",

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -42,7 +42,7 @@
 		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/html-entities": "^3.3.1",
 		"@wordpress/i18n": "^4.3.1",
-		"@wordpress/icons": "^6.3.0",
+		"@wordpress/icons": "^8.1.0",
 		"@wordpress/keycodes": "^3.3.1",
 		"@wordpress/url": "^3.4.1",
 		"@wordpress/viewport": "^4.1.2",

--- a/packages/js/data/CHANGELOG.md
+++ b/packages/js/data/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Update dependency `@wordpress/hooks` to ^3.5.0
+
 # 3.1.0
 
 -   Add "moment" to peerDependencies. #8349

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -30,7 +30,7 @@
 		"@wordpress/data-controls": "^2.3.2",
 		"@wordpress/deprecated": "^3.3.1",
 		"@wordpress/element": "^4.1.1",
-		"@wordpress/hooks": "^2.12.3",
+		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/i18n": "^4.3.1",
 		"@wordpress/url": "^3.4.1",
 		"dompurify": "^2.3.6",

--- a/packages/js/experimental/CHANGELOG.md
+++ b/packages/js/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Update dependency `@wordpress/icons` to ^8.1.0
+
 # 3.0.1
 
 -   Update all js packages with minor/patch version changes. #8392

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/components": "^19.5.0",
 		"@wordpress/element": "^4.1.1",
 		"@wordpress/i18n": "^4.3.1",
-		"@wordpress/icons": "^6.3.0",
+		"@wordpress/icons": "^8.1.0",
 		"@wordpress/keycodes": "^3.3.1",
 		"classnames": "^2.3.1",
 		"dompurify": "^2.3.6",

--- a/packages/js/explat/CHANGELOG.md
+++ b/packages/js/explat/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Update dependency `@wordpress/hooks` to ^3.5.0
+
 # 2.1.0
 
 -   Add missing dependencies. #8349

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -28,7 +28,7 @@
 		"@automattic/explat-client": "^0.0.3",
 		"@automattic/explat-client-react-helpers": "^0.0.4",
 		"@wordpress/api-fetch": "^6.0.1",
-		"@wordpress/hooks": "^2.12.3",
+		"@wordpress/hooks": "^3.5.0",
 		"cookie": "^0.4.2",
 		"qs": "^6.10.3"
 	},

--- a/packages/js/navigation/CHANGELOG.md
+++ b/packages/js/navigation/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Update dependency `@wordpress/hooks` to ^3.5.0
+
 # 7.0.1
 
 -   Add missing dependencies. #8349

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -25,7 +25,7 @@
 		"@wordpress/components": "^19.5.0",
 		"@wordpress/compose": "^5.1.2",
 		"@wordpress/element": "^4.1.1",
-		"@wordpress/hooks": "^2.12.3",
+		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/notices": "^3.3.2",
 		"@wordpress/url": "^3.4.1",
 		"history": "^4.10.1",

--- a/packages/js/notices/CHANGELOG.md
+++ b/packages/js/notices/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+-   Update dependency `@wordpress/a11y` to ^3.5.0
+
 # 4.0.1
 
 -   Update all js packages with minor/patch version changes. #8392

--- a/packages/js/notices/package.json
+++ b/packages/js/notices/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@wordpress/a11y": "^2.15.3",
+		"@wordpress/a11y": "^3.5.0",
 		"@wordpress/data": "^6.3.0",
 		"@wordpress/notices": "^3.3.2"
 	},

--- a/packages/js/style-build/package.json
+++ b/packages/js/style-build/package.json
@@ -19,7 +19,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"@automattic/color-studio": "^2.5.0",
-		"@wordpress/base-styles": "^3.6.0",
+		"@wordpress/base-styles": "^4.3.0",
 		"@wordpress/postcss-plugins-preset": "^1.6.0",
 		"css-loader": "^3.6.0",
 		"mini-css-extract-plugin": "^2.6.0",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -96,7 +96,7 @@
 		"@woocommerce/api": "^0.2.0",
 		"@woocommerce/e2e-environment": "^0.3.0",
 		"@woocommerce/e2e-utils": "^0.2.0",
-		"@wordpress/a11y": "^2.15.3",
+		"@wordpress/a11y": "^3.5.0",
 		"@wordpress/api-fetch": "^6.0.1",
 		"@wordpress/base-styles": "^3.6.0",
 		"@wordpress/components": "^19.5.0",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -107,7 +107,7 @@
 		"@wordpress/dom": "^3.3.2",
 		"@wordpress/dom-ready": "^3.3.1",
 		"@wordpress/element": "^4.1.1",
-		"@wordpress/hooks": "^2.12.3",
+		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/html-entities": "^3.3.1",
 		"@wordpress/i18n": "^4.3.1",
 		"@wordpress/icons": "^6.3.0",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -98,7 +98,7 @@
 		"@woocommerce/e2e-utils": "^0.2.0",
 		"@wordpress/a11y": "^3.5.0",
 		"@wordpress/api-fetch": "^6.0.1",
-		"@wordpress/base-styles": "^3.6.0",
+		"@wordpress/base-styles": "^4.3.0",
 		"@wordpress/components": "^19.5.0",
 		"@wordpress/compose": "^5.1.2",
 		"@wordpress/core-data": "^4.1.2",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -110,7 +110,7 @@
 		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/html-entities": "^3.3.1",
 		"@wordpress/i18n": "^4.3.1",
-		"@wordpress/icons": "^6.3.0",
+		"@wordpress/icons": "^8.1.0",
 		"@wordpress/keycodes": "^3.3.1",
 		"@wordpress/notices": "^3.3.2",
 		"@wordpress/plugins": "^4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
       '@wordpress/dom': ^3.3.2
       '@wordpress/element': ^4.1.1
       '@wordpress/eslint-plugin': ^11.0.0
-      '@wordpress/hooks': ^2.12.3
+      '@wordpress/hooks': ^3.5.0
       '@wordpress/html-entities': ^3.3.1
       '@wordpress/i18n': ^4.3.1
       '@wordpress/icons': ^6.3.0
@@ -230,7 +230,7 @@ importers:
       '@wordpress/deprecated': 3.4.1
       '@wordpress/dom': 3.4.1
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 2.12.3
+      '@wordpress/hooks': 3.5.0
       '@wordpress/html-entities': 3.4.1
       '@wordpress/i18n': 4.4.1
       '@wordpress/icons': 6.3.0
@@ -428,7 +428,7 @@ importers:
       '@wordpress/deprecated': ^3.3.1
       '@wordpress/element': ^4.1.1
       '@wordpress/eslint-plugin': ^11.0.0
-      '@wordpress/hooks': ^2.12.3
+      '@wordpress/hooks': ^3.5.0
       '@wordpress/i18n': ^4.3.1
       '@wordpress/url': ^3.4.1
       dompurify: ^2.3.6
@@ -451,7 +451,7 @@ importers:
       '@wordpress/data-controls': 2.4.1
       '@wordpress/deprecated': 3.4.1
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 2.12.3
+      '@wordpress/hooks': 3.5.0
       '@wordpress/i18n': 4.4.1
       '@wordpress/url': 3.5.1
       dompurify: 2.3.6
@@ -795,7 +795,7 @@ importers:
       '@types/qs': ^6.9.7
       '@wordpress/api-fetch': ^6.0.1
       '@wordpress/eslint-plugin': ^11.0.0
-      '@wordpress/hooks': ^2.12.3
+      '@wordpress/hooks': ^3.5.0
       cookie: ^0.4.2
       eslint: ^8.12.0
       jest: ^27.5.1
@@ -808,7 +808,7 @@ importers:
       '@automattic/explat-client': 0.0.3
       '@automattic/explat-client-react-helpers': 0.0.4
       '@wordpress/api-fetch': 6.1.1
-      '@wordpress/hooks': 2.12.3
+      '@wordpress/hooks': 3.5.0
       cookie: 0.4.2
       qs: 6.10.3
     devDependencies:
@@ -866,7 +866,7 @@ importers:
       '@wordpress/compose': ^5.1.2
       '@wordpress/element': ^4.1.1
       '@wordpress/eslint-plugin': ^11.0.0
-      '@wordpress/hooks': ^2.12.3
+      '@wordpress/hooks': ^3.5.0
       '@wordpress/notices': ^3.3.2
       '@wordpress/url': ^3.4.1
       eslint: ^8.12.0
@@ -882,7 +882,7 @@ importers:
       '@wordpress/components': 19.6.1_@babel+core@7.17.8
       '@wordpress/compose': 5.2.1
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 2.12.3
+      '@wordpress/hooks': 3.5.0
       '@wordpress/notices': 3.4.1
       '@wordpress/url': 3.5.1
       history: 4.10.1
@@ -1242,7 +1242,7 @@ importers:
       '@wordpress/dom-ready': ^3.3.1
       '@wordpress/element': ^4.1.1
       '@wordpress/eslint-plugin': ^11.0.0
-      '@wordpress/hooks': ^2.12.3
+      '@wordpress/hooks': ^3.5.0
       '@wordpress/html-entities': ^3.3.1
       '@wordpress/i18n': ^4.3.1
       '@wordpress/icons': ^6.3.0
@@ -1359,7 +1359,7 @@ importers:
       '@wordpress/dom': 3.4.1
       '@wordpress/dom-ready': 3.4.1
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 2.12.3
+      '@wordpress/hooks': 3.5.0
       '@wordpress/html-entities': 3.4.1
       '@wordpress/i18n': 4.4.1
       '@wordpress/icons': 6.3.0
@@ -13983,7 +13983,7 @@ packages:
       '@wordpress/deprecated': 3.4.1
       '@wordpress/dom': 3.4.1
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 3.4.1
+      '@wordpress/hooks': 3.5.0
       '@wordpress/html-entities': 3.4.1
       '@wordpress/i18n': 4.4.1
       '@wordpress/is-shallow-equal': 4.4.1
@@ -14012,7 +14012,7 @@ packages:
       '@wordpress/deprecated': 3.4.1
       '@wordpress/dom': 3.4.1
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 3.4.1
+      '@wordpress/hooks': 3.5.0
       '@wordpress/html-entities': 3.4.1
       '@wordpress/i18n': 4.4.1
       '@wordpress/is-shallow-equal': 4.4.1
@@ -14062,7 +14062,7 @@ packages:
       '@wordpress/dom': 3.4.1
       '@wordpress/element': 4.2.1
       '@wordpress/escape-html': 2.4.1
-      '@wordpress/hooks': 3.4.1
+      '@wordpress/hooks': 3.5.0
       '@wordpress/i18n': 4.4.1
       '@wordpress/icons': 8.0.1
       '@wordpress/is-shallow-equal': 4.4.1
@@ -14115,7 +14115,7 @@ packages:
       '@wordpress/dom': 3.4.1
       '@wordpress/element': 4.2.1
       '@wordpress/escape-html': 2.4.1
-      '@wordpress/hooks': 3.4.1
+      '@wordpress/hooks': 3.5.0
       '@wordpress/i18n': 4.4.1
       '@wordpress/icons': 8.0.1
       '@wordpress/is-shallow-equal': 4.4.1
@@ -14364,7 +14364,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.17.7
-      '@wordpress/hooks': 3.4.1
+      '@wordpress/hooks': 3.5.0
     dev: false
 
   /@wordpress/dom-ready/3.4.1:
@@ -14973,7 +14973,7 @@ packages:
       '@babel/runtime': 7.17.7
       '@wordpress/compose': 5.2.1_react@17.0.2
       '@wordpress/element': 4.2.1
-      '@wordpress/hooks': 3.4.1
+      '@wordpress/hooks': 3.5.0
       '@wordpress/icons': 8.0.1
       lodash: 4.17.21
       memize: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
       '@wordpress/hooks': ^3.5.0
       '@wordpress/html-entities': ^3.3.1
       '@wordpress/i18n': ^4.3.1
-      '@wordpress/icons': ^6.3.0
+      '@wordpress/icons': ^8.1.0
       '@wordpress/keycodes': ^3.3.1
       '@wordpress/scripts': ^12.6.1
       '@wordpress/url': ^3.4.1
@@ -233,7 +233,7 @@ importers:
       '@wordpress/hooks': 3.5.0
       '@wordpress/html-entities': 3.4.1
       '@wordpress/i18n': 4.4.1
-      '@wordpress/icons': 6.3.0
+      '@wordpress/icons': 8.1.0
       '@wordpress/keycodes': 3.4.1
       '@wordpress/url': 3.5.1
       '@wordpress/viewport': 4.2.1
@@ -725,7 +725,7 @@ importers:
       '@wordpress/element': ^4.1.1
       '@wordpress/eslint-plugin': ^11.0.0
       '@wordpress/i18n': ^4.3.1
-      '@wordpress/icons': ^6.3.0
+      '@wordpress/icons': ^8.1.0
       '@wordpress/keycodes': ^3.3.1
       classnames: ^2.3.1
       concurrently: ^7.0.0
@@ -750,7 +750,7 @@ importers:
       '@wordpress/components': 19.6.1_@babel+core@7.17.8
       '@wordpress/element': 4.2.1
       '@wordpress/i18n': 4.4.1
-      '@wordpress/icons': 6.3.0
+      '@wordpress/icons': 8.1.0
       '@wordpress/keycodes': 3.4.1
       classnames: 2.3.1
       dompurify: 2.3.6
@@ -1007,7 +1007,7 @@ importers:
     specifiers:
       '@automattic/color-studio': ^2.5.0
       '@babel/core': ^7.17.5
-      '@wordpress/base-styles': ^3.6.0
+      '@wordpress/base-styles': ^4.3.0
       '@wordpress/eslint-plugin': ^11.0.0
       '@wordpress/postcss-plugins-preset': ^1.6.0
       css-loader: ^3.6.0
@@ -1025,7 +1025,7 @@ importers:
       webpack-rtl-plugin: ^2.0.0
     dependencies:
       '@automattic/color-studio': 2.5.0
-      '@wordpress/base-styles': 3.6.0
+      '@wordpress/base-styles': 4.3.0
       '@wordpress/postcss-plugins-preset': 1.6.0
       css-loader: 3.6.0_webpack@5.70.0
       mini-css-extract-plugin: 2.6.0_webpack@5.70.0
@@ -1230,7 +1230,7 @@ importers:
       '@wordpress/api-fetch': ^6.0.1
       '@wordpress/babel-plugin-makepot': ^2.1.3
       '@wordpress/babel-preset-default': ^6.5.1
-      '@wordpress/base-styles': ^3.6.0
+      '@wordpress/base-styles': ^4.3.0
       '@wordpress/browserslist-config': ^4.1.1
       '@wordpress/components': ^19.5.0
       '@wordpress/compose': ^5.1.2
@@ -1245,7 +1245,7 @@ importers:
       '@wordpress/hooks': ^3.5.0
       '@wordpress/html-entities': ^3.3.1
       '@wordpress/i18n': ^4.3.1
-      '@wordpress/icons': ^6.3.0
+      '@wordpress/icons': ^8.1.0
       '@wordpress/jest-preset-default': ^8.0.1
       '@wordpress/keycodes': ^3.3.1
       '@wordpress/notices': ^3.3.2
@@ -1350,7 +1350,7 @@ importers:
       '@woocommerce/e2e-utils': link:../../packages/js/e2e-utils
       '@wordpress/a11y': 3.5.0
       '@wordpress/api-fetch': 6.1.1
-      '@wordpress/base-styles': 3.6.0
+      '@wordpress/base-styles': 4.3.0
       '@wordpress/components': 19.6.1_978f344c876a57c1143ffe356b90df31
       '@wordpress/compose': 5.2.1_react@17.0.2
       '@wordpress/core-data': 4.2.1_react@17.0.2
@@ -1362,7 +1362,7 @@ importers:
       '@wordpress/hooks': 3.5.0
       '@wordpress/html-entities': 3.4.1
       '@wordpress/i18n': 4.4.1
-      '@wordpress/icons': 6.3.0
+      '@wordpress/icons': 8.1.0
       '@wordpress/keycodes': 3.4.1
       '@wordpress/notices': 3.4.1_react@17.0.2
       '@wordpress/plugins': 4.2.1_react@17.0.2
@@ -13954,6 +13954,10 @@ packages:
   /@wordpress/base-styles/3.6.0:
     resolution: {integrity: sha512-6/vXAmc9FSX7Y17UjKgUJoVU++Pv1U1G8uMx7iClRUaLetc7/jj2DD9PTyX/cdJjHr32e3yXuLVT9wfEbo6SEg==}
 
+  /@wordpress/base-styles/4.3.0:
+    resolution: {integrity: sha512-e9Z+txhEQ3zyAHkzzsuYg1ADFhKArz1eGU3ayqCNtCdakrgNjI6Q/sPODI26LlwTmjJPBIJ5wSCBrsDjMhdWqA==}
+    dev: false
+
   /@wordpress/blob/3.4.1:
     resolution: {integrity: sha512-rGm7nXaxnsXStIu9v9IjbUOKtE9UzkvgYiJMX5SyVyzAGLOo2Aq759+JNRDLRR0RDkS6igH/G7qBXS6xSgLFgA==}
     engines: {node: '>=12'}
@@ -14492,6 +14496,19 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
 
+  /@wordpress/element/4.3.0:
+    resolution: {integrity: sha512-QN5qsNN6kzbHgrCL9CG2877iOu01KMEwls1K3iKk43EQ8hr/D/Ms/h5TqfOgF6oIGUR/QUlbeZQJs4zdvEnFOg==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.17.7
+      '@types/react': 17.0.40
+      '@types/react-dom': 17.0.13
+      '@wordpress/escape-html': 2.5.0
+      lodash: 4.17.21
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
   /@wordpress/escape-html/1.12.2:
     resolution: {integrity: sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==}
     dependencies:
@@ -14510,6 +14527,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.17.7
+
+  /@wordpress/escape-html/2.5.0:
+    resolution: {integrity: sha512-WV4jI6uBPZNxxOQdftiOsx1WgimkjxnwCfx6T+K7Ltfnm78Q5q2P5R98twGOqSVI/rPqtZubv9e7oMDbpp4H2w==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.17.7
+    dev: false
 
   /@wordpress/eslint-plugin/11.0.1_2205da2c9bef219d53091cb9dbc5524c:
     resolution: {integrity: sha512-HDKwKjOmCaWdyJEtWKRAd0xK/NAXL/ykUP/I8l+zCvzvCXbS1UuixWN09RRzl09tv17JUtPiEqehDilkWRCBZg==}
@@ -14772,15 +14796,6 @@ packages:
       tannin: 1.2.0
     dev: false
 
-  /@wordpress/icons/6.3.0:
-    resolution: {integrity: sha512-Vliw7QsFuTsrA05GZov4i3PQiLQOGO97PR2keUeY53fVZdeoJKv/nfDqOZxZCIts5jR2Mfje6P6hc/KlurxsKg==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.17.7
-      '@wordpress/element': 4.2.1
-      '@wordpress/primitives': 3.2.1
-    dev: false
-
   /@wordpress/icons/8.0.1:
     resolution: {integrity: sha512-+K0yWNSMR6d/Q/Zlixw6I7/s8UIeMFuJUET3LhprMGLO3K+t+o/8xqfgXAMf4GiVkc0YV+kXOuCsMMXFFwzi+A==}
     engines: {node: '>=12'}
@@ -14788,6 +14803,15 @@ packages:
       '@babel/runtime': 7.17.7
       '@wordpress/element': 4.2.1
       '@wordpress/primitives': 3.2.1
+    dev: false
+
+  /@wordpress/icons/8.1.0:
+    resolution: {integrity: sha512-fNq0Mnzzf03uxIwKqQeU/G48wElyypwkhcBZWYQRpmwLZrOR231dxUeK9mzPOSGlYbgM+YKK+k3lzysGmrJU0A==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.17.7
+      '@wordpress/element': 4.3.0
+      '@wordpress/primitives': 3.3.0
     dev: false
 
   /@wordpress/is-shallow-equal/4.4.1:
@@ -14974,7 +14998,7 @@ packages:
       '@wordpress/compose': 5.2.1_react@17.0.2
       '@wordpress/element': 4.2.1
       '@wordpress/hooks': 3.5.0
-      '@wordpress/icons': 8.0.1
+      '@wordpress/icons': 8.1.0
       lodash: 4.17.21
       memize: 1.1.0
       react: 17.0.2
@@ -15024,6 +15048,15 @@ packages:
     dependencies:
       '@babel/runtime': 7.17.7
       '@wordpress/element': 4.2.1
+      classnames: 2.3.1
+    dev: false
+
+  /@wordpress/primitives/3.3.0:
+    resolution: {integrity: sha512-iwlFGSaI2RnQF0SxsWJ3KaM0LPdUosI5mb9879JXOh/vAFVObrQdyk5Fv+++vGUzDfxRnxAH68UpJi7nOzcRRA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.17.7
+      '@wordpress/element': 4.3.0
       classnames: 2.3.1
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,7 +901,7 @@ importers:
   packages/js/notices:
     specifiers:
       '@babel/core': ^7.17.5
-      '@wordpress/a11y': ^2.15.3
+      '@wordpress/a11y': ^3.5.0
       '@wordpress/data': ^6.3.0
       '@wordpress/eslint-plugin': ^11.0.0
       '@wordpress/notices': ^3.3.2
@@ -912,7 +912,7 @@ importers:
       ts-jest: ^27.1.3
       typescript: ^4.6.2
     dependencies:
-      '@wordpress/a11y': 2.15.3
+      '@wordpress/a11y': 3.5.0
       '@wordpress/data': 6.4.1
       '@wordpress/notices': 3.4.1
     devDependencies:
@@ -1226,7 +1226,7 @@ importers:
       '@woocommerce/onboarding': workspace:*
       '@woocommerce/style-build': workspace:*
       '@woocommerce/tracks': workspace:*
-      '@wordpress/a11y': ^2.15.3
+      '@wordpress/a11y': ^3.5.0
       '@wordpress/api-fetch': ^6.0.1
       '@wordpress/babel-plugin-makepot': ^2.1.3
       '@wordpress/babel-preset-default': ^6.5.1
@@ -1348,7 +1348,7 @@ importers:
       '@woocommerce/api': link:../../packages/js/api
       '@woocommerce/e2e-environment': link:../../packages/js/e2e-environment
       '@woocommerce/e2e-utils': link:../../packages/js/e2e-utils
-      '@wordpress/a11y': 2.15.3
+      '@wordpress/a11y': 3.5.0
       '@wordpress/api-fetch': 6.1.1
       '@wordpress/base-styles': 3.6.0
       '@wordpress/components': 19.6.1_978f344c876a57c1143ffe356b90df31
@@ -13779,14 +13779,6 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@wordpress/a11y/2.15.3:
-    resolution: {integrity: sha512-uoCznHY3/TaNWeXutLI6juC198ykaBwZ34P51PNHHQqi3WzVoBhFx6AnAR/9Uupl3tZcekefpkVHy7AJHMAPIA==}
-    dependencies:
-      '@babel/runtime': 7.17.7
-      '@wordpress/dom-ready': 2.13.2
-      '@wordpress/i18n': 3.20.0
-    dev: false
-
   /@wordpress/a11y/3.4.1:
     resolution: {integrity: sha512-SjeLO8x/Y/QAcKBrvyJiu8KVAPckRLNwuFfgX7zCGM8vBfg+Depj94Hp55ARLjq0oXHg7EWKxSdzNkvmTz8AIA==}
     engines: {node: '>=12'}
@@ -13794,6 +13786,15 @@ packages:
       '@babel/runtime': 7.17.7
       '@wordpress/dom-ready': 3.4.1
       '@wordpress/i18n': 4.4.1
+    dev: false
+
+  /@wordpress/a11y/3.5.0:
+    resolution: {integrity: sha512-pJyDexol4yFfUNs6BAW1IKftdxZBsxvNRpzmYcwXiFA+1jSnMJFehp0nu47skdzxiHS6CKyLqBks17J+a/GqGA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.17.7
+      '@wordpress/dom-ready': 3.5.0
+      '@wordpress/i18n': 4.5.0
     dev: false
 
   /@wordpress/api-fetch/5.2.6:
@@ -14366,14 +14367,15 @@ packages:
       '@wordpress/hooks': 3.4.1
     dev: false
 
-  /@wordpress/dom-ready/2.13.2:
-    resolution: {integrity: sha512-COH7n2uZfBq4FtluSbl37N3nCEcdMXzV42ETCWKUcumiP1Zd3qnkfQKcsxTaHWY8aVt/358RvJ7ghWe3xAd+fg==}
+  /@wordpress/dom-ready/3.4.1:
+    resolution: {integrity: sha512-w6DVKKpNwX0XUp0Cuh1OyFyGXLabr47k/ecRHKmQkQh9LdjRew7QvxUHYDN1rejRvq5GqcDb7Gnkz4E6hWIo4Q==}
+    engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.17.7
     dev: false
 
-  /@wordpress/dom-ready/3.4.1:
-    resolution: {integrity: sha512-w6DVKKpNwX0XUp0Cuh1OyFyGXLabr47k/ecRHKmQkQh9LdjRew7QvxUHYDN1rejRvq5GqcDb7Gnkz4E6hWIo4Q==}
+  /@wordpress/dom-ready/3.5.0:
+    resolution: {integrity: sha512-xhxZx3qH0UoWI3AMvZpB7NnKkHR5m5ifrBlinXM3+kSPQ8bIUkuOi2cFYdCnglPi0a+dd7OahWKFzXwDvgjO1w==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.17.7
@@ -14716,6 +14718,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.17.7
 
+  /@wordpress/hooks/3.5.0:
+    resolution: {integrity: sha512-6Ko+1rWLq75s2LeZah6e0sJC5lC2nL1M+DDLlP/EZ+YCGZlIKoCvkhVBuCdI2wgIHRPXU56OqLvw85rUjsfDJw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@babel/runtime': 7.17.7
+    dev: false
+
   /@wordpress/html-entities/3.4.1:
     resolution: {integrity: sha512-wSuwgONTefnhCB9B7mKS+e8islHuCkprfDc+FhqVAa6r5RbVBGvaHUJs8embgdtww7MwBRMnskNf/buQ8Jr02A==}
     engines: {node: '>=12'}
@@ -14748,6 +14757,20 @@ packages:
       memize: 1.1.0
       sprintf-js: 1.1.2
       tannin: 1.2.0
+
+  /@wordpress/i18n/4.5.0:
+    resolution: {integrity: sha512-BhOHsgnbWeUWT+23P/vksen0MiZ+OyhemZkKUHtQnelRKY4FnFEYvjp5q9v/O7DY3J0Hqc+Ss4wLNqajRQmMIw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.17.7
+      '@wordpress/hooks': 3.5.0
+      gettext-parser: 1.4.0
+      lodash: 4.17.21
+      memize: 1.1.0
+      sprintf-js: 1.1.2
+      tannin: 1.2.0
+    dev: false
 
   /@wordpress/icons/6.3.0:
     resolution: {integrity: sha512-Vliw7QsFuTsrA05GZov4i3PQiLQOGO97PR2keUeY53fVZdeoJKv/nfDqOZxZCIts5jR2Mfje6P6hc/KlurxsKg==}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32296.

- Update @wordpress/a11y from ^2.15.3 to ^3.5.0
- Update @wordpress/hooks from ^2.12.3 to ^3.5.0
- Update @wordpress/base-styles from ^3.6.0 to ^4.3.0
- Update @wordpress/icons from ^6.3.0 to ^8.1.0

The breaking changes in these updates are:

## @wordpress/a11y

* Drop support for Internet Explorer 11
* Increase the minimum Node.js version to v12

https://github.com/WordPress/gutenberg/blob/50b5bfa7de660d41a3b0e0693bf3fc9fc56836d8/packages/a11y/CHANGELOG.md

## @wordpress/base-styles   

* Remove the background-colors, foreground-colors, and gradient-colors mixins.
https://github.com/WordPress/gutenberg/blob/50b5bfa7de660d41a3b0e0693bf3fc9fc56836d8/packages/base-styles/CHANGELOG.md

## @wordpress/hooks 

* Drop support for Internet Explorer 11
* Increase the minimum Node.js version to v12

https://github.com/WordPress/gutenberg/blob/50b5bfa7de660d41a3b0e0693bf3fc9fc56836d8/packages/hooks/CHANGELOG.md

## @wordpress/icons

* Changed dragHandle footprint from 18x18 to 24x24 to match other icons. 
* Removed icons that were added by mistake: alignJustifyAlt, cogAlt, sparkles, trashFilled. 

https://github.com/WordPress/gutenberg/blob/50b5bfa7de660d41a3b0e0693bf3fc9fc56836d8/packages/icons/CHANGELOG.md

----

We've already dropped support for Internet Explorer 11 and increased the minimum Node.js version to v12.

And I just found our code don't use

- background-colors, foreground-colors, and gradient-colors mixins from @wordpress/base-styles .
- alignJustifyAlt, cogAlt, sparkles, trashFilled from @wordpress/icons.

So breaking changes shouldn't affect us.

### How to test the changes in this Pull Request:

1. All actions should pass
2. Run `pnpm install & pnpm nx build woocommerce`
3. Go through pages to ensure everything still work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

dev: Update @wordpress/* dependencies

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
