### PR TITLE
Add filtered tracks properties to client-side tracks

### DIFF
--- a/plugins/woocommerce/changelog/add-32178
+++ b/plugins/woocommerce/changelog/add-32178
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add filtered tracks properties to client-side tracks #32690

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -21,6 +21,8 @@ class WC_Site_Tracking {
 		 * Don't track users if a filter has been applied to turn it off.
 		 * `woocommerce_apply_tracking` will be deprecated. Please use
 		 * `woocommerce_apply_user_tracking` instead.
+		 *
+		 * @since 3.6.0
 		 */
 		if ( ! apply_filters( 'woocommerce_apply_user_tracking', true ) || ! apply_filters( 'woocommerce_apply_tracking', true ) ) {
 			return false;
@@ -62,6 +64,11 @@ class WC_Site_Tracking {
 	 * Adds the tracking function to the admin footer.
 	 */
 	public static function add_tracking_function() {
+		/**
+		 * Add global tracks event properties.
+		 *
+		 * @since 6.5.0
+		 */
 		$filtered_properties = apply_filters( 'woocommerce_tracks_event_properties', array(), false );
 		?>
 		<!-- WooCommerce Tracks -->
@@ -73,8 +80,8 @@ class WC_Site_Tracking {
 					return;
 				}
 
-				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
-				var eventProperties = properties || {};
+				const eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
+				const eventProperties = properties || {};
 				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties ); ?> };
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -139,7 +139,7 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
-		add_filter( 'woocommerce_tracks_event_properties', array( __CLASS__, 'add_global_properties' ) );
+		add_filter( 'woocommerce_tracks_event_properties', array( __CLASS__, 'add_global_properties' ), 10, 2 );
 
 		// Define window.wcTracks.recordEvent in case it is enabled client-side.
 		self::register_scripts();
@@ -242,18 +242,22 @@ class WC_Site_Tracking {
 	 * Add global properties to tracks.
 	 *
 	 * @param array $properties Array of event properties.
+	 * @param array $event_name Name of the event, if passed.
 	 * @return array
 	 */
-	public static function add_global_properties( $properties ) {
-		$data = array(
-			'_en' => $prefixed_event_name,
-			'_ts' => WC_Tracks_Client::build_timestamp(),
-		);
+	public static function add_global_properties( $properties, $event_name = null ) {
+		$user = wp_get_current_user();
+		$data = $event_name
+			? array(
+				'_en' => $event_name,
+				'_ts' => WC_Tracks_Client::build_timestamp(),
+			)
+			: array();
 
 		$server_details = self::get_server_details();
 		$identity       = WC_Tracks_Client::get_identity( $user->ID );
 		$blog_details   = self::get_blog_details( $user->ID );
 
-		return array_merge( $properties, $server_details, $identity, $blog_details );
+		return array_merge( $data, $properties, $server_details, $identity, $blog_details );
 	}
 }

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -16,57 +16,6 @@ class WC_Tracks {
 	const PREFIX = 'wcadmin_';
 
 	/**
-	 * Get total product counts.
-	 *
-	 * @return int Number of products.
-	 */
-	public static function get_products_count() {
-		$product_counts = WC_Tracker::get_product_counts();
-		return $product_counts['total'];
-	}
-
-	/**
-	 * Gather blog related properties.
-	 *
-	 * @param int $user_id User id.
-	 * @return array Blog details.
-	 */
-	public static function get_blog_details( $user_id ) {
-		$blog_details = get_transient( 'wc_tracks_blog_details' );
-		if ( false === $blog_details ) {
-			$blog_details = array(
-				'url'            => home_url(),
-				'blog_lang'      => get_user_locale( $user_id ),
-				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
-				'products_count' => self::get_products_count(),
-				'wc_version'     => WC()->version,
-			);
-			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
-		}
-		return $blog_details;
-	}
-
-	/**
-	 * Gather details from the request to the server.
-	 *
-	 * @return array Server details.
-	 */
-	public static function get_server_details() {
-		$data = array();
-
-		$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
-		$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? wc_clean( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-		$data['_lg']     = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
-		$data['_dr']     = isset( $_SERVER['HTTP_REFERER'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
-
-		$uri         = isset( $_SERVER['REQUEST_URI'] ) ? wc_clean( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		$host        = isset( $_SERVER['HTTP_HOST'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
-		$data['_dl'] = isset( $_SERVER['REQUEST_SCHEME'] ) ? wc_clean( wp_unslash( $_SERVER['REQUEST_SCHEME'] ) ) . '://' . $host . $uri : '';
-
-		return $data;
-	}
-
-	/**
 	 * Record an event in Tracks - this is the preferred way to record events from PHP.
 	 * Note: the event request won't be made if $properties has a member called `error`.
 	 *
@@ -90,15 +39,6 @@ class WC_Tracks {
 		}
 		$prefixed_event_name = self::PREFIX . $event_name;
 
-		$data = array(
-			'_en' => $prefixed_event_name,
-			'_ts' => WC_Tracks_Client::build_timestamp(),
-		);
-
-		$server_details = self::get_server_details();
-		$identity       = WC_Tracks_Client::get_identity( $user->ID );
-		$blog_details   = self::get_blog_details( $user->ID );
-
 		// Allow event props to be filtered to enable adding site-wide props.
 		$filtered_properties = apply_filters( 'woocommerce_tracks_event_properties', $properties, $prefixed_event_name );
 
@@ -106,7 +46,7 @@ class WC_Tracks {
 		unset( $filtered_properties['_ui'] );
 		unset( $filtered_properties['_ut'] );
 
-		$event_obj = new WC_Tracks_Event( array_merge( $data, $server_details, $identity, $blog_details, $filtered_properties ) );
+		$event_obj = new WC_Tracks_Event( $filtered_properties );
 
 		if ( is_wp_error( $event_obj->error ) ) {
 			return $event_obj->error;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds `wc_version` to the frontend tracks.  Since a filter was already in place to capture a number of properties, this PR moves the filter so that these properties are shared across both the backend and frontend.

Closes #32178  .

### How to test the changes in this Pull Request:

1. Build this branch of the plugin.
2. Install on a JN site.
3. Opt into tracking.
4. Trigger some frontend events.
5. Watch for events in MC live tracks.
6. Note that the `wc_version` and other shared properties come through.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
