### PR TITLE
Add Mini Cart Block Tracking

### DIFF
--- a/plugins/woocommerce/changelog/add-track_mini_cart_block
+++ b/plugins/woocommerce/changelog/add-track_mini_cart_block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Adds usage data for the Mini Cart Block to the WC Tracker snapshot.

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -60,6 +60,27 @@ class WC_Blocks_Utils {
 	}
 
 	/**
+	 * Get all instances of the specified block on a specific template part.
+	 *
+	 * @param string $block_name The name (id) of a block, e.g. `woocommerce/mini-cart`.
+	 * @param string $template_part_slug The woo page to search, e.g. `header`.
+	 * @return array Array of blocks as returned by parse_blocks().
+	 */
+	public static function get_block_from_template_part( $block_name, $template_part_slug ) {
+		$template = get_block_template( get_stylesheet() . '//' . $template_part_slug, 'wp_template_part' );
+		$blocks   = parse_blocks( $template->content );
+
+		return array_values(
+			array_filter(
+				$blocks,
+				function ( $block ) use ( $block_name ) {
+					return ( $block_name === $block['blockName'] );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Check if a given page contains a particular block.
 	 *
 	 * @param int|WP_Post $page Page post ID or post object.

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -60,29 +60,6 @@ class WC_Blocks_Utils {
 	}
 
 	/**
-	 * Get all instances of the specified block on a specific template part.
-	 *
-	 * @param string $block_name The name (id) of a block, e.g. `woocommerce/mini-cart`.
-	 * @param string $template_part_slug The woo page to search, e.g. `header`.
-	 * @return array Array of blocks as returned by parse_blocks().
-	 */
-	public static function get_block_from_template_part( $block_name, $template_part_slug ) {
-		$template = get_block_template( get_stylesheet() . '//' . $template_part_slug, 'wp_template_part' );
-		$blocks   = parse_blocks( $template->content );
-
-		$flatten_blocks = self::flatten_blocks( $blocks );
-
-		return array_values(
-			array_filter(
-				$flatten_blocks,
-				function ( $block ) use ( $block_name ) {
-					return ( $block_name === $block['blockName'] );
-				}
-			)
-		);
-	}
-
-	/**
 	 * Check if a given page contains a particular block.
 	 *
 	 * @param int|WP_Post $page Page post ID or post object.
@@ -103,48 +80,5 @@ class WC_Blocks_Utils {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Return blocks with their inner blocks flattened.
-	 *
-	 * @param array $blocks Array of blocks as returned by parse_blocks().
-	 * @return array All blocks.
-	 */
-	public static function flatten_blocks( $blocks ) {
-		return array_reduce(
-			$blocks,
-			function( $carry, $block ) {
-				array_push( $carry, array_diff_key( $block, array_flip( array( 'innerBlocks' ) ) ) );
-				if ( isset( $block['innerBlocks'] ) ) {
-					$inner_blocks = self::flatten_blocks( $block['innerBlocks'] );
-					return array_merge( $carry, $inner_blocks );
-				}
-
-				return $carry;
-			},
-			array()
-		);
-	}
-
-	/**
-	 * Get all instances of the specified block from the widget area.
-	 *
-	 * @param array $block_name The name (id) of a block, e.g. `woocommerce/mini-cart`.
-	 * @return array Array of blocks as returned by parse_blocks().
-	 */
-	public static function get_blocks_from_widget_area( $block_name ) {
-		return array_reduce(
-			get_option( 'widget_block' ),
-			function ( $acc, $block ) use ( $block_name ) {
-				$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
-				if ( ! empty( $parsed_blocks ) && $block_name === $parsed_blocks[0]['blockName'] ) {
-					array_push( $acc, $parsed_blocks[0] );
-					return $acc;
-				}
-				return $acc;
-			},
-			array()
-		);
 	}
 }

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -70,9 +70,11 @@ class WC_Blocks_Utils {
 		$template = get_block_template( get_stylesheet() . '//' . $template_part_slug, 'wp_template_part' );
 		$blocks   = parse_blocks( $template->content );
 
+		$flatten_blocks = self::flatten_blocks( $blocks );
+
 		return array_values(
 			array_filter(
-				$blocks,
+				$flatten_blocks,
 				function ( $block ) use ( $block_name ) {
 					return ( $block_name === $block['blockName'] );
 				}
@@ -101,5 +103,48 @@ class WC_Blocks_Utils {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Return blocks with their inner blocks flattened.
+	 *
+	 * @param array $blocks Array of blocks as returned by parse_blocks().
+	 * @return array All blocks.
+	 */
+	public static function flatten_blocks( $blocks ) {
+		return array_reduce(
+			$blocks,
+			function( $carry, $block ) {
+				array_push( $carry, array_diff_key( $block, array_flip( array( 'innerBlocks' ) ) ) );
+				if ( isset( $block['innerBlocks'] ) ) {
+					$inner_blocks = self::flatten_blocks( $block['innerBlocks'] );
+					return array_merge( $carry, $inner_blocks );
+				}
+
+				return $carry;
+			},
+			array()
+		);
+	}
+
+	/**
+	 * Get all instances of the specified block from the widget area.
+	 *
+	 * @param array $block_name The name (id) of a block, e.g. `woocommerce/mini-cart`.
+	 * @return array Array of blocks as returned by parse_blocks().
+	 */
+	public static function get_blocks_from_widget_area( $block_name ) {
+		return array_reduce(
+			get_option( 'widget_block' ),
+			function ( $acc, $block ) use ( $block_name ) {
+				$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
+				if ( ! empty( $parsed_blocks ) && $block_name === $parsed_blocks[0]['blockName'] ) {
+					array_push( $acc, $parsed_blocks[0] );
+					return $acc;
+				}
+				return $acc;
+			},
+			array()
+		);
 	}
 }

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -11,6 +11,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Utilities\BlocksUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -784,9 +785,9 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	public static function get_mini_cart_info() {
+	private static function get_mini_cart_info() {
 		$mini_cart_block_name = 'woocommerce/mini-cart';
-		$mini_cart_block_data = wc_current_theme_is_fse_theme() ? WC_Blocks_Utils::get_block_from_template_part( $mini_cart_block_name, 'header' ) : WC_Blocks_Utils::get_blocks_from_widget_area( $mini_cart_block_name );
+		$mini_cart_block_data = wc_current_theme_is_fse_theme() ? BlocksUtil::get_block_from_template_part( $mini_cart_block_name, 'header' ) : BlocksUtil::get_blocks_from_widget_area( $mini_cart_block_name );
 		return array(
 			'mini_cart_used'             => empty( $mini_cart_block_data[0] ) ? 'No' : 'Yes',
 			'mini_cart_block_attributes' => empty( $mini_cart_block_data[0] ) ? array() : $mini_cart_block_data[0]['attrs'],

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -166,6 +166,9 @@ class WC_Tracker {
 		// Cart & checkout tech (blocks or shortcodes).
 		$data['cart_checkout'] = self::get_cart_checkout_info();
 
+		// Mini Cart block.
+		$data['mini_cart_block'] = self::get_mini_cart_info();
+
 		// WooCommerce Admin info.
 		$data['wc_admin_disabled'] = apply_filters( 'woocommerce_admin_disabled', false ) ? 'yes' : 'no';
 
@@ -773,6 +776,33 @@ class WC_Tracker {
 			'cart_block_attributes'                     => $cart_block_data['block_attributes'],
 			'checkout_page_contains_checkout_block'     => $checkout_block_data['page_contains_block'],
 			'checkout_block_attributes'                 => $checkout_block_data['block_attributes'],
+		);
+	}
+
+	/**
+	 * Get info about the Mini Cart Block.
+	 *
+	 * @return array
+	 */
+	public static function get_mini_cart_info() {
+		$mini_cart_block_name = 'woocommerce/mini-cart';
+		$mini_cart_block_data = wc_current_theme_is_fse_theme() ? WC_Blocks_Utils::get_block_from_template_part( $mini_cart_block_name, 'header' ) :
+			array_reduce(
+				get_option( 'widget_block' ),
+				function ( $acc, $block ) use ( $mini_cart_block_name ) {
+					$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
+					if ( ! empty( $parsed_blocks ) && $mini_cart_block_name === $parsed_blocks[0]['blockName'] ) {
+						array_push( $acc, $parsed_blocks[0] );
+						return $acc;
+					}
+					return $acc;
+				},
+				array()
+			);
+
+		return array(
+			'mini_cart_used'             => empty( $mini_cart_block_data[0] ) ? 'No' : 'Yes',
+			'mini_cart_block_attributes' => empty( $mini_cart_block_data[0] ) ? array() : $mini_cart_block_data[0]['attrs'],
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -786,20 +786,7 @@ class WC_Tracker {
 	 */
 	public static function get_mini_cart_info() {
 		$mini_cart_block_name = 'woocommerce/mini-cart';
-		$mini_cart_block_data = wc_current_theme_is_fse_theme() ? WC_Blocks_Utils::get_block_from_template_part( $mini_cart_block_name, 'header' ) :
-			array_reduce(
-				get_option( 'widget_block' ),
-				function ( $acc, $block ) use ( $mini_cart_block_name ) {
-					$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
-					if ( ! empty( $parsed_blocks ) && $mini_cart_block_name === $parsed_blocks[0]['blockName'] ) {
-						array_push( $acc, $parsed_blocks[0] );
-						return $acc;
-					}
-					return $acc;
-				},
-				array()
-			);
-
+		$mini_cart_block_data = wc_current_theme_is_fse_theme() ? WC_Blocks_Utils::get_block_from_template_part( $mini_cart_block_name, 'header' ) : WC_Blocks_Utils::get_blocks_from_widget_area( $mini_cart_block_name );
 		return array(
 			'mini_cart_used'             => empty( $mini_cart_block_data[0] ) ? 'No' : 'Yes',
 			'mini_cart_block_attributes' => empty( $mini_cart_block_data[0] ) ? array() : $mini_cart_block_data[0]['attrs'],

--- a/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+/**
+ * Helper functions for working with blocks.
+ */
+class BlocksUtil {
+
+	/**
+	 * Return blocks with their inner blocks flattened.
+	 *
+	 * @param array $blocks Array of blocks as returned by parse_blocks().
+	 * @return array All blocks.
+	 */
+	public static function flatten_blocks( $blocks ) {
+		return array_reduce(
+			$blocks,
+			function( $carry, $block ) {
+				array_push( $carry, array_diff_key( $block, array_flip( array( 'innerBlocks' ) ) ) );
+				if ( isset( $block['innerBlocks'] ) ) {
+					$inner_blocks = self::flatten_blocks( $block['innerBlocks'] );
+					return array_merge( $carry, $inner_blocks );
+				}
+
+				return $carry;
+			},
+			array()
+		);
+	}
+
+	/**
+	 * Get all instances of the specified block from the widget area.
+	 *
+	 * @param array $block_name The name (id) of a block, e.g. `woocommerce/mini-cart`.
+	 * @return array Array of blocks as returned by parse_blocks().
+	 */
+	public static function get_blocks_from_widget_area( $block_name ) {
+		return array_reduce(
+			get_option( 'widget_block' ),
+			function ( $acc, $block ) use ( $block_name ) {
+				$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
+				if ( ! empty( $parsed_blocks ) && $block_name === $parsed_blocks[0]['blockName'] ) {
+					array_push( $acc, $parsed_blocks[0] );
+					return $acc;
+				}
+				return $acc;
+			},
+			array()
+		);
+	}
+
+	/**
+	 * Get all instances of the specified block on a specific template part.
+	 *
+	 * @param string $block_name The name (id) of a block, e.g. `woocommerce/mini-cart`.
+	 * @param string $template_part_slug The woo page to search, e.g. `header`.
+	 * @return array Array of blocks as returned by parse_blocks().
+	 */
+	public static function get_block_from_template_part( $block_name, $template_part_slug ) {
+		$template = get_block_template( get_stylesheet() . '//' . $template_part_slug, 'wp_template_part' );
+		$blocks   = parse_blocks( $template->content );
+
+		$flatten_blocks = self::flatten_blocks( $blocks );
+
+		return array_values(
+			array_filter(
+				$flatten_blocks,
+				function ( $block ) use ( $block_name ) {
+					return ( $block_name === $block['blockName'] );
+				}
+			)
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds extra information to the WC Tracker snapshot about the settings related to the Mini Cart Block.

For stores that are opted into the tracker, this will allow us to get useful information on how the Mini Cart Block block is used.

This is a follow up to https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6307

### How to test the changes in this Pull Request:

#### FSE theme
1. Enable an FSE Theme.
2. Open the FSE editor and add the Mini Cart Block in the Header. 
3. Click on the Mini Cart block and customize `Add-to-Cart behaviour` setting.
4. Ensure your test site is opted into tracking (`WooCommerce > Settings > Advanced > WooCommerce.com > Usage Tracking`). 

Using `wp shell`, you can call the new method directly to check the results:

- `WC_Tracker::get_mini_cart_info();` 

For example:

```
wp> WC_Tracker::get_mini_cart_info()
=> array(2) {
  ["mini_cart_used"]=>
  string(3) "Yes"
  ["mini_cart_block_attributes"]=>
  array(0) {
  }
}
```

In this case, the `Add-to-Cart behavior` setting is set to `Do Nothing`.


#### Classic theme
1. Enable a classic theme.
2. Open the widget editor and add the Mini Cart Block in a widget area.
3. Click on the Mini Cart block and customize the `Add-to-Cart behavior` setting.
4. Ensure your test site is opted into tracking (`WooCommerce > Settings > Advanced > WooCommerce.com > Usage Tracking`). 

Using `wp shell`, you can call the method directly to check the results:

- `WC_Tracker::get_tracking_data();` 

For example:

```
wp> WC_Tracker::get_tracking_data()
=> ...
 ["mini_cart_block"]=>
  array(2) {
    ["mini_cart_used"]=>
    string(2) "No"
    ["mini_cart_block_attributes"]=>
    array(0) {
    }
  }

```

In this case, the `Add-to-Cart behavior` setting is set to `Open Cart Drawer`.

When the Mini Cart is not used as a widget or added to the header, the payload will be this:

```
wp> WC_Tracker::get_tracking_data()
=> ...
["mini_cart_block"]=> 
array(2) {
  ["mini_cart_used"]=>
  string(2) "No"
  ["mini_cart_block_attributes"]=>
  array(0) {
  }
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adds usage data for the Mini Cart Block to the WC Tracker snapshot.
