### PR TITLE
Adds `read` method to custom table data store.

### DIFF
--- a/plugins/woocommerce/changelog/cot-32669
+++ b/plugins/woocommerce/changelog/cot-32669
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add `read` method to custom order table datastore.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -19,6 +19,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 */
 	public static function get_orders_table_name() {
 		global $wpdb;
+
 		return $wpdb->prefix . 'wc_orders';
 	}
 
@@ -29,6 +30,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 */
 	public static function get_addresses_table_name() {
 		global $wpdb;
+
 		return $wpdb->prefix . 'wc_order_addresses';
 	}
 
@@ -39,6 +41,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 */
 	public static function get_operational_data_table_name() {
 		global $wpdb;
+
 		return $wpdb->prefix . 'wc_order_operational_data';
 	}
 
@@ -49,6 +52,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 */
 	public static function get_meta_table_name() {
 		global $wpdb;
+
 		return $wpdb->prefix . 'wc_orders_meta';
 	}
 
@@ -66,10 +70,267 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		);
 	}
 
-	// TODO: Add methods for other table names as appropriate.
+	/**
+	 * Table column to WC_Order mapping for wc_orders table.
+	 *
+	 * @var \string[][]
+	 */
+	protected $order_column_mapping = array(
+		'id'                   => array(
+			'type' => 'int',
+			'name' => 'id',
+		),
+		'status'               => array(
+			'type' => 'string',
+			'name' => 'status',
+		),
+		'currency'             => array(
+			'type' => 'string',
+			'name' => 'currency',
+		),
+		'tax_amount'           => array(
+			'type' => 'decimal',
+			'name' => 'cart_tax',
+		),
+		'total_amount'         => array(
+			'type' => 'decimal',
+			'name' => 'total',
+		),
+		'customer_id'          => array(
+			'type' => 'int',
+			'name' => 'customer_id',
+		),
+		'billing_email'        => array(
+			'type' => 'int',
+			'name' => 'billing_email',
+		),
+		'date_created_gmt'     => array(
+			'type' => 'date',
+			'name' => 'date_created',
+		),
+		'date_updated_gmt'     => array(
+			'type' => 'date',
+			'name' => 'date_modified',
+		),
+		'parent_order_id'      => array(
+			'type' => 'int',
+			'name' => 'parent_id',
+		),
+		'payment_method'       => array(
+			'type' => 'string',
+			'name' => 'payment_method',
+		),
+		'payment_method_title' => array(
+			'type' => 'string',
+			'name' => 'payment_method_title',
+		),
+		'ip_address'           => array(
+			'type' => 'string',
+			'name' => 'customer_ip_address',
+		),
+		'transaction_id'       => array(
+			'type' => 'string',
+			'name' => 'transaction_id',
+		),
+		'user_agent'           => array(
+			'type' => 'string',
+			'name' => 'customer_user_agent',
+		),
+	);
+
+	/**
+	 * Table column to WC_Order mapping for billing addresses in wc_address table.
+	 *
+	 * @var \string[][]
+	 */
+	protected $billing_address_column_mapping = array(
+		'id'           => array( 'type' => 'int' ),
+		'order_id'     => array( 'type' => 'int' ),
+		'address_type' => array( 'type' => 'string' ),
+		'first_name'   => array(
+			'type' => 'string',
+			'name' => 'billing_first_name',
+		),
+		'last_name'    => array(
+			'type' => 'string',
+			'name' => 'billing_last_name',
+		),
+		'company'      => array(
+			'type' => 'string',
+			'name' => 'billing_company',
+		),
+		'address_1'    => array(
+			'type' => 'string',
+			'name' => 'billing_address_1',
+		),
+		'address_2'    => array(
+			'type' => 'string',
+			'name' => 'billing_address_2',
+		),
+		'city'         => array(
+			'type' => 'string',
+			'name' => 'billing_city',
+		),
+		'state'        => array(
+			'type' => 'string',
+			'name' => 'billing_state',
+		),
+		'postcode'     => array(
+			'type' => 'string',
+			'name' => 'billing_postcode',
+		),
+		'country'      => array(
+			'type' => 'string',
+			'name' => 'billing_country',
+		),
+		'email'        => array(
+			'type' => 'string',
+			'name' => 'billing_email',
+		),
+		'phone'        => array(
+			'type' => 'string',
+			'name' => 'billing_phone',
+		),
+	);
+
+	/**
+	 * Table column to WC_Order mapping for shipping addresses in wc_address table.
+	 *
+	 * @var \string[][]
+	 */
+	protected $shipping_address_column_mapping = array(
+		'id'           => array( 'type' => 'int' ),
+		'order_id'     => array( 'type' => 'int' ),
+		'address_type' => array( 'type' => 'string' ),
+		'first_name'   => array(
+			'type' => 'string',
+			'name' => 'shipping_first_name',
+		),
+		'last_name'    => array(
+			'type' => 'string',
+			'name' => 'shipping_last_name',
+		),
+		'company'      => array(
+			'type' => 'string',
+			'name' => 'shipping_company',
+		),
+		'address_1'    => array(
+			'type' => 'string',
+			'name' => 'shipping_address_1',
+		),
+		'address_2'    => array(
+			'type' => 'string',
+			'name' => 'shipping_address_2',
+		),
+		'city'         => array(
+			'type' => 'string',
+			'name' => 'shipping_city',
+		),
+		'state'        => array(
+			'type' => 'string',
+			'name' => 'shipping_state',
+		),
+		'postcode'     => array(
+			'type' => 'string',
+			'name' => 'shipping_postcode',
+		),
+		'country'      => array(
+			'type' => 'string',
+			'name' => 'shipping_country',
+		),
+		'email'        => array( 'type' => 'string' ),
+		'phone'        => array(
+			'type' => 'string',
+			'name' => 'shipping_phone',
+		),
+	);
+
+	/**
+	 * Table column to WC_Order mapping for wc_operational_data table.
+	 *
+	 * @var \string[][]
+	 */
+	protected $operational_data_column_mapping = array(
+		'id'                          => array( 'type' => 'int' ),
+		'order_id'                    => array( 'type' => 'int' ),
+		'created_via'                 => array(
+			'type' => 'string',
+			'name' => 'created_via',
+		),
+		'woocommerce_version'         => array(
+			'type' => 'string',
+			'name' => 'version',
+		),
+		'prices_include_tax'          => array(
+			'type' => 'string',
+			'name' => 'prices_include_tax',
+		),
+		'coupon_usages_are_counted'   => array( 'type' => 'bool' ),
+		'download_permission_granted' => array( 'type' => 'bool' ),
+		'cart_hash'                   => array(
+			'type' => 'string',
+			'name' => 'cart_hash',
+		),
+		'new_order_email_sent'        => array( 'type' => 'string' ),
+		'order_key'                   => array(
+			'type' => 'string',
+			'name' => 'order_key',
+		),
+		'order_stock_reduced'         => array( 'type' => 'bool' ),
+		'date_paid_gmt'               => array(
+			'type' => 'date',
+			'name' => 'date_paid',
+		),
+		'date_completed_gmt'          => array(
+			'type' => 'date',
+			'name' => 'date_completed',
+		),
+		'shipping_tax_amount'         => array(
+			'type' => 'decimal',
+			'name' => 'shipping_tax',
+		),
+		'shipping_total_amount'       => array(
+			'type' => 'decimal',
+			'name' => 'shipping_total',
+		),
+		'discount_tax_amount'         => array(
+			'type' => 'decimal',
+			'name' => 'discount_tax',
+		),
+		'discount_total_amount'       => array(
+			'type' => 'decimal',
+			'name' => 'discount_total_amount',
+		),
+	);
+
+	/**
+	 * Cache variable to store combined mapping.
+	 *
+	 * @var array[][][]
+	 */
+	private $all_order_column_mapping;
+
+	/**
+	 * Return combined mappings for all order tables.
+	 *
+	 * @return array|\array[][][] Return combined mapping.
+	 */
+	public function get_all_order_column_mappings() {
+		if ( ! isset( $this->all_order_column_mapping ) ) {
+			$this->all_order_column_mapping = array(
+				'orders'           => $this->order_column_mapping,
+				'billing_address'  => $this->billing_address_column_mapping,
+				'shipping_address' => $this->shipping_address_column_mapping,
+				'operational_data' => $this->operational_data_column_mapping,
+			);
+		}
+
+		return $this->all_order_column_mapping;
+	}
 
 	//phpcs:disable Squiz.Commenting, Generic.Commenting
 
