### PR TITLE
Update import product task to record completion time in time frame format

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -36,7 +36,7 @@ import { sellingVenueOptions } from '../../data/selling-venue-options';
 import { getRevenueOptions } from '../../data/revenue-options';
 import { getProductCountOptions } from '../../data/product-options';
 import { SelectiveExtensionsBundle } from './selective-extensions-bundle';
-import { getPluginSlug, getPluginTrackKey } from '~/utils';
+import { getPluginSlug, getPluginTrackKey, getTimeFrame } from '~/utils';
 import './style.scss';
 
 const BUSINESS_DETAILS_TAB_NAME = 'business-details';
@@ -59,27 +59,6 @@ export const filterBusinessExtensions = (
 			.filter( ( item, index, arr ) => arr.indexOf( item ) === index )
 	);
 };
-
-const timeFrames = [
-	{ name: '0-2s', max: 2 },
-	{ name: '2-5s', max: 5 },
-	{ name: '5-10s', max: 10 },
-	{ name: '10-15s', max: 15 },
-	{ name: '15-20s', max: 20 },
-	{ name: '20-30s', max: 30 },
-	{ name: '30-60s', max: 60 },
-	{ name: '>60s' },
-];
-function getTimeFrame( timeInMs ) {
-	for ( const timeFrame of timeFrames ) {
-		if ( ! timeFrame.max ) {
-			return timeFrame.name;
-		}
-		if ( timeInMs < timeFrame.max * 1000 ) {
-			return timeFrame.name;
-		}
-	}
-}
 
 export const prepareExtensionTrackingData = (
 	extensionInstallationOptions

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/test/index.tsx
@@ -89,7 +89,7 @@ describe( 'Products', () => {
 				'task_completion_time',
 				{
 					task_name: 'products',
-					time: 1000,
+					time: '0-2s',
 				}
 			)
 		);

--- a/plugins/woocommerce-admin/client/tasks/fills/use-record-completion-time.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/use-record-completion-time.ts
@@ -4,13 +4,18 @@
 import { useRef } from '@wordpress/element';
 import { recordEvent } from '@woocommerce/tracks';
 
+/**
+ * Internal dependencies
+ */
+import { getTimeFrame } from '~/utils';
+
 const useRecordCompletionTime = ( taskName: string, startTime?: number ) => {
 	const _startTime = useRef( startTime || window.performance.now() );
 
 	const recordCompletionTime = () => {
 		recordEvent( 'task_completion_time', {
 			task_name: taskName,
-			time: window.performance.now() - _startTime.current,
+			time: getTimeFrame( window.performance.now() - _startTime.current ),
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/utils/index.js
+++ b/plugins/woocommerce-admin/client/utils/index.js
@@ -59,3 +59,32 @@ export const sift = ( arr, partitioner ) =>
 		},
 		[ [], [] ]
 	);
+
+const timeFrames = [
+	{ name: '0-2s', max: 2 },
+	{ name: '2-5s', max: 5 },
+	{ name: '5-10s', max: 10 },
+	{ name: '10-15s', max: 15 },
+	{ name: '15-20s', max: 20 },
+	{ name: '20-30s', max: 30 },
+	{ name: '30-60s', max: 60 },
+	{ name: '>60s' },
+];
+
+/**
+ * Returns time frame for a given time in milliseconds.
+ *
+ * @param {number} timeInMs - time in milliseconds
+ *
+ * @return {string} - Time frame.
+ */
+export const getTimeFrame = ( timeInMs ) => {
+	for ( const timeFrame of timeFrames ) {
+		if ( ! timeFrame.max ) {
+			return timeFrame.name;
+		}
+		if ( timeInMs < timeFrame.max * 1000 ) {
+			return timeFrame.name;
+		}
+	}
+};

--- a/plugins/woocommerce-admin/client/utils/test/index.js
+++ b/plugins/woocommerce-admin/client/utils/test/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getUrlParams } from '../index';
+import { getUrlParams, getTimeFrame } from '../index';
 
 describe( 'getUrlParams', () => {
 	let locationSearch = '?param1=text1&param2=text2';
@@ -28,4 +28,26 @@ describe( 'getUrlParams', () => {
 		const { no_value: noValue } = getUrlParams( locationSearch );
 		expect( noValue ).toBeUndefined();
 	} );
+} );
+
+describe( 'getTimeFrame', () => {
+	test.each( [
+		{
+			timeInMs: 1000,
+			expected: '0-2s',
+		},
+		{
+			timeInMs: 3000,
+			expected: '2-5s',
+		},
+		{
+			timeInMs: 100000,
+			expected: '>60s',
+		},
+	] )(
+		'should return time frames $expected when given $timeInMs',
+		( { timeInMs, expected } ) => {
+			expect( getTimeFrame( timeInMs ) ).toEqual( expected );
+		}
+	);
 } );

--- a/plugins/woocommerce/changelog/update-task-completion-time
+++ b/plugins/woocommerce/changelog/update-task-completion-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update to record completion time in time frame format


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Use the same time format that we use in onboarding flow for the completion time  as confirmed [here](https://github.com/woocommerce/woocommerce/issues/32811#issuecomment-1120912630)
 
Moved `getTimeFrame` function to `~/utils` and use it in the completion time hook.

### How to test the changes in this Pull Request:

1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-import-products-task`
4. Go to OBW.
5. Enabling tracking
6. Choose `Yes, on another platform` in the Business Details step.
7. Navigate to `WoocCommerce -> Home` and `click Add my products`
8. Enable track logging `localStorage.setItem( 'debug', 'wc-admin:*' );` & tick the `Preserve log` option
![Screen Shot 2022-05-09 at 13 55 43](https://user-images.githubusercontent.com/4344253/167349039-c2289c42-6a81-4d3a-a5c4-a32645cdeb07.png)
10. Click `Or add your products from scratch`
11. It should also trigger a `wcadmin_tasklist_add_product_from_scratch_click` track
12. Click `FROM A CSV FILE`
13. It should also trigger a `wcadmin_task_completion_time` track with a time prop in the time frames  `( '0-2s','3-4s','5-9s'...)`

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
