### PR TITLE
Fix notice on empty product page

### DIFF
--- a/plugins/woocommerce/changelog/fix-32956-notice-on-empty-product-page
+++ b/plugins/woocommerce/changelog/fix-32956-notice-on-empty-product-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix notice on emptry product page

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -158,8 +158,7 @@ class Products extends Task {
 	 * @param string $hook Page hook.
 	 */
 	public function possibly_add_load_sample_return_notice_script( $hook ) {
-		global $post;
-		if ( 'edit.php' !== $hook || 'product' !== $post->post_type ) {
+		if ( 'edit.php' !== $hook || 'product' !== get_query_var( 'post_type' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32956.

Fixes the notice on the empty product page. 

### How to test the changes in this Pull Request:

**Test no notice on the empty Products page**

1. Make sure debug is enabled
2. On a fresh site, go to the Products page
3. Observe NO notice

**Test load sample products notice**

1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-products-task`
4. Go to Tools > WCA Test Helper > Experiments
5. Enable treatment for `woocommerce_products_task_layout_stacked`
6. Make sure your site has `woocommerce_allow_tracking` option set to `yes`
7. Navigate to WooCommerce > Home
8. Go to "Add products" task
9. Click "Load Sample Products"
10. Observe that 9 products are loaded, and a notice is displayed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
