### PR TITLE
Fix smoke test on release

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -15,48 +15,42 @@ jobs:
         if: "${{ contains(github.event.label.name, 'run: smoke tests') }}"
         runs-on: ubuntu-20.04
         steps:
-            - name: Create dirs.
-              run: |
-                  mkdir -p code/woocommerce
-                  mkdir -p package/woocommerce
-                  mkdir -p tmp/woocommerce
-
             - name: Checkout code.
               uses: actions/checkout@v3
-              with:
-                  path: package/woocommerce
 
-            - name: Get cached composer and pnpm directories
+            - name: Cache modules
               uses: actions/cache@v3
               id: cache-deps
               with:
                 path: |
                   ~/.pnpm-store
-                  package/woocommerce/plugins/woocommerce/packages
-                  package/woocommerce/plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-smoke-test-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+                  plugins/woocommerce/packages
+                  plugins/woocommerce/**/vendor
+                key: ${{ runner.os }}-npm-composer-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
 
             - name: Install PNPM
               run: npm install -g pnpm@^6.24.2
 
+            - name: Install Jest
+              run: pnpm install -g jest
+
             - name: Install dependencies
-              working-directory: package/woocommerce/plugins/woocommerce
               run: pnpm install
 
             - name: Install Composer dependencies
-              working-directory: package/woocommerce/plugins/woocommerce
               if: steps.cache-deps.outputs.cache-hit != 'true'
               run: pnpm nx composer-install-no-dev woocommerce
 
-            - name: Install prerequisites.
-              working-directory: package/woocommerce/plugins/woocommerce
-              id: installation
-              run: |
-                  pnpm nx build-assets woocommerce
-                  pnpm install jest
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
+
+            - name: Run build
+              run: pnpm nx build woocommerce
 
             - name: Run smoke test.
-              working-directory: package/woocommerce/plugins/woocommerce
+              working-directory: plugins/woocommerce
               if: always()
               env:
                   SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
@@ -83,11 +77,11 @@ jobs:
               with:
                   github-token: ${{secrets.GITHUB_TOKEN}}
                   script: |
-                      const script = require( './package/woocommerce/packages/js/e2e-environment/bin/post-results-to-github-pr.js' )
+                      const script = require( './packages/js/e2e-environment/bin/post-results-to-github-pr.js' )
                       await script({github, context})
 
             - name: Run E2E tests.
-              working-directory: package/woocommerce/plugins/woocommerce
+              working-directory: plugins/woocommerce
               if: always()
               env:
                   SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
@@ -114,7 +108,7 @@ jobs:
               with:
                   github-token: ${{secrets.GITHUB_TOKEN}}
                   script: |
-                      const script = require( './package/woocommerce/packages/js/e2e-environment/bin/post-results-to-github-pr.js' )
+                      const script = require( './packages/js/e2e-environment/bin/post-results-to-github-pr.js' )
                       await script({github, context})
 
             - name: Remove label from pull request.

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -7,46 +7,63 @@ jobs:
         name: Daily smoke test on trunk.
         runs-on: ubuntu-20.04
         steps:
-            - name: Create dirs.
-              run: |
-                  mkdir -p code/woocommerce
-                  mkdir -p package/woocommerce
-                  mkdir -p tmp/woocommerce
-
             - name: Checkout code.
               uses: actions/checkout@v3
               with:
-                  path: package/woocommerce
                   ref: trunk
 
-            - name: Install prerequisites.
-              working-directory: package/woocommerce/plugins/woocommerce
-              run: |
-                  npm install -g pnpm@^6.24.2
-                  pnpm install
-                  pnpm nx composer-install-no-dev woocommerce
-                  pnpm nx build-assets woocommerce
-                  pnpm install jest
+            - name: Cache modules
+              uses: actions/cache@v3
+              id: cache-deps
+              with:
+                path: |
+                  ~/.pnpm-store
+                  plugins/woocommerce/packages
+                  plugins/woocommerce/**/vendor
+                key: ${{ runner.os }}-npm-composer-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+
+            - name: Install PNPM
+              run: npm install -g pnpm@^6.24.2
+
+            - name: Install Jest
+              run: pnpm install -g jest
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Install Composer dependencies
+              if: steps.cache-deps.outputs.cache-hit != 'true'
+              run: pnpm nx composer-install-no-dev woocommerce
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
+
+            - name: Run build
+              run: pnpm nx build woocommerce
 
             - name: Run smoke test.
