### PR TITLE
Product downloads → Support a concept of active/inactive files.

### DIFF
--- a/plugins/woocommerce/changelog/fix-downloadable-file-data
+++ b/plugins/woocommerce/changelog/fix-downloadable-file-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Make it possible for downloadable files to be in an enabled or disabled state.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1202,44 +1202,90 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Set downloads.
 	 *
-	 * @since 3.0.0
+	 * @throws WC_Data_Exception
+	 *
 	 * @param array $downloads_array Array of WC_Product_Download objects or arrays.
+	 *
+	 * @since 3.0.0
 	 */
 	public function set_downloads( $downloads_array ) {
-		$downloads = array();
-		$errors    = array();
+		// When the object is first hydrated, only the previously persisted downloads will be passed in.
+		$existing_downloads = $this->get_object_read() ? (array) $this->get_prop( 'downloads' ) : $downloads_array;
+		$downloads          = array();
+		$errors             = array();
+
+		$downloads_array    = $this->build_downloads_map( $downloads_array );
+		$existing_downloads = $this->build_downloads_map( $existing_downloads );
 
 		foreach ( $downloads_array as $download ) {
-			if ( is_a( $download, 'WC_Product_Download' ) ) {
-				$download_object = $download;
-			} else {
-				$download_object = new WC_Product_Download();
-
-				// If we don't have a previous hash, generate UUID for download.
-				if ( empty( $download['download_id'] ) ) {
-					$download['download_id'] = wp_generate_uuid4();
-				}
-
-				$download_object->set_id( $download['download_id'] );
-				$download_object->set_name( $download['name'] );
-				$download_object->set_file( $download['file'] );
-			}
+			$download_id = $download->get_id();
+			$is_new      = ! isset( $existing_downloads[ $download_id ] );
 
 			try {
-				$download_object->check_is_valid();
-				$downloads[ $download_object->get_id() ] = $download_object;
+				$download->check_is_valid( $this->get_object_read() );
+				$downloads[ $download_id ] = $download;
 			} catch ( Exception $e ) {
-				if ( $this->get_object_read() ) {
+				// We only add error messages for newly added downloads (let's not overwhelm the user if there are
+				// multiple existing files which are problematic).
+				if ( $is_new ) {
 					$errors[] = $e->getMessage();
 				}
-			}
-		}
 
-		if ( $errors ) {
-			$this->error( 'product_invalid_download', $errors[0] );
+				// If the problem is with an existing download, disable it.
+				if ( ! $is_new ) {
+					$download->set_enabled( false );
+					$downloads[ $download_id ] = $download;
+				}
+			}
 		}
 
 		$this->set_prop( 'downloads', $downloads );
+
+		if ( $errors && $this->get_object_read() ) {
+			$this->error( 'product_invalid_download', $errors[0] );
+		}
+	}
+
+	/**
+	 * Takes an array of downloadable file representations and converts it into an array of
+	 * WC_Product_Download objects, indexed by download ID.
+	 *
+	 * @param array[]|WC_Product_Download[] $downloads Download data to be re-mapped.
+	 *
+	 * @return WC_Product_Download[]
+	 */
+	private function build_downloads_map( array $downloads ): array {
+		$downloads_map = array();
+
+		foreach ( $downloads as $download_data ) {
+			// If the item is already a WC_Product_Download we can add it to the map and move on.
+			if ( is_a( $download_data, 'WC_Product_Download' ) ) {
+				$downloads_map[ $download_data->get_id() ] = $download_data;
+				continue;
+			}
+
+			// If the item is not an array, there is nothing else we can do (bad data).
+			if ( ! is_array( $download_data ) ) {
+				continue;
+			}
+
+			// Otherwise, transform the array to a WC_Product_Download and add to the map.
+			$download_object = new WC_Product_Download();
+
+			// If we don't have a previous hash, generate UUID for download.
+			if ( empty( $download_data['download_id'] ) ) {
+				$download_data['download_id'] = wp_generate_uuid4();
+			}
+
+			$download_object->set_id( $download_data['download_id'] );
+			$download_object->set_name( $download_data['name'] );
+			$download_object->set_file( $download_data['file'] );
+			$download_object->set_enabled( isset( $download_data['enabled'] ) ? $download_data['enabled'] : true );
+
+			$downloads_map[ $download_object->get_id() ] = $download_object;
+		}
+
+		return $downloads_map;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1202,7 +1202,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Set downloads.
 	 *
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception If an error relating to one of the downloads is encountered.
 	 *
 	 * @param array $downloads_array Array of WC_Product_Download objects or arrays.
 	 *

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -88,9 +88,13 @@ defined( 'ABSPATH' ) || exit;
 				</thead>
 				<tbody>
 					<?php
-					$downloadable_files = $product_object->get_downloads( 'edit' );
+					$downloadable_files       = $product_object->get_downloads( 'edit' );
+					$disabled_downloads_count = 0;
+
 					if ( $downloadable_files ) {
 						foreach ( $downloadable_files as $key => $file ) {
+							$disabled_download = isset( $file['enabled'] ) && false === $file['enabled'];
+							$disabled_downloads_count += (int) $disabled_download;
 							include __DIR__ . '/html-product-download.php';
 						}
 					}
@@ -98,7 +102,7 @@ defined( 'ABSPATH' ) || exit;
 				</tbody>
 				<tfoot>
 					<tr>
-						<th colspan="5">
+						<th colspan="2">
 							<a href="#" class="button insert" data-row="
 							<?php
 								$key  = '';
@@ -106,11 +110,25 @@ defined( 'ABSPATH' ) || exit;
 									'file' => '',
 									'name' => '',
 								);
