### PR TITLE
Make sure variable is actually set

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -259,7 +259,7 @@ class WC_Admin_Status {
 		$update_theme_version = 0;
 
 		// Check .org for updates.
-		if ( is_object( $api ) && ! is_wp_error( $api ) ) {
+		if ( is_object( $api ) && ! is_wp_error( $api ) && isset( $api->version ) ) {
 			$update_theme_version = $api->version;
 		} elseif ( strstr( $theme->{'Author URI'}, 'woothemes' ) ) { // Check WooThemes Theme Version.
 			$theme_dir          = substr( strtolower( str_replace( ' ', '', $theme->Name ) ), 0, 45 ); // @codingStandardsIgnoreLine.


### PR DESCRIPTION
themes_api() may return unexpected results see https://wordpress.org/support/topic/php-warnings-flooding-log-undefined-property-class-wc-admin-status-php for example.

### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
