### PR TITLE
Add context param for get_notes and related methods

### DIFF
--- a/plugins/woocommerce/changelog/add-32573-context-arg-for-get-notes
+++ b/plugins/woocommerce/changelog/add-32573-context-arg-for-get-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Add a context param with a default value of global to Admin\Notes\DataStore::get_notes(), get_notes_count(), and get_notes_where_clauses(). #32574

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -11,6 +11,9 @@ defined( 'ABSPATH' ) || exit;
  * WC Admin Note Data Store (Custom Tables)
  */
 class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Interface {
+	// Extensions should define their own contexts and use them to avoid applying woocommerce_note_where_clauses when not needed.
+	const WC_ADMIN_NOTE_OPER_GLOBAL = 'global';
+
 	/**
 	 * Method to create a new note in the database.
 	 *
@@ -324,9 +327,10 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 * Return an ordered list of notes.
 	 *
 	 * @param array $args Query arguments.
+	 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
 	 * @return array An array of objects containing a note id.
 	 */
-	public function get_notes( $args = array() ) {
+	public function get_notes( $args = array(), $context = self::WC_ADMIN_NOTE_OPER_GLOBAL ) {
 		global $wpdb;
 
 		$defaults = array(
@@ -338,7 +342,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		$args     = wp_parse_args( $args, $defaults );
 
 		$offset        = $args['per_page'] * ( $args['page'] - 1 );
-		$where_clauses = $this->get_notes_where_clauses( $args );
+		$where_clauses = $this->get_notes_where_clauses( $args, $context );
 
 		$query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -378,16 +382,18 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 *
 	 * @param string $type Comma separated list of note types.
 	 * @param string $status Comma separated list of statuses.
+	 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
 	 * @return array An array of objects containing a note id.
 	 */
-	public function get_notes_count( $type = array(), $status = array() ) {
+	public function get_notes_count( $type = array(), $status = array(), $context = self::WC_ADMIN_NOTE_OPER_GLOBAL ) {
 		global $wpdb;
 
 		$where_clauses = $this->get_notes_where_clauses(
 			array(
 				'type'   => $type,
 				'status' => $status,
-			)
+			),
+			$context
 		);
 
 		if ( ! empty( $where_clauses ) ) {
@@ -426,9 +432,10 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 *
 	 * @uses args_to_where_clauses
 	 *  @param array $args Array of args to pass.
+	 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
 	 * @return string Where clauses for the query.
 	 */
-	public function get_notes_where_clauses( $args = array() ) {
+	public function get_notes_where_clauses( $args = array(), $context = self::WC_ADMIN_NOTE_OPER_GLOBAL ) {
 		$where_clauses = $this->args_to_where_clauses( $args );
 
 		/**
@@ -438,8 +445,9 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		 *
 		 * @param string $where_clauses The generated WHERE clause.
 		 * @param array  $args          The original arguments for the request.
+		 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
 		 */
-		return apply_filters( 'woocommerce_note_where_clauses', $where_clauses, $args );
+		return apply_filters( 'woocommerce_note_where_clauses', $where_clauses, $args, $context );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -326,7 +326,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	/**
 	 * Return an ordered list of notes.
 	 *
-	 * @param array $args Query arguments.
+	 * @param array  $args Query arguments.
 	 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
 	 * @return array An array of objects containing a note id.
 	 */
@@ -431,7 +431,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 * Applies woocommerce_note_where_clauses filter.
 	 *
 	 * @uses args_to_where_clauses
-	 *  @param array $args Array of args to pass.
+	 * @param array  $args Array of args to pass.
 	 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
 	 * @return string Where clauses for the query.
 	 */


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This simply adds a $context param (default value 'global') to the method signatures of Admin\Notes\DataStore::get_notes(), get_notes_count(), and get_notes_where_clauses() so that it can be used by third party developers to avoid applying custom woocommerce_note_where_clauses changes when not needed.

Closes #32573 

### How to test the changes in this Pull Request:

There should be no change in behavior, but you can use a custom plugin to add a filter function to 'woocommerce_note_where_clauses' and verify that it receives 'global' as its third parameter. For extra points you can call get_notes() and/or get_notes_count() yourself with a different value for $context and verify that it comes through as expected. See the new unit tests for ideas.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
