### PR TITLE
API: Orders: Add `needs_payment` field

### DIFF
--- a/plugins/woocommerce/changelog/add-api-order-needs-payment-field
+++ b/plugins/woocommerce/changelog/add-api-order-needs-payment-field
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-REST API: Adds a `needs_payment` field to order requests.
+REST API: Adds a `needs_payment` field to order responses.

--- a/plugins/woocommerce/changelog/add-api-order-needs-payment-field
+++ b/plugins/woocommerce/changelog/add-api-order-needs-payment-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+REST API: Adds a `needs_payment` field to order requests.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -324,7 +324,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function get_formatted_item_data( $order ) {
-		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url' );
+		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url', 'needs_payment' );
 		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
 		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
 		// These fields are dependent on other fields.
@@ -386,6 +386,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					break;
 				case 'payment_url':
 					$data['payment_url'] = $order->get_checkout_payment_url();
+					break;
+				case 'needs_payment':
+					$data['needs_payment'] = $order->needs_payment();
 					break;
 			}
 		}
@@ -453,6 +456,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			'coupon_lines',
 			'refunds',
 			'payment_url',
+			'needs_payment',
 		);
 
 		$data = array_intersect_key( $data, array_flip( $allowed_fields ) );
@@ -1848,6 +1852,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 				'payment_url' => array(
 					'description' => __( 'Order payment URL.', 'woocommerce' ),
 					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'needs_payment' => array(
+					'description' => __( 'Define if the order needs to be paid.', 'woocommerce' ),
+					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is so we can mirror the core behavior of showing a payment URL. It
essentially gives us the filtered value of
`woocommerce_order_needs_payment`. We can approximate this based on the
order status, but returning the precise value in the API will allow us
to cope with changes made my extensions.

ref: https://github.com/woocommerce/woocommerce-ios/pull/6609

### How to test the changes in this Pull Request:

1. Create a pending order.
2. GET /wp-json/wc/v3/orders/<id>
3. Observe that `needs_payment` is `true`.
4. Change the order status to completed.
5. GET /wp-json/wc/v3/orders/<id>
6. Observe that `needs_payment` is `false`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