+								$disabled_download = false;
 								ob_start();
 								require __DIR__ . '/html-product-download.php';
 								echo esc_attr( ob_get_clean() );
 								?>
 							"><?php esc_html_e( 'Add File', 'woocommerce' ); ?></a>
+						</th>
+						<th colspan="3">
+							<?php if ( $disabled_downloads_count ) : ?>
+								<span class="disabled">*</span>
+								<?php
+									printf(
+										/* translators: 1: opening link tag, 2: closing link tag. */
+										esc_html__( 'The indicated downloads have been disabled (invalid location or filetype&mdash;%1$slearn more%2$s).', 'woocommerce' ),
+										'<a href="https://woocommerce.com/document/approved-download-directories" target="_blank">',
+										'</a>'
+									);
+								?>
+							<?php endif; ?>
 						</th>
 					</tr>
 				</tfoot>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-download.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-download.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Template used to form individual rows within the downloadable files table.
+ *
+ * @package WooCommerce\Admin\Views
+ *
+ * @var bool   $disabled_download Indicates if the current downloadable file is disabled.
+ * @var array  $file              Product download data.
+ * @var string $key               Product download key.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -9,7 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="text" class="input_text" placeholder="<?php esc_attr_e( 'File name', 'woocommerce' ); ?>" name="_wc_file_names[]" value="<?php echo esc_attr( $file['name'] ); ?>" />
 		<input type="hidden" name="_wc_file_hashes[]" value="<?php echo esc_attr( $key ); ?>" />
 	</td>
-	<td class="file_url"><input type="text" class="input_text" placeholder="<?php esc_attr_e( 'http://', 'woocommerce' ); ?>" name="_wc_file_urls[]" value="<?php echo esc_attr( $file['file'] ); ?>" /></td>
+	<td class="file_url">
+		<input type="text" class="input_text" placeholder="<?php esc_attr_e( 'http://', 'woocommerce' ); ?>" name="_wc_file_urls[]" value="<?php echo esc_attr( $file['file'] ); ?>" />
+		<?php if ( $disabled_download ) : ?>
+			<span class="disabled">*</span>
+		<?php endif; ?>
+	</td>
 	<td class="file_url_choose" width="1%"><a href="#" class="button upload_file_button" data-choose="<?php esc_attr_e( 'Choose file', 'woocommerce' ); ?>" data-update="<?php esc_attr_e( 'Insert file URL', 'woocommerce' ); ?>"><?php echo esc_html__( 'Choose file', 'woocommerce' ); ?></a></td>
 	<td width="1%"><a href="#" class="delete"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a></td>
 </tr>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-variation-download.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-variation-download.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Template used to form individual rows within the downloadable files table for variables.
