### PR TITLE
Added Version to WooCommerce 6.5's `composer.json`

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -2,6 +2,7 @@
 	"name": "woocommerce/woocommerce",
 	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
 	"homepage": "https://woocommerce.com/",
+	"version": "6.5.0",
 	"type": "wordpress-plugin",
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, Composer pulls the version of the current code from the branch name. In our case, since it has no idea what to call them, they are versioned as `1.0.0.0`. When we run Core alongside the feature plugin, all of the PHP files included in it have a higher version. Our solution here is to add an explicit version to `composer.json` in order to tell Composer what to put instead of `1.0.0.0`. The end result should be that Core's PHP class files are preferred and everything loads correctly.

Closes #32732.

### How to test the changes in this Pull Request:

1. Run `composer install` in `plugins/woocommerce`.
2. Review `plugins/woocommerce/vendor/composer/jetpack_autoload_classmap.php` and verify that Core PHP files are `6.5.0.0`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
