### PR TITLE
Update bulk edit price placeholders

### DIFF
--- a/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</span>
 			</label>
 			<label class="change-input">
-				<input type="text" name="_regular_price" class="text regular_price" placeholder="<?php printf( esc_attr__( 'Enter price (%s)', 'woocommerce' ), get_woocommerce_currency_symbol() ); ?>" value="" />
+				<input type="text" name="_regular_price" class="text regular_price" placeholder="<?php printf( esc_attr__( 'Enter Price (%s) or % value (e.g. 20%)', 'woocommerce' ), get_woocommerce_currency_symbol() ); ?>" value="" />
 			</label>
 		</div>
 
@@ -61,7 +61,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</span>
 			</label>
 			<label class="change-input">
-				<input type="text" name="_sale_price" class="text sale_price" placeholder="<?php printf( esc_attr__( 'Enter sale price (%s)', 'woocommerce' ), get_woocommerce_currency_symbol() ); ?>" value="" />
+				<input type="text" name="_sale_price" class="text sale_price" placeholder="<?php printf( esc_attr__( 'Enter Sale Price (%s) or % value (e.g. 20%)', 'woocommerce' ), get_woocommerce_currency_symbol() ); ?>" value="" />
 			</label>
 		</div>
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the placeholder text for both the Regular Price and Sale Price.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32547 

### How to test the changes in this Pull Request:

1. Go to Products > All Products
2. Use the Bulk Editor, and view the Price and Sale Price tabs


### Other information:

-   [-] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [-] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [-] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
