### PR TITLE
Bumping WP tested up to version to 6.0

### DIFF
--- a/plugins/woocommerce/changelog/bump-wp-tested-to
+++ b/plugins/woocommerce/changelog/bump-wp-tested-to
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Bumps the WP version for the WP tested up to.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce
 Requires at least: 5.7
-Tested up to: 5.9
+Tested up to: 6.0
 Requires PHP: 7.0
 Stable tag: 6.5.0
 License: GPLv3


### PR DESCRIPTION
This just bumps the WP tested up to version to 6.0.