### PR TITLE
Changed unminify plugin to hook into step before optimization

### DIFF
--- a/plugins/woocommerce-admin/unminify.js
+++ b/plugins/woocommerce-admin/unminify.js
@@ -47,7 +47,7 @@ class UnminifyWebpackPlugin {
 				compilation.hooks.processAssets.tap(
 					{
 						name: 'UnminifyWebpackPlugin',
-						stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+						stage: webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED,
 					},
 					( assets ) => {
 						Object.entries( assets ).forEach(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/issues/32485#issuecomment-1093384417 it was discovered that the unminify webpack plugin was not doing any unminifying as both the <x>.js and <x>.min.js files were identical in the build output.

This is due to a mistake in a previous PR that upgraded [webpack from 4 to 5](https://github.com/woocommerce/woocommerce-admin/pull/8476). 

The unminify webpack plugin is a modified copy of [the original](https://github.com/leftstick/unminified-webpack-plugin/blob/aa8fee41712ca086e1d474a7aec0c33cbf626d30/support5.js). 

In the webpack 5 migration, a mistake was made in the compilation pipeline hook that the unminify webpack plugin was triggering on, and it was applying after minification had already happened so it had no access to the original source. This PR changes the hook from `stage: webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE` to `stage: webpack.Compilation.PROCESS_ASSETS_STAGE_DERIVED`.

However, this PR does not close the above linked issue, as it does not seem to be the cause.


### How to test the changes in this Pull Request:

1. Build the `woocommerce.zip plugin`
2. Spin up an instance of WordPress and install the plugin
3. Check in the network tab, by default if SCRIPT_DEBUG is not set to 'true' in `wp-config.php`, the scripts that are loaded should take the form of index.min.js, etc
4. After setting SCRIPT_DEBUG to 'true' it should take the form of `index.js` etc

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed unminify webpack plugin to run correctly for woocommerce-admin

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
