### PR TITLE
REST: Add product image URL to order line items

### DIFF
--- a/plugins/woocommerce/changelog/fix-27364-api-order-lineitem-image
+++ b/plugins/woocommerce/changelog/fix-27364-api-order-lineitem-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an 'image_src' field to product line items returned by the orders endpoint (v2 and v3). This contains the URL of the main product image.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -218,7 +218,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']       = $item->get_product() ? $item->get_product()->get_sku() : null;
 			$data['price']     = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
-			$data['image_src'] = $item->get_product() ? wp_get_attachment_image_url( $item->get_product()->get_image_id() ) : null;
+			$data['image_src'] = $item->get_product() ? wp_get_attachment_image_url( $item->get_product()->get_image_id(), 'full' ) : null;
 		}
 
 		// Add parent_name if the product is a variation.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -214,11 +214,16 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			}
 		}
 
-		// Add SKU, PRICE, and IMAGE_SRC to products.
+		// Add SKU, PRICE, and IMAGE to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']       = $item->get_product() ? $item->get_product()->get_sku() : null;
 			$data['price']     = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
-			$data['image_src'] = $item->get_product() ? wp_get_attachment_image_url( $item->get_product()->get_image_id(), 'full' ) : null;
+
+			$image_id = $item->get_product() ? $item->get_product()->get_image_id() : 0;
+			$data['image'] = array(
+				'id'  => $image_id,
+				'src' => $image_id ? wp_get_attachment_image_url( $image_id, 'full' ) : '',
+			);
 		}
 
 		// Add parent_name if the product is a variation.
@@ -1488,11 +1493,27 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'image_src'    => array(
-								'description' => __( 'URL for the main product image.', 'woocommerce' ),
-								'type'        => 'string',
+							'image'        => array(
+								'description' => __( 'Properties of the main product image.', 'woocommerce' ),
+								'type'        => 'object',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
+								'properties'  => array(
+									'type'       => 'object',
+									'properties' => array(
+										'id'                => array(
+											'description' => __( 'Image ID.', 'woocommerce' ),
+											'type'        => 'integer',
+											'context'     => array( 'view', 'edit' ),
+										),
+										'src'               => array(
+											'description' => __( 'Image URL.', 'woocommerce' ),
+											'type'        => 'string',
+											'format'      => 'uri',
+											'context'     => array( 'view', 'edit' ),
+										),
+									),
+								),
 							),
 						),
 					),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -214,11 +214,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			}
 		}
 
-		// Add SKU, PRICE, and IMAGE_URL to products.
+		// Add SKU, PRICE, and IMAGE_SRC to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']       = $item->get_product() ? $item->get_product()->get_sku() : null;
 			$data['price']     = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
-			$data['image_url'] = $item->get_product() ? wp_get_attachment_image_url( $item->get_product()->get_image_id() ) : null;
+			$data['image_src'] = $item->get_product() ? wp_get_attachment_image_url( $item->get_product()->get_image_id() ) : null;
 		}
 
 		// Add parent_name if the product is a variation.
@@ -1488,8 +1488,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
-							'image_url'    => array(
-								'description' => __( 'Product image URL.', 'woocommerce' ),
+							'image_src'    => array(
+								'description' => __( 'URL for the main product image.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -214,10 +214,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			}
 		}
 
-		// Add SKU and PRICE to products.
+		// Add SKU, PRICE, and IMAGE_URL to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
-			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
-			$data['price'] = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['sku']       = $item->get_product() ? $item->get_product()->get_sku() : null;
+			$data['price']     = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['image_url'] = $item->get_product() ? wp_get_attachment_image_url( $item->get_product()->get_image_id() ) : null;
 		}
 
 		// Add parent_name if the product is a variation.
@@ -1484,6 +1485,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							'price'        => array(
 								'description' => __( 'Product price.', 'woocommerce' ),
 								'type'        => 'number',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'image_url'    => array(
+								'description' => __( 'Product image URL.', 'woocommerce' ),
+								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -545,7 +545,10 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 			'sku'          => null,
 			'price'        => 4,
 			'parent_name'  => null,
-			'image_src'    => null,
+			'image'        => array(
+				'id'  => '',
+				'src' => '',
+			),
 		);
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -546,7 +546,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 			'price'        => 4,
 			'parent_name'  => null,
 			'image'        => array(
-				'id'  => '',
+				'id'  => 0,
 				'src' => '',
 			),
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -545,6 +545,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 			'sku'          => null,
 			'price'        => 4,
 			'parent_name'  => null,
+			'image_src'    => null,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -785,7 +786,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 15, count( $line_item_properties ) );
+		$this->assertEquals( 16, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -657,6 +657,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			'sku'          => null,
 			'price'        => 4,
 			'parent_name'  => null,
+			'image_src'    => null,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -1155,7 +1156,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 15, count( $line_item_properties ) );
+		$this->assertEquals( 16, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -658,7 +658,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			'price'        => 4,
 			'parent_name'  => null,
 			'image'        => array(
-				'id'  => '',
+				'id'  => 0,
 				'src' => '',
 			),
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -657,7 +657,10 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			'sku'          => null,
 			'price'        => 4,
 			'parent_name'  => null,
-			'image_src'    => null,
+			'image'        => array(
+				'id'  => '',
+				'src' => '',
+			),
 		);
 
 		$this->assertEquals( 200, $response->get_status() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new property to the line item schema, `image` that contains `id` and `src` properties for the full size of the main product image. At some point if the need arises, other properties like a `sizes` array could be added to `image` as well.

Closes #27364.

### How to test the changes in this Pull Request:

1. Spin up some products and orders with wc-smooth-generator.
2. Using a client like Insomnia, request a particular order with `wp-json/wc/v3/orders/{order ID}`.
3. In the response for the order, in the `line_items` property, each product object should include an `image` property, which will have populated sub properties if the product has an image added. Otherwise the sub properties will be empty.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
