### PR TITLE
Copy composer.json to a different path

### DIFF
--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -73,7 +73,7 @@ jobs:
           rm -rf woocommerce/woocommerce-production/woocommerce
 
       - name: Copy Composer over to production
-        run: cp monorepo/plugins/woocommerce/composer.json tmp/woocommerce-build
+        run: cp monorepo/plugins/woocommerce/composer.json woocommerce/woocommerce-production
 
       - name: Set up mirror
         working-directory: tmp/woocommerce-build


### PR DESCRIPTION
This is a 2nd attempt to fix the issue of composer.json not being copied over to production. Please see here for the first attempt https://github.com/woocommerce/woocommerce/pull/32927

Unfortunately we're unable to test this until it is merged. To check after merged make sure the workflow is ran successfully here https://github.com/woocommerce/woocommerce/actions/workflows/mirrors.yml and then go to https://github.com/woocommerce/woocommerce-production and ensure `composer.json` file is in the root.