### PR TITLE
Update PHPCS ruleset for PHP 7.2.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,7 +27,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.2" />
-	<config name="testVersion" value="7.0-" />
+	<config name="testVersion" value="7.2-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />


### PR DESCRIPTION
Now we have PHP 7.2 as our minimum, we can use things like `public const` — currently, though, the linter complains about these things. This PR fixes that.

### How to test the changes in this Pull Request:

Pick a file using some shiny new 7.2 syntax and run it through the linter:

`composer run phpcs src/Internal/DataStores/Orders/CustomOrdersTableController.php`

Without this change, you will see something like:

```
FILE: plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
----------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------
 24 | ERROR | Visibility indicators for class constants are not supported in PHP 7.0 or 
    |       | earlier. Found "private const"
    |       | (PHPCompatibility.Classes.NewConstVisibility.Found)
----------------------------------------------------------------------------------------
```

With this change, you will see something like the following, and you may also find you emit a little sigh of satisfaction:

```
. 1 / 1 (100%)
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Not required (in fact, the change-logger doesn't even ask for a blank changelog file).

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
