### PR TITLE
Adding legal messaging and fixing click behavior on task list experiment

### DIFF
--- a/packages/js/experimental/CHANGELOG.md
+++ b/packages/js/experimental/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+-   Update TaskItem props type definition.
 -   Fix setup task list style conflict #32704
 -   Update dependency `@wordpress/icons` to ^8.1.0
 -   Added Typescript type declarations. #32615

--- a/packages/js/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/js/experimental/src/experimental-list/task-item/index.tsx
@@ -39,7 +39,7 @@ type ActionArgs = {
 type TaskItemProps = {
 	title: string;
 	completed: boolean;
-	onClick: () => void;
+	onClick: React.MouseEventHandler< HTMLElement >;
 	onCollapse?: () => void;
 	onDelete?: () => void;
 	onDismiss?: () => void;

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -176,6 +176,7 @@
 			position: absolute;
 			width: 100%;
 			height: 100%;
+			pointer-events: none;
 		}
 	}
 	.woocommerce-task-list__item:not(.complete) .woocommerce-task__icon {

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { OPTIONS_STORE_NAME, TaskType } from '@woocommerce/data';
+import { TaskItem, useSlot } from '@woocommerce/experimental';
+import { useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
+import classnames from 'classnames';
+
+export type TaskListItemProps = {
+	task: TaskType;
+	activeTaskId: string;
+	taskIndex: number;
+	goToTask: () => void;
+	trackClick: () => void;
+};
+
+export const TaskListItemTwoColumn: React.FC< TaskListItemProps > = ( {
+	task,
+	activeTaskId,
+	taskIndex,
+	goToTask,
+	trackClick,
+} ) => {
+	const { createNotice } = useDispatch( 'core/notices' );
+	const { dismissTask, undoDismissTask } = useDispatch( OPTIONS_STORE_NAME );
+
+	const {
+		id: taskId,
+		title,
+		content,
+		time,
+		actionLabel,
+		isComplete,
+		additionalInfo,
+		isDismissable,
+	} = task;
+
+	const slot = useSlot( `woocommerce_onboarding_task_list_item_${ taskId }` );
+	const hasFills = Boolean( slot?.fills?.length );
+
+	const onDismissTask = ( onDismiss?: () => void ) => {
+		dismissTask( taskId );
+		createNotice( 'success', __( 'Task dismissed' ), {
+			actions: [
+				{
+					label: __( 'Undo', 'woocommerce' ),
+					onClick: () => undoDismissTask( taskId ),
+				},
+			],
+		} );
+
+		if ( onDismiss ) {
+			onDismiss();
+		}
+	};
+
+	const DefaultTaskItem = useCallback(
+		( props ) => {
+			const className = classnames(
+				'woocommerce-task-list__item index-' + taskIndex,
+				{
+					complete: isComplete,
+					'is-active': taskId === activeTaskId,
+				}
+			);
+
+			const onClickActions = () => {
+				if ( props.onClick ) {
+					trackClick();
+					return props.onClick();
+				}
+				goToTask();
+			};
+			return (
+				<TaskItem
+					key={ taskId }
+					className={ className }
+					title={ title }
+					completed={ isComplete }
+					additionalInfo={ additionalInfo }
+					content={ content }
+					onClick={ ( e: React.ChangeEvent ) => {
+						if ( e.target.tagName === 'A' ) {
+							return;
+						}
+						onClickActions();
+					} }
+					onDismiss={
+						isDismissable ? () => onDismissTask() : undefined
+					}
+					action={ () => {} }
+					actionLabel={ actionLabel }
+				/>
+			);
+		},
+		[ taskId, title, content, time, actionLabel, isComplete, activeTaskId ]
+	);
+
+	return hasFills ? (
+		<WooOnboardingTaskListItem.Slot
+			id={ taskId }
+			fillProps={ {
+				defaultTaskItem: DefaultTaskItem,
+				isComplete,
+			} }
+		/>
+	) : (
+		<DefaultTaskItem />
+	);
+};

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
@@ -83,8 +83,8 @@ export const TaskListItemTwoColumn: React.FC< TaskListItemProps > = ( {
 					completed={ isComplete }
 					additionalInfo={ additionalInfo }
 					content={ content }
-					onClick={ ( e: React.ChangeEvent ) => {
-						if ( e.target?.tagName === 'A' ) {
+					onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+						if ( ( e.target as HTMLElement ).tagName === 'A' ) {
 							return;
 						}
 						onClickActions();

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
@@ -84,7 +84,7 @@ export const TaskListItemTwoColumn: React.FC< TaskListItemProps > = ( {
 					additionalInfo={ additionalInfo }
 					content={ content }
 					onClick={ ( e: React.ChangeEvent ) => {
-						if ( e.target.tagName === 'A' ) {
+						if ( e.target?.tagName === 'A' ) {
 							return;
 						}
 						onClickActions();

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -123,8 +123,8 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 					action={ () => {} }
 					actionLabel={ task.actionLabel }
 					{ ...props }
-					onClick={ () => {
-						if ( task.isDisabled ) {
+					onClick={ ( e: React.ChangeEvent ) => {
+						if ( task.isDisabled || e.target.tagName === 'A' ) {
 							return;
 						}
 						onClickActions();

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -118,7 +118,6 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 					completed={ task.isComplete }
 					expanded={ ! task.isComplete }
 					additionalInfo={ task.additionalInfo }
-					content={ task.content }
 					onDismiss={ task.isDismissable && onDismiss }
 					action={ () => {} }
 					actionLabel={ task.actionLabel }

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -20,7 +20,7 @@ import {
 	TaskListType,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { List, TaskItem } from '@woocommerce/experimental';
+import { List } from '@woocommerce/experimental';
 import classnames from 'classnames';
 import { History } from 'history';
 
@@ -32,6 +32,7 @@ import taskHeaders from './task-headers';
 import DismissModal from './dismiss-modal';
 import TaskListCompleted from './completed';
 import { ProgressHeader } from '~/task-lists/progress-header';
+import { TaskListItemTwoColumn } from './task-list-item-two-column';
 
 export type TaskListProps = TaskListType & {
 	eventName?: string;
@@ -53,10 +54,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	displayProgressHeader,
 } ) => {
 	const listEventPrefix = eventName ? eventName + '_' : eventPrefix;
-	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateOptions, dismissTask, undoDismissTask } = useDispatch(
-		OPTIONS_STORE_NAME
-	);
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 		return {
@@ -105,23 +103,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		( task ) => ! task.isComplete && ! task.isDismissed
 	);
 
-	const onDismissTask = ( taskId: string, onDismiss?: () => void ) => {
-		dismissTask( taskId );
-		createNotice( 'success', __( 'Task dismissed' ), {
-			actions: [
-				{
-					label: __( 'Undo', 'woocommerce' ),
-					onClick: () => undoDismissTask( taskId ),
-				},
-			],
-		} );
-
-		if ( onDismiss ) {
-			onDismiss();
-		}
-	};
-
-	const hideTasks = ( event: string ) => {
+	const hideTasks = () => {
 		hideTaskList( id );
 	};
 
@@ -153,7 +135,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 										setShowDismissModal( true );
 										onToggle();
 									} else {
-										hideTasks( 'remove_card' );
+										hideTasks();
 									}
 								} }
 							>
@@ -234,15 +216,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		}
 	};
 
-	const onTaskSelected = ( task: TaskType ) => {
-		if ( task.id === 'woocommerce-payments' ) {
-			// With WCPay, we have to show the header content for user to read t&c first.
-			showTaskHeader( task );
-		} else {
-			goToTask( task );
-		}
-	};
-
 	useEffect( () => {
 		if ( selectedHeaderCard ) {
 			showTaskHeader( selectedHeaderCard );
@@ -299,31 +272,14 @@ export const TaskList: React.FC< TaskListProps > = ( {
 					</div>
 					<List animation="custom">
 						{ visibleTasks.map( ( task, index ) => {
-							++index;
-							const className = classnames(
-								'woocommerce-task-list__item index-' + index,
-								{
-									complete: task.isComplete,
-									'is-active': task.id === activeTaskId,
-								}
-							);
 							return (
-								<TaskItem
+								<TaskListItemTwoColumn
 									key={ task.id }
-									className={ className }
-									title={ task.title }
-									completed={ task.isComplete }
-									content={ task.content }
-									onClick={ () => {
-										onTaskSelected( task );
-									} }
-									onDismiss={
-										task.isDismissable
-											? () => onDismissTask( task.id )
-											: undefined
-									}
-									action={ () => {} }
-									actionLabel={ task.actionLabel }
+									taskIndex={ ++index }
+									activeTaskId={ activeTaskId }
+									task={ task }
+									goToTask={ () => goToTask( task ) }
+									trackClick={ () => trackClick( task ) }
 								/>
 							);
 						} ) }

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -15,6 +15,7 @@ jest.mock( '@woocommerce/tracks', () => ( {
 } ) );
 jest.mock( '@woocommerce/experimental', () => ( {
 	TaskItem: ( props: { title: string } ) => <div>{ props.title }</div>,
+	useSlot: jest.fn(),
 	List: jest.fn().mockImplementation( ( { children } ) => children ),
 } ) );
 jest.mock( '@woocommerce/components', () => ( {

--- a/plugins/woocommerce/changelog/add-32762
+++ b/plugins/woocommerce/changelog/add-32762
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add legal messaging on WCPay task and fix click behavior


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There are a few issues with the WCPay task and the active task list experiments:
`woocommerce_tasklist_setup_experiment_1_2022_04`
- Missing legal text
- Click behavior not functioning

`woocommerce_tasklist_setup_experiment_2_2022_04`
- Legal text does not match design
- Clicking on legal terms and conditions link still follows task click as well




Closes #32762  .

**Experiment 1:**
![image](https://user-images.githubusercontent.com/444632/165830525-dd5962f1-c7f2-45f2-a139-85c1eeba332f.png)

**Experiment 2:**
![image](https://user-images.githubusercontent.com/444632/165830437-a1247a80-3e4c-49ca-8458-5b3b7d67c633.png)


### How to test the changes in this Pull Request:

1. Checkout branch on fresh site.
2. Install the WC Admin Test Helper plugin
3. Fill out OBW, and ensure that you enable marketing.
4. Be sure to install WCPay on the Business Step of the OBW.
5. Use WC Admin Test Helper to enable `woocommerce_tasklist_setup_experiment_1_2022_04` experiment.
6. Go back to Homescreen.
7. Observe WCPay task, which should now include legal text with Terms and Conditions link.
8. Click Terms link, ensure that opens the terms and conditions in a new tab.
9. Go back to setup task list, and click the WCPay task. Ensure that it directs you to WCPay Connect screen.
10. Use WC Admin Test Helper to disable that experiment, and enable `woocommerce_tasklist_setup_experiment_2_2022_04` instead. 
11. Go back to Homescreen and click visible terms link. Ensure it works as expected.
12. Click WCPay task again and ensure it directs to WCPay Connect screen as expected.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
