### PR TITLE
Fix admin js-tests config path

### DIFF
--- a/packages/js/js-tests/src/setup-globals.js
+++ b/packages/js/js-tests/src/setup-globals.js
@@ -107,7 +107,7 @@ wooCommercePackages.forEach( ( lib ) => {
 	} );
 } );
 
-const config = require( '../../../../plugins/woocommerce-admin/config/development.json' );
+const config = require( '../../../../plugins/woocommerce/client/admin/config/development.json' );
 
 // Check if test is jsdom or node
 if ( global.window ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32549.

Fixed the path since the config files have been moved to woocommerce plugin in this commit:
https://github.com/woocommerce/woocommerce/commit/407b22513367c1b0bd59100b66f9addf51f064ae

### How to test the changes in this Pull Request:

1. Lint and Test action should pass
2. Should be able to run `pnpm nx test woocommerce-admin` locally


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix admin js-tests config path

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
