### PR TITLE
Update history package to the latest 5.3.0 version

### DIFF
--- a/packages/js/navigation/CHANGELOG.md
+++ b/packages/js/navigation/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Update dependency `@wordpress/hooks` to ^3.5.0
 -   Added Typescript type declarations. #32615
+-   Update dependency `history` to ^5.3.0
 # 7.0.1
 
 -   Add missing dependencies. #8349

--- a/packages/js/navigation/changelog/update-32881-history-to-530
+++ b/packages/js/navigation/changelog/update-32881-history-to-530
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update dependency history to ^5.3.0

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/hooks": "^3.5.0",
 		"@wordpress/notices": "^3.3.2",
 		"@wordpress/url": "^3.4.1",
-		"history": "^4.10.1",
+		"history": "^5.3.0",
 		"qs": "^6.10.3"
 	},
 	"peerDependencies": {

--- a/plugins/woocommerce-admin/client/navigation/components/container/test/index.js
+++ b/plugins/woocommerce-admin/client/navigation/components/container/test/index.js
@@ -154,7 +154,7 @@ describe( 'Container', () => {
 			window.location = new URL(
 				getAdminLink( 'admin.php?page=wc-admin&path=/child' )
 			);
-			getHistory().push( getAdminLink( '/child' ) );
+			getHistory().push( new URL( getAdminLink( '/child' ) ) );
 		} );
 
 		await waitFor( () =>

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -90,7 +90,7 @@
 		"github-label-sync": "^2.0.2",
 		"grapheme-splitter": "^1.0.4",
 		"gridicons": "^3.4.0",
-		"history": "^4.10.1",
+		"history": "^5.3.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"qs": "^6.10.3",

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -122,7 +122,6 @@
 		"@types/cookie": "^0.4.1",
 		"@types/dompurify": "^2.3.3",
 		"@types/expect-puppeteer": "^4.4.7",
-		"@types/history": "^4.7.11",
 		"@types/jest": "^27.4.1",
 		"@types/lodash": "^4.14.179",
 		"@types/puppeteer": "^4.0.2",

--- a/plugins/woocommerce/changelog/update-32881-history-to-530
+++ b/plugins/woocommerce/changelog/update-32881-history-to-530
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update dependency history to ^5.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,7 +975,7 @@ importers:
       '@wordpress/notices': ^3.3.2
       '@wordpress/url': ^3.4.1
       eslint: ^8.12.0
-      history: ^4.10.1
+      history: ^5.3.0
       jest: ^27.5.1
       jest-cli: ^27.5.1
       qs: ^6.10.3
@@ -990,7 +990,7 @@ importers:
       '@wordpress/hooks': 3.5.0
       '@wordpress/notices': 3.4.1
       '@wordpress/url': 3.5.1
-      history: 4.10.1
+      history: 5.3.0
       qs: 6.10.3
     devDependencies:
       '@babel/core': 7.17.8
@@ -1377,7 +1377,7 @@ importers:
       github-label-sync: ^2.0.2
       grapheme-splitter: ^1.0.4
       gridicons: ^3.4.0
-      history: ^4.10.1
+      history: ^5.3.0
       jest: ^27.5.1
       jest-environment-jsdom: ~27.5.0
       jest-environment-node: ^27.5.1
@@ -1459,7 +1459,7 @@ importers:
       github-label-sync: 2.0.2
       grapheme-splitter: 1.0.4
       gridicons: 3.4.0_react@17.0.2
-      history: 4.10.1
+      history: 5.3.0
       lodash: 4.17.21
       memize: 1.1.0
       qs: 6.10.3
@@ -24966,7 +24966,6 @@ packages:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
       '@babel/runtime': 7.17.7
-    dev: true
 
   /hjson/1.8.4:
     resolution: {integrity: sha1-C8j/sCGY0hjEm1iZGxH2BIUBHTY=}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1282,7 +1282,6 @@ importers:
       '@types/cookie': ^0.4.1
       '@types/dompurify': ^2.3.3
       '@types/expect-puppeteer': ^4.4.7
-      '@types/history': ^4.7.11
       '@types/jest': ^27.4.1
       '@types/lodash': ^4.14.179
       '@types/puppeteer': ^4.0.2
@@ -1490,7 +1489,6 @@ importers:
       '@types/cookie': 0.4.1
       '@types/dompurify': 2.3.3
       '@types/expect-puppeteer': 4.4.7
-      '@types/history': 4.7.11
       '@types/jest': 27.4.1
       '@types/lodash': 4.14.180
       '@types/puppeteer': 4.0.2


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32881 .

This PR updates `history` package to the latest `5.3.0` It also removes `@types/history` as it is part of `hisotry` now.

Please keep in mind that we're updating to a major version with the following breaking changes. We're not affected from the braking changes as far as I know.

- Removed support for browsers that do not support the HTML5 history API (no pushState)
- Removed relative pathname support in hash history and memory history
- Removed getUserConfirmation, keyLength, and hashType APIs

### How to test the changes in this Pull Request:

There are no visual changes.

- Please visit as many pages as possible and make sure no errors are shown.
- Please also enable the navigation from `WooCommerce -> Settings -> Advanced -> Features` and make sure the Navigation works as expected without any errors.


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
