### PR TITLE
Redirect to the create subscription product step after installing WC Payments via Subscriptions experiment page

### DIFF
--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -125,8 +125,7 @@ const GetStartedButton: React.FC< GetStartedButtonProps > = ( {
 						 * Navigate to either newSubscriptionProductUrl or onboardingUrl
 						 * depending on the which treatment the user is assigned to.
 						 */
-						// eslint-disable-next-line no-console
-						console.log( 'It was a success!' );
+						window.location.href = newSubscriptionProductUrl;
 					} )
 					.catch( () => {
 						setIsGettingStarted( false );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a temporary change to be enable testing the full flow whilst we work on setting up the experiment and directing users through their designated flows.

Part of #32694

### How to test the changes in this Pull Request:

1. Checkout this branch and run `pnpm nx build-watch woocommerce-admin` to build assets
2. Make sure you meet all the eligibility criteria by uninstalling WooCommerce Payments and WooCommerce Subscriptions
4. Navigate to **WooCommerce > Subscriptions**
5. Click the **"Get started"** button.
6. Once the plugin activation is complete, you should be redirected to the create product screen with subscription product type preselected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
