### PR TITLE
Remove WCPay in core experiment request

### DIFF
--- a/plugins/woocommerce/changelog/fix-32751-remove-wcpay-in-core-experiment-request
+++ b/plugins/woocommerce/changelog/fix-32751-remove-wcpay-in-core-experiment-request
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove `woocommerce_payments_menu_promo_nz_ie` experiment request

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -14,12 +14,6 @@ class WcPayWelcomePage {
 	const EXPERIMENT_NAME_BASE = 'woocommerce_payments_menu_promo_nz_ie_:yyyy_:mm';
 
 	/**
-	 * WCPayWelcomePage constructor.
-	 */
-	public function __construct() {
-		add_action( 'admin_menu', array( $this, 'register_payments_welcome_page' ) );
-	}
-	/**
 	 * Registers the WooCommerce Payments welcome page.
 	 */
 	public function register_payments_welcome_page() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #32751.

### How to test the changes in this Pull Request:

1. In your local, remove these lines to simulate all conditions are met to display WCPay menu : https://github.com/woocommerce/woocommerce/blob/1adbc1bdf825fca670fc79a546ead516bfd37c78/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php#L22-L37
2. Deactivate WCPay plugin if you have it
3. Refresh
4. Observe no WCPay menu is displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
