### PR TITLE
Fetch more git history for changelogger comparison

### DIFF
--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,4 +1,4 @@
-name: Run lint checks potentially affected projects across the monorepo
+name: Run lint checks potentially affecting projects across the monorepo
 on: pull_request
 concurrency:
   group: changelogger-${{ github.event_name }}-${{ github.ref }}
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 10
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR increases the fetch depth for the GitHub action that verifies the changelog is in place. This is a more naive approach than the one taken in #32525, but problems arose while testing that one. Since this workflow is broken in most cases, I think the approach in #32525 should be revisited once we unblock people being stopped by current failures.

### How to test the changes in this Pull Request:

(These instructions are the same as #32525)
1. Create a new PR based on `trunk` with at least 10 commits, with at least one commit in a changelogger project (such as `plugins/woocommerce`). **Do not add a changelog file.**
2. The changelogger linting action should fail without actually verifying whether the PR contains a changelog file, with a message like "Invalid symmetric difference expression..."
3. Include the changes in this PR in your branch and update your PR. The action should now fail because you haven't added a changelog file.
4. Add a changelog file to your PR, and verify that the changes pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No changelog entry needed

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