+	// TODO: Add methods for other table names as appropriate.
 	public function get_total_refunded( $order ) {
 		// TODO: Implement get_total_refunded() method.
 		return 0;
@@ -142,6 +403,205 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		return 'shop_order';
 	}
 
+	//phpcs:enable Squiz.Commenting, Generic.Commenting
+
+	/**
+	 * Method to read an order from custom tables.
+	 *
+	 * @param \WC_Order $order Order object.
+	 *
+	 * @throws \Exception If passed order is invalid.
+	 */
+	public function read( &$order ) {
+		$order->set_defaults();
+		if ( ! $order->get_id() ) {
+			throw new \Exception( __( 'ID must be set for an order to be read', 'woocommerce' ) );
+		}
+		$order_data = $this->get_order_data_for_id( $order->get_id() );
+		foreach ( $this->get_all_order_column_mappings() as $table_name => $column_mapping ) {
+			foreach ( $column_mapping as $column_name => $prop_details ) {
+				if ( ! isset( $prop_details['name'] ) ) {
+					continue;
+				}
+				$prop_setter_function_name = "set_{$prop_details['name']}";
+				if ( is_callable( array( $order, $prop_setter_function_name ) ) ) {
+					$order->{$prop_setter_function_name}( $order_data->{$prop_details['name']} );
+				}
+			}
+		}
+
+		$order->set_object_read();
+	}
+
+	/**
+	 * Return order data for a single order ID.
+	 *
+	 * @param int $id Order ID.
+	 *
+	 * @return object|\WP_Error DB order object or WP_Error.
+	 */
+	private function get_order_data_for_id( $id ) {
+		$results = $this->get_order_data_for_ids( array( $id ) );
+
+		return is_array( $results ) && count( $results ) > 0 ? $results[0] : $results;
+	}
+
+	/**
+	 * Return order data for multiple IDs.
+	 *
+	 * @param array $ids List of order IDs.
+	 *
+	 * @return array|object|null DB Order objects or error.
+	 */
+	private function get_order_data_for_ids( $ids ) {
+		global $wpdb;
+		$order_table_query = $this->get_order_table_select_statement();
+		$id_placeholder    = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_table_query is autogenerated and should already be prepared.
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"$order_table_query WHERE wc_order.id in ( $id_placeholder )",
+				$ids
+			)
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Helper method to generate combined select statement.
+	 *
+	 * @return string Select SQL statement to fetch order.
+	 */
+	private function get_order_table_select_statement() {
+		$order_table                  = $this::get_orders_table_name();
+		$order_table_alias            = 'wc_order';
+		$select_clause                = $this->generate_select_clause_for_props( $order_table_alias, $this->order_column_mapping );
+		$billing_address_table_alias  = 'address_billing';
+		$shipping_address_table_alias = 'address_shipping';
+		$op_data_table_alias          = 'order_operational_data';
+		$billing_address_clauses      = $this->join_billing_address_table_to_order_query( $order_table_alias, $billing_address_table_alias );
+		$shipping_address_clauses     = $this->join_shipping_address_table_to_order_query( $order_table_alias, $shipping_address_table_alias );
+		$operational_data_clauses     = $this->join_operational_data_table_to_order_query( $order_table_alias, $op_data_table_alias );
+
+		return "
+SELECT $select_clause, {$billing_address_clauses['select']}, {$shipping_address_clauses['select']}, {$operational_data_clauses['select']}
+FROM $order_table $order_table_alias
+LEFT JOIN {$billing_address_clauses['join']}
+LEFT JOIN {$shipping_address_clauses['join']}
+LEFT JOIN {$operational_data_clauses['join']}
+";
+	}
+
+	/**
+	 * Helper method to generate join query for billing addresses in wc_address table.
+	 *
+	 * @param string $order_table_alias Alias for order table to use in join.
+	 * @param string $address_table_alias Alias for address table to use in join.
+	 *
+	 * @return array Select and join statements for billing address table.
+	 */
+	private function join_billing_address_table_to_order_query( $order_table_alias, $address_table_alias ) {
+		return $this->join_address_table_order_query( 'billing', $order_table_alias, $address_table_alias );
+	}
+
+	/**
+	 * Helper method to generate join query for shipping addresses in wc_address table.
+	 *
+	 * @param string $order_table_alias Alias for order table to use in join.
+	 * @param string $address_table_alias Alias for address table to use in join.
+	 *
+	 * @return array Select and join statements for shipping address table.
+	 */
+	private function join_shipping_address_table_to_order_query( $order_table_alias, $address_table_alias ) {
+		return $this->join_address_table_order_query( 'shipping', $order_table_alias, $address_table_alias );
+	}
+
+	/**
+	 * Helper method to generate join and select query for address table.
+	 *
+	 * @param string $address_type Type of address. Typically will be `billing` or `shipping`.
+	 * @param string $order_table_alias Alias of order table to use.
+	 * @param string $address_table_alias Alias for address table to use.
+	 *
+	 * @return array Select and join statements for address table.
+	 */
+	private function join_address_table_order_query( $address_type, $order_table_alias, $address_table_alias ) {
+		global $wpdb;
+		$address_table    = $this::get_addresses_table_name();
+		$column_props_map = 'billing' === $address_type ? $this->billing_address_column_mapping : $this->shipping_address_column_mapping;
+		$clauses          = $this->generate_select_and_join_clauses( $order_table_alias, $address_table, $address_table_alias, $column_props_map );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $clauses['join'] and $address_table_alias are hardcoded.
+		$clauses['join'] = $wpdb->prepare(
+			"{$clauses['join']} AND $address_table_alias.address_type = %s",
+			$address_type
+		);
+		// phpcs:enable
+		return array(
+			'select' => $clauses['select'],
+			'join'   => $clauses['join'],
+		);
+	}
+
+	/**
+	 * Helper method to join order operational data table.
+	 *
+	 * @param string $order_table_alias Alias to use for order table.
+	 * @param string $operational_table_alias Alias to use for operational data table.
+	 *
+	 * @return array Select and join queries for operational data table.
+	 */
+	private function join_operational_data_table_to_order_query( $order_table_alias, $operational_table_alias ) {
+		$operational_data_table = $this::get_operational_data_table_name();
+
+		return $this->generate_select_and_join_clauses(
+			$order_table_alias,
+			$operational_data_table,
+			$operational_table_alias,
+			$this->operational_data_column_mapping
+		);
+	}
+
+	/**
+	 * Helper method to generate join and select clauses.
+	 *
+	 * @param string  $order_table_alias Alias for order table.
+	 * @param string  $table Table to join.
+	 * @param string  $table_alias Alias for table to join.
+	 * @param array[] $column_props_map Column to prop map for table to join.
+	 *
+	 * @return array Select and join queries.
+	 */
+	private function generate_select_and_join_clauses( $order_table_alias, $table, $table_alias, $column_props_map ) {
+		// Add aliases to column names so they will be unique when fetching.
+		$select_clause = $this->generate_select_clause_for_props( $table_alias, $column_props_map );
+		$join_clause   = "$table $table_alias ON $table_alias.order_id = $order_table_alias.id";
+
+		return array(
+			'select' => $select_clause,
+			'join'   => $join_clause,
+		);
+	}
+
+	/**
+	 * Helper method to generate select clause for props.
+	 *
+	 * @param string  $table_alias Alias for table.
+	 * @param array[] $props Props to column mapping for table.
+	 *
+	 * @return string Select clause.
+	 */
+	private function generate_select_clause_for_props( $table_alias, $props ) {
+		$select_clauses = array();
+		foreach ( $props as $column_name => $prop_details ) {
+			$select_clauses[] = isset( $prop_details['name'] ) ? "$table_alias.$column_name as {$prop_details['name']}" : "$table_alias.$column_name as {$table_alias}_$column_name";
+		}
+
+		return implode( ', ', $select_clauses );
+	}
+
+
+	//phpcs:disable Squiz.Commenting, Generic.Commenting
 	/**
 	 * @param \WC_Order $order
 	 */
