### PR TITLE
Fix eventPrefix for new task list - experiment 1

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -46,12 +46,14 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	query,
 	id,
 	eventName,
+	eventPrefix,
 	tasks,
 	twoColumns,
 	keepCompletedTaskList,
 	isComplete,
 	displayProgressHeader,
 } ) => {
+	const listEventPrefix = eventName ? eventName + '_' : eventPrefix;
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateOptions, dismissTask, undoDismissTask } = useDispatch(
 		OPTIONS_STORE_NAME
@@ -80,7 +82,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 			return;
 		}
 
-		recordEvent( `${ eventName }_view`, {
+		recordEvent( `${ listEventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
 		} );
@@ -199,7 +201,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	};
 
 	const trackClick = ( task: TaskType ) => {
-		recordEvent( `${ eventName }_click`, {
+		recordEvent( `${ listEventPrefix }click`, {
 			task_name: task.id,
 		} );
 	};

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -152,6 +152,28 @@ describe( 'TaskList', () => {
 		} );
 	} );
 
+	it( 'should trigger tasklist_view event on initial render for setup task list with eventPrefix if eventName is undefined', () => {
+		render(
+			<TaskList
+				id="setup"
+				tasks={ [] }
+				title="List title"
+				query={ {} }
+				isComplete={ false }
+				isHidden={ false }
+				eventPrefix={ 'tasklist_' }
+				displayProgressHeader={ false }
+				keepCompletedTaskList="no"
+				isVisible={ true }
+			/>
+		);
+		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
+			number_tasks: 0,
+			store_connected: null,
+		} );
+	} );
+
 	it( 'should trigger {id}_tasklist_view event on initial render for setup task list if id is not setup', () => {
 		render(
 			<TaskList

--- a/plugins/woocommerce/changelog/fix-32745_task_list_experiment_1_tracks
+++ b/plugins/woocommerce/changelog/fix-32745_task_list_experiment_1_tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix event names for tracks in new Task List. #32759


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Make sure we make use of `eventPrefix` prop that is part of each task list definition.

Closes #32745 

<img width="1252" alt="Screen Shot 2022-04-25 at 10 48 37 AM" src="https://user-images.githubusercontent.com/2240960/165102556-48c7f62d-f356-438c-97ae-f842b9a61222.png">

### How to test the changes in this Pull Request:

1. Install  [WooCommerce Admin Test Helper 0.7.2](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/tag/v0.7.2)
2. Finish the onboarding, making sure you enable usage tracking
4. Visit Tools > WCA Test Helper > Experiments and enable woocommerce_tasklist_setup_experiment_1_2022_04
5. Run `localStorage.setItem( 'debug', 'wc-admin:*' );` in your browser console
6. Visit the home screen and make sure it doesn't output a `wcadmin_undefined_view` track, it should instead trigger a `wcadmin_tasklist_view`
7. Click one of the tasks, like `Add products` and make sure it triggers a `wcadmin_tasklist_click` action with the correct task_name.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
