### PR TITLE
Allow removal of all zone regions from a shipping zone

### DIFF
--- a/plugins/woocommerce/changelog/fix-32016-shipping-zones-loop
+++ b/plugins/woocommerce/changelog/fix-32016-shipping-zones-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow removal of all zone regions from a shipping zone

--- a/plugins/woocommerce/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/legacy/js/admin/wc-shipping-zone-methods.js
@@ -34,11 +34,17 @@
 					this.trigger( 'change:methods' );
 				},
 				save: function() {
+					// Special handling for an empty 'zone_locations' array, which jQuery filters out during $.post().
+					var changes = _.clone( this.changes );
+					if ( _.has( changes, 'zone_locations' ) && _.isEmpty( changes.zone_locations ) ) {
+						changes.zone_locations = [''];
+					}
+
 					$.post(
 						ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?' ) + 'action=woocommerce_shipping_zone_methods_save_changes',
 						{
 							wc_shipping_zones_nonce : data.wc_shipping_zones_nonce,
-							changes                 : this.changes,
+							changes                 : changes,
 							zone_id                 : data.zone_id
 						},
 						this.onSaveResponse,


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR makes sure that the AJAX request that saves changes to a shipping zone correctly handles the case when all zone regions have been removed (for example, to make the zone apply to all regions).

The current behavior is the result of [jQuery stripping empty object attributes](https://stackoverflow.com/questions/14999897/jquery-ajax-omits-empty-object-attributes) when building the AJAX request. As such, the backend action that handles the update [does not receive a `'changes'` array key](https://github.com/woocommerce/woocommerce/blob/870ea59738df0883630e9205a9899d6ca331d0fa/plugins/woocommerce/includes/class-wc-ajax.php#L2864) and falls back to returning an error.

This PR makes sure that when the `zone_locations` array is changed in the model and it's empty, we send `['']` to the backend, preventing jQuery from stripping the argument. This isn't technically correct (i.e. `[''] != []`), but unless we change the whole request to use JSON or similar it works around jQuery's behavior, fixing the issue. [Thanks to `array_filter()` and other validation on the backend](https://github.com/woocommerce/woocommerce/blob/870ea59738df0883630e9205a9899d6ca331d0fa/plugins/woocommerce/includes/class-wc-ajax.php#L2891), things are handled gracefully.

For context on why the fix lives in JS code, it's because only "changes" are sent to the backend, and so we can't assume that a missing `zone_locations` key means the zone has no regions. If so, we could end up wiping all regions from a shipping zone that only received a name change, for instance. 

Closes #32016.

### How to test the changes in this Pull Request:

1. Go to WC > Settings > Shipping.
2. Give it a name and choose a region.
3. Save changes.
4. Remove all the zone regions and click "Save Changes" again.
5. Confirm that...
   - On `trunk`: [an error is displayed and changes can't be saved](https://camo.githubusercontent.com/49f9fe5ab88d829b9da021898069cef94b07124659f8d86a25369fb4f4bca88c/68747470733a2f2f63646e2d7374642e64726f706c722e6e65742f66696c65732f6163635f313230323239362f527279327358).
   - On this branch: Changes are saved correctly.
  
### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [X] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
