### PR TITLE
Center view more/less button for add product task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.scss
@@ -13,11 +13,17 @@
 		text-align: center;
 	}
 
+	.woocommerce-product-content {
+		display: flex;
+		flex-direction: column;
+	}
+
 	.woocommerce-task-products__button-view-less-product-types {
 		color: #007cba;
 		padding: 0;
 		height: fit-content;
 		margin-top: 25px;
+		justify-content: center;
 
 		svg {
 			margin-left: 8px;

--- a/plugins/woocommerce/changelog/update-center-view-more-button
+++ b/plugins/woocommerce/changelog/update-center-view-more-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Center experimental products view more button


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As confirmed [here](https://github.com/woocommerce/woocommerce/issues/32143#issuecomment-1113742670),  the`View more product types button`should be at the center.

### How to test the changes in this Pull Request:

1. Open the `plugins/woocommerce/client/admin/config/development.json` and change `experimental-products-task` to true
2. Run `pnpm nx dev woocommerce-admin`
3. Navigate to `WoocCommerce -> Home` and click `Add my products`
4. Observe view more types button is  for at the center.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
