### PR TITLE
Address possible type error during install on PHP 8.x

### DIFF
--- a/plugins/woocommerce/changelog/fix-32028-settings-method-exists-fatal
+++ b/plugins/woocommerce/changelog/fix-32028-settings-method-exists-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix possible fatal error during install on PHP 8.x

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -700,7 +700,7 @@ class WC_Install {
 		$settings = WC_Admin_Settings::get_settings_pages();
 
 		foreach ( $settings as $section ) {
-			if ( ! method_exists( $section, 'get_settings' ) ) {
+			if ( ! is_a( $section, 'WC_Settings_Page' ) || ! method_exists( $section, 'get_settings' ) ) {
 				continue;
 			}
 			$subsections = array_unique( array_merge( array( '' ), array_keys( $section->get_sections() ) ) );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The settings pages returned by `WC_Admin_Settings::get_settings_pages()` are used [during install](https://github.com/woocommerce/woocommerce/blob/85324ea2cf2cd1f1091fdd2c92c951b9074fc39c/plugins/woocommerce/includes/class-wc-install.php#L700-L703) to create options/set defaults. If, for any reason, one of the values returned in this array is not a string or object (which can happen as this can be altered via filter "woocommerce_get_settings_pages"), the `method_exists()` call results in a fatal error (on PHP 8.x).

This PR adds an additional check to make sure that we only iterate over valid settings pages (i.e. subclasses of `WC_Settings_Page`).

While this doesn't happen very often, I found at least a couple of very popular plugins that use `include_once()` when including their settings classes in the `$settings` array (instead of just `include()` [as we do](https://github.com/woocommerce/woocommerce/blob/2c1885f69a7ed66fd56ef8cf028b9184939664a2/plugins/woocommerce/includes/admin/class-wc-admin-settings.php#L52)). This is one of the ways an invalid value can make it into this array, because `include_once()` returns `true` immediately, thus adding this incorrect value to the list.

Closes #32028.

### How to test the changes in this Pull Request:

1. Make sure you're on PHP 8.x.
1. Activate a snippet such as the following to simulate an invalid value in the settings pages array:
   ```php
   add_filter(
	   'woocommerce_get_settings_pages',
	   function( $settings ) {
		   $settings[] = 1;
   
		   return $settings;
	   }
   );
   ```
1. Trigger the install routine by changing the `woocommerce_db_version` to a lesser value.
1. Refresh your test site and confirm that...
   - On `trunk`, a fatal error is triggered/logged:
      > PHP Fatal error:  Uncaught TypeError: method_exists(): Argument \# 1 ($object_or_class) must be of type object|string, int given in [...]woocommerce/plugins/woocommerce/includes/class-wc-install.php:703
   - On this branch: no error is triggered.
      Make sure you remove the `wc_installing` transient between tests.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
* [X] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
