### PR TITLE
Revert "Use integers for menu page priority."

### DIFF
--- a/plugins/woocommerce/changelog/revert-31779-fix-31729-add-menu-page-arg
+++ b/plugins/woocommerce/changelog/revert-31779-fix-31729-add-menu-page-arg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert back menu position to floats as string for WP compatibility.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -61,7 +61,7 @@ class WC_Admin_Menus {
 			$menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' ); // WPCS: override ok.
 		}
 
-		add_menu_page( __( 'WooCommerce', 'woocommerce' ), __( 'WooCommerce', 'woocommerce' ), 'edit_others_shop_orders', 'woocommerce', null, $woocommerce_icon, 55 );
+		add_menu_page( __( 'WooCommerce', 'woocommerce' ), __( 'WooCommerce', 'woocommerce' ), 'edit_others_shop_orders', 'woocommerce', null, $woocommerce_icon, '55.5' );
 
 		add_submenu_page( 'edit.php?post_type=product', __( 'Attributes', 'woocommerce' ), __( 'Attributes', 'woocommerce' ), 'manage_product_terms', 'product_attributes', array( $this, 'attributes_page' ) );
 	}
@@ -73,7 +73,7 @@ class WC_Admin_Menus {
 		if ( self::can_view_woocommerce_menu_item() ) {
 			add_submenu_page( 'woocommerce', __( 'Reports', 'woocommerce' ), __( 'Reports', 'woocommerce' ), 'view_woocommerce_reports', 'wc-reports', array( $this, 'reports_page' ) );
 		} else {
-			add_menu_page( __( 'Sales reports', 'woocommerce' ), __( 'Sales reports', 'woocommerce' ), 'view_woocommerce_reports', 'wc-reports', array( $this, 'reports_page' ), 'dashicons-chart-bar', 56 );
+			add_menu_page( __( 'Sales reports', 'woocommerce' ), __( 'Sales reports', 'woocommerce' ), 'view_woocommerce_reports', 'wc-reports', array( $this, 'reports_page' ), 'dashicons-chart-bar', '55.6' );
 		}
 	}
 


### PR DESCRIPTION
Reverts woocommerce/woocommerce#31779

We added #31779, to respond to https://core.trac.wordpress.org/ticket/54798, but seems like that change never made it to prod and was reverted with https://core.trac.wordpress.org/changeset/53104 which allowed `float` value to be passed in string.

This also possible fixed #32609 

To test:
1. Add this code snippet to simulate disappearing WC menu:
```php

add_action( 'admin_menu', 'add_custom_menu_page' );
function add_custom_menu_page() {
	add_menu_page( __( 'Test Page', 'woocommerce' ), __( 'Test menu entry', 'woocommerce' ), 'view_woocommerce_reports', 'wc-tests', null, 'dashicons-chart-bar', 55.5 );

}
```
2. Open wp-admin page, and you will see that `WooCommerce` menu item has disappeared.
3. Switch to this branch, confirm that `WooCommerce` menu item is displayed again.

## Changelog
Revert - 31779 incorrect position value for registering menu pages.