### PR TITLE
Fix minor css issues with complete task list item

### DIFF
--- a/packages/js/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/js/experimental/src/experimental-list/task-item/index.tsx
@@ -130,7 +130,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	}, [ expanded ] );
 
 	const className = classnames( 'woocommerce-task-list__item', {
-		complete: completed,
+		'is-complete': completed,
 		expanded: isTaskExpanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,

--- a/packages/js/experimental/src/experimental-list/task-item/style.scss
+++ b/packages/js/experimental/src/experimental-list/task-item/style.scss
@@ -121,7 +121,7 @@ $task-alert-yellow: #f0b849;
 		left: 5px;
 	}
 
-	&.complete {
+	&.is-complete {
 		.woocommerce-task__icon {
 			background-color: var(--wp-admin-theme-color);
 		}
@@ -136,7 +136,7 @@ $task-alert-yellow: #f0b849;
 		}
 	}
 
-	&:not(.complete) {
+	&:not(.is-complete) {
 		.woocommerce-task__icon {
 			border: 1px solid $gray-100;
 			background: $white;

--- a/plugins/woocommerce-admin/client/tasks/tasks.scss
+++ b/plugins/woocommerce-admin/client/tasks/tasks.scss
@@ -236,7 +236,7 @@
 }
 
 .woocommerce-task-list__setup_experiment_1 {
-	.woocommerce-experimental-list .woocommerce-experimental-list__item.complete {
+	.woocommerce-experimental-list .woocommerce-experimental-list__item.is-complete {
 		text-decoration: line-through;
 
 		.woocommerce-task-list__item-title {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update task list changes that got broken by changes merged in the sectioned task list PR. This keeps the `is-complete` task consistent.

<img width="686" alt="Screen Shot 2022-04-13 at 4 06 25 PM" src="https://user-images.githubusercontent.com/2240960/163252567-90e4feb8-3aa7-4b0f-b976-e75063e62f6b.png">

### How to test the changes in this Pull Request:

1. Install and enable the [WCA test helper](https://github.com/woocommerce/woocommerce-admin-test-helper/)
2. Navigate to Tools->WCA Test Helper->Features
3. Toggle the `tasklist-setup-experiment-1` experiment to `true`
5. Navigate to the homescreen
6. Check that the experiment 1 task list is shown that completed tasks show a check mark and are crossed out

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
