### PR TITLE
Fix/download dir table key

### DIFF
--- a/plugins/woocommerce/changelog/fix-download_dir_table_key
+++ b/plugins/woocommerce/changelog/fix-download_dir_table_key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Specify a maximum index size for the URL column in the Download Directories table.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -206,6 +206,9 @@ class WC_Install {
 		'6.5.0' => array(
 			'wc_update_650_approved_download_directories',
 		),
+		'6.5.1' => array(
+			'wc_update_651_approved_download_directories',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1232,7 +1232,7 @@ CREATE TABLE {$wpdb->prefix}wc_product_download_directories (
 	url varchar(256) NOT NULL,
 	enabled TINYINT(1) NOT NULL DEFAULT 0,
 	PRIMARY KEY (url_id),
-	KEY `url` (`url`)
+	KEY url (url($max_index_length))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_stats (
 	order_id bigint(20) unsigned NOT NULL,

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2416,7 +2416,7 @@ function wc_update_651_approved_download_directories() {
 	$directory_sync       = wc_get_container()->get( Download_Directories_Sync::class );
 
 	// Check if at least 1 row exists, without scanning the entire table.
-	$is_populated = (bool) $wpdb->get_col(
+	$is_populated = (bool) $wpdb->get_var(
 		'SELECT 1 FROM ' . $download_directories->get_table() . ' LIMIT 1'
 	);
 

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -92,7 +92,7 @@ class Synchronize {
 				$this->start();
 			}
 		} catch ( Exception $e ) {
-			wc_get_logger()->log( 'warning', __( 'It was not possible to synchronize download directories following the update to 6.4.0.', 'woocommerce' ) );
+			wc_get_logger()->log( 'warning', __( 'It was not possible to synchronize download directories following the most recent update.', 'woocommerce' ) );
 		}
 
 		$this->register->set_mode(

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -125,15 +125,16 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	public function db_update_version_provider() {
 		return array(
 			// [DB Update version string, # of expected pending jobs]
-			array( '3.9.0', 33 ),
-			array( '4.0.0', 26 ),
-			array( '4.4.0', 22 ),
-			array( '4.5.0', 20 ),
-			array( '5.0.0', 16 ),
-			array( '5.6.0', 14 ),
-			array( '6.0.0', 7 ),
-			array( '6.3.0', 4 ),
-			array( '6.4.0', 1 ),
+			array( '3.9.0', 34 ),
+			array( '4.0.0', 27 ),
+			array( '4.4.0', 23 ),
+			array( '4.5.0', 21 ),
+			array( '5.0.0', 17 ),
+			array( '5.6.0', 15 ),
+			array( '6.0.0', 8 ),
+			array( '6.3.0', 5 ),
+			array( '6.4.0', 2 ),
+			array( '6.5.0', 1 ),
 		);
 	}
 


### PR DESCRIPTION
Shortly after releasing WooCommerce 6.5 we became aware of a problem *[[1]](https://wordpress.org/support/topic/missing-table-after-updating-to-woocommerce-6-5/) [[2]](https://wordpress.org/support/topic/missing-tables-12/) [[3]](https://wordpress.org/support/topic/missing-database-table-6/)* that was preventing the creation of the `*_wc_product_download_directories` table in some cases:

```
WordPress database error Index column size too large. The maximum column size is 767 bytes.
```

We have a [general solution](https://github.com/woocommerce/woocommerce/blob/f994ba1839c2472aaa95560f7cfcfc259372e739/plugins/woocommerce/includes/class-wc-install.php#L1005) to this problem but, unfortunately, it was not applied to this new table. This change corrects that oversight.

---

### How to test the changes in this Pull Request:

When testing, you will need to drop the download directories table and change the plugin version options on at least a couple of occasions. In case handy, here are some WP CLI commands for that (of course, update `x.y.z` to the appropriate version number):

```sh
wp db query "DROP TABLE $(wp db prefix)wc_product_download_directories"
```

```sh
wp option set woocommerce_version x.y.z ;\
wp option set woocommerce_db_version x.y.z
```

Let's begin!

1. Drop the `*_wc_product_download_directories` table (or temporarily rename it, if you wish to restore your existing settings after the test).
2. Confirm you can see the problem: if you navigate to a screen such as **WooCommerce ▸ Settings ▸ Products ▸ Approved Download Directories** you should see the missing table error in your database logs (even better, use [Query Monitor](https://wordpress.org/plugins/query-monitor/) or similar).
3. Reset the database version to 6.4.0.
    - You should then see a prompt within the admin environment asking you to update the database.
    - Wait until the process completes ... shortcut is to run `wp wc update`.
4. The table should have been created. To verify:
    - Re-visit the same admin screen as before, you should not see the same database error(s).
    - Inspect your database, you should see `*_wc_product_download_directories` has been created.
    - Optionally, using a tool of your choosing, verify that the index set on the table's `url` column is set to 191 chars.
5. Rinse and repeat, but simulate the process as experienced by someone who already updated to `6.5.0` and is now updating to `6.5.1` (so, the relevant version options should be set to `6.5.0`):
    1. Do this once, and be sure to drop the db table first of all (ie, simulate the problem experienced in the linked support forum threads). 
    2. Repeat, but this time without dropping the db table (ie, run through the process as if you were a user for whom the 6.5.0 update was successful).
    3. Look out for errors/problems.

Please let me know if I can clarify any of the above.

### Other information:

- In the linked support requests, the common pattern for those users who were impacted (ie, where the table could not be created because the index column size was too large) seems to be that they were using an older version of MySQL (/Maria), with  `STRICT_ALL_TABLES` in effect, and where the default collation is a form of `utf8mb4`. 
- I was unable to replicate those conditions, even using MySQL 5.5, so in the above testing instructions I've concentrated on the mechanics of the update procedure. I'm fairly confident in the index size fix, simply because it's a strategy we've used on lots of other existing tables. That said, if you are able to create the conditions necessary to see the 'true' problem, please do.
- There's still a more general problem I'm not addressing: the database table may still fail to be created despite the change in table definition ... that's not specific to this table or feature, though, and we probably need to think of a more generalized answer to that problem.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