@@ -235,7 +695,8 @@ CREATE TABLE $addresses_table_name (
 	country text null,
 	email varchar(320) null,
 	phone varchar(100) null,
-	KEY order_id (order_id)
+	KEY order_id (order_id),
+	KEY address_type_order_id (address_type, order_id)
 );
 CREATE TABLE $operational_data_table_name (
 	id bigint(20) unsigned auto_increment primary key,

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1,0 +1,47 @@
+<?php
+
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigrator;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+
+class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
+
+	/**
+	 * @var WPPostToCOTMigrator
+	 */
+	private $migrator;
+
+	/**
+	 * @var OrdersTableDataStore
+	 */
+	private $sut;
+
+	/**
+	 * @var WC_Order_Data_Store_CPT
+	 */
+	private $cpt_data_store;
+
+	public function setUp(): void {
+		parent::setUp();
+		OrderHelper::create_order_custom_table_if_not_exist();
+		$this->sut = wc_get_container()->get( OrdersTableDataStore::class );
+		$this->migrator = wc_get_container()->get( WPPostToCOTMigrator::class );
+		$this->cpt_data_store = new WC_Order_Data_Store_CPT();
+	}
+
+	public function test_read_from_migrated_order() {
+		$post_order_id = OrderHelper::create_complex_wp_post_order();
+		$this->migrator->process_migration_for_ids( array( $post_order_id ) );
+
+		$cot_order = new WC_Order();
+		$cot_order->set_id( $post_order_id );
+		$this->sut->read( $cot_order );
+
+		$post_order = new WC_Order();
+		$post_order->set_id( $post_order_id );
+		$this->cpt_data_store->read( $post_order );
+
+		$this->assertEquals( $cot_order->get_status(), $post_order->get_status() );
+	}
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -31,10 +31,16 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 		OrderHelper::create_order_custom_table_if_not_exist();
 		$this->sut            = wc_get_container()->get( OrdersTableDataStore::class );
 		$this->migrator       = wc_get_container()->get( WPPostToCOTMigrator::class );
 		$this->cpt_data_store = new WC_Order_Data_Store_CPT();
+		// Add back removed filter.
+		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -4,6 +4,11 @@ use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigra
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
+/**
+ * Class OrdersTableDataStoreTests.
+ *
+ * Test or OrdersTableDataStore class.
+ */
 class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 	/**
@@ -21,14 +26,20 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 */
 	private $cpt_data_store;
 
+	/**
+	 * Initializes system under test.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		OrderHelper::create_order_custom_table_if_not_exist();
-		$this->sut = wc_get_container()->get( OrdersTableDataStore::class );
-		$this->migrator = wc_get_container()->get( WPPostToCOTMigrator::class );
+		$this->sut            = wc_get_container()->get( OrdersTableDataStore::class );
+		$this->migrator       = wc_get_container()->get( WPPostToCOTMigrator::class );
 		$this->cpt_data_store = new WC_Order_Data_Store_CPT();
 	}
 
+	/**
+	 * Test reading from migrated post order.
+	 */
 	public function test_read_from_migrated_order() {
 		$post_order_id = OrderHelper::create_complex_wp_post_order();
 		$this->migrator->process_migration_for_ids( array( $post_order_id ) );
@@ -41,7 +52,18 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$post_order->set_id( $post_order_id );
 		$this->cpt_data_store->read( $post_order );
 
-		$this->assertEquals( $cot_order->get_status(), $post_order->get_status() );
+		$post_order_data    = $post_order->get_data();
+		$string_to_num_keys = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'cart_tax' );
+		array_walk(
+			$post_order_data,
+			function ( &$data, $key ) use ( $string_to_num_keys ) {
+				if ( in_array( $key, $string_to_num_keys, true ) ) {
+					$data = (float) $data;
+				}
+			}
+		);
+
+		$this->assertEquals( $post_order_data, $cot_order->get_data() );
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Implements `reads` method in custom order table data store. Note that this intentionally does not add cache, that would be something we will implement in separate PR.

Closes #32669 

### How to test the changes in this Pull Request:

1. There is no UX currently, but the test I added in `test_read_from_migrated_order` function should cover this correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
