### PR TITLE
Fix namespace of DatabaseUtil

### DIFF
--- a/plugins/woocommerce/src/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Utilities/DatabaseUtil.php
@@ -3,7 +3,7 @@
  * DatabaseUtil class file.
  */
 
-namespace Automattic\WooCommerce\Internal\Utilities;
+namespace Automattic\WooCommerce\Utilities;
 
 /**
  * A class of utilities for dealing with the database.


### PR DESCRIPTION
This PR does not resolve the problem. Should this file be moved to `src/Internal/`?

Please note that Composer's autoloader emits a warning for this problem: `namespace <> filesystem path`
