### PR TITLE
Fix WCA fatal with bail conditions for WCA execution paths

### DIFF
--- a/plugins/woocommerce/changelog/fix-32797-wca-fatal
+++ b/plugins/woocommerce/changelog/fix-32797-wca-fatal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix fatal errors when activated alongside WooCommerce Admin plugin

--- a/plugins/woocommerce/src/Admin/Loader.php
+++ b/plugins/woocommerce/src/Admin/Loader.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Admin;
 
 use Automattic\WooCommerce\Admin\DeprecatedClassFacade;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 
 /**
  * Loader Class.
@@ -11,6 +12,20 @@ use Automattic\WooCommerce\Admin\Features\Features;
  * @deprecated since 6.3.0, use WooCommerce\Internal\Admin\Loader.
  */
 class Loader extends DeprecatedClassFacade {
+
+	/**
+	 * The name of the non-deprecated class that this facade covers.
+	 *
+	 * @var string
+	 */
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Internal\Admin\Loader';
+
+	/**
+	 * The version that this class was deprecated in.
+	 *
+	 * @var string
+	 */
+	protected static $deprecated_in_version = '6.3.0';
 
 	/**
 	 * Returns if a specific wc-admin feature is enabled.
@@ -54,5 +69,22 @@ class Loader extends DeprecatedClassFacade {
 	public static function is_embed_page() {
 		wc_deprecated_function( 'is_embed_page', '6.3', '\Automattic\WooCommerce\Admin\PageController::is_embed_page()' );
 		return PageController::is_embed_page();
+	}
+
+	/**
+	 * Determines if a minified JS file should be served.
+	 *
+	 * @param  boolean $script_debug Only serve unminified files if script debug is on.
+	 * @return boolean If js asset should use minified version.
+	 *
+	 * @deprecated since 6.3.0, use WCAdminAssets::should_use_minified_js_file( $script_debug )
+	 */
+	public static function should_use_minified_js_file( $script_debug ) {
+		// Bail if WC isn't initialized (This can be called from WCAdmin's entrypoint).
+		if ( ! defined( 'WC_ABSPATH' ) ) {
+			return;
+		}
+		wc_deprecated_function( 'should_use_minified_js_file', '6.3', '\Automattic\WooCommerce\Internal\Admin\WCAdminAssets::should_use_minified_js_file()' );
+		return WCAdminAssets::should_use_minified_js_file( $script_debug );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Loader.php
+++ b/plugins/woocommerce/src/Admin/Loader.php
@@ -84,7 +84,6 @@ class Loader extends DeprecatedClassFacade {
 		if ( ! defined( 'WC_ABSPATH' ) ) {
 			return;
 		}
-		wc_deprecated_function( 'should_use_minified_js_file', '6.3', '\Automattic\WooCommerce\Internal\Admin\WCAdminAssets::should_use_minified_js_file()' );
 		return WCAdminAssets::should_use_minified_js_file( $script_debug );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -120,7 +120,7 @@ class FeaturePlugin {
 		 * @deprecated 3.3.0
 		 * @var string
 		 */
-		define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -68,6 +68,11 @@ class FeaturePlugin {
 	 * Init the feature plugin, only if we can detect both Gutenberg and WooCommerce.
 	 */
 	public function init() {
+		// Bail if WC isn't initialized (This can be called from WCAdmin's entrypoint).
+		if ( ! defined( 'WC_ABSPATH' ) ) {
+			return;
+		}
+
 		// Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin.
 		$this->define_constants();
 		require_once WC_ADMIN_ABSPATH . '/includes/react-admin/page-controller-functions.php';

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -124,9 +124,9 @@ class FeaturePlugin {
 			/**
 			  * Define the current WC Admin version.
 			  *
- 			  * @deprecated 3.3.0
- 			  * @var string
- 			  */
+			  * @deprecated 3.3.0
+			  * @var string
+			  */
 			define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -120,7 +120,15 @@ class FeaturePlugin {
 		 * @deprecated 3.3.0
 		 * @var string
 		 */
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
+		if ( ! defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
+			/**
+			  * Define the current WC Admin version.
+			  *
+ 			  * @deprecated 3.3.0
+ 			  * @var string
+ 			  */
+			define( 'WC_ADMIN_VERSION_NUMBER', '3.3.0' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -84,7 +84,7 @@ class Loader {
 		*/
 		remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 
-		add_action( 'admin_init', array( __CLASS__, 'is_using_installed_wc_admin_plugin' ) );
+		add_action( 'admin_init', array( __CLASS__, 'deactivate_wc_admin_plugin' ) );
 	}
 
 	/**
@@ -108,6 +108,30 @@ class Loader {
 					}
 				);
 			}
+		}
+	}
+
+	/**
+	 * Verifies which plugin version is being used. If WooCommerce Admin is installed and activated but not in use
+	 * it will show a warning.
+	 */
+	public static function deactivate_wc_admin_plugin() {
+		if ( PluginsHelper::is_plugin_active( 'woocommerce-admin' ) ) {
+			$path = PluginsHelper::get_plugin_path_from_slug( 'woocommerce-admin' );
+			deactivate_plugins( $path );
+			add_action(
+				'admin_notices',
+				function() {
+					echo '<div class="error"><p>';
+					printf(
+						/* translators: %s: is referring to the plugin's name. */
+						esc_html__( '%1$s plugin has been deactivated to avoid conflicts with %2$s plugin.', 'woocommerce' ),
+						'<code>WooCommerce Admin</code>',
+						'<code>WooCommerce</code>'
+					);
+					echo '</p></div>';
+				}
+			);
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -88,32 +88,7 @@ class Loader {
 	}
 
 	/**
-	 * Verifies which plugin version is being used. If WooCommerce Admin is installed and activated but not in use
-	 * it will show a warning.
-	 */
-	public static function is_using_installed_wc_admin_plugin() {
-		if ( PluginsHelper::is_plugin_active( 'woocommerce-admin' ) ) {
-			$path = PluginsHelper::get_plugin_data( 'woocommerce-admin' );
-			if ( WC_ADMIN_VERSION_NUMBER !== $path['Version'] ) {
-				add_action(
-					'admin_notices',
-					function() {
-						echo '<div class="error"><p>';
-						printf(
-							/* translators: %s: is referring to the plugin's name. */
-							esc_html__( 'You have the %s plugin activated but it is not being used.', 'woocommerce' ),
-							'<code>WooCommerce Admin</code>'
-						);
-						echo '</p></div>';
-					}
-				);
-			}
-		}
-	}
-
-	/**
-	 * Verifies which plugin version is being used. If WooCommerce Admin is installed and activated but not in use
-	 * it will show a warning.
+	 * If WooCommerce Admin is installed and activated, it will attempt to deactivate and show a notice.
 	 */
 	public static function deactivate_wc_admin_plugin() {
 		if ( PluginsHelper::is_plugin_active( 'woocommerce-admin' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32797. This PR: 

1. Attempts to resolve fatal errors when WCAdmin plugin is activated alongside
2. Deactivate WCAdmin plugin when it's detected

### How to test the changes in this Pull Request:

#### Build WooCommerce zip
1. In your local, run `git cherry-pick 1bbf2f50d390acad83b023d1ebe61224944fd102` to get proper WC version in autoloader (Original [PR](https://github.com/woocommerce/woocommerce/pull/32765)). Otherwise WCAdmin plugin may take precedence
3. Run `pnpm nx build:zip woocommerce` to build the zip

#### Testing on existing activated plugin
1. In a JN, install the latest stable WooCommerce
4. Install and activate WooCommerce Admin
5. Build the plugin in your local and upload it to the JN instance
6. Observe no fatal error

#### Testing new activation
1. Install and activate WooCommerce Admin
2. Observe no fatal error and a notice appears after the plugin is deactivated
<img width="774" alt="image" src="https://user-images.githubusercontent.com/3747241/165678413-50e957a1-9769-42c5-875c-6cde0cc3b70e.png">

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
