### PR TITLE
[COT] Effectively synchronize orders from the posts table to the custom orders table

### DIFF
--- a/plugins/woocommerce/changelog/cot-effectively_sync_posts_to_cot
+++ b/plugins/woocommerce/changelog/cot-effectively_sync_posts_to_cot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Effectively synchronize orders from the posts table to the custom orders table.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/MetaToMetaTableMigrator.php
@@ -8,9 +8,8 @@ namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 use Automattic\WooCommerce\Database\Migrations\MigrationHelper;
 
 /**
- * Class MetaToMetaTableMigrator.
- *
- * Generic class for powering migrations from one meta table to another table.
+ * Base class for implementing migrations from the standard WordPress meta table
+ * to custom meta (key-value pairs) tables.
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
@@ -61,7 +60,7 @@ abstract class MetaToMetaTableMigrator {
 	 *  ),
 	 * )
 	 */
-	abstract public function get_meta_config();
+	abstract public function get_meta_config(): array;
 
 	/**
 	 * MetaToMetaTableMigrator constructor.
@@ -76,7 +75,7 @@ abstract class MetaToMetaTableMigrator {
 	 *
 	 * @param array $entity_ids Entity IDs to process migration for.
 	 */
-	public function process_migration_batch_for_ids( $entity_ids ) {
+	public function process_migration_batch_for_ids( array $entity_ids ): void {
 		global $wpdb;
 		$to_migrate = $this->fetch_data_for_migration_for_ids( $entity_ids );
 
@@ -111,7 +110,7 @@ abstract class MetaToMetaTableMigrator {
 	 *
 	 * @return string Query to update batch records.
 	 */
-	public function generate_update_sql_for_batch( $batch ) {
+	public function generate_update_sql_for_batch( array $batch ): string {
 		global $wpdb;
 
 		$table             = $this->schema_config['destination']['meta']['table_name'];
@@ -149,7 +148,7 @@ abstract class MetaToMetaTableMigrator {
 	 *
 	 * @return string Insert SQL query.
 	 */
-	public function generate_insert_sql_for_batch( $batch ) {
+	public function generate_insert_sql_for_batch( array $batch ): string {
 		global $wpdb;
 
 		$table             = $this->schema_config['destination']['meta']['table_name'];
@@ -196,7 +195,7 @@ abstract class MetaToMetaTableMigrator {
 	 *      ...,
 	 * )
 	 */
-	public function fetch_data_for_migration_for_ids( $entity_ids ) {
+	public function fetch_data_for_migration_for_ids( array $entity_ids ): array {
 		global $wpdb;
 		if ( empty( $entity_ids ) ) {
 			return array(
@@ -241,7 +240,7 @@ abstract class MetaToMetaTableMigrator {
 	 *
 	 * @return array Already migrated records.
 	 */
-	private function get_already_migrated_records( $entity_ids ) {
+	private function get_already_migrated_records( array $entity_ids ): array {
 		global $wpdb;
 
 		$destination_table_name        = $this->schema_config['destination']['meta']['table_name'];
@@ -298,7 +297,7 @@ WHERE destination.$destination_entity_id_column in ( $entity_ids_placeholder ) O
 	 *
 	 * @return array[] Returns two arrays, first for records to migrate, and second for records to upgrade.
 	 */
-	private function classify_update_insert_records( $to_migrate, $already_migrated ) {
+	private function classify_update_insert_records( array $to_migrate, array $already_migrated ): array {
 		$to_update = array();
 		$to_insert = array();
 
@@ -347,7 +346,7 @@ WHERE destination.$destination_entity_id_column in ( $entity_ids_placeholder ) O
 	 *
 	 * @return string Query that can be used to fetch data.
 	 */
-	private function build_meta_table_query( $entity_ids ) {
+	private function build_meta_table_query( array $entity_ids ): string {
 		global $wpdb;
 		$source_meta_table        = $this->schema_config['source']['meta']['table_name'];
 		$source_meta_key_column   = $this->schema_config['source']['meta']['meta_key_column'];

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
@@ -6,7 +6,8 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class PostMetaToOrderMetaMigrator.
+ * Helper class to migrate records from the WordPress post meta table
+ * to the custom orders meta table.
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
@@ -34,7 +35,7 @@ class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 	 *
 	 * @return array Meta data migration config.
 	 */
-	public function get_meta_config() {
+	public function get_meta_config(): array {
 		global $wpdb;
 		// TODO: Remove hardcoding.
 		$this->table_names = array(

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
@@ -6,11 +6,11 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class WPPostMetaToOrderMetaMigrator.
+ * Class PostMetaToOrderMetaMigrator.
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
-class WPPostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
+class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 
 	/**
 	 * List of meta keys to exclude from migration.
@@ -20,7 +20,7 @@ class WPPostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 	private $excluded_columns;
 
 	/**
-	 * WPPostMetaToOrderMetaMigrator constructor.
+	 * PostMetaToOrderMetaMigrator constructor.
 	 *
 	 * @param array $excluded_columns List of meta keys to exclude from migration.
 	 */

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
@@ -6,7 +6,8 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class PostToOrderAddressTableMigrator
+ * Helper class to migrate records from the WordPress post table
+ * to the custom order addresses table.
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
@@ -33,7 +34,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return array Config.
 	 */
-	public function get_schema_config() {
+	public function get_schema_config(): array {
 		global $wpdb;
 		// TODO: Remove hardcoding.
 		$this->table_names = array(
@@ -72,7 +73,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return \string[][] Config.
 	 */
-	public function get_core_column_mapping() {
+	public function get_core_column_mapping(): array {
 		$type = $this->type;
 
 		return array(
@@ -93,7 +94,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return \string[][] Config.
 	 */
-	public function get_meta_column_config() {
+	public function get_meta_column_config(): array {
 		$type = $this->type;
 
 		return array(
@@ -158,7 +159,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	 *      ...
 	 * )
 	 */
-	public function get_already_migrated_records( $entity_ids ) {
+	public function get_already_migrated_records( array $entity_ids ): array {
 		global $wpdb;
 		$source_table                   = $this->schema_config['source']['entity']['table_name'];
 		$source_destination_join_column = $this->schema_config['source']['entity']['destination_rel_column'];

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
@@ -6,11 +6,11 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class WPPostToOrderAddressTableMigrator
+ * Class PostToOrderAddressTableMigrator
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
-class WPPostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
+class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	/**
 	 * Type of addresses being migrated, could be billing|shipping.
 	 *
@@ -19,7 +19,7 @@ class WPPostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	protected $type;
 
 	/**
-	 * WPPostToOrderAddressTableMigrator constructor.
+	 * PostToOrderAddressTableMigrator constructor.
 	 *
 	 * @param string $type Type of addresses being migrated, could be billing|shipping.
 	 */

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
@@ -6,11 +6,11 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class WPPostToOrderOpTableMigrator
+ * Class PostToOrderOpTableMigrator
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
-class WPPostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
+class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 
 	/**
 	 * Get schema config for wp_posts and wc_order_operational_detail table.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
@@ -6,7 +6,8 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class PostToOrderOpTableMigrator
+ * Helper class to migrate records from the WordPress post table
+ * to the custom order operations table.
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
@@ -17,7 +18,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return array Config.
 	 */
-	public function get_schema_config() {
+	public function get_schema_config(): array {
 		global $wpdb;
 		// TODO: Remove hardcoding.
 		$this->table_names = array(
@@ -57,7 +58,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return \string[][] Config.
 	 */
-	public function get_core_column_mapping() {
+	public function get_core_column_mapping(): array {
 		return array(
 			'id' => array(
 				'type'        => 'int',
@@ -72,7 +73,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return \string[][] Config.
 	 */
-	public function get_meta_column_config() {
+	public function get_meta_column_config(): array {
 		return array(
 			'_created_via'                  => array(
 				'type'        => 'string',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
@@ -6,7 +6,9 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class PostToOrderTableMigrator.
+ * Helper class to migrate records from the WordPress post table
+ * to the custom order table (and only that table - PostsToOrdersMigrationController
+ * is used for fully migrating orders).
  */
 class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 
@@ -15,7 +17,7 @@ class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return array Config.
 	 */
-	public function get_schema_config() {
+	public function get_schema_config(): array {
 		global $wpdb;
 
 		// TODO: Remove hardcoding.
@@ -55,7 +57,7 @@ class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return \string[][] Config.
 	 */
-	public function get_core_column_mapping() {
+	public function get_core_column_mapping(): array {
 		return array(
 			'ID'                => array(
 				'type'        => 'int',
@@ -85,7 +87,7 @@ class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 	 *
 	 * @return \string[][] Config.
 	 */
-	public function get_meta_column_config() {
+	public function get_meta_column_config(): array {
 		return array(
 			'_order_currency'       => array(
 				'type'        => 'string',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
@@ -6,9 +6,9 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 /**
- * Class WPPostToOrderTableMigrator.
+ * Class PostToOrderTableMigrator.
  */
-class WPPostToOrderTableMigrator extends MetaToCustomTableMigrator {
+class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 
 	/**
 	 * Get schema config for wp_posts and wc_order table.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -8,11 +8,12 @@ namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 use Automattic\WooCommerce\Database\Migrations\MigrationErrorLogger;
 
 /**
- * Class WPPostToCOTMigrator
+ * This is the main class used to perform the complete migration of orders
+ * from the posts table to the custom orders table.
  *
  * @package Automattic\WooCommerce\Database\Migrations\CustomOrderTable
  */
-class WPPostToCOTMigrator {
+class PostsToOrdersMigrationController {
 
 	/**
 	 * Error logger for migration errors.
@@ -57,7 +58,7 @@ class WPPostToCOTMigrator {
 	private $meta_table_migrator;
 
 	/**
-	 * WPPostToCOTMigrator constructor.
+	 * PostsToOrdersMigrationController constructor.
 	 */
 	public function __construct() {
 
@@ -76,30 +77,11 @@ class WPPostToCOTMigrator {
 	}
 
 	/**
-	 * Process next migration batch, uses option `wc_cot_migration` to checkpoints of what have been processed so far.
+	 * Migrates a set of orders from the posts table to the custom orders tables.
 	 *
-	 * @param int $batch_size Batch size of records to migrate.
-	 *
-	 * @return bool True if migration is completed, false if there are still records to process.
+	 * @param array $order_post_ids List of post IDs of the orders to migrate.
 	 */
-	public function process_next_migration_batch( $batch_size = 100 ) {
-		$order_post_ids = $this->get_next_batch_ids( $batch_size );
-		if ( 0 === count( $order_post_ids ) ) {
-			return true;
-		}
-		$this->process_migration_for_ids( $order_post_ids );
-		$last_post_migrated = max( $order_post_ids );
-		$this->update_checkpoint( $last_post_migrated );
-
-		return false;
-	}
-
-	/**
-	 * Process migration for specific order post IDs.
-	 *
-	 * @param array $order_post_ids List of post IDs to migrate.
-	 */
-	public function process_migration_for_ids( $order_post_ids ) {
+	public function migrate_orders( array $order_post_ids ): void {
 		$this->order_table_migrator->process_migration_batch_for_ids( $order_post_ids );
 		$this->billing_address_table_migrator->process_migration_batch_for_ids( $order_post_ids );
 		$this->shipping_address_table_migrator->process_migration_batch_for_ids( $order_post_ids );
@@ -109,62 +91,12 @@ class WPPostToCOTMigrator {
 	}
 
 	/**
-	 * Method to migrate single record.
+	 * Migrates an order from the posts table to the custom orders tables.
 	 *
-	 * @param int $post_id Post ID of record to migrate.
+	 * @param int $order_post_id Post ID of the order to migrate.
 	 */
-	public function process_single( $post_id ) {
-		$this->process_migration_for_ids( array( $post_id ) );
+	public function migrate_order( int $order_post_id ): void {
+		$this->migrate_orders( array( $order_post_id ) );
 		// TODO: Return error.
-	}
-
-	/**
-	 * Helper function to get where clause to send to MetaToCustomTableMigrator instance.
-	 *
-	 * @param int $batch_size Number of orders in batch.
-	 *
-	 * @return array List of IDs in the current patch.
-	 */
-	private function get_next_batch_ids( $batch_size ) {
-		global $wpdb;
-
-		$checkpoint = $this->get_checkpoint();
-		$post_ids   = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT ID FROM $wpdb->posts WHERE ID > %d AND post_type = %s ORDER BY ID ASC LIMIT %d ",
-				$checkpoint['id'],
-				'shop_order',
-				$batch_size
-			)
-		);
-
-		return $post_ids;
-	}
-
-	/**
-	 * Current checkpoint status.
-	 *
-	 * @return false|mixed|void
-	 */
-	private function get_checkpoint() {
-		return get_option( 'wc_cot_migration', array( 'id' => 0 ) );
-	}
-
-	/**
-	 * Updates current checkpoint
-	 *
-	 * @param int $id Order ID.
-	 */
-	public function update_checkpoint( $id ) {
-		return update_option( 'wc_cot_migration', array( 'id' => $id ), false );
-	}
-
-	/**
-	 * Remove checkpoint.
-	 *
-	 * @return bool Whether checkpoint was removed.
-	 */
-	public function delete_checkpoint() {
-		return delete_option( 'wp_cot_migration' );
 	}
 }

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -25,28 +25,28 @@ class PostsToOrdersMigrationController {
 	/**
 	 * Migrator instance to migrate data into wc_order table.
 	 *
-	 * @var WPPostToOrderTableMigrator
+	 * @var PostToOrderTableMigrator
 	 */
 	private $order_table_migrator;
 
 	/**
 	 * Migrator instance to migrate billing data into address table.
 	 *
-	 * @var WPPostToOrderAddressTableMigrator
+	 * @var PostToOrderAddressTableMigrator
 	 */
 	private $billing_address_table_migrator;
 
 	/**
 	 * Migrator instance to migrate shipping data into address table.
 	 *
-	 * @var WPPostToOrderAddressTableMigrator
+	 * @var PostToOrderAddressTableMigrator
 	 */
 	private $shipping_address_table_migrator;
 
 	/**
 	 * Migrator instance to migrate operational data.
 	 *
-	 * @var WPPostToOrderOpTableMigrator
+	 * @var PostToOrderOpTableMigrator
 	 */
 	private $operation_data_table_migrator;
 
@@ -62,17 +62,17 @@ class PostsToOrdersMigrationController {
 	 */
 	public function __construct() {
 
-		$this->order_table_migrator            = new WPPostToOrderTableMigrator();
-		$this->billing_address_table_migrator  = new WPPostToOrderAddressTableMigrator( 'billing' );
-		$this->shipping_address_table_migrator = new WPPostToOrderAddressTableMigrator( 'shipping' );
-		$this->operation_data_table_migrator   = new WPPostToOrderOpTableMigrator();
+		$this->order_table_migrator            = new PostToOrderTableMigrator();
+		$this->billing_address_table_migrator  = new PostToOrderAddressTableMigrator( 'billing' );
+		$this->shipping_address_table_migrator = new PostToOrderAddressTableMigrator( 'shipping' );
+		$this->operation_data_table_migrator   = new PostToOrderOpTableMigrator();
 
 		$excluded_columns = array_keys( $this->order_table_migrator->get_meta_column_config() );
 		$excluded_columns = array_merge( $excluded_columns, array_keys( $this->billing_address_table_migrator->get_meta_column_config() ) );
 		$excluded_columns = array_merge( $excluded_columns, array_keys( $this->shipping_address_table_migrator->get_meta_column_config() ) );
 		$excluded_columns = array_merge( $excluded_columns, array_keys( $this->operation_data_table_migrator->get_meta_column_config() ) );
 
-		$this->meta_table_migrator             = new WPPostMetaToOrderMetaMigrator( $excluded_columns );
+		$this->meta_table_migrator             = new PostMetaToOrderMetaMigrator( $excluded_columns );
 		$this->error_logger                    = new MigrationErrorLogger();
 	}
 

--- a/plugins/woocommerce/src/Database/Migrations/MigrationErrorLogger.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationErrorLogger.php
@@ -6,8 +6,6 @@
 namespace Automattic\WooCommerce\Database\Migrations;
 
 /**
- * Class MigrationErrorLogger.
- *
  * Error logging for custom table migrations.
  *
  * @package Automattic\WooCommerce\Database\Migrations

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -6,8 +6,6 @@
 namespace Automattic\WooCommerce\Database\Migrations;
 
 /**
- * Class MigrationHelper.
- *
  * Helper class to assist with migration related operations.
  */
 class MigrationHelper {
@@ -33,7 +31,7 @@ class MigrationHelper {
 	 *
 	 * @return string Insert clause.
 	 */
-	public static function get_insert_switch( $switch ) {
+	public static function get_insert_switch( string $switch ): string {
 		switch ( $switch ) {
 			case 'insert_ignore':
 				$insert_query = 'INSERT IGNORE';
@@ -59,7 +57,7 @@ class MigrationHelper {
 	 *
 	 * @return array Schema config escaped for backtick.
 	 */
-	public static function escape_schema_for_backtick( $schema_config ) {
+	public static function escape_schema_for_backtick( array $schema_config ): array {
 		array_walk( $schema_config['source']['entity'], array( self::class, 'escape_and_add_backtick' ) );
 		array_walk( $schema_config['source']['meta'], array( self::class, 'escape_and_add_backtick' ) );
 		array_walk( $schema_config['destination'], array( self::class, 'escape_and_add_backtick' ) );
@@ -85,7 +83,7 @@ class MigrationHelper {
 	 *
 	 * @return string $wpdb placeholder.
 	 */
-	public static function get_wpdb_placeholder_for_type( $type ) {
+	public static function get_wpdb_placeholder_for_type( string $type ): string {
 		return self::$wpdb_placeholder_for_type[ $type ];
 	}
 
@@ -96,7 +94,7 @@ class MigrationHelper {
 	 *
 	 * @return string SQL clause for INSERT...ON DUPLICATE KEY UPDATE
 	 */
-	public static function generate_on_duplicate_statement_clause( $columns ) {
+	public static function generate_on_duplicate_statement_clause( array $columns ): string {
 		$update_value_statements = array();
 		foreach ( $columns as $column ) {
 			$update_value_statements[] = "$column = VALUES( $column )";

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -24,6 +24,11 @@ class CustomOrdersTableController {
 	public const CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION = 'woocommerce_custom_orders_table_enabled';
 
 	/**
+	 * The name of the option that tells that the authoritative table must be flipped once sync finishes.
+	 */
+	private const AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION = 'woocommerce_auto_flip_authoritative_table_roles';
+
+	/**
 	 * The data store object to use.
 	 *
 	 * @var OrdersTableDataStore
@@ -371,7 +376,7 @@ class CustomOrdersTableController {
 						__( 'Switch to using the orders table as the authoritative data store for orders when sync finishes', 'woocommerce' );
 					$settings[] = array(
 						'desc' => $message,
-						'id'   => DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION,
+						'id'   => self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION,
 						'type' => 'checkbox',
 					);
 				}
@@ -435,11 +440,11 @@ class CustomOrdersTableController {
 	 * Here we switch the authoritative table if needed.
 	 */
 	private function process_sync_finished() {
-		if ( $this->auto_flip_authoritative_table_enabled() ) {
+		if ( ! $this->auto_flip_authoritative_table_enabled() ) {
 			return;
 		}
 
-		update_option( DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
+		update_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
 
 		if ( $this->custom_orders_table_usage_is_enabled() ) {
 			update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
@@ -454,7 +459,7 @@ class CustomOrdersTableController {
 	 * @return bool
 	 */
 	private function auto_flip_authoritative_table_enabled(): bool {
-		return 'yes' === get_option( DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION );
+		return 'yes' === get_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION );
 	}
 
 	/**
@@ -465,7 +470,7 @@ class CustomOrdersTableController {
 
 		// Disabling the sync implies disabling the automatic authoritative table switch too.
 		if ( ! $data_sync_is_enabled && $this->auto_flip_authoritative_table_enabled() ) {
-			update_option( DataSynchronizer::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
+			update_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
 		}
 
 		// Enabling the sync implies starting it too, if needed.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -427,10 +427,14 @@ class CustomOrdersTableController {
 			return $value;
 		}
 
+		// TODO: Re-enable the following code once the COT to posts table sync is implemented (it's currently disabled to ease testing).
+
+		/*
 		$sync_is_pending = 0 !== $this->data_synchronizer->get_current_orders_pending_sync_count();
 		if ( $sync_is_pending ) {
 			throw new \Exception( "The authoritative table for orders storage can't be changed while there are orders out of sync" );
 		}
+		*/
 
 		return $value;
 	}
@@ -477,7 +481,7 @@ class CustomOrdersTableController {
 		// We do this check here, and not in process_pre_update_option, so that if for some reason
 		// the setting is enabled but no sync is in process, sync will start by just saving the
 		// settings even without modifying them.
-		$this->data_synchronizer->maybe_start_synchronizing_pending_orders();
+		$this->data_synchronizer->maybe_start_synchronizing_pending_orders( true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -477,9 +477,7 @@ class CustomOrdersTableController {
 		// We do this check here, and not in process_pre_update_option, so that if for some reason
 		// the setting is enabled but no sync is in process, sync will start by just saving the
 		// settings even without modifying them.
-		if ( $data_sync_is_enabled && ! $this->data_synchronizer->pending_data_sync_is_in_progress() ) {
-			$this->data_synchronizer->start_synchronizing_pending_orders();
-		}
+		$this->data_synchronizer->maybe_start_synchronizing_pending_orders();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -242,10 +242,19 @@ WHERE
 	}
 
 	/**
-	 * Start an orders synchronization process.
-	 * This will setup the appropriate status information and schedule the first synchronization batch.
+	 * Start an orders synchronization process if all the following is true:
+	 *
+	 * 1. Data synchronization is enabled.
+	 * 2. Data synchronization isn't already in progress.
+	 * 3. There's at least one out of sync order.
+	 *
+	 * This will set up the appropriate status information and schedule the first synchronization batch.
 	 */
-	public function start_synchronizing_pending_orders() {
+	public function maybe_start_synchronizing_pending_orders() {
+		if ( ! $this->data_sync_is_enabled() || $this->pending_data_sync_is_in_progress() ) {
+			return;
+		}
+
 		$initial_pending_count = $this->get_current_orders_pending_sync_count();
 		if ( 0 === $initial_pending_count ) {
 			return;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -17,13 +17,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class DataSynchronizer {
 
-	public const ORDERS_DATA_SYNC_ENABLED_OPTION            = 'woocommerce_custom_orders_table_data_sync_enabled';
-	private const INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION  = 'woocommerce_initial_orders_pending_sync_count';
-	public const AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION = 'woocommerce_auto_flip_authoritative_table_roles';
-	private const PENDING_SYNC_IS_IN_PROGRESS_OPTION        = 'woocommerce_custom_orders_table_pending_sync_in_progress';
-	private const ORDERS_SYNC_SCHEDULED_ACTION_CALLBACK     = 'woocommerce_run_orders_sync_callback';
-	public const PENDING_SYNCHRONIZATION_FINISHED_ACTION    = 'woocommerce_orders_sync_finished';
-	public const PLACEHOLDER_ORDER_POST_TYPE                = 'shop_order_placehold';
+	public const ORDERS_DATA_SYNC_ENABLED_OPTION           = 'woocommerce_custom_orders_table_data_sync_enabled';
+	private const INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION = 'woocommerce_initial_orders_pending_sync_count';
+	private const PENDING_SYNC_IS_IN_PROGRESS_OPTION       = 'woocommerce_custom_orders_table_pending_sync_in_progress';
+	private const ORDERS_SYNC_SCHEDULED_ACTION_CALLBACK    = 'woocommerce_run_orders_sync_callback';
+	public const PENDING_SYNCHRONIZATION_FINISHED_ACTION   = 'woocommerce_orders_sync_finished';
+	public const PLACEHOLDER_ORDER_POST_TYPE               = 'shop_order_placehold';
 
 	// Allowed values for $type in get_ids_of_orders_pending_sync method.
 	public const ID_TYPE_MISSING_IN_ORDERS_TABLE = 0;
@@ -128,7 +127,6 @@ class DataSynchronizer {
 		return array(
 			'initial_pending_count' => (int) get_option( self::INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION, 0 ),
 			'current_pending_count' => $this->get_current_orders_pending_sync_count(),
-			'auto_flip'             => 'yes' === get_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION ),
 			'sync_in_progress'      => $this->pending_data_sync_is_in_progress(),
 		);
 	}
@@ -312,6 +310,5 @@ WHERE
 	public function cleanup_synchronization_state() {
 		delete_option( self::INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION );
 		delete_option( self::PENDING_SYNC_IS_IN_PROGRESS_OPTION );
-		delete_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -25,7 +25,7 @@ class DataSynchronizer {
 	public const PENDING_SYNCHRONIZATION_FINISHED_ACTION   = 'woocommerce_orders_sync_finished';
 	public const PLACEHOLDER_ORDER_POST_TYPE               = 'shop_order_placehold';
 
-	private const ORDERS_SYNC_BATCH_SIZE      = 50;
+	private const ORDERS_SYNC_BATCH_SIZE      = 250;
 	private const SECONDS_BETWEEN_BATCH_SYNCS = 5;
 
 	// Allowed values for $type in get_ids_of_orders_pending_sync method.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
-use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigrator;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -79,12 +79,12 @@ class DataSynchronizer {
 	/**
 	 * Class initialization, invoked by the DI container.
 	 *
-	 * @internal
-	 * @param OrdersTableDataStore $data_store The data store to use.
-	 * @param DatabaseUtil         $database_util The database util class to use.
-	 * @param WPPostToCOTMigrator  $posts_to_cot_migrator The posts to COT migration class to use.
+	 * @param OrdersTableDataStore             $data_store The data store to use.
+	 * @param DatabaseUtil                     $database_util The database util class to use.
+	 * @param PostsToOrdersMigrationController $posts_to_cot_migrator The posts to COT migration class to use.
+	 *@internal
 	 */
-	final public function init( OrdersTableDataStore $data_store, DatabaseUtil $database_util, WPPostToCOTMigrator $posts_to_cot_migrator ) {
+	final public function init( OrdersTableDataStore $data_store, DatabaseUtil $database_util, PostsToOrdersMigrationController $posts_to_cot_migrator ) {
 		$this->data_store            = $data_store;
 		$this->database_util         = $database_util;
 		$this->posts_to_cot_migrator = $posts_to_cot_migrator;
@@ -355,7 +355,7 @@ WHERE
 			// TODO: Load $order_ids orders from the orders table and create them (by updating the corresponding placeholder record) in the posts table.
 		} else {
 			$order_ids = $this->get_ids_of_orders_pending_sync( self::ID_TYPE_MISSING_IN_ORDERS_TABLE, $batch_size );
-			$this->posts_to_cot_migrator->process_migration_for_ids( $order_ids );
+			$this->posts_to_cot_migrator->migrate_orders( $order_ids );
 		}
 
 		$batch_size -= count( $order_ids );
@@ -372,7 +372,7 @@ WHERE
 		if ( $this->custom_orders_table_is_authoritative() ) {
 			// TODO: Load $order_ids orders from the orders table and update them in the posts table.
 		} else {
-			$this->posts_to_cot_migrator->process_migration_for_ids( $order_ids );
+			$this->posts_to_cot_migrator->migrate_orders( $order_ids );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/COTMigrationServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/COTMigrationServiceProvider.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
-use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigrator;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 
 /**
@@ -21,7 +21,7 @@ class COTMigrationServiceProvider extends AbstractServiceProvider {
 	 * @var string[]
 	 */
 	protected $provides = array(
-		WPPostToCOTMigrator::class,
+		PostsToOrdersMigrationController::class,
 	);
 
 	/**
@@ -32,6 +32,6 @@ class COTMigrationServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->share( WPPostToCOTMigrator::class );
+		$this->share( PostsToOrdersMigrationController::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
-use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigrator;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
@@ -32,7 +32,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 	 * Register the classes.
 	 */
 	public function register() {
-		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, WPPostToCOTMigrator::class ) );
+		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, PostsToOrdersMigrationController::class ) );
 		$this->share( CustomOrdersTableController::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class ) );
 		$this->share( OrdersTableDataStore::class );
 	}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigrator;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
@@ -31,7 +32,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 	 * Register the classes.
 	 */
 	public function register() {
-		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class ) );
+		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, WPPostToCOTMigrator::class ) );
 		$this->share( CustomOrdersTableController::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class ) );
 		$this->share( OrdersTableDataStore::class );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\WPPostToCOTMigrator;
+use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 	/**
-	 * @var WPPostToCOTMigrator
+	 * @var PostsToOrdersMigrationController
 	 */
 	private $migrator;
 
@@ -36,7 +36,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 		OrderHelper::create_order_custom_table_if_not_exist();
 		$this->sut            = wc_get_container()->get( OrdersTableDataStore::class );
-		$this->migrator       = wc_get_container()->get( WPPostToCOTMigrator::class );
+		$this->migrator       = wc_get_container()->get( PostsToOrdersMigrationController::class );
 		$this->cpt_data_store = new WC_Order_Data_Store_CPT();
 		// Add back removed filter.
 		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
@@ -48,7 +48,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 */
 	public function test_read_from_migrated_order() {
 		$post_order_id = OrderHelper::create_complex_wp_post_order();
-		$this->migrator->process_migration_for_ids( array( $post_order_id ) );
+		$this->migrator->migrate_orders( array( $post_order_id ) );
 
 		$cot_order = new WC_Order();
 		$cot_order->set_id( $post_order_id );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#### TLDR:

This pull request combines the the settings UI/scheduled actions for orders sync work that was implemented in #32062 (and adjusted in #32706) with the posts/meta tables to custom tables migration classes that were implemented in #32034 and #32640. Additionally, creating and updating orders will now cause a synchronization process to be started, provided that synchronization is enabled. It also fixes a bug related to the automatic authoritative table switch and does some significant refactor on the migration classes.

#### More precisely:

1. The scheduled action handler implemented in the `DataSynchronizer` class will now effectively synchronize orders from the posts table to the custom orders table (**but not the other way around!** That part will be implemented separately).
2. The order creation and update process will be captured by the `DataSynchronizer` class (via `woocommerce_after_order_object_save` hook) and will start a data synchronization process (only if data synchronization is enabled in settings).
    * Note/remember that another way to start a data synchronization process is to go to _Settings - Advanced - Custom data stores_ and hitting "Save", even without actually modifying any settings.
    * Also, remember that for now, actual sync will only happen when the posts table is the authoritative data source for orders.
3. Fixes the handling of the "Switch to using the other table when sync finishes" option handling, which was reversed (also, option cleanup was happening _before_ that option was actually read which made it useless).
4. Classes in the `Database\Migrations\CustomOrderTable` namespace have been refactored:
    * Some have been renamed.
    * More descriptive doc comments have been added.
    * (Now) redundant methods used during the development of the classes have been removed.
    * Type hints for parameters and return values have been added to all the methods.
5. Changes have been implemented to ease testing:
    * The code that throws an exception if a switch of the authoritative table is attempted while there are out of sync orders has been temporarily disabled. Thus it's now possible to run `wp option update woocommerce_custom_orders_table_enabled yes|no`.
    * Saving the settings will always restart the sync process, even if it's in progress already (this is currently the only way to recover from an error thrown inside the scheduled action that performs the sync).
    * Added a new filter, `woocommerce_orders_cot_and_posts_sync_step_size`, to customize the count of orders that will be synchronized in each scheduled action run.

**NOTE:** Given the scope of this pull request it's recommended to review the individual commits separately.
   
### How to test the changes in this Pull Request:

_Prerrequisite:_ having some orders in the posts table.

1. Enable the feature by adding the following code snippet somewhere, for example at the end of `woocommerce.php`:

```php
wc_get_container()
   ->get('Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController')
   ->show_feature();
```

2. If you hadn't created the orders table previously, go to _Status - Tools_ and run the  "Create and  fill custom orders table" tool. If you had, make sure that the table is empty (`truncate table wp_wc_orders` is fine).

3. Go to _WooCommerce - Settings - Advanced - Custom data stores_, you should see a message saying that there are out of sync orders (all your orders, actually) but no mention to sync being in progress.

4. Make sure that the "Use the WordPress table" radio is selected and that "Keep the posts table and the orders table synchronized" is checked, and save (save even if you didn't need to change anything).

5. Once the page reloads, you'll see that the message has changed to indicate that the sync process is in progress. Reload again repeatedly, until the message disappears.

7. Verify that the `wp_wc_orders` table now contains proper entries for all the existing orders.

8. Repeat the process (manually truncate the table, save settings with "Keep the posts table and the orders table synchronized" checked) but this time, once the first reload of the settings page check "Switch to using the orders table as the authoritative data store when sync finishes" and save. Now, after the sync finishes you should see that the "Use the WooCommerce orders table" is selected instead.

9. Make the posts table authoritative again.

10. Modify any of the existing orders, for example change its status.

11. Immediately after the previous step reload the settings page. You should see that the message appears again saying that there's one order pending sync, _**and**_ that the sync is in progress.

12. Once the sync has happened verify that the corresponding order (same value for the `id` field) has been updated accordingly in `wp_wc_orders`.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