-              working-directory: package/woocommerce/plugins/woocommerce
+              working-directory: plugins/woocommerce
               env:
-                  SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
-                  SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-                  SMOKE_TEST_ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-                  SMOKE_TEST_ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
-                  SMOKE_TEST_CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
-                  SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+                  SMOKE_TEST_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  SMOKE_TEST_ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  SMOKE_TEST_ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  SMOKE_TEST_ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
+                  SMOKE_TEST_CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+                  SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
                   WC_E2E_SCREENSHOTS: 1
                   E2E_RETEST: 1
                   E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
-                  E2E_SLACK_CHANNEL: 'C01U0H617MY'
+                  E2E_SLACK_CHANNEL: 'C02DS4NE72S'
+                  TEST_RELEASE: 1
                   UPDATE_WC: 1
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
-                  USER_KEY: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-                  USER_SECRET: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
               run: |
+                  pnpm exec wc-e2e docker:up
                   pnpm exec wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
                   pnpm exec wc-e2e test:e2e
                   pnpm exec wc-api-tests test api
@@ -55,39 +72,40 @@ jobs:
         name: Build zip for PR
         runs-on: ubuntu-20.04
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
+          - name: Checkout code.
+            uses: actions/checkout@v3
 
-            - name: Get cached composer and pnpm directories
-              uses: actions/cache@v3
-              id: cache-deps
-              with:
-                path: |
-                  ~/.pnpm-store
-                  plugins/woocommerce/packages
-                  plugins/woocommerce/**/vendor
-                key: ${{ runner.os }}-npm-composer-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+          - name: Cache modules
+            uses: actions/cache@v3
+            id: cache-deps
+            with:
+              path: |
+                ~/.pnpm-store
+              key: ${{ runner.os }}-npm-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
-            - name: Install PNPM
-              run: npm install -g pnpm@^6.24.2
+          - name: Install PNPM
+            run: npm install -g pnpm@^6.24.2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                php-version: '7.4'
+          - name: Setup PHP
+            uses: shivammathur/setup-php@v2
+            with:
+              php-version: '7.4'
 
-            - name: Build zip
-              working-directory: plugins/woocommerce
-              run: bash bin/build-zip.sh
+          - name: Build zip
+            working-directory: plugins/woocommerce
+            run: bash bin/build-zip.sh
 
-            - name: Upload PR zip
-              uses: actions/upload-artifact@v3
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  name: woocommerce
-                  path: plugins/woocommerce/woocommerce.zip
-                  retention-days: 7
+          - name: Unzip the file (prevents double zip problem)
+            run: unzip plugins/woocommerce/woocommerce.zip -d zipfile
+
+          - name: Upload the zip file as an artifact
+            uses: actions/upload-artifact@v3
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            with:
+              name: woocommerce
+              path: zipfile
+              retention-days: 7
 
     test-plugins:
         name: Smoke tests with ${{ matrix.plugin }} plugin installed
@@ -113,7 +131,6 @@ jobs:
         steps:
             - name: Create dirs.
               run: |
-                  mkdir -p code/woocommerce
                   mkdir -p package/woocommerce
                   mkdir -p tmp/woocommerce
 
@@ -122,18 +139,29 @@ jobs:
               with:
                   path: package/woocommerce
 
-            - name: Install PNPM and install dependencies
+            - name: Cache modules
+              uses: actions/cache@v3
+              id: cache-deps
+              with:
+                path: |
+                  ~/.pnpm-store
+                key: ${{ runner.os }}-npm-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+            - name: Install PNPM
+              run: npm install -g pnpm@^6.24.2
+
+            - name: Install dependencies
               working-directory: package/woocommerce
-              run: |
-                  npm install -g pnpm@^6.24.2
-                  pnpm install
+              run: pnpm install
 
-            - name: Load docker images and start containers.
-              working-directory: package/woocommerce/plugins/woocommerce
-              run: pnpm exec wc-e2e docker:up
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
 
