### PR TITLE
Add tracks for experimental import products task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/importTypes.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/importTypes.tsx
@@ -7,6 +7,7 @@ import ReblogIcon from 'gridicons/dist/reblog';
 import { getAdminLink } from '@woocommerce/settings';
 import interpolateComponents from '@automattic/interpolate-components';
 import { ExternalLink } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
 
 export const importTypes = [
 	{
@@ -20,6 +21,8 @@ export const importTypes = [
 		href: getAdminLink(
 			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
 		),
+		onClick: () =>
+			recordEvent( 'tasklist_add_product', { method: 'import' } ),
 	},
 	{
 		key: 'from-cart2cart' as const,
@@ -37,5 +40,7 @@ export const importTypes = [
 			},
 		} ),
 		before: <ReblogIcon />,
+		onClick: () =>
+			recordEvent( 'tasklist_add_product', { method: 'migrate' } ),
 	},
 ];

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
@@ -6,8 +6,9 @@ import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { getAdminLink } from '@woocommerce/settings';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -20,9 +21,23 @@ import useProductTypeListItems from '../experimental-products/use-product-types-
 import { getProductTypes } from '../experimental-products/utils';
 import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
+import useRecordCompletionTime from '../use-record-completion-time';
 
-const Products = () => {
+export const Products = () => {
 	const [ showStacks, setStackVisibility ] = useState< boolean >( false );
+	const { recordCompletionTime } = useRecordCompletionTime( 'products' );
+
+	const importTypesWithTimeRecord = useMemo(
+		() =>
+			importTypes.map( ( importType ) => ( {
+				...importType,
+				onClick: () => {
+					importType.onClick();
+					recordCompletionTime();
+				},
+			} ) ),
+		[ recordCompletionTime ]
+	);
 
 	const {
 		loadSampleProduct,
@@ -32,20 +47,34 @@ const Products = () => {
 			'edit.php?post_type=product&wc_onboarding_active_task=products'
 		),
 	} );
+
+	const productTypeListItems = useProductTypeListItems(
+		getProductTypes( [ 'subscription' ] ),
+		{
+			onClick: recordCompletionTime,
+		}
+	);
+
 	const StacksComponent = (
 		<Stacks
-			items={ useProductTypeListItems(
-				getProductTypes( [ 'subscription' ] )
-			) }
+			items={ productTypeListItems }
 			onClickLoadSampleProduct={ loadSampleProduct }
 		/>
 	);
+
 	return (
 		<div className="woocommerce-task-import-products">
 			<h1>{ __( 'Import your products', 'woocommerce' ) }</h1>
-			<CardList items={ importTypes } />
+			<CardList items={ importTypesWithTimeRecord } />
 			<div className="woocommerce-task-import-products-stacks">
-				<Button onClick={ () => setStackVisibility( ! showStacks ) }>
+				<Button
+					onClick={ () => {
+						recordEvent(
+							'tasklist_add_product_from_scratch_click'
+						);
+						setStackVisibility( ! showStacks );
+					} }
+				>
 					{ __( 'Or add your products from scratch', 'woocommerce' ) }
 					<Icon icon={ showStacks ? chevronUp : chevronDown } />
 				</Button>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/test/index.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { render, waitFor } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import { Products } from '../';
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+
+describe( 'Products', () => {
+	beforeEach( () => {
+		( recordEvent as jest.Mock ).mockClear();
+	} );
+
+	test( 'should fire "tasklist_add_product_from_scratch_click" event when the button clicked', async () => {
+		const { getByRole } = render( <Products /> );
+
+		userEvent.click(
+			getByRole( 'button', { name: 'Or add your products from scratch' } )
+		);
+		await waitFor( () =>
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'tasklist_add_product_from_scratch_click'
+			)
+		);
+	} );
+
+	test( 'should fire "tasklist_add_product" event when the csv option clicked', async () => {
+		const { getByRole } = render( <Products /> );
+
+		userEvent.click(
+			getByRole( 'menuitem', {
+				name:
+					'FROM A CSV FILE Import all products at once by uploading a CSV file.',
+			} )
+		);
+		await waitFor( () =>
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'tasklist_add_product',
+				{
+					method: 'import',
+				}
+			)
+		);
+	} );
+
+	test( 'should fire "tasklist_add_product" event when the cart2cart option clicked', async () => {
+		const { getByRole } = render( <Products /> );
+
+		userEvent.click(
+			getByRole( 'menuitem', {
+				name:
+					'FROM CART2CART Migrate all store data like products, customers, and orders in no time with this 3rd party plugin. Learn more (opens in a new tab)',
+			} )
+		);
+		await waitFor( () =>
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'tasklist_add_product',
+				{
+					method: 'migrate',
+				}
+			)
+		);
+	} );
+
+	test( 'should fire "task_completion_time" event when an option clicked', async () => {
+		Object.defineProperty( window, 'performance', {
+			value: {
+				now: jest
+					.fn()
+					.mockReturnValueOnce( 0 )
+					.mockReturnValueOnce( 1000 ),
+			},
+		} );
+		const { getByRole } = render( <Products /> );
+
+		userEvent.click(
+			getByRole( 'menuitem', {
+				name:
+					'FROM A CSV FILE Import all products at once by uploading a CSV file.',
+			} )
+		);
+		await waitFor( () =>
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'task_completion_time',
+				{
+					task_name: 'products',
+					time: 1000,
+				}
+			)
+		);
+	} );
+} );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-types-list-items.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-types-list-items.tsx
@@ -9,14 +9,26 @@ import { useMemo } from '@wordpress/element';
 import useCreateProductByType from './use-create-product-by-type';
 import { ProductType } from './constants';
 
