### PR TITLE
Add safeguards to ensure ExPlat API requests are valid

### DIFF
--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -7,13 +7,30 @@ import apiFetch from '@wordpress/api-fetch';
 
 const EXPLAT_VERSION = '0.1.0';
 
-const getRequestQueryString = ( {
+type QueryParams = {
+	[ key: string ]: unknown;
+} & {
+	experiment_name: string;
+	anon_id: string | null;
+	woo_country_code: string;
+};
+
+const isValidQueryParams = (
+	queryParams: unknown
+): queryParams is QueryParams => {
+	return (
+		( queryParams as QueryParams ).hasOwnProperty( 'experiment_name' ) &&
+		( queryParams as QueryParams ).hasOwnProperty( 'woo_country_code' )
+	);
+};
+
+const getRequestQueryParams = ( {
 	experimentName,
 	anonId,
 }: {
 	experimentName: string;
 	anonId: string | null;
-} ): string => {
+} ): QueryParams => {
 	/**
 	 * List of URL query parameters to be sent to the server.
 	 *
@@ -27,17 +44,29 @@ const getRequestQueryString = ( {
 	 * 	return args;
 	 * });
 	 */
-	return stringify(
-		applyFilters( 'woocommerce_explat_request_args', {
-			experiment_name: experimentName,
-			anon_id: anonId ?? undefined,
-			woo_country_code:
-				window.wcSettings?.preloadSettings?.general
-					?.woocommerce_default_country ||
-				window.wcSettings?.admin?.preloadSettings?.general
-					?.woocommerce_default_country,
-		} )
-	);
+	const queryParams = applyFilters( 'woocommerce_explat_request_args', {
+		experiment_name: experimentName,
+		anon_id: anonId ?? undefined,
+		woo_country_code:
+			window.wcSettings?.preloadSettings?.general
+				?.woocommerce_default_country ||
+			window.wcSettings?.admin?.preloadSettings?.general
+				?.woocommerce_default_country,
+	} );
+
+	if ( ! isValidQueryParams( queryParams ) ) {
+		throw new Error(
+			`Invalid query Params: ${ JSON.stringify( queryParams ) }`
+		);
+	}
+
+	// Make sure test name is a valid one.
+	if ( ! /^[A-Za-z0-9_]+$/.test( queryParams.experiment_name ) ) {
+		throw new Error(
+			`Invalid A/B test name: ${ queryParams.experiment_name }`
+		);
+	}
+	return queryParams;
 };
 
 export const fetchExperimentAssignment = async ( {
@@ -52,18 +81,17 @@ export const fetchExperimentAssignment = async ( {
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);
 	}
-	if ( ! anonId ) {
+
+	const queryParams = getRequestQueryParams( { experimentName, anonId } );
+	if ( ! queryParams.anon_id ) {
 		throw new Error(
 			`Can't fetch experiment assignment without an anonId or auth, please initialize anonId first or use fetchExperimentAssignmentWithAuth instead.`
 		);
 	}
 
 	return await window.fetch(
-		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ getRequestQueryString(
-			{
-				experimentName,
-				anonId,
-			}
+		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ stringify(
+			queryParams
 		) }`
 	);
 };
@@ -82,9 +110,11 @@ export const fetchExperimentAssignmentWithAuth = async ( {
 	}
 	// Use apiFetch to send request with credentials and nonce to our backend api to get the assignment with a user token via Jetpack.
 	return await apiFetch( {
-		path: `/wc-admin/experiments/assignment?${ getRequestQueryString( {
-			experimentName,
-			anonId,
-		} ) }`,
+		path: `/wc-admin/experiments/assignment?${ stringify(
+			getRequestQueryParams( {
+				experimentName,
+				anonId,
+			} )
+		) }`,
 	} );
 };

--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -52,6 +52,12 @@ export const fetchExperimentAssignment = async ( {
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);
 	}
+	if ( ! anonId ) {
+		throw new Error(
+			`Can't fetch experiment assignment without an anonId or auth, please initialize anonId first or use fetchExperimentAssignmentWithAuth instead.`
+		);
+	}
+
 	return await window.fetch(
 		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ getRequestQueryString(
 			{

--- a/packages/js/explat/src/test/assignment-test.js
+++ b/packages/js/explat/src/test/assignment-test.js
@@ -41,6 +41,14 @@ describe( 'fetchExperimentAssignment', () => {
 			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test'
 		);
 	} );
+
+	it( 'should throw error when anonId is empty', async () => {
+		const fetchPromise = fetchExperimentAssignment( {
+			experimentId: '123',
+			anonId: null,
+		} );
+		await expect( fetchPromise ).rejects.toThrowError();
+	} );
 } );
 
 describe( 'fetchExperimentAssignmentWithAuth', () => {

--- a/packages/js/explat/src/test/assignment-test.js
+++ b/packages/js/explat/src/test/assignment-test.js
@@ -32,19 +32,35 @@ describe( 'fetchExperimentAssignment', () => {
 		);
 
 		const fetchPromise = fetchExperimentAssignment( {
-			experimentId: '123',
+			experimentName: '123',
 			anonId: 'abc',
 		} );
 		Promise.resolve( fetchPromise );
 
 		expect( fetchMock ).toHaveBeenCalledWith(
-			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test'
+			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?experiment_name=123&anon_id=abc&test=test'
 		);
 	} );
 
 	it( 'should throw error when anonId is empty', async () => {
 		const fetchPromise = fetchExperimentAssignment( {
-			experimentId: '123',
+			experimentName: '123',
+			anonId: null,
+		} );
+		await expect( fetchPromise ).rejects.toThrowError();
+	} );
+
+	it( 'should throw error when experiment_name is empty', async () => {
+		const fetchPromise = fetchExperimentAssignment( {
+			experimentName: '',
+			anonId: null,
+		} );
+		await expect( fetchPromise ).rejects.toThrowError();
+	} );
+
+	it( 'should throw error when experiment_name is invalid', async () => {
+		const fetchPromise = fetchExperimentAssignment( {
+			experimentName: '',
 			anonId: null,
 		} );
 		await expect( fetchPromise ).rejects.toThrowError();
@@ -64,13 +80,13 @@ describe( 'fetchExperimentAssignmentWithAuth', () => {
 		);
 
 		const fetchPromise = fetchExperimentAssignmentWithAuth( {
-			experimentId: '123',
+			experimentName: '123',
 			anonId: 'abc',
 		} );
 		Promise.resolve( fetchPromise );
 
 		expect( fetchMock ).toHaveBeenCalledWith(
-			'/wc-admin/experiments/assignment?anon_id=abc&test=test&_locale=user',
+			'/wc-admin/experiments/assignment?experiment_name=123&anon_id=abc&test=test&_locale=user',
 			{
 				body: undefined,
 				credentials: 'include',

--- a/plugins/woocommerce/changelog/update-32716-explat-api-requests
+++ b/plugins/woocommerce/changelog/update-32716-explat-api-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add safeguards to ensure ExPlat API requests are valid

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -122,6 +122,10 @@ final class Experimental_Abtest {
 
 		// Request as anonymous user.
 		if ( ! isset( $response ) ) {
+			if ( ! isset( $args['anon_id'] ) || empty( $args['anon_id'] ) ) {
+				return new \WP_Error( 'invalid_anon_id', 'anon_id must be an none empty string.' );
+			}
+
 			$url      = add_query_arg(
 				$args,
 				sprintf(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -61,9 +61,9 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		);
 	}
 
-		/**
-		 * Tests retrieve the test variation when consent is false
-		 */
+	/**
+	 * Tests retrieve the test variation when consent is false
+	 */
 	public function test_get_variation() {
 		delete_transient( 'abtest_variation_control' );
 		add_filter(
@@ -88,6 +88,19 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			$exp->get_variation( 'test_experiment_name' ),
 			'treatment'
+		);
+	}
+
+
+	/**
+	 * Tests return request_assignment wp error when anon_id is empty
+	 */
+	public function test_request_assignment_returns_wp_error_when_anon_id_is_empty() {
+		$exp = new Experimental_Abtest( '', 'platform', true );
+
+		$this->assertEquals(
+			is_wp_error( $exp->request_assignment( 'test_experiment_name' ) ),
+			true
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32716.

Add safeguards to make sure a user either has an `anon_id` defined and not empty or logged in to WordPress.com via Jetpack.

### How to test the changes in this Pull Request:


### Frontend

1. Run `pnpm nx build-watch woocommerce-admin`
2. Update this filter function to return an empty `anon_id`

https://github.com/woocommerce/woocommerce/blob/4c9097d6394b9524b1086ae3dac7335f06db8a85/plugins/woocommerce-admin/client/homescreen/hooks/use-headercard-experiment-hook.js#L32-L41

```js
delete args.anon_id;
// or
args.anon_id = '';
```
3. Go to WooCommerce > Home
4. Open DevTools and clear local storage `window.localStorage.clear()`
5. Reload the page
6. Should see the errors like below:

![Screen Shot 2022-05-03 at 15 49 54](https://user-images.githubusercontent.com/4344253/166420016-f3d19655-f0c1-4c35-9ca0-27457b8f82dd.png)

7. Go to the Network tab and confirm NO requests are sent to `https://public-api.wordpress.com`

### Backend


1. To test backend changes, modify `get_variation` method to **throw** the error when fetching assignments with empty `anon_id`. 

https://github.com/woocommerce/woocommerce/blob/4c9097d6394b9524b1086ae3dac7335f06db8a85/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php#L87-L101


```php
	public function get_variation( $test_name ) {
		// Default to the control variation when users haven't consented to tracking.
		if ( ! $this->consent ) {
			return 'control';
		}

                 // use filter to make anon_id empty
		add_filter(
			'woocommerce_explat_request_args',
			function( $args ) {
				$args['anon_id'] = '';
				return $args;
			},
			10,
			1
		);

                 // clear caches
		unset( $this->tests[ $test_name ] );
		if ( ! empty( get_transient( 'abtest_variation_' . $test_name ) ) ) {
			delete_transient( 'abtest_variation_' . $test_name );
		}

		$variation = $this->fetch_variation( $test_name );

		// If there was an error retrieving a variation, conceal the error for the consumer.
		if ( is_wp_error( $variation ) ) {
			throw new \Exception( $variation->get_error_message() );
		}

		return $variation;
	}
```

2. Go to WooCommerce > Home
3. Should see `Fatal error: Uncaught Exception: Unable to fetch the requested data.`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
