### PR TITLE
Adding badge to legacy admin menu to indicate remaining onboarding tasks

### DIFF
--- a/plugins/woocommerce-admin/client/header/index.js
+++ b/plugins/woocommerce-admin/client/header/index.js
@@ -95,21 +95,32 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 		}
 	}, [ isEmbedded, sections, siteTitle ] );
 
-	const { hasTasksReminderFeature } = useSelect( ( select ) => {
+	const { activeSetuplist } = useSelect( ( select ) => {
 		const taskLists = select( ONBOARDING_STORE_NAME ).getTaskLists();
+
+		const visibleSetupList = taskLists
+			.filter( ( list ) => list.isVisible )
+			.filter( ( list ) =>
+				[
+					'setup_experiment_1',
+					'setup_experiment_2',
+					'setup',
+				].includes( list.id )
+			);
+
 		return {
-			hasTasksReminderFeature: taskLists.some(
-				( list ) => list.id === 'setup_experiment_1'
-			),
+			activeSetuplist: visibleSetupList.length
+				? visibleSetupList[ 0 ].id
+				: null,
 		};
 	} );
 
 	return (
 		<div className={ className } ref={ headerElement }>
-			{ hasTasksReminderFeature && (
+			{ activeSetuplist && (
 				<TasksReminderBar
-					pageTitle={ pageTitle }
 					updateBodyMargin={ updateBodyMargin }
+					taskListId={ activeSetuplist }
 				/>
 			) }
 			<div className="woocommerce-layout__header-wrapper">

--- a/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
@@ -24,7 +24,6 @@ import './reminder-bar.scss';
 
 type ReminderBarProps = {
 	taskListId: string;
-	pageTitle: string;
 	updateBodyMargin: () => void;
 };
 
@@ -83,7 +82,7 @@ const ReminderText: React.FC< ReminderTextProps > = ( {
 };
 
 export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
-	taskListId = 'setup_experiment_1',
+	taskListId,
 	updateBodyMargin,
 } ) => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );

--- a/plugins/woocommerce-admin/client/tasks/task.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task.tsx
@@ -25,6 +25,19 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 		optimisticallyCompleteTask,
 	} = useDispatch( ONBOARDING_STORE_NAME );
 
+	const updateBadge = useCallback( () => {
+		const badgeElement: HTMLElement | null = document.querySelector(
+			'.toplevel_page_woocommerce .remaining-tasks-badge'
+		);
+
+		if ( ! badgeElement ) {
+			return;
+		}
+
+		const currentBadgeCount = Number( badgeElement.innerText );
+		badgeElement.innerHTML = String( currentBadgeCount - 1 );
+	}, [] );
+
 	const onComplete = useCallback(
 		( options ) => {
 			optimisticallyCompleteTask( id );
@@ -34,6 +47,7 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 					: getNewPath( {}, '/', {} )
 			);
 			invalidateResolutionForStoreSelector( 'getTaskLists' );
+			updateBadge();
 		},
 		[ id ]
 	);

--- a/plugins/woocommerce-admin/client/tasks/task.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task.tsx
@@ -35,6 +35,11 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 		}
 
 		const currentBadgeCount = Number( badgeElement.innerText );
+
+		if ( currentBadgeCount === 1 ) {
+			badgeElement.remove();
+		}
+
 		badgeElement.innerHTML = String( currentBadgeCount - 1 );
 	}, [] );
 

--- a/plugins/woocommerce/changelog/add-32160-add-reminder-badge
+++ b/plugins/woocommerce/changelog/add-32160-add-reminder-badge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding badge to homescreen item on admin menu for setup tasks

--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -190,6 +190,7 @@ class CoreMenu {
 		}
 
 		$home_item = array();
