### PR TITLE
Mark marketing task as complete when an extension is installed

### DIFF
--- a/plugins/woocommerce/changelog/fix-32149_mark_marketing_task_as_complete
+++ b/plugins/woocommerce/changelog/fix-32149_mark_marketing_task_as_complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Mark marketing task as complete when an extension is installed #32630

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -125,13 +125,8 @@ class Marketing extends Task {
 			}
 		}
 
-		// Make sure the task has been actioned or all extensions installed
-		// or a marketing extension has been installed.
-		if (
-			count( $installed ) > 0 ||
-			Task::is_task_actioned( 'marketing' ) ||
-			count( $remaining ) === 0
-		) {
+		// Make sure the task has been actioned or a marketing extension has been installed.
+		if ( count( $installed ) > 0 || Task::is_task_actioned( 'marketing' ) ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -130,8 +130,8 @@ class Marketing extends Task {
 			return true;
 		}
 
-		// Make sure the task has been actioned and at least one extension is installed.
-		if ( count( $installed ) > 0 && Task::is_task_actioned( 'marketing' ) ) {
+		// Make sure the task has been actioned or at least one extension is installed.
+		if ( count( $installed ) > 0 || Task::is_task_actioned( 'marketing' ) ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -125,13 +125,13 @@ class Marketing extends Task {
 			}
 		}
 
-		// All extensions installed.
-		if ( count( $remaining ) === 0 ) {
-			return true;
-		}
-
-		// Make sure the task has been actioned or at least one extension is installed.
-		if ( count( $installed ) > 0 || Task::is_task_actioned( 'marketing' ) ) {
+		// Make sure the task has been actioned or all extensions installed
+		// or a marketing extension has been installed.
+		if (
+			count( $installed ) > 0 ||
+			Task::is_task_actioned( 'marketing' ) ||
+			count( $remaining ) === 0
+		) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32149.

### How to test the changes in this Pull Request:

1. In a brand new store, go through the OBW, and in step 4 (Business Details), go to `Free features` and install the `MailPoet` extension.
2. Finish the OBW.
3. Go to the `Home` screen and verify that the marketing task is marked as completed.
4. Delete the `MailPoet` extension.
5. Verify that the marketing task is not marked as completed now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
