### PR TITLE
Admin list table [COT]

### DIFF
--- a/plugins/woocommerce/changelog/add-32385-cot-admin-list-table
+++ b/plugins/woocommerce/changelog/add-32385-cot-admin-list-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a new admin list table implementation that works with the Custom Order Table.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -6,6 +6,7 @@
  * @version 2.5.0
  */
 
+use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable as Custom_Orders_List_Table;
 
 defined( 'ABSPATH' ) || exit;
@@ -316,6 +317,7 @@ class WC_Admin_Menus {
 	public function orders_menu(): void {
 		add_submenu_page( 'woocommerce', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_others_shop_orders', 'wc-orders', array( $this, 'orders_page' ) );
 		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'orders_table' ) );
+		Screen::add_screen( 'wc-orders', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -6,7 +6,6 @@
  * @version 2.5.0
  */
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable as Custom_Orders_List_Table;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
@@ -319,7 +318,15 @@ class WC_Admin_Menus {
 		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
 			add_submenu_page( 'woocommerce', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_others_shop_orders', 'wc-orders', array( $this, 'orders_page' ) );
 			add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'orders_table' ) );
-			Screen::add_screen( 'wc-orders', 'woocommerce' );
+
+			// In some cases (such as if the authoritative order store was changed earlier in the current request) we
+			// need an extra step to remove the menu entry for the menu post type.
+			add_action(
+				'admin_init',
+				function () {
+					remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
+				}
+			);
 		}
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -8,6 +8,7 @@
 
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable as Custom_Orders_List_Table;
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -310,14 +311,16 @@ class WC_Admin_Menus {
 	}
 
 	/**
-	 * Link to the oder admin list table from the main WooCommerce menu.
+	 * Link to the order admin list table from the main WooCommerce menu.
 	 *
 	 * @return void
 	 */
 	public function orders_menu(): void {
-		add_submenu_page( 'woocommerce', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_others_shop_orders', 'wc-orders', array( $this, 'orders_page' ) );
-		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'orders_table' ) );
-		Screen::add_screen( 'wc-orders', 'woocommerce' );
+		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
+			add_submenu_page( 'woocommerce', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_others_shop_orders', 'wc-orders', array( $this, 'orders_page' ) );
+			add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'orders_table' ) );
+			Screen::add_screen( 'wc-orders', 'woocommerce' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -6,6 +6,8 @@
  * @version 2.5.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\Orders\ListTable as Custom_Orders_List_Table;
+
 defined( 'ABSPATH' ) || exit;
 
 if ( class_exists( 'WC_Admin_Menus', false ) ) {
@@ -16,6 +18,10 @@ if ( class_exists( 'WC_Admin_Menus', false ) ) {
  * WC_Admin_Menus Class.
  */
 class WC_Admin_Menus {
+	/**
+	 * @var Custom_Orders_List_Table
+	 */
+	private $orders_list_table;
 
 	/**
 	 * Hook in tabs.
@@ -25,6 +31,7 @@ class WC_Admin_Menus {
 		add_action( 'admin_menu', array( $this, 'menu_highlight' ) );
 		add_action( 'admin_menu', array( $this, 'menu_order_count' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 9 );
+		add_action( 'admin_menu', array( $this, 'orders_menu' ), 9 );
 		add_action( 'admin_menu', array( $this, 'reports_menu' ), 20 );
 		add_action( 'admin_menu', array( $this, 'settings_menu' ), 50 );
 		add_action( 'admin_menu', array( $this, 'status_menu' ), 60 );
@@ -299,6 +306,36 @@ class WC_Admin_Menus {
 	 */
 	public function addons_page() {
 		WC_Admin_Addons::output();
+	}
+
+	/**
+	 * Link to the oder admin list table from the main WooCommerce menu.
+	 *
+	 * @return void
+	 */
+	public function orders_menu(): void {
+		add_submenu_page( 'woocommerce', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_others_shop_orders', 'wc-orders', array( $this, 'orders_page' ) );
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'orders_table' ) );
+	}
+
+	/**
+	 * Set-up the orders admin list table.
+	 *
+	 * @return void
+	 */
+	public function orders_table(): void {
+		$this->orders_list_table = new Custom_Orders_List_Table();
+		$this->orders_list_table->setup();
+	}
+
+	/**
+	 * Render the orders admin list table.
+	 *
+	 * @return void
+	 */
+	public function orders_page(): void {
+		$this->orders_list_table->prepare_items();
+		$this->orders_list_table->display();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -629,26 +629,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * Render any custom filters and search inputs for the list table.
 	 */
 	protected function render_filters() {
-		$user_string = '';
-		$user_id     = '';
-
-		if ( ! empty( $_GET['_customer_user'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
-			$user_id = absint( $_GET['_customer_user'] ); // WPCS: input var ok, sanitization ok.
-			$user    = get_user_by( 'id', $user_id );
-
-			$user_string = sprintf(
-				/* translators: 1: user display name 2: user ID 3: user email */
-				esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
-				$user->display_name,
-				absint( $user->ID ),
-				$user->user_email
-			);
-		}
-		?>
-		<select class="wc-customer-search" name="_customer_user" data-placeholder="<?php esc_attr_e( 'Filter by registered customer', 'woocommerce' ); ?>" data-allow_clear="true">
-			<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( $user_string ) ); // htmlspecialchars to prevent XSS when rendered by selectWoo. ?></option>
-		</select>
-		<?php
+		$this->orders_list_table->customers_filter();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -183,7 +183,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * Render column: order_number.
 	 */
 	protected function render_order_number_column() {
-		$this->orders_list_table->column_order( $this->object );
+		$this->orders_list_table->column_order_number( $this->object );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -6,6 +6,8 @@
  * @version 3.3.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -31,10 +33,19 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	protected $list_table_type = 'shop_order';
 
 	/**
+	 * The data store-agnostic list table implementation (introduced to support custom order tables),
+	 * which we use here to render columns.
+	 *
+	 * @var ListTable $orders_list_table
+	 */
+	private $orders_list_table;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		parent::__construct();
+		$this->orders_list_table = new ListTable();
 		add_action( 'admin_notices', array( $this, 'bulk_admin_notices' ) );
 		add_action( 'admin_footer', array( $this, 'order_preview_template' ) );
 		add_filter( 'get_search_query', array( $this, 'search_label' ) );
@@ -172,181 +183,49 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * Render column: order_number.
 	 */
 	protected function render_order_number_column() {
-		$buyer = '';
-
-		if ( $this->object->get_billing_first_name() || $this->object->get_billing_last_name() ) {
-			/* translators: 1: first name 2: last name */
-			$buyer = trim( sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $this->object->get_billing_first_name(), $this->object->get_billing_last_name() ) );
-		} elseif ( $this->object->get_billing_company() ) {
-			$buyer = trim( $this->object->get_billing_company() );
-		} elseif ( $this->object->get_customer_id() ) {
-			$user  = get_user_by( 'id', $this->object->get_customer_id() );
-			$buyer = ucwords( $user->display_name );
-		}
-
-		/**
-		 * Filter buyer name in list table orders.
-		 *
-		 * @since 3.7.0
-		 * @param string   $buyer Buyer name.
-		 * @param WC_Order $order Order data.
-		 */
-		$buyer = apply_filters( 'woocommerce_admin_order_buyer_name', $buyer, $this->object );
-
-		if ( $this->object->get_status() === 'trash' ) {
-			echo '<strong>#' . esc_attr( $this->object->get_order_number() ) . ' ' . esc_html( $buyer ) . '</strong>';
-		} else {
-			echo '<a href="#" class="order-preview" data-order-id="' . absint( $this->object->get_id() ) . '" title="' . esc_attr( __( 'Preview', 'woocommerce' ) ) . '">' . esc_html( __( 'Preview', 'woocommerce' ) ) . '</a>';
-			echo '<a href="' . esc_url( admin_url( 'post.php?post=' . absint( $this->object->get_id() ) ) . '&action=edit' ) . '" class="order-view"><strong>#' . esc_attr( $this->object->get_order_number() ) . ' ' . esc_html( $buyer ) . '</strong></a>';
-		}
+		$this->orders_list_table->column_order( $this->object );
 	}
 
 	/**
 	 * Render column: order_status.
 	 */
 	protected function render_order_status_column() {
-		$tooltip                 = '';
-		$comment_count           = get_comment_count( $this->object->get_id() );
-		$approved_comments_count = absint( $comment_count['approved'] );
-
-		if ( $approved_comments_count ) {
-			$latest_notes = wc_get_order_notes(
-				array(
-					'order_id' => $this->object->get_id(),
-					'limit'    => 1,
-					'orderby'  => 'date_created_gmt',
-				)
-			);
-
-			$latest_note = current( $latest_notes );
-
-			if ( isset( $latest_note->content ) && 1 === $approved_comments_count ) {
-				$tooltip = wc_sanitize_tooltip( $latest_note->content );
-			} elseif ( isset( $latest_note->content ) ) {
-				/* translators: %d: notes count */
-				$tooltip = wc_sanitize_tooltip( $latest_note->content . '<br/><small style="display:block">' . sprintf( _n( 'Plus %d other note', 'Plus %d other notes', ( $approved_comments_count - 1 ), 'woocommerce' ), $approved_comments_count - 1 ) . '</small>' );
-			} else {
-				/* translators: %d: notes count */
-				$tooltip = wc_sanitize_tooltip( sprintf( _n( '%d note', '%d notes', $approved_comments_count, 'woocommerce' ), $approved_comments_count ) );
-			}
-		}
-
-		if ( $tooltip ) {
-			printf( '<mark class="order-status %s tips" data-tip="%s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $this->object->get_status() ) ), wp_kses_post( $tooltip ), esc_html( wc_get_order_status_name( $this->object->get_status() ) ) );
-		} else {
-			printf( '<mark class="order-status %s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $this->object->get_status() ) ), esc_html( wc_get_order_status_name( $this->object->get_status() ) ) );
-		}
+		$this->orders_list_table->column_status( $this->object );
 	}
 
 	/**
 	 * Render column: order_date.
 	 */
 	protected function render_order_date_column() {
-		$order_timestamp = $this->object->get_date_created() ? $this->object->get_date_created()->getTimestamp() : '';
-
-		if ( ! $order_timestamp ) {
-			echo '&ndash;';
-			return;
-		}
-
-		// Check if the order was created within the last 24 hours, and not in the future.
-		if ( $order_timestamp > strtotime( '-1 day', time() ) && $order_timestamp <= time() ) {
-			$show_date = sprintf(
-				/* translators: %s: human-readable time difference */
-				_x( '%s ago', '%s = human-readable time difference', 'woocommerce' ),
-				human_time_diff( $this->object->get_date_created()->getTimestamp(), time() )
-			);
-		} else {
-			$show_date = $this->object->get_date_created()->date_i18n( apply_filters( 'woocommerce_admin_order_date_format', __( 'M j, Y', 'woocommerce' ) ) );
-		}
-		printf(
-			'<time datetime="%1$s" title="%2$s">%3$s</time>',
-			esc_attr( $this->object->get_date_created()->date( 'c' ) ),
-			esc_html( $this->object->get_date_created()->date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) ),
-			esc_html( $show_date )
-		);
+		$this->orders_list_table->column_date( $this->object );
 	}
 
 	/**
 	 * Render column: order_total.
 	 */
 	protected function render_order_total_column() {
-		if ( $this->object->get_payment_method_title() ) {
-			/* translators: %s: method */
-			echo '<span class="tips" data-tip="' . esc_attr( sprintf( __( 'via %s', 'woocommerce' ), $this->object->get_payment_method_title() ) ) . '">' . wp_kses_post( $this->object->get_formatted_order_total() ) . '</span>';
-		} else {
-			echo wp_kses_post( $this->object->get_formatted_order_total() );
-		}
+		$this->orders_list_table->column_total( $this->object );
 	}
 
 	/**
 	 * Render column: wc_actions.
 	 */
 	protected function render_wc_actions_column() {
-		echo '<p>';
-
-		do_action( 'woocommerce_admin_order_actions_start', $this->object );
-
-		$actions = array();
-
-		if ( $this->object->has_status( array( 'pending', 'on-hold' ) ) ) {
-			$actions['processing'] = array(
-				'url'    => wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_status&status=processing&order_id=' . $this->object->get_id() ), 'woocommerce-mark-order-status' ),
-				'name'   => __( 'Processing', 'woocommerce' ),
-				'action' => 'processing',
-			);
-		}
-
-		if ( $this->object->has_status( array( 'pending', 'on-hold', 'processing' ) ) ) {
-			$actions['complete'] = array(
-				'url'    => wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_status&status=completed&order_id=' . $this->object->get_id() ), 'woocommerce-mark-order-status' ),
-				'name'   => __( 'Complete', 'woocommerce' ),
-				'action' => 'complete',
-			);
-		}
-
-		$actions = apply_filters( 'woocommerce_admin_order_actions', $actions, $this->object );
-
-		echo wc_render_action_buttons( $actions ); // WPCS: XSS ok.
-
-		do_action( 'woocommerce_admin_order_actions_end', $this->object );
-
-		echo '</p>';
+		$this->orders_list_table->column_actions( $this->object );
 	}
 
 	/**
 	 * Render column: billing_address.
 	 */
 	protected function render_billing_address_column() {
-		$address = $this->object->get_formatted_billing_address();
-
-		if ( $address ) {
-			echo esc_html( preg_replace( '#<br\s*/?>#i', ', ', $address ) );
-
-			if ( $this->object->get_payment_method() ) {
-				/* translators: %s: payment method */
-				echo '<span class="description">' . sprintf( __( 'via %s', 'woocommerce' ), esc_html( $this->object->get_payment_method_title() ) ) . '</span>'; // WPCS: XSS ok.
-			}
-		} else {
-			echo '&ndash;';
-		}
+		$this->orders_list_table->column_billing( $this->object );
 	}
 
 	/**
 	 * Render column: shipping_address.
 	 */
 	protected function render_shipping_address_column() {
-		$address = $this->object->get_formatted_shipping_address();
-
-		if ( $address ) {
-			echo '<a target="_blank" href="' . esc_url( $this->object->get_shipping_address_map_url() ) . '">' . esc_html( preg_replace( '#<br\s*/?>#i', ', ', $address ) ) . '</a>';
-			if ( $this->object->get_shipping_method() ) {
-				/* translators: %s: shipping method */
-				echo '<span class="description">' . sprintf( __( 'via %s', 'woocommerce' ), esc_html( $this->object->get_shipping_method() ) ) . '</span>'; // WPCS: XSS ok.
-			}
-		} else {
-			echo '&ndash;';
-		}
+		$this->orders_list_table->column_ship_to( $this->object );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -190,42 +190,42 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * Render column: order_status.
 	 */
 	protected function render_order_status_column() {
-		$this->orders_list_table->column_status( $this->object );
+		$this->orders_list_table->column_order_status( $this->object );
 	}
 
 	/**
 	 * Render column: order_date.
 	 */
 	protected function render_order_date_column() {
-		$this->orders_list_table->column_date( $this->object );
+		$this->orders_list_table->column_order_date( $this->object );
 	}
 
 	/**
 	 * Render column: order_total.
 	 */
 	protected function render_order_total_column() {
-		$this->orders_list_table->column_total( $this->object );
+		$this->orders_list_table->column_order_total( $this->object );
 	}
 
 	/**
 	 * Render column: wc_actions.
 	 */
 	protected function render_wc_actions_column() {
-		$this->orders_list_table->column_actions( $this->object );
+		$this->orders_list_table->column_wc_actions( $this->object );
 	}
 
 	/**
 	 * Render column: billing_address.
 	 */
 	protected function render_billing_address_column() {
-		$this->orders_list_table->column_billing( $this->object );
+		$this->orders_list_table->column_billing_address( $this->object );
 	}
 
 	/**
 	 * Render column: shipping_address.
 	 */
 	protected function render_shipping_address_column() {
-		$this->orders_list_table->column_ship_to( $this->object );
+		$this->orders_list_table->column_shipping_address( $this->object );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -57,17 +57,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * Render blank state.
 	 */
 	protected function render_blank_state() {
-		echo '<div class="woocommerce-BlankState">';
-
-		echo '<h2 class="woocommerce-BlankState-message">' . esc_html__( 'When you receive a new order, it will appear here.', 'woocommerce' ) . '</h2>';
-
-		echo '<div class="woocommerce-BlankState-buttons">';
-		echo '<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://docs.woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin">' . esc_html__( 'Learn more about orders', 'woocommerce' ) . '</a>';
-		echo '</div>';
-
-		do_action( 'wc_marketplace_suggestions_orders_empty_state' );
-
-		echo '</div>';
+		$this->orders_list_table->render_blank_state();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/plugins/woocommerce/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -145,7 +145,7 @@ class WC_Marketplace_Suggestions {
 	 */
 	public static function show_suggestions_for_screen( $screen_id ) {
 		// We only show suggestions on certain admin screens.
-		if ( ! in_array( $screen_id, array( 'edit-product', 'edit-shop_order', 'product' ), true ) ) {
+		if ( ! in_array( $screen_id, array( 'edit-product', 'edit-shop_order', 'product', 'woocommerce_page_wc-orders' ), true ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -20,6 +20,7 @@ function wc_get_screen_ids() {
 	$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
 	$screen_ids   = array(
 		'toplevel_page_' . $wc_screen_id,
+		$wc_screen_id . '_page_wc-orders',
 		$wc_screen_id . '_page_wc-reports',
 		$wc_screen_id . '_page_wc-shipping',
 		$wc_screen_id . '_page_wc-settings',

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -384,10 +384,6 @@ class WC_Post_Types {
 			)
 		);
 
-		// When custom order tables are in effect, we should not display the regular WP Posts-based admin list table.
-		$hide_orders_from_menu = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
-		$orders_menu_location  = current_user_can( 'edit_others_shop_orders' ) ? 'woocommerce' : true;
-
 		wc_register_order_type(
 			'shop_order',
 			apply_filters(
@@ -418,7 +414,7 @@ class WC_Post_Types {
 					'map_meta_cap'        => true,
 					'publicly_queryable'  => false,
 					'exclude_from_search' => true,
-					'show_in_menu'        => $hide_orders_from_menu ? false : $orders_menu_location,
+					'show_in_menu'        => current_user_can( 'edit_others_shop_orders' ) ? 'woocommerce' : true,
 					'hierarchical'        => false,
 					'show_in_nav_menus'   => false,
 					'rewrite'             => false,

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -10,6 +10,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
 /**
  * Post types Class.
  */
@@ -382,6 +384,10 @@ class WC_Post_Types {
 			)
 		);
 
+		// When custom order tables are in effect, we should not display the regular WP Posts-based admin list table.
+		$hide_orders_from_menu = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
+		$orders_menu_location  = current_user_can( 'edit_others_shop_orders' ) ? 'woocommerce' : true;
+
 		wc_register_order_type(
 			'shop_order',
 			apply_filters(
@@ -412,7 +418,7 @@ class WC_Post_Types {
 					'map_meta_cap'        => true,
 					'publicly_queryable'  => false,
 					'exclude_from_search' => true,
-					'show_in_menu'        => current_user_can( 'edit_others_shop_orders' ) ? 'woocommerce' : true,
+					'show_in_menu'        => $hide_orders_from_menu ? false : $orders_menu_location,
 					'hierarchical'        => false,
 					'show_in_nav_menus'   => false,
 					'rewrite'             => false,

--- a/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
+++ b/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
@@ -134,6 +134,16 @@ wc_admin_connect_page(
 	)
 );
 
+// WooCommerce > Orders (COT)
+wc_admin_connect_page(
+	array(
+		'id'        => 'woocommerce-orders',
+		'screen_id' => 'woocommerce_page_wc-orders',
+		'title'     => __( 'Orders', 'woocommerce' ),
+		'path'      => 'admin.php?page=wc-orders',
+	)
+);
+
 // WooCommerce > Orders > Add New.
 wc_admin_connect_page(
 	array(

--- a/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
+++ b/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
@@ -137,7 +137,7 @@ wc_admin_connect_page(
 // WooCommerce > Orders (COT)
 wc_admin_connect_page(
 	array(
-		'id'        => 'woocommerce-orders',
+		'id'        => 'woocommerce-custom-orders',
 		'screen_id' => 'woocommerce_page_wc-orders',
 		'title'     => __( 'Orders', 'woocommerce' ),
 		'path'      => 'admin.php?page=wc-orders',

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -6515,9 +6515,11 @@ table.bar_chart {
 	}
 }
 
-.post-type-shop_order .woocommerce-BlankState-message::before {
-
-	@include icon("\e01d");
+.woocommerce_page_wc-orders,
+.post-type-shop_order {
+	.woocommerce-BlankState-message::before {
+		@include icon("\e01d");
+	}
 }
 
 .post-type-shop_coupon .woocommerce-BlankState-message::before {
@@ -6575,6 +6577,7 @@ table.bar_chart {
 	}
 }
 
+.woocommerce_page_wc-orders .woocommerce-BlankState,
 .post-type-product .woocommerce-BlankState,
 .post-type-shop_order .woocommerce-BlankState {
 	max-width: 764px;

--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -2594,6 +2594,7 @@ ul.wc_coupon_list_block {
 	}
 }
 
+.woocommerce_page_wc-orders,
 .post-type-shop_order {
 
 	.tablenav .one-page .displaying-num {
@@ -7338,6 +7339,7 @@ table.bar_chart {
 	}
 }
 
+.woocommerce_page_wc-orders .tablenav,
 .post-type-product .tablenav,
 .post-type-shop_order .tablenav {
 

--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
 /**
  * CoreMenu class. Handles registering Core menu items.
@@ -60,14 +61,14 @@ class CoreMenu {
 		foreach ( $tabs as $key => $setting ) {
 			$order       += 10;
 			$menu_items[] = (
-				array(
-					'parent'     => 'woocommerce-settings',
-					'title'      => $setting,
-					'capability' => 'manage_woocommerce',
-					'id'         => 'settings-' . $key,
-					'url'        => 'admin.php?page=wc-settings&tab=' . $key,
-					'order'      => $order,
-				)
+			array(
+				'parent'     => 'woocommerce-settings',
+				'title'      => $setting,
+				'capability' => 'manage_woocommerce',
+				'id'         => 'settings-' . $key,
+				'url'        => 'admin.php?page=wc-settings&tab=' . $key,
+				'order'      => $order,
+			)
 			);
 		}
 
@@ -104,18 +105,18 @@ class CoreMenu {
 				'order' => 20,
 			),
 			$analytics_enabled ?
-			array(
-				'title' => __( 'Analytics', 'woocommerce' ),
-				'id'    => 'woocommerce-analytics',
-				'order' => 30,
-			) : null,
+				array(
+					'title' => __( 'Analytics', 'woocommerce' ),
+					'id'    => 'woocommerce-analytics',
+					'order' => 30,
+				) : null,
 			$analytics_enabled ?
-			array(
-				'title'  => __( 'Reports', 'woocommerce' ),
-				'id'     => 'woocommerce-reports',
-				'parent' => 'woocommerce-analytics',
-				'order'  => 200,
-			) : null,
+				array(
+					'title'  => __( 'Reports', 'woocommerce' ),
+					'id'     => 'woocommerce-reports',
+					'parent' => 'woocommerce-analytics',
+					'order'  => 200,
+				) : null,
 			array(
 				'title' => __( 'Marketing', 'woocommerce' ),
 				'id'    => 'woocommerce-marketing',
@@ -143,7 +144,7 @@ class CoreMenu {
 	 * @return array
 	 */
 	public static function get_items() {
-		$order_items       = Menu::get_post_type_items( 'shop_order', array( 'parent' => 'woocommerce-orders' ) );
+		$order_items       = self::get_order_menu_items();
 		$product_items     = Menu::get_post_type_items( 'product', array( 'parent' => 'woocommerce-products' ) );
 		$product_tag_items = Menu::get_taxonomy_items(
 			'product_tag',
@@ -250,6 +251,44 @@ class CoreMenu {
 			$setting_items,
 			// Legacy report items.
 			self::get_legacy_report_items()
+		);
+	}
+
+	/**
+	 * Supplies menu items for orders.
+	 *
+	 * This varies depending on whether we are actively using traditional post type-based orders or the new custom
+	 * table-based orders.
+	 *
+	 * @return ?array
+	 */
+	private static function get_order_menu_items(): ?array {
+		if ( ! wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
+			return Menu::get_post_type_items( 'shop_order', array( 'parent' => 'woocommerce-orders' ) );
+		}
+
+		$main_orders_menu = array(
+			'title'      => __( 'Orders', 'woocommerce' ),
+			'capability' => 'edit_others_shop_orders',
+			'id'         => 'woocommerce-orders-default',
+			'url'        => 'admin.php?page=wc-orders',
+			'parent'     => 'woocommerce-orders',
+		);
+
+		$all_orders_entry          = $main_orders_menu;
+		$all_orders_entry['id']    = 'woocommerce-orders-all-items';
+		$all_orders_entry['order'] = 10;
+
+		$new_orders_entry          = $main_orders_menu;
+		$new_orders_entry['title'] = __( 'Add order', 'woocommerce' );
+		$new_orders_entry['id']    = 'woocommerce-orders-add-item';
+		$new_orders_entry['url']   = 'admin.php?page=TBD';
+		$new_orders_entry['order'] = 20;
+
+		return array(
+			'default' => $main_orders_menu,
+			'all'     => $all_orders_entry,
+			'new'     => $new_orders_entry,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -90,6 +90,27 @@ class ListTable extends WP_List_Table {
 
 		echo '</form> </div>';
 	}
+
+	/**
+	 * Retrieves the list of bulk actions available for this table.
+	 *
+	 * @return array
+	 */
+	protected function get_bulk_actions() {
+		$actions = array(
+			'mark_processing' => __( 'Change status to processing', 'woocommerce' ),
+			'mark_on-hold'    => __( 'Change status to on-hold', 'woocommerce' ),
+			'mark_completed'  => __( 'Change status to completed', 'woocommerce' ),
+			'mark_cancelled'  => __( 'Change status to cancelled', 'woocommerce' ),
+		);
+
+		if ( wc_string_to_bool( get_option( 'woocommerce_allow_bulk_remove_personal_data', 'no' ) ) ) {
+			$actions['remove_personal_data'] = __( 'Remove personal data', 'woocommerce' );
+		}
+
+		return $actions;
+	}
+
 	/**
 	 * Prepares the list of items for displaying.
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Orders;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use WC_Order;
+use WC_Order_Data_Store_Interface;
+use WP_List_Table;
+
+/**
+ * Admin list table for orders as managed by the OrdersTableDataStore.
+ */
+class ListTable extends WP_List_Table {
+	/**
+	 * Sets up the admin list table for orders (specifically, for orders managed by the OrdersTableDataStore).
+	 *
+	 * @see WC_Admin_List_Table_Orders for the corresponding class used in relation to the traditional WP Post store.
+	 */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'singular' => 'order',
+				'plural'   => 'orders',
+				'ajax'     => false,
+			)
+		);
+	}
+
+	/**
+	 * Performs setup work required before rendering the table.
+	 *
+	 * @return void
+	 */
+	public function setup(): void {
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'get_columns' ) );
+		add_filter( 'set_screen_option_edit_orders_per_page', array( $this, 'set_items_per_page' ), 10, 3 );
+		$this->items_per_page();
+		set_screen_options();
+	}
+
+	/**
+	 * Sets up an items-per-page control.
+	 */
+	private function items_per_page(): void {
+		add_screen_option(
+			'per_page',
+			array(
+				'default' => 20,
+				'option'  => 'edit_orders_per_page',
+			)
+		);
+	}
+
+	/**
+	 * Saves the items-per-page setting.
+	 *
+	 * @param mixed  $default The default value.
+	 * @param string $option  The option being configured.
+	 * @param int    $value   The submitted option value.
+	 *
+	 * @return mixed
+	 */
+	public function set_items_per_page( $default, string $option, int $value ) {
+		return 'edit_orders_per_page' === $option ? absint( $value ) : $default;
+	}
+
+	/**
+	 * Render the table.
+	 *
+	 * @return void
+	 */
+	public function display() {
+		$title   = esc_html__( 'Orders', 'woocommerce' );
+		$add_new = esc_html__( 'Add New', 'woocommerce' );
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo "
+			<div class='wrap'>
+				<h1 class='wp-heading-inline'>{$title}</h1>
+				<a href='/to-implement' class='page-title-action'>{$add_new}</a>
+		";
+
+		$this->views();
+		parent::display();
+
+		echo '</div>';
+	}
+	/**
+	 * Prepares the list of items for displaying.
+	 */
+	public function prepare_items() {
+		$status = sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) );
+		$search = sanitize_text_field( wp_unslash( $_REQUEST['s'] ?? '' ) );
+
+		$args = array(
+			'limit' => $this->get_items_per_page( 'edit_orders_per_page' ),
+			'page'  => $this->get_pagenum(),
+		);
+
+		// @todo Confirm this is the best way to query.
+		//       An alternative is using `$this->data_store->get_orders()` however in the case of the order CPT store
+		//       that method is considered deprecated (not sure if that carries over to the new COT store).
+		$this->items = wc_get_orders( $args );
+	}
+
+	/**
+	 * Get list columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		return array(
+			'cb'      => '<input type="checkbox" />',
+			'order'   => esc_html__( 'Order', 'woocommerce' ),
+			'date'    => esc_html__( 'Date', 'woocommerce' ),
+			'status'  => esc_html__( 'Status', 'woocommerce' ),
+			'billing' => esc_html__( 'Billing', 'woocommerce' ),
+			'ship_to' => esc_html__( 'Ship to', 'woocommerce' ),
+			'total'   => esc_html__( 'Total', 'woocommerce' ),
+			'actions' => esc_html__( 'Actions', 'woocommerce' ),
+		);
+	}
+
+	/**
+	 * Checklist column, used for selecting items for processing by a bulk action.
+	 *
+	 * @param WC_Order $item The order object for the current row.
+	 *
+	 * @return string
+	 */
+	public function column_cb( $item ) {
+		return sprintf( '<input type="checkbox" name="%1$s[]" value="%2$s" />', esc_attr( $this->_args['singular'] ), esc_attr( $item->get_id() ) );
+	}
+
+	/**
+	 * Renders the order number, customer name and provides a preview link.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_order( WC_Order $order ): void {
+		$buyer = '';
+
+		if ( $order->get_billing_first_name() || $order->get_billing_last_name() ) {
+			/* translators: 1: first name 2: last name */
+			$buyer = trim( sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $order->get_billing_first_name(), $order->get_billing_last_name() ) );
+		} elseif ( $order->get_billing_company() ) {
+			$buyer = trim( $order->get_billing_company() );
+		} elseif ( $order->get_customer_id() ) {
+			$user  = get_user_by( 'id', $order->get_customer_id() );
+			$buyer = ucwords( $user->display_name );
+		}
+
+		/**
+		 * Filter buyer name in list table orders.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param string   $buyer Buyer name.
+		 * @param WC_Order $order Order data.
+		 */
+		$buyer = apply_filters( 'woocommerce_admin_order_buyer_name', $buyer, $order );
+
+		if ( $order->get_status() === 'trash' ) {
+			echo '<strong>#' . esc_attr( $order->get_order_number() ) . ' ' . esc_html( $buyer ) . '</strong>';
+		} else {
+			echo '<a href="#" class="order-preview" data-order-id="' . absint( $order->get_id() ) . '" title="' . esc_attr( __( 'Preview', 'woocommerce' ) ) . '">' . esc_html( __( 'Preview', 'woocommerce' ) ) . '</a>';
+			echo '<a href="' . esc_url( admin_url( 'post.php?post=' . absint( $order->get_id() ) ) . '&action=edit' ) . '" class="order-view"><strong>#' . esc_attr( $order->get_order_number() ) . ' ' . esc_html( $buyer ) . '</strong></a>';
+		}
+	}
+
+	/**
+	 * Renders the order date.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_date( WC_Order $order ): void {
+		$order_timestamp = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : '';
+
+		if ( ! $order_timestamp ) {
+			echo '&ndash;';
+			return;
+		}
+
+		// Check if the order was created within the last 24 hours, and not in the future.
+		if ( $order_timestamp > strtotime( '-1 day', time() ) && $order_timestamp <= time() ) {
+			$show_date = sprintf(
+			/* translators: %s: human-readable time difference */
+				_x( '%s ago', '%s = human-readable time difference', 'woocommerce' ),
+				human_time_diff( $order->get_date_created()->getTimestamp(), time() )
+			);
+		} else {
+			$show_date = $order->get_date_created()->date_i18n( apply_filters( 'woocommerce_admin_order_date_format', __( 'M j, Y', 'woocommerce' ) ) );
+		}
+		printf(
+			'<time datetime="%1$s" title="%2$s">%3$s</time>',
+			esc_attr( $order->get_date_created()->date( 'c' ) ),
+			esc_html( $order->get_date_created()->date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) ),
+			esc_html( $show_date )
+		);
+	}
+
+	/**
+	 * Renders the order status.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_status( WC_Order $order ): void {
+		$tooltip                 = '';
+		$comment_count           = get_comment_count( $order->get_id() );
+		$approved_comments_count = absint( $comment_count['approved'] );
+
+		if ( $approved_comments_count ) {
+			$latest_notes = wc_get_order_notes(
+				array(
+					'order_id' => $order->get_id(),
+					'limit'    => 1,
+					'orderby'  => 'date_created_gmt',
+				)
+			);
+
+			$latest_note = current( $latest_notes );
+
+			if ( isset( $latest_note->content ) && 1 === $approved_comments_count ) {
+				$tooltip = wc_sanitize_tooltip( $latest_note->content );
+			} elseif ( isset( $latest_note->content ) ) {
+				/* translators: %d: notes count */
+				$tooltip = wc_sanitize_tooltip( $latest_note->content . '<br/><small style="display:block">' . sprintf( _n( 'Plus %d other note', 'Plus %d other notes', ( $approved_comments_count - 1 ), 'woocommerce' ), $approved_comments_count - 1 ) . '</small>' );
+			} else {
+				/* translators: %d: notes count */
+				$tooltip = wc_sanitize_tooltip( sprintf( _n( '%d note', '%d notes', $approved_comments_count, 'woocommerce' ), $approved_comments_count ) );
+			}
+		}
+
+		if ( $tooltip ) {
+			printf( '<mark class="order-status %s tips" data-tip="%s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $order->get_status() ) ), wp_kses_post( $tooltip ), esc_html( wc_get_order_status_name( $order->get_status() ) ) );
+		} else {
+			printf( '<mark class="order-status %s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $order->get_status() ) ), esc_html( wc_get_order_status_name( $order->get_status() ) ) );
+		}
+	}
+
+	/**
+	 * Renders order billing information.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_billing( WC_Order $order ): void {
+		$address = $order->get_formatted_billing_address();
+
+		if ( $address ) {
+			echo esc_html( preg_replace( '#<br\s*/?>#i', ', ', $address ) );
+
+			if ( $order->get_payment_method() ) {
+				/* translators: %s: payment method */
+				echo '<span class="description">' . sprintf( esc_html__( 'via %s', 'woocommerce' ), esc_html( $order->get_payment_method_title() ) ) . '</span>';
+			}
+		} else {
+			echo '&ndash;';
+		}
+	}
+
+	/**
+	 * Renders order shipping information.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_ship_to( WC_Order $order ): void {
+		$address = $order->get_formatted_shipping_address();
+
+		if ( $address ) {
+			echo '<a target="_blank" href="' . esc_url( $order->get_shipping_address_map_url() ) . '">' . esc_html( preg_replace( '#<br\s*/?>#i', ', ', $address ) ) . '</a>';
+			if ( $order->get_shipping_method() ) {
+				/* translators: %s: shipping method */
+				echo '<span class="description">' . sprintf( esc_html__( 'via %s', 'woocommerce' ), esc_html( $order->get_shipping_method() ) ) . '</span>';
+			}
+		} else {
+			echo '&ndash;';
+		}
+	}
+
+	/**
+	 * Renders the order total.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_total( WC_Order $order ): void {
+		if ( $order->get_payment_method_title() ) {
+			/* translators: %s: method */
+			echo '<span class="tips" data-tip="' . esc_attr( sprintf( __( 'via %s', 'woocommerce' ), $order->get_payment_method_title() ) ) . '">' . wp_kses_post( $order->get_formatted_order_total() ) . '</span>';
+		} else {
+			echo wp_kses_post( $order->get_formatted_order_total() );
+		}
+	}
+
+	/**
+	 * Renders order actions.
+	 *
+	 * @param WC_Order $order The order object for the current row.
+	 *
+	 * @return void
+	 */
+	public function column_actions( WC_Order $order ): void {
+		echo '<p>';
+
+		do_action( 'woocommerce_admin_order_actions_start', $order );
+
+		$actions = array();
+
+		if ( $order->has_status( array( 'pending', 'on-hold' ) ) ) {
+			$actions['processing'] = array(
+				'url'    => wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_status&status=processing&order_id=' . $order->get_id() ), 'woocommerce-mark-order-status' ),
+				'name'   => __( 'Processing', 'woocommerce' ),
+				'action' => 'processing',
+			);
+		}
+
+		if ( $order->has_status( array( 'pending', 'on-hold', 'processing' ) ) ) {
+			$actions['complete'] = array(
+				'url'    => wp_nonce_url( admin_url( 'admin-ajax.php?action=woocommerce_mark_order_status&status=completed&order_id=' . $order->get_id() ), 'woocommerce-mark-order-status' ),
+				'name'   => __( 'Complete', 'woocommerce' ),
+				'action' => 'complete',
+			);
+		}
+
+		$actions = apply_filters( 'woocommerce_admin_order_actions', $actions, $order );
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wc_render_action_buttons( $actions );
+
+		do_action( 'woocommerce_admin_order_actions_end', $order );
+
+		echo '</p>';
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -320,14 +320,14 @@ class ListTable extends WP_List_Table {
 	 */
 	public function get_columns() {
 		return array(
-			'cb'           => '<input type="checkbox" />',
-			'order_number' => esc_html__( 'Order', 'woocommerce' ),
-			'date'         => esc_html__( 'Date', 'woocommerce' ),
-			'status'       => esc_html__( 'Status', 'woocommerce' ),
-			'billing'      => esc_html__( 'Billing', 'woocommerce' ),
-			'ship_to'      => esc_html__( 'Ship to', 'woocommerce' ),
-			'total'        => esc_html__( 'Total', 'woocommerce' ),
-			'actions'      => esc_html__( 'Actions', 'woocommerce' ),
+			'cb'               => '<input type="checkbox" />',
+			'order_number'     => esc_html__( 'Order', 'woocommerce' ),
+			'order_date'       => esc_html__( 'Date', 'woocommerce' ),
+			'order_status'     => esc_html__( 'Status', 'woocommerce' ),
+			'billing_address'  => esc_html__( 'Billing', 'woocommerce' ),
+			'shipping_address' => esc_html__( 'Ship to', 'woocommerce' ),
+			'order_total'      => esc_html__( 'Total', 'woocommerce' ),
+			'wc_actions'       => esc_html__( 'Actions', 'woocommerce' ),
 		);
 	}
 
@@ -344,9 +344,9 @@ class ListTable extends WP_List_Table {
 			$hidden = array_merge(
 				$hidden,
 				array(
-					'billing',
-					'ship_to',
-					'actions',
+					'billing_address',
+					'shipping_address',
+					'wc_actions',
 				)
 			);
 		}
@@ -410,7 +410,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_date( WC_Order $order ): void {
+	public function column_order_date(WC_Order $order ): void {
 		$order_timestamp = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : '';
 
 		if ( ! $order_timestamp ) {
@@ -443,7 +443,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_status( WC_Order $order ): void {
+	public function column_order_status(WC_Order $order ): void {
 		$tooltip                 = '';
 		$comment_count           = get_comment_count( $order->get_id() );
 		$approved_comments_count = absint( $comment_count['approved'] );
@@ -484,7 +484,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_billing( WC_Order $order ): void {
+	public function column_billing_address(WC_Order $order ): void {
 		$address = $order->get_formatted_billing_address();
 
 		if ( $address ) {
@@ -506,7 +506,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_ship_to( WC_Order $order ): void {
+	public function column_shipping_address(WC_Order $order ): void {
 		$address = $order->get_formatted_shipping_address();
 
 		if ( $address ) {
@@ -527,7 +527,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_total( WC_Order $order ): void {
+	public function column_order_total(WC_Order $order ): void {
 		if ( $order->get_payment_method_title() ) {
 			/* translators: %s: method */
 			echo '<span class="tips" data-tip="' . esc_attr( sprintf( __( 'via %s', 'woocommerce' ), $order->get_payment_method_title() ) ) . '">' . wp_kses_post( $order->get_formatted_order_total() ) . '</span>';
@@ -543,7 +543,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_actions( WC_Order $order ): void {
+	public function column_wc_actions(WC_Order $order ): void {
 		echo '<p>';
 
 		do_action( 'woocommerce_admin_order_actions_start', $order );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -73,7 +73,7 @@ class ListTable extends WP_List_Table {
 	 */
 	public function display() {
 		$title   = esc_html__( 'Orders', 'woocommerce' );
-		$add_new = esc_html__( 'Add New', 'woocommerce' );
+		$add_new = esc_html__( 'Add Order', 'woocommerce' );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo "
@@ -83,15 +83,46 @@ class ListTable extends WP_List_Table {
 				<hr class='wp-header-end'>
 		";
 
-		$this->views();
+		if ( $this->has_items() ) {
+			$this->views();
 
-		echo '<form id="wc-orders-filter" method="get" action="' . esc_url( get_admin_url( null, 'admin.php' ) ) . '">';
-		$this->print_hidden_form_fields();
-		$this->search_box( esc_html__( 'Search orders', 'woocommerce' ), 'orders-search-input' );
+			echo '<form id="wc-orders-filter" method="get" action="' . esc_url( get_admin_url( null, 'admin.php' ) ) . '">';
+			$this->print_hidden_form_fields();
+			$this->search_box( esc_html__( 'Search orders', 'woocommerce' ), 'orders-search-input' );
 
-		parent::display();
+			parent::display();
+			echo '</form> </div>';
+		} else {
+			$this->render_blank_state();
+		}
+	}
 
-		echo '</form> </div>';
+	/**
+	 * Renders advice in the event that no orders exist yet.
+	 *
+	 * @return void
+	 */
+	public function render_blank_state(): void {
+		?>
+			<div class="woocommerce-BlankState">
+
+				<h2 class="woocommerce-BlankState-message">
+					<?php esc_html_e( 'When you receive a new order, it will appear here.', 'woocommerce' ); ?>
+				</h2>
+
+				<div class="woocommerce-BlankState-buttons">
+					<a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="https://docs.woocommerce.com/document/managing-orders/?utm_source=blankslate&utm_medium=product&utm_content=ordersdoc&utm_campaign=woocommerceplugin"><?php esc_html_e( 'Learn more about orders', 'woocommerce' ); ?></a>
+				</div>
+
+			<?php
+			/**
+			 * Renders after the 'blank state' message for the order list table has rendered.
+			 */
+			do_action( 'wc_marketplace_suggestions_orders_empty_state' );
+			?>
+
+			</div>
+		<?php
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -155,6 +155,7 @@ class ListTable extends WP_List_Table {
 			'page'     => $this->get_pagenum(),
 			'paginate' => true,
 			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? 'all' ) ),
+			'type'     => 'shop_order',
 		);
 
 		$orders      = wc_get_orders( $args );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -115,16 +115,23 @@ class ListTable extends WP_List_Table {
 	 * Prepares the list of items for displaying.
 	 */
 	public function prepare_items() {
-		$args = array(
-			'limit'  => $this->get_items_per_page( 'edit_orders_per_page' ),
-			'page'   => $this->get_pagenum(),
-			'status' => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ),
+		$limit = $this->get_items_per_page( 'edit_orders_per_page' );
+		$args  = array(
+			'limit'    => $limit,
+			'page'     => $this->get_pagenum(),
+			'paginate' => true,
+			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ),
 		);
 
-		// @todo Confirm this is the best way to query.
-		//       An alternative is using `$this->data_store->get_orders()` however in the case of the order CPT store
-		//       that method is considered deprecated (not sure if that carries over to the new COT store).
-		$this->items = wc_get_orders( $args );
+		$orders      = wc_get_orders( $args );
+		$this->items = $orders->orders;
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $orders->total,
+				'per_page'    => $limit,
+			)
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use WC_Order;
 use WC_Order_Data_Store_Interface;
 use WP_List_Table;
+use WP_Screen;
 
 /**
  * Admin list table for orders as managed by the OrdersTableDataStore.
@@ -34,6 +35,7 @@ class ListTable extends WP_List_Table {
 	public function setup(): void {
 		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'get_columns' ) );
 		add_filter( 'set_screen_option_edit_orders_per_page', array( $this, 'set_items_per_page' ), 10, 3 );
+		add_filter( 'default_hidden_columns', array( $this, 'default_hidden_columns' ), 10, 2 );
 		$this->items_per_page();
 		set_screen_options();
 	}
@@ -326,6 +328,29 @@ class ListTable extends WP_List_Table {
 			'total'        => esc_html__( 'Total', 'woocommerce' ),
 			'actions'      => esc_html__( 'Actions', 'woocommerce' ),
 		);
+	}
+
+	/**
+	 * Specify the columns we wish to hide by default.
+	 *
+	 * @param array     $hidden Columns set to be hidden.
+	 * @param WP_Screen $screen Screen object.
+	 *
+	 * @return array
+	 */
+	public function default_hidden_columns( array $hidden, WP_Screen $screen ) {
+		if ( isset( $screen->id ) && 'woocommerce_page_wc-orders' === $screen->id ) {
+			$hidden = array_merge(
+				$hidden,
+				array(
+					'billing',
+					'ship_to',
+					'actions',
+				)
+			);
+		}
+
+		return $hidden;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -85,7 +85,8 @@ class ListTable extends WP_List_Table {
 
 		$this->views();
 
-		echo '<form id="wc-orders-filter" method="get">';
+		echo '<form id="wc-orders-filter" method="get" action="' . esc_url( get_admin_url( null, 'admin.php' ) ) . '">';
+		$this->print_hidden_form_fields();
 		$this->search_box( esc_html__( 'Search orders', 'woocommerce' ), 'orders-search-input' );
 
 		parent::display();
@@ -122,7 +123,7 @@ class ListTable extends WP_List_Table {
 			'limit'    => $limit,
 			'page'     => $this->get_pagenum(),
 			'paginate' => true,
-			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ),
+			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? 'all' ) ),
 		);
 
 		$orders      = wc_get_orders( $args );
@@ -573,5 +574,29 @@ class ListTable extends WP_List_Table {
 		do_action( 'woocommerce_admin_order_actions_end', $order );
 
 		echo '</p>';
+	}
+
+	/**
+	 * Outputs hidden fields used to retain state when filtering.
+	 *
+	 * @return void
+	 */
+	private function print_hidden_form_fields(): void {
+		echo '<input type="hidden" name="page" value="wc-orders" >';
+
+		$state_params = array(
+			'_customer_user',
+			'm',
+			'paged',
+			'status',
+		);
+
+		foreach ( $state_params as $param ) {
+			if ( ! isset( $_GET[ $param ] ) ) {
+				continue;
+			}
+
+			echo '<input type="hidden" name="status" value="' . esc_attr( sanitize_text_field( wp_unslash( $_GET[ $param ] ) ) ) . '" >';
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -410,7 +410,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_date(WC_Order $order ): void {
+	public function column_order_date( WC_Order $order ): void {
 		$order_timestamp = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : '';
 
 		if ( ! $order_timestamp ) {
@@ -443,7 +443,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_status(WC_Order $order ): void {
+	public function column_order_status( WC_Order $order ): void {
 		$tooltip                 = '';
 		$comment_count           = get_comment_count( $order->get_id() );
 		$approved_comments_count = absint( $comment_count['approved'] );
@@ -484,7 +484,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_billing_address(WC_Order $order ): void {
+	public function column_billing_address( WC_Order $order ): void {
 		$address = $order->get_formatted_billing_address();
 
 		if ( $address ) {
@@ -506,7 +506,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_shipping_address(WC_Order $order ): void {
+	public function column_shipping_address( WC_Order $order ): void {
 		$address = $order->get_formatted_shipping_address();
 
 		if ( $address ) {
@@ -527,7 +527,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_total(WC_Order $order ): void {
+	public function column_order_total( WC_Order $order ): void {
 		if ( $order->get_payment_method_title() ) {
 			/* translators: %s: method */
 			echo '<span class="tips" data-tip="' . esc_attr( sprintf( __( 'via %s', 'woocommerce' ), $order->get_payment_method_title() ) ) . '">' . wp_kses_post( $order->get_formatted_order_total() ) . '</span>';
@@ -543,9 +543,15 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_wc_actions(WC_Order $order ): void {
+	public function column_wc_actions( WC_Order $order ): void {
 		echo '<p>';
 
+		/**
+		 * Fires before the order action buttons (within the actions column for the order list table)
+		 * are registered.
+		 *
+		 * @param WC_Order $order Current order object.
+		 */
 		do_action( 'woocommerce_admin_order_actions_start', $order );
 
 		$actions = array();
@@ -566,11 +572,23 @@ class ListTable extends WP_List_Table {
 			);
 		}
 
+		/**
+		 * Provides an opportunity to modify the action buttons within the order list table.
+		 *
+		 * @param array    $action Order actions.
+		 * @param WC_Order $order  Current order object.
+		 */
 		$actions = apply_filters( 'woocommerce_admin_order_actions', $actions, $order );
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo wc_render_action_buttons( $actions );
 
+		/**
+		 * Fires after the order action buttons (within the actions column for the order list table)
+		 * are rendered.
+		 *
+		 * @param WC_Order $order Current order object.
+		 */
 		do_action( 'woocommerce_admin_order_actions_end', $order );
 
 		echo '</p>';

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -317,14 +317,14 @@ class ListTable extends WP_List_Table {
 	 */
 	public function get_columns() {
 		return array(
-			'cb'      => '<input type="checkbox" />',
-			'order'   => esc_html__( 'Order', 'woocommerce' ),
-			'date'    => esc_html__( 'Date', 'woocommerce' ),
-			'status'  => esc_html__( 'Status', 'woocommerce' ),
-			'billing' => esc_html__( 'Billing', 'woocommerce' ),
-			'ship_to' => esc_html__( 'Ship to', 'woocommerce' ),
-			'total'   => esc_html__( 'Total', 'woocommerce' ),
-			'actions' => esc_html__( 'Actions', 'woocommerce' ),
+			'cb'           => '<input type="checkbox" />',
+			'order_number' => esc_html__( 'Order', 'woocommerce' ),
+			'date'         => esc_html__( 'Date', 'woocommerce' ),
+			'status'       => esc_html__( 'Status', 'woocommerce' ),
+			'billing'      => esc_html__( 'Billing', 'woocommerce' ),
+			'ship_to'      => esc_html__( 'Ship to', 'woocommerce' ),
+			'total'        => esc_html__( 'Total', 'woocommerce' ),
+			'actions'      => esc_html__( 'Actions', 'woocommerce' ),
 		);
 	}
 
@@ -346,7 +346,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order( WC_Order $order ): void {
+	public function column_order_number( WC_Order $order ): void {
 		$buyer = '';
 
 		if ( $order->get_billing_first_name() || $order->get_billing_last_name() ) {


### PR DESCRIPTION
Adds a new list table implementation that works with COT, and otherwise strives to emulate the existing post-based admin list table.

![cot-admin-list-table](https://user-images.githubusercontent.com/3594411/167032599-8842b60f-adbe-480f-bb7b-04f0db286a73.png)

- Per the linked issue, we are not implementing all of the functionality in this PR (bulk actions, filters etc will not work).
- We're aiming to get close to the look and feel of the existing posts based table, but the result may not be identical and that's ok.
- In the above screenshot you may notice two **WooCommerce > Orders** menu entries: that's because, for testing purposes (remembering the new data-store is not 100% operational just yet):
    - I configured the WP Posts store as authoritative (therefore, the original admin list table and its menu entry remain accessible).
    - I temporarily tweaked [this line of code](https://github.com/woocommerce/woocommerce/pull/32864/files#diff-1c0f35a6fb307b4248784e1f47ff1e71754b02fd1315315e44b5b5eb725f30b4R319) by adding `true ||` to the start of the condition, to make the new admin list table render anyway.
    - With a few exceptions, the new implementation mostly doesn't care which data store is authoritative (both implement the same interface), which is why this approach essentially works.

Closes #32385.

### Testing

1. For completeness, you may wish to follow the steps in [the linked issue](https://github.com/woocommerce/woocommerce/issues/32385) to enable and hydrate the new order table (though this probably isn't strictly required, since at time of writing we can't read from the new store in any case—however, that will change in the future).
2. Per the above notes, temporarily tweak the code (inside the `WC_Admin_Menus::orders_menu()` method) as suggested and set the WP Posts store as default via **WooCommerce > Settings > Advanced > Custom Data Stores**.
3. Navigate to the **new** admin list table (look for `admin.php?page=wc-orders` in the URL).
4. Compare and contrast with the original post-based admin list table, remembering per the above notes that not everything is fully functional just yet.
5. Check the no-results page. There are two ways to see this:
    - At time of writing, you can do this by setting COT to authoritative and removing the temporary shim from `WC_Admin_Menus::orders_menu()`.
    - Or, keeping the shim in place (and keeping the post table as authoritative) you can instead simply hide your post table orders with a query as follows (to undo, just reverse the post type values):

```sh
wp db query "UPDATE $(wp db prefix)posts SET post_type = 'shop_order_hidden' WHERE post_type = 'shop_order'" ;\
wp cache flush
```

### Notes/questions

- You may need to rebuild assets and hard-refresh your browser for the relevant CSS+JS changes to show up.
- We may (or may not) wish to expand e2e-core-tests to cover this area (I don't believe the existing list table is covered, either); but it probably makes sense to defer that until we're at a more advanced stage of the COT project.
- Are we happy with the placement inside the `Admin\Internal` namespace (sidenote: its location is the reason an automated action applies the `focus: react admin` label) or might we prefer to place it in some other namespace?
- Admin UI for the order editor is not yet implemented (so following the link to add a new order will fail when COT is authoritative).
- Normally, if some orders are pending, a number will display next to the Orders menu entry, as in the following screenshot (something similar happens with the new WC Admin navigation feature) ... this will not currently work when COT is authoritative, because the necessary logic to perform order counts is not yet implemented.

![orders-posts-needing-attention-bubble](https://user-images.githubusercontent.com/3594411/167725095-898be602-b72a-43d3-9915-af479dedf4c5.png)
