### PR TITLE
Add FeaturePlugin facade under the Admin namespace to avoid conflict WCA conflict

### DIFF
--- a/plugins/woocommerce/changelog/fix-32962_fatal_error_wc_admin_conflict
+++ b/plugins/woocommerce/changelog/fix-32962_fatal_error_wc_admin_conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue where FeaturePlugin class caused a conflict with older WooCommerce Admin versions. #32966

--- a/plugins/woocommerce/src/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Admin/FeaturePlugin.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * WooCommerce Admin: Feature plugin main class.
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Feature plugin main class.
+ *
+ * @deprecated since 6.4.0
+ */
+class FeaturePlugin extends DeprecatedClassFacade {
+	/**
+	 * The name of the non-deprecated class that this facade covers.
+	 *
+	 * @var string
+	 */
+	protected static $facade_over_classname = 'Automattic\WooCommerce\Internal\Admin\FeaturePlugin';
+
+	/**
+	 * The version that this class was deprecated in.
+	 *
+	 * @var string
+	 */
+	protected static $deprecated_in_version = '6.4.0';
+
+	/**
+	 * Constructor
+	 *
+	 * @return void
+	 */
+	protected function __construct() {}
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	final public static function instance() {
+		return new static();
+	}
+
+	/**
+	 * Init the feature plugin, only if we can detect both Gutenberg and WooCommerce.
+	 *
+	 * @deprecated 6.4.0
+	 */
+	public function init() {}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32962  .

### How to test the changes in this Pull Request:

1. Install and activate WooCommerce 6.4.1 or any version lower than 6.5.
2. Install and activate WooCommerce Admin 3.2.1 or lower
3. Upgrade WooCommerce to version 6.5.0.
4. It should correctly disable WooCommerce Admin and not show an error

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
