### PR TITLE
Fix `get_options` function deprecation notice in WC 6.5 RC

### DIFF
--- a/plugins/woocommerce/changelog/fix-32863-get-option-deprecated-notices
+++ b/plugins/woocommerce/changelog/fix-32863-get-option-deprecated-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix get_options function deprecation notice

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -179,6 +179,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_admin_install_timestamp',
 			'woocommerce_task_list_tracked_completed_tasks',
 			'woocommerce_show_marketplace_suggestions',
+			'woocommerce_task_list_reminder_bar_hidden',
 			'wc_connect_options',
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32863.

Looks like we deprecated the `get_options` function in [this PR](https://github.com/woocommerce/woocommerce-admin/pull/8279/) and only allow API requests to fetch options in `woocommerce_permissions` list.

The Reminder bar was added in https://github.com/woocommerce/woocommerce/pull/32320 and it fetch the `reminderBarHiddenOption` option, but didn't add it to `woocommerce_permissions`.


### How to test the changes in this Pull Request:

1. Use a JN site
2. Build zip via `pnpm nx build:zip woocommerce`
3. Upload and activate Woocommerce
4. Go to **WooCommerce > Settings**
5. Confirm no deprecation notice in the PHP error log - `WC 6.5 RC: The Automattic\WooCommerce\Admin\API\Options::get_options function is deprecated since version 3.1`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
