### PR TITLE
Add experimental product stack component

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/constants.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/constants.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import ProductIcon from 'gridicons/dist/product';
+import CloudOutlineIcon from 'gridicons/dist/cloud-outline';
+import TypesIcon from 'gridicons/dist/types';
+import CalendarIcon from 'gridicons/dist/calendar';
+import { Icon, chevronRight, widget, link } from '@wordpress/icons';
+
+export const productTypes = Object.freeze( [
+	{
+		key: 'physical' as const,
+		title: __( 'Physical product', 'woocommerce' ),
+		content: __(
+			'A tangible item that gets delivered to customers.',
+			'woocommerce'
+		),
+		before: <ProductIcon />,
+		after: <Icon icon={ chevronRight } />,
+	},
+	{
+		key: 'digital' as const,
+		title: __( 'Digital product', 'woocommerce' ),
+		content: __(
+			'A digital product like service, downloadable book, music or video.',
+			'woocommerce'
+		),
+		before: <CloudOutlineIcon />,
+		after: <Icon icon={ chevronRight } />,
+	},
+	{
+		key: 'variable' as const,
+		title: __( 'Variable product', 'woocommerce' ),
+		content: __(
+			'A product with variations like color or size.',
+			'woocommerce'
+		),
+		before: <TypesIcon />,
+		after: <Icon icon={ chevronRight } />,
+	},
+	{
+		key: 'subscription' as const,
+		title: __( 'Subscription product', 'woocommerce' ),
+		content: __(
+			'Item that customers receive on a regular basis.',
+			'woocommerce'
+		),
+		before: <CalendarIcon />,
+		after: <Icon icon={ chevronRight } />,
+	},
+	{
+		key: 'grouped' as const,
+		title: __( 'Grouped product', 'woocommerce' ),
+		content: __( 'A collection of related products.', 'woocommerce' ),
+		before: <Icon icon={ widget } />,
+		after: <Icon icon={ chevronRight } />,
+	},
+	{
+		key: 'external' as const,
+		title: __( 'External product', 'woocommerce' ),
+		content: __( 'Link a product to an external website.', 'woocommerce' ),
+		before: <Icon icon={ link } />,
+		after: <Icon icon={ chevronRight } />,
+	},
+] );
+
+export type ProductType = typeof productTypes[ number ];
+export type ProductTypeKey = ProductType[ 'key' ];

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/constants.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/constants.tsx
@@ -6,7 +6,13 @@ import ProductIcon from 'gridicons/dist/product';
 import CloudOutlineIcon from 'gridicons/dist/cloud-outline';
 import TypesIcon from 'gridicons/dist/types';
 import CalendarIcon from 'gridicons/dist/calendar';
