### PR TITLE
Update path to email template for analytics report

### DIFF
--- a/plugins/woocommerce/changelog/fix-email-template--path
+++ b/plugins/woocommerce/changelog/fix-email-template--path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update path to email template for analytics report.

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -25,7 +25,7 @@ class ReportCSVEmail extends \WC_Email {
 	 */
 	public function __construct() {
 		$this->id             = 'admin_report_export_download';
-		$this->template_base  = dirname( __DIR__ ) . '/includes/emails/';
+		$this->template_base  = WC()->plugin_path() . '/includes/react-admin/emails/';
 		$this->template_html  = 'html-admin-report-export-download.php';
 		$this->template_plain = 'plain-admin-report-export-download.php';
 		$this->report_labels  = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the path to the Analytics "Report Download" email template in the `ReportCSVEmail` class. This template has a new path due to the WooCommerce feature plugin merge.

Closes #32707  .

### How to test the changes in this Pull Request:

1. Install the WP Mail Logging plugin.
1. Install WooCommerce Smooth Generator.
1. Using WooCommerce Smooth Generator, generate orders and products. For example:
  ```
  wp wc generate orders 100 --date-start=2022-01-01
  wp wc generate products 100
  ```
1. Wait for the Scheduled actions to run.
1. Go to Analytics > Revenue.
1. Set the date range to "Year to date". 
1. Click on the "Download" icon in the "Revenue" table.
1. Go to Tools > WP Mail Log
1. View the Revenue report email.
1. See that the email template is rendered with a link to download the report.

<img width="646" alt="Screen Shot 2022-05-02 at 12 35 54 pm" src="https://user-images.githubusercontent.com/9312929/166184878-1bdad371-1984-462a-b5f0-93d1cd8a6f50.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
