### PR TITLE
Adopt migrations so that custom order id is equal to posts.id it's migrated from.

### DIFF
--- a/plugins/woocommerce/changelog/cot-32663
+++ b/plugins/woocommerce/changelog/cot-32663
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Modify migration to make cot.id === posts.id.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/MetaToCustomTableMigrator.php
@@ -196,6 +196,9 @@ abstract class MetaToCustomTableMigrator {
 		$columns      = array();
 		$placeholders = array();
 		foreach ( $columns_schema as $prev_column => $schema ) {
+			if ( in_array( $schema['destination'], $columns ) ) {
+				continue;
+			}
 			$columns[]      = $schema['destination'];
 			$placeholders[] = MigrationHelper::get_wpdb_placeholder_for_type( $schema['type'] );
 		}

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostMetaToOrderMetaMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostMetaToOrderMetaMigrator.php
@@ -54,7 +54,7 @@ class WPPostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 				),
 				'entity'        => array(
 					'table_name'       => $this->table_names['orders'],
-					'source_id_column' => 'post_id',
+					'source_id_column' => 'id',
 					'id_column'        => 'id',
 				),
 				'excluded_keys' => $this->excluded_columns,

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostToOrderAddressTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostToOrderAddressTableMigrator.php
@@ -47,9 +47,9 @@ class WPPostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 			'source'      => array(
 				'entity' => array(
 					'table_name'             => $this->table_names['orders'],
-					'meta_rel_column'        => 'post_id',
+					'meta_rel_column'        => 'id',
 					'destination_rel_column' => 'id',
-					'primary_key'            => 'post_id',
+					'primary_key'            => 'id',
 				),
 				'meta'   => array(
 					'table_name'        => $wpdb->postmeta,

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostToOrderOpTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostToOrderOpTableMigrator.php
@@ -31,9 +31,9 @@ class WPPostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 			'source'      => array(
 				'entity' => array(
 					'table_name'             => $this->table_names['orders'],
-					'meta_rel_column'        => 'post_id',
+					'meta_rel_column'        => 'id',
 					'destination_rel_column' => 'id',
-					'primary_key'            => 'post_id',
+					'primary_key'            => 'id',
 				),
 				'meta'   => array(
 					'table_name'        => $wpdb->postmeta,

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostToOrderTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/WPPostToOrderTableMigrator.php
@@ -43,7 +43,7 @@ class WPPostToOrderTableMigrator extends MetaToCustomTableMigrator {
 			),
 			'destination' => array(
 				'table_name'        => $this->table_names['orders'],
-				'source_rel_column' => 'post_id',
+				'source_rel_column' => 'id',
 				'primary_key'       => 'id',
 				'primary_key_type'  => 'int',
 			),
@@ -59,7 +59,7 @@ class WPPostToOrderTableMigrator extends MetaToCustomTableMigrator {
 		return array(
 			'ID'                => array(
 				'type'        => 'int',
-				'destination' => 'post_id',
+				'destination' => 'id',
 			),
 			'post_status'       => array(
 				'type'        => 'string',

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -1,12 +1,15 @@
-<?php
+<?php // phpcs:ignore
 /**
  * Orders helper.
+ *
+ * @package Automattic\WooCommerce\RestApi\UnitTests\Helpers
  */
 
 namespace Automattic\WooCommerce\RestApi\UnitTests\Helpers;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use WC_Mock_Payment_Gateway;
 use \WC_Tax;
@@ -47,10 +50,10 @@ class OrderHelper {
 	 * @since   2.4
 	 * @version 3.0 New parameter $product.
 	 *
-	 * @param int        $customer_id
-	 * @param WC_Product $product
+	 * @param int        $customer_id Customer ID.
+	 * @param WC_Product $product     Product object.
 	 *
-	 * @return WC_Order
+	 * @return WC_Order WC_Order object.
 	 */
 	public static function create_order( $customer_id = 1, $product = null ) {
 
@@ -67,10 +70,10 @@ class OrderHelper {
 			'total'         => '',
 		);
 
-		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception.
 		$order                  = wc_create_order( $order_data );
 
-		// Add order products
+		// Add order products.
 		$item = new WC_Order_Item_Product();
 		$item->set_props(
 			array(
@@ -83,7 +86,7 @@ class OrderHelper {
 		$item->save();
 		$order->add_item( $item );
 
-		// Set billing address
+		// Set billing address.
 		$order->set_billing_first_name( 'Jeroen' );
 		$order->set_billing_last_name( 'Sormani' );
 		$order->set_billing_company( 'WooCompany' );
@@ -96,7 +99,7 @@ class OrderHelper {
 		$order->set_billing_email( 'admin@example.org' );
 		$order->set_billing_phone( '555-32123' );
 
-		// Add shipping costs
+		// Add shipping costs.
 		$shipping_taxes = WC_Tax::calc_shipping_tax( '10', WC_Tax::get_shipping_tax_rates() );
 		$rate           = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', $shipping_taxes, 'flat_rate' );
 		$item           = new WC_Order_Item_Shipping();
@@ -113,17 +116,17 @@ class OrderHelper {
 		}
 		$order->add_item( $item );
 
-		// Set payment gateway
+		// Set payment gateway.
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 		$order->set_payment_method( $payment_gateways['bacs'] );
 
-		// Set totals
+		// Set totals.
 		$order->set_shipping_total( 10 );
 		$order->set_discount_total( 0 );
 		$order->set_discount_tax( 0 );
 		$order->set_cart_tax( 0 );
 		$order->set_shipping_tax( 0 );
-		$order->set_total( 50 ); // 4 x $10 simple helper product
+		$order->set_total( 50 ); // 4 x $10 simple helper product.
 		$order->save();
 
 		return $order;
@@ -134,7 +137,7 @@ class OrderHelper {
 	 */
 	public static function create_order_custom_table_if_not_exist() {
 		$order_table_controller = wc_get_container()
-			->get( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' );
+			->get( CustomOrdersTableController::class );
 		$order_table_controller->show_feature();
 		$synchronizer = wc_get_container()
 			->get( DataSynchronizer::class );
@@ -166,7 +169,7 @@ class OrderHelper {
 
 		ShippingHelper::create_simple_flat_rate();
 
-		$order = OrderHelper::create_order();
+		$order = self::create_order();
 		// Make sure this is a wp_post order.
 		$post = get_post( $order->get_id() );
 		assert( isset( $post ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\RestApi\UnitTests\Helpers;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use WC_Mock_Payment_Gateway;
 use \WC_Tax;
 use \WC_Shipping_Rate;
@@ -126,6 +127,20 @@ class OrderHelper {
 		$order->save();
 
 		return $order;
+	}
+
+	/**
+	 * Helper method to create custom tables if not present.
+	 */
+	public static function create_order_custom_table_if_not_exist() {
+		$order_table_controller = wc_get_container()
+			->get( 'Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' );
+		$order_table_controller->show_feature();
+		$synchronizer = wc_get_container()
+			->get( DataSynchronizer::class );
+		if ( ! $synchronizer->check_orders_table_exists() ) {
+			$synchronizer->create_database_tables();
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/WPPostToCOTMigratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/WPPostToCOTMigratorTest.php
@@ -44,7 +44,7 @@ class WPPostToCOTMigratorTest extends WC_Unit_Test_Case {
 	 * Test that migration for a normal order happens as expected.
 	 */
 	public function test_process_next_migration_batch_normal_order() {
-		$order = wc_get_order( $this->create_complex_wp_post_order() );
+		$order = wc_get_order( OrderHelper::create_complex_wp_post_order() );
 		$this->clear_all_orders_and_reset_checkpoint();
 		$this->sut->process_next_migration_batch( 100 );
 
@@ -59,7 +59,7 @@ class WPPostToCOTMigratorTest extends WC_Unit_Test_Case {
 	 */
 	public function test_process_next_migration_batch_already_migrated_order() {
 		global $wpdb;
-		$order = wc_get_order( $this->create_complex_wp_post_order() );
+		$order = wc_get_order( OrderHelper::create_complex_wp_post_order() );
 		$this->clear_all_orders_and_reset_checkpoint();
 
 		// Run the migration once.
@@ -210,82 +210,6 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		// phpcs:ignore
 		return $wpdb->get_results( "SELECT * FROM $metadata_table WHERE order_id = $order_id;" );
-	}
-
-	/**
-	 * Helper method to create complex wp_post based order.
-	 *
-	 * @return int Order ID
-	 */
-	private function create_complex_wp_post_order() {
-		update_option( 'woocommerce_prices_include_tax', 'yes' );
-		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$uniq_cust_id = wp_generate_password( 10, false );
-		$customer     = CustomerHelper::create_customer( "user$uniq_cust_id", $uniq_cust_id, "user$uniq_cust_id@example.com" );
-		$tax_rate     = array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '15.0000',
-			'tax_rate_name'     => 'tax',
-			'tax_rate_priority' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_shipping' => '1',
-		);
-		WC_Tax::_insert_tax_rate( $tax_rate );
-
-		ShippingHelper::create_simple_flat_rate();
-
-		$order = OrderHelper::create_order();
-		// Make sure this is a wp_post order.
-		$post = get_post( $order->get_id() );
-		$this->assertNotNull( $post, 'Order is not created in wp_post table.' );
-		$this->assertEquals( 'shop_order', $post->post_type, 'Order is not created in wp_post table.' );
-
-		$order->save();
-
-		$order->set_status( 'completed' );
-		$order->set_currency( 'INR' );
-		$order->set_customer_id( $customer->get_id() );
-		$order->set_billing_email( $customer->get_billing_email() );
-
-		$payment_gateway = new WC_Mock_Payment_Gateway();
-		$order->set_payment_method( 'mock' );
-		$order->set_transaction_id( 'mock1' );
-
-		$order->set_customer_ip_address( '1.1.1.1' );
-		$order->set_customer_user_agent( 'wc_unit_tests' );
-
-		$order->save();
-
-		$order->set_shipping_first_name( 'Albert' );
-		$order->set_shipping_last_name( 'Einstein' );
-		$order->set_shipping_company( 'The Olympia Academy' );
-		$order->set_shipping_address_1( '112 Mercer Street' );
-		$order->set_shipping_address_2( 'Princeton' );
-		$order->set_shipping_city( 'New Jersey' );
-		$order->set_shipping_postcode( '08544' );
-		$order->set_shipping_phone( '299792458' );
-		$order->set_shipping_country( 'US' );
-
-		$order->set_created_via( 'unit_tests' );
-		$order->set_version( '0.0.2' );
-		$order->set_prices_include_tax( true );
-		wc_update_coupon_usage_counts( $order->get_id() );
-		$order->get_data_store()->set_download_permissions_granted( $order, true );
-		$order->set_cart_hash( '1234' );
-		$order->update_meta_data( '_new_order_email_sent', 'true' );
-		$order->update_meta_data( '_order_stock_reduced', 'true' );
-		$order->set_date_paid( time() );
-		$order->set_date_completed( time() );
-		$order->calculate_shipping();
-
-		$order->add_meta_data( 'unique_key_1', 'unique_value_1', true );
-		$order->add_meta_data( 'non_unique_key_1', 'non_unique_value_1', false );
-		$order->add_meta_data( 'non_unique_key_1', 'non_unique_value_2', false );
-		$order->save();
-		$order->save_meta_data();
-
-		return $order->get_id();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1,9 +1,0 @@
-<?php
-
-class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
-
-	public function test_read_from_migrated_order() {
-
-	}
-
-}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1,0 +1,9 @@
+<?php
+
+class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
+
+	public function test_read_from_migrated_order() {
+
+	}
+
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Note that this PR targets `cot/meta_migrations` and not trunk. In case #32640 is merged earlier, target for this PR would need to be updated to trunk.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #32663. Handles migration part of that change. DB schema will be handled as part of separate PR.

### How to test the changes in this Pull Request:

1. Make sure that you have {prefix}_wc_orders, {prefix}_wc_order_addresses, {prefix}_wc_order_operational_data and {prefix}_wc_orders_meta table created by following steps from https://github.com/woocommerce/woocommerce/pull/31811.
3. Run migration using the following snippet:
```php
namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
$done = false;
$migrator = new WPPostToCOTMigrator();
delete_option( 'wc_cot_migration' );
$start_time = microtime( true );
while( ! $done ) {
	$batch_start = microtime( true );
	$done = $migrator->process_next_migration_batch( 500 );
	echo 'Batch completed in ' . ( microtime( true ) - $batch_start ) . ' seconds' . "\n";
}
$duration = microtime( true ) - $start_time;
echo $duration;
```
4. Make sure that migrated order records have the same ID as their corresponding posts id.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
