### PR TITLE
Add a dismiss ("No thanks") button to the WCPay Subscriptions welcome page

### DIFF
--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -4,10 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { Button, Card, CardBody, Notice } from '@wordpress/components';
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { PLUGINS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -69,6 +68,7 @@ const ErrorNotice = () => {
 
 const NoThanksButton = () => {
 	const [ isNoThanksClicked, setIsNoThanksClicked ] = useState( false );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
 	return (
 		<Button
@@ -80,12 +80,8 @@ const NoThanksButton = () => {
 					'wccore_subscriptions_empty_state_no_thanks_click',
 					{}
 				);
-				apiFetch( {
-					path: 'wc-admin/options',
-					method: 'POST',
-					data: {
-						[ dismissOptionKey ]: 'yes',
-					},
+				updateOptions( {
+					[ dismissOptionKey ]: 'yes',
 				} ).then( () => {
 					window.location.href = noThanksUrl;
 				} );

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -7,6 +7,7 @@ import { Button, Card, CardBody, Notice } from '@wordpress/components';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -24,6 +25,8 @@ declare global {
 		wcWcpaySubscriptions: {
 			newSubscriptionProductUrl: string;
 			onboardingUrl: string;
+			noThanksUrl: string;
+			dismissOptionKey: string;
 		};
 	}
 }
@@ -31,6 +34,8 @@ declare global {
 const {
 	newSubscriptionProductUrl,
 	onboardingUrl,
+	noThanksUrl,
+	dismissOptionKey,
 } = window.wcWcpaySubscriptions;
 
 type setHasErrorFunction = React.Dispatch< React.SetStateAction< boolean > >;
@@ -62,6 +67,35 @@ const ErrorNotice = () => {
 	);
 };
 
+const NoThanksButton = () => {
+	const [ isNoThanksClicked, setIsNoThanksClicked ] = useState( false );
+
+	return (
+		<Button
+			isBusy={ isNoThanksClicked }
+			isSecondary
+			onClick={ () => {
+				setIsNoThanksClicked( true );
+				recordEvent(
+					'wccore_subscriptions_empty_state_no_thanks_click',
+					{}
+				);
+				apiFetch( {
+					path: 'wc-admin/options',
+					method: 'POST',
+					data: {
+						[ dismissOptionKey ]: 'yes',
+					},
+				} ).then( () => {
+					window.location.href = noThanksUrl;
+				} );
+			} }
+		>
+			{ __( 'No thanks', 'woocommerce' ) }
+		</Button>
+	);
+};
+
 type GetStartedButtonProps = {
 	setHasError: setHasErrorFunction;
 };
@@ -73,36 +107,34 @@ const GetStartedButton: React.FC< GetStartedButtonProps > = ( {
 	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
 
 	return (
-		<div className="wcpay-empty-subscriptions__button_container">
-			<Button
-				disabled={ isGettingStarted }
-				isBusy={ isGettingStarted }
-				isPrimary
-				onClick={ () => {
-					setIsGettingStarted( true );
-					recordEvent(
-						'wccore_subscriptions_empty_state_get_started_click',
-						{}
-					);
-					installAndActivatePlugins( [ 'woocommerce-payments' ] )
-						.then( () => {
-							/*
-							 * TODO:
-							 * Navigate to either newSubscriptionProductUrl or onboardingUrl
-							 * depending on the which treatment the user is assigned to.
-							 */
-							// eslint-disable-next-line no-console
-							console.log( 'It was a success!' );
-						} )
-						.catch( () => {
-							setIsGettingStarted( false );
-							setHasError( true );
-						} );
-				} }
-			>
-				{ __( 'Get started', 'woocommerce' ) }
-			</Button>
-		</div>
+		<Button
+			disabled={ isGettingStarted }
+			isBusy={ isGettingStarted }
+			isPrimary
+			onClick={ () => {
+				setIsGettingStarted( true );
+				recordEvent(
+					'wccore_subscriptions_empty_state_get_started_click',
+					{}
+				);
+				installAndActivatePlugins( [ 'woocommerce-payments' ] )
+					.then( () => {
+						/*
+						 * TODO:
+						 * Navigate to either newSubscriptionProductUrl or onboardingUrl
+						 * depending on the which treatment the user is assigned to.
+						 */
+						// eslint-disable-next-line no-console
+						console.log( 'It was a success!' );
+					} )
+					.catch( () => {
+						setIsGettingStarted( false );
+						setHasError( true );
+					} );
+			} }
+		>
+			{ __( 'Get started', 'woocommerce' ) }
+		</Button>
 	);
 };
 
@@ -176,7 +208,10 @@ const MainContent: React.FC< MainContentProps > = ( { setHasError } ) => {
 				<TermsOfService />
 			</p>
 
-			<GetStartedButton setHasError={ setHasError } />
+			<div className="wcpay-empty-subscriptions__button_container">
+				<NoThanksButton></NoThanksButton>
+				<GetStartedButton setHasError={ setHasError } />
+			</div>
 		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -209,8 +209,8 @@ const MainContent: React.FC< MainContentProps > = ( { setHasError } ) => {
 			</p>
 
 			<div className="wcpay-empty-subscriptions__button_container">
-				<NoThanksButton></NoThanksButton>
 				<GetStartedButton setHasError={ setHasError } />
+				<NoThanksButton />
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-admin/client/subscriptions/style.scss
+++ b/plugins/woocommerce-admin/client/subscriptions/style.scss
@@ -85,7 +85,7 @@ $max-width: 680px;
 					hr {
 						position: relative;
 						left: -24px;
-						width: calc( 100% + 48px );
+						width: calc(100% + 48px);
 					}
 				}
 			}
@@ -104,6 +104,12 @@ $max-width: 680px;
 			h2 {
 				margin-top: 0;
 			}
+		}
+	}
+
+	.wcpay-empty-subscriptions__button_container {
+		button:not(:first-child) {
+			margin-left: 10px;
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/WcPaySubscriptionsPage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPaySubscriptionsPage.php
@@ -25,6 +25,13 @@ class WcPaySubscriptionsPage {
 	private $user_viewed_option = 'woocommerce-wcpay-subscriptions_page_viewed';
 
 	/**
+	 * The option key used to record when the user dismisses the WCPay Subscriptions page.
+	 *
+	 * @var string
+	 */
+	private $user_dismissed_option = 'woocommerce-wcpay-subscriptions_dismissed';
+
+	/**
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
@@ -41,6 +48,10 @@ class WcPaySubscriptionsPage {
 	 */
 	public function register_subscriptions_page() {
 		global $submenu;
+
+		if ( 'yes' === get_option( $this->user_dismissed_option, 'no' ) ) {
+			return;
+		}
 
 		// WC Payments must not be active.
 		if ( is_plugin_active( 'woocommerce-payments/woocommerce-payments.php' ) ) {
@@ -113,6 +124,8 @@ class WcPaySubscriptionsPage {
 				),
 				admin_url( 'admin.php' )
 			),
+			'dismissOptionKey'          => $this->user_dismissed_option,
+			'noThanksUrl'               => wc_admin_url(),
 		);
 
 		wp_add_inline_script( WC_ADMIN_APP, 'window.wcWcpaySubscriptions = ' . wp_json_encode( $data ), 'before' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such change**s.** -->

This PR adds a button to the WooCommerce > Subscriptions screen that users can use to hide/dismiss the menu item. 

Closes #32909 

<img width="730" alt="Screen Shot 2022-05-09 at 3 11 43 pm" src="https://user-images.githubusercontent.com/8490476/167344626-0944572c-afe7-45c7-90e7-ac10c5c324c7.png">

### How to test the changes in this Pull Request:

1. Checkout this branch and build assets with `pnpm nx build-watch woocommerce-admin `
2. With WooCommerce Payments and WooCommerce Subscriptions inactive, navigate to **WooCommerce > Subscriptions**
3. There should be a "No thanks" button. 
4. Clicking "No thanks" should redirect you to the **WooCommerce > Home** screen * and the subscriptions menu item should no longer appear in the navigation. 

\* this UX hasn't been agreed to so feel free to give me feedback on that. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?
     - NA for this PR. We'll submit a single change log entry for this project. 

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
