### PR TITLE
Fix: Twenty Twenty-Two integration

### DIFF
--- a/plugins/woocommerce/changelog/fix-twenty-twenty-two-integration
+++ b/plugins/woocommerce/changelog/fix-twenty-twenty-two-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: Content width issue and Classic Template blocks alignment issue for Twenty Twenty-Two.

--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-two.php
@@ -20,10 +20,6 @@ class WC_Twenty_Twenty_Two {
 	 */
 	public static function init() {
 
-		// Change WooCommerce wrappers.
-		remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
-		remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
-
 		// This theme doesn't have a traditional sidebar.
 		remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
 
@@ -38,7 +34,8 @@ class WC_Twenty_Twenty_Two {
 		add_theme_support( 'wc-product-gallery-zoom' );
 		add_theme_support( 'wc-product-gallery-lightbox' );
 		add_theme_support( 'wc-product-gallery-slider' );
-		add_theme_support( 'woocommerce',
+		add_theme_support(
+			'woocommerce',
 			array(
 				'thumbnail_image_width' => 450,
 				'single_image_width'    => 600,

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -43,6 +43,13 @@ $tt2-gray: #f7f7f7;
 	h2 {
 		font-size: var(--wp--preset--font-size--large);
 	}
+
+	main {
+		.woocommerce {
+			@include clearfix();
+			max-width: 1000px;
+		}
+	}
 }
 
 .woocommerce {
@@ -1125,14 +1132,6 @@ $tt2-gray: #f7f7f7;
  * Account section
  */
 .woocommerce-account {
-
-	main {
-
-		.woocommerce {
-			@include clearfix();
-			max-width: 1000px;
-		}
-	}
 
 	.woocommerce-MyAccount-navigation {
 

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -45,33 +45,7 @@ $tt2-gray: #f7f7f7;
 	}
 }
 
-.woocommerce-page {
-
-	main {
-
-		.woocommerce {
-			@include clearfix();
-			max-width: 1000px;
-		}
-	}
-}
-
 .woocommerce {
-
-	.woocommerce-products-header,
-	.woocommerce-notices-wrapper,
-	.woocommerce-result-count,
-	.woocommerce-ordering,
-	.woocommerce-breadcrumb,
-	.products {
-		max-width: 1000px;
-	}
-
-	.wp-site-blocks > .wp-block-group {
-		max-width: 1000px;
-		margin-left: auto;
-		margin-right: auto;
-	}
 
 	// Common
 	.woocommerce-products-header {
@@ -272,7 +246,6 @@ $tt2-gray: #f7f7f7;
 
 	div.product {
 		position: relative;
-		max-width: 1000px;
 
 		> span.onsale {
 			position: absolute;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


### Changes proposed in this Pull Request:

There are some issues with the current Twenty Twenty-Two integration (which is detailed in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5863):

- The wrapper with of Single Product and Product Catalog page is fixed to 1000px and can't be changed.
- The current implementation breaks the alignment and alignment setting of the Classic Template block.

This PR fixes those issues by removing the hard-coded width and adding the wrapper back to fix the alignment issue.

The initial width of the wrapper will be set to 650px. This can be fixed in `woocommerce/woocommerce-gutenberg-products-block` by setting the default alignment of the Classic Template block to `wide`.
Update: The default layout was changed to `wide` in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6356.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5863.

### How to test the changes in this Pull Request:

1. With Twenty Twenty-Two, edit the Product Catalog template.
2. Select the Group block that contains the Classic Template.
3. Set an arbitrary background color.
4. On a new tab, go to the shop page on the front end, see the background is set and the layout doesn't break.
5. Back to the Site Editor tab, select the Classic Template block, and set the alignment to Wide.
6. See it reflects on the front end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
