### PR TITLE
Fix: product attributes lookup table not being updated on WooCommerce update and on REST API batch requests

### DIFF
--- a/plugins/woocommerce/changelog/fix-product_attributes_lookup_table_update
+++ b/plugins/woocommerce/changelog/fix-product_attributes_lookup_table_update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product attributes lookup table is now properly updated on WooCommerce upgrade and when using REST API batch endpoints

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -227,7 +227,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $items['create'] ) ) {
 			foreach ( $items['create'] as $item ) {
-				$_item = new WP_REST_Request( 'POST' );
+				$_item = new WP_REST_Request( 'POST', $request->get_route() );
 
 				// Default parameters.
 				$defaults = array();
@@ -264,7 +264,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 
 		if ( ! empty( $items['update'] ) ) {
 			foreach ( $items['update'] as $item ) {
-				$_item = new WP_REST_Request( 'PUT' );
+				$_item = new WP_REST_Request( 'PUT', $request->get_route() );
 				$_item->set_body_params( $item );
 				$_response = $this->update_item( $_item );
 
@@ -291,7 +291,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 					continue;
 				}
 
-				$_item = new WP_REST_Request( 'DELETE' );
+				$_item = new WP_REST_Request( 'DELETE', $request->get_route() );
 				$_item->set_query_params(
 					array(
 						'id'    => $id,

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2358,9 +2358,9 @@ function wc_update_630_create_product_attributes_lookup_table() {
 
 	/**
 	 * If the table exists and contains data, it was manually created by user before the migration ran.
-	 * If the table exists but is empty, it was likely created right now via dbDelta, so a table regenerations is needed.
+	 * If the table exists but is empty, it was likely created right now via dbDelta, so a table regenerations is needed (unless one is in progress already).
 	 */
-	if ( ! $data_store->check_lookup_table_exists() || ! $data_store->lookup_table_has_data() ) {
+	if ( ! $data_store->check_lookup_table_exists() || ( ! $data_store->lookup_table_has_data() && ! $data_store->regeneration_is_in_progress() ) ) {
 		$data_regenerator->initiate_regeneration();
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal\ProductAttributesLookup;
 
 use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -64,6 +65,15 @@ class LookupDataStore {
 			},
 			100,
 			1
+		);
+
+		add_action(
+			'woocommerce_rest_insert_product',
+			function ( $product_post, $request ) {
+				$this->on_product_created_or_updated_via_rest_api( $product_post, $request );
+			},
+			100,
+			2
 		);
 
 		add_filter(
@@ -631,6 +641,20 @@ class LookupDataStore {
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Handler for the woocommerce_rest_insert_product hook.
+	 * Needed to update the lookup table when the REST API batch insert/update endpoints are used.
+	 *
+	 * @param WP_Post          $product The post representing the created or updated product.
+	 * @param \WP_REST_Request $request The REST request that caused the hook to be fired.
+	 * @return void
+	 */
+	private function on_product_created_or_updated_via_rest_api( WP_Post $product, \WP_REST_Request $request ): void {
+		if ( StringUtil::ends_with( $request->get_route(), '/batch' ) ) {
+			$this->on_product_changed( $product->ID );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull requests fixes two bugs related to the product attributes lookup table.

#### Table not initialized on WooCommerce update

When WooCommerce was updated from version 6.2 or older the product attributes lookup table was created and its usage was activated. However the table filling wasn't triggered if the admin user didn't trigger a database update, so the table was left empty. This caused search to stop working (no products matched any search), and the corresponding filtering widget to not show (since it assumed that there were no products at all and thus no attributes to filter by).

#### Table not updated on REST API batch updates

When the `products/batch` REST API endpoint was used to create or update products the product attributes lookup table wasn't being updated (the individual product endpoints were working fine).

Closes #32065.

### How to test the changes in this Pull Request:

#### To test the WooCommerce update

1. Install WooCommerce 6.2 or earlier and create some products with attributes (NOT custom product attributes).

2. Update WooCommerce to the version that implements this fix. Do NOT click the "Update database" button in the "Database required" notice.

Alternatively to the above, you can also run the following commands and simply load any admin page:

```bash
wp db query 'drop table wp_wc_product_attributes_lookup'
wp option update woocommerce_db_version 6.2.0
wp option update woocommerce_version 6.2.0
```

3. Immediately after the update go to _WooCommerce - Settings - Products - Advanced_. You should see a _"These settings are not available while the lookup table regeneration is in progress"_ message; or if the number of products is small, maybe you'll see that the regeneration has finished already and table usage is enabled.

4. Once the regeneration finishes, query the `wp_wc_product_attributes_lookup` table, it should contain data for all the existing products.

5. Try also a new WooCommerce install (with the fix). This time the lookup table will be empty because there are no products yet, but the table usage will still be enabled.


#### To test the REST API batch endpoints

1. To ease testing set the "Update the table directly upon product changes, instead of scheduling a deferred update" option in _WooCommerce - Settings - Products - Advanced_.

2. Run the following to create a product using the batch endpoint, you'll need to adjust the "attributes" item to the values of an attribute that actually exists in your setup and set the proper user credentials (user/password combination will work if you have a HTTP basic authentication plugin installed):

```bash
curl -X POST http://localhost/wp-json/wc/v3/products/batch \
    -u user:password \
    -H "Content-Type: application/json" \
    -d '{
  "create": [
    {
      "name": "The Simple Product",
      "type": "simple",
      "regular_price": "1",
      "attributes": [
         {
          "id": 1,
          "name": "Color",
          "options": [
            "Blue"
          ]
         }
      ]
    }
  ]
}'
```

3. Take note of the generated product id and verify that the attributes lookup table has a new entry for the product, you can run the following for that:

```bash
wp db query "select * from wp_wc_product_attributes_lookup where product_or_parent_id=<id>"
```

Note that the `in_stock` field in the returned data has the value 1.

4. Update the product so that it doesn't have stock:

```bash
curl -X POST http://localhost/wp-json/wc/v3/products/batch \
    -u user:password \
    -H "Content-Type: application/json" \
    -d '{
  "update": [
    {
        "id": <id>,
        "stock_status": "outofstock"
    }
  ]
}'
```

5. Query the table again and verify that this time `in_stock` is 0.

6. Delete the product:

```bash
curl -X POST http://localhost/wp-json/wc/v3/products/batch \
    -u user:password \
    -H "Content-Type: application/json" \
    -d '{
  "delete": [
      <id>
  ]
}'
```

7. Query the table, you shouldn't get any result now.

8. Try again but this time using the individual product endpoints:

```bash
curl -X POST http://localhost/wp-json/wc/v3/products \
    -u user:password \
    -H "Content-Type: application/json" \
    -d '{
      "name": "The Simple Product",
      "type": "simple",
      "regular_price": "1",
      "attributes": [
         {
          "id": 1,
          "name": "Color",
          "options": [
            "Blue"
          ]
         }
      ]
}'
```

```bash
curl -X PUT http://localhost/wp-json/wc/v3/products/<id>\
    -u user:password \
    -H "Content-Type: application/json" \
    -d '{
      "stock_status": "outofstock"
}'
```

```bash
curl -u user:password -X DELETE http://localhost/wp-json/wc/v3/products/<id>?force=true
```

9. Try again with v1 and v2 of the API. Note that you'll need to replace `"stock_status": "outofstock"` with `"in_stock": false`.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
