### PR TITLE
Fixing blank screen when Store Details task clicked on sectioned task list

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -5,7 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { updateQueryString } from '@woocommerce/navigation';
+import {
+	updateQueryString,
+	getHistory,
+	getNewPath,
+} from '@woocommerce/navigation';
 import {
 	OPTIONS_STORE_NAME,
 	ONBOARDING_STORE_NAME,
@@ -127,13 +131,18 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		} );
 	};
 
-	const goToTask = ( task: TaskType ) => {
-		trackClick( task );
-		updateQueryString( { task: task.id } );
-	};
-
 	const onTaskSelected = ( task: TaskType ) => {
-		goToTask( task );
+		trackClick( task );
+		if ( task.actionUrl ) {
+			if ( task.actionUrl.startsWith( 'http' ) ) {
+				window.location.href = task.actionUrl;
+			} else {
+				getHistory().push( getNewPath( {}, task.actionUrl, {} ) );
+			}
+			return;
+		}
+
+		updateQueryString( { task: task.id } );
 	};
 
 	const getSectionTasks = ( sectionTaskIds: string[] ) => {

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -202,7 +202,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		}
 		if ( task.actionUrl ) {
 			if ( task.actionUrl.startsWith( 'http' ) ) {
-				window.location.href = actionUrl;
+				window.location.href = task.actionUrl;
 			} else {
 				getHistory().push( getNewPath( {}, task.actionUrl, {} ) );
 			}

--- a/plugins/woocommerce/changelog/fix-32705
+++ b/plugins/woocommerce/changelog/fix-32705
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixing bug on sectioned task list for tasks with actionUrl property


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

There was a bug with the sectioned version of the task list (_tasklist_setup_experiment_2_) that didn't support tasks that need to follow an `actionUrl` parameter instead of directing to a slotfill. This resulted in a blank screen when the "Store Details" task was clicked on.

Closes #32705 .

### How to test the changes in this Pull Request:

1. Checkout this branch on fresh site.
2. Don't complete OBW, but ensure marketing is enabled (you can complete the just first step of the OBW to do this)
3. Install and activate the latest WooCommerce Test Helper plugin
4. Navigate to Tools > WCA Test Helper > Experiments and toggle `woocommerce_tasklist_setup_experiment_2_2022_*` to treatment.
5. Go back to Homescreen (ensure page refresh)
6. You should see the sectioned task list
7. Click on "Store Details" step. 
8. It should correctly direct you to the Onboarding Wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
