### PR TITLE
Enable "Save changes" for variations on the admin when a textfield receives input

### DIFF
--- a/plugins/woocommerce/changelog/issue-31347
+++ b/plugins/woocommerce/changelog/issue-31347
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Enable "Save changes" for variations on the admin when a textfield receives input.

--- a/plugins/woocommerce/changelog/issue-31347
+++ b/plugins/woocommerce/changelog/issue-31347
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Enable "Save changes" for variations on the admin when a textfield receives input.
+Enable the "Save changes" button within the variations panel when a textfield receives input.

--- a/plugins/woocommerce/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/legacy/js/admin/meta-boxes-product-variation.js
@@ -350,7 +350,7 @@ jQuery( function( $ ) {
 				.on( 'click','.downloadable_files a.delete', this.input_changed );
 
 			$( document.body )
-				.on( 'change', '#variable_product_options .woocommerce_variations :input', this.input_changed )
+				.on( 'change input', '#variable_product_options .woocommerce_variations :input', this.input_changed )
 				.on( 'change', '.variations-defaults select', this.defaults_changed );
 
 			var postForm = $( 'form#post' );
@@ -705,12 +705,17 @@ jQuery( function( $ ) {
 		/**
 		 * Add new class when have changes in some input
 		 */
-		input_changed: function() {
+		input_changed: function( event ) {
 			$( this )
 				.closest( '.woocommerce_variation' )
 				.addClass( 'variation-needs-update' );
 
 			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
+
+			// Do not trigger 'woocommerce_variations_input_changed' for 'input' events for backwards compat.
+			if ( 'input' === event.type && $( this ).is( ':text' ) ) {
+				return;
+			}
 
 			$( '#variable_product_options' ).trigger( 'woocommerce_variations_input_changed' );
 		},


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, the "Save changes" button in the variations form (product edit screen) is disabled at page load and gets re-enabled when a field in the form triggers a "change" event. This makes sense for most field types except textfields, because "change" is only triggered for those when the input in the text field is modified *and* the text field loses focus, meaning you have to click outside of the field or select a different one to be able to click the save button.

Given most fields in the form are text fields, this is a bit counter-intuitive and affects e2e tests, as described in #31347.

This PR makes sure the save button is enabled as soon as any textfield receives input. For backwards compat (and to prevent dispatching tons of events) the "woocommerce_variations_input_changed" event is still tied to the "change" event.

This doesn't result in any loss of functionality because clicking the save button means any selected field loses focus, thus triggering "change" event anyways.

Closes #31347.

### How to test the changes in this Pull Request:

1. Create or edit a variation product with at least one variation.
2. Modify any of the textfields (sale price, for example) without leaving the field.
3.
   - On `trunk`: confirm the "Save changes" button remains disabled.
   - On this branch: confirm the "Save changes" button is enabled.
4. Confirm that on any branch the "Save changes" button is enabled when the textfield loses focus (current behavior).

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Enable "Save changes" for variations on the admin when a textfield receives input.



### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
