### PR TITLE
Add pre-req checks to tests suite installation script.

### DIFF
--- a/plugins/woocommerce/changelog/fix-29705-tests-install
+++ b/plugins/woocommerce/changelog/fix-29705-tests-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add basic pre-requisite checking to the test suite installation script.

--- a/plugins/woocommerce/tests/bin/install.sh
+++ b/plugins/woocommerce/tests/bin/install.sh
@@ -6,6 +6,18 @@ if [ $# -lt 3 ]; then
 	exit 1
 fi
 
+function check_command_exists {
+	if ! which "$1" > /dev/null; then
+		echo "It looks as if $1 is not installed. Please ensure it is installed and on the path."
+		exit 1
+	fi
+}
+
+# Basic pre-requisite checks
+check_command_exists "mysqladmin"
+check_command_exists "php"
+check_command_exists "svn"
+
 DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3
@@ -107,6 +119,8 @@ install_test_suite() {
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	else
+		echo -e "\nTest suite already installed at:\n\n\t$WP_TESTS_DIR\n\n(If you experience difficulties running the tests, consider removing it then re-running this script.)\n"
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Minor changes to `tests/bin/install.sh` to address some of the criticisms [raised here](https://github.com/woocommerce/woocommerce/issues/29705). Namely, if key utilities like `svn` are not installed, execution will end early (and, **before** the WP Tests Dir is created) with an appropriate warning.

Additionally, if the script is run a second time and the WP Tests Dir has indeed already been created (this may or may not be a problem, depending on the context) then a slightly more obvious and human readable warning is emitted to suggest deleting it and starting again in the event of any difficulties.

<details>
<summary>Screenshots</summary>

<img width="594" alt="svn-not-installed" src="https://user-images.githubusercontent.com/3594411/164065186-b101adc4-30bb-4e0f-a8e0-fa73a93c354e.png">

<p>👆🏼 <i>If it is determined that `svn` is not on the path.</i></p>

<img width="723" alt="test-suite-already-installed" src="https://user-images.githubusercontent.com/3594411/164063668-33482d3b-c848-4001-b5db-1583a99b8bb7.png">

<p>👆🏼 <i>If it is determined that the WP test suite was already setup.</i></p>
</details>

Closes #29705.

### How to test the changes in this Pull Request:

1. "Uninstall" `svn` (or `php`, or `mysqladmin`).
    1. You can of course actually remove the relevant package if you wish.
    2. Or, determine where the binary lives (example: `which svn`) then rename it (example: `sudo mv /usr/bin/svn /usr/bin/svn.tmp`) and restore after testing.
2. Run the script (example: `./tests/bin/install/sh`).
3. It should exit early, warning that `svn` (or other required binary) is not installed.
4. Restore the tool you were testing, and run the script a couple of times.
5. You should find that after the script has run once and the WP Test Dir has been created, on subsequent runs an additional warning is present in the script output:

```
Test suite already installed at:

	/tmp/wordpress-tests-lib

(If you experience difficulties running the tests, consider removing it then re-running this script.)
```


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