+ *
+ * @package WooCommerce\Admin\Views
+ *
+ * @var bool   $disabled_download Indicates if the current downloadable file is disabled.
+ * @var array  $file              Product download data.
+ * @var string $key               Product download key.
+ * @var int    $variation_id      Variation ID.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -8,7 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="text" class="input_text" placeholder="<?php esc_attr_e( 'File name', 'woocommerce' ); ?>" name="_wc_variation_file_names[<?php echo esc_attr( $variation_id ); ?>][]" value="<?php echo esc_attr( $file['name'] ); ?>" />
 		<input type="hidden" name="_wc_variation_file_hashes[<?php echo esc_attr( $variation_id ); ?>][]" value="<?php echo esc_attr( $key ); ?>" />
 	</td>
-	<td class="file_url"><input type="text" class="input_text" placeholder="<?php esc_attr_e( 'http://', 'woocommerce' ); ?>" name="_wc_variation_file_urls[<?php echo esc_attr( $variation_id ); ?>][]" value="<?php echo esc_attr( $file['file'] ); ?>" /></td>
+	<td class="file_url">
+		<input type="text" class="input_text" placeholder="<?php esc_attr_e( 'http://', 'woocommerce' ); ?>" name="_wc_variation_file_urls[<?php echo esc_attr( $variation_id ); ?>][]" value="<?php echo esc_attr( $file['file'] ); ?>" />
+		<?php if ( $disabled_download ) : ?>
+			<span class="disabled">*</span>
+		<?php endif; ?>
+	</td>
 	<td class="file_url_choose" width="1%"><a href="#" class="button upload_file_button" data-choose="<?php esc_attr_e( 'Choose file', 'woocommerce' ); ?>" data-update="<?php esc_attr_e( 'Insert file URL', 'woocommerce' ); ?>"><?php esc_html_e( 'Choose file', 'woocommerce' ); ?></a></td>
 	<td width="1%"><a href="#" class="delete"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a></td>
 </tr>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -404,10 +404,13 @@ defined( 'ABSPATH' ) || exit;
 						</thead>
 						<tbody>
 							<?php
-							$downloads = $variation_object->get_downloads( 'edit' );
+							$downloadable_files       = $variation_object->get_downloads( 'edit' );
+							$disabled_downloads_count = 0;
 
