### PR TITLE
Fix duplicate task list shown in some occurrences

### DIFF
--- a/packages/js/data/CHANGELOG.md
+++ b/packages/js/data/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   Convert `use-user-preferences.js` to TS. #32695
 -   Added PaymentGateway type to exports #32697
 -   Add `@types/wordpress__compose`, `@types/wordpress__data`, `redux` types and fix related type errors. #32735
+-   Fix issue in `onboarding` data package for the unhide and hide success actions. #32926
 
 ## Breaking change
 

--- a/packages/js/data/src/onboarding/actions.js
+++ b/packages/js/data/src/onboarding/actions.js
@@ -169,6 +169,7 @@ export function hideTaskListSuccess( taskList ) {
 	return {
 		type: TYPES.HIDE_TASK_LIST_SUCCESS,
 		taskList,
+		taskListId: taskList.id,
 	};
 }
 
@@ -191,6 +192,7 @@ export function unhideTaskListSuccess( taskList ) {
 	return {
 		type: TYPES.UNHIDE_TASK_LIST_SUCCESS,
 		taskList,
+		taskListId: taskList.id,
 	};
 }
 

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -246,7 +246,10 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 				if ( currentLocation !== homescreenLocation ) {
 					// Ensure that if the user is trying to get to the task list they can see it even if
 					// it was dismissed.
-					if ( setupTaskListHidden === 'no' ) {
+					if (
+						setupTaskListHidden === 'no' ||
+						setupTaskListHidden === false
+					) {
 						redirectToHomeScreen();
 					} else {
 						unhideTaskList( 'setup' ).then( redirectToHomeScreen );

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -246,10 +246,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 				if ( currentLocation !== homescreenLocation ) {
 					// Ensure that if the user is trying to get to the task list they can see it even if
 					// it was dismissed.
-					if (
-						setupTaskListHidden === 'no' ||
-						setupTaskListHidden === false
-					) {
+					if ( setupTaskListHidden === false ) {
 						redirectToHomeScreen();
 					} else {
 						unhideTaskList( 'setup' ).then( redirectToHomeScreen );

--- a/plugins/woocommerce/changelog/fix-32896_two_tasklists
+++ b/plugins/woocommerce/changelog/fix-32896_two_tasklists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update finish setup button logic to adhere to new Task List data structure. #32926


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32896 

Made two changes, one fix is in the activity panel with the check if the Task list is hidden, checking if it is set to `false` which is the new default.
Secondly the success actions for hide and unhide task lists weren't passing the `taskListId` to the reducer, causing an `undefined` task list and hence an extra task list showing up.

### How to test the changes in this Pull Request:

1. Load `trunk` first and finish the onboarding wizard
2. Go to **WooCommerce > Home** (one task list should show) and navigate to **WooCommerce > Analytics > Overview**
3. Notice the **Finish setup** button in the top right, open your console to monitor network requests, and click the Finish setup button (it should redirect home)
4. Notice how a second task list shows up and a request has been made to `/onboarding/tasks/<task list id>/unhide`
5. Now load this branch and refresh the home screen
6. Follow steps 2-4 again, this time it should not have made a request to `unhide` and a second task list should not be shown.
7. Try hiding the task list and see if that works correctly.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
