### PR TITLE
Add Preview store button to Home screen

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -298,9 +298,27 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			},
 		};
 
-		return [ activity, setup, previewSite, displayOptions, help ].filter(
-			( tab ) => tab.visible
-		);
+		const previewStore = {
+			name: 'previewStore',
+			title: __( 'Preview store', 'woocommerce' ),
+			icon: <Icon icon={ external } />,
+			visible: isHomescreen(),
+			onClick: () => {
+				window.open( getSetting( 'siteUrl' ) );
+				recordEvent( 'wcadmin_previewstore_click' );
+
+				return null;
+			},
+		};
+
+		return [
+			activity,
+			setup,
+			previewSite,
+			previewStore,
+			displayOptions,
+			help,
+		].filter( ( tab ) => tab.visible );
 	};
 
 	const getPanelContent = ( tab ) => {

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -6,7 +6,7 @@ import { lazy, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
-import { getAdminLink, getSetting } from '@woocommerce/settings';
+import { getAdminLink } from '@woocommerce/settings';
 import { H, Section } from '@woocommerce/components';
 import {
 	ONBOARDING_STORE_NAME,
@@ -37,6 +37,7 @@ import {
 } from '../homescreen/activity-panel/orders/utils';
 import { getUnapprovedReviews } from '../homescreen/activity-panel/reviews/utils';
 import { ABBREVIATED_NOTIFICATION_SLOT_NAME } from './panels/inbox/abbreviated-notifications-panel';
+import { getAdminSetting } from '~/utils/admin-settings';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -286,9 +287,9 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			name: 'previewSite',
 			title: __( 'Preview site', 'woocommerce' ),
 			icon: <Icon icon={ external } />,
-			visible: query.page === 'wc-admin' && query.task === 'appearance',
+			visible: isHomescreen() && query.task === 'appearance',
 			onClick: () => {
-				window.open( getSetting( 'siteUrl' ) );
+				window.open( getAdminSetting( 'siteUrl' ) );
 				recordEvent(
 					'wcadmin_tasklist_previewsite',
 					previewSiteBtnTrackData
@@ -302,9 +303,9 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			name: 'previewStore',
 			title: __( 'Preview store', 'woocommerce' ),
 			icon: <Icon icon={ external } />,
-			visible: isHomescreen(),
+			visible: isHomescreen() && query.task !== 'appearance',
 			onClick: () => {
-				window.open( getSetting( 'siteUrl' ) );
+				window.open( getAdminSetting( 'shopUrl' ) );
 				recordEvent( 'wcadmin_previewstore_click' );
 
 				return null;

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -90,7 +90,7 @@ describe( 'Activity Panel', () => {
 		expect( screen.queryByText( 'Inbox' ) ).toBeNull();
 	} );
 
-	it( 'should render preview 2 tab on home screen', () => {
+	it( 'should render preview store tab on home screen', () => {
 		render( <ActivityPanel query={ { page: 'wc-admin' } } /> );
 
 		expect( screen.getByText( 'Preview store' ) ).toBeDefined();

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -90,6 +90,12 @@ describe( 'Activity Panel', () => {
 		expect( screen.queryByText( 'Inbox' ) ).toBeNull();
 	} );
 
+	it( 'should render preview 2 tab on home screen', () => {
+		render( <ActivityPanel query={ { page: 'wc-admin' } } /> );
+
+		expect( screen.getByText( 'Preview store' ) ).toBeDefined();
+	} );
+
 	it( 'should not render help tab if not on home screen', () => {
 		render(
 			<ActivityPanel query={ { page: 'wc-admin', path: '/customers' } } />

--- a/plugins/woocommerce/changelog/add-32156_preview-store-button
+++ b/plugins/woocommerce/changelog/add-32156_preview-store-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add Preview store button to Home screen #32739


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a `Preview store` button to the Home screen.

Closes #32156.

**Acceptance Criteria:**

- [ ] The `Preview store` button is visible on the Home screen
- [ ] Button uses Gutenberg's external link icon
- [ ] Clicking it opens the store's URL in a new tab

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Go to the Home screen and verify the `Preview store` button is visible in the Activity panel. 
3. Press the button.
4. The store's URL should be opened in a new tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
