### PR TITLE
Add experiment functionality to the WooCommerce → Subscriptions page

### DIFF
--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -248,7 +248,7 @@ const OnboardingSteps = () => (
 				<StepNumber>1</StepNumber>
 				<h3>
 					{ experimentAssignment === Treatment.A
-						? __( 'Create and connect your account', 'woocommerce' )
+						? __( 'Create a subscription', 'woocommerce' )
 						: __(
 								'Create and connect your account',
 								'woocommerce'
@@ -257,7 +257,7 @@ const OnboardingSteps = () => (
 				<p>
 					{ experimentAssignment === Treatment.A
 						? __(
-								'To ensure safe and secure transactions, a WordPress.com account is required.',
+								'Add a name, price and image to your subscription product and then publish it.',
 								'woocommerce'
 						  )
 						: __(
@@ -270,7 +270,7 @@ const OnboardingSteps = () => (
 				<StepNumber>2</StepNumber>
 				<h3>
 					{ experimentAssignment === Treatment.A
-						? __( 'Provide a few business details', 'woocommerce' )
+						? __( 'Create and connect your account', 'woocommerce' )
 						: __(
 								'Provide a few business details',
 								'woocommerce'
@@ -279,7 +279,7 @@ const OnboardingSteps = () => (
 				<p>
 					{ experimentAssignment === Treatment.A
 						? __(
-								'Next we’ll ask you to verify your business and payment details to enable deposits.',
+								'To ensure safe and secure transactions, a WordPress.com account is required.',
 								'woocommerce'
 						  )
 						: __(
@@ -292,13 +292,13 @@ const OnboardingSteps = () => (
 				<StepNumber>3</StepNumber>
 				<h3>
 					{ experimentAssignment === Treatment.A
-						? __( 'Create subscriptions', 'woocommerce' )
+						? __( 'Provide a few business details', 'woocommerce' )
 						: __( 'Create subscriptions', 'woocommerce' ) }
 				</h3>
 				<p>
 					{ experimentAssignment === Treatment.A
 						? __(
-								'Finally, publish subscription products to offer on your store.',
+								'Finally, we’ll ask you to verify your business and payment details to enable deposits.',
 								'woocommerce'
 						  )
 						: __(
@@ -315,13 +315,6 @@ const SubscriptionsPage = () => {
 	const [ hasError, setHasError ] = useState( false );
 
 	useEffect( () => {
-		// TODO: Remove this.
-		console.log(
-			experimentAssignment === Treatment.A
-				? 'Treatment A: Create a subscription product then WCPay onboarding.'
-				: 'Treatment B: WCPay onboarding then create a subscription product.'
-		);
-
 		recordEvent( 'wccore_subscriptions_empty_state_view' );
 	}, [] );
 

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -30,6 +30,7 @@ declare global {
 			onboardingUrl: string;
 			noThanksUrl: string;
 			dismissOptionKey: string;
+			experimentAssignment: 'A' | 'B';
 		};
 	}
 }
@@ -39,6 +40,7 @@ const {
 	onboardingUrl,
 	noThanksUrl,
 	dismissOptionKey,
+	experimentAssignment,
 } = window.wcWcpaySubscriptions;
 
 type setHasErrorFunction = React.Dispatch< React.SetStateAction< boolean > >;
@@ -120,12 +122,10 @@ const GetStartedButton: React.FC< GetStartedButtonProps > = ( {
 				);
 				installAndActivatePlugins( [ 'woocommerce-payments' ] )
 					.then( () => {
-						/*
-						 * TODO:
-						 * Navigate to either newSubscriptionProductUrl or onboardingUrl
-						 * depending on the which treatment the user is assigned to.
-						 */
-						window.location.href = newSubscriptionProductUrl;
+						window.location.href =
+							experimentAssignment === 'A'
+								? newSubscriptionProductUrl
+								: onboardingUrl;
 					} )
 					.catch( () => {
 						recordEvent(
@@ -270,6 +270,13 @@ const SubscriptionsPage = () => {
 	const [ hasError, setHasError ] = useState( false );
 
 	useEffect( () => {
+		// TODO: Remove this.
+		console.log(
+			experimentAssignment === 'A'
+				? 'Treatment A: Create a subscription product then WCPay onboarding.'
+				: 'Treatment B: WCPay onboarding then create a subscription product.'
+		);
+
 		recordEvent( 'wccore_subscriptions_empty_state_view' );
 	}, [] );
 

--- a/plugins/woocommerce-admin/client/subscriptions/index.tsx
+++ b/plugins/woocommerce-admin/client/subscriptions/index.tsx
@@ -23,6 +23,22 @@ import Discover from './cards/discover.js';
 import JCB from './cards/jcb.js';
 import UnionPay from './cards/unionpay.js';
 import './style.scss';
+
+/**
+ * The available experiment treatments.
+ */
+enum Treatment {
+	/**
+	 * Treatment A: Create a subscription product then WCPay onboarding.
+	 */
+	A = 'A',
+
+	/**
+	 * Treatment B: WCPay onboarding then create a subscription product.
+	 */
+	B = 'B',
+}
+
 declare global {
 	interface Window {
 		wcWcpaySubscriptions: {
@@ -30,7 +46,7 @@ declare global {
 			onboardingUrl: string;
 			noThanksUrl: string;
 			dismissOptionKey: string;
-			experimentAssignment: 'A' | 'B';
+			experimentAssignment: Treatment;
 		};
 	}
 }
@@ -123,7 +139,7 @@ const GetStartedButton: React.FC< GetStartedButtonProps > = ( {
 				installAndActivatePlugins( [ 'woocommerce-payments' ] )
 					.then( () => {
 						window.location.href =
-							experimentAssignment === 'A'
+							experimentAssignment === Treatment.A
 								? newSubscriptionProductUrl
 								: onboardingUrl;
 					} )
@@ -231,35 +247,64 @@ const OnboardingSteps = () => (
 			<div className="subscriptions-page-onboarding-steps-item">
 				<StepNumber>1</StepNumber>
 				<h3>
-					{ __( 'Create and connect your account', 'woocommerce' ) }
+					{ experimentAssignment === Treatment.A
+						? __( 'Create and connect your account', 'woocommerce' )
+						: __(
+								'Create and connect your account',
+								'woocommerce'
+						  ) }
 				</h3>
 				<p>
-					{ __(
-						'To ensure safe and secure transactions, a WordPress.com account is required.',
-						'woocommerce'
-					) }
+					{ experimentAssignment === Treatment.A
+						? __(
+								'To ensure safe and secure transactions, a WordPress.com account is required.',
+								'woocommerce'
+						  )
+						: __(
+								'To ensure safe and secure transactions, a WordPress.com account is required.',
+								'woocommerce'
+						  ) }
 				</p>
 			</div>
 			<div className="subscriptions-page-onboarding-steps-item">
 				<StepNumber>2</StepNumber>
 				<h3>
-					{ __( 'Provide a few business details', 'woocommerce' ) }
+					{ experimentAssignment === Treatment.A
+						? __( 'Provide a few business details', 'woocommerce' )
+						: __(
+								'Provide a few business details',
+								'woocommerce'
+						  ) }
 				</h3>
 				<p>
-					{ __(
-						'Next we’ll ask you to verify your business and payment details to enable deposits.',
-						'woocommerce'
-					) }
+					{ experimentAssignment === Treatment.A
+						? __(
+								'Next we’ll ask you to verify your business and payment details to enable deposits.',
+								'woocommerce'
+						  )
+						: __(
+								'Next we’ll ask you to verify your business and payment details to enable deposits.',
+								'woocommerce'
+						  ) }
 				</p>
 			</div>
 			<div className="subscriptions-page-onboarding-steps-item">
 				<StepNumber>3</StepNumber>
-				<h3>{ __( 'Create subscriptions', 'woocommerce' ) }</h3>
+				<h3>
+					{ experimentAssignment === Treatment.A
+						? __( 'Create subscriptions', 'woocommerce' )
+						: __( 'Create subscriptions', 'woocommerce' ) }
+				</h3>
 				<p>
-					{ __(
-						'Finally, publish subscription products to offer on your store.',
-						'woocommerce'
-					) }
+					{ experimentAssignment === Treatment.A
+						? __(
+								'Finally, publish subscription products to offer on your store.',
+								'woocommerce'
+						  )
+						: __(
+								'Finally, publish subscription products to offer on your store.',
+								'woocommerce'
+						  ) }
 				</p>
 			</div>
 		</div>
@@ -272,7 +317,7 @@ const SubscriptionsPage = () => {
 	useEffect( () => {
 		// TODO: Remove this.
 		console.log(
-			experimentAssignment === 'A'
+			experimentAssignment === Treatment.A
 				? 'Treatment A: Create a subscription product then WCPay onboarding.'
 				: 'Treatment B: WCPay onboarding then create a subscription product.'
 		);

--- a/plugins/woocommerce/src/Internal/Admin/WcPaySubscriptionsPage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPaySubscriptionsPage.php
@@ -257,16 +257,6 @@ class WcPaySubscriptionsPage {
 			$allow_tracking
 		);
 
-		$date = new \DateTime();
-		$date->setTimeZone( new \DateTimeZone( 'UTC' ) );
-
-		$experiment_name = sprintf(
-			'%s_%s_%s',
-			'woocommerce_wcpay_subscriptions_page',
-			$date->format( 'Y' ),
-			$date->format( 'm' )
-		);
-
-		return $abtest->get_variation( $experiment_name ) === 'control' ? 'A' : 'B';
+		return $abtest->get_variation( 'woocommerce_wcpay_subscriptions_page_202207_v1' ) === 'control' ? 'A' : 'B';
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Internal project: pdjTHR-Vi-p2

This PR adds code to:
- Request assignment for the `woocommerce_wcpay_subscriptions_page_202207_v1` experiment.
- Handle the two experiment treatments, i.e.
	- Treatment A: Redirect the user to the to the “Add new product” page when they click the "Get started" button.
	- Treatment B: Redirect the user to the WCPay onboarding flow when they click the "Get started" button.

Additionally, each treatment has its own set of steps in the "You’re only steps away from selling subscriptions" section. These steps should accurately reflect their respective flow described above.

### How to test the changes in this Pull Request:

**Note:** Because this PR requires interacting with ExPlat/Abacus it's much easier to test this PR in an environment that communicates with the production WPCOM servers. As such, these instructions are written specifically for testing on Jurassic Ninja or another non-local environment.

You can grab a zip of this PR for testing here: [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/8683359/woocommerce.zip)

1. **Plugin eligibility**: Ensure the following plugins are not installed at all: 
    - WooCommerce Subscriptions
    - WooCommerce Payments
    - Sumo Subscriptions
    - Yith Subscriptions
    - Subscripto
    - Subscriptions For WooCommerce
2. **Store location eligibility:** For the menu item to be displayed your store needs to based in the US. 
     - Go to **WooCommerce > Settings** and make sure your store is set to a US based address. 
3. **Store age criteria:** To view the subscription menu item your store will need to have been active for more than 6 months - we're testing this experiment on established stores. If your store doesn't meet this criteria, you can use the following code snippet: 
    - `update_option( 'woocommerce_admin_install_timestamp', strtotime( '-6 month' ) );`
4. **Paid order criteria:** Only stores with at least 1 order in the last 30 days are eligible. If your store doesn't have an order in the last 30 days. Either: 
     1. Set any existing pending or failed order to processing or completed 
     2. If you don't have any order at all, you can just manually create one in **WooCommerce > Orders > Add new** and set it to processing or completed status
     3. ⚠️ **Note:** this order sale query is cached and so you may need to delete the `'woocommerce-wcpay-subscriptions_recent_sales_eligibility'` transient if this criteria failed previously. 
5. If you meet all the criteria above you should see a **WooCommerce > Subscriptions (new)** menu item.
6. View the **WooCommerce > Subscriptions (new)** page. 
     - The 'new' badge should disappear on subsequent page loads.

#### Testing the treatments

Download, install and activate the [WooCommerce Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper) plugin.

Navigate to **Tools → WCA Test Helper → Experiments**. This page should contain a row for the "woocommerce_wcpay_subscriptions_page_202207_v1" experiment.

Here you can toggle between the control (treatment A) and the treatment (treatment B).

#### Treatment A

1. Toggle to the control experience from **Tools → WCA Test Helper → Experiments**.
2. Navigate to **WooCommerce → Subscriptions**.
3. Observe the following step headers in the "You’re only steps away from selling subscriptions" section.
     1. Create a subscription
     2. Create and connect your account
     3. Provide a few business details
4. Click the "Get started" button.
5. The WooCommerce Payments plugin will be installed & activated and you will be redirected to the “Add new product” page.

#### Treatment B

1. Toggle to the treatment experience from **Tools → WCA Test Helper → Experiments**.
2. Navigate to **WooCommerce → Subscriptions**.
3. Observe the following step headers in the "You’re only steps away from selling subscriptions" section.
     1. Create and connect your account
     2. Provide a few business details
     3. Create subscriptions
4. Click the "Get started" button.
5. The WooCommerce Payments plugin will be installed & activated and you will be redirected to the WCPay onboarding flow.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.