### PR TITLE
Protect against inappropriate use of saved download links

### DIFF
--- a/plugins/woocommerce/changelog/fix-32754-inactive-downloads
+++ b/plugins/woocommerce/changelog/fix-32754-inactive-downloads
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: We're adding extra protections to a newly introduced feature; a further changelog entry is not needed.
+
+

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -665,7 +665,9 @@ class WC_Download_Handler {
 		 * Since we will now render a message instead of serving a download, we should unwind some of the previously set
 		 * headers.
 		 */
-		if ( ! headers_sent() ) {
+		if ( headers_sent() ) {
+			wc_get_logger()->log( 'warning', __( 'Headers already sent when generating download error message.', 'woocommerce' ) );
+		} else {
 			header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
 			header_remove( 'Content-Description;' );
 			header_remove( 'Content-Disposition' );

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -665,10 +665,12 @@ class WC_Download_Handler {
 		 * Since we will now render a message instead of serving a download, we should unwind some of the previously set
 		 * headers.
 		 */
-		header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
-		header_remove( 'Content-Description;' );
-		header_remove( 'Content-Disposition' );
-		header_remove( 'Content-Transfer-Encoding' );
+		if ( ! headers_sent() ) {
+			header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
+			header_remove( 'Content-Description;' );
+			header_remove( 'Content-Disposition' );
+			header_remove( 'Content-Transfer-Encoding' );
+		}
 
 		if ( ! strstr( $message, '<a ' ) ) {
 			$message .= ' <a href="' . esc_url( wc_get_page_permalink( 'shop' ) ) . '" class="wc-forward">' . esc_html__( 'Go to shop', 'woocommerce' ) . '</a>';

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Approved_Directories;
+
 /**
  * Class WC_Download_Handler_Tests.
  */
@@ -48,5 +50,98 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 		$remote_file_path = 'https://dummy.woocommerce.com/dummy_file.jpg';
 		$parsed_file_path = WC_Download_Handler::parse_file_path( $remote_file_path );
 		$this->assertTrue( $parsed_file_path['remote_file'] );
+	}
+
+	/**
+	 * @testdox Customers may not use a direct download link to obtain a downloadable file that has been disabled.
+	 */
+	public function test_inactive_downloads_will_not_be_served() {
+		self::remove_download_handlers();
+
+		$downloads_served = 0;
+		$download_counter = function () use ( &$downloads_served ) {
+			$downloads_served++;
+		};
+
+		// Track downloads served.
+		add_action( 'woocommerce_download_file_force', $download_counter );
+
+		/**
+		 * @var Approved_Directories $approved_directories
+		 */
+		$approved_directories = wc_get_container()->get( Approved_Directories::class );
+		$approved_directories->set_mode( Approved_Directories::MODE_ENABLED );
+		$approved_directories->add_approved_directory( 'https://always.trusted' );
+		$approved_directory_rule_id = $approved_directories->add_approved_directory( 'https://new.supplier' );
+
+		$product = WC_Helper_Product::create_downloadable_product(
+			array(
+				array(
+					'name' => 'Book 1',
+					'file' => 'https://always.trusted/123.pdf',
+				),
+				array(
+					'name' => 'Book 2',
+					'file' => 'https://new.supplier/456.pdf',
+				),
+			)
+		);
+
+		$customer = WC_Helper_Customer::create_customer();
+		$email    = 'admin@example.org';
+		$order    = WC_Helper_Order::create_order( $customer->get_id(), $product );
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$product_id    = $product->get_id();
+		$downloads     = $product->get_downloads();
+		$download_keys = array_keys( $downloads );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$_GET = array(
+			'download_file' => $product_id,
+			'order'         => $order->get_order_key(),
+			'email'         => $email,
+			'uid'           => hash( 'sha256', $email ),
+			'key'           => $download_keys[0],
+		);
+
+		WC_Download_Handler::download_product();
+		$this->assertEquals( 1, $downloads_served, 'Valid download request (download key 1 - corresponding approved directory rule enabled) was successfully served.' );
+
+		$_GET['key'] = $download_keys[1];
+		WC_Download_Handler::download_product();
+		$this->assertEquals( 2, $downloads_served, 'Valid download request (download key 2 - corresponding approved directory rule enabled) was successfully served.' );
+
+		$approved_directories->disable_by_id( $approved_directory_rule_id );
+		$this->expectException( WPDieException::class );
+		WC_Download_Handler::download_product();
+		$this->assertEquals( 2, $downloads_served, 'Invalid download request (download key 2 - corresponding approved directory rule disabled) was not served.' );
+
+		$_GET['key'] = $download_keys[0];
+		WC_Download_Handler::download_product();
+		$this->assertEquals( 1, $downloads_served, 'Valid download request (download key 1 - corresponding approved directory rule remained enabled) was still successfully served.' );
+
+		// Cleanup.
+		add_action( 'woocommerce_download_file_force', $download_counter );
+		self::restore_download_handlers();
+	}
+
+	/**
+	 * Unregister download handlers to prevent unwanted output and side-effects.
+	 */
+	private static function remove_download_handlers() {
+		remove_action( 'woocommerce_download_file_xsendfile', array( WC_Download_Handler::class, 'download_file_xsendfile' ) );
+		remove_action( 'woocommerce_download_file_redirect', array( WC_Download_Handler::class, 'download_file_redirect' ) );
+		remove_action( 'woocommerce_download_file_force', array( WC_Download_Handler::class, 'download_file_force' ) );
+	}
+
+	/**
+	 * Restores download handlers in case needed by other tests.
+	 */
+	private static function restore_download_handlers() {
+		add_action( 'woocommerce_download_file_redirect', array( WC_Download_Handler::class, 'download_file_redirect' ), 10, 2 );
+		add_action( 'woocommerce_download_file_xsendfile', array( WC_Download_Handler::class, 'download_file_xsendfile' ), 10, 2 );
+		add_action( 'woocommerce_download_file_force', array( WC_Download_Handler::class, 'download_file_force' ), 10, 2 );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -1,7 +1,6 @@
 <?php
 
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Approved_Directories;
-use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 
 /**
  * Class WC_Download_Handler_Tests.

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -11,7 +11,7 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	 * Test for local file path.
 	 */
 	public function test_parse_file_path_for_local_file() {
-		$local_file_path = trailingslashit( wp_upload_dir()['basedir'] ) . 'dummy_file.jpg';
+		$local_file_path  = trailingslashit( wp_upload_dir()['basedir'] ) . 'dummy_file.jpg';
 		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
 		$this->assertFalse( $parsed_file_path['remote_file'] );
 	}
@@ -20,7 +20,7 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	 * Test for local URL without protocol.
 	 */
 	public function test_parse_file_path_for_local_url() {
-		$local_file_path = trailingslashit( wp_upload_dir()['baseurl'] ) . 'dummy_file.jpg';
+		$local_file_path  = trailingslashit( wp_upload_dir()['baseurl'] ) . 'dummy_file.jpg';
 		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
 		$this->assertFalse( $parsed_file_path['remote_file'] );
 	}
@@ -29,7 +29,7 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	 * Test for local file with `file` protocol.
 	 */
 	public function test_parse_file_path_for_local_file_protocol() {
-		$local_file_path = 'file:/' . trailingslashit( wp_upload_dir()['basedir'] ) . 'dummy_file.jpg';
+		$local_file_path  = 'file:/' . trailingslashit( wp_upload_dir()['basedir'] ) . 'dummy_file.jpg';
 		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
 		$this->assertFalse( $parsed_file_path['remote_file'] );
 	}
@@ -38,7 +38,7 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 	 * Test for local file with https protocom.
 	 */
 	public function test_parse_file_path_for_local_file_https_protocol() {
-		$local_file_path = site_url( '/', 'https' ) . 'dummy_file.jpg';
+		$local_file_path  = site_url( '/', 'https' ) . 'dummy_file.jpg';
 		$parsed_file_path = WC_Download_Handler::parse_file_path( $local_file_path );
 		$this->assertFalse( $parsed_file_path['remote_file'] );
 	}


### PR DESCRIPTION
When the Approved Download Directories feature is enabled, suppose that:

- A customer purchases a downloadable product containing one or more downloadable files.
- The approved directory rules for one or more of those files are subsequently disabled or deleted.
- On visiting **My Account ▸ Downloads** the customer will no longer be able to access the corresponding downloads 👍🏽 
- However, if they saved the download link or retrieve it from the order confirmation email, it will still be possible for them to access the download 👎🏽 

This change corrects that, by adding an additional check in the download handler.

Closes #32754.

### How to test the changes in this Pull Request:

1. As an administrator, visit **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** and ensure the feature is enabled (you should see a `Stop Enforcing Rules` button if it is enabled ... if you do not, click on the `Start Enforcing Rules` button).
2. Please also visit **WooCommerce ▸ Settings ▸ Products ▸ Product Downloads** and ensure the file download method is "Force Downloads" (this fix does not apply to sites operating in redirect mode).
3. Create a downloadable product and add some downloadable files. In this case, for ease of testing, it probably makes most sense to use real files/URLs.
4. As a customer, purchase the above product. As admin, set the order to "completed".
5. As the customer, visit **My Account ▸ Downloads**. You should see the expected download links, which should function as expected. Capture the download link URLs.
6. As admin, disable one or more approved download directory rules relating to those downloadable files.
7. As customer, you should see that the expected range of downloadable files are no longer present in **My Account ▸ Downloads** (this was already the case, but let's confirm it continues to work as expected).
8. Still acting as customer, try using the download links you captured earlier to by-pass this feature. They should not work (you should instead see an "Invalid download link. [Go to shop](https://example.com/shop/)" error).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

- The download handler and some of the classes it calls are not super easy to test; to that end I'm happy to revise the added test if there is a better way.
- ~Newly added test is failing locally (headers-already-sent issue). Keeping this as a draft until I figure that one out.~
- Some PHPCS clean-up is included in this change (but in a separate commit to make it easier to separate out during review). The download handler itself has lots of unaddressed (and unrelated) linting issues, which will be flagged by our automated checks, but they are mostly not of a variety that can be cleaned automatically and so I did not address.

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
