### PR TITLE
Fix `@woocommerce/number` readme

### DIFF
--- a/packages/js/number/README.md
+++ b/packages/js/number/README.md
@@ -15,19 +15,19 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ## Usage
 
 ```JS
-import { formatNumber, formatValue, calculateDelta } from '@woocommerce/number';
+import { numberFormat, formatValue, calculateDelta } from '@woocommerce/number';
 
 // It's best to retrieve the site currency settings and compose them with the format functions.
 import { partial } from 'lodash';
 // Retrieve this from the API or a global settings object.
 const siteNumberOptions = {
-    precision: 2,
-	decimalSeparator: '.',
-	thousandSeparator: ',',
+  precision: 2,
+  decimalSeparator: '.',
+  thousandSeparator: ',',
 };
 // Compose.
-const formatStoreNumber = partial( siteNumberOptions, formatNumber );
-const formatStoreValue = partial( siteNumberOptions, formatValue );
+const formatStoreNumber = partial( numberFormat, siteNumberOptions );
+const formatStoreValue = partial( formatValue, siteNumberOptions );
 
 // Formats a number using site's current locale.
 const localizedNumber = formatStoreNumber( 1337 ); // '1,377'

--- a/packages/js/number/README.md
+++ b/packages/js/number/README.md
@@ -1,6 +1,6 @@
 # Number
 
-A collection of utilities to propery localize numerical values in WooCommerce
+A collection of utilities to properly localize numerical values in WooCommerce
 
 ## Installation
 

--- a/packages/js/number/changelog/fix-number-readme
+++ b/packages/js/number/changelog/fix-number-readme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Update readme code example.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Change import `formatNumber` to `numberFormat` in readme code example

https://github.com/woocommerce/woocommerce/blob/d56c79605c6de8db0db76c5ad27d789ee4a63175/packages/js/number/src/index.js#L20-L23

- Change lodash partial fn call params order in readme code example. Function to apply arguments to comes first: https://lodash.com/docs/4.17.15#partial

- Fix typo

- Add changelog entry

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Update readme code example.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