-const useProductTypeListItems = ( _productTypes: ProductType[] ) => {
+const useProductTypeListItems = (
+	_productTypes: ProductType[],
+	{
+		onClick,
+	}: {
+		onClick?: () => void;
+	} = {}
+) => {
 	const { createProductByType } = useCreateProductByType();
 
 	const productTypes = useMemo(
 		() =>
 			_productTypes.map( ( productType ) => ( {
 				...productType,
-				onClick: () => createProductByType( productType.key ),
+				onClick: () => {
+					createProductByType( productType.key );
+					if ( typeof onClick === 'function' ) {
+						onClick();
+					}
+				},
 			} ) ),
 		[ createProductByType ]
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/use-record-completion-time.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/use-record-completion-time.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
+
+const useRecordCompletionTime = ( taskName: string, startTime?: number ) => {
+	const _startTime = useRef( startTime || window.performance.now() );
+
+	const recordCompletionTime = () => {
+		recordEvent( 'task_completion_time', {
+			task_name: taskName,
+			time: window.performance.now() - _startTime.current,
+		} );
+	};
+
+	return {
+		recordCompletionTime,
+	};
+};
+
+export default useRecordCompletionTime;

--- a/plugins/woocommerce/changelog/add-32811-import-prdocuts-tracks
+++ b/plugins/woocommerce/changelog/add-32811-import-prdocuts-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add track events for experimental import products task


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32811.

Add the following tracks for experimental import products task:

- `wcadmin_tasklist_add_product`
  -  **import**:  fired when the user selects the import option
  -  **migrate**: fired when the user selects the migration option
- `tasklist_add_product_from_scratch_click`: fired when the user clicks "add your products from scratch"
- `task_completion_time` (the amount of time it takes a user to select an option and move to the next step)

Acceptance criteria:


- Task completion time on average (the amount of time it takes a user to select an option and move to the next step).
- % of users that clicks on one of the two recommended options
- % of users that clicks on "add your products from scratch"
- List of the most clicked import products option (from CSV or Cart2Cart)

Note: `wcadmin_task_view` will be updated in https://github.com/woocommerce/woocommerce/issues/32633 PR.

### How to test the changes in this Pull Request:

1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-import-products-task`
4. Go to OBW.
5. Enabling tracking
6. Choose `Yes, on another platform` in the Business Details step.
7. Navigate to `WoocCommerce -> Home` and `click Add my products`
8. Enable track logging `localStorage.setItem( 'debug', 'wc-admin:*' );` & tick the `Preserve log` option
![Screen Shot 2022-05-09 at 13 55 43](https://user-images.githubusercontent.com/4344253/167349039-c2289c42-6a81-4d3a-a5c4-a32645cdeb07.png)
10. Click `Or add your products from scratch`
11. It should also trigger a `wcadmin_tasklist_add_product_from_scratch_click` track
12. Click `FROM A CSV FILE`
13. It should also trigger a `wcadmin_tasklist_add_product` track with the `{method: 'import'}` prop & a `wcadmin_task_completion_time` track
12. Go back & click `FROM CART2CART`
13. It should also trigger a `wcadmin_tasklist_add_product` track with the `{method: 'migrate'}` prop & a `wcadmin_task_completion_time` track


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
