### PR TITLE
Removed Jetpack Changelogger from test js packages as they follow another approach for handling changelogs.

### DIFF
--- a/packages/js/api-core-tests/composer.json
+++ b/packages/js/api-core-tests/composer.json
@@ -4,24 +4,6 @@
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"minimum-stability": "dev",
-	"require-dev": {
-		"automattic/jetpack-changelogger": "3.0.2"
-	},
-	"extra": {
-		"changelogger": {
-			"formatter": {
-				"filename": "../../../tools/changelogger/PackageFormatter.php"
-			},
-			"types": {
-				"fix": "Fixes an existing bug",
-				"add": "Adds functionality",
-				"update": "Update existing functionality",
-				"dev": "Development related task",
-				"tweak": "A minor adjustment to the codebase",
-				"performance": "Address performance issues",
-				"enhancement": "Improve existing functionality"
-			},
-			"changelog": "NEXT_CHANGELOG.md"
-		}
-	}
+	"require-dev": {},
+	"extra": {}
 }

--- a/packages/js/api-core-tests/composer.json
+++ b/packages/js/api-core-tests/composer.json
@@ -1,9 +1,0 @@
-{
-	"name": "woocommerce/api-core-tests",
-	"description": "WooCommerce API core test",
-	"type": "library",
-	"license": "GPL-3.0-or-later",
-	"minimum-stability": "dev",
-	"require-dev": {},
-	"extra": {}
-}

--- a/packages/js/api-core-tests/package.json
+++ b/packages/js/api-core-tests/package.json
@@ -4,7 +4,6 @@
 	"description": "API tests for WooCommerce",
 	"main": "index.js",
 	"scripts": {
-		"postinstall": "composer install",
 		"test": "jest",
 		"test:api": "jest --group=api",
 		"test:hello": "jest --group=hello",

--- a/packages/js/e2e-core-tests/composer.json
+++ b/packages/js/e2e-core-tests/composer.json
@@ -4,24 +4,6 @@
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"minimum-stability": "dev",
-	"require-dev": {
-		"automattic/jetpack-changelogger": "3.0.2"
-	},
-	"extra": {
-		"changelogger": {
-			"formatter": {
-				"filename": "../../../tools/changelogger/PackageFormatter.php"
-			},
-			"types": {
-				"fix": "Fixes an existing bug",
-				"add": "Adds functionality",
-				"update": "Update existing functionality",
-				"dev": "Development related task",
-				"tweak": "A minor adjustment to the codebase",
-				"performance": "Address performance issues",
-				"enhancement": "Improve existing functionality"
-			},
-			"changelog": "NEXT_CHANGELOG.md"
-		}
-	}
+	"require-dev": {},
+	"extra": {}
 }

--- a/packages/js/e2e-core-tests/composer.json
+++ b/packages/js/e2e-core-tests/composer.json
@@ -1,9 +1,0 @@
-{
-	"name": "woocommerce/e2e-core-tests",
-	"description": "WooCommerce end to end core tests",
-	"type": "library",
-	"license": "GPL-3.0-or-later",
-	"minimum-stability": "dev",
-	"require-dev": {},
-	"extra": {}
-}

--- a/packages/js/e2e-core-tests/package.json
+++ b/packages/js/e2e-core-tests/package.json
@@ -47,7 +47,6 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
 		"prepare": "pnpm run build",
 		"clean": "rm -rf ./build ./build-module",
 		"compile": "e2e-builds",

--- a/packages/js/e2e-environment/composer.json
+++ b/packages/js/e2e-environment/composer.json
@@ -4,24 +4,6 @@
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"minimum-stability": "dev",
-	"require-dev": {
-		"automattic/jetpack-changelogger": "3.0.2"
-	},
-	"extra": {
-		"changelogger": {
-			"formatter": {
-				"filename": "../../../tools/changelogger/PackageFormatter.php"
-			},
-			"types": {
-				"fix": "Fixes an existing bug",
-				"add": "Adds functionality",
-				"update": "Update existing functionality",
-				"dev": "Development related task",
-				"tweak": "A minor adjustment to the codebase",
-				"performance": "Address performance issues",
-				"enhancement": "Improve existing functionality"
-			},
-			"changelog": "NEXT_CHANGELOG.md"
-		}
-	}
+	"require-dev": {},
+	"extra": {}
 }

