### PR TITLE
Fix setup task list style conflict

### DIFF
--- a/packages/js/experimental/CHANGELOG.md
+++ b/packages/js/experimental/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
+-   Fix setup task list style conflict #32704
 -   Update dependency `@wordpress/icons` to ^8.1.0
 -   Added Typescript type declarations. #32615
+
 # 3.0.1
 
 -   Update all js packages with minor/patch version changes. #8392
@@ -14,6 +16,7 @@
 -   Drop support for IE11. #8305
 
 # 2.2.0
+
 -   Make the Inbox note title clickable. #7975
 -   Fix incorrectly displayed note created date. #8179
 -   Fix inbox note css #7983

--- a/packages/js/experimental/src/experimental-list/style.scss
+++ b/packages/js/experimental/src/experimental-list/style.scss
@@ -134,7 +134,7 @@ a.woocommerce-experimental-list__item {
 		fill: $chevron-color;
 	}
 
-	&.is-complete {
+	&.complete {
 		.woocommerce-task__icon {
 			background-color: var(--wp-admin-theme-color);
 		}

--- a/packages/js/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/js/experimental/src/experimental-list/task-item/index.tsx
@@ -130,7 +130,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	}, [ expanded ] );
 
 	const className = classnames( 'woocommerce-task-list__item', {
-		'is-complete': completed,
+		complete: completed,
 		expanded: isTaskExpanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,

--- a/packages/js/experimental/src/experimental-list/task-item/style.scss
+++ b/packages/js/experimental/src/experimental-list/task-item/style.scss
@@ -121,7 +121,7 @@ $task-alert-yellow: #f0b849;
 		left: 5px;
 	}
 
-	&.is-complete {
+	&.complete {
 		.woocommerce-task__icon {
 			background-color: var(--wp-admin-theme-color);
 		}
@@ -136,7 +136,7 @@ $task-alert-yellow: #f0b849;
 		}
 	}
 
-	&:not(.is-complete) {
+	&:not(.complete) {
 		.woocommerce-task__icon {
 			border: 1px solid $gray-100;
 			background: $white;

--- a/plugins/woocommerce-admin/client/tasks/tasks.scss
+++ b/plugins/woocommerce-admin/client/tasks/tasks.scss
@@ -236,7 +236,7 @@
 }
 
 .woocommerce-task-list__setup_experiment_1 {
-	.woocommerce-experimental-list .woocommerce-experimental-list__item.is-complete {
+	.woocommerce-experimental-list .woocommerce-experimental-list__item.complete {
 		text-decoration: line-through;
 
 		.woocommerce-task-list__item-title {

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.scss
@@ -63,14 +63,14 @@
 			pointer-events: none;
 		}
 
-		&:not(.is-complete)
+		&:not(.complete)
 		.woocommerce-task-list__item-before
 		.woocommerce-task__icon {
 			border-color: $gray-300;
 		}
 	}
 
-	.woocommerce-task-list__item.is-complete .woocommerce-task__icon {
+	.woocommerce-task-list__item.complete .woocommerce-task__icon {
 		background-color: $alert-green;
 	}
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -220,8 +220,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 											const className = classnames(
 												'woocommerce-task-list__item',
 												{
-													'is-complete':
-														task.isComplete,
+													complete: task.isComplete,
 													'is-disabled':
 														task.isDisabled,
 												}

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -103,7 +103,7 @@
 	margin: 0 auto;
 	justify-content: space-between;
 
-	ul li.is-complete .woocommerce-task-list__item-title {
+	ul li.complete .woocommerce-task-list__item-title {
 		font-weight: 600;
 		color: $gray-600;
 	}
@@ -178,11 +178,11 @@
 			height: 100%;
 		}
 	}
-	.woocommerce-task-list__item:not(.is-complete) .woocommerce-task__icon {
+	.woocommerce-task-list__item:not(.complete) .woocommerce-task__icon {
 		border: 1px solid var(--wp-admin-theme-color);
 		background: transparent;
 	}
-	.woocommerce-task-list__item.is-complete:not(.complete) .woocommerce-task__icon {
+	.woocommerce-task-list__item.complete:not(.complete) .woocommerce-task__icon {
 		border: none;
 	}
 
@@ -206,7 +206,7 @@
 	}
 
 	@for $i from 1 through 10 {
-		.woocommerce-task-list__item:not(.is-complete).index-#{$i} .woocommerce-task__icon::after {
+		.woocommerce-task-list__item:not(.complete).index-#{$i} .woocommerce-task__icon::after {
 			content: '#{$i}';
 			@extend .numbered-circle;
 			color: var(--wp-admin-theme-color);

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -291,7 +291,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 							const className = classnames(
 								'woocommerce-task-list__item index-' + index,
 								{
-									'is-complete': task.isComplete,
+									complete: task.isComplete,
 									'is-active': task.id === activeTaskId,
 								}
 							);

--- a/plugins/woocommerce/changelog/fix-task-list-style-conflict
+++ b/plugins/woocommerce/changelog/fix-task-list-style-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix setup task list style conflict #32704


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a few CSS problems resulting from a class renaming and the installation of the extensions: `Pinterest for WooCommerce` and `WooCommerce Payments`. More context in the link (pb22l9-1cO-p2#comment-1202).

The plugins mentioned above use an old version of `woocommerce/experimental` that uses the old class name. This is why a few styles are never applied.

This PR renames the class to use the old name and fix the bug.

### How to test the changes in this Pull Request:

1. Create a brand new site.
2. Go through the OBW, during the `Business Details` step only install `WooCommerce Payments` and finish it.
3. On the `Home` screen press `Set up marketing tools`.
4. Install `Pinterest for WooCommerce`.
5. The setup task list should be shown normally (the already done tasks should be marked as completed).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.