### PR TITLE
Update changelog to reflect 6.5.1 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 == Changelog ==
 
+= 6.5.1 2022-05-12 =
+
+**WooCommerce**
+
+* Fix - Specify a maximum index size for the URL column in the Download Directories table. ([#32968](https://github.com/woocommerce/woocommerce/pull/32968))
+* Fix - Fix issue where FeaturePlugin class caused a conflict with older WooCommerce Admin versions. ([#32966](https://github.com/woocommerce/woocommerce/pull/32966))
+
 = 6.5.0 2022-05-10 =
 
 **WooCommerce**

--- a/plugins/woocommerce/changelog/prep-post-6.5.1
+++ b/plugins/woocommerce/changelog/prep-post-6.5.1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+ Updates the stable tag and changelog from 6.5.1 release.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 6.5.0
+Stable tag: 6.5.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR just updates the stable tag and changelog from 6.5.1 release.