### PR TITLE
Fix phpdoc return type for WC_Order_Refund::get_reason

### DIFF
--- a/plugins/woocommerce/includes/class-wc-order-refund.php
+++ b/plugins/woocommerce/includes/class-wc-order-refund.php
@@ -83,7 +83,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 *
 	 * @since 2.2
 	 * @param  string $context What the value is for. Valid values are view and edit.
-	 * @return int|float
+	 * @return string
 	 */
 	public function get_reason( $context = 'view' ) {
 		return $this->get_prop( 'reason', $context );
@@ -219,7 +219,7 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * Get refund reason.
 	 *
 	 * @deprecated 3.0
-	 * @return int|float
+	 * @return string
 	 */
 	public function get_refund_reason() {
 		wc_deprecated_function( 'get_refund_reason', '3.0', 'get_reason' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix phpdoc return type for WC_Order_Refund::get_reason. Refund reason is a string.

https://github.com/woocommerce/woocommerce/blob/ba17630dca398918e83543d4927f989970367570/plugins/woocommerce/tests/legacy/unit-tests/crud/refunds.php#L33-L37

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
