### PR TITLE
Use maybe_un|serialize() to handle post meta arrays in import/export.…

### DIFF
--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -714,12 +714,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 						continue;
 					}
 
-					// Allow 3rd parties to process the meta, e.g. to transform non-scalar values to scalar.
-					$meta_value = apply_filters( 'woocommerce_product_export_meta_value', $meta->value, $meta, $product, $row );
-
-					if ( ! is_scalar( $meta_value ) ) {
-						continue;
-					}
+					$meta_value = apply_filters( 'woocommerce_product_export_meta_value', maybe_serialize( $meta->value ), $meta, $product, $row );
 
 					$column_key = 'meta:' . esc_attr( $meta->key );
 					/* translators: %s: meta data name */

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -323,7 +323,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	protected function set_meta_data( &$product, $data ) {
 		if ( isset( $data['meta_data'] ) ) {
 			foreach ( $data['meta_data'] as $meta ) {
-				$product->update_meta_data( $meta['key'], $meta['value'] );
+				$product->update_meta_data( $meta['key'], maybe_unserialize( $meta['value'] ) );
 			}
 		}
 	}


### PR DESCRIPTION
… Closes #32818.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32818

### How to test the changes in this Pull Request:

1. Store some product meta as an array
2. Export products
3. Import products

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