-            - name: Move current directory to code. We will install zip file in this dir later.
-              run: mv ./package/woocommerce/plugins/woocommerce/* ./code/woocommerce
+            - name: Run build
+              working-directory: package/woocommerce
+              run: pnpm nx build woocommerce
 
             - name: Download WooCommerce ZIP.
               uses: actions/download-artifact@v3
@@ -145,13 +173,11 @@ jobs:
               working-directory: tmp
               run: |
                   unzip woocommerce.zip -d woocommerce
-                  mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+                  rsync -a woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
 
-            - name: Install dependencies again
+            - name: Load docker images and start containers.
               working-directory: package/woocommerce
-              run: |
-                  npm install -g pnpm@^6.24.2
-                  pnpm install
+              run: pnpm nx docker-up woocommerce
 
             - name: Run tests command.
               working-directory: package/woocommerce/plugins/woocommerce

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -10,30 +10,44 @@ jobs:
         name: Daily smoke test on release.
         runs-on: ubuntu-20.04
         steps:
-            - name: Create dirs.
-              run: |
-                  mkdir -p code/woocommerce
-                  mkdir -p package/woocommerce
-                  mkdir -p tmp/woocommerce
-                  mkdir -p node_modules
-
             - name: Checkout code.
               uses: actions/checkout@v3
               with:
-                  path: package/woocommerce
                   ref: trunk
 
-            - name: Install prerequisites.
-              working-directory: package/woocommerce/plugins/woocommerce
-              run: |
-                  npm install -g pnpm@^6.24.2
-                  pnpm install
-                  pnpm nx composer-install-no-dev woocommerce
-                  pnpm nx build-assets woocommerce
-                  pnpm install jest
+            - name: Cache modules
+              uses: actions/cache@v3
+              id: cache-deps
+              with:
+                path: |
+                  ~/.pnpm-store
+                  plugins/woocommerce/packages
+                  plugins/woocommerce/**/vendor
+                key: ${{ runner.os }}-npm-composer-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/composer.lock', '**/pnpm-lock.yaml') }}
+
+            - name: Install PNPM
+              run: npm install -g pnpm@^6.24.2
+
+            - name: Install Jest
+              run: pnpm install -g jest
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Install Composer dependencies
+              if: steps.cache-deps.outputs.cache-hit != 'true'
+              run: pnpm nx composer-install-no-dev woocommerce
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
+
+            - name: Run build
+              run: pnpm nx build woocommerce
 
             - name: Run smoke test.
-              working-directory: package/woocommerce/plugins/woocommerce
+              working-directory: plugins/woocommerce
               env:
                   SMOKE_TEST_URL: ${{ secrets.RELEASE_TEST_URL }}
                   SMOKE_TEST_ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
@@ -52,6 +66,7 @@ jobs:
                   USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
                   USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
               run: |
+                  pnpm exec wc-e2e docker:up
                   pnpm exec wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
                   pnpm exec wc-e2e test:e2e
                   pnpm exec wc-api-tests test api
@@ -64,15 +79,22 @@ jobs:
         steps:
             - name: Create dirs.
               run: |
-                  mkdir -p code/woocommerce
                   mkdir -p package/woocommerce
-                  mkdir -p tmp/woocommerce
-                  mkdir -p node_modules
+                  mkdir -p tmp/woocommerce 
 
             - name: Checkout code.
               uses: actions/checkout@v3
               with:
                   path: package/woocommerce
+
+            - name: Cache modules
+              uses: actions/cache@v3
+              id: cache-deps
+              with:
+                path: |
+                  ~/.pnpm-store
+                key: ${{ runner.os }}-npm-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
             - name: Fetch Asset ID
               id: fetch_asset_id
               uses: actions/github-script@v5
@@ -85,20 +107,21 @@ jobs:
                       const script = require( './package/woocommerce/.github/workflows/scripts/fetch-asset-id.js' )
                       await script({github, context, core})
 
-            - name: Install PNPM and install dependencies
+            - name: Install PNPM
+              run: npm install -g pnpm@^6.24.2
+
+            - name: Install dependencies
               working-directory: package/woocommerce
-              run: |
-                  npm install -g pnpm@^6.24.2
-                  pnpm install
+              run: pnpm install
 
-            - name: Load docker images and start containers.
-              working-directory: package/woocommerce/plugins/woocommerce
-              env:
-                  LATEST_WP_VERSION_MINUS: ${{ matrix.wp }}
-              run: pnpm nx docker-up woocommerce
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
 
