### PR TITLE
Copy file to correct path

### DIFF
--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -73,7 +73,7 @@ jobs:
           rm -rf woocommerce/woocommerce-production/woocommerce
 
       - name: Copy Composer over to production
-        run: cp monorepo/plugins/woocommerce/composer.json tmp/woocommerce-build
+        run: cp monorepo/plugins/woocommerce/composer.json tmp/woocommerce-build/woocommerce/woocommerce-production
 
       - name: Set up mirror
         working-directory: tmp/woocommerce-build


### PR DESCRIPTION
This PR "tries" to correct the copying of `composer.json` to the correct path.

**Test**
* After merging, check the workflow against this PR https://github.com/woocommerce/woocommerce/actions/workflows/mirrors.yml and ensure it passes.
* Then go to https://github.com/woocommerce/woocommerce-production and ensure `composer.json` file is now there in root.

Hoping this doesn't fail otherwise have to revert again. 