### PR TITLE
Fix report days calculation to account for DST

### DIFF
--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -229,17 +229,8 @@ class TimeInterval {
 
 				return (int) floor( ( (int) $diff_timestamp ) / HOUR_IN_SECONDS ) + 1 + $addendum;
 			case 'day':
-				$end_timestamp      = (int) $end_datetime->format( 'U' );
-				$start_timestamp    = (int) $start_datetime->format( 'U' );
-				$addendum           = 0;
-				$end_hour_min_sec   = (int) $end_datetime->format( 'H' ) * HOUR_IN_SECONDS + (int) $end_datetime->format( 'i' ) * MINUTE_IN_SECONDS + (int) $end_datetime->format( 's' );
-				$start_hour_min_sec = (int) $start_datetime->format( 'H' ) * HOUR_IN_SECONDS + (int) $start_datetime->format( 'i' ) * MINUTE_IN_SECONDS + (int) $start_datetime->format( 's' );
-				if ( $end_hour_min_sec < $start_hour_min_sec ) {
-					$addendum = 1;
-				}
-				$diff_timestamp = $end_timestamp - $start_timestamp;
-
-				return (int) floor( ( (int) $diff_timestamp ) / DAY_IN_SECONDS ) + 1 + $addendum;
+				$days = $start_datetime->diff( $end_datetime )->format( '%r%a' );
+				return $days + 1;
 			case 'week':
 				// @todo Optimize? approximately day count / 7, but year end is tricky, a week can have fewer days.
 				$week_count = 0;

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -229,7 +229,13 @@ class TimeInterval {
 
 				return (int) floor( ( (int) $diff_timestamp ) / HOUR_IN_SECONDS ) + 1 + $addendum;
 			case 'day':
-				$days = $start_datetime->diff( $end_datetime )->format( '%r%a' );
+				$days               = $start_datetime->diff( $end_datetime )->format( '%r%a' );
+				$end_hour_min_sec   = (int) $end_datetime->format( 'H' ) * HOUR_IN_SECONDS + (int) $end_datetime->format( 'i' ) * MINUTE_IN_SECONDS + (int) $end_datetime->format( 's' );
+				$start_hour_min_sec = (int) $start_datetime->format( 'H' ) * HOUR_IN_SECONDS + (int) $start_datetime->format( 'i' ) * MINUTE_IN_SECONDS + (int) $start_datetime->format( 's' );
+				if ( $end_hour_min_sec < $start_hour_min_sec ) {
+					$days++;
+				}
+
 				return $days + 1;
 			case 'week':
 				// @todo Optimize? approximately day count / 7, but year end is tricky, a week can have fewer days.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -617,10 +617,11 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 				'start'      => '2021-10-01T00:00:00',
 				'end'        => '2021-10-31T23:59:59',
 				'week_start' => 1,
+				'timezone'   => 'EST',
 				'intervals'  => array(
 					'hour'    => 31 * 24,
 					'day'     => 31,
-					'week'    => 5,
+					'week'    => 6,
 					'month'   => 1,
 					'quarter' => 1,
 					'year'    => 1,
@@ -631,8 +632,9 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 		foreach ( $test_settings as $setting ) {
 			update_option( 'start_of_week', $setting['week_start'] );
 			foreach ( $setting['intervals'] as $interval => $exp_value ) {
-				$start_datetime = new DateTime( $setting['start'], self::$local_tz );
-				$end_datetime   = new DateTime( $setting['end'], self::$local_tz );
+				$timezone       = isset( $setting['timezone'] ) ? new DateTimeZone( $setting['timezone'] ) : self::$local_tz;
+				$start_datetime = new DateTime( $setting['start'], $timezone );
+				$end_datetime   = new DateTime( $setting['end'], $timezone );
 				$this->assertEquals( $exp_value, TimeInterval::intervals_between( $start_datetime, $end_datetime, $interval ), "First Day of Week: {$setting['week_start']}; Start: {$setting['start']}; End: {$setting['end']}; Interval: {$interval}" );
 			}
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -612,6 +612,20 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 					'year'    => 4,
 				),
 			),
+			// Test change of DST times.
+			array(
+				'start'      => '2021-10-01T00:00:00',
+				'end'        => '2021-10-31T23:59:59',
+				'week_start' => 1,
+				'intervals'  => array(
+					'hour'    => 31 * 24,
+					'day'     => 31,
+					'week'    => 5,
+					'month'   => 1,
+					'quarter' => 1,
+					'year'    => 1,
+				),
+			),
 		);
 
 		foreach ( $test_settings as $setting ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the calculation for days between two dates to fix issues where DST based timezones would miscalculate days and cause reports to not be exported properly.

Closes #32220  .

### How to test the changes in this Pull Request:

1. Select a timezone (US, London, etc) that utilizes DST in your site's General settings
2. Install an email logging plugin
3. Go to the Revenue report
4. Select October 1 - October 31 as a custom date
5. Click "Download" to export the report
6. Check your email logs to make sure the report is sent and can be downloaded
7. Check that the number of "days" is correct in the summary numbers at the bottom of the Revenue report
8. Smoketest other areas of the app to make sure no regressions have occurred

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
