### PR TITLE
Added temporary path fixes to fix broken i18n due to path changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-broken-i18n-from-wca-merge
+++ b/plugins/woocommerce/changelog/fix-broken-i18n-from-wca-merge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added a temporary filter to patch the WCA JS packages i18n json files #32603

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -43,8 +43,40 @@ class Translations {
 		// Handler for WooCommerce and WooCommerce Admin plugin activation.
 		add_action( 'woocommerce_activated_plugin', array( $this, 'potentially_generate_translation_strings' ) );
 		add_action( 'activated_plugin', array( $this, 'potentially_generate_translation_strings' ) );
+
+		// Adding this filter to adjust the path after woocommerce-admin was merged into woocommerce core.
+		// Remove after the translations strings have been updated to the new path (probably woocommerce 6.6).
+		add_filter( 'load_script_textdomain_relative_path', array( $this, 'adjust_script_path' ), 10, 2 );
 	}
 
+	/**
+	 * This filter is temporarily used to produce the correct i18n paths as they were moved in WC 6.5.
+	 *
+	 * @param string $relative Relative path to the script.
+	 * @param string $src      The script's source URL.
+	 */
+	public function adjust_script_path( $relative, $src ) {
+		// only rewrite the path if the translation file is from the old woocommerce-admin dist folder.
+		if ( false === strpos( $relative, 'assets/client/admin' ) ) {
+			return $relative;
+		}
+
+		// translation filenames are always based on the unminified path.
+		if ( substr( $relative, -7 ) === '.min.js' ) {
+			$relative = substr( $relative, 0, -7 ) . '.js';
+		}
+
+		$file_base = 'woocommerce-' . determine_locale(); // e.g woocommerce-fr_FR.
+		$md5_filename = $file_base . '-' . md5( $relative ) . '.json';
+
+		$languages_path = WP_LANG_DIR . '/plugins/'; // get path to translations folder.
+
+		if ( ! is_readable( $languages_path . $md5_filename ) ) {
+			return str_replace( 'assets/client/admin', 'packages/woocommerce-admin/dist', $relative );
+		} else {
+			return $relative;
+		}
+	}
 	/**
 	 * Generate a filename to cache translations from JS chunks.
 	 *
@@ -101,8 +133,13 @@ class Translations {
 
 			// Only combine "app" files (not scripts registered with WP).
 			if (
+				// paths for woocommerce < 6.5. can be removed from 6.6 onwards or when i18n json file names are updated.
 				false === strpos( $reference_file, 'dist/chunks/' ) &&
-				false === strpos( $reference_file, 'dist/app/index.js' )
+				false === strpos( $reference_file, 'dist/app/index.js' ) &&
+
+				// paths for woocommerce >= 6.5 (post-merge of woocommerce-admin).
+				false === strpos( $reference_file, 'assets/admin/app/index.js' ) &&
+				false === strpos( $reference_file, 'assets/admin/chunks/' )
 			) {
 				continue;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During the merge of woocommerce-admin into the woocommerce monorepo, the build directory for woocommerce-admin was changed from `packages/woocommerce-admin/dist` to `assets/client/admin`. This resulted in a breakage of the code that inlines the JSON translation files into the page source.

The JSON translation files are automatically generated by `translate.wordpress.org`, and have file names that are determined by the files that the translated text comes from. 

The filename is calculated as `<textdomain>-<locale>-<md5 of script relative path>.json`. 

E.g for `{$domain: 'woocommerce', $locale: 'fr_FR', $relative:'assets/client/admin/date/index.js'}` 

we get `woocommerce-fr_FR-fe5bd46cad4d94d410bb4f072377120f.json`

As the translation files are updated out-of-band, until they have been updated, WooCommerce 6.5 will have broken translations for the JS translated strings.

This PR is a temporary filter that hooks in before each translation files is loaded, and attempts to look for the file using the expected paths. If the files are not found, it means that the translation files are still using the old file paths, and we patch the path by doing a substitution of the new path for the old path.

Additionally, there is also a fix for some code that compiles the translations for `dist/app/chunks/*` and `dist/app/index.js` into a single large json. The added modification allows the code to also support the new paths.

Closes #32485 .

### How to test the changes in this Pull Request:

To test if this is working correctly there are two scenarios

1. The present, before the translation strings have been fixed
2. The (simulated) future when the translation strings have been fixed

For the first scenario, simply install the zip after building it, and try out a localized language such as French or German or any other language with good coverage.

Two good indicators that it is working correctly:
1. The date period strings in the WooCommerce Analytics Dashboard dates dropdown box are translated correctly:
![image](https://user-images.githubusercontent.com/27843274/163179521-af8c40b8-1c00-49e5-b09a-f675bf0caafa.png)
2. If you inspect the page source you should see that the i18n json for WCA JS packages have been inlined correctly - i.e it should **not** look like `( "woocommerce", { "locale_data": { "messages": { "": {} } } } );` 
![image](https://user-images.githubusercontent.com/27843274/163179772-5652f6b9-0275-46af-be4e-581e1f38e03b.png)


For the second scenario we need to simulate the case where the translation files have the new names

1. Use the same install as above
2. SSH / SFTP into the WP install or if you have it running locally, do that. Look in `./wp-content/languages/plugins/`
3. Rename `woocommerce-fr_FR-97d11a05fccdd9ecef9e4fcb7c0a6a46.json` to `woocommerce-fr_FR-fe5bd46cad4d94d410bb4f072377120f.json` (change the locale to suit your testing setup)
4. Check that the i18n json for `wc-date-js-translations` is correctly inlined:
![image](https://user-images.githubusercontent.com/27843274/163188825-60c94c25-804e-4add-ab19-44e582f20fcd.png)



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
