### PR TITLE
Remove featured request user agent headers

### DIFF
--- a/plugins/woocommerce/changelog/remove-32444-featured-request-user-agent-headers
+++ b/plugins/woocommerce/changelog/remove-32444-featured-request-user-agent-headers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove custom user-agent from featured extensions requests.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -104,6 +104,7 @@ class WC_Admin_Addons {
 				/* translators: %d: HTTP error code. */
 				$message = sprintf(
 					esc_html(
+						/* translators: Error code  */
 						__(
 							'Our request to the featured API got error code %d.',
 							'woocommerce'
@@ -134,6 +135,13 @@ class WC_Admin_Addons {
 		self::output_featured( $featured );
 	}
 
+	/**
+	 * Check if the error is due to an SSL error
+	 *
+	 * @param string $error_message Error message.
+	 *
+	 * @return bool True if SSL error, false otherwise
+	 */
 	public static function is_ssl_error( $error_message ) {
 		return false !== stripos( $error_message, 'cURL error 35' );
 	}
@@ -190,14 +198,23 @@ class WC_Admin_Addons {
 		$response_code = (int) wp_remote_retrieve_response_code( $raw_extensions );
 		if ( 200 !== $response_code ) {
 			do_action( 'woocommerce_page_wc-addons_connection_error', $response_code );
-			return new WP_Error( 'error', __( "Our request to the search API got response code $response_code.", 'woocommerce' ) );
+			return new WP_Error(
+				'error',
+				sprintf(
+					esc_html(
+						/* translators: Error code  */
+						__( 'Our request to the search API got response code %s.', 'woocommerce' )
+					),
+					$response_code
+				)
+			);
 		}
 
 		$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) );
 
 		if ( ! is_object( $addons ) || ! isset( $addons->products ) ) {
 			do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
-			return new WP_Error( 'error', __( "Our request to the search API got a malformed response.", 'woocommerce' ) );
+			return new WP_Error( 'error', __( 'Our request to the search API got a malformed response.', 'woocommerce' ) );
 		}
 
 		return $addons;
@@ -961,6 +978,13 @@ class WC_Admin_Addons {
 		<?php
 	}
 
+	/**
+	 * Output HTML for a promotion action if data couldn't be fetched.
+	 *
+	 * @param string $message Error message.
+	 *
+	 * @return void
+	 */
 	public static function output_empty( $message = '' ) {
 		?>
 		<div class="wc-addons__empty">
@@ -970,9 +994,9 @@ class WC_Admin_Addons {
 			<?php endif; ?>
 			<p>
 				<?php
-				/* translators: a url */
 				printf(
 					wp_kses_post(
+						/* translators: a url */
 						__(
 							'To start growing your business, head over to <a href="%s">WooCommerce.com</a>, where you\'ll find the most popular WooCommerce extensions.',
 							'woocommerce'

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -38,8 +38,7 @@ class WC_Admin_Addons {
 			$raw_featured = wp_safe_remote_get(
 				'https://woocommerce.com/wp-json/wccom-extensions/1.0/featured',
 				array(
-					'headers'    => $headers,
-					'user-agent' => 'WooCommerce Addons Page',
+					'headers' => $headers,
 				)
 			);
 
@@ -82,8 +81,7 @@ class WC_Admin_Addons {
 			$raw_featured = wp_safe_remote_get(
 				'https://woocommerce.com/wp-json/wccom-extensions/2.0/featured' . $parameter_string,
 				array(
-					'headers'    => $headers,
-					'user-agent' => 'WooCommerce Addons Page',
+					'headers' => $headers,
 				)
 			);
 
@@ -258,7 +256,7 @@ class WC_Admin_Addons {
 		if ( ! empty( $section->endpoint ) ) {
 			$section_data = get_transient( 'wc_addons_section_' . $section_id );
 			if ( false === $section_data ) {
-				$raw_section = wp_safe_remote_get( esc_url_raw( $section->endpoint ), array( 'user-agent' => 'WooCommerce Addons Page' ) );
+				$raw_section = wp_safe_remote_get( esc_url_raw( $section->endpoint ) );
 
 				if ( ! is_wp_error( $raw_section ) ) {
 					$section_data = json_decode( wp_remote_retrieve_body( $raw_section ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32444 

When making an API request to `wccom-extensions/1.0/featured/` from within WP Admin, the user-agent header is entirely overridden.
This PR removes the unused custom header to preserve the original user agent.

### How to test the changes in this Pull Request:

1. Pull this branch into your local enviroment
2. Remove featured transients by running
```
wp transient delete wc_addons_featured
wp transient delete wc_addons_featured_2
```
3. Open the extensions tab (/wp-admin/admin.php?page=wc-addons)
4. Confirm that recommend extensions are loading

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove custom user-agent from featured extensions requests.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
