### PR TITLE
Fix no padding between the task section and things to do next in experiment 2

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -110,7 +110,7 @@
 	justify-content: space-between;
 
 	&.woocommerce-task-list__setup_experiment_2 {
-		margin-bottom: 16px;
+		margin-bottom: $gap;
 	}
 
 	ul li.complete .woocommerce-task-list__item-title {

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -109,6 +109,10 @@
 	margin: 0 auto;
 	justify-content: space-between;
 
+	&.woocommerce-task-list__setup_experiment_2 {
+		margin-bottom: 16px;
+	}
+
 	ul li.complete .woocommerce-task-list__item-title {
 		font-weight: 600;
 		color: $gray-600;

--- a/plugins/woocommerce/changelog/fix-32761-exp2-task-no-padding
+++ b/plugins/woocommerce/changelog/fix-32761-exp2-task-no-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix no padding between the task section and things to do next in experiment 2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32761.

Add `margin-bottom` style to make sure the padding is the same as between Things to do next and Inbox.

before:

![Screen Shot 2022-05-04 at 12 07 32](https://user-images.githubusercontent.com/4344253/166621925-a1d037fd-072d-4025-9669-b6d698a4f981.png)


After:

![Screen Shot 2022-05-04 at 11 58 32](https://user-images.githubusercontent.com/4344253/166621759-bf7328c1-7821-4a81-86ec-461838a752d9.png)


### How to test the changes in this Pull Request:

1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper`
3. Select `Experiments` tab
4. Toggle `woocommerce_tasklist_setup_experiment_2_2022_05` to treatment group
5. Go to `Woocommerce > Home`
6. Confirm the padding between the last task section and the `"Things to do next"` is the same as the one between `"Things to do next"` and `Inbox`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
