### PR TITLE
Addressing issues with certain tasks in task list experiment leading to blank page

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -1,24 +1,17 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	updateQueryString,
-	getHistory,
-	getNewPath,
-} from '@woocommerce/navigation';
-import {
+	getVisibleTasks,
 	OPTIONS_STORE_NAME,
 	ONBOARDING_STORE_NAME,
-	TaskType,
-	getVisibleTasks,
 	WCDataSelector,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { List, TaskItem } from '@woocommerce/experimental';
+import { List } from '@woocommerce/experimental';
 import classnames from 'classnames';
 
 /**
@@ -30,6 +23,7 @@ import TaskListCompleted from './completed';
 import { TaskListProps } from '~/tasks/task-list';
 import { ProgressHeader } from '~/task-lists/progress-header';
 import { SectionPanelTitle } from './section-panel-title';
+import { TaskListItem } from './task-list-item';
 
 type PanelBodyProps = Omit< PanelBody.Props, 'title' | 'onToggle' > & {
 	title: string | React.ReactNode | undefined;
@@ -47,10 +41,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	sections,
 	displayProgressHeader,
 } ) => {
-	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateOptions, dismissTask, undoDismissTask } = useDispatch(
-		OPTIONS_STORE_NAME
-	);
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { profileItems } = useSelect( ( select: WCDataSelector ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 		return {
@@ -91,18 +82,6 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		}
 	}, [ query ] );
 
-	const onDismissTask = ( taskId: string ) => {
-		dismissTask( taskId );
-		createNotice( 'success', __( 'Task dismissed' ), {
-			actions: [
-				{
-					label: __( 'Undo', 'woocommerce-admin' ),
-					onClick: () => undoDismissTask( taskId ),
-				},
-			],
-		} );
-	};
-
 	const hideTasks = () => {
 		hideTaskList( id );
 	};
@@ -125,26 +104,6 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	if ( ! selectedHeaderCard ) {
 		selectedHeaderCard = visibleTasks[ visibleTasks.length - 1 ];
 	}
-
-	const trackClick = ( task: TaskType ) => {
-		recordEvent( `${ eventPrefix }_click`, {
-			task_name: task.id,
-		} );
-	};
-
-	const onTaskSelected = ( task: TaskType ) => {
-		trackClick( task );
-		if ( task.actionUrl ) {
-			if ( task.actionUrl.startsWith( 'http' ) ) {
-				window.location.href = task.actionUrl;
-			} else {
-				getHistory().push( getNewPath( {}, task.actionUrl, {} ) );
-			}
-			return;
-		}
-
-		updateQueryString( { task: task.id } );
-	};
 
 	const getSectionTasks = ( sectionTaskIds: string[] ) => {
 		return visibleTasks.filter( ( task ) =>
@@ -226,52 +185,14 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 							<PanelRow>
 								<List animation="custom">
 									{ getSectionTasks( section.tasks ).map(
-										( task ) => {
-											const className = classnames(
-												'woocommerce-task-list__item',
-												{
-													'is-complete':
-														task.isComplete,
-													'is-disabled':
-														task.isDisabled,
-												}
-											);
-											return (
-												<TaskItem
-													key={ task.id }
-													className={ className }
-													title={ task.title }
-													completed={
-														task.isComplete
-													}
-													expanded={
-														! task.isComplete
-													}
-													content={ task.content }
-													onClick={ () => {
-														if (
-															! task.isDisabled
-														) {
-															onTaskSelected(
-																task
-															);
-														}
-													} }
-													onDismiss={
-														task.isDismissable
-															? () =>
-																	onDismissTask(
-																		task.id
-																	)
-															: undefined
-													}
-													action={ () => {} }
-													actionLabel={
-														task.actionLabel
-													}
-												/>
-											);
-										}
+										( task, index ) => (
+											<TaskListItem
+												key={ task.id }
+												task={ task }
+												eventPrefix={ eventPrefix }
+												itemIndex={ ++index }
+											/>
+										)
 									) }
 								</List>
 							</PanelRow>

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	getHistory,
+	getNewPath,
+	updateQueryString,
+} from '@woocommerce/navigation';
+import { OPTIONS_STORE_NAME, TaskType } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
+import { TaskItem, useSlot } from '@woocommerce/experimental';
+import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './task-list.scss';
+
+export type TaskListItemProps = {
+	task: TaskType;
+	eventPrefix?: string;
+	itemIndex: number;
+	activeTaskId?: string;
+};
+
+export const TaskListItem: React.FC< TaskListItemProps > = ( {
+	task,
+	eventPrefix,
+	activeTaskId,
+	itemIndex,
+} ) => {
+	const { createNotice } = useDispatch( 'core/notices' );
+	const { dismissTask, undoDismissTask } = useDispatch( OPTIONS_STORE_NAME );
+
+	const slot = useSlot(
+		`woocommerce_onboarding_task_list_item_${ task.id }`
+	);
+	const hasFills = Boolean( slot?.fills?.length );
+
+	const trackClick = () => {
+		recordEvent( `${ eventPrefix }_click`, {
+			task_name: task.id,
+		} );
+	};
+
+	const onTaskSelected = () => {
+		trackClick();
+
+		if ( task.actionUrl ) {
+			if ( task.actionUrl.startsWith( 'http' ) ) {
+				window.location.href = task.actionUrl;
+			} else {
+				getHistory().push( getNewPath( {}, task.actionUrl, {} ) );
+			}
+			return;
+		}
+
+		window.document.documentElement.scrollTop = 0;
+		updateQueryString( { task: task.id } );
+	};
+
+	const onDismissTask = ( taskId: string ) => {
+		dismissTask( taskId );
+		createNotice( 'success', __( 'Task dismissed' ), {
+			actions: [
+				{
+					label: __( 'Undo', 'woocommerce-admin' ),
+					onClick: () => undoDismissTask( taskId ),
+				},
+			],
+		} );
+	};
+
+	const className = classnames(
+		'woocommerce-task-list__item index-' + itemIndex,
+		{
+			'is-complete': task.isComplete,
+			'is-disabled': task.isDisabled,
+			'is-active': task.id === activeTaskId,
+		}
+	);
+
+	const taskItemProps = {
+		completed: task.isComplete,
+		onSnooze: task.isSnoozeable && task.onSnooze,
+		onDismiss: task.isDismissable && task.onDismiss,
+	};
+
+	const DefaultTaskItem = useCallback(
+		( props ) => {
+			const onClickActions = () => {
+				trackClick();
+
+				if ( props.onClick ) {
+					return props.onClick();
+				}
+
+				return onTaskSelected();
+			};
+			return (
+				<TaskItem
+					key={ task.id }
+					className={ className }
+					title={ task.title }
+					completed={ task.isComplete }
+					expanded={ ! task.isComplete }
+					content={ task.content }
+					onClick={ () => {
+						if ( task.isDisabled ) {
+							return;
+						}
+
+						onClickActions();
+					} }
+					onDismiss={
+						task.isDismissable
+							? () => onDismissTask( task.id )
+							: undefined
+					}
+					action={ () => {} }
+					actionLabel={ task.actionLabel }
+				/>
+			);
+		},
+		[
+			task.id,
+			task.title,
+			task.content,
+			task.time,
+			task.actionLabel,
+			task.isComplete,
+		]
+	);
+
+	return hasFills ? (
+		<WooOnboardingTaskListItem.Slot
+			id={ task.id }
+			fillProps={ {
+				defaultTaskItem: DefaultTaskItem,
+				isComplete: task.isComplete,
+				...taskItemProps,
+			} }
+		/>
+	) : (
+		<DefaultTaskItem />
+	);
+};

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.scss
@@ -1,0 +1,24 @@
+.woocommerce-task-list__item {
+	overflow: hidden;
+	&.woocommerce-list__item-enter {
+		opacity: 0;
+		max-height: 0;
+	}
+
+	&.woocommerce-list__item-enter-active {
+		opacity: 1;
+		max-height: 100px;
+		transition: opacity 500ms, max-height 500ms;
+	}
+
+	&.woocommerce-list__item-exit {
+		opacity: 1;
+		max-height: 100px;
+	}
+
+	&.woocommerce-list__item-exit-active {
+		opacity: 0;
+		max-height: 0;
+		transition: opacity 500ms, max-height 500ms;
+	}
+}

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -21,7 +21,7 @@ import {
 	TaskListType,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { List, TaskItem } from '@woocommerce/experimental';
+import { List } from '@woocommerce/experimental';
 import classnames from 'classnames';
 import { History } from 'history';
 
@@ -33,6 +33,7 @@ import taskHeaders from './task-headers';
 import DismissModal from './dismiss-modal';
 import TaskListCompleted from './completed';
 import { ProgressHeader } from '~/task-lists/progress-header';
+import { TaskListItem } from './task-list-item';
 
 export type TaskListProps = TaskListType & {
 	eventName?: string;
@@ -52,10 +53,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	isComplete,
 	displayProgressHeader,
 } ) => {
-	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateOptions, dismissTask, undoDismissTask } = useDispatch(
-		OPTIONS_STORE_NAME
-	);
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { profileItems } = useSelect( ( select: WCDataSelector ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 		return {
@@ -104,23 +102,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		( task ) => ! task.isComplete && ! task.isDismissed
 	);
 
-	const onDismissTask = ( taskId: string, onDismiss?: () => void ) => {
-		dismissTask( taskId );
-		createNotice( 'success', __( 'Task dismissed' ), {
-			actions: [
-				{
-					label: __( 'Undo', 'woocommerce' ),
-					onClick: () => undoDismissTask( taskId ),
-				},
-			],
-		} );
-
-		if ( onDismiss ) {
-			onDismiss();
-		}
-	};
-
-	const hideTasks = ( event: string ) => {
+	const hideTasks = () => {
 		hideTaskList( id );
 	};
 
@@ -152,7 +134,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 										setShowDismissModal( true );
 										onToggle();
 									} else {
-										hideTasks( 'remove_card' );
+										hideTasks();
 									}
 								} }
 							>
@@ -233,15 +215,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		}
 	};
 
-	const onTaskSelected = ( task: TaskType ) => {
-		if ( task.id === 'woocommerce-payments' ) {
-			// With WCPay, we have to show the header content for user to read t&c first.
-			showTaskHeader( task );
-		} else {
-			goToTask( task );
-		}
-	};
-
 	useEffect( () => {
 		if ( selectedHeaderCard ) {
 			showTaskHeader( selectedHeaderCard );
@@ -299,30 +272,14 @@ export const TaskList: React.FC< TaskListProps > = ( {
 					<List animation="custom">
 						{ visibleTasks.map( ( task, index ) => {
 							++index;
-							const className = classnames(
-								'woocommerce-task-list__item index-' + index,
-								{
-									'is-complete': task.isComplete,
-									'is-active': task.id === activeTaskId,
-								}
-							);
+
 							return (
-								<TaskItem
+								<TaskListItem
 									key={ task.id }
-									className={ className }
-									title={ task.title }
-									completed={ task.isComplete }
-									content={ task.content }
-									onClick={ () => {
-										onTaskSelected( task );
-									} }
-									onDismiss={
-										task.isDismissable
-											? () => onDismissTask( task.id )
-											: undefined
-									}
-									action={ () => {} }
-									actionLabel={ task.actionLabel }
+									itemIndex={ index }
+									activeTaskId={ activeTaskId }
+									task={ task }
+									eventPrefix={ eventName }
 								/>
 							);
 						} ) }

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -15,6 +15,7 @@ jest.mock( '@woocommerce/tracks', () => ( {
 } ) );
 jest.mock( '@woocommerce/experimental', () => ( {
 	TaskItem: ( props: { title: string } ) => <div>{ props.title }</div>,
+	useSlot: () => [],
 	List: jest.fn().mockImplementation( ( { children } ) => children ),
 } ) );
 jest.mock( '@woocommerce/components', () => ( {

--- a/plugins/woocommerce/changelog/fix-32714
+++ b/plugins/woocommerce/changelog/fix-32714
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Addressing issues with certain tasks in task list experiment leading to blank page


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

It was noticed that certain task actions on the new experiment task lists were not working correctly, primarily the "Get Paid with WooCommerce Payments" task that is added when you install WCPay during the onboarding wizard.

This turned out to require a more significant refactor that I'd originally thought since the new experiment task lists didn't support the `<WooOnboardingTaskListItem />` slot-fill, triggering this issue, and it made sense to refactor the item logic into a separate file as we're doing on the original task list.

Closes #32714  .

### How to test the changes in this Pull Request:

1. Checkout branch on fresh site & install the WooCommerce Admin Test Helper
2. Enable usage tracking
3. Complete OBW and install WooCommerce Payments in the Business features step
4. Visit Tools > WCA Test Helper > Experiments and enable `woocommerce_tasklist_setup_experiment_2_2022_04`
5. Visit the home screen and click "Get paid with WCPay" task to ensure that it redirects as it should.
6. Visit Tools > WCA Test Helper > Experiments and enable woocommerce_tasklist_setup_experiment_1_2022_04
7. Visit the home screen and click "Get paid with WCPay" task to ensure that it redirects as it should.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
