### PR TITLE
Fix/e2e utils eslint config

### DIFF
--- a/packages/js/e2e-utils/.eslintrc.js
+++ b/packages/js/e2e-utils/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	parser: '@typescript-eslint/parser',
 	env: {
 		'jest/globals': true,

--- a/packages/js/e2e-utils/CHANGELOG.md
+++ b/packages/js/e2e-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixed
+
+- Added the `root: true` flag to `e2e-utils` ESLint config file so that ESLint ignores other ancestor config files when checking that package. This solves a version conflict when running ESLint.
+
 ## Added
 
 - `createSimpleDownloadableProduct` component which creates a simple downloadable product, containing four parameters for title, price, download name and download limit.

--- a/packages/js/e2e-utils/package.json
+++ b/packages/js/e2e-utils/package.json
@@ -46,10 +46,5 @@
     "build": "pnpm run clean && pnpm run compile",
     "prepare": "pnpm run build",
     "lint": "eslint src"
-  },
-  "lint-staged": {
-	"*.(t|j)s?(x)": [
-		"eslint --fix"
-	]
   }
 }


### PR DESCRIPTION
### All Submissions:

* [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Reason for change

Husky hooks were fixed in [this PR](https://github.com/woocommerce/woocommerce/pull/32411). After that, ESLint is run every time that a commit is created introducing changes in any `js` or `ts` file from any of our packages.

Therefore, new issues appear now when trying to commit any change to `e2e-utils`, as that package might not respect ESLint rules. Seems inconsistencies were there previously but we just realized about them after the PR mentioned above was merged.

First of all, the first issue appeared when attempting to commit any change to `e2e-utils`:

```
✖ eslint --fix:

Oops! Something went wrong! :(

ESLint: 8.1.0

ESLint couldn't determine the plugin "@typescript-eslint" uniquely.

- /Users/alopezari/Projects/WooCommerce/woocommerce/node_modules/.pnpm/@typescript-eslint+eslint-plugin@5.3.0_ef742ec0d85d332d26b421951e243e75/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in ".eslintrc.js")
- /Users/alopezari/Projects/WooCommerce/woocommerce/node_modules/.pnpm/@typescript-eslint+eslint-plugin@5.4.0_b983626bd16070d34b18187cb6bde052/node_modules/@typescript-eslint/eslint-plugin/dist/index.js (loaded in "../../../.eslintrc.js » plugin:@woocommerce/recommended » plugin:@wordpress/recommended")

Please remove the "plugins" setting from either config or remove either plugin installation.

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.

husky - pre-commit hook exited with code 1 (error)
```

According to this [explanation](https://github.com/eslint/eslint/issues/13385#issuecomment-641252879), this might be happening because we have different ESLint versions for multiple packages and also for parent directories, so seems we might need to stop ESLint from loading other config files from ancestor directories when working with `e2e-utils` and focus just on this package's config file. Note: we already do that for other packages, but it was missing in `e2e-utils`.

Apart from that, when this issue is solved, hundreds of lint issues appear in this package when attempting to create a commit, blocking our development until these are addressed. 

### Changes proposed in this Pull Request:

- Added the `root: true` flag to `e2e-utils` ESLint config file so that ESLint ignores other ancestor config files when checking that package. This solves the problem where ESLint couldn't determine the plugin "@typescript-eslint" uniquely.
- Removed temporarily the husky hook that runs ESLint for `e2e-utils` when creating a commit that adds any change to that package, to unblock development.

### How to test the changes in this Pull Request:

1. Add any change to any `*.js` or `*.ts` file from `e2e-utils`.
2. Create a commit. 
3. Check that commit is created.

### Additional comments

The main purpose of this PR is unblock the development of new WooCommerce's E2E tests. However, it also has the intention of raising a discussion about how the `e2e-utils` lint errors should be addressed and how ESLint should be configured for that package.

### Other information:

* [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ N/A ] Have you written new tests for your changes, as applicable?
* [ x ] Have you successfully run tests with your changes locally?
* [ N/A? ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
