### PR TITLE
Update woocommerce-admin links to point to woocommerce repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,9 +41,8 @@ If you have questions about the process to contribute code or want to discuss de
 - Make sure to write good and detailed commit messages (see [this post](https://chris.beams.io/posts/git-commit/) for more on this) and follow all the applicable sections of the pull request template.
 - Please avoid modifying the changelog directly or updating the .pot files. These will be updated by the WooCommerce team.
 
-If you are contributing code to the (Javascript-driven) WooCommerce Admin project or to Gutenberg blocks, note that these are developed in external packages.
+If you are contributing code to the (Javascript-driven) to Gutenberg blocks, note that it's developed in external package.
 
-- [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin)
 - [Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block)
 
 ## Feature Requests 🚀

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,7 +41,7 @@ If you have questions about the process to contribute code or want to discuss de
 - Make sure to write good and detailed commit messages (see [this post](https://chris.beams.io/posts/git-commit/) for more on this) and follow all the applicable sections of the pull request template.
 - Please avoid modifying the changelog directly or updating the .pot files. These will be updated by the WooCommerce team.
 
-If you are contributing code to the (Javascript-driven) to Gutenberg blocks, note that it's developed in external package.
+If you are contributing code to the (Javascript-driven) Gutenberg blocks, note that it's developed in an external package.
 
 - [Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block)
 

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -36,13 +36,13 @@ To create a new package, add a new folder to `/packages`, containing…
     	"author": "Automattic",
     	"license": "GPL-2.0-or-later",
     	"keywords": [ "wordpress", "woocommerce" ],
-    	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/[_YOUR_PACKAGE_]/README.md",
+    	"homepage": "https://github.com/woocommerce/woocommerce/tree/main/packages/[_YOUR_PACKAGE_]/README.md",
     	"repository": {
     		"type": "git",
-    		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+    		"url": "https://github.com/woocommerce/woocommerce.git"
     	},
     	"bugs": {
-    		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+    		"url": "https://github.com/woocommerce/woocommerce/issues"
     	},
     	"main": "build/index.js",
     	"module": "build-module/index.js",

--- a/packages/js/admin-e2e-tests/package.json
+++ b/packages/js/admin-e2e-tests/package.json
@@ -3,10 +3,10 @@
 	"version": "1.0.0",
 	"author": "Automattic",
 	"description": "E2E tests for the new WooCommerce interface.",
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/admin-e2e-tests/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/admin-e2e-tests/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"keywords": [
 		"woocommerce",

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"components"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/components/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/components/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/components/src/advanced-filters/README.md
+++ b/packages/js/components/src/advanced-filters/README.md
@@ -124,7 +124,7 @@ const config = {
 };
 ```
 
-`type`: A string Autocompleter type used by the [Search Component](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/components/src/search).
+`type`: A string Autocompleter type used by the [Search Component](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/components/src/search).
 `getLabels`: A function returning a Promise resolving to an array of objects with `id` and `label` properties.
 
 ### Date

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"csv"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/csv-export/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/csv-export/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"currency"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/currency/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/currency/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -8,13 +8,13 @@
 		"wordpress",
 		"woocommerce"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/customer-effort-score/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/customer-effort-score/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"data"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/data/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/data/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"date"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/date/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/date/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/dependency-extraction-webpack-plugin/package.json
+++ b/packages/js/dependency-extraction-webpack-plugin/package.json
@@ -8,13 +8,13 @@
 		"wordpress",
 		"woocommerce"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/dependency-extraction-webpack-plugin/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/dependency-extraction-webpack-plugin/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "src/index.js",
 	"dependencies": {

--- a/packages/js/eslint-plugin/package.json
+++ b/packages/js/eslint-plugin/package.json
@@ -10,14 +10,14 @@
 		"eslint",
 		"plugin"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/eslint-plugin/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/eslint-plugin/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git",
+		"url": "https://github.com/woocommerce/woocommerce.git",
 		"directory": "packages/eslint-plugin"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"files": [
 		"configs",

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"experimental"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/experimental/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/experimental/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -10,13 +10,13 @@
 		"abtest",
 		"explat"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/explat/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/explat/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/js-tests/package.json
+++ b/packages/js/js-tests/package.json
@@ -4,14 +4,14 @@
 	"description": "JavaScript test tooling.",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/js-tests/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/js-tests/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git",
+		"url": "https://github.com/woocommerce/woocommerce.git",
 		"directory": "packages/js-tests"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"private": true,
 	"main": "build/util/index.js",

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"navigation"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/navigation/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/navigation/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -8,13 +8,13 @@
 		"wordpress",
 		"woocommerce"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/number/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/number/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"onboarding"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/onboarding/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/packages/js/style-build/package.json
+++ b/packages/js/style-build/package.json
@@ -8,13 +8,13 @@
 		"wordpress",
 		"woocommerce"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/style-build/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/style-build/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "index.js",
 	"dependencies": {

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -9,13 +9,13 @@
 		"woocommerce",
 		"tracks"
 	],
-	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/tracks/README.md",
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/tracks/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+		"url": "https://github.com/woocommerce/woocommerce.git"
 	},
 	"bugs": {
-		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",

--- a/plugins/woocommerce-admin/bin/starter-pack/README.md
+++ b/plugins/woocommerce-admin/bin/starter-pack/README.md
@@ -5,12 +5,12 @@ Scaffold a modern JavaScript WordPress plugin with WooCommerce tooling.
 ## Includes
 
 -   [wp-scripts](https://github.com/WordPress/gutenberg/tree/master/packages/scripts)
--   [WooCommerce Dependency Extraction Webpack Plugin](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/dependency-extraction-webpack-plugin)
--   [WooCommerce ESLint Plugin with WordPress Prettier](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/eslint-plugin)
+-   [WooCommerce Dependency Extraction Webpack Plugin](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/dependency-extraction-webpack-plugin)
+-   [WooCommerce ESLint Plugin with WordPress Prettier](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/eslint-plugin)
 
 ### Usage
 
-At the root of a [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin) installation, run the create extension command.
+At the root of a [WooCommerce Admin](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-admin) installation, run the create extension command.
 
 ```
 pnpm run create-wc-extension

--- a/plugins/woocommerce-admin/docs/data.md
+++ b/plugins/woocommerce-admin/docs/data.md
@@ -1,7 +1,7 @@
 Data
 ====
 
-WooCommerce Admin data stores implement the [`SqlQuery` class](https://github.com/woocommerce/woocommerce-admin/blob/main/src/API/Reports/SqlQuery.php). 
+WooCommerce Admin data stores implement the [`SqlQuery` class](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/API/Reports/SqlQuery.php). 
 
 ### SqlQuery Class
 

--- a/plugins/woocommerce-admin/docs/features/onboarding.md
+++ b/plugins/woocommerce-admin/docs/features/onboarding.md
@@ -35,7 +35,7 @@ To power the new onboarding flow client side, new REST API endpoints have been i
 * `woocommerce_admin_onboarding_plugins_whitelist` filters the list of plugins that can installed & activated via onboarding. This acts as a whitelist so only certain plugins can be used via the `/wc-admin/onboarding/profile/install` and `/wc-admin/onboarding/profile/activate` endpoints.
 * `woocommerce_admin_onboarding_themes` filters the themes displayed in the profile wizard.
 * `woocommerce_admin_onboarding_jetpack_connect_redirect_url` filters the Jetpack connection redirect URL outlined in the Jetpack connection section below.
-* `woocommerce_admin_onboarding_task_list` filters the list of tasks on the task list dashboard. This allows extensions to add new tasks. See [the extension docs](https://github.com/woocommerce/woocommerce-admin/tree/42015d17a919e8f9e54ba75869c50b04b8dc9241/docs/examples/extensions) for an example of how to do this.
+* `woocommerce_admin_onboarding_task_list` filters the list of tasks on the task list dashboard. This allows extensions to add new tasks. See [the extension docs](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-admin/docs/examples/extensions) for an example of how to do this.
 * `woocommerce_rest_onboarding_profile_collection_params` filters the collection parameters for requests to  `/wc-admin/onboarding/profile`.
 * `woocommerce_rest_onboarding_profile_object_query` filters the query arguments for requests to `/wc-admin/onboarding/profile`.
 * `woocommerce_rest_onboarding_prepare_onboarding_profile` filters the response for requests to `/wc-admin/onboarding/profile`.
@@ -48,7 +48,7 @@ A few new WordPress options have been introduced to store information and settin
 * `woocommerce_task_list_hidden_lists`. This option houses the task lists that have been hidden from view by the user.
 * `woocommerce_task_list_welcome_modal_dismissed`. This option is used to show a congratulations modal during the transition between the profile wizard and task list.
 
-We also use existing options from WooCommerce Core or extensions like WooCommerce Shipping & Tax or Stripe. The list below may not be complete, as new tasks are introduced, but you can generally find usage of these by searching for the [getOptions selector](https://github.com/woocommerce/woocommerce-admin/search?q=getOptions&unscoped_q=getOptions).
+We also use existing options from WooCommerce Core or extensions like WooCommerce Shipping & Tax or Stripe. The list below may not be complete, as new tasks are introduced, but you can generally find usage of these by searching for the [getOptions selector](https://github.com/woocommerce/woocommerce/search?q=getOptions&unscoped_q=getOptions).
 
 * `woocommerce_setup_jetpack_opted_in` and `wc_connect_options` are both used to control Jetpack's Terms of Service opt-in, which is necessary to set for a user during the connection process, so that they can use services like automated tax rates.
 * `woocommerce_allow_tracking` is used to control Tracks opt-in, allowing us to gather usage data from WooCommerce Admin and WooCommerce core.
@@ -59,7 +59,7 @@ We also use existing options from WooCommerce Core or extensions like WooCommerc
 
 During the profile wizard, merchants can select paid product type extensions (like WooCommerce Memberships) or a paid theme. To make installation easier and to finish purchasing, it is necessary to make a [WooCommerce.com connection](https://woocommerce.com/document/managing-woocommerce-com-subscriptions/). We also prompt users to connect on the task list if they chose extensions in the profile wizard, but did not finish connecting.
 
-To make the connection from the new onboarding experience possible, we build our own connection endpoints [/wc-admin/plugins/request-wccom-connect](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L298-L355) and [/wc-admin/plugins/finish-wccom-connect](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L357-L417).
+To make the connection from the new onboarding experience possible, we build our own connection endpoints [/wc-admin/plugins/request-wccom-connect](https://github.com/woocommerce/woocommerce/blob/feba6a8dcd55d4f5c7edc05478369c76df082293/plugins/woocommerce/src/Admin/API/Plugins.php#L419-L476) and [/wc-admin/plugins/finish-wccom-connect](https://github.com/woocommerce/woocommerce/blob/feba6a8dcd55d4f5c7edc05478369c76df082293/plugins/woocommerce/src/Admin/API/Plugins.php#L478-L538).
 
 Both of these endpoints use WooCommerce Core's `WC_Helper_API` directly. The main difference with our connection (compared to the connection on the subscriptions page) is the addition of two additional query string parameters:
 
@@ -72,7 +72,7 @@ To disconnect from WooCommerce.com, go to `WooCommerce > Extensions > WooCommerc
 
 Using Jetpack & WooCommerce Shipping & Tax allows us to offer additional features to new WooCommerce users as well as simplify parts of the setup process. For example, we can do automated tax calculations for certain countries, significantly simplifying the tax task. To make this work, the user needs to be connected to a WordPress.com account. This also means development and testing of these features needs to be done on a Jetpack connected site. Search the MGS & the Feld  Guide for additional resources on testing Jetpack with local setups.
 
-We have a special Jetpack connection flow designed specifically for WooCommerce onboarding, so that the user feels that they are connecting as part of a cohesive experience. To access this flow, we have a custom Jetpack connection endpoint [/wc-admin/plugins/connect-jetpack](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L273-L296).
+We have a special Jetpack connection flow designed specifically for WooCommerce onboarding, so that the user feels that they are connecting as part of a cohesive experience. To access this flow, we have a custom Jetpack connection endpoint [/wc-admin/plugins/connect-jetpack](https://github.com/woocommerce/woocommerce/blob/feba6a8dcd55d4f5c7edc05478369c76df082293/plugins/woocommerce/src/Admin/API/Plugins.php#L395-L417).
 
 We use Jetpack's `build_connect_url` function directly, but add the following two query parameters:
 
@@ -115,7 +115,7 @@ If you are running the development version of WooCommerce Admin, and have [`WP_D
 
 The `onboarding` feature flag is enabled in the main WooCommerce Admin plugin build. That means the published version of the plugin on WordPress.org contains the onboarding feature, but it is visually off by default. See the "enable onboarding" section above.
 
-Sometimes, it may be necessary to generate a separate build of the plugin between public releases for internal testing or debugging. This can be done using the [building custom plugin builds](https://github.com/woocommerce/woocommerce-admin/blob/main/docs/feature-flags.md#building-custom-plugin-builds) feature of our build system.
+Sometimes, it may be necessary to generate a separate build of the plugin between public releases for internal testing or debugging. This can be done using the [building custom plugin builds](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/docs/features/feature-flags.md#building-custom-plugin-builds) feature of our build system.
 
 * Switch to the latest `main` branch and pull down any changes
 * Run `pnpm run build:release -- --slug onboarding --features '{"onboarding":true}'`

--- a/plugins/woocommerce-admin/docs/features/payment-gateway-suggestions.md
+++ b/plugins/woocommerce-admin/docs/features/payment-gateway-suggestions.md
@@ -41,7 +41,7 @@ The data source schema defines the recommended payment gateways and required plu
 ]
 ```
 
-The specs use the [rule processor](https://github.com/woocommerce/woocommerce-admin/blob/main/src/RemoteInboxNotifications/README.md#rule) to determine if a gateway should be shown using the `is_visible` property.
+The specs use the [rule processor](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/src/Admin/RemoteInboxNotifications#rule) to determine if a gateway should be shown using the `is_visible` property.
 
 ## Payment Gateway Configs
 
@@ -64,13 +64,13 @@ By default, the client will generate a payment gateway setup form from the setti
 
 ### WooPaymentGatewayConfigure
 
-To customize the configuration form used in the payment setup, you can use [WooPaymentGatewayConfigure](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewayConfigure). 
+To customize the configuration form used in the payment setup, you can use [WooPaymentGatewayConfigure](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/onboarding/src/components/WooPaymentGatewayConfigure). 
 
 This will leave the default gateway installation and stepper in place, but allow the form to be customized as needed.
 
 ### WooPaymentGatewaySetup
 
-To completely override the stepper and default installation behavior, the gateway can be SlotFilled using [WooPaymentGatewaySetup](https://github.com/woocommerce/woocommerce-admin/tree/main/packages/onboarding/src/components/WooPaymentGatewaySetup).
+To completely override the stepper and default installation behavior, the gateway can be SlotFilled using [WooPaymentGatewaySetup](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/onboarding/src/components/WooPaymentGatewaySetup).
 
 ## Post install setup
 

--- a/plugins/woocommerce-admin/docs/woocommerce.com/analytics-orders-report.md
+++ b/plugins/woocommerce-admin/docs/woocommerce.com/analytics-orders-report.md
@@ -2,7 +2,7 @@
 
 The Orders Report provides insight about your store's orders.
 
-By default, orders with non-excluded statuses are listed by order date descending. Excluded statuses can be edited on the [Settings page](https://github.com/woocommerce/woocommerce-admin/blob/main/docs/woocommerce.com/analytics-settings.md#excluded-statuses)
+By default, orders with non-excluded statuses are listed by order date descending. Excluded statuses can be edited on the [Settings page](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/docs/woocommerce.com/analytics-settings.md#excluded-statuses)
 
 Refunded orders cannot be excluded from the orders report. Refunded orders have two rows in the report: one for the date of the original order and one for the date of refund.
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32516.

- Update the links of woocommerce-admin in docs and package.json to point to https://github.com/woocommerce/woocommerce.
- Removed woocommerce-admin link from contributing guide.

### How to test the changes in this Pull Request:

1. Review the changes and make sure all links are correctly updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

docs: Update woocommerce-admin links to point to woocommerce repo

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