+		$setup_tasks_remaining = TaskLists::setup_tasks_remaining();
 		if ( defined( '\Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG' ) ) {
 			$home_item = array(
 				'id'              => 'woocommerce-home',
@@ -197,7 +198,7 @@ class CoreMenu {
 				'url'             => \Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG,
 				'order'           => 0,
 				'matchExpression' => 'page=wc-admin((?!path=).)*$',
-				'badge'           => TaskLists::setup_tasks_remaining(),
+				'badge'           => $setup_tasks_remaining ? $setup_tasks_remaining : null,
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin\Features\Navigation;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 
 /**
  * CoreMenu class. Handles registering Core menu items.
@@ -196,6 +197,7 @@ class CoreMenu {
 				'url'             => \Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG,
 				'order'           => 0,
 				'matchExpression' => 'page=wc-admin((?!path=).)*$',
+				'badge'		=> TaskLists::setup_tasks_remaining(),
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -197,7 +197,7 @@ class CoreMenu {
 				'url'             => \Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG,
 				'order'           => 0,
 				'matchExpression' => 'page=wc-admin((?!path=).)*$',
-				'badge'		=> TaskLists::setup_tasks_remaining(),
+				'badge'           => TaskLists::setup_tasks_remaining(),
 			);
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -468,11 +468,14 @@ class TaskLists {
 	 * @return number
 	 */
 	public static function setup_tasks_remaining () {
-		if( ! Features::is_enabled( 'tasklist-setup-experiment-1' )) {
+
+		$active_list = self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ) ? 'setup_experiment_1' : self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' ) ? 'setup_experiment_1' : null;
+
+		if( is_null( $active_list ) ) {
 			return;
 		}
 
-		$setup_list = self::get_list( 'setup_experiment_1' );
+		$setup_list = self::get_list( $active_list );
 
 		if( $setup_list->is_hidden() || $setup_list->is_complete() ) {
 			return;

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -507,7 +507,7 @@ class TaskLists {
 
 		foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
 			if ( 0 === strpos( $menu_item[0], _x( 'Home', 'Admin menu name', 'woocommerce' ) ) ) {
-				$submenu['woocommerce'][ $key ][0] .= ' <span class="awaiting-mod update-plugins count-' . esc_attr( $tasks_count ) . '">' . number_format_i18n( $tasks_count ) . '</span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$submenu['woocommerce'][ $key ][0] .= ' <span class="awaiting-mod update-plugins remaining-tasks-badge count-' . esc_attr( $tasks_count ) . '">' . number_format_i18n( $tasks_count ) . '</span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				break;
 			}
 		}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -70,6 +70,7 @@ class TaskLists {
 		self::init_default_lists();
 		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
 		add_action( 'init', array( __CLASS__, 'init_tasks' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'menu_task_count' ) );
 		add_filter( 'woocommerce_admin_shared_settings', array( __CLASS__, 'task_list_preloaded_settings' ), 20 );
 	}
 
@@ -459,6 +460,55 @@ class TaskLists {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Return number of setup tasks remaining
+	 *
+	 * @return number
+	 */
+	public static function setup_tasks_remaining () {
+		if(!Features::is_enabled( 'tasklist-setup-experiment-1' )) {
+			return;
+		}
+
+		$setup_list = self::get_list('setup_experiment_1');
+
+		if($setup_list->is_hidden() || $setup_list->is_complete()) {
+			return;
+		}
+
+		$remaining_tasks = array_values(
+			array_filter(
+				$setup_list->get_viewable_tasks(),
+				function( $task ) {
+					return ! $task->is_complete();
+				}
+			)
+		);
+
+		return count($remaining_tasks);
+	}
+
+	/**
+	 * Add badge to homescreen menu item for remaining tasks
+	 */
+	public static function menu_task_count() {
+		global $submenu;
+
+		$tasks_count = self::setup_tasks_remaining();
+
+		if(!$tasks_count) {
+			return;
+		}
+
+		foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
+			if ( 0 === strpos( $menu_item[0], _x( 'Home', 'Admin menu name', 'woocommerce' ) ) ) {
+				$submenu['woocommerce'][ $key ][0] .= ' <span class="awaiting-mod update-plugins count-' . esc_attr( $tasks_count ) . '">' . number_format_i18n( $tasks_count ) . '</span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				break;
+			}
+		}
+
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -469,15 +469,11 @@ class TaskLists {
 	 */
 	public static function setup_tasks_remaining () {
 
-		$active_list = self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ) ? 'setup_experiment_1' : self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' ) ? 'setup_experiment_1' : null;
-
-		if( is_null( $active_list ) ) {
-			return;
-		}
+		$active_list = self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ) ? 'setup_experiment_1' : ( self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' ) ? 'setup_experiment_2' : 'setup' );
 
 		$setup_list = self::get_list( $active_list );
 
-		if( $setup_list->is_hidden() || $setup_list->is_complete() ) {
+		if( ! $setup_list || $setup_list->is_hidden() || $setup_list->is_complete() ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -468,13 +468,13 @@ class TaskLists {
 	 * @return number
 	 */
 	public static function setup_tasks_remaining () {
-		if(!Features::is_enabled( 'tasklist-setup-experiment-1' )) {
+		if( ! Features::is_enabled( 'tasklist-setup-experiment-1' )) {
 			return;
 		}
 
-		$setup_list = self::get_list('setup_experiment_1');
+		$setup_list = self::get_list( 'setup_experiment_1' );
 
-		if($setup_list->is_hidden() || $setup_list->is_complete()) {
+		if( $setup_list->is_hidden() || $setup_list->is_complete() ) {
 			return;
 		}
 
@@ -487,7 +487,7 @@ class TaskLists {
 			)
 		);
 
-		return count($remaining_tasks);
+		return count( $remaining_tasks );
 	}
 
 	/**
@@ -498,7 +498,7 @@ class TaskLists {
 
 		$tasks_count = self::setup_tasks_remaining();
 
-		if(!$tasks_count) {
+		if( !$tasks_count ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -497,7 +497,7 @@ class TaskLists {
 
 		$tasks_count = self::setup_tasks_remaining();
 
-		if( !$tasks_count ) {
+		if( ! $tasks_count ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding a badge to the home-screen item on the admin menu to indicate how many setup tasks remain. 

_Notes:_
- I also added the badge to the new woo navigation Home item, although I noticed some buggy behavior. Given the state of the woo navigation project I wasn't sure whether to pursue it further in the context of this PR, so I left it as is for now.
- The admin menu is only updated on a page refresh, so if a task completes with this it won't updated the badge. Updating this on the legacy admin menu will likely be somewhat hacky, but I'm glad to do this if we deem it necessary. 

![image](https://user-images.githubusercontent.com/444632/163244183-66822cfc-0f7b-47af-b0c3-6de266fcb47a.png)


Closes #32160  .

### How to test the changes in this Pull Request:

1. Checkout this branch on a fresh site.
2. Note that this should work with either task list experiment or without entirely.
3. Notice that no badge is displayed before completing any tasks (Unless one is auto-completed, which is true for at least one of the experiments)
4. Complete the setup wizard, and notice that the badge is now displayed indicated remaining tasks
5. Complete a couple other tasks, notice that the badge is updated properly. (don't complete all of them)
6. Hide the task list, and notice that the badge disappears
7. Display the task list again through Help -> Setup Wizard -> Task List -> Enable
8. Notice badge reappears
9. Complete the setup task list.
10. Notice the badge now disappears again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
