### PR TITLE
Reduce risk of prematurely dropping meta box error messages

### DIFF
--- a/plugins/woocommerce/changelog/fix-errors-flash-messaging
+++ b/plugins/woocommerce/changelog/fix-errors-flash-messaging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Changes to reduce the risk of admin error messages being discarded prematurely.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2226,7 +2226,7 @@ class WC_AJAX {
 			echo '<button type="button" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'woocommerce' ) . '</span></button>';
 			echo '</div>';
 
-			delete_option( 'woocommerce_meta_box_errors' );
+			delete_option( WC_Admin_Meta_Boxes::ERROR_STORE );
 		}
 
 		wp_die();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3095,7 +3095,7 @@ class WC_AJAX {
 				}
 				$enabled = $gateway->get_option( 'enabled', 'no' );
 				$option  = array(
-					'id' => $gateway->get_option_key()
+					'id' => $gateway->get_option_key(),
 				);
 
 				if ( ! wc_string_to_bool( $enabled ) ) {

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-meta-boxes-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-meta-boxes-test.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Tests for meta box-related functionality in the product editor.
+ */
+class WC_Admin_Meta_Boxes_Test extends WC_Unit_Test_Case {
+	/**
+	 * @var WC_Admin_Meta_Boxes
+	 */
+	private $sut;
+
+	/**
+	 * Create subject-under-test.
+	 */
+	public function set_up() {
+		$this->sut = new WC_Admin_Meta_Boxes();
+		parent::set_up();
+	}
+
+	/**
+	 * @testdox Test that meta box errors can be stored and retrieved as expected.
+	 */
+	public function test_persistence_of_meta_box_errors() {
+		WC_Admin_Meta_Boxes::add_error( 'Oh no!' );
+		WC_Admin_Meta_Boxes::add_error( 'Crikey!' );
+
+		$error_output = $this->get_meta_box_error_output();
+		$this->assertEmpty( $error_output, 'If the errors have not first been saved to the database, they cannot be retrieved for display.' );
+
+		$this->simulate_shutdown();
+		$error_output = $this->get_meta_box_error_output();
+		$this->assertStringContainsString( 'Oh no!', $error_output, 'The error output contains the expected error string (test #1).' );
+		$this->assertStringContainsString( 'Crikey!', $error_output, 'The error output contains the expected error string (test #2).' );
+
+		$error_output = $this->get_meta_box_error_output();
+		$this->assertEmpty( $error_output, 'The error store is cleared after errors have been output.' );
+	}
+
+	/**
+	 * @testdox Test that the stored meta box errors are not accidentally cleared by concurrent requests before they are rendered.
+	 */
+	public function test_meta_box_errors_are_not_accidentally_cleared_during_shutdown() {
+		WC_Admin_Meta_Boxes::add_error( 'Yikes!' );
+
+		$this->simulate_shutdown();
+		$this->simulate_shutdown();
+
+		$error_output = $this->get_meta_box_error_output();
+		$this->assertStringContainsString( 'Yikes!', $error_output, 'The stored error persisted across requests.' );
+	}
+
+	/**
+	 * Calls the WC_Admin_Meta_Boxes::output_errors() method, capturing and returning the output.
+	 *
+	 * @return string
+	 */
+	private function get_meta_box_error_output(): string {
+		ob_start();
+		$this->sut->output_errors();
+		return ob_get_clean();
+	}
+
+	/**
+	 * Simulates what normally happens when `shutdown` occurs, in relation to the WC_Admin_Meta_Boxes class.
+	 * We avoid actually calling `do_action( 'shutdown' )` because we do not have perfect isolation between tests, and
+	 * wish to avoid unwanted side-effects unrelated to this set of tests.
+	 */
+	private function simulate_shutdown() {
+		// Previously (prior to 6.5.0), $this->sut->save_errors() would have been called during shutdown.
+		$this->sut->append_to_error_store();
+		WC_Admin_Meta_Boxes::$meta_box_errors = array();
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Within the product editor—and perhaps some other admin screens we own—we use flash messaging to display errors. That is, we add error messages in one request, temporarily storing them via the options API, then retrieve and render them on a subsequent request. However, in some cases this fails:

1. Suppose a product is updated. If a validation issue is detected we will attempt to [add an error](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php#L79-L81) which will be [stored in an option](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php#L86-L88) as soon as we reach [request shutdown](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php#L69).
2. Note here that when publishing/updating a product (or any post):
    - It may take several seconds for the editor to fully reload.
    - Post submissions also involve a redirect step.
3. Concurrently to this, other requests may be received (a possible origin being an admin ajax heartbeat from another tab that happens to be open) and, during that unrelated request's shutdown, the same thing will happen ... except the [instance var](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php#L31) used to temporarily store error strings will be empty, and therefore any previously stored errors [will be overwritten](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php#L87).

### How to test the changes in this Pull Request:

Owing to the nature of the problem, it's hard to contrive a test. You may or may not encounter this issue depending on how lucky or unlucky you are. However, we can at least confirm that, with this change in place, flash errors still work as expected within the product editor:

1. Go to the product editor, create a downloadable product.
2. Add a local filepath in the downloadable files area with a disallowed mimetype (the file doesn't actually need to exist—though it may need to be a suitably Windows-like filepath if you are using that OS, not entirely sure about that—do be sure to use a local path and not a remote URL, however, to trigger this particular error):

<img width="790" alt="bad-filepath" src="https://user-images.githubusercontent.com/3594411/162543052-1c627632-051c-45d3-bd1d-00832137ece3.png">

3. When the editor reloads, you should see the expected error (and in this case, that's a good thing: with this step we're just verifying that this change does not break admin error messaging):

<img width="1147" alt="bad-mimetype-err" src="https://user-images.githubusercontent.com/3594411/162543201-d9085c29-60c5-421d-b34f-3d02f833f9a1.png">

Additionally, with reference to the tests I added, temporarily changing [this line](https://github.com/woocommerce/woocommerce/compare/fix/errors-flash-messaging?expand=1#diff-91b4aa2f0eca47a5193a9d7e9b0f2b8cb1665d8a951901946ccba762552ae20dR70) from:

```php
$this->sut->append_to_error_store();
```

To:

```php
$this->sut->save_errors();
```

Mimics how things previously worked (in that the `save_errors()` method was being called during request shutdown), and will cause that test to fail. Could be helpful as a different way to see the problem and the fix.

### Other information:

This closes off one scenario, but I'd note there are other failings it doesn't touch. For instance, in a busy multi-user system one person could make an edit to a product resulting in an error, and another could open the same product for editing a split-second later and be presented with the error (could be confusing for them), which the first user would then not see (and they may then move on without addressing the problem, which they would be unaware of). 

We aren't fixing that here, however. Perhaps aspects like this would be better dealt with when we rebuild more of the admin environment.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
