### PR TITLE
Add `_recorded_sales` meta to COT

### DIFF
--- a/plugins/woocommerce/changelog/issue-32843
+++ b/plugins/woocommerce/changelog/issue-32843
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add 'recorded_sales' meta to operational data table.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
@@ -135,6 +135,10 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 				'type'        => 'decimal',
 				'destination' => 'discount_total_amount',
 			),
+			'_recorded_sales'               => array(
+				'type'        => 'bool',
+				'destination' => 'recorded_sales',
+			),
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -301,6 +301,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 			'type' => 'decimal',
 			'name' => 'discount_total_amount',
 		),
+		'recorded_sales'              => array( 'type' => 'bool' ),
 	);
 
 	/**
@@ -716,6 +717,7 @@ CREATE TABLE $operational_data_table_name (
 	shipping_total_amount decimal(26, 8) NULL,
 	discount_tax_amount decimal(26, 8) NULL,
 	discount_total_amount decimal(26, 8) NULL,
+	recorded_sales tinyint(1) NULL,
 	KEY order_id (order_id),
 	KEY order_key (order_key)
 );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -206,6 +206,7 @@ class OrderHelper {
 		$order->set_prices_include_tax( true );
 		wc_update_coupon_usage_counts( $order->get_id() );
 		$order->get_data_store()->set_download_permissions_granted( $order, true );
+		$order->get_data_store()->set_recorded_sales( $order, true );
 		$order->set_cart_hash( '1234' );
 		$order->update_meta_data( '_new_order_email_sent', 'true' );
 		$order->update_meta_data( '_order_stock_reduced', 'true' );

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
@@ -311,6 +311,10 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$this->assertEquals( (float) $order->get_shipping_total(), (float) $db_order_op_data->shipping_total_amount );
 		$this->assertEquals( (float) $order->get_discount_tax(), (float) $db_order_op_data->discount_tax_amount );
 		$this->assertEquals( (float) $order->get_discount_total(), (float) $db_order_op_data->discount_total_amount );
+		$this->assertEquals(
+			$order->get_data_store()->get_recorded_sales( $order ),
+			(bool) $db_order_op_data->recorded_sales
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds `recorded_sales` to the meta in the operational data table and updates migration and tests code to account for that.

Closes #32843.

### How to test the changes in this Pull Request:

1. Attempt to migrate a batch or an order and see that despite the metadata `_recorded_sales` (stored as "yes"/"no") being available in `wp_postmeta` for orders, no similar record exists in COT tables.
2. Re-create COT tables by going to WC > Status > Tools and using "Create the custom orders tables" or "Delete the custom orders tables" as necessary.
3. Re-attempt the migration from step 1 and confirm that `recorded_sales` is now a column in the `wc_order_operational_data` table and correctly registers the value from the original post meta.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
