### PR TITLE
Update `@woocomerce/data` client api error types

### DIFF
--- a/packages/js/data/changelog/update-client-api-error-types
+++ b/packages/js/data/changelog/update-client-api-error-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update @woocomerce/data client api error types. #32939

--- a/packages/js/data/src/countries/actions.ts
+++ b/packages/js/data/src/countries/actions.ts
@@ -3,7 +3,6 @@
  */
 import TYPES from './action-types';
 import { Locales, Country } from './types';
-import { RestApiError } from '../types';
 
 export function getLocalesSuccess( locales: Locales ) {
 	return {
@@ -12,7 +11,7 @@ export function getLocalesSuccess( locales: Locales ) {
 	};
 }
 
-export function getLocalesError( error: RestApiError ) {
+export function getLocalesError( error: unknown ) {
 	return {
 		type: TYPES.GET_LOCALES_ERROR as const,
 		error,
@@ -26,7 +25,7 @@ export function getCountriesSuccess( countries: Country[] ) {
 	};
 }
 
-export function getCountriesError( error: RestApiError ) {
+export function getCountriesError( error: unknown ) {
 	return {
 		type: TYPES.GET_COUNTRIES_ERROR as const,
 		error,

--- a/packages/js/data/src/countries/resolvers.ts
+++ b/packages/js/data/src/countries/resolvers.ts
@@ -16,7 +16,6 @@ import {
 import { NAMESPACE } from '../constants';
 import { Locales, Country } from './types';
 import { STORE_NAME } from './constants';
-import { RestApiError } from '../types';
 
 const resolveSelect =
 	controls && controls.resolveSelect ? controls.resolveSelect : select;
@@ -35,7 +34,7 @@ export function* getLocales() {
 
 		return getLocalesSuccess( results );
 	} catch ( error ) {
-		return getLocalesError( error as RestApiError );
+		return getLocalesError( error );
 	}
 }
 
@@ -53,6 +52,6 @@ export function* getCountries() {
 
 		return getCountriesSuccess( results );
 	} catch ( error ) {
-		return getCountriesError( error as RestApiError );
+		return getCountriesError( error );
 	}
 }

--- a/packages/js/data/src/countries/types.ts
+++ b/packages/js/data/src/countries/types.ts
@@ -41,7 +41,7 @@ export type Locales = {
 
 export type CountriesState = {
 	errors: {
-		[ key: string ]: string | RestApiError | undefined;
+		[ key: string ]: unknown;
 	};
 	locales: Locales;
 	countries: Country[];

--- a/packages/js/data/src/payment-gateways/actions.ts
+++ b/packages/js/data/src/payment-gateways/actions.ts
@@ -9,7 +9,6 @@ import { apiFetch } from '@wordpress/data-controls';
 import { ACTION_TYPES } from './action-types';
 import { API_NAMESPACE } from './constants';
 import { PaymentGateway } from './types';
-import { RestApiError } from '../types';
 
 export function getPaymentGatewaysRequest(): {
 	type: ACTION_TYPES.GET_PAYMENT_GATEWAYS_REQUEST;
@@ -32,10 +31,10 @@ export function getPaymentGatewaysSuccess(
 }
 
 export function getPaymentGatewaysError(
-	error: RestApiError
+	error: unknown
 ): {
 	type: ACTION_TYPES.GET_PAYMENT_GATEWAYS_ERROR;
-	error: RestApiError;
+	error: unknown;
 } {
 	return {
 		type: ACTION_TYPES.GET_PAYMENT_GATEWAYS_ERROR,
@@ -52,10 +51,10 @@ export function getPaymentGatewayRequest(): {
 }
 
 export function getPaymentGatewayError(
-	error: RestApiError
+	error: unknown
 ): {
 	type: ACTION_TYPES.GET_PAYMENT_GATEWAY_ERROR;
-	error: RestApiError;
+	error: unknown;
 } {
 	return {
 		type: ACTION_TYPES.GET_PAYMENT_GATEWAY_ERROR,
@@ -95,10 +94,10 @@ export function updatePaymentGatewayRequest(): {
 }
 
 export function updatePaymentGatewayError(
-	error: RestApiError
+	error: unknown
 ): {
 	type: ACTION_TYPES.UPDATE_PAYMENT_GATEWAY_ERROR;
-	error: RestApiError;
+	error: unknown;
 } {
 	return {
 		type: ACTION_TYPES.UPDATE_PAYMENT_GATEWAY_ERROR,
@@ -127,7 +126,7 @@ export function* updatePaymentGateway(
 			return response;
 		}
 	} catch ( e ) {
-		yield updatePaymentGatewayError( e as RestApiError );
+		yield updatePaymentGatewayError( e );
 		throw e;
 	}
 }

--- a/packages/js/data/src/payment-gateways/resolvers.ts
+++ b/packages/js/data/src/payment-gateways/resolvers.ts
@@ -21,7 +21,6 @@ import {
 
 import { API_NAMESPACE, STORE_KEY } from './constants';
 import { PaymentGateway } from './types';
-import { RestApiError } from '../types';
 
 // Can be removed in WP 5.9.
 const dispatch =
@@ -44,7 +43,7 @@ export function* getPaymentGateways() {
 			);
 		}
 	} catch ( e ) {
-		yield getPaymentGatewaysError( e as RestApiError );
+		yield getPaymentGatewaysError( e );
 	}
 }
 
@@ -61,6 +60,6 @@ export function* getPaymentGateway( id: string ) {
 			return response;
 		}
 	} catch ( e ) {
-		yield getPaymentGatewayError( e as RestApiError );
+		yield getPaymentGatewayError( e );
 	}
 }

--- a/packages/js/data/src/payment-gateways/selectors.ts
+++ b/packages/js/data/src/payment-gateways/selectors.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { PaymentGateway, PluginsState } from './types';
-import { RestApiError, WPDataSelector, WPDataSelectors } from '../types';
+import { WPDataSelector, WPDataSelectors } from '../types';
 
 export function getPaymentGateway(
 	state: PluginsState,
@@ -22,7 +22,7 @@ export function getPaymentGateways(
 export function getPaymentGatewayError(
 	state: PluginsState,
 	selector: string
-): RestApiError | null {
+): unknown | null {
 	return state.errors[ selector ] || null;
 }
 

--- a/packages/js/data/src/payment-gateways/test/reducer.ts
+++ b/packages/js/data/src/payment-gateways/test/reducer.ts
@@ -18,9 +18,6 @@ const defaultState: PluginsState = {
 
 const restApiError = {
 	code: 'error code',
-	data: {
-		status: 400,
-	},
 	message: 'error message',
 };
 

--- a/packages/js/data/src/payment-gateways/types.ts
+++ b/packages/js/data/src/payment-gateways/types.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { RestApiError } from '../types';
 
 export type SettingDefinition = {
 	default: string;
@@ -31,5 +30,5 @@ export type PaymentGateway = {
 export type PluginsState = {
 	paymentGateways: PaymentGateway[];
 	isUpdating: boolean;
-	errors: Record< string, RestApiError >;
+	errors: Record< string, unknown >;
 };

--- a/packages/js/data/src/plugins/resolvers.ts
+++ b/packages/js/data/src/plugins/resolvers.ts
@@ -22,7 +22,6 @@ import {
 	setRecommendedPlugins,
 } from './actions';
 import { PaypalOnboardingStatus, RecommendedTypes } from './types';
-import { WPError } from '../types';
 
 // Can be removed in WP 5.9, wp.data is supported in >5.7.
 const resolveSelect =
@@ -52,7 +51,7 @@ export function* getActivePlugins() {
 
 		yield updateActivePlugins( results.plugins, true );
 	} catch ( error ) {
-		yield setError( 'getActivePlugins', error as WPError[ 'errors' ] );
+		yield setError( 'getActivePlugins', error );
 	}
 }
 
@@ -68,7 +67,7 @@ export function* getInstalledPlugins() {
 
 		yield updateInstalledPlugins( results.plugins, true );
 	} catch ( error ) {
-		yield setError( 'getInstalledPlugins', error as WPError[ 'errors' ] );
+		yield setError( 'getInstalledPlugins', error );
 	}
 }
 
@@ -84,7 +83,7 @@ export function* isJetpackConnected() {
 
 		yield updateIsJetpackConnected( results.isActive );
 	} catch ( error ) {
-		yield setError( 'isJetpackConnected', error as WPError[ 'errors' ] );
+		yield setError( 'isJetpackConnected', error );
 	}
 
 	yield setIsRequesting( 'isJetpackConnected', false );
@@ -108,7 +107,7 @@ export function* getJetpackConnectUrl( query: { redirect_url: string } ) {
 			results.connectAction
 		);
 	} catch ( error ) {
-		yield setError( 'getJetpackConnectUrl', error as WPError[ 'errors' ] );
+		yield setError( 'getJetpackConnectUrl', error );
 	}
 
 	yield setIsRequesting( 'getJetpackConnectUrl', false );
@@ -162,10 +161,7 @@ export function* getPaypalOnboardingStatus() {
 			yield setPaypalOnboardingStatus( results );
 		} catch ( error ) {
 			yield setOnboardingStatusWithOptions();
-			yield setError(
-				'getPaypalOnboardingStatus',
-				error as WPError[ 'errors' ]
-			);
+			yield setError( 'getPaypalOnboardingStatus', error );
 		}
 	}
 
@@ -188,7 +184,7 @@ export function* getRecommendedPlugins( type: RecommendedTypes ) {
 
 		yield setRecommendedPlugins( type, results );
 	} catch ( error ) {
-		yield setError( 'getRecommendedPlugins', error as WPError[ 'errors' ] );
+		yield setError( 'getRecommendedPlugins', error );
 	}
 
 	yield setIsRequesting( 'getRecommendedPlugins', false );

--- a/packages/js/data/src/plugins/types.ts
+++ b/packages/js/data/src/plugins/types.ts
@@ -63,9 +63,9 @@ export type PaypalOnboardingStatus = {
 	};
 };
 
-type PluginsResponse< PluginData > = {
+export type PluginsResponse< PluginData > = {
 	data: PluginData;
-	errors: WPError< PluginNames >;
+	errors: WPError< Partial< PluginNames > >;
 	success: boolean;
 	message: string;
 } & Response;

--- a/packages/js/data/src/types/api.ts
+++ b/packages/js/data/src/types/api.ts
@@ -1,4 +1,19 @@
-export type RestApiError = {
+type WPApiFetchError = {
 	code: string;
 	message: string;
 };
+
+type WPInternalServerError = {
+	code: string;
+	message: string;
+	additional_errors: unknown[];
+	data: {
+		status: number;
+	};
+};
+
+export type RestApiError = WPApiFetchError | WPInternalServerError;
+
+export const isRestApiError = ( error: unknown ): error is RestApiError =>
+	( error as RestApiError ).code !== undefined &&
+	( error as RestApiError ).message !== undefined;

--- a/packages/js/data/src/types/api.ts
+++ b/packages/js/data/src/types/api.ts
@@ -1,9 +1,4 @@
-export interface RestApiErrorData {
-	status?: number;
-}
-
 export type RestApiError = {
 	code: string;
-	data?: RestApiErrorData;
 	message: string;
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #32146. 

This PR updates the `@woocomerce/data` client api error types:

- [Correct the `RestApiError` type.](https://github.com/woocommerce/woocommerce/pull/32939/files#diff-e506d667ceb20f9e27b08a1812ad338bb395742a43e2795fca32c96b2de930a3R1-R13)

Two kinds of errors:
![Screen Shot 2022-05-11 at 12 24 46](https://user-images.githubusercontent.com/4344253/167782526-0ee280e4-984f-4827-852f-1207942a3b9d.png)

- Change error type annotations to `unknown` for data stores rather than cast the error type to `RestApiError` without any checking.
- Handle Plugin APIError type properly



### How to test the changes in this Pull Request:

1. Run `pnpm nx build @woocommerce/data` -> no type errors
2. Change this line https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx#L140 to install an invalid plugin. (for example `installAndActivatePlugins( [ 'plugin 123' ] )`
3. Go to `Woocommerce > Home`
4. Go to `Set up marketing tools`
5. Click `Google Listings & Ads`
6. Should see the `Could not install plugin 123 plugin, The requested plugin `plugin123` could not be installed. Plugin API call failed.`
7. Block the `rest_route=%2Fwc-admin%2Fplugins%2Finstall&_locale=user` API request using the browser devtools
![Screen Shot 2022-05-11 at 14 45 18](https://user-images.githubusercontent.com/4344253/167785598-b0f9192e-61dd-4c98-b392-3e1ee4826f87.png)
8. Click `Google Listings & Ads` again
9. Should see the error notice `Could not install plugin 123 plugin, You are probably offline.`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