--- a/packages/js/e2e-environment/composer.json
+++ b/packages/js/e2e-environment/composer.json
@@ -1,9 +1,0 @@
-{
-	"name": "woocommerce/e2e-environment",
-	"description": "WooCommerce end to end testing environment",
-	"type": "library",
-	"license": "GPL-3.0-or-later",
-	"minimum-stability": "dev",
-	"require-dev": {},
-	"extra": {}
-}

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -62,7 +62,6 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
 		"clean": "rm -rf ./build ./build-module",
 		"compile": "e2e-builds",
 		"build": "pnpm run clean && pnpm run compile",

--- a/packages/js/e2e-utils/composer.json
+++ b/packages/js/e2e-utils/composer.json
@@ -4,24 +4,6 @@
 	"type": "library",
 	"license": "GPL-3.0-or-later",
 	"minimum-stability": "dev",
-	"require-dev": {
-		"automattic/jetpack-changelogger": "3.0.2"
-	},
-	"extra": {
-		"changelogger": {
-			"formatter": {
-				"filename": "../../../tools/changelogger/PackageFormatter.php"
-			},
-			"types": {
-				"fix": "Fixes an existing bug",
-				"add": "Adds functionality",
-				"update": "Update existing functionality",
-				"dev": "Development related task",
-				"tweak": "A minor adjustment to the codebase",
-				"performance": "Address performance issues",
-				"enhancement": "Improve existing functionality"
-			},
-			"changelog": "NEXT_CHANGELOG.md"
-		}
-	}
+	"require-dev": {},
+	"extra": {}
 }

--- a/packages/js/e2e-utils/composer.json
+++ b/packages/js/e2e-utils/composer.json
@@ -1,9 +1,0 @@
-{
-	"name": "woocommerce/e2e-utiles",
-	"description": "WooCommerce end to end testing utilities",
-	"type": "library",
-	"license": "GPL-3.0-or-later",
-	"minimum-stability": "dev",
-	"require-dev": {},
-	"extra": {}
-}

--- a/packages/js/e2e-utils/package.json
+++ b/packages/js/e2e-utils/package.json
@@ -41,7 +41,6 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
 		"clean": "rm -rf ./build ./build-module",
 		"compile": "e2e-builds",
 		"build": "pnpm run clean && pnpm run compile",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some JS packages such as `e2e-core-tests`, `api-core-tests`, `e2e-environment` and `e2e-utils` have their own way of handling changelogs, like using the `CHANGELOG` file, which is manually maintained. However, Jetpack Changelogger checked every single change in these packages during pipeline executions, making them fail and blocking development in these packages.

It was agreed to exclude changes in these packages from Jetpack Changelogger, as they do not belong to the actual WooCommerce code.

### How to test the changes in this Pull Request:

1. Commit a new change in `e2e-core-tests`, `api-core-tests`, `e2e-environment` or `e2e-utils`.
2. Run `php tools/monorepo/check-changelogger-use.php --debug $BASE $HEAD`, replacing `$BASE` with the commit hash before your new change was added and `$HEAD` with the commit hash of your change.
3. Check that all files are ignored because changelogger is not used. For example:
```
php tools/monorepo/check-changelogger-use.php --debug 79c953c2f295067ad57712dd9a9415fe2c3c9c03 13e7f9cebdcec5d8a58cfe0d886c140055b5c81c

Checking diff from 79c953c2f295067ad57712dd9a9415fe2c3c9c03...13e7f9cebdcec5d8a58cfe0d886c140055b5c81c.
Ignoring file packages/js/api-core-tests/composer.json, project packages/js/api-core-tests does not use changelogger.
Ignoring file packages/js/e2e-core-tests/composer.json, project packages/js/e2e-core-tests does not use changelogger.
Ignoring file packages/js/e2e-environment/composer.json, project packages/js/e2e-environment does not use changelogger.
Ignoring file packages/js/e2e-utils/composer.json, project packages/js/e2e-utils does not use changelogger.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [N/A] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [N/A] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
