### PR TITLE
Display but do not require Street Address 2 for Vietnam.

### DIFF
--- a/plugins/woocommerce/changelog/fix-32600-vietnam
+++ b/plugins/woocommerce/changelog/fix-32600-vietnam
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+For Vietnam, the second street address line should be displayed but not required.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -996,7 +996,7 @@ class WC_Countries {
 							'label' => __( 'Province', 'woocommerce' ),
 						),
 					),
-          'EC' => array(
+					'EC' => array(
 						'state'    => array(
 							'label' => __( 'Province', 'woocommerce' ),
 						),

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1498,7 +1498,7 @@ class WC_Countries {
 						),
 						'address_2' => array(
 							'required' => false,
-							'hidden'   => true,
+							'hidden'   => false,
 						),
 					),
 					'WS' => array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Do not hide street address line 2 for Vietnam. I don't think there are any CLDR rules governing this, but see [UPU factsheet for Vietnam](https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/vnmEn.pdf) and this internal conversation p1649771863490019-slack-C7U3Y3VMY.

Closes #32600.

### How to test the changes in this Pull Request:

1. Add an item to the cart, proceed to checkout.
2. Select Vietnam as the destination country.
3. With this change, Street Address 2 — *"Apartment, suite, unit etc (optional)"* — should be visible, but should not be required.

<img width="480" alt="vietnam-street-addr-2" src="https://user-images.githubusercontent.com/3594411/163226709-1262f5ea-0086-4ea3-8118-75f9d531fd96.png">

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.