### PR TITLE
Remove ExPlat calls for woocommerce_tasklist_progression_headercard experiments

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -35,11 +35,9 @@ import { TasksPlaceholder } from '../tasks';
 import {
 	WELCOME_MODAL_DISMISSED_OPTION_NAME,
 	WELCOME_FROM_CALYPSO_MODAL_DISMISSED_OPTION_NAME,
-	WOOCOMMERCE_ADMIN_INSTALL_TIMESTAMP_OPTION_NAME,
 } from './constants';
 import { WelcomeFromCalypsoModal } from './welcome-from-calypso-modal';
 import { WelcomeModal } from './welcome-modal';
-import { useHeadercardExperimentHook } from './hooks/use-headercard-experiment-hook';
 import './style.scss';
 import '../dashboard/style.scss';
 import { getAdminSetting } from '~/utils/admin-settings';
@@ -70,8 +68,6 @@ export const Layout = ( {
 	shouldShowWelcomeFromCalypsoModal,
 	isTaskListHidden,
 	updateOptions,
-	installTimestamp,
-	installTimestampHasResolved,
 } ) => {
 	const userPrefs = useUserPreferences();
 	const shouldShowStoreLinks = taskListComplete || isTaskListHidden;
@@ -79,15 +75,18 @@ export const Layout = ( {
 		shouldShowStoreLinks || window.wcAdminFeatures.analytics;
 	const [ showInbox, setShowInbox ] = useState( true );
 	const isDashboardShown = ! query.task;
+
 	const {
 		isLoadingExperimentAssignment,
 		isLoadingTwoColExperimentAssignment,
 		experimentAssignment,
 		twoColExperimentAssignment,
-	} = useHeadercardExperimentHook(
-		installTimestampHasResolved,
-		installTimestamp
-	);
+	} = {
+		isLoadingExperimentAssignment: false,
+		isLoadingTwoColExperimentAssignment: false,
+		experimentAssignment: null,
+		twoColExperimentAssignment: null,
+	};
 
 	const isRunningTwoColumnExperiment =
 		twoColExperimentAssignment?.variationName === 'treatment';
@@ -317,18 +316,9 @@ export default compose(
 		const welcomeModalDismissed =
 			getOption( WELCOME_MODAL_DISMISSED_OPTION_NAME ) !== 'no';
 
-		const installTimestamp = getOption(
-			WOOCOMMERCE_ADMIN_INSTALL_TIMESTAMP_OPTION_NAME
-		);
-
 		const welcomeModalDismissedHasResolved = hasFinishedResolution(
 			'getOption',
 			[ WELCOME_MODAL_DISMISSED_OPTION_NAME ]
-		);
-
-		const installTimestampHasResolved = hasFinishedResolution(
-			'getOption',
-			[ WOOCOMMERCE_ADMIN_INSTALL_TIMESTAMP_OPTION_NAME ]
 		);
 
 		const shouldShowWelcomeModal =
@@ -353,8 +343,6 @@ export default compose(
 				( list ) => list.isVisible && list.displayProgressHeader
 			),
 			taskListComplete: getTaskList( 'setup' )?.isComplete,
-			installTimestamp,
-			installTimestampHasResolved,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/plugins/woocommerce/changelog/update-32911-remove-explat-calls-for-headercard-exp
+++ b/plugins/woocommerce/changelog/update-32911-remove-explat-calls-for-headercard-exp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove ExPlat calls for woocommerce_tasklist_progression_headercard_2col_2022_05 and woocommerce_tasklist_progression_headercard_2022_05

--- a/plugins/woocommerce/src/Admin/API/Notes.php
+++ b/plugins/woocommerce/src/Admin/API/Notes.php
@@ -275,6 +275,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		 *
 		 * @param array           $args    Key value array of query var to query value.
 		 * @param WP_REST_Request $request The request used.
+		 * @since 3.9.0
 		 */
 		$args = apply_filters( 'woocommerce_rest_notes_object_query', $args, $request );
 
@@ -600,6 +601,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		 * @param WP_REST_Response $response The response object.
 		 * @param array            $data The original note.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 * @since 3.9.0
 		 */
 		return apply_filters( 'woocommerce_rest_prepare_note', $response, $data, $request );
 	}

--- a/plugins/woocommerce/src/Admin/API/Notes.php
+++ b/plugins/woocommerce/src/Admin/API/Notes.php
@@ -267,12 +267,6 @@ class Notes extends \WC_REST_CRUD_Controller {
 			$args['orderby'] = 'date_created';
 		}
 
-		// Hide selected notes for users not in experiment.
-		$is_tasklist_experiment_assigned_treatment = $this->is_tasklist_experiment_assigned_treatment();
-		if ( false === $is_tasklist_experiment_assigned_treatment ) {
-			$args['excluded_name'] = array( 'wc-admin-complete-store-details', 'wc-admin-update-store-details' );
-		}
-
 		/**
 		 * Filter the query arguments for a request.
 		 *

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/admin-notes.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/admin-notes.php
@@ -98,7 +98,7 @@ class WC_Admin_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Create a new note containing an action with a nonce.
 		$note = new \Automattic\WooCommerce\Admin\Notes\Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://woocommerce.com/', 'unactioned' );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce' ), 'https://woocommerce.com/', 'unactioned' );
 		$note->add_nonce_to_action( 'learn-more', 'foo', 'bar' );
 		$note->save();
 
@@ -121,7 +121,7 @@ class WC_Admin_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Create a new note containing an action with a nonce.
 		$note = new \Automattic\WooCommerce\Admin\Notes\Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/?x=1&y=2', 'unactioned' );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce' ), 'https://example.com/?x=1&y=2', 'unactioned' );
 		$note->add_nonce_to_action( 'learn-more', 'foo', 'bar' );
 		$note->save();
 
@@ -257,10 +257,10 @@ class WC_Admin_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Test getting notes when the user is not in tasklist experiment excludes two notes.
-	 *
 	 * @since 3.5.0
 	 */
 	public function test_getting_notes_when_user_is_not_in_tasklist_experiment_excludes_two_notes() {
+		$this->markTestSkipped( 'We are disabling the experiments for now.' );
 		// Given.
 		wp_set_current_user( $this->user );
 		WC_Helper_Admin_Notes::reset_notes_dbs();


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32911 .

This PR removes ExPlat calls for `woocommerce_tasklist_progression_headercard_2col_2022_05` and `woocommerce_tasklist_progression_headercard_2022_05` from both frontend and backend. 

Note: PHPCS complained about missing `@since` tags in Notes.php

Looking at the git blame, the filters were added in this [PR](https://github.com/woocommerce/woocommerce-admin/commit/1f261998e7287b77bc13c3d4ee2e84b717da7957) on 2019-12-09. I used version `3.9.0` since it was released  on `2020-01-22`

### How to test the changes in this Pull Request:

1. Navigate to WordPress Admin and open browser inspector.
2. Run `localStorage.clear();` to clear the localStorage
3. Navigate to WooCommerce -> Home
4. Select `Network` tab
5. Search `public-api.wordpress.com` and make sure no request has been made for `woocommerce_tasklist_progression_headercard_2col_2022_05` and `woocommerce_tasklist_progression_headercard_2022_05`

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?
* [X] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
