### PR TITLE
Change wcpay task display logic

### DIFF
--- a/plugins/woocommerce/changelog/update-32451-wcpay-task-display-logic
+++ b/plugins/woocommerce/changelog/update-32451-wcpay-task-display-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Change WCPayments task display logic

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as Suggestions;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
 
 /**
  * WooCommercePayments Task
@@ -86,7 +87,9 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		return self::is_requested() &&
+		$has_task_list_previously_completed = ( new TaskList( array( 'id' => 'setup' ) ) )->has_previously_completed();
+
+		return ! $has_task_list_previously_completed && // Do not re-display the task if the task list has already been completed.
 			self::is_installed() &&
 			self::is_supported() &&
 			( $this->get_parent_id() !== 'setup_two_column' || ! self::is_connected() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32451.

This PR changes the wcpay task display logic:

- Display the task regardless of how it's installed
- Only display the task if the task list has not been completed.

### How to test the changes in this Pull Request:

**Display the wcpay task when WooCommerce Payments is installed during the OBW**

1.  Use a fresh site
2. Choose a supported country like US in the `Store Details` step
3. Install WooCommerce Payments in the Business Details / Free Features step.
4. Go to `Woocommerce > Home`
5. Observe that `Get paid with WooCommerce Payments` task is displayed

**Display the wcpay task when WooCommerce Payments is installed via Plugins > Add New**

1.  Use a fresh site
2. Choose a supported country like US in the `Store Details` step
3. **Uncheck** WooCommerce Payments in the Business Details / Free Features step.
4. Install `WooCommerce Payments` via `Plugins > Add New`
5. Go to `Woocommerce > Home`
6. Observe that `Get paid with WooCommerce Payments` task is displayed

**Do not display the wcpay task when task list has been completed**

1.  Use a fresh site
2. Choose a supported country like US in the `Store Details` step
3. **Uncheck** WooCommerce Payments in the Business Details / Free Features step.
4. Go to `Woocommerce > Home`
5. Complete all tasks
6. Install `WooCommerce Payments` via `Plugins > Add New`
7. Go to `Woocommerce > Home`
8. Observe that `Get paid with WooCommerce Payments` task is **NOT** displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