-            - name: Move current directory to code. We will install zip file in this dir later.
-              run: mv ./package/woocommerce/plugins/woocommerce/* ./code/woocommerce
+            - name: Run build
+              working-directory: package/woocommerce
+              run: pnpm nx build woocommerce
 
             - name: Download WooCommerce release zip
               working-directory: tmp
@@ -106,7 +129,13 @@ jobs:
                   curl https://api.github.com/repos/${{ github.repository }}/releases/assets/${{ steps.fetch_asset_id.outputs.asset_id }} -LJOH 'Accept: application/octet-stream'
 
                   unzip woocommerce.zip -d woocommerce
-                  mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+                  rsync -a woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+
+            - name: Load docker images and start containers.
+              working-directory: package/woocommerce
+              env:
+                  LATEST_WP_VERSION_MINUS: ${{ matrix.wp }}
+              run: pnpm nx docker-up woocommerce
 
             - name: Run tests command.
               working-directory: package/woocommerce/plugins/woocommerce
@@ -114,7 +143,7 @@ jobs:
                   WC_E2E_SCREENSHOTS: 1
                   E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
                   E2E_SLACK_CHANNEL: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
-              run: pnpm nx test-e2e woocommerce
+              run: pnpm exec wc-e2e test:e2e
 
     test-plugins:
         name: Smoke tests with ${{ matrix.plugin }} plugin installed
@@ -139,15 +168,22 @@ jobs:
         steps:
             - name: Create dirs.
               run: |
-                  mkdir -p code/woocommerce
                   mkdir -p package/woocommerce
                   mkdir -p tmp/woocommerce
-                  mkdir -p node_modules
 
             - name: Checkout code.
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   path: package/woocommerce
+
+            - name: Cache modules
+              uses: actions/cache@v3
+              id: cache-deps
+              with:
+                path: |
+                  ~/.pnpm-store
+                key: ${{ runner.os }}-npm-smoke-version-${{ secrets.WORKFLOW_CACHE }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
             - name: Fetch Asset ID
               id: fetch_asset_id
               uses: actions/github-script@v5
@@ -160,20 +196,21 @@ jobs:
                       const script = require( './package/woocommerce/.github/workflows/scripts/fetch-asset-id.js' )
                       await script({github, context, core})
 
-            - name: Install PNPM and install dependencies
+            - name: Install PNPM
+              run: npm install -g pnpm@^6.24.2
+
+            - name: Install dependencies
               working-directory: package/woocommerce
-              run: |
-                  npm install -g pnpm@^6.24.2
-                  pnpm install
+              run: pnpm install
 
-            - name: Load docker images and start containers.
-              working-directory: package/woocommerce/plugins/woocommerce
-              env:
-                  LATEST_WP_VERSION_MINUS: ${{ matrix.wp }}
-              run: pnpm nx docker-up woocommerce
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
 
-            - name: Move current directory to code. We will install zip file in this dir later.
-              run: mv ./package/woocommerce/plugins/woocommerce/* ./code/woocommerce
+            - name: Run build
+              working-directory: package/woocommerce
+              run: pnpm nx build woocommerce
 
             - name: Download WooCommerce release zip
               working-directory: tmp
@@ -181,7 +218,13 @@ jobs:
                   curl https://api.github.com/repos/${{ github.repository }}/releases/assets/${{ steps.fetch_asset_id.outputs.asset_id }} -LJOH 'Accept: application/octet-stream'
 
                   unzip woocommerce.zip -d woocommerce
-                  mv woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+                  rsync -a woocommerce/woocommerce/* ../package/woocommerce/plugins/woocommerce/
+
+            - name: Load docker images and start containers.
+              working-directory: package/woocommerce
+              env:
+                  LATEST_WP_VERSION_MINUS: ${{ matrix.wp }}
+              run: pnpm nx docker-up woocommerce
 
             - name: Run tests command.
               working-directory: package/woocommerce/plugins/woocommerce


### PR DESCRIPTION
This PR fixes the running of smoke tests. They don't necessarily have to pass but they should be ran.

* Ensure below PR tests all pass. Note `Run smoke tests against pull request` does not pass and that is ok because the test runs where it didn't before.
* Optionally go to https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml and manually run the workflow by clicking on `Run workflow` and select this branch `fix/smoke-tests-2` and for `Release ID` you can enter `66507990`. Ensure the tests are ran particularly the test commands. They won't pass but that's ok.