### PR TITLE
Add unique secrets cache key to enable clearing of cache

### DIFF
--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -22,7 +22,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,7 +18,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -19,7 +19,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -25,7 +25,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
                   ~/.pnpm-store
                   plugins/woocommerce/packages
                   plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+                key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
             - name: Install PNPM
               run: npm install -g pnpm@^6.24.2
@@ -76,7 +76,7 @@ jobs:
                   ~/.pnpm-store
                   plugins/woocommerce/packages
                   plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+                key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
             - name: Install PNPM
               run: npm install -g pnpm@^6.24.2
@@ -132,7 +132,7 @@ jobs:
                   ~/.pnpm-store
                   plugins/woocommerce/packages
                   plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+                key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
             - name: Install PNPM
               run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -47,7 +47,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: |
             ~/.pnpm-store
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -34,7 +34,7 @@ jobs:
                   ~/.pnpm-store
                   package/woocommerce/plugins/woocommerce/packages
                   package/woocommerce/plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-smoke-test-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+                key: ${{ runner.os }}-smoke-test-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
             - name: Install PNPM
               run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -59,7 +59,7 @@ jobs:
             ~/.pnpm-store
             plugins/woocommerce/packages
             plugins/woocommerce/**/vendor
-          key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
       - name: Install PNPM
         run: npm install -g pnpm@^6.24.2

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -66,7 +66,7 @@ jobs:
                   ~/.pnpm-store
                   plugins/woocommerce/packages
                   plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-npm-composer-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+                key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
             - name: Install PNPM
               run: npm install -g pnpm@^6.24.2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently our cache is running fine on our action workflows. However, I've seen instances where the cached version of installed dependencies from npm packages and composer packages are not behaving correctly or even exist and this causes failing workflow jobs. In most cases clearing the cache fixes the issue.

GitHub currently does not support clearing this cache (it is on their radar). The cache is retained for 7 days. Only if no access to that cache for 7 days is when the cache will clear but that is impossible for us to make that happen. So we need a way to clear the cache.

This PR adds a secret for actions to use in the workflow environment seen [here](https://github.com/woocommerce/woocommerce/settings/secrets/actions) (WORKFLOW_CACHE). This allows us to change this secret to clear any cache that is on the server without having to commit any code.

### How to test the changes in this Pull Request:

1. Ensure all tests passes below.
2. In the test, you can look up a job such as the [PHP 8.0 unit test](https://github.com/woocommerce/woocommerce/runs/6298284642?check_suite_focus=true). You can see if the job used the cache or not. It should have in this instance seen below. You should a "SKIP" icon next to the `Install Composer dependencies`.
3. Now go to https://github.com/woocommerce/woocommerce/settings/secrets/actions and update the `WORKFLOW_CACHE` secret to a current timestamp.
4. Re-run the job and check and now you should see the job does not find the cache and will install dependencies as usual.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
