### PR TITLE
Add tracks to task list reminder bar

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
@@ -15,6 +15,7 @@ import { close as closeIcon } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useEffect } from '@wordpress/element';
 import { getQuery } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -29,11 +30,19 @@ type ReminderBarProps = {
 
 type ReminderTextProps = {
 	remainingCount: number | null;
+	tracksProps: {
+		completed: number;
+		is_homescreen: boolean;
+		is_active_task_page: boolean;
+	};
 };
 
 const REMINDER_BAR_HIDDEN_OPTION = 'woocommerce_task_list_reminder_bar_hidden';
 
-const ReminderText: React.FC< ReminderTextProps > = ( { remainingCount } ) => {
+const ReminderText: React.FC< ReminderTextProps > = ( {
+	remainingCount,
+	tracksProps,
+} ) => {
 	const translationText =
 		remainingCount === 1
 			? /* translators: 1: remaining tasks count */
@@ -56,6 +65,12 @@ const ReminderText: React.FC< ReminderTextProps > = ( { remainingCount } ) => {
 					setupLink: (
 						<Link
 							href={ getAdminLink( 'admin.php?page=wc-admin' ) }
+							onClick={ () =>
+								recordEvent(
+									'tasklist_reminder_bar_continue',
+									tracksProps
+								)
+							}
 							type="wp-admin"
 						/>
 					),
@@ -123,7 +138,7 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 		getQuery().page && getQuery().page === 'wc-admin' && ! getQuery().path;
 	const isActiveTaskPage = Boolean( getQuery().wc_onboarding_active_task );
 
-	const hideReminderBar =
+	const isHidden =
 		loading ||
 		taskListHidden ||
 		taskListComplete ||
@@ -134,24 +149,40 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 
 	useEffect( () => {
 		updateBodyMargin();
-	}, [ hideReminderBar, updateBodyMargin ] );
+	}, [ isHidden, updateBodyMargin ] );
 
-	if ( hideReminderBar ) {
+	const tracksProps = {
+		completed: completedTasksCount,
+		is_homescreen: isHomescreen,
+		is_active_task_page: isActiveTaskPage,
+	};
+
+	useEffect( () => {
+		if ( loading || isHidden ) {
+			return;
+		}
+
+		recordEvent( 'tasklist_reminder_bar_view', tracksProps );
+	}, [ isHidden, loading ] );
+
+	const onClose = () => {
+		updateOptions( {
+			[ REMINDER_BAR_HIDDEN_OPTION ]: 'yes',
+		} );
+		recordEvent( 'tasklist_reminder_bar_close', tracksProps );
+	};
+
+	if ( isHidden ) {
 		return null;
 	}
 
 	return (
 		<div className="woocommerce-layout__header-tasks-reminder-bar">
-			<ReminderText remainingCount={ remainingCount } />
-			<Button
-				isSmall
-				onClick={ () =>
-					updateOptions( {
-						[ REMINDER_BAR_HIDDEN_OPTION ]: 'yes',
-					} )
-				}
-				icon={ closeIcon }
+			<ReminderText
+				remainingCount={ remainingCount }
+				tracksProps={ tracksProps }
 			/>
+			<Button isSmall onClick={ onClose } icon={ closeIcon } />
 		</div>
 	);
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds missing tracks to the newly added task list reminder bar.

Closes #32161 .

### How to test the changes in this Pull Request:

1. In your browser console, enter `localStorage.setItem( 'debug', 'wc-admin:*' );`
2. On a new site with at least one completed task, but not entirely completed task list, visit any non-homescreen page with the WCA header.
3. Note the tracks events in the console upon viewing the bar, clicking "Continue," and closing the task reminder bar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

Changelog not necessary since this work was included as part of this release.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
