### PR TITLE
Remove legacy image sizes which were planned for removal into 4.6.0

### DIFF
--- a/plugins/woocommerce/changelog/remove_legacy_image_sizes
+++ b/plugins/woocommerce/changelog/remove_legacy_image_sizes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove legacy image sizes

--- a/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
@@ -145,16 +145,6 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 					$new_metadata['sizes'][ $old_size ] = $old_metadata['sizes'][ $old_size ];
 				}
 			}
-			// Handle legacy sizes.
-			if ( isset( $new_metadata['sizes']['shop_thumbnail'], $new_metadata['sizes']['woocommerce_gallery_thumbnail'] ) ) {
-				$new_metadata['sizes']['shop_thumbnail'] = $new_metadata['sizes']['woocommerce_gallery_thumbnail'];
-			}
-			if ( isset( $new_metadata['sizes']['shop_catalog'], $new_metadata['sizes']['woocommerce_thumbnail'] ) ) {
-				$new_metadata['sizes']['shop_catalog'] = $new_metadata['sizes']['woocommerce_thumbnail'];
-			}
-			if ( isset( $new_metadata['sizes']['shop_single'], $new_metadata['sizes']['woocommerce_single'] ) ) {
-				$new_metadata['sizes']['shop_single'] = $new_metadata['sizes']['woocommerce_single'];
-			}
 		}
 
 		// Update the meta data with the new size values.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -68,7 +68,7 @@ class WC_Regenerate_Images {
 	 * @return array
 	 */
 	public static function filter_image_get_intermediate_size( $data, $attachment_id, $size ) {
-		if ( ! is_string( $size ) || ! in_array( $size, apply_filters( 'woocommerce_image_sizes_to_resize', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single', 'shop_thumbnail', 'shop_catalog', 'shop_single' ) ), true ) ) {
+		if ( ! is_string( $size ) || ! in_array( $size, apply_filters( 'woocommerce_image_sizes_to_resize', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single' ) ), true ) ) {
 			return $data;
 		}
 
@@ -204,7 +204,7 @@ class WC_Regenerate_Images {
 		}
 
 		// List of sizes we want to resize. Ignore others.
-		if ( ! $image || ! in_array( $size, apply_filters( 'woocommerce_image_sizes_to_resize', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single', 'shop_thumbnail', 'shop_catalog', 'shop_single' ) ), true ) ) {
+		if ( ! $image || ! in_array( $size, apply_filters( 'woocommerce_image_sizes_to_resize', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single' ) ), true ) ) {
 			return $image;
 		}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -701,15 +701,6 @@ final class WooCommerce {
 		add_image_size( 'woocommerce_thumbnail', $thumbnail['width'], $thumbnail['height'], $thumbnail['crop'] );
 		add_image_size( 'woocommerce_single', $single['width'], $single['height'], $single['crop'] );
 		add_image_size( 'woocommerce_gallery_thumbnail', $gallery_thumbnail['width'], $gallery_thumbnail['height'], $gallery_thumbnail['crop'] );
-
-		/**
-		 * Legacy image sizes.
-		 *
-		 * @deprecated 3.3.0 These sizes will be removed in 4.6.0.
-		 */
-		add_image_size( 'shop_catalog', $thumbnail['width'], $thumbnail['height'], $thumbnail['crop'] );
-		add_image_size( 'shop_single', $single['width'], $single['height'], $single['crop'] );
-		add_image_size( 'shop_thumbnail', $gallery_thumbnail['width'], $gallery_thumbnail['height'], $gallery_thumbnail['crop'] );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -949,15 +949,6 @@ function wc_get_image_size( $image_size ) {
 	} else {
 		$image_size = str_replace( 'woocommerce_', '', $image_size );
 
-		// Legacy size mapping.
-		if ( 'shop_single' === $image_size ) {
-			$image_size = 'single';
-		} elseif ( 'shop_catalog' === $image_size ) {
-			$image_size = 'thumbnail';
-		} elseif ( 'shop_thumbnail' === $image_size ) {
-			$image_size = 'gallery_thumbnail';
-		}
-
 		if ( 'single' === $image_size ) {
 			$size['width']  = absint( wc_get_theme_support( 'single_image_width', get_option( 'woocommerce_single_image_width', 600 ) ) );
 			$size['height'] = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By using a function `get_intermediate_image_sizes` i saw that `woocommerce_thumbnail` is exacly that same as `shop_catalog`.
Wanting to see why they are duplicated, I found a comment:

> These sizes will be removed in 4.6.0.

Time to remove them.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. dump `get_intermediate_image_sizes()` before changes:

> array(12) {
  [0]=>
  string(9) "thumbnail"
  [1]=>
  string(6) "medium"
  [2]=>
  string(12) "medium_large"
  [3]=>
  string(5) "large"
  [4]=>
  string(9) "1536x1536"
  [5]=>
  string(9) "2048x2048"
  [6]=>
  string(21) "woocommerce_thumbnail"
  [7]=>
  string(18) "woocommerce_single"
  [8]=>
  string(29) "woocommerce_gallery_thumbnail"
  [9]=>
  string(12) "shop_catalog"
  [10]=>
  string(11) "shop_single"
  [11]=>
  string(14) "shop_thumbnail"
}

2. After:
>array(9) {
  [0]=>
  string(9) "thumbnail"
  [1]=>
  string(6) "medium"
  [2]=>
  string(12) "medium_large"
  [3]=>
  string(5) "large"
  [4]=>
  string(9) "1536x1536"
  [5]=>
  string(9) "2048x2048"
  [6]=>
  string(21) "woocommerce_thumbnail"
  [7]=>
  string(18) "woocommerce_single"
  [8]=>
  string(29) "woocommerce_gallery_thumbnail"
}

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
