### PR TITLE
Fixed Monorepo Merge Build

### DIFF
--- a/tools/monorepo-merge/tsconfig.json
+++ b/tools/monorepo-merge/tsconfig.json
@@ -6,7 +6,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
-    "target": "es2019"
+    "target": "es2019",
+    "typeRoots": [
+			"./node_modules/@types"
+		],
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since by default TypeScript looks for type definitions in parent `node_modules` directories, we are getting build errors. This is because there are React types from Storybook causing issues. This pull request fixes that by explicitly defining the type roots.

### How to test the changes in this Pull Request:

1. Run `cd tools/monorepo-merge`
2. Run `pnpm build` and ensure it works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
