### PR TITLE
Added a filter to change the Error message and allow developers to add custom text after each table row

### DIFF
--- a/packages/js/components/src/table/table.js
+++ b/packages/js/components/src/table/table.js
@@ -14,6 +14,7 @@ import { find, get, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
+import { applyFilters } from '@wordpress/hooks';
 
 const ASC = 'asc';
 const DESC = 'desc';
@@ -297,46 +298,52 @@ class Table extends Component {
 						</tr>
 						{ hasData ? (
 							rows.map( ( row, i ) => (
-								<tr key={ this.getRowKey( row, i ) }>
-									{ row.map( ( cell, j ) => {
-										const {
-											cellClassName,
-											isLeftAligned,
-											isNumeric,
-										} = headers[ j ];
-										const isHeader = rowHeader === j;
-										const Cell = isHeader ? 'th' : 'td';
-										const cellClasses = classnames(
-											'woocommerce-table__item',
-											cellClassName,
-											{
-												'is-left-aligned':
-													isLeftAligned ||
-													! isNumeric,
-												'is-numeric': isNumeric,
-												'is-sorted':
-													sortedBy ===
-													headers[ j ].key,
-											}
-										);
-										const cellKey =
-											this.getRowKey(
-												row,
-												i
-											).toString() + j;
-										return (
-											<Cell
-												scope={
-													isHeader ? 'row' : null
+								applyFilters(
+									'woocommerce_admin_table_row',
+									<tr key={ this.getRowKey( row, i ) }>
+										{ row.map( ( cell, j ) => {
+											const {
+												cellClassName,
+												isLeftAligned,
+												isNumeric,
+											} = headers[ j ];
+											const isHeader = rowHeader === j;
+											const Cell = isHeader ? 'th' : 'td';
+											const cellClasses = classnames(
+												'woocommerce-table__item',
+												cellClassName,
+												{
+													'is-left-aligned':
+														isLeftAligned ||
+														! isNumeric,
+													'is-numeric': isNumeric,
+													'is-sorted':
+														sortedBy ===
+														headers[ j ].key,
 												}
-												key={ cellKey }
-												className={ cellClasses }
-											>
-												{ getDisplay( cell ) }
-											</Cell>
-										);
-									} ) }
-								</tr>
+											);
+											const cellKey =
+												this.getRowKey(
+													row,
+													i
+												).toString() + j;
+											return (
+												<Cell
+													scope={
+														isHeader ? 'row' : null
+													}
+													key={ cellKey }
+													className={ cellClasses }
+												>
+													{ getDisplay( cell ) }
+												</Cell>
+											);
+										} ) }
+									</tr>,
+									i,
+									row,
+									query
+								)
 							) )
 						) : (
 							<tr>
@@ -344,9 +351,12 @@ class Table extends Component {
 									className="woocommerce-table__empty-item"
 									colSpan={ headers.length }
 								>
-									{ __(
-										'No data to display',
-										'woocommerce'
+									{ applyFilters(
+										'woocommerce_admin_nodata_text',
+										__(
+											'No data to display',
+											'woocommerce'
+										)
 									) }
 								</td>
 							</tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Currently, there is no way to add custom content right after the table. A filter will help developers who want to toggle certain content when a table row is clicked. It would be great if you could include this filter or a similar solution in the WC tables package.

### Screencast
[i.rankmath.com/42piMc](https://i.rankmath.com/42piMc)
The toggle you see in the screencast is implemented by making the changes directly in the WC table files.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
