### PR TITLE
Products API: revert get_objects method to protected

### DIFF
--- a/plugins/woocommerce/changelog/fix-products-api-method-visibility
+++ b/plugins/woocommerce/changelog/fix-products-api-method-visibility
@@ -1,4 +1,3 @@
 Significance: patch
 Type: fix
-
-Changelog added in #32046, which has not yet been released, and this simply fixes a bug from that.
+Comment: Changelog added in #32046, which has not yet been released, and this simply fixes a bug from that.

--- a/plugins/woocommerce/changelog/fix-products-api-method-visibility
+++ b/plugins/woocommerce/changelog/fix-products-api-method-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Changelog added in #32046, which has not yet been released, and this simply fixes a bug from that.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -242,7 +242,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @param array $query_args Query args.
 	 * @return array
 	 */
-	public function get_objects( $query_args ) {
+	protected function get_objects( $query_args ) {
 		// Add filters for search criteria in product postmeta via the lookup table.
 		if ( ! empty( $this->search_sku_in_product_lookup_table ) ) {
 			add_filter( 'posts_join', array( $this, 'add_search_criteria_to_wp_query_join' ) );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/commit/029257be30b3c7ef0177c5a16bbbaea34c9b1d41 I inadvertently changed the visibility of the get_objects method to `public`. There is no need for its visibility to differ from the parent class, and it ended up causing fatal errors for other classes that are extending WC_REST_Products_Controller (see 3336-gh-woocommerce/woocommerce-bookings). This simply changes the visibility back to `protected`.

### How to test the changes in this Pull Request:

1. With WooCommerce Bookings plugin enabled, and without this patch, the main WooCommerce dashboard screen should be blank because of errors.
2. Apply the patch. Then the dashboard screen should render normally.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.