### PR TITLE
Move copy of composer.json step to after unzipping

### DIFF
--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -58,9 +58,6 @@ jobs:
         with:
           path: monorepo
 
-      - name: Copy Composer over to production
-        run: cp monorepo/plugins/woocommerce/composer.json tmp/woocommerce-build
-
       - name: Download WooCommerce ZIP
         uses: actions/download-artifact@v3
         with:
@@ -74,6 +71,9 @@ jobs:
           unzip woocommerce.zip -d woocommerce/woocommerce-production
           mv woocommerce/woocommerce-production/woocommerce/* woocommerce/woocommerce-production
           rm -rf woocommerce/woocommerce-production/woocommerce
+
+      - name: Copy Composer over to production
+        run: cp monorepo/plugins/woocommerce/composer.json tmp/woocommerce-build
 
       - name: Set up mirror
         working-directory: tmp/woocommerce-build


### PR DESCRIPTION
This PR tries to fix the issue where the `Mirrors` workflow isn't copying over the `composer.json` file to  [woocommerce-production](https://github.com/woocommerce/woocommerce-production) repo. I am basically moving the copy step to after the unzip step.

This is more of trial and error as we can only test it after merging it.