-							if ( $downloads ) {
-								foreach ( $downloads as $key => $file ) {
+							if ( $downloadable_files ) {
+								foreach ( $downloadable_files as $key => $file ) {
+									$disabled_download = isset( $file['enabled'] ) && false === $file['enabled'];
+									$disabled_downloads_count += (int) $disabled_download;
 									include __DIR__ . '/html-product-variation-download.php';
 								}
 							}
@@ -415,7 +418,7 @@ defined( 'ABSPATH' ) || exit;
 						</tbody>
 						<tfoot>
 							<div>
-								<th colspan="4">
+								<th colspan="1">
 									<a href="#" class="button insert" data-row="
 									<?php
 									$key  = '';
@@ -423,11 +426,25 @@ defined( 'ABSPATH' ) || exit;
 										'file' => '',
 										'name' => '',
 									);
+									$disabled_download = false;
 									ob_start();
 									require __DIR__ . '/html-product-variation-download.php';
 									echo esc_attr( ob_get_clean() );
 									?>
 									"><?php esc_html_e( 'Add file', 'woocommerce' ); ?></a>
+								</th>
+								<th colspan="3">
+									<?php if ( $disabled_downloads_count ) : ?>
+										<span class="disabled">*</span>
+										<?php
+										printf(
+											/* translators: 1: opening link tag, 2: closing link tag. */
+											esc_html__( 'The indicated downloads have been disabled (invalid location or filetype&mdash;%1$slearn more%2$s).', 'woocommerce' ),
+											'<a href="https://woocommerce.com/document/approved-download-directories" target="_blank">',
+											'</a>'
+										);
+										?>
+									<?php endif; ?>
 								</th>
 							</div>
 						</tfoot>

--- a/plugins/woocommerce/includes/class-wc-product-download.php
+++ b/plugins/woocommerce/includes/class-wc-product-download.php
@@ -25,9 +25,10 @@ class WC_Product_Download implements ArrayAccess {
 	 * @var array
 	 */
 	protected $data = array(
-		'id'   => '',
-		'name' => '',
-		'file' => '',
+		'id'      => '',
+		'name'    => '',
+		'file'    => '',
+		'enabled' => true,
 	);
 
 	/**
@@ -106,10 +107,20 @@ class WC_Product_Download implements ArrayAccess {
 	public function check_is_valid( bool $auto_add_to_approved_directory_list = true ) {
 		$download_file = $this->get_file();
 
+		if ( ! $this->data['enabled'] ) {
+			throw new Exception(
+				sprintf(
+					/* translators: %s: Downloadable file. */
+					__( 'The downloadable file %s cannot be used as it has been disabled.', 'woocommerce' ),
+					'<code>' . basename( $download_file ) . '</code>'
+				)
+			);
+		}
+
 		if ( ! $this->is_allowed_filetype() ) {
 			throw new Exception(
 				sprintf(
-				/* translators: %1$s: Downloadable file */
+					/* translators: 1: Downloadable file, 2: List of allowed filetypes. */
 					__( 'The downloadable file %1$s cannot be used as it does not have an allowed file type. Allowed types include: %2$s', 'woocommerce' ),
 					'<code>' . basename( $download_file ) . '</code>',
 					'<code>' . implode( ', ', array_keys( $this->get_allowed_mime_types() ) ) . '</code>'
@@ -121,7 +132,7 @@ class WC_Product_Download implements ArrayAccess {
 		if ( ! $this->file_exists() ) {
 			throw new Exception(
 				sprintf(
-				/* translators: %s: Downloadable file */
+					/* translators: %s: Downloadable file */
 					__( 'The downloadable file %s cannot be used as it does not exist on the server.', 'woocommerce' ),
 					'<code>' . $download_file . '</code>'
 				)
@@ -215,25 +226,22 @@ class WC_Product_Download implements ArrayAccess {
 		$is_site_administrator   = is_multisite() ? current_user_can( 'manage_sites' ) : current_user_can( 'manage_options' );
 		$valid_storage_directory = $download_directories->is_valid_path( $download_file );
 
-		if ( ! $valid_storage_directory && $auto_add_to_approved_directory_list ) {
+		if ( $valid_storage_directory ) {
+			return;
+		}
+
+		if ( $auto_add_to_approved_directory_list ) {
 			try {
 				// Add the parent URL to the approved directories list, but *do not enable it* unless the current user is a site admin.
 				$download_directories->add_approved_directory( ( new URL( $download_file ) )->get_parent_url(), $is_site_administrator );
-			} catch ( Exception $e ) {
-				/* translators: %s: Downloadable file */
-				throw new Exception(
-					sprintf(
-						/* translators: %1$s is the downloadable file path, %2$s is an opening link tag, %3%s is a closing link tag. */
-						__( 'The downloadable file %1$s cannot be used: it is not located in an approved directory. Please contact a site administrator and request their approval. %2$sLearn more.%3$s', 'woocommerce' ),
-						'<code>' . $download_file . '</code>',
-						'<a href="https://woocommerce.com/document/approved-download-directories">',
-						'</a>'
-					)
-				);
+				$valid_storage_directory = $download_directories->is_valid_path( $download_file );
+			} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// At this point, $valid_storage_directory will be false. Fall-through so the appropriate exception is
+				// triggered (same as if the storage directory was invalid and $auto_add_to_approved_directory_list was false.
 			}
 		}
 
-		if ( ! $valid_storage_directory && ! $is_site_administrator ) {
+		if ( ! $valid_storage_directory ) {
 			throw new Exception(
 				sprintf(
 					/* translators: %1$s is the downloadable file path, %2$s is an opening link tag, %3%s is a closing link tag. */
@@ -302,6 +310,15 @@ class WC_Product_Download implements ArrayAccess {
 		}
 	}
 
+	/**
+	 * Sets the status of the download to enabled (true) or disabled (false).
+	 *
+	 * @param bool $enabled True indicates the downloadable file is enabled, false indicates it is disabled.
+	 */
+	public function set_enabled( bool $enabled = true ) {
+		$this->data['enabled'] = $enabled;
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Getters
@@ -344,6 +361,15 @@ class WC_Product_Download implements ArrayAccess {
 	 */
 	public function get_file() {
 		return $this->data['file'];
+	}
+
+	/**
+	 * Get status of the download.
+	 *
+	 * @return bool
+	 */
+	public function get_enabled(): bool {
+		return $this->data['enabled'];
 	}
 
 	/*

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -614,6 +614,11 @@ function wc_get_customer_available_downloads( $customer_id ) {
 
 			$download_file = $_product->get_file( $result->download_id );
 
+			// If the downloadable file has been disabled (it may be located in an untrusted location) then do not return it.
+			if ( ! $download_file->get_enabled() ) {
+				continue;
+			}
+
 			// Download name will be 'Product Name' for products with a single downloadable file, and 'Product Name - File X' for products with multiple files.
 			$download_name = apply_filters(
 				'woocommerce_downloadable_product_name',

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -5110,6 +5110,14 @@ img.help_tip {
 				margin: 1px 0;
 			}
 
+			&.file_url {
+				/* Reduce the size of this field to make space for a warning asterisk. */
+				input {
+					display: inline-block;
+					width: 96%;
+				}
+			}
+
 			.upload_file_button {
 				width: auto;
 				float: right;
@@ -5159,6 +5167,11 @@ img.help_tip {
 			&:hover::before {
 				color: #333;
 			}
+		}
+
+		/* Warning asterisk (indicates if there is a problem with a downloadable file). */
+		span.disabled {
+			color: var( --wc-red );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/importer/product.php
@@ -35,11 +35,14 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		// Callback used by WP_HTTP_TestCase to decide whether to perform HTTP requests or to provide a mocked response.
 		$this->http_responder = array( $this, 'mock_http_responses' );
 		$this->csv_file = dirname( __FILE__ ) . '/sample.csv';
-		$this->sut = new WC_Product_CSV_Importer( $this->csv_file, array(
-			'mapping'          => $this->get_csv_mapped_items(),
-			'parse'            => true,
-			'prevent_timeouts' => false,
-		) );
+		$this->sut = new WC_Product_CSV_Importer(
+			$this->csv_file,
+			array(
+				'mapping'          => $this->get_csv_mapped_items(),
+				'parse'            => true,
+				'prevent_timeouts' => false,
+			)
+		);
 	}
 
 	/**
@@ -112,7 +115,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, count( $results['skipped'] ) );
 		$this->assertEquals(
 			7,
-			count( $results['imported'] ) ,
+			count( $results['imported'] ),
 			'One import item references a downloadable file stored in an unapproved location: if the import is triggered by an admin user, that location will be automatically approved.'
 		);
 	}

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -18,16 +18,18 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$download_directories->add_approved_directory( 'https://always.trusted/' );
 		$problematic_file_source_id = $download_directories->add_approved_directory( 'https://new.supplier/' );
 
-		$product = WC_Helper_Product::create_downloadable_product( array(
+		$product = WC_Helper_Product::create_downloadable_product(
 			array(
-				'name' => 'Book 1',
-				'file' => 'https://always.trusted/123.pdf'
-			),
-			array(
-				'name' => 'Book 2',
-				'file' => 'https://new.supplier/456.pdf'
-			),
-		) );
+				array(
+					'name' => 'Book 1',
+					'file' => 'https://always.trusted/123.pdf',
+				),
+				array(
+					'name' => 'Book 2',
+					'file' => 'https://new.supplier/456.pdf',
+				),
+			)
+		);
 
 		$this->assertCount(
 			2,
@@ -36,17 +38,17 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		);
 
 		$download_directories->disable_by_id( $problematic_file_source_id );
+		$product_downloads = wc_get_product( $product->get_id() )->get_downloads();
 
 		$this->assertCount(
-			1,
-			wc_get_product( $product->get_id() )->get_downloads(),
-			'If a trusted download directory is disabled, we expect any individual download files from that location will not be listed.'
+			2,
+			$product_downloads,
+			'If a trusted download directory rule is disabled, we still expect it to be fetched.'
 		);
 
-		$this->assertEquals(
-			'Book 1',
-			current( wc_get_product( $product->get_id() )->get_downloads() )->get_name(),
-			'Only individual download files that are stored in trusted locations will be fetched.'
+		$this->assertFalse(
+			next( $product_downloads )->get_enabled(),
+			'If a trusted download directory rule is disabled, corresponding product downloads will also be marked as disabled.'
 		);
 
 		$download_directories->set_mode( Download_Directories::MODE_DISABLED );
@@ -54,7 +56,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 		$this->assertCount(
 			2,
 			wc_get_product( $product->get_id() )->get_downloads(),
-			'If the Approved Download Directories system is completely disabled, we expect all product downloads to be fetched irrespective of where they are stored.'
+			'Disabling the Approved Download Directories system entirely does not impact our ability to fetch product downloads.'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-downloads-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-downloads-test.php
@@ -9,7 +9,7 @@ class WC_Product_Download_Test extends WC_Unit_Test_Case {
 	 * Test for file without extension.
 	 */
 	public function test_is_allowed_filetype_with_no_extension() {
-		$upload_dir = trailingslashit( wp_upload_dir()['basedir'] );
+		$upload_dir                  = trailingslashit( wp_upload_dir()['basedir'] );
 		$file_path_with_no_extension = $upload_dir . 'upload_file';
 		if ( ! file_exists( $file_path_with_no_extension ) ) {
 			// Copy an existing file without extension.
@@ -24,7 +24,7 @@ class WC_Product_Download_Test extends WC_Unit_Test_Case {
 	 * Simulates test condition for windows when filename ends with a period.
 	 */
 	public function test_is_allowed_filetype_on_windows_with_period_at_end() {
-		$upload_dir = trailingslashit( wp_upload_dir()['basedir'] );
+		$upload_dir                   = trailingslashit( wp_upload_dir()['basedir'] );
 		$file_path_with_period_at_end = $upload_dir . 'upload_file.';
 		if ( ! file_exists( $file_path_with_period_at_end ) ) {
 			// Copy an existing file without extension.
@@ -45,8 +45,20 @@ class WC_Product_Download_Test extends WC_Unit_Test_Case {
 		$download_directories = wc_get_container()->get( Download_Directories::class );
 		$download_directories->set_mode( Download_Directories::MODE_ENABLED );
 
-		$non_admin_user = wp_insert_user( array( 'user_login' => uniqid(), 'role' => 'editor', 'user_pass' => 'x' ) );
-		$admin_user     = wp_insert_user( array( 'user_login' => uniqid(), 'role' => 'administrator', 'user_pass' => 'x' ) );
+		$non_admin_user = wp_insert_user(
+			array(
+				'user_login' => uniqid(),
+				'role'       => 'editor',
+				'user_pass'  => 'x',
+			)
+		);
+		$admin_user     = wp_insert_user(
+			array(
+				'user_login' => uniqid(),
+				'role'       => 'administrator',
+				'user_pass'  => 'x',
+			)
+		);
 		$ebook_url      = 'https://external.site/books/ultimate-guide-to-stuff.pdf';
 		$podcast_url    = 'https://external.site/podcasts/ultimate-guide-to-stuff.mp3';
 
@@ -62,5 +74,58 @@ class WC_Product_Download_Test extends WC_Unit_Test_Case {
 		$download->set_file( $podcast_url );
 		$this->expectExceptionMessage( 'cannot be used: it is not located in an approved directory' );
 		$download->check_is_valid();
+	}
+
+	/**
+	 * Test handling of filepaths described via shortcodes in relation to the Approved Download Directory
+	 * feature. This is to simulate scenarios such as encountered when using the S3 Downloads extension.
+	 */
+	public function test_shortcode_resolution_for_approved_directory_rules() {
+		/** @var Download_Directories $download_directories */
+		$download_directories = wc_get_container()->get( Download_Directories::class );
+		$download_directories->set_mode( Download_Directories::MODE_ENABLED );
+		$dynamic_filepath = 'https://fast.reliable.external.fileserver.com/bucket-123/textbook.pdf';
+
+		// We select an admin user because we wish to automatically add Approved Directory rules.
+		$admin_user = wp_insert_user(
+			array(
+				'user_login' => uniqid(),
+				'role'       => 'administrator',
+				'user_pass'  => 'x',
+			)
+		);
+		wp_set_current_user( $admin_user );
+
+		add_shortcode(
+			'dynamic-download',
+			function () {
+				return 'https://fast.reliable.external.fileserver.com/bucket-123/textbook.pdf';
+			}
+		);
+
+		$this->assertFalse(
+			$download_directories->is_valid_path( $dynamic_filepath ),
+			'Confirm the filepath returned by the test URL is not yet valid.'
+		);
+
+		$download = new WC_Product_Download();
+		$download->set_file( '[dynamic-download]' );
+
+		$this->assertNull(
+			$download->check_is_valid(),
+			'The downloadable file successfully validates (if it did not, an exception would be thrown).'
+		);
+
+		$this->assertTrue(
+			$download_directories->is_valid_path( $dynamic_filepath ),
+			'Confirm the filepath returned by the test URL is now considered valid.'
+		);
+
+		remove_shortcode( 'dynamic-download' );
+
+		// Now the shortcode is removed (perhaps the parent plugin has been removed/disabled) it will not resolve
+		// and so the filepath will not validate.
+		$this->expectException( 'Error' );
+		$download_directories->check_is_valid();
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-downloads-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-downloads-test.php
@@ -63,48 +63,4 @@ class WC_Product_Download_Test extends WC_Unit_Test_Case {
 		$this->expectExceptionMessage( 'cannot be used: it is not located in an approved directory' );
 		$download->check_is_valid();
 	}
-
-	/**
-	 * Test handling of filepaths described via shortcodes in relation to the Approved Download Directory
-	 * feature. This is to simulate scenarios such as encountered when using the S3 Downloads extension.
-	 */
-	public function test_shortcode_resolution_for_approved_directory_rules() {
-		/** @var Download_Directories $download_directories */
-		$download_directories = wc_get_container()->get( Download_Directories::class );
-		$download_directories->set_mode( Download_Directories::MODE_ENABLED );
-		$dynamic_filepath = 'https://fast.reliable.external.fileserver.com/bucket-123/textbook.pdf';
-
-		// We select an admin user because we wish to automatically add Approved Directory rules.
-		$admin_user = wp_insert_user( array( 'user_login' => uniqid(), 'role' => 'administrator', 'user_pass' => 'x' ) );
-		wp_set_current_user( $admin_user );
-
-		add_shortcode( 'dynamic-download', function () {
-			return 'https://fast.reliable.external.fileserver.com/bucket-123/textbook.pdf';
-		} );
-
-		$this->assertFalse(
-			$download_directories->is_valid_path( $dynamic_filepath ),
-			'Confirm the filepath returned by the test URL is not yet valid.'
-		);
-
-		$download = new WC_Product_Download();
-		$download->set_file( '[dynamic-download]' );
-
-		$this->assertNull(
-			$download->check_is_valid(),
-			'The downloadable file successfully validates (if it did not, an exception would be thrown).'
-		);
-
-		$this->assertTrue(
-			$download_directories->is_valid_path( $dynamic_filepath ),
-			'Confirm the filepath returned by the test URL is now considered valid.'
-		);
-
-		remove_shortcode( 'dynamic-download' );
-
-		// Now the shortcode is removed (perhaps the parent plugin has been removed/disabled) it will not resolve
-		// and so the filepath will not validate.
-		$this->expectException( 'Error' );
-		$download_directories->check_is_valid();
-	}
 }


### PR DESCRIPTION
### Background

I think this change deserves a short primer...

Consider a scenario where one or more locally-stored PDF files have been added to a downloadable product. Normally, this is fine ... but what if at some later point the range of [allowed mime types](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/class-wc-product-download.php#L99) is [modified](https://github.com/woocommerce/woocommerce/blob/6.3.1/plugins/woocommerce/includes/class-wc-product-download.php#L46) and PDFs are suddenly excluded? 

Well, in this scenario and with 6.4.0 or earlier, if someone was to open the product in the editor any PDF files would now be absent from the list of downloadable files, _however,_ they would at least initially still be present in the database. Subsequently, if the product is actually updated (suppose the product description is being edited, and the person making the edit doesn't notice that any files are missing), any PDF file references will now be deleted from the database (at least in relation to this specific product).

Essentially, then, what we are addressing in this PR is an existing problem: however, because of the introduction of Approved Download Directories, the risk of users encountering this problem and the risk of data being lost has increased—because, while the above example is based on a change to the list of allowed mime types, it will now also be possible for the same problem to happen if an Approved Download Directory rule is deleted or disabled. This seems undesirable and worth resolving before the new feature ships.

### Changes proposed in this Pull Request:

Product downloads can now be enabled or disabled. An existing download file can become disabled if:

- It is no longer an acceptable mime type.
- Its location is no longer approved (via the Approved Download Directories list ... this is the main focus of this PR).

When a file is disabled it will still be listed in the product editor, but with a warning linking to a support article:

<img width="858" alt="disabled-downloads-ui" src="https://user-images.githubusercontent.com/3594411/162843212-bc129eff-b58d-4d9e-8d45-1eaf5a82dfce.png">

The above applies to **existing** downloads that have become disabled due to changes in various rules. On the other hand, if a user such as a shop manager attempts to add a **new** downloadable file that does not meet the existing criteria, it will not be added to the list but will instead be rejected with an appropriate error message:

<img width="982" alt="unapproved-location-error" src="https://user-images.githubusercontent.com/3594411/162843690-66225e01-67a8-40d4-a5e0-83672d5ff050.png">

### How to test the changes in this Pull Request:

1. As an administrator, edit a downloadable product and add a file such as `https://remote.server/file.pdf`. 
    - Because you are an administrator, a rule will automatically be added to the Approved Download Directories list.
    - Visit **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** to see and edit this rule.
2. Still functioning as an administrator, locate the rule and disable it (or delete it).
3. As a shop manager, edit the same downloadable product and review the list of downloadable files.
   - You should see that `https://remote.server/file.pdf` is still present.
   - It should be marked with an asterisk to indicate it has been disabled.
4. Still functioning as a shop manager, add another downloadable file and think of a random URL that is not on the list of approved locations. Save the product: you should see an error message and the file should not be added to the product.
5. As an administrator, re-add or re-enable the deleted rule.
6. Back to the shop manager role, open the product editor once more: the disabled download file should once again be enabled.
7. Final testing consideration: if as a customer you purchased the product before any files became disabled, you should find that your access to the download is contingent on whether the downloadable files in question are enabled or disabled (ie, when a downloadable file becomes disabled, it should stop being listed at **My Account ▸ Downloads**.

### Other information:

Things to be aware of:

- Remember that site admins have 'special powers' in relation to Approved Download Directories. Adding a new file stored in a completely new location will not cause a problem, because a new rule will automatically be generated.
- Occasionally you may find that admin errors are not rendered even though you are expecting them. Note that there is a further (pre-existing) issue afoot in relation to this [(see this PR)](https://github.com/woocommerce/woocommerce/pull/32540).

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
