### PR TITLE
Fix ASCII Sorting in Different Locales

### DIFF
--- a/plugins/woocommerce/changelog/fix-ascii-uasort
+++ b/plugins/woocommerce/changelog/fix-ascii-uasort
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+String sorting when using different locales.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1775,19 +1775,8 @@ function wc_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
-	// 'setlocale' is required for compatibility with PHP 8.
-	// Without it, 'iconv' will return '?'s instead of transliterated characters.
-	$prev_locale = setlocale( LC_CTYPE, 0 );
-	setlocale( LC_ALL, 'C.UTF-8' );
-
-	// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
-	if ( function_exists( 'iconv' ) && defined( 'ICONV_IMPL' ) && @strcasecmp( ICONV_IMPL, 'unknown' ) !== 0 ) {
-		$a = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $a );
-		$b = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $b );
-	}
-	// phpcs:enable WordPress.PHP.NoSilencedErrors.Discouraged
-
-	setlocale( LC_ALL, $prev_locale );
+	$a = remove_accents( $a );
+	$b = remove_accents( $b );
 	return strcmp( $a, $b );
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While working on #32456, I've encountered a few different tests that fail in the new environment. One such failure is `--filter=WC_Core_Functions_Test::test_wc_ascii_uasort_comparison`. For some reason (likely due to locale differences between testing environments), the `É` accent is being converted to `'E` instead of `E`. I started by poking at the `iconv` implementation we were already using, but I realized that WordPress Core has [a `remove_accents` function](https://developer.wordpress.org/reference/functions/remove_accents/) that is aimed to more or less accomplish the same task.

This pull request replaces the conversion logic with the Core function.

### How to test the changes in this Pull Request:

1. Ensure that the test suite passes, since it has coverage of this function.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Using Changelogger.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
