### PR TITLE
Update PR template and post-merge comment for changelogger

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,12 +25,9 @@ Closes # .
 * [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
 * [ ] Have you written new tests for your changes, as applicable?
 * [ ] Have you successfully run tests with your changes locally?
+* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?
 
 <!-- Mark completed items with an [x] -->
-
-### Changelog entry
-
-> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
 
 ### FOR PR REVIEWER ONLY:
 

--- a/.github/workflows/scripts/add-post-merge-comment.php
+++ b/.github/workflows/scripts/add-post-merge-comment.php
@@ -57,7 +57,6 @@ echo "The pull request was merged by: $merger_user_name\n";
 
 $comment_body = "Hi @$merger_user_name, thanks for merging this pull request. Please take a look at these follow-up tasks you may need to perform:
 
-- [ ] Add the `release: add changelog` label
 - [ ] Add the `release: add testing instructions` label";
 
 $add_comment_mutation = "


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the PR template to remove the changelog line (as this should now be supplied via the changelogger), as well as removing the request to add the changelog label from the post-merge comment.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Fork the repo and merge this PR into your forked trunk. Enable actions if they aren't so that the post-merge comment runs.
2. Create a new PR on your forked trunk, and verify that the PR template doesn't contain changelogger comment.
3. Merge PR and verify that the post-merge comment no longer requests that you add the changelog label.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
