### PR TITLE
Fix bug in changelogger detection action for larger PRs

### DIFF
--- a/.github/actions/deepen-to-merge-base/action.yml
+++ b/.github/actions/deepen-to-merge-base/action.yml
@@ -1,0 +1,62 @@
+# From https://raw.githubusercontent.com/Automattic/jetpack/3642768c7b1cc88c94066fb2da62a11dafb3e604/.github/actions/deepen-to-merge-base/action.yml
+name: "Deepen to merge-base"
+description: "Deepens a checkout to the merge-base with another branch."
+inputs:
+  head:
+    description: "Branch (or other git refspec) to be checked out."
+    default: ${{ github.event.pull_request.head.sha }}
+  branch:
+    description: "Branch (or other git refspec) to deepen with respect to."
+    default: ${{ github.event.pull_request.base.sha }}
+  checkout:
+    description: "Whether to check out the head. Default is true."
+    default: true
+  initial-depth:
+    description: "Initial depth to check out."
+    default: 10
+outputs:
+  merge-base:
+    description: "The merge-base sha found."
+    value: ${{ steps.end.outputs.merge-base }}
+runs:
+  using: composite
+  steps:
+    - name: "Deepen"
+      shell: bash
+      env:
+        DEPTH: ${{ inputs.initial-depth }}
+        HEAD: ${{ inputs.head }}
+        BRANCH: ${{ inputs.branch }}
+      run: |
+        depth=$DEPTH
+        echo "::group::Initial fetch to $depth"
+        echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth origin $HEAD $BRANCH"
+        /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth origin "$HEAD" "$BRANCH"
+        echo "::endgroup::"
+        while ! /usr/bin/git merge-base "$HEAD" "$BRANCH" >/dev/null 2>&1; do
+          depth=$((depth * 2))
+          echo "::group::Deepen to $depth"
+          echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth origin $HEAD $BRANCH"
+          /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth origin "$HEAD" "$BRANCH"
+          echo "::endgroup::"
+        done
+    - name: "Check out new head"
+      shell: bash
+      env:
+        CHECKOUT: ${{ inputs.checkout }}
+        HEAD: ${{ inputs.head }}
+      run: |
+        if [[ "$CHECKOUT" == "true" ]]; then
+          echo "/usr/bin/git checkout $HEAD"
+          /usr/bin/git checkout "$HEAD"
+        fi
+    - name: "Output"
+      id: end
+      shell: bash
+      env:
+        HEAD: ${{ inputs.head }}
+        BRANCH: ${{ inputs.branch }}
+      run: |
+        MERGE_BASE=$( /usr/bin/git merge-base "$HEAD" "$BRANCH" )
+        echo "Merge base is $MERGE_BASE"
+        echo "::set-output name=merge-base::$MERGE_BASE"

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -9,10 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 10
+
+      - uses: ./.github/actions/deepen-to-merge-base
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds `deepen-to-merge-base` action, so that PRs with more than 10 commits don't cause trouble with the base commit not being included in checkout.

### How to test the changes in this Pull Request:

1. Create a new PR based on `trunk` with at least 10 commits, with at least one commit in a changelogger project (such as `plugins/woocommerce`). **Do not add a changelog file.**
2. The changelogger linting action should fail without actually verifying whether the PR contains a changelog file, with a message like "Invalid symmetric difference expression..."
3. Include the changes in this PR in your branch and update your PR. The action should now fail because you haven't added a changelog file.
4. Add a changelog file to your PR, and verify that the changes pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
