### PR TITLE
Normalize auto-draft as a status in the abstract order class

### DIFF
--- a/plugins/woocommerce/changelog/fix-32539-order-autodraft-validation
+++ b/plugins/woocommerce/changelog/fix-32539-order-autodraft-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure that an existing order with auto-draft status won't be interpreted as pending when determining if the status has changed.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -201,7 +201,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		} catch ( Exception $e ) {
 			$message_id = $this->get_id() ? $this->get_id() : __( '(no ID)', 'woocommerce' );
-			$this->handle_exception( $e,
+			$this->handle_exception(
+				$e,
 				wp_kses_post(
 					sprintf(
 						/* translators: 1: Order ID or "(no ID)" if not known. */
@@ -551,15 +552,17 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$old_status = $this->get_status();
 		$new_status = 'wc-' === substr( $new_status, 0, 3 ) ? substr( $new_status, 3 ) : $new_status;
 
+		$status_exceptions = array( 'auto-draft', 'trash' );
+
 		// If setting the status, ensure it's set to a valid status.
 		if ( true === $this->object_read ) {
 			// Only allow valid new status.
-			if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses(), true ) && 'trash' !== $new_status && 'auto-draft' !== $new_status ) {
+			if ( ! in_array( 'wc-' . $new_status, $this->get_valid_statuses(), true ) && ! in_array( $new_status, $status_exceptions, true ) ) {
 				$new_status = 'pending';
 			}
 
 			// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && 'trash' !== $old_status ) {
+			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && ! in_array( $old_status, $status_exceptions, true ) ) {
 				$old_status = 'pending';
 			}
 		}


### PR DESCRIPTION
Ensures that an existing order with auto-draft status won't be interpreted as pending when determining if the status has changed.

This also fixes an unrelated phpcs formatting error in order to pass the precommit checks.

Closes #32539.

Note that this takes the first, simplest approach described in #32539. After briefly exploring the complexity around when an order status should have a `wc-` prefix and when it shouldn't, and what it would take to update the `wc_is_order_status()` function and add `auto-draft` to the canonical list of order statuses, I decided not to risk breaking things.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Following the steps to reproduce in #32539 should no longer result in an extra order note being created every time the endpoint request is submitted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Ensure that an existing order with auto-draft status won't be interpreted as pending when determining if the status has changed.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
