### PR TITLE
Add task_view tracks prop for experimental products

### DIFF
--- a/packages/js/onboarding/changelog/add-32933_task_view_prop_experimental_products
+++ b/packages/js/onboarding/changelog/add-32933_task_view_prop_experimental_products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Add
+
+Add task_view tracks prop for experimental products #32933

--- a/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
+++ b/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
@@ -20,6 +20,8 @@ export const trackView = ( taskId ) => {
 
 	recordEvent( 'task_view', {
 		task_name: taskId,
+		experimental_products:
+			window.wcAdminFeatures[ 'experimental-products-task' ],
 		wcs_installed: installedPlugins.includes( 'woocommerce-services' ),
 		wcs_active: activePlugins.includes( 'woocommerce-services' ),
 		jetpack_installed: installedPlugins.includes( 'jetpack' ),

--- a/plugins/woocommerce/changelog/add-32933_task_view_prop_experimental_products
+++ b/plugins/woocommerce/changelog/add-32933_task_view_prop_experimental_products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Add
+
+Add task_view tracks prop for experimental products #32933


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add task_view tracks prop for experimental products to address #32633 

Closes #32633 .

### How to test the changes in this Pull Request:

1. Set experimental-products-task to true in feature config (./plugins/woocommerce/client/admin/config/development.json)
2. Navigate to add products task
3. Check that the tracks event has the correct prop and value

Should look like:
![image](https://user-images.githubusercontent.com/27843274/167535738-62409a54-1d1c-4268-b056-02afee183885.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
