### PR TITLE
Change Approved Directory update routine

### DIFF
--- a/plugins/woocommerce/changelog/fix-650-update-routines
+++ b/plugins/woocommerce/changelog/fix-650-update-routines
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Omitting a changelog entry, because we're correcting an unreleased oversight.
+
+

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -200,9 +200,11 @@ class WC_Install {
 		),
 		'6.4.0' => array(
 			'wc_update_640_add_primary_key_to_product_attributes_lookup_table',
-			'wc_update_640_approved_download_directories',
 			'wc_admin_update_340_remove_is_primary_from_note_action',
 			'wc_update_640_db_version',
+		),
+		'6.5.0' => array(
+			'wc_update_650_approved_download_directories',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2376,15 +2376,6 @@ function wc_update_630_db_version() {
 }
 
 /**
- * Add the standard WooCommerce upload directories to the Approved Product Download Directories list
- * and start populating it based on existing product download URLs, but do not enable the feature
- * (for existing installations, a site admin should review and make a conscious decision to enable).
- */
-function wc_update_640_approved_download_directories() {
-	wc_get_container()->get( Download_Directories_Sync::class )->init_feature( true, false );
-}
-
-/**
  * Create the primary key for the product attributes lookup table if it doesn't exist already.
  *
  * @return bool Always false.
@@ -2401,4 +2392,13 @@ function wc_update_640_add_primary_key_to_product_attributes_lookup_table() {
  */
 function wc_update_640_db_version() {
 	WC_Install::update_db_version( '6.4.0' );
+}
+
+/**
+ * Add the standard WooCommerce upload directories to the Approved Product Download Directories list
+ * and start populating it based on existing product download URLs, but do not enable the feature
+ * (for existing installations, a site admin should review and make a conscious decision to enable).
+ */
+function wc_update_650_approved_download_directories() {
+	wc_get_container()->get( Download_Directories_Sync::class )->init_feature( true, false );
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2400,5 +2400,7 @@ function wc_update_640_db_version() {
  * (for existing installations, a site admin should review and make a conscious decision to enable).
  */
 function wc_update_650_approved_download_directories() {
-	wc_get_container()->get( Download_Directories_Sync::class )->init_feature( true, false );
+	$directory_sync = wc_get_container()->get( Download_Directories_Sync::class );
+	$directory_sync->init_hooks();
+	$directory_sync->init_feature( true, false );
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -133,7 +133,7 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 			array( '5.6.0', 14 ),
 			array( '6.0.0', 7 ),
 			array( '6.3.0', 4 ),
-			array( '6.4.0', 0 ),
+			array( '6.4.0', 1 ),
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This addresses two separate issues, but both happen to touch the same function.

1. **Upgrade Version** → the *Approved Download Directories* feature was originally intended to ship in 6.4.0, before being bumped to 6.5.0. Unfortunately, we missed the requirement to change the matching upgrade routine.
2. **Ensure Hooks are Initialized** → specifically when run via a traditional WP Cron *async web request,* the scheduled action callback (responsible for syncing directories) was not being registered.

On that second point, one of the reasons this problem may not have been captured earlier is that when cron is triggered via WP CLI (whether on demand or through crontab) the order-of-operations is a little different and [this code](https://github.com/woocommerce/woocommerce/blob/d951b218f25a7fd5f9135abf61ea482e15ea823e/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php#L49-L54) was reliably triggered earlier in the request. When WP Cron runs via async HTTP requests, though, things unfold differently.

For ref, an internal conversation can be found here (with findings that led to the creation of this PR): pb22l9-1dC-p2#comment-1234

---

### Before testing

When testing, please ensure that you have at least one downloadable product with a downloadable file set to something outside of the default `woocommerce_uploads` directory. You could for example add a downloadable file URL like `https://some.external.site/ebook.pdf` to a product (for our purposes here, it does not matter that it does not exist).

Please also repeat the test A) using only WP CLI to run cron and B) using only async HTTP requests to run cron. See notes below on suggested ways of setting this up.

- To only use WP CLI:
    - In `wp-config.php` set `define( 'DISABLE_WP_CRON', true );`
    - In your local crontab, add something like `* * * * * wp cron event run --due-now --path=/path/to/wp/root`
    - *Or,* you can manually run `wp cron event run --due-now` as needed.
- To use only async HTTP requests:
    - Remove or comment out the crontab rule from the previous steps (if that is the approach you used)
    - In `wp-config.php` set `define( 'DISABLE_WP_CRON', false );`

### Testing instructions

1. Reset the database version and also clear out any existing download directory rules, scheduled actions and log entries:

```sh
wp db query "DELETE FROM $(wp db prefix)actionscheduler_actions";\
wp db query "DELETE FROM $(wp db prefix)woocommerce_log";\
wp db query "DELETE FROM $(wp db prefix)wc_product_download_directories";\
wp option set woocommerce_db_version 6.4.0
```

2. Now visit **WooCommerce ▸ Home** and you should see the *"Update Required"* banner ... click to update:

<img width="1023" alt="wc-update-required" src="https://user-images.githubusercontent.com/3594411/164761994-33a462cb-d0f0-475b-bddf-8d54795fa5ac.png">

3. Now visit **Tools ▸ Scheduled Actions**:
    1. It should be possible to locate a `woocommerce_run_update_callback` action referencing `wc_update_650_approved_download_directories` in its args.
    2. Shortly after the above has run, it should also be possible to locate a pending or completed `woocommerce_download_dir_sync` action.
    3. Remember that, depending on your current wp-cron config, it may take some seconds or minutes for everything to finish processing.
4. Once all the scheduled events have finished processing, visit **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** and confirm you see the expected range of download rules:
    1. At least two rules referencing your local `wp-content/uploads/woocommerce_uploads` path.
    2. At least one more rule (referencing `https://some.external.site` or other test URL).

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.