### PR TITLE
Display an error message when WC Payments fails to install via the Subscriptions menu item

### DIFF
--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -42,7 +42,7 @@ const ErrorNotice = ( { isError }: { isError: boolean } ) => {
 			{ createInterpolateElement(
 				__(
 					'Installing WooCommerce Payments failed. To continue with WooCommerce Payments built-in subscriptions functionality, please install <a>WooCommerce Payments</a> manually.',
-					'woocommerce-payments'
+					'woocommerce'
 				),
 				{
 					a: (
@@ -64,7 +64,7 @@ const TOS = () => (
 		{ createInterpolateElement(
 			__(
 				'By clicking "Get started", you agree to the <a>Terms of Service</a>',
-				'woocommerce-payments'
+				'woocommerce'
 			),
 			{
 				a: (
@@ -113,7 +113,7 @@ const GetStartedButton = ( { setIsError }: { setIsError: Function } ) => {
 						} );
 				} }
 			>
-				{ __( 'Get started', 'woocommerce-payments' ) }
+				{ __( 'Get started', 'woocommerce' ) }
 			</Button>
 		</div>
 	);
@@ -129,7 +129,7 @@ const SubscriptionsPage = () => {
 			<p className="wcpay-empty-subscriptions__description">
 				{ __(
 					'Track recurring revenue and manage active subscriptions directly from your store’s dashboard — powered by WooCommerce Payments.',
-					'woocommerce-payments'
+					'woocommerce'
 				) }
 			</p>
 			<TOS />

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -48,7 +48,7 @@ const ErrorNotice = ( { isError }: { isError: boolean } ) => {
 					a: (
 						// eslint-disable-next-line jsx-a11y/anchor-has-content
 						<a
-							href="https://woocommerce.com/payments"
+							href="https://wordpress.org/plugins/woocommerce-payments/"
 							target="_blank"
 							rel="noreferrer"
 						/>

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -28,6 +28,37 @@ const {
 	onboardingUrl,
 } = window.wcWcpaySubscriptions;
 
+const ErrorNotice = ( { isError }: { isError: boolean } ) => {
+	if ( ! isError ) {
+		return null;
+	}
+
+	return (
+		<Notice
+			className="wcpay-empty-subscriptions__error"
+			status="error"
+			isDismissible={ false }
+		>
+			{ createInterpolateElement(
+				__(
+					'WooCommerce Payments failed to install. To continue with WooCommerce Payments built-in subscriptions functionality, please install <a>WooCommerce Payments</a> manually.',
+					'woocommerce-payments'
+				),
+				{
+					a: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							href="https://woocommerce.com/payments"
+							target="_blank"
+							rel="noreferrer"
+						/>
+					),
+				}
+			) }
+		</Notice>
+	);
+};
+
 const TOS = () => (
 	<p className="wcpay-empty-subscriptions__tos">
 		{ createInterpolateElement(
@@ -49,7 +80,8 @@ const TOS = () => (
 	</p>
 );
 
-const GetStartedButton = () => {
+// eslint-disable-next-line @typescript-eslint/ban-types
+const GetStartedButton = ( { setIsError }: { setIsError: Function } ) => {
 	const [ isGettingStarted, setIsGettingStarted ] = useState( false );
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
 
@@ -72,11 +104,12 @@ const GetStartedButton = () => {
 							 * Navigate to either newSubscriptionProductUrl or onboardingUrl
 							 * depending on the which treatment the user is assigned to.
 							 */
+							// eslint-disable-next-line no-console
 							console.log( 'It was a success!' );
 						} )
-						.catch( ( error ) => {
-							// TODO: Handle erorr.
-							console.log( 'Oh no, there was an error!' );
+						.catch( () => {
+							setIsGettingStarted( false );
+							setIsError( true );
 						} );
 				} }
 			>
@@ -86,18 +119,23 @@ const GetStartedButton = () => {
 	);
 };
 
-const SubscriptionsPage = () => (
-	<div className="wcpay-empty-subscriptions__container">
-		<img src={ unconnectedImage } alt="" />
-		<p className="wcpay-empty-subscriptions__description">
-			{ __(
-				'Track recurring revenue and manage active subscriptions directly from your store’s dashboard — powered by WooCommerce Payments.',
-				'woocommerce-payments'
-			) }
-		</p>
-		<TOS />
-		<GetStartedButton />
-	</div>
-);
+const SubscriptionsPage = () => {
+	const [ isError, setIsError ] = useState( false );
+
+	return (
+		<div className="wcpay-empty-subscriptions__container">
+			<ErrorNotice isError={ isError } />
+			<img src={ unconnectedImage } alt="" />
+			<p className="wcpay-empty-subscriptions__description">
+				{ __(
+					'Track recurring revenue and manage active subscriptions directly from your store’s dashboard — powered by WooCommerce Payments.',
+					'woocommerce-payments'
+				) }
+			</p>
+			<TOS />
+			<GetStartedButton setIsError={ setIsError } />
+		</div>
+	);
+};
 
 export default SubscriptionsPage;

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -41,7 +41,7 @@ const ErrorNotice = ( { isError }: { isError: boolean } ) => {
 		>
 			{ createInterpolateElement(
 				__(
-					'WooCommerce Payments failed to install. To continue with WooCommerce Payments built-in subscriptions functionality, please install <a>WooCommerce Payments</a> manually.',
+					'Installing WooCommerce Payments failed. To continue with WooCommerce Payments built-in subscriptions functionality, please install <a>WooCommerce Payments</a> manually.',
 					'woocommerce-payments'
 				),
 				{

--- a/plugins/woocommerce-admin/client/subscriptions/style.scss
+++ b/plugins/woocommerce-admin/client/subscriptions/style.scss
@@ -6,7 +6,7 @@
 	padding: 48px 0;
 	position: static;
 	height: 344px;
-	left: calc( 50% - 1240px / 2 );
+	left: calc(50% - 1240px / 2);
 	top: 271px;
 	flex: none;
 	order: 1;
@@ -27,5 +27,9 @@
 
 	.wcpay-empty-subscriptions__button_container {
 		margin: 8px 0;
+	}
+
+	.wcpay-empty-subscriptions__error {
+		margin: 15px 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds error handling to the **WooCommerce > Subscriptions** (experiment) page if the "Get Started" buttons fails to install WooCommerce Payments.

part of #32694

### How to test the changes in this Pull Request:

0. Checkout this branch and run `pnpm nx build-watch woocommerce-admin` to build assets
1. Add the `'DISALLOW_FILE_MODS'` const to your site (see example below).
2. With WooCommerce Payments and WooCommerce Subscriptions inactive, navigate to **WooCommerce > Subscriptions**
3. Click the "**Get started**" button. 
4. Once the plugin activation is attempted, you should see the following error message. 

```
define( 'DISALLOW_FILE_MODS', true );
```

<img width="1167" alt="Screen Shot 2022-05-03 at 2 16 22 pm" src="https://user-images.githubusercontent.com/8490476/166404035-bfafffd3-a225-4c2b-942d-7ad5a7e2c8ee.png">

**Note:** without the `DISALLOW_FILE_MODS` set to true, the "Get started" button will install (if necessary) and activate WooCommerce Payments but the page will appear to hang and the button will be stuck on processing. This is intended for now and will be handled by the rest of #32694 once the experiment allocation is settled.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
