### PR TITLE
Removing Postcode and State field for Belize

### DIFF
--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -912,6 +912,14 @@ class WC_Countries {
 							'hidden'   => true,
 						),
 					),
+					'BZ' => array(
+						'postcode' => array(
+							'required' => false,
+							'hidden'   => true,
+						),
+						'state' 	=> array(
+							'required' => false,
+					),
 					'CA' => array(
 						'postcode' => array(
 							'label' => __( 'Postal code', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -919,6 +919,7 @@ class WC_Countries {
 						),
 						'state' 	=> array(
 							'required' => false,
+						),
 					),
 					'CA' => array(
 						'postcode' => array(


### PR DESCRIPTION
The country Belize does not use Postcode and State.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # . Remove the Post Code field and make State field not required from the checkout page when 'Belize' is selected

### How to test the changes in this Pull Request:

1. On the checkout page, select 'Belize' as country,
2. Confirm the State and Post code fields do not show on the page.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
