### PR TITLE
Add ExPlat call for product task experiment

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -6,7 +6,7 @@ import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { Text } from '@woocommerce/experimental';
 import { registerPlugin } from '@wordpress/plugins';
 import { useMemo, useState } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 
@@ -17,15 +17,13 @@ import './index.scss';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { getSurfacedProductTypeKeys, getProductTypes } from './utils';
 import useProductTypeListItems from './use-product-types-list-items';
+import useLayoutExperiment from '../use-product-layout-experiment';
 import Stack from './stack';
 import Footer from './footer';
 import CardLayout from './card-layout';
 import { LoadSampleProductType } from './constants';
 import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
-
-// TODO: Use experiment data from the API, not hardcoded.
-const SHOW_STACK_LAYOUT = true;
 
 const getOnboardingProductType = (): string[] => {
 	const onboardingData = getAdminSetting( 'onboarding' );
@@ -52,6 +50,7 @@ const ViewControlButton: React.FC< {
 
 export const Products = () => {
 	const [ isExpanded, setIsExpanded ] = useState< boolean >( false );
+	const [ isLoadingExperiment, experimentLayout ] = useLayoutExperiment();
 
 	const productTypes = useProductTypeListItems( getProductTypes() );
 	const surfacedProductTypeKeys = getSurfacedProductTypeKeys(
@@ -79,7 +78,7 @@ export const Products = () => {
 					surfacedProductTypes.push( productType )
 			);
 
-			if ( ! SHOW_STACK_LAYOUT ) {
+			if ( experimentLayout === 'card' ) {
 				surfacedProductTypes.push( {
 					...LoadSampleProductType,
 					onClick: loadSampleProduct,
@@ -91,35 +90,45 @@ export const Products = () => {
 		surfacedProductTypeKeys,
 		isExpanded,
 		productTypes,
+		experimentLayout,
 		loadSampleProduct,
 	] );
 
 	return (
 		<div className="woocommerce-task-products">
-			<Text
-				variant="title"
-				as="h2"
-				className="woocommerce-task-products__title"
-			>
-				{ __( 'What product do you want to add?', 'woocommerce' ) }
-			</Text>
+			{ isLoadingExperiment ? (
+				<Spinner />
+			) : (
+				<>
+					<Text
+						variant="title"
+						as="h2"
+						className="woocommerce-task-products__title"
+					>
+						{ __(
+							'What product do you want to add?',
+							'woocommerce'
+						) }
+					</Text>
 
-			<div className="woocommerce-product-content">
-				{ SHOW_STACK_LAYOUT ? (
-					<Stack
-						items={ visibleProductTypes }
-						onClickLoadSampleProduct={ loadSampleProduct }
-					/>
-				) : (
-					<CardLayout items={ visibleProductTypes } />
-				) }
-				<ViewControlButton
-					isExpanded={ isExpanded }
-					onClick={ () => setIsExpanded( ! isExpanded ) }
-				/>
-				<Footer />
-			</div>
-			{ isLoadingSampleProducts && <LoadSampleProductModal /> }
+					<div className="woocommerce-product-content">
+						{ experimentLayout === 'stacked' ? (
+							<Stack
+								items={ visibleProductTypes }
+								onClickLoadSampleProduct={ loadSampleProduct }
+							/>
+						) : (
+							<CardLayout items={ visibleProductTypes } />
+						) }
+						<ViewControlButton
+							isExpanded={ isExpanded }
+							onClick={ () => setIsExpanded( ! isExpanded ) }
+						/>
+						<Footer />
+					</div>
+					{ isLoadingSampleProducts && <LoadSampleProductModal /> }
+				</>
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { Products } from '../';
 import { defaultSurfacedProductTypes, productTypes } from '../constants';
 import { getAdminSetting } from '~/utils/admin-settings';
+import useLayoutExperiment from '../../use-product-layout-experiment';
 
 jest.mock( '@wordpress/data', () => ( {
 	...jest.requireActual( '@wordpress/data' ),
@@ -21,7 +22,7 @@ jest.mock( '~/utils/admin-settings', () => ( {
 } ) );
 
 jest.mock( '../../use-product-layout-experiment', () => ( {
-	default: () => [ false, 'stacked' ],
+	default: jest.fn().mockReturnValue( [ false, 'stacked' ] ),
 	__esModule: true,
 } ) );
 
@@ -109,5 +110,40 @@ describe( 'Products', () => {
 				}
 			)
 		);
+	} );
+
+	it( 'should show spinner when layout experiment is loading', async () => {
+		( useLayoutExperiment as jest.Mock ).mockImplementation( () => [
+			true,
+			'card',
+		] );
+		const { container } = render( <Products /> );
+		expect(
+			container.getElementsByClassName( 'components-spinner' )
+		).toHaveLength( 1 );
+	} );
+
+	it( 'should render card layout when experiment is assigned', async () => {
+		( useLayoutExperiment as jest.Mock ).mockImplementation( () => [
+			false,
+			'card',
+		] );
+		const { container } = render( <Products /> );
+		expect(
+			container.getElementsByClassName(
+				'woocommerce-products-card-layout'
+			)
+		).toHaveLength( 1 );
+	} );
+
+	it( 'should render stacked layout when experiment is assigned', async () => {
+		( useLayoutExperiment as jest.Mock ).mockImplementation( () => [
+			false,
+			'stacked',
+		] );
+		const { container } = render( <Products /> );
+		expect(
+			container.getElementsByClassName( 'woocommerce-products-stack' )
+		).toHaveLength( 1 );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -20,6 +20,11 @@ jest.mock( '~/utils/admin-settings', () => ( {
 	getAdminSetting: jest.fn(),
 } ) );
 
+jest.mock( '../../use-product-layout-experiment', () => ( {
+	default: () => [ false, 'stacked' ],
+	__esModule: true,
+} ) );
+
 global.fetch = jest.fn().mockImplementation( () =>
 	Promise.resolve( {
 		json: () => Promise.resolve( {} ),

--- a/plugins/woocommerce-admin/client/tasks/fills/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/index.js
@@ -15,7 +15,7 @@ import './purchase';
 
 const onboardingData = getAdminSetting( 'onboarding' );
 
-const importProductTask = async () => {
+const possiblyImportProductTaskExperiment = async () => {
 	const isExperiment = await isExperimentProductTask();
 	if ( isExperiment ) {
 		import( './experimental-products' );
@@ -35,7 +35,7 @@ if (
 	window.wcAdminFeatures &&
 	window.wcAdminFeatures[ 'experimental-products-task' ]
 ) {
-	importProductTask();
+	possiblyImportProductTaskExperiment();
 } else {
 	import( './products' );
 }

--- a/plugins/woocommerce-admin/client/tasks/fills/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { getAdminSetting } from '~/utils/admin-settings';
+import { isExperimentProductTask } from './use-product-layout-experiment';
 
 import './PaymentGatewaySuggestions';
 import './shipping';
@@ -14,6 +15,15 @@ import './purchase';
 
 const onboardingData = getAdminSetting( 'onboarding' );
 
+const importProductTask = async () => {
+	const isExperiment = await isExperimentProductTask();
+	if ( isExperiment ) {
+		import( './experimental-products' );
+	} else {
+		import( './products' );
+	}
+};
+
 if (
 	window.wcAdminFeatures &&
 	window.wcAdminFeatures[ 'experimental-import-products-task' ] &&
@@ -25,7 +35,7 @@ if (
 	window.wcAdminFeatures &&
 	window.wcAdminFeatures[ 'experimental-products-task' ]
 ) {
-	import( './experimental-products' );
+	importProductTask();
 } else {
 	import( './products' );
 }

--- a/plugins/woocommerce-admin/client/tasks/fills/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/use-product-layout-experiment.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { loadExperimentAssignment } from '@woocommerce/explat';
+
+type Layout = 'control' | 'card' | 'stacked';
+
+export const getProductLayoutExperiment = async (): Promise< Layout > => {
+	const [ cardAssignment, stackedAssignment ] = await Promise.all( [
+		loadExperimentAssignment( `woocommerce_products_task_layout_card` ),
+		loadExperimentAssignment( `woocommerce_products_task_layout_stacked` ),
+	] );
+	// This logic may look flawed as in both looks like they can be assigned treatment at the same time,
+	// but in backend we segment the experiments by store country, so it will never be.
+	if ( cardAssignment?.variationName === 'treatment' ) {
+		return 'card';
+	} else if ( stackedAssignment?.variationName === 'treatment' ) {
+		return 'stacked';
+	}
+	return 'control';
+};
+
+export const isExperimentProductTask = async (): Promise< boolean > => {
+	return ( await getProductLayoutExperiment() ) !== 'control';
+};
+
+export const useLayoutExperiment = () => {
+	const [ isLoading, setIsLoading ] = useState< boolean >( true );
+	const [ experimentLayout, setExperimentLayout ] = useState< Layout >(
+		'control'
+	);
+
+	useEffect( () => {
+		getProductLayoutExperiment().then( ( layout ) => {
+			setExperimentLayout( layout );
+			setIsLoading( false );
+		} );
+	}, [ setExperimentLayout ] );
+
+	return [ isLoading, experimentLayout ];
+};
+
+export default useLayoutExperiment;

--- a/plugins/woocommerce/changelog/dev-32635-implement-product-task-experiment
+++ b/plugins/woocommerce/changelog/dev-32635-implement-product-task-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add ExPlat call for product task experiment


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #32635.

- Adds ExPlat API calls for experiment assignment query for both `woocommerce_products_task_layout_card` and `woocommerce_products_task_layout_stacked` experiment
- Adds the experiment condition prior loading experimental product task fills

### How to test the changes in this Pull Request:

**Prerequisite**
1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-products-task`
4. Make sure your site has `woocommerce_allow_tracking` option set to `yes`

**Testing control**
1. Navigate to WooCommerce > Home
2. Go to "Add products" task
3. Observe the old products task is displayed

**Testing card layout**
1. Install `WooCommerce Admin Test Helper`
5. Go to `Tools > WCA Test Helper > Experiments`
2. Enable treatment for `woocommerce_products_task_layout_card`
1. Navigate to WooCommerce > Home
2. Go to "Add products" task
3. Observe new products task with card layout

**Testing stacked layout**
1. Install `WooCommerce Admin Test Helper`
4. Go to `Tools > WCA Test Helper > Experiments`
2. Enable treatment for `woocommerce_products_task_layout_stacked` and disable `woocommerce_products_task_layout_card` if required
1. Navigate to WooCommerce > Home
2. Go to "Add products" task
3. Observe new products task with stacked layout


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
