### PR TITLE
Remove WCAdmin deactivation note

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-deactivate-wcadmin-note
+++ b/plugins/woocommerce/changelog/fix-remove-deactivate-wcadmin-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add wc-admin-deactivate-plugin to list of obselete notes so it gets deleted on upgrade

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -768,6 +768,7 @@ class WC_Install {
 			'wc-admin-navigation-feedback',
 			'wc-admin-navigation-feedback-follow-up',
 			'wc-admin-set-up-additional-payment-types',
+			'wc-admin-deactivate-plugin',
 		);
 
 		$additional_obsolete_notes_names = apply_filters(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Automatically removes the note `Deactivate old WooCommerce Admin version` upon install/upgrade WooCommerce

<img width="708" alt="image" src="https://user-images.githubusercontent.com/3747241/168200994-264f8d03-5572-47d5-9fb3-ccd33c975de2.png">


### How to test the changes in this Pull Request:

1. In a fresh site, install & activate [WooCommerce 6.4.1](https://downloads.wordpress.org/plugin/woocommerce.6.4.1.zip)
2. Install & activate [WooCommerce Admin 3.2.1](https://github.com/woocommerce/woocommerce-admin/releases/download/v3.2.1/woocommerce-admin.zip)
3. Go to Home > WooCommerce
4. Observe the note "Deactivate old WooCommerce Admin version" exists
5. Zip plugin with this change (or download the zip here [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/8683735/woocommerce.zip))
6. Upload & activate the plugin
7. Observe the note is removed after install

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
