### PR TITLE
Test Failures: Check WP version 5.9 before adding mini_cart_block to WC Tracker

### DIFF
--- a/plugins/woocommerce/changelog/fix-mini_cart_block-tests-failing
+++ b/plugins/woocommerce/changelog/fix-mini_cart_block-tests-failing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Check WP version 5.9 before adding mini_cart_block to WC Tracker

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -167,8 +167,10 @@ class WC_Tracker {
 		// Cart & checkout tech (blocks or shortcodes).
 		$data['cart_checkout'] = self::get_cart_checkout_info();
 
-		// Mini Cart block.
-		$data['mini_cart_block'] = self::get_mini_cart_info();
+		// Mini Cart block, which only exists since wp 5.9.
+		if ( version_compare( get_bloginfo( 'version' ), '5.9', '>=' ) ) {
+			$data['mini_cart_block'] = self::get_mini_cart_info();
+		}
 
 		// WooCommerce Admin info.
 		$data['wc_admin_disabled'] = apply_filters( 'woocommerce_admin_disabled', false ) ? 'yes' : 'no';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use of `get_block_template` in WC Tracker should only be used in WP >= 5.9 [since the function does not exist prior](https://developer.wordpress.org/reference/functions/get_block_template/). This functionality was added in https://github.com/woocommerce/woocommerce/pull/32777 and breaks tests for wp 5.8 and 5.7.

### How to test the changes in this Pull Request:

1. See that tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
