### PR TITLE
Orders API: Add response fields for some order _states_

### DIFF
--- a/plugins/woocommerce/changelog/add-order-state-fields
+++ b/plugins/woocommerce/changelog/add-order-state-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the `is_editable`, `needs_payment`, and `needs_processing` boolean properties to order response objects in both v2 and v3 of the WC REST API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -330,7 +330,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function get_formatted_item_data( $order ) {
-		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url' );
+		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url', 'is_editable', 'needs_payment', 'needs_processing' );
 		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
 		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
 		// These fields are dependent on other fields.
@@ -392,6 +392,15 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					break;
 				case 'payment_url':
 					$data['payment_url'] = $order->get_checkout_payment_url();
+					break;
+				case 'is_editable':
+					$data['is_editable'] = $order->is_editable();
+					break;
+				case 'needs_payment':
+					$data['needs_payment'] = $order->needs_payment();
+					break;
+				case 'needs_processing':
+					$data['needs_processing'] = $order->needs_processing();
 					break;
 			}
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -468,6 +468,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			'coupon_lines',
 			'refunds',
 			'payment_url',
+			'is_editable',
+			'needs_payment',
+			'needs_processing',
 		);
 
 		$data = array_intersect_key( $data, array_flip( $allowed_fields ) );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1873,7 +1873,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 						),
 					),
 				),
-				'payment_url' => array(
+				'payment_url'          => array(
 					'description' => __( 'Order payment URL.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -1884,6 +1884,24 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					'type'        => 'boolean',
 					'default'     => false,
 					'context'     => array( 'edit' ),
+				),
+				'is_editable'          => array(
+					'description' => __( 'Whether an order can be edited.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'needs_payment'        => array(
+					'description' => __( 'Whether an order needs payment, based on status and order total.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'needs_processing'     => array(
+					'description' => __( 'Whether an order needs processing before it can be completed.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -773,7 +773,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 43, count( $properties ) );
+		$this->assertEquals( 46, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -1143,7 +1143,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 43, count( $properties ) );
+		$this->assertEquals( 46, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -67,6 +67,9 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			'currency_symbol',
 			'refunds',
 			'payment_url',
+			'is_editable',
+			'needs_payment',
+			'needs_processing',
 		);
 	}
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -67,6 +67,9 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 			'currency_symbol',
 			'refunds',
 			'payment_url',
+			'is_editable',
+			'needs_payment',
+			'needs_processing',
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some order _states_ (different than statuses) have complex logic involving other order properties and/or they are filterable by extensions. These states are difficult to calculate in a client app whose only data source is the REST API, and thus they are best added as separate properties to the API response object. These are the states that will be added here, based on their usefulness to the mobile apps:

* `is_editable`
* `needs_payment`
* `needs_processing`

### How to test the changes in this Pull Request:

1. Do a GET request to `wc/v3/orders`.
2. Each order object in the response should include these three new fields, each with a boolean value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
