### PR TITLE
Add tracks to products list page

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
@@ -26,7 +26,7 @@ const hasValue = ( selector ) => {
 
 filterButton?.addEventListener( 'click', function () {
 	recordEvent( 'products_list_filter_click', {
-		search_string_length: searchInput.value.length,
+		search_string_length: searchInput?.value.length,
 		filter_category: productCategory.value !== '',
 		filter_product_type: productType.value,
 		filter_stock_status: stockStatus.value,

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
@@ -7,6 +7,7 @@ const actionButtons = document.querySelectorAll( '.row-actions span' );
 const bulkActions = document.querySelector( '#bulk-action-selector-top' );
 const bulkActionsButton = document.querySelector( '#doaction' );
 const bulkActionsCancelButton = document.querySelector( '#bulk-edit .cancel' );
+const bulkActionsUpdateButton = document.querySelector( '#bulk_edit' );
 const featuredButtons = document.querySelectorAll( '#the-list .featured a' );
 const filterButton = document.querySelector( '#post-query-submit' );
 const productCategory = document.querySelector( '#product_cat' );
@@ -23,7 +24,7 @@ const hasValue = ( selector ) => {
 	return !! element && element.value !== '' && element.value !== '-1';
 };
 
-filterButton.addEventListener( 'click', function () {
+filterButton?.addEventListener( 'click', function () {
 	recordEvent( 'products_list_filter_click', {
 		search_string_length: searchInput.value.length,
 		filter_category: productCategory.value !== '',
@@ -32,7 +33,7 @@ filterButton.addEventListener( 'click', function () {
 	} );
 } );
 
-bulkActionsButton.addEventListener( 'click', function () {
+bulkActionsButton?.addEventListener( 'click', function () {
 	const productNumber = document.querySelectorAll( '[name="post[]"]:checked' )
 		.length;
 	recordEvent( 'products_list_bulk_actions_click', {
@@ -41,7 +42,7 @@ bulkActionsButton.addEventListener( 'click', function () {
 	} );
 } );
 
-document.querySelector( '#bulk_edit' ).addEventListener( 'click', function () {
+bulkActionsUpdateButton?.addEventListener( 'click', function () {
 	recordEvent( 'products_list_bulk_edit_update', {
 		product_number: document.querySelector( '#bulk-titles' )?.children
 			.length,
@@ -69,7 +70,7 @@ document.querySelector( '#bulk_edit' ).addEventListener( 'click', function () {
 	} );
 } );
 
-bulkActionsCancelButton.addEventListener( 'click', function () {
+bulkActionsCancelButton?.addEventListener( 'click', function () {
 	recordEvent( 'products_list_bulk_edit_cancel' );
 } );
 
@@ -105,7 +106,7 @@ featuredButtons.forEach( ( button ) => {
 	} );
 } );
 
-searchButton.addEventListener( 'click', function () {
+searchButton?.addEventListener( 'click', function () {
 	recordEvent( 'products_search', {
 		search_string_length: searchInput.value.length,
 		filter_category: productCategory.value !== '',

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
@@ -35,24 +35,6 @@ bulkActionsButton.addEventListener( 'click', function () {
 	} );
 } );
 
-bulkActionsButton.addEventListener( 'click', function () {
-	const productNumber = document.querySelectorAll( '[name="post[]"]:checked' )
-		.length;
-	recordEvent( 'products_list_bulk_actions_click', {
-		selected_action: bulkActions.value,
-		product_number: productNumber,
-	} );
-} );
-
-bulkActionsButton.addEventListener( 'click', function () {
-	const productNumber = document.querySelectorAll( '[name="post[]"]:checked' )
-		.length;
-	recordEvent( 'products_list_bulk_actions_click', {
-		selected_action: bulkActions.value,
-		product_number: productNumber,
-	} );
-} );
-
 document.querySelector( '#bulk_edit' ).addEventListener( 'click', function () {
 	recordEvent( 'products_list_bulk_edit_update', {
 		product_number: document.querySelector( '#bulk-titles' ).children
@@ -126,15 +108,6 @@ featuredButtons.forEach( ( button ) => {
 		recordEvent( 'products_list_featured_click', {
 			featured: willFeature ? 'yes' : 'no',
 		} );
-	} );
-} );
-
-searchButton.addEventListener( 'click', function () {
-	recordEvent( 'products_search', {
-		search_string_length: searchInput.value.length,
-		filter_category: productCategory.value !== '',
-		filter_product_type: productType.value,
-		filter_stock_status: stockStatus.value,
 	} );
 } );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
@@ -6,6 +6,7 @@ import { recordEvent } from '@woocommerce/tracks';
 const actionButtons = document.querySelectorAll( '.row-actions span' );
 const bulkActions = document.querySelector( '#bulk-action-selector-top' );
 const bulkActionsButton = document.querySelector( '#doaction' );
+const bulkActionsCancelButton = document.querySelector( '#bulk-edit .cancel' );
 const featuredButtons = document.querySelectorAll( '#the-list .featured a' );
 const filterButton = document.querySelector( '#post-query-submit' );
 const productCategory = document.querySelector( '#product_cat' );
@@ -66,6 +67,10 @@ document.querySelector( '#bulk_edit' ).addEventListener( 'click', function () {
 		backorders: hasValue( '[name="_backorders"]' ),
 		sold_individually: hasValue( '[name="_sold_individually"]' ),
 	} );
+} );
+
+bulkActionsCancelButton.addEventListener( 'click', function () {
+	recordEvent( 'products_list_bulk_edit_cancel' );
 } );
 
 actionButtons.forEach( ( button ) => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
@@ -17,6 +17,11 @@ const sortableColumnHeaders = document.querySelectorAll(
 );
 const stockStatus = document.querySelector( '[name="stock_status"]' );
 
+const hasValue = ( selector ) => {
+	const element = document.querySelector( selector );
+	return !! element && element.value !== '' && element.value !== '-1';
+};
+
 filterButton.addEventListener( 'click', function () {
 	recordEvent( 'products_list_filter_click', {
 		search_string_length: searchInput.value.length,
@@ -37,45 +42,29 @@ bulkActionsButton.addEventListener( 'click', function () {
 
 document.querySelector( '#bulk_edit' ).addEventListener( 'click', function () {
 	recordEvent( 'products_list_bulk_edit_update', {
-		product_number: document.querySelector( '#bulk-titles' ).children
+		product_number: document.querySelector( '#bulk-titles' )?.children
 			.length,
 		product_categories:
 			document.querySelectorAll(
 				'[name="tax_input[product_cat][]"]:checked'
-			).length > 0,
-		comments:
-			document.querySelector( '[name="comment_status"]' ).value !== '',
-		status: document.querySelector( '[name="_status"]' ).value !== '',
-		product_tags:
-			document.querySelector( '[name="tax_input[product_tag]"]' )
-				.value !== '',
-		price:
-			document.querySelector( '[name="change_regular_price"]' ).value !==
-			'',
-		sale:
-			document.querySelector( '[name="change_sale_price"]' ).value !== '',
-		tax_status:
-			document.querySelector( '[name="_tax_status"]' ).value !== '',
-		tax_class: document.querySelector( '[name="_tax_class"]' ).value !== '',
-		weight: document.querySelector( '[name="change_weight"]' ).value !== '',
-		dimensions:
-			document.querySelector( '[name="change_dimensions"]' ).value !== '',
-		shipping_class:
-			document.querySelector( '[name="_shipping_class"]' ).value !== '',
-		visibility:
-			document.querySelector( '[name="_visibility"]' ).value !== '',
-		featured: document.querySelector( '[name="_featured"]' ).value !== '',
-		stock_status:
-			document.querySelector( '[name="_stock_status"]' ).value !== '',
-		manage_stock:
-			document.querySelector( '[name="_manage_stock"]' ).value !== '',
-		stock_quantity:
-			document.querySelector( '[name="change_stock"]' ).value !== '',
-		backorders:
-			document.querySelector( '[name="_backorders"]' ).value !== '',
-		sold_individually:
-			document.querySelector( '[name="_sold_individually"]' ).value !==
-			'',
+			)?.length > 0,
+		comments: hasValue( '[name="comment_status"]' ),
+		status: hasValue( '[name="_status"]' ),
+		product_tags: hasValue( '[name="tax_input[product_tag]"]' ),
+		price: hasValue( '[name="change_regular_price"]' ),
+		sale: hasValue( '[name="change_sale_price"]' ),
+		tax_status: hasValue( '[name="_tax_status"]' ),
+		tax_class: hasValue( '[name="_tax_class"]' ),
+		weight: hasValue( '[name="change_weight"]' ),
+		dimensions: hasValue( '[name="change_dimensions"]' ),
+		shipping_class: hasValue( '[name="_shipping_class"]' ),
+		visibility: hasValue( '[name="_visibility"]' ),
+		featured: hasValue( '[name="_featured"]' ),
+		stock_status: hasValue( '[name="_stock_status"]' ),
+		manage_stock: hasValue( '[name="_manage_stock"]' ),
+		stock_quantity: hasValue( '[name="change_stock"]' ),
+		backorders: hasValue( '[name="_backorders"]' ),
+		sold_individually: hasValue( '[name="_sold_individually"]' ),
 	} );
 } );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/index.js
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+const actionButtons = document.querySelectorAll( '.row-actions span' );
+const bulkActions = document.querySelector( '#bulk-action-selector-top' );
+const bulkActionsButton = document.querySelector( '#doaction' );
+const featuredButtons = document.querySelectorAll( '#the-list .featured a' );
+const filterButton = document.querySelector( '#post-query-submit' );
+const productCategory = document.querySelector( '#product_cat' );
+const productType = document.querySelector( '#dropdown_product_type' );
+const searchButton = document.querySelector( '#search-submit' );
+const searchInput = document.querySelector( '#post-search-input' );
+const sortableColumnHeaders = document.querySelectorAll(
+	'.wp-list-table.posts thead .sortable a, .wp-list-table.posts thead .sorted a'
+);
+const stockStatus = document.querySelector( '[name="stock_status"]' );
+
+filterButton.addEventListener( 'click', function () {
+	recordEvent( 'products_list_filter_click', {
+		search_string_length: searchInput.value.length,
+		filter_category: productCategory.value !== '',
+		filter_product_type: productType.value,
+		filter_stock_status: stockStatus.value,
+	} );
+} );
+
+bulkActionsButton.addEventListener( 'click', function () {
+	const productNumber = document.querySelectorAll( '[name="post[]"]:checked' )
+		.length;
+	recordEvent( 'products_list_bulk_actions_click', {
+		selected_action: bulkActions.value,
+		product_number: productNumber,
+	} );
+} );
+
+bulkActionsButton.addEventListener( 'click', function () {
+	const productNumber = document.querySelectorAll( '[name="post[]"]:checked' )
+		.length;
+	recordEvent( 'products_list_bulk_actions_click', {
+		selected_action: bulkActions.value,
+		product_number: productNumber,
+	} );
+} );
+
+bulkActionsButton.addEventListener( 'click', function () {
+	const productNumber = document.querySelectorAll( '[name="post[]"]:checked' )
+		.length;
+	recordEvent( 'products_list_bulk_actions_click', {
+		selected_action: bulkActions.value,
+		product_number: productNumber,
+	} );
+} );
+
+document.querySelector( '#bulk_edit' ).addEventListener( 'click', function () {
+	recordEvent( 'products_list_bulk_edit_update', {
+		product_number: document.querySelector( '#bulk-titles' ).children
+			.length,
+		product_categories:
+			document.querySelectorAll(
+				'[name="tax_input[product_cat][]"]:checked'
+			).length > 0,
+		comments:
+			document.querySelector( '[name="comment_status"]' ).value !== '',
+		status: document.querySelector( '[name="_status"]' ).value !== '',
+		product_tags:
+			document.querySelector( '[name="tax_input[product_tag]"]' )
+				.value !== '',
+		price:
+			document.querySelector( '[name="change_regular_price"]' ).value !==
+			'',
+		sale:
+			document.querySelector( '[name="change_sale_price"]' ).value !== '',
+		tax_status:
+			document.querySelector( '[name="_tax_status"]' ).value !== '',
+		tax_class: document.querySelector( '[name="_tax_class"]' ).value !== '',
+		weight: document.querySelector( '[name="change_weight"]' ).value !== '',
+		dimensions:
+			document.querySelector( '[name="change_dimensions"]' ).value !== '',
+		shipping_class:
+			document.querySelector( '[name="_shipping_class"]' ).value !== '',
+		visibility:
+			document.querySelector( '[name="_visibility"]' ).value !== '',
+		featured: document.querySelector( '[name="_featured"]' ).value !== '',
+		stock_status:
+			document.querySelector( '[name="_stock_status"]' ).value !== '',
+		manage_stock:
+			document.querySelector( '[name="_manage_stock"]' ).value !== '',
+		stock_quantity:
+			document.querySelector( '[name="change_stock"]' ).value !== '',
+		backorders:
+			document.querySelector( '[name="_backorders"]' ).value !== '',
+		sold_individually:
+			document.querySelector( '[name="_sold_individually"]' ).value !==
+			'',
+	} );
+} );
+
+actionButtons.forEach( ( button ) => {
+	button.addEventListener( 'click', function ( event ) {
+		const actionClass = event.target.parentElement.classList[ 0 ];
+
+		const actions = {
+			edit: 'edit',
+			inline: 'quick_edit',
+			trash: 'trash',
+			view: 'preview',
+			duplicate: 'duplicate',
+		};
+
+		if ( ! actions[ actionClass ] ) {
+			return;
+		}
+
+		recordEvent( 'products_list_product_action_click', {
+			selected_action: actions[ actionClass ],
+		} );
+	} );
+} );
+
+featuredButtons.forEach( ( button ) => {
+	button.addEventListener( 'click', function ( event ) {
+		const willFeature = event.target.classList.contains( 'not-featured' );
+
+		recordEvent( 'products_list_featured_click', {
+			featured: willFeature ? 'yes' : 'no',
+		} );
+	} );
+} );
+
+searchButton.addEventListener( 'click', function () {
+	recordEvent( 'products_search', {
+		search_string_length: searchInput.value.length,
+		filter_category: productCategory.value !== '',
+		filter_product_type: productType.value,
+		filter_stock_status: stockStatus.value,
+	} );
+} );
+
+searchButton.addEventListener( 'click', function () {
+	recordEvent( 'products_search', {
+		search_string_length: searchInput.value.length,
+		filter_category: productCategory.value !== '',
+		filter_product_type: productType.value,
+		filter_stock_status: stockStatus.value,
+	} );
+} );
+
+sortableColumnHeaders.forEach( ( header ) => {
+	header.addEventListener( 'click', function ( event ) {
+		const tableHeader = event.target.closest( 'th' );
+		const willBeDescending = tableHeader.classList.contains( 'asc' );
+		recordEvent( 'products_list_column_header_click', {
+			field_slug: tableHeader.id,
+			order: willBeDescending ? 'desc' : 'asc',
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -49,6 +49,7 @@ const wpAdminScripts = [
 	'beta-features-tracking-modal',
 	'payment-method-promotions',
 	'onboarding-load-sample-products-notice',
+	'product-tracking',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/add-32671
+++ b/plugins/woocommerce/changelog/add-32671
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracks to products list page #32949


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds tracks to the products page to better understand the features that are being used.

Closes #32671  .

### How to test the changes in this Pull Request:

1.  Open your browser console and run `localStorage.setItem( 'debug', 'wc-admin:*' );`
2.  Navigate to the products page
3.  Check that the below events fire with your expected values
4.  Navigate to non-product pages and make sure the `product-tracking` script is not loaded on those pages by viewing the page's source code.

**Tracks:**
* Filter products - Select some filter dropdown options and click "Filter"
* Bulk action - Select some product checkboxes and click "Apply" after selecting a bulk action
* Bulk update - Click "Update" after selecting some fields to bulk update
* Action buttons - Hover a product row and click each of the actions that appear, (Edit, Quick Edit, Trash, etc)
* Feature button - Toggle a product as featured using the star icon
* Search - Type a search query and click "Search products"
* Sort columns - Sort the header columns both ascending and descending

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
