### PR TITLE
Fix `pnpm nx clean woocommerce-admin` command

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -15,7 +15,7 @@
 		"build-storybook": "build-storybook  -c ./storybook/.storybook",
 		"build:feature-config": "php ../woocommerce/bin/generate-feature-config.php",
 		"build:packages": "cross-env NODE_ENV=production pnpm run:packages -- build",
-		"clean": "rimraf ./dist && pnpm run:packages -- clean --parallel",
+		"clean": "rimraf ../woocommerce/assets/client/admin/* && pnpm run:packages -- clean --parallel",
 		"client:watch": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development webpack --watch",
 		"create-hook-reference": "node ./bin/hook-reference/index.js",
 		"create-wc-extension": "node ./bin/starter-pack/starter-pack.js",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix `pnpm nx clean woocommerce-admin` command to remove the build folder correctly.

### How to test the changes in this Pull Request:

1. Run `pnpm nx build woocommerce-admin` -> Should output files to `plugins/woocommerce/assets/client/admin`
3. Run`pnpm nx clean woocommerce-admin` -> Should remove files from `plugins/woocommerce/assets/client/admin`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Dev: Fix `pnpm nx clean woocommerce-admin` command

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
