### PR TITLE
Fix/sanitize notes order by

### DIFF
--- a/plugins/woocommerce/changelog/fix-sanitize-notes-order-by
+++ b/plugins/woocommerce/changelog/fix-sanitize-notes-order-by
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sanitize order and orderby args in get_notes and lookup_notes. #32614

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -344,9 +344,13 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		$offset        = $args['per_page'] * ( $args['page'] - 1 );
 		$where_clauses = $this->get_notes_where_clauses( $args, $context );
 
+		// sanitize order and orderby.
+		$order_by  = '`' . str_replace( '`', '', $args['orderby'] ) . '`';
+		$order_dir = 'asc' === strtolower( $args['order'] ) ? 'ASC' : 'DESC';
+
 		$query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
+			"SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$order_by} {$order_dir} LIMIT %d, %d",
 			$offset,
 			$args['per_page']
 		);
@@ -372,7 +376,11 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		$where_clauses = $this->args_to_where_clauses( $args );
 
-		$query = "SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']}";
+		// sanitize order and orderby.
+		$order_by  = '`' . str_replace( '`', '', $args['orderby'] ) . '`';
+		$order_dir = 'asc' === strtolower( $args['order'] ) ? 'ASC' : 'DESC';
+
+		$query = "SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$order_by} {$order_dir}";
 
 		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-data-store.php
@@ -249,6 +249,78 @@ class WC_Admin_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test order and orderby sanitization in get_notes()
+	 */
+	public function test_get_notes_order_args_sanitized() {
+		global $wpdb;
+
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		// Attempt to pass a nonstandard direction.
+		// It should be replaced with the default: DESC.
+		$data_store->get_notes( array( 'order' => 'increasing' ) );
+		$this->assertFalse( stripos( 'increasing', $wpdb->last_query ) );
+		$this->assertTrue( stripos( 'DESC', $wpdb->last_query ) >= 0 );
+
+		// Attempt to pass a standard direction in lowercase.
+		// It should be replaced with the all-caps equivalent.
+		$data_store->get_notes( array( 'order' => 'asc' ) );
+		$this->assertFalse( strpos( 'asc', $wpdb->last_query ) );
+		$this->assertTrue( strpos( 'ASC', $wpdb->last_query ) >= 0 );
+
+		// Attempt to pass a suspicious string for orderby.
+		// It should have backticks stripped from it and get wrapped in backticks, thus causing an error.
+		$log_file = ini_set( 'error_log', '/dev/null' );
+		$wpdb->hide_errors();
+		$this->assertTrue( '' === $wpdb->last_error );
+
+		$data_store->get_notes( array( 'orderby' => '`name`;select 1;' ) );
+
+		$this->assertFalse( stripos( '`name`;select', $wpdb->last_query ) );
+		$this->assertTrue( stripos( '`name;select 1;`', $wpdb->last_query ) >= 0 );
+		$this->assertFalse( '' === $wpdb->last_error );
+
+		ini_set( 'error_log', $log_file );
+		$wpdb->show_errors();
+	}
+
+	/**
+	 * Test order and orderby sanitization in lookup_notes()
+	 */
+	public function test_lookup_notes_order_args_sanitized() {
+		global $wpdb;
+
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		// Attempt to pass a nonstandard direction.
+		// It should be replaced with the default: DESC.
+		$data_store->lookup_notes( array( 'order' => 'increasing' ) );
+		$this->assertFalse( stripos( 'increasing', $wpdb->last_query ) );
+		$this->assertTrue( stripos( 'DESC', $wpdb->last_query ) >= 0 );
+
+		// Attempt to pass a standard direction in lowercase.
+		// It should be replaced with the all-caps equivalent.
+		$data_store->lookup_notes( array( 'order' => 'asc' ) );
+		$this->assertFalse( strpos( 'asc', $wpdb->last_query ) );
+		$this->assertTrue( strpos( 'ASC', $wpdb->last_query ) >= 0 );
+
+		// Attempt to pass a suspicious string for orderby.
+		// It should have backticks stripped from it and get wrapped in backticks, thus causing an error.
+		$log_file = ini_set( 'error_log', '/dev/null' );
+		$wpdb->hide_errors();
+		$this->assertTrue( '' === $wpdb->last_error );
+
+		$data_store->lookup_notes( array( 'orderby' => '`name`;select 1;' ) );
+
+		$this->assertFalse( stripos( '`name`;select', $wpdb->last_query ) );
+		$this->assertTrue( stripos( '`name;select 1;`', $wpdb->last_query ) >= 0 );
+		$this->assertFalse( '' === $wpdb->last_error );
+
+		ini_set( 'error_log', $log_file );
+		$wpdb->show_errors();
+	}
+
+	/**
 	 * Test that sources are correctly added to where clause.
 	 */
 	public function test_get_notes_where_clauses_with_sources() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `get_notes()` and `lookup_notes()` methods in the Notes DataStore accept args for `'order'` (default `'DESC'`) and `'orderby'` (default `'date_created'`), which get inserted directly into the SQL query.

This change wraps the orderby field name in backticks and forces the order direction to be either `'DESC'` or `'ASC'`.

If there's a way to make `$wpdb->prepare()` work with identifiers (the orderby field name) and SQL keywords (the order direction), please chime in, because that would be preferable to doing it on the fly like this.

### Detailed test instructions:

If the wc-admin home page shows notes, then `get_notes()` is working with default args. The easiest way to test how it handles more complex bad inputs is to make spurious `get_notes()` calls from a custom plugin. See the new unit test for examples.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
