### PR TITLE
Track when task list sections are closed

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -35,7 +35,7 @@ const PanelBodyWithUpdatedType = PanelBody as React.ComponentType< PanelBodyProp
 export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	query,
 	id,
-	eventName,
+	eventPrefix,
 	tasks,
 	keepCompletedTaskList,
 	isComplete,
@@ -66,7 +66,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 			return;
 		}
 
-		recordEvent( `${ eventName }_view`, {
+		recordEvent( `${ eventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
 		} );
@@ -122,7 +122,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	}
 
 	const trackClick = ( task: TaskType ) => {
-		recordEvent( `${ eventName }_click`, {
+		recordEvent( `${ eventPrefix }_click`, {
 			task_name: task.id,
 		} );
 	};
@@ -182,8 +182,24 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 							opened={ openPanel === section.id }
 							onToggle={ ( isOpen: boolean ) => {
 								if ( ! isOpen && openPanel === section.id ) {
+									recordEvent(
+										`${ eventPrefix }section_closed`,
+										{
+											id: section.id,
+											all: true,
+										}
+									);
 									setOpenPanel( null );
 								} else {
+									if ( openPanel ) {
+										recordEvent(
+											`${ eventPrefix }section_closed`,
+											{
+												id: openPanel,
+												all: false,
+											}
+										);
+									}
 									setOpenPanel( section.id );
 								}
 							} }

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -202,6 +202,14 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 									}
 									setOpenPanel( section.id );
 								}
+								if ( isOpen ) {
+									recordEvent(
+										`${ eventPrefix }section_opened`,
+										{
+											id: section.id,
+										}
+									);
+								}
 							} }
 							initialOpen={ false }
 						>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds tracks to the new task list experiment 2 layout when sections are closed.

<img width="523" alt="Screen Shot 2022-04-14 at 10 07 59 AM" src="https://user-images.githubusercontent.com/10561050/163411389-6d2292bf-ab1e-4ab2-80d8-85bf76eb1381.png">

<img width="622" alt="Screen Shot 2022-04-14 at 10 36 55 AM" src="https://user-images.githubusercontent.com/10561050/163413442-6693315a-6bff-4503-a17c-447e7cc6db2a.png">

Closes #32442  .

### How to test the changes in this Pull Request:

1. Install the WCA Test Helper if not yet installed
2. Open your browser console.
3. If you haven't enabled tracks debug, type in localStorage.setItem( 'debug', 'wc-admin:tracks*' ); to enable it.
4. Go to Tools -> WCA Test Helper -> Experiments
5. Change `woocommerce_tasklist_setup_experiment_2_X_X` to `treatment`
6. Navigate to the homepage
7. Open and close sections of the task list
8. Note the tracks and respective section ID in the console when a section is closed
9. Note that `all` is `true` when all sections are closed
10. Hide the task list
11. Complete the task list
12. Navigate to WooCommerce -> Status -> Logs and to the latest tracks log
13. Note the task list tracks for hiding and completion

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
