### PR TITLE
Add : "name" and "id" attributes of input html tags can now be different in wc-admin-settings

### DIFF
--- a/plugins/woocommerce/changelog/add-wc-admin-settings
+++ b/plugins/woocommerce/changelog/add-wc-admin-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Make it possible to specify input field names separately from the ID.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -213,11 +213,11 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				if ( ! isset( $value['id'] ) ) {
 					$value['id'] = '';
 				}
-				if ( ! isset( $value['name'] ) ) {
-					$value['name'] = $value['id'];
+				if ( ! isset( $value['field_name'] ) ) {
+					$value['field_name'] = $value['id'];
 				}
 				if ( ! isset( $value['title'] ) ) {
-					$value['title'] = '';
+					$value['title'] = isset( $value['name'] ) ? $value['name'] : '';
 				}
 				if ( ! isset( $value['class'] ) ) {
 					$value['class'] = '';
@@ -315,7 +315,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<input
-									name="<?php echo esc_attr( $value['name'] ); ?>"
+									name="<?php echo esc_attr( $value['field_name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="<?php echo esc_attr( $value['type'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
@@ -341,7 +341,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">&lrm;
 								<span class="colorpickpreview" style="background: <?php echo esc_attr( $option_value ); ?>">&nbsp;</span>
 								<input
-									name="<?php echo esc_attr( $value['name'] ); ?>"
+									name="<?php echo esc_attr( $value['field_name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="text"
 									dir="ltr"
@@ -370,7 +370,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 								<?php echo $description; // WPCS: XSS ok. ?>
 
 								<textarea
-									name="<?php echo esc_attr( $value['name'] ); ?>"
+									name="<?php echo esc_attr( $value['field_name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
 									class="<?php echo esc_attr( $value['class'] ); ?>"
@@ -394,7 +394,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<select
-									name="<?php echo esc_attr( $value['name'] ); ?><?php echo ( 'multiselect' === $value['type'] ) ? '[]' : ''; ?>"
+									name="<?php echo esc_attr( $value['field_name'] ); ?><?php echo ( 'multiselect' === $value['type'] ) ? '[]' : ''; ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
 									class="<?php echo esc_attr( $value['class'] ); ?>"
@@ -443,7 +443,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 										?>
 										<li>
 											<label><input
-												name="<?php echo esc_attr( $value['name'] ); ?>"
+												name="<?php echo esc_attr( $value['field_name'] ); ?>"
 												value="<?php echo esc_attr( $key ); ?>"
 												type="radio"
 												<?php if( in_array( $key, $disabled_values ) ) { echo 'disabled'; } ?>
@@ -506,7 +506,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						?>
 							<label for="<?php echo esc_attr( $value['id'] ); ?>">
 								<input
-									name="<?php echo esc_attr( $value['name'] ); ?>"
+									name="<?php echo esc_attr( $value['field_name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="checkbox"
 									class="<?php echo esc_attr( isset( $value['class'] ) ? $value['class'] : '' ); ?>"
@@ -552,9 +552,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						</th>
 							<td class="forminp image_width_settings">
 
-								<input name="<?php echo esc_attr( $value['name'] ); ?>[width]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-width" type="text" size="3" value="<?php echo esc_attr( $width ); ?>" /> &times; <input name="<?php echo esc_attr( $value['id'] ); ?>[height]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-height" type="text" size="3" value="<?php echo esc_attr( $height ); ?>" />px
+								<input name="<?php echo esc_attr( $value['field_name'] ); ?>[width]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-width" type="text" size="3" value="<?php echo esc_attr( $width ); ?>" /> &times; <input name="<?php echo esc_attr( $value['id'] ); ?>[height]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-height" type="text" size="3" value="<?php echo esc_attr( $height ); ?>" />px
 
-								<label><input name="<?php echo esc_attr( $value['name'] ); ?>[crop]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-crop" type="checkbox" value="1" <?php checked( 1, $crop ); ?> /> <?php esc_html_e( 'Hard crop?', 'woocommerce' ); ?></label>
+								<label><input name="<?php echo esc_attr( $value['field_name'] ); ?>[crop]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-crop" type="checkbox" value="1" <?php checked( 1, $crop ); ?> /> <?php esc_html_e( 'Hard crop?', 'woocommerce' ); ?></label>
 
 								</td>
 						</tr>
@@ -564,7 +564,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					// Single page selects.
 					case 'single_select_page':
 						$args = array(
-							'name'             => $value['name'],
+							'name'             => $value['field_name'],
 							'id'               => $value['id'],
 							'sort_column'      => 'menu_order',
 							'sort_order'       => 'ASC',
@@ -611,7 +611,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<select
-									name="<?php echo esc_attr( $value['name'] ); ?>"
+									name="<?php echo esc_attr( $value['field_name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
 									class="<?php echo esc_attr( $value['class'] ); ?>"
@@ -649,7 +649,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
-							<td class="forminp"><select name="<?php echo esc_attr( $value['name'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>" data-placeholder="<?php esc_attr_e( 'Choose a country / region&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
+							<td class="forminp"><select name="<?php echo esc_attr( $value['field_name'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>" data-placeholder="<?php esc_attr_e( 'Choose a country / region&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
 								<?php WC()->countries->country_dropdown_options( $country, $state ); ?>
 							</select> <?php echo $description; // WPCS: XSS ok. ?>
 							</td>
@@ -674,7 +674,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
 							<td class="forminp">
-								<select multiple="multiple" name="<?php echo esc_attr( $value['name'] ); ?>[]" style="width:350px" data-placeholder="<?php esc_attr_e( 'Choose countries / regions&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
+								<select multiple="multiple" name="<?php echo esc_attr( $value['field_name'] ); ?>[]" style="width:350px" data-placeholder="<?php esc_attr_e( 'Choose countries / regions&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
 									<?php
 									if ( ! empty( $countries ) ) {
 										foreach ( $countries as $key => $val ) {
@@ -704,7 +704,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp">
 							<input
-									name="<?php echo esc_attr( $value['name'] ); ?>[number]"
+									name="<?php echo esc_attr( $value['field_name'] ); ?>[number]"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="number"
 									style="width: 80px;"
@@ -715,7 +715,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 									min="1"
 									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
 								/>&nbsp;
-								<select name="<?php echo esc_attr( $value['name'] ); ?>[unit]" style="width: auto;">
+								<select name="<?php echo esc_attr( $value['field_name'] ); ?>[unit]" style="width: auto;">
 									<?php
 									foreach ( $periods as $value => $label ) {
 										echo '<option value="' . esc_attr( $value ) . '"' . selected( $option_value['unit'], $value, false ) . '>' . esc_html( $label ) . '</option>';
@@ -803,7 +803,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					continue;
 				}
 
-				$option_name = $option['name'] ?? $option['id'];
+				$option_name = $option['field_name'] ?? $option['id'];
 
 				// Get posted value.
 				if ( strstr( $option_name, '[' ) ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -799,6 +799,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 			// Loop options and get values to save.
 			foreach ( $options as $option ) {
+				if( isset( $option['name'] ) ) {
+					$option['id'] = $option['name'];
+				}
+				
 				if ( ! isset( $option['name'] ) || ! isset( $option['type'] ) || ( isset( $option['is_option'] ) && false === $option['is_option'] ) ) {
 					continue;
 				}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -802,21 +802,21 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				if( isset( $option['name'] ) ) {
 					$option['id'] = $option['name'];
 				}
-				
-				if ( ! isset( $option['name'] ) || ! isset( $option['type'] ) || ( isset( $option['is_option'] ) && false === $option['is_option'] ) ) {
+
+				if ( ! isset( $option['id'] ) || ! isset( $option['type'] ) || ( isset( $option['is_option'] ) && false === $option['is_option'] ) ) {
 					continue;
 				}
 
 				// Get posted value.
-				if ( strstr( $option['name'], '[' ) ) {
-					parse_str( $option['name'], $option_name_array );
+				if ( strstr( $option['id'], '[' ) ) {
+					parse_str( $option['id'], $option_name_array );
 					$option_name  = current( array_keys( $option_name_array ) );
 					$setting_name = key( $option_name_array[ $option_name ] );
 					$raw_value    = isset( $data[ $option_name ][ $setting_name ] ) ? wp_unslash( $data[ $option_name ][ $setting_name ] ) : null;
 				} else {
-					$option_name  = $option['name'];
+					$option_name  = $option['id'];
 					$setting_name = '';
-					$raw_value    = isset( $data[ $option['name'] ] ) ? wp_unslash( $data[ $option['name'] ] ) : null;
+					$raw_value    = isset( $data[ $option['id'] ] ) ? wp_unslash( $data[ $option['id'] ] ) : null;
 				}
 
 				// Format the value based on option type.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -799,7 +799,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 			// Loop options and get values to save.
 			foreach ( $options as $option ) {
-				if( isset( $option['name'] ) ) {
+				if ( isset( $option['name'] ) ) {
 					$option['id'] = $option['name'];
 				}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -213,6 +213,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				if ( ! isset( $value['id'] ) ) {
 					$value['id'] = '';
 				}
+				if ( ! isset( $value['name'] ) ) {
+					$value['name'] = $value['id'];
+				}
 				if ( ! isset( $value['title'] ) ) {
 					$value['title'] = isset( $value['name'] ) ? $value['name'] : '';
 				}
@@ -312,7 +315,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
+									name="<?php echo esc_attr( $value['name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="<?php echo esc_attr( $value['type'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
@@ -338,7 +341,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">&lrm;
 								<span class="colorpickpreview" style="background: <?php echo esc_attr( $option_value ); ?>">&nbsp;</span>
 								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
+									name="<?php echo esc_attr( $value['name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="text"
 									dir="ltr"
@@ -367,7 +370,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 								<?php echo $description; // WPCS: XSS ok. ?>
 
 								<textarea
-									name="<?php echo esc_attr( $value['id'] ); ?>"
+									name="<?php echo esc_attr( $value['name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
 									class="<?php echo esc_attr( $value['class'] ); ?>"
@@ -391,7 +394,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<select
-									name="<?php echo esc_attr( $value['id'] ); ?><?php echo ( 'multiselect' === $value['type'] ) ? '[]' : ''; ?>"
+									name="<?php echo esc_attr( $value['name'] ); ?><?php echo ( 'multiselect' === $value['type'] ) ? '[]' : ''; ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
 									class="<?php echo esc_attr( $value['class'] ); ?>"
@@ -440,7 +443,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 										?>
 										<li>
 											<label><input
-												name="<?php echo esc_attr( $value['id'] ); ?>"
+												name="<?php echo esc_attr( $value['name'] ); ?>"
 												value="<?php echo esc_attr( $key ); ?>"
 												type="radio"
 												<?php if( in_array( $key, $disabled_values ) ) { echo 'disabled'; } ?>
@@ -503,7 +506,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						?>
 							<label for="<?php echo esc_attr( $value['id'] ); ?>">
 								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
+									name="<?php echo esc_attr( $value['name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="checkbox"
 									class="<?php echo esc_attr( isset( $value['class'] ) ? $value['class'] : '' ); ?>"
@@ -549,9 +552,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						</th>
 							<td class="forminp image_width_settings">
 
-								<input name="<?php echo esc_attr( $value['id'] ); ?>[width]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-width" type="text" size="3" value="<?php echo esc_attr( $width ); ?>" /> &times; <input name="<?php echo esc_attr( $value['id'] ); ?>[height]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-height" type="text" size="3" value="<?php echo esc_attr( $height ); ?>" />px
+								<input name="<?php echo esc_attr( $value['name'] ); ?>[width]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-width" type="text" size="3" value="<?php echo esc_attr( $width ); ?>" /> &times; <input name="<?php echo esc_attr( $value['id'] ); ?>[height]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-height" type="text" size="3" value="<?php echo esc_attr( $height ); ?>" />px
 
-								<label><input name="<?php echo esc_attr( $value['id'] ); ?>[crop]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-crop" type="checkbox" value="1" <?php checked( 1, $crop ); ?> /> <?php esc_html_e( 'Hard crop?', 'woocommerce' ); ?></label>
+								<label><input name="<?php echo esc_attr( $value['name'] ); ?>[crop]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-crop" type="checkbox" value="1" <?php checked( 1, $crop ); ?> /> <?php esc_html_e( 'Hard crop?', 'woocommerce' ); ?></label>
 
 								</td>
 						</tr>
@@ -561,7 +564,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					// Single page selects.
 					case 'single_select_page':
 						$args = array(
-							'name'             => $value['id'],
+							'name'             => $value['name'],
 							'id'               => $value['id'],
 							'sort_column'      => 'menu_order',
 							'sort_order'       => 'ASC',
@@ -608,7 +611,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<select
-									name="<?php echo esc_attr( $value['id'] ); ?>"
+									name="<?php echo esc_attr( $value['name'] ); ?>"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									style="<?php echo esc_attr( $value['css'] ); ?>"
 									class="<?php echo esc_attr( $value['class'] ); ?>"
@@ -646,7 +649,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
-							<td class="forminp"><select name="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>" data-placeholder="<?php esc_attr_e( 'Choose a country / region&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
+							<td class="forminp"><select name="<?php echo esc_attr( $value['name'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>" data-placeholder="<?php esc_attr_e( 'Choose a country / region&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
 								<?php WC()->countries->country_dropdown_options( $country, $state ); ?>
 							</select> <?php echo $description; // WPCS: XSS ok. ?>
 							</td>
@@ -671,7 +674,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
 							<td class="forminp">
-								<select multiple="multiple" name="<?php echo esc_attr( $value['id'] ); ?>[]" style="width:350px" data-placeholder="<?php esc_attr_e( 'Choose countries / regions&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
+								<select multiple="multiple" name="<?php echo esc_attr( $value['name'] ); ?>[]" style="width:350px" data-placeholder="<?php esc_attr_e( 'Choose countries / regions&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country / Region', 'woocommerce' ); ?>" class="wc-enhanced-select">
 									<?php
 									if ( ! empty( $countries ) ) {
 										foreach ( $countries as $key => $val ) {
@@ -701,7 +704,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp">
 							<input
-									name="<?php echo esc_attr( $value['id'] ); ?>[number]"
+									name="<?php echo esc_attr( $value['name'] ); ?>[number]"
 									id="<?php echo esc_attr( $value['id'] ); ?>"
 									type="number"
 									style="width: 80px;"
@@ -712,7 +715,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 									min="1"
 									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
 								/>&nbsp;
-								<select name="<?php echo esc_attr( $value['id'] ); ?>[unit]" style="width: auto;">
+								<select name="<?php echo esc_attr( $value['name'] ); ?>[unit]" style="width: auto;">
 									<?php
 									foreach ( $periods as $value => $label ) {
 										echo '<option value="' . esc_attr( $value ) . '"' . selected( $option_value['unit'], $value, false ) . '>' . esc_html( $label ) . '</option>';
@@ -796,20 +799,20 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 			// Loop options and get values to save.
 			foreach ( $options as $option ) {
-				if ( ! isset( $option['id'] ) || ! isset( $option['type'] ) || ( isset( $option['is_option'] ) && false === $option['is_option'] ) ) {
+				if ( ! isset( $option['name'] ) || ! isset( $option['type'] ) || ( isset( $option['is_option'] ) && false === $option['is_option'] ) ) {
 					continue;
 				}
 
 				// Get posted value.
-				if ( strstr( $option['id'], '[' ) ) {
-					parse_str( $option['id'], $option_name_array );
+				if ( strstr( $option['name'], '[' ) ) {
+					parse_str( $option['name'], $option_name_array );
 					$option_name  = current( array_keys( $option_name_array ) );
 					$setting_name = key( $option_name_array[ $option_name ] );
 					$raw_value    = isset( $data[ $option_name ][ $setting_name ] ) ? wp_unslash( $data[ $option_name ][ $setting_name ] ) : null;
 				} else {
-					$option_name  = $option['id'];
+					$option_name  = $option['name'];
 					$setting_name = '';
-					$raw_value    = isset( $data[ $option['id'] ] ) ? wp_unslash( $data[ $option['id'] ] ) : null;
+					$raw_value    = isset( $data[ $option['name'] ] ) ? wp_unslash( $data[ $option['name'] ] ) : null;
 				}
 
 				// Format the value based on option type.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -217,7 +217,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					$value['name'] = $value['id'];
 				}
 				if ( ! isset( $value['title'] ) ) {
-					$value['title'] = isset( $value['name'] ) ? $value['name'] : '';
+					$value['title'] = '';
 				}
 				if ( ! isset( $value['class'] ) ) {
 					$value['class'] = '';

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -799,24 +799,21 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 			// Loop options and get values to save.
 			foreach ( $options as $option ) {
-				if ( isset( $option['name'] ) ) {
-					$option['id'] = $option['name'];
-				}
-
 				if ( ! isset( $option['id'] ) || ! isset( $option['type'] ) || ( isset( $option['is_option'] ) && false === $option['is_option'] ) ) {
 					continue;
 				}
 
+				$option_name = $option['name'] ?? $option['id'];
+
 				// Get posted value.
-				if ( strstr( $option['id'], '[' ) ) {
-					parse_str( $option['id'], $option_name_array );
+				if ( strstr( $option_name, '[' ) ) {
+					parse_str( $option_name, $option_name_array );
 					$option_name  = current( array_keys( $option_name_array ) );
 					$setting_name = key( $option_name_array[ $option_name ] );
 					$raw_value    = isset( $data[ $option_name ][ $setting_name ] ) ? wp_unslash( $data[ $option_name ][ $setting_name ] ) : null;
 				} else {
-					$option_name  = $option['id'];
 					$setting_name = '';
-					$raw_value    = isset( $data[ $option['id'] ] ) ? wp_unslash( $data[ $option['id'] ] ) : null;
+					$raw_value    = isset( $data[ $option_name ] ) ? wp_unslash( $data[ $option_name ] ) : null;
 				}
 
 				// Format the value based on option type.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -213,6 +213,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				if ( ! isset( $value['id'] ) ) {
 					$value['id'] = '';
 				}
+
+				// The 'field_name' key can be used when it is useful to specify an input field name that is different
+				// from the input field ID. We use the key 'field_name' because 'name' is already in use for a different
+				// purpose.
 				if ( ! isset( $value['field_name'] ) ) {
 					$value['field_name'] = $value['id'];
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Allow better control over forms structure. 
Handle different values for `name` and `id` html inputs attributes from wc-admin-settings class.
To perform this, developers only needs to set a `"field_name" => "foo"` pairs when creating form fields from 'woocommerce_account_settings' filter. 
If the key `"field_name"` is not defined, then `id` and `name` will have the same values.

This may be useful to dissociate `id` and `name` values when you need to use **square bracket syntax** for `name` attribute.

NB : If the `name` attribute uses the `name[]` bracket syntax, then an array will be stored on form submit. 
In this case, we also need to define the `"value" => "$bar[i]"` pair to our field data to indicate the value to get on display, and not the entire array to causing array to string conversion error. (See the example below)

### How to test the changes in this Pull Request:

1. First, visit **WooCommerce ‣ Settings** and test that you can change and save the settings across different tabs.
2. Next, create two new custom fields within the **WooCommerce ‣ Settings ‣ Accounts & Privacy** tab by adding the following code to `wp-content/mu-plugins/test-32728.php` (this can safely be removed after testing is completed):

```php
<?php

add_filter( 'woocommerce_account_settings', function ( array $settings ) {
	return array_merge(
		$settings,
		array(
			array(
				'title'         => __( '[FR] Digit Code : Error message', 'woocommerce' ),
				'id'            => 'number_error_message_fr',
				'field_name'    => 'number_error_message[fr]',
				'value'         => get_option('number_error_message')['fr'] ?? '',
				'default'       => 'Le numéro doit contenir 6 chiffres',
				'type'          => 'text',
				'autoload'      => false,
			),
			array(
				'title'         => __( '[EN] Digit Code : Error message', 'woocommerce' ),
				'id'            => 'number_error_message_en',
				'field_name'    => 'number_error_message[en]',
				'value'         => get_option('number_error_message')['en'] ?? '',
				'default'       => 'The number must contain 6 digits',
				'type'          => 'text',
				'autoload'      => false,
			),
		)
	);
} );
```

3. At the bottom of that screen, you should now see two new settings looking something like this (of course, they will not initially have the same values you see in the screenshot):

<img width="841" alt="test-32728" src="https://user-images.githubusercontent.com/3594411/177226873-0c406e63-1ab7-474f-a386-d98aeed63ac2.png">

4. Change the values for both fields and save, confirm the changes were persisted.
5. There should be no "Array to string conversion" error when redisplaying the form. You may wish to install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/) or some similar tool to help verify this.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
