### PR TITLE
Add support select2 for log_file dropdown

### DIFF
--- a/plugins/woocommerce/changelog/add-support-select2-for-log_file-dropdown
+++ b/plugins/woocommerce/changelog/add-support-select2-for-log_file-dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for select2 for the log files dropdown

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-logs.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-logs.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 		<div class="alignright">
 			<form action="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=logs' ) ); ?>" method="post">
-				<select name="log_file">
+				<select class="wc-enhanced-select" name="log_file">
 					<?php foreach ( $logs as $log_key => $log_file ) : ?>
 						<?php
 							$timestamp = filemtime( WC_LOG_DIR . $log_file );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

Go to **WooCommerce » Settings » Status » Log **, you have to see the log file dropdown loads by select2

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
