### PR TITLE
Updating an existing downloadable file to a bad path should trigger an admin notice

### DIFF
--- a/plugins/woocommerce/changelog/fix-download-file-warnings
+++ b/plugins/woocommerce/changelog/fix-download-file-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Improves a newly added feature, so a further changelog entry is not required.
+
+

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1220,6 +1220,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		foreach ( $downloads_array as $download ) {
 			$download_id = $download->get_id();
 			$is_new      = ! isset( $existing_downloads[ $download_id ] );
+			$has_changed = ! $is_new && $existing_downloads[ $download_id ]->get_file() !== $downloads_array[ $download_id ]->get_file();
 
 			try {
 				$download->check_is_valid( $this->get_object_read() );
@@ -1227,7 +1228,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			} catch ( Exception $e ) {
 				// We only add error messages for newly added downloads (let's not overwhelm the user if there are
 				// multiple existing files which are problematic).
-				if ( $is_new ) {
+				if ( $is_new || $has_changed ) {
 					$errors[] = $e->getMessage();
 				}
 

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -7,18 +7,25 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Registe
  */
 class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	/**
-	 * @testdox Ensure that individual Downloadable Products follow the rules regarding Approved Download Directories.
+	 * @var Download_Directories $download_directories
 	 */
-	public function test_fetching_of_approved_downloads() {
-		/**
-		 * @var Download_Directories $download_directories
-		 */
-		$download_directories = wc_get_container()->get( Download_Directories::class );
-		$download_directories->set_mode( Download_Directories::MODE_ENABLED );
-		$download_directories->add_approved_directory( 'https://always.trusted/' );
-		$problematic_file_source_id = $download_directories->add_approved_directory( 'https://new.supplier/' );
+	private $download_directories;
 
-		$product = WC_Helper_Product::create_downloadable_product(
+	/**
+	 * @var WC_Product_Simple
+	 */
+	private $product;
+
+	/**
+	 * Setup items we need repeatedly across tests in this class.
+	 */
+	public function set_up() {
+		$this->download_directories = wc_get_container()->get( Download_Directories::class );
+		$this->download_directories->set_mode( Download_Directories::MODE_ENABLED );
+		$this->download_directories->add_approved_directory( 'https://always.trusted/' );
+		$this->download_directories->add_approved_directory( 'https://new.supplier/' );
+
+		$this->product = WC_Helper_Product::create_downloadable_product(
 			array(
 				array(
 					'name' => 'Book 1',
@@ -31,14 +38,21 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 			)
 		);
 
+		parent::set_up();
+	}
+
+	/**
+	 * @testdox Ensure that individual Downloadable Products follow the rules regarding Approved Download Directories.
+	 */
+	public function test_fetching_of_approved_downloads() {
 		$this->assertCount(
 			2,
-			wc_get_product( $product->get_id() )->get_downloads(),
+			wc_get_product( $this->product->get_id() )->get_downloads(),
 			'If we load the downloadable product and all of its downloads are stored in trusted directories, we expect to fetch all of them.'
 		);
 
-		$download_directories->disable_by_id( $problematic_file_source_id );
-		$product_downloads = wc_get_product( $product->get_id() )->get_downloads();
+		$this->download_directories->disable_by_id( $this->download_directories->get_by_url( 'https://new.supplier/' )->get_id() );
+		$product_downloads = wc_get_product( $this->product->get_id() )->get_downloads();
 
 		$this->assertCount(
 			2,
@@ -51,12 +65,95 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 			'If a trusted download directory rule is disabled, corresponding product downloads will also be marked as disabled.'
 		);
 
-		$download_directories->set_mode( Download_Directories::MODE_DISABLED );
+		$this->download_directories->set_mode( Download_Directories::MODE_DISABLED );
 
 		$this->assertCount(
 			2,
-			wc_get_product( $product->get_id() )->get_downloads(),
+			wc_get_product( $this->product->get_id() )->get_downloads(),
 			'Disabling the Approved Download Directories system entirely does not impact our ability to fetch product downloads.'
+		);
+	}
+
+	/**
+	 * @testdox Confirm that when product downloads are set, the operation is successful (or else errors are raised) as appropriate.
+	 */
+	public function test_setting_of_product_downloads() {
+		$administrator = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$shop_manager  = self::factory()->user->create( array( 'role' => 'shop_manager' ) );
+		wp_set_current_user( $administrator );
+
+		$downloads   = $this->product->get_downloads();
+		$downloads[] = array(
+			'id'   => '',
+			'file' => 'https://not.yet.added/file.pdf',
+			'name' => 'A file',
+		);
+
+		wp_set_current_user( $administrator );
+		$this->product->set_downloads( $downloads );
+		$this->product->save();
+		$this->assertCount(
+			3,
+			$this->product->get_downloads(),
+			'Administrators can add new downloadable files and a matching download directory rule will automatically be generated if necessary.'
+		);
+
+		wp_set_current_user( $shop_manager );
+		$exception_thrown    = false;
+		$downloads   = $this->product->get_downloads();
+		$downloads[] = array(
+			'id'   => '',
+			'file' => 'https://also.not.yet.added/file.pdf',
+			'name' => 'Another file',
+		);
+
+		try {
+			$this->product->set_downloads( $downloads );
+			$this->product->save();
+		} catch ( WC_Data_Exception $e ) {
+			$exception_thrown = true;
+		}
+
+		$this->assertTrue(
+			$exception_thrown,
+			'If a shop manager attempts to add a new downloadable file (not covered by an approved directory rule) an error is generated.'
+		);
+
+		$exception_thrown                = false;
+		$downloads                       = $this->product->get_downloads();
+		$existing_file_key               = key( $downloads );
+		$downloads[ $existing_file_key ] = array(
+			'id'   => $existing_file_key,
+			'file' => 'https://another.bad.location/file.pdf',
+			'name' => 'Yet another file',
+		);
+
+		try {
+			$this->product->set_downloads( $downloads );
+			$this->product->save();
+		} catch ( WC_Data_Exception $e ) {
+			$exception_thrown = true;
+		}
+
+		$this->assertTrue(
+			$exception_thrown,
+			'If a shop manager attempts to change an existing downloadable file to a new path (not covered by an approved directory rule) an error is generated.'
+		);
+
+		$downloads                       = $this->product->get_downloads();
+		$downloads[ $existing_file_key ] = array(
+			'id'   => $existing_file_key,
+			'file' => 'https://always.trusted/why-we-test-code.pdf',
+			'name' => 'And one more file',
+		);
+
+		$this->product->set_downloads( $downloads );
+		$this->product->save();
+
+		$this->assertCount(
+			4,
+			$this->product->get_downloads(),
+			'If a shop manager attempts to change an existing downloadable file to a valid path (that is covered by an approved directory rule) that is okay.'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-product-test.php
@@ -88,7 +88,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Confirm behavior that when product downloads are set by an admin-level user.
+	 * @testdox Confirm admin-level users can update product downloads, even if the new path is initially unapproved.
 	 */
 	public function test_updating_of_product_downloads_by_admin_user() {
 		wp_set_current_user( $this->admin_user );
@@ -109,7 +109,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Confirm that attempts to add an invalid downloadable file to a product is rejected.
+	 * @testdox Confirm that attempts (by a shop manager) to add an invalid downloadable file to a product are rejected.
 	 */
 	public function test_addition_of_invalid_product_downloads_by_shop_manager() {
 		wp_set_current_user( $this->shop_manager_user );
@@ -126,7 +126,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Confirm that attempts to update a downloadable file to an invalid path is rejected.
+	 * @testdox Confirm that attempts (by a shop manager) to update a downloadable file to an invalid path are rejected.
 	 */
 	public function test_invalid_update_of_product_downloads_by_shop_manager() {
 		$downloads                       = $this->product->get_downloads();
@@ -143,7 +143,7 @@ class WC_Abstract_Product_Test extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Confirm that attempts to update a downloadable file to a different but valid path works as expected.
+	 * @testdox Confirm that attempts (by a shop manager) to update a downloadable file to a different but valid path work as expected.
 	 */
 	public function test_valid_update_of_product_downloads_by_shop_manager() {
 		$downloads                       = $this->product->get_downloads();


### PR DESCRIPTION
*Addresses an issue with product downloads (and Approved Download Directories), discovered during 6.5 release testing. Internal link for context: pb22l9-1dC-p2#comment-1236*

Let's start with a product containing two valid downloadable files:

<img width="1020" alt="2-valid-files" src="https://user-images.githubusercontent.com/3594411/165256401-35894e2c-56ca-41b9-9734-2aede0568334.png">

Suppose, as a shop manager (or other less privileged admin user), we add another file but it is in an invalid location (ie, the Approved Download Directories feature is enabled but a rule does not exist for this location):

<img width="1016" alt="add-a-bad-file" src="https://user-images.githubusercontent.com/3594411/165256624-7ec9d664-ce87-41fc-ae58-11895f2a996d.png">

Well, in that case, after saving the changes we expect to see an error message:

<img width="856" alt="bad-location-error" src="https://user-images.githubusercontent.com/3594411/165256901-2eeb495e-7299-4c3d-861d-47e7b6b7db52.png">

However, what if instead of adding a **new** downloadable file you edit an **existing** one? Using the above screenshots as an example, let's say the shop manager changes existing file *"Fine Art 001"* to an 'illegal' path: it won't be allowed (the download will be disabled), which is good, but an error message is not displayed, which is less ideal.

This change fixes that, and ensures error messages are also displayed when a less privileged admin user modifies an **existing** downloadable file to something unacceptable.

### How to test the changes in this Pull Request:

1. Enable the Approved Download Directories feature (visit **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** and confirm you see a `Stop Enforcing Rules` button: if you do not see this, click on the `Start Enforcing Rules` button instead).
2. Find an existing downloadable product (or create one) with one or more valid downloadable files.
3. As a shop manager, edit and try to add a new 'illegal' path (any path not covered by an Approved Download Directory rule): this should fail, and the expected admin error message should render.
4. As a shop manager, edit and change an existing downloadable file to an illegal path: the expected admin error message should now render for this case.
5. As a shop manager, repeat the above two steps but this time use valid paths: the changes should persist and no error should display.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.