### PR TITLE
Use the price decimal separator to format product weight and dimensions

### DIFF
--- a/plugins/woocommerce/changelog/use-configured-decimal-separator-for-product-weight-and-dimensions
+++ b/plugins/woocommerce/changelog/use-configured-decimal-separator-for-product-weight-and-dimensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the configured decimal separator to format product weight and dimensions

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -181,7 +181,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'jquery-ui-autocomplete' );
 
 				$locale  = localeconv();
-				$decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
+				$decimal_point = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
+				$decimal = ( ! empty( wc_get_price_decimal_separator() ) ) ? wc_get_price_decimal_separator() : $decimal_point;
 
 				$params = array(
 					/* translators: %s: decimal */

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -345,14 +345,16 @@ function wc_format_localized_price( $value ) {
 }
 
 /**
- * Format a decimal with PHP Locale settings.
+ * Format a decimal with the decimal separator for prices or PHP Locale settings.
  *
  * @param  string $value Decimal to localize.
  * @return string
  */
 function wc_format_localized_decimal( $value ) {
 	$locale = localeconv();
-	return apply_filters( 'woocommerce_format_localized_decimal', str_replace( '.', $locale['decimal_point'], strval( $value ) ), $value );
+	$decimal_point = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
+	$decimal = ( ! empty( wc_get_price_decimal_separator() ) ) ? wc_get_price_decimal_separator() : $decimal_point;
+	return apply_filters( 'woocommerce_format_localized_decimal', str_replace( '.', $decimal, strval( $value ) ), $value );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR link the price decimal separator to the product weight and dimensions decimal separator. Since a decimal separator is used to separate an integer, no matter if this is used for a price, weight, dimension, etc., it has sense to have a consistence in the whole site using this, settings for weight and dimensions too.

If, for some reason, a user would need to use different decimal separators for prices and weight/dimensions in the admin dashboard or front-end, they can use the following filter hooks:

- `woocommerce_format_localized_decimal`
- `woocommerce_format_weight`
- `woocommerce_format_dimensions`

Please note that this only modify the display, not the storage of the data that remains using the dot (.) as decimal separator.

This change will benefit many users, considering that [most countries](https://en.wikipedia.org/wiki/Decimal_separator#Usage_worldwide) use a comma as decimal separator than a dot.

Closes #25864.

### How to test the changes in this Pull Request:

1. Set your thousand separator as a dot (.) and decimal separator as a comma (,):
 ![image](https://user-images.githubusercontent.com/38109855/164837691-b1f9cff5-59c8-467d-8b20-0013d678f0c3.png)
2. Edit a product or create a new, and try to add a dot as decimal in the weight and any of dimensions fields (you shouldn't be able to):
 ![image](https://user-images.githubusercontent.com/38109855/164838082-db66793c-40c4-46c2-95c7-5ed67056951d.png)
3. Save your changes and check if they're still using the comma as separator:
 ![image](https://user-images.githubusercontent.com/38109855/164838064-b321cb09-0f1d-473b-bdbc-b88f6b257ce6.png)
4. Set your thousand separator as a comma (,) and decimal separator as a dot (.) and check if the weight and dimensions values follows your new settings:
 ![image](https://user-images.githubusercontent.com/38109855/164838139-4971b5a5-130e-4fff-9542-1de3896c2909.png)
5. Now, the warning will appear if you try to use a comma instead:
 ![image](https://user-images.githubusercontent.com/38109855/164838342-2122aab1-5ffd-4abc-bda1-f3492b23960b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?