### PR TITLE
Update WooCommerce Blocks to 7.4.3

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update to WooCommerce Blocks 7.4.3

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"pelago/emogrifier": "^6.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.0",
-		"woocommerce/woocommerce-blocks": "7.4.1"
+		"woocommerce/woocommerce-blocks": "7.4.3"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03a229b123645dbf035c87685be1043a",
+    "content-hash": "2304bec8ba9ea1f4eeba718d2afe0f5d",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -681,16 +681,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v7.4.1",
+            "version": "v7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "bde2a5771ddc7970c2114da621c28b0f7b6296ca"
+                "reference": "5bba24fdaf41166a4ad24a1a45758e5ec7e8625c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/bde2a5771ddc7970c2114da621c28b0f7b6296ca",
-                "reference": "bde2a5771ddc7970c2114da621c28b0f7b6296ca",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/5bba24fdaf41166a4ad24a1a45758e5ec7e8625c",
+                "reference": "5bba24fdaf41166a4ad24a1a45758e5ec7e8625c",
                 "shasum": ""
             },
             "require": {
@@ -734,9 +734,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v7.4.1"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v7.4.3"
             },
-            "time": "2022-04-14T16:44:52+00:00"
+            "time": "2022-04-27T12:18:37+00:00"
         }
     ],
     "packages-dev": [
@@ -3021,5 +3021,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin from 7.4.1 > 7.4.3. 

Details from all the different releases included in this pull:

## Blocks 7.4.3

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6335)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/63abd07733ae4e4c12e05eb6d3828f9ab3ff4667/docs/testing/releases/743.md)

## Blocks 7.4.2

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6271)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/9f1d2341b4c50bee59bb9a6046ffb4f83edcd60c/docs/testing/releases/742.md)

### Changelog entry

> Dev - Update WooCommerce Blocks version to 7.4.3
