### PR TITLE
Remove Pinterest extension from OBW

### DIFF
--- a/plugins/woocommerce/changelog/fix-32141_remove_pinterest_extension_from_obw
+++ b/plugins/woocommerce/changelog/fix-32141_remove_pinterest_extension_from_obw
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove Pinterest extension from OBW #32626

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -397,7 +397,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 						'creative-mail-by-constant-contact',
 						'facebook-for-woocommerce',
 						'google-listings-and-ads',
-						'pinterest-for-woocommerce',
 						'mailpoet',
 					),
 					'type' => 'string',

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -36,7 +36,6 @@ class DefaultFreeExtensions {
 				'plugins' => [
 					self::get_plugin( 'mailpoet' ),
 					self::get_plugin( 'google-listings-and-ads' ),
-					self::get_plugin( 'pinterest-for-woocommerce' ),
 				],
 			],
 			[
@@ -53,7 +52,7 @@ class DefaultFreeExtensions {
 				'title'   => __( 'Grow your store', 'woocommerce' ),
 				'plugins' => [
 					self::get_plugin( 'google-listings-and-ads:alt' ),
-					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
+					self::get_plugin( 'pinterest-for-woocommerce' ),
 				],
 			],
 		];
@@ -100,30 +99,7 @@ class DefaultFreeExtensions {
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc' => true,
 			],
-			'pinterest-for-woocommerce'         => [
-				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
-				'description'    => sprintf(
-					/* translators: 1: opening product link tag. 2: closing link tag */
-					__( 'Inspire shoppers with %1$sPinterest for WooCommerce%2$s', 'woocommerce' ),
-					'<a href="https://woocommerce.com/products/pinterest-for-woocommerce" target="_blank">',
-					'</a>'
-				),
-				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
-				'manage_url'     => 'admin.php?page=pinterest-for-woocommerce',
-				'is_visible'     => [
-					[
-						'type'    => 'not',
-						'operand' => [
-							[
-								'type'    => 'plugins_activated',
-								'plugins' => [ 'pinterest-for-woocommerce' ],
-							],
-						],
-					],
-				],
-				'is_built_by_wc' => false,
-			],
-			'pinterest-for-woocommerce:alt'     => [
+			'pinterest-for-woocommerce'     => [
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

To address the change suggested [here](https://github.com/woocommerce/woocommerce/issues/32141#issuecomment-1099216490), this PR removes the Pinterest extension from the OBW.

### How to test the changes in this Pull Request:

1. Delete the option named: `_transient_woocommerce_admin_remote_free_extensions_specs` (you can use the [WooCommerce Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper) plugin to do it).
2. Install [this plugin](https://gist.github.com/octaedro/7d9f83a4dec9f3fc1918404ad69c421f) to modify [this call](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/RemoteFreeExtensionsDataSourcePoller.php#L13).
3. Go to the testing plugin that you just downloaded (step 2) and set `$use_broken_url` as `true` [here](https://gist.github.com/octaedro/7d9f83a4dec9f3fc1918404ad69c421f#file-wc-overwrite-woocommerce-com-url-php-L12). That will make the plugin use a broken URL instead of `woocommerce.test`.
4. Go to the `Business Details` step in the OBW.
5. Verify that the item: "Inspire shoppers with [Pinterest for WooCommerce](https://woocommerce.com/products/pinterest-for-woocommerce/)" is not visible anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
