### PR TITLE
Adding workflow to check status of site used for daily smoke tests.

### DIFF
--- a/.github/workflows/smoke-test-daily-site-check.yml
+++ b/.github/workflows/smoke-test-daily-site-check.yml
@@ -1,0 +1,23 @@
+name: Check daily smoke test site status.
+on:
+  push:
+
+jobs:
+  ping_site:
+    runs-on: ubuntu-latest
+    name: Check site and notify if not found
+    steps:
+    - name: Check site status
+      id: sitecheck
+      uses: srt32/uptime@958231f4d95c117f08eb0fc70907e80d0dfedf2b
+      with:
+        url-to-hit: "${{ secrets.SMOKE_TEST_URL }}ready/"
+        expected-statuses: "200,301"
+    - name: Send message to Slack API
+      if: failure()
+      uses: archive/github-actions-slack@deecc2edc496dc642d643de1d7cf3a47f51fb27a
+      id: notify
+      with:
+        slack-bot-user-oauth-access-token: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
+        slack-channel: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
+        slack-text: ':warning: <!subteam^${{ secrets.SMOKE_TEST_SLACK_GROUP }}> FYI the URL ${{ secrets.SMOKE_TEST_URL }}ready/ appears to be returning `404 not found` :x:'

--- a/.github/workflows/smoke-test-daily-site-check.yml
+++ b/.github/workflows/smoke-test-daily-site-check.yml
@@ -1,6 +1,7 @@
 name: Check daily smoke test site status.
 on:
-  push:
+  schedule:
+    - cron: '25 7 * * *'
 
 jobs:
   ping_site:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sometimes the Nightly Smoke Tests will fail with error `Testing environment couldn't be found`

This is likely due to the `Ready` page from the smoke tests site needing to be republished.

This error doesn't currently appear in the Slack results channel so we may not realise the page needs republished.

This action pings the `Ready` page once a day after the nightly tests have ran to check that it is published by checking the HTTP status code. If the site is up as expected the action does not notify. If the `Ready` page is not found a message is added to the Slack results channel and the team is mentioned to let them know.

Closes 252-gh-woocommerce/woocommerce-quality

### How to test the changes in this Pull Request:

It isn't possible to test this action from the PR.

Instead to test it I changed to the trigger to `on:push` and ran the workflow. The `Ready` page was found and no notification sent.
I then un-published the `Ready` page and re-ran the workflow. The `Ready` page was not found and notification was sent to Slack.

![Screenshot_2022-04-19_at_09_43_16](https://user-images.githubusercontent.com/24649833/163983192-22f419a4-c37e-4c32-a416-844c27fa0c3d.jpg)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
