### PR TITLE
Fix product task text shown before accordion is expanded on stack layout

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.scss
@@ -22,7 +22,7 @@
 		color: #007cba;
 		padding: 0;
 		height: fit-content;
-		margin-top: 25px;
+		margin-top: 21px;
 		justify-content: center;
 
 		svg {

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -116,6 +116,7 @@ export const Products = () => {
 							<Stack
 								items={ visibleProductTypes }
 								onClickLoadSampleProduct={ loadSampleProduct }
+								showOtherOptions={ isExpanded }
 							/>
 						) : (
 							<CardLayout items={ visibleProductTypes } />

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
@@ -67,6 +67,7 @@
 	.woocommerce-stack__other-options {
 		display: block;
 		margin-top: 20px;
+		margin-bottom: 4px;
 		color: $gray-700;
 		line-height: 16px;
 	}

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
@@ -1,4 +1,12 @@
 .woocommerce-products-stack {
+	width: 550px;
+
+	@media (max-width: 550px ) {
+		& {
+			width: 100%;
+		}
+	}
+
 	a {
 		text-decoration: none;
 		color: #007cba;

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.tsx
@@ -18,52 +18,55 @@ type StackProps = {
 		onClick: () => void;
 	} )[];
 	onClickLoadSampleProduct: () => void;
+	showOtherOptions?: boolean;
 };
 
 const Stack: React.FC< StackProps > = ( {
 	items,
 	onClickLoadSampleProduct,
+	showOtherOptions = true,
 } ) => {
 	return (
 		<div className="woocommerce-products-stack">
 			<List items={ items } />
-			<Text className="woocommerce-stack__other-options">
-				{ interpolateComponents( {
-					mixedString: __(
-						'Can’t find your product type? {{sbLink}}Start Blank{{/sbLink}} or {{LspLink}}Load Sample Products{{/LspLink}} to see what they look like in your store.',
-						'woocommerce'
-					),
-					components: {
-						sbLink: (
-							<Link
-								onClick={ () => {
-									window.location = getAdminLink(
-										'post-new.php?post_type=product&wc_onboarding_active_task=products&tutorial=true'
-									);
-									return false;
-								} }
-								href=""
-								type="wc-admin"
-							>
-								<></>
-							</Link>
+			{ showOtherOptions && (
+				<Text className="woocommerce-stack__other-options">
+					{ interpolateComponents( {
+						mixedString: __(
+							'Can’t find your product type? {{sbLink}}Start Blank{{/sbLink}} or {{LspLink}}Load Sample Products{{/LspLink}} to see what they look like in your store.',
+							'woocommerce'
 						),
-						LspLink: (
-							// TODO: Update this to the load sample product.
-							<Link
-								href=""
-								type="wc-admin"
-								onClick={ () => {
-									onClickLoadSampleProduct();
-									return false;
-								} }
-							>
-								<></>
-							</Link>
-						),
-					},
-				} ) }
-			</Text>
+						components: {
+							sbLink: (
+								<Link
+									onClick={ () => {
+										window.location = getAdminLink(
+											'post-new.php?post_type=product&wc_onboarding_active_task=products&tutorial=true'
+										);
+										return false;
+									} }
+									href=""
+									type="wc-admin"
+								>
+									<></>
+								</Link>
+							),
+							LspLink: (
+								<Link
+									href=""
+									type="wc-admin"
+									onClick={ () => {
+										onClickLoadSampleProduct();
+										return false;
+									} }
+								>
+									<></>
+								</Link>
+							),
+						},
+					} ) }
+				</Text>
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -93,6 +93,10 @@ describe( 'Products', () => {
 		const fetchMock = jest.spyOn( global, 'fetch' );
 		const { queryByText, getByRole } = render( <Products /> );
 
+		userEvent.click(
+			getByRole( 'button', { name: 'View more product types' } )
+		);
+
 		expect( queryByText( 'Load Sample Products' ) ).toBeInTheDocument();
 
 		userEvent.click(

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/stack.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/stack.tsx
@@ -27,6 +27,24 @@ describe( 'Stack', () => {
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 2 );
 	} );
 
+	it( 'should not render other product options', () => {
+		const { queryByText } = render(
+			<Stack
+				showOtherOptions={ false }
+				onClickLoadSampleProduct={ () => {} }
+				items={ [
+					{
+						...productTypes[ 0 ],
+						onClick: () => {},
+					},
+				] }
+			/>
+		);
+
+		expect( queryByText( 'Start Blank' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'Load Sample Products' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'should call onClickLoadSampleProduct when the "Load Sample Products" link is clicked', async () => {
 		const onClickLoadSampleProduct = jest.fn();
 		const { getByRole } = render(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32959.

- Add a prop to show/hide the other product type options on the stack layout
- Update the CSS style to have proper padding.

### How to test the changes in this Pull Request:

1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-products-task`
4. Go to `Tools > WCA Test Helper > Experiments`
5. Enable treatment for `woocommerce_products_task_layout_stacked`
6. Make sure your site has `woocommerce_allow_tracking` option set to `yes`
7. Navigate to `WooCommerce > Home`
8. Go to "Add products" task
9. Observe that `Can’t find your product type?...` text is not shown when accordion is not expanded on stack layout

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