-import { Icon, chevronRight, widget, link } from '@wordpress/icons';
+import { Icon, chevronRight } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Link from './icon/link_24px.svg';
+import Widget from './icon/widgets_24px.svg';
 
 export const productTypes = Object.freeze( [
 	{
@@ -53,14 +59,14 @@ export const productTypes = Object.freeze( [
 		key: 'grouped' as const,
 		title: __( 'Grouped product', 'woocommerce' ),
 		content: __( 'A collection of related products.', 'woocommerce' ),
-		before: <Icon icon={ widget } />,
+		before: <img src={ Widget } alt="Widget" />,
 		after: <Icon icon={ chevronRight } />,
 	},
 	{
 		key: 'external' as const,
 		title: __( 'External product', 'woocommerce' ),
 		content: __( 'Link a product to an external website.', 'woocommerce' ),
-		before: <Icon icon={ link } />,
+		before: <img src={ Link } alt="Link" />,
 		after: <Icon icon={ chevronRight } />,
 	},
 ] );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/icon/link_24px.svg
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/icon/link_24px.svg
@@ -1,0 +1,8 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1133_132681" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="2" y="7" width="21" height="10">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 15H7.5C5.85 15 4.5 13.65 4.5 12C4.5 10.35 5.85 9 7.5 9H11.5V7H7.5C4.74 7 2.5 9.24 2.5 12C2.5 14.76 4.74 17 7.5 17H11.5V15ZM17.5 7H13.5V9H17.5C19.15 9 20.5 10.35 20.5 12C20.5 13.65 19.15 15 17.5 15H13.5V17H17.5C20.26 17 22.5 14.76 22.5 12C22.5 9.24 20.26 7 17.5 7ZM16.5 11H8.5V13H16.5V11Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_1133_132681)">
+<rect x="0.5" width="24" height="24" fill="#007CBA"/>
+</g>
+</svg>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/icon/widgets_24px.svg
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/icon/widgets_24px.svg
@@ -1,0 +1,8 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1133_132667" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="21" height="20">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.5 2.34497L10.84 7.99497V3.65497H2.84003V11.655H10.84V7.99497L16.5 13.655H12.84V21.655H20.84V13.655H16.5L22.16 7.99497L16.5 2.34497ZM19.33 8.00497L16.5 5.17497L13.67 8.00497L16.5 10.835L19.33 8.00497ZM8.84003 9.65497V5.65497H4.84003V9.65497H8.84003ZM18.84 15.655V19.655H14.84V15.655H18.84ZM8.84003 19.655V15.655H4.84003V19.655H8.84003ZM2.84003 13.655H10.84V21.655H2.84003V13.655Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_1133_132667)">
+<rect x="0.5" width="24" height="24" fill="#007CBA"/>
+</g>
+</svg>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.scss
@@ -1,0 +1,6 @@
+.woocommerce-task-products {
+	display: flex;
+	flex-direction: column;
+	width: 550px;
+	margin: auto;
+}

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -4,8 +4,20 @@
 import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { registerPlugin } from '@wordpress/plugins';
 
+/**
+ * Internal dependencies
+ */
+import { getProductTypes } from './utils';
+import './index.scss';
+import Stack from './stack';
+
 const Products = () => {
-	return <h1>Experimental products</h1>;
+	const productTypes = getProductTypes();
+	return (
+		<div className="woocommerce-task-products">
+			<Stack items={ productTypes } />
+		</div>
+	);
 };
 
 registerPlugin( 'wc-admin-onboarding-task-products', {

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
@@ -1,0 +1,61 @@
+.woocommerce-products-stack {
+	a {
+		text-decoration: none;
+		color: #007cba;
+	}
+
+	.woocommerce-list__item {
+		margin-top: 8px;
+		border-radius: 3px;
+		border: 1px solid #dcdcde;
+
+		&:hover {
+			background-color: #fff;
+			border: 1.5px solid #007cba;
+		}
+
+		&:not(.transitions-disabled) {
+			&.woocommerce-list__item-enter {
+				transform: none;
+			}
+
+			&.woocommerce-list__item-enter-active {
+				transform: none;
+			}
+
+			&.woocommerce-list__item-exit-active {
+				display: none;
+			}
+		}
+	}
+
+	.woocommerce-list__item-before {
+		background: #f0f6fc;
+		padding: 8px;
+		border-radius: 50%;
+	}
+
+	.woocommerce-list__item-title {
+		color: $gray-900;
+		line-height: 16px;
+		font-weight: 600;
+	}
+
+	.woocommerce-list__item-content {
+		color: $gray-700;
+		line-height: 16px;
+		font-weight: 400;
+	}
+
+	.woocommerce-list__item-after {
+		svg {
+			fill: $gray-600;
+		}
+	}
+
+	.woocommerce-stack-other-options {
+		margin-top: 20px;
+		color: $gray-700;
+		line-height: 16px;
+	}
+}

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { List, Link } from '@woocommerce/components';
+import interpolateComponents from '@automattic/interpolate-components';
+import { getAdminLink } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import { ProductType } from './constants';
+import './stack.scss';
+
+type StackProps = {
+	items: ProductType[];
+};
+
+const Stack: React.FC< StackProps > = ( { items } ) => {
+	return (
+		<div className="woocommerce-products-stack">
+			<List items={ items } />
+			<div className="woocommerce-stack-other-options">
+				{ interpolateComponents( {
+					mixedString: __(
+						'Can’t find your product type? {{sbLink}}Start Blank{{/sbLink}} or {{LspLink}}Load Sample Products{{/LspLink}} to see what they look like in your store.',
+						'woocommerce'
+					),
+					components: {
+						sbLink: (
+							<Link
+								onClick={ () => {
+									window.location = getAdminLink(
+										'post-new.php?post_type=product&wc_onboarding_active_task=products&tutorial=true'
+									);
+									return false;
+								} }
+								href=""
+								type="wc-admin"
+							>
+								<></>
+							</Link>
+						),
+						LspLink: (
+							// TODO: Update this to the load sample product.
+							<Link href="" type="wc-admin">
+								<></>
+							</Link>
+						),
+					},
+				} ) }
+			</div>
+		</div>
+	);
+};
+
+export default Stack;

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/utils.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/utils.tsx
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { productTypes, ProductTypeKey } from './constants';
+
+export const getProductTypes = ( exclude: ProductTypeKey[] = [] ) =>
+	productTypes.filter(
+		( productType ) => ! exclude.includes( productType.key )
+	);

--- a/plugins/woocommerce/changelog/add-product-stack
+++ b/plugins/woocommerce/changelog/add-product-stack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add experimental product stack component


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a stack component for #32634 and #32143. I'll implement functionalities in the following PRs.

![Screen Shot 2022-04-26 at 18 47 12](https://user-images.githubusercontent.com/4344253/165283701-c382e9da-4fbf-415b-a85b-0e616d35165b.png)

### How to test the changes in this Pull Request:

1. Open the `plugins/woocommerce/client/admin/config/development.json` and change `experimental-products-task` to true
2. Run `pnpm nx dev woocommerce-admin `
3. Go to WooCommerce > Home & click the "Add my products" task
4. Observe that the stack component is shown, including a 1.5 px Gutenberg-blue border when components are hovered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
