### PR TITLE
Fix Beta Tester Uglification

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-preuglify
+++ b/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-preuglify
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This is an infrastructure change.
+
+

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -27,8 +27,7 @@
 		"build": "pnpm run uglify",
 		"build:zip": "./bin/build-zip.sh",
 		"build:dev": "pnpm run lint:js && pnpm run uglify",
-		"preuglify": "rm -f $npm_package_assets_js_min",
-		"uglify": "for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
+		"uglify": "rm -f $npm_package_assets_js_min && for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
 		"lint": "eslint assets/js --ext=js",
 		"lint:fix": "eslint assets/js --ext=js --fix"
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

PNPM does not run "pre" and "post" scripts for user-defined scripts. This commit removed the "preuglify" script from the beta tester plugin so that it builds correctly.

### How to test the changes in this Pull Request:

1. Run `pnpm nx build woocommerce-beta-tester`
2. Make sure `plugins/woocommerce-beta-tester/assets/js/version-information.min.js` is not duplicated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
