### PR TITLE
Flexslider CLS enhancements - followup #31418

### DIFF
--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -484,6 +484,23 @@ class WC_Frontend_Scripts {
 				$params = array(
 					'i18n_required_rating_text' => esc_attr__( 'Please select a rating', 'woocommerce' ),
 					'review_rating_required'    => wc_review_ratings_required() ? 'yes' : 'no',
+					/**
+					 * Flexslider options.
+					 *
+					 * @since 2.7.0
+					 *
+					 * @param bool    $is_rtl             Whether locale is RTL.
+					 * @param string  $animation_type     The type of animation. Accepts 'slide' or 'fade'.
+					 * @param bool    $height_transition  Allow height of the slider to animate smoothly in horizontal mode.
+					 * @param bool    $nav                Create navigation for previous/next navigation.
+					 * @param string  $controlNav         Create navigation for paging control of each slide.
+					 * @param string  $manualControls     Declare custom control navigation, accepts a valid jQuery selector.
+					 * @param bool    $slideshow          Create navigation for previous/next navigation.
+					 * @param int     $animationSpeed     Set the speed of animations, in milliseconds.
+					 * @param bool    $animationLoop      Enable the animation loop (start over after finishing).
+					 * @param bool    $allowOneSlide      Whether to allow a slider comprised of a single slide.
+					 *
+					 */
 					'flexslider'                => apply_filters(
 						'woocommerce_single_product_carousel_options',
 						array(
@@ -492,6 +509,13 @@ class WC_Frontend_Scripts {
 							'smoothHeight'   => true,
 							'directionNav'   => false,
 							'controlNav'     => 'thumbnails',
+							/**
+							 * Controls if manual controls for the single product flexslider should be enabled.
+							 *
+							 * @since 6.7.0
+							 *
+							 * @param bool $enable Enable manual controls.
+							 */
 							'manualControls' => apply_filters( 'woocommerce_single_product_nav_flexslider', get_theme_support( 'wc-product-gallery-slider-nav' ) ) ? '.flex-control-nav img' : null,
 							'slideshow'      => false,
 							'animationSpeed' => 500,

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -492,6 +492,7 @@ class WC_Frontend_Scripts {
 							'smoothHeight'   => true,
 							'directionNav'   => false,
 							'controlNav'     => 'thumbnails',
+							'manualControls' => apply_filters( 'woocommerce_single_product_nav_flexslider', false ) ? '.flex-control-nav img' : '',
 							'slideshow'      => false,
 							'animationSpeed' => 500,
 							'animationLoop'  => false, // Breaks photoswipe pagination if true.

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -492,7 +492,7 @@ class WC_Frontend_Scripts {
 							'smoothHeight'   => true,
 							'directionNav'   => false,
 							'controlNav'     => 'thumbnails',
-							'manualControls' => apply_filters( 'woocommerce_single_product_nav_flexslider', false ) ? '.flex-control-nav img' : '',
+							'manualControls' => apply_filters( 'woocommerce_single_product_nav_flexslider', get_theme_support( 'wc-product-gallery-slider-nav' ) ) ? '.flex-control-nav img' : null,
 							'slideshow'      => false,
 							'animationSpeed' => 500,
 							'animationLoop'  => false, // Breaks photoswipe pagination if true.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1559,7 +1559,7 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  */
 function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
-	$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', false );
+	$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', get_theme_support( 'wc-product-gallery-slider-nav' ) );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
@@ -1567,6 +1567,8 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
 	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $flexslider_nav || is_bool($main_image)  ? 'woocommerce_single' : $thumbnail_size );
 
+
+	// Gallery uses true false to indicate whether it is the main image
 	if (is_bool($main_image)) {
 		$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 		$image_params = array(
@@ -1580,7 +1582,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 			'loading'                 => esc_attr( $main_image ? 'eager' : 'lazy' ),
 		);
 	} else {
-		$image_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+		// Nav use int values in order to have different parameters
 		$image_params = array(
 			'alt' => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
 			'loading' => ($main_image <= apply_filters( 'woocommerce_product_thumbnails_columns', 4 )) ? null : 'lazy',
@@ -1605,42 +1607,6 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 		return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
 	else
 		return '<li>' . $image . '</li>';
-}
-
-/**
- * Get HTML for slider navigation.
- *
- * Hooks: woocommerce_gallery_thumbnail_size accept name based image sizes, or an array of width/height values.
- * woocommerce_gallery_nav_image_html_attachment_image_params accept an array of attributes for nav items.
- *
- * @since 6.1.0
- * @param int  $attachment_id Attachment ID.
- * @return string
- */
-function wc_get_gallery_nav_image_html( $attachment_id, $count = false ) {
-	$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_flexslider_nav_enabled', get_theme_support( 'wc-product-gallery-slider-nav' ) );
-	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
-	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
-	if ($flexslider_nav && $attachment_id){
-		$thumbnail = wp_get_attachment_image(
-			$attachment_id,
-			$thumbnail_size,
-			false,
-			apply_filters(
-				'woocommerce_gallery_nav_image_html_attachment_image_params',
-				array(
-					'title' => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
-					'class' => $count === 0 ? 'flex-active' : null,
-				),
-				$attachment_id,
-				$thumbnail_size
-			)
-		);
-
-		return '<li>' . $thumbnail . '</li>';
-	}
-
-	return false;
 }
 
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1559,6 +1559,7 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  */
 function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
+	/** This filter is documented in includes/class-wc-frontend-scripts.php */
 	$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', get_theme_support( 'wc-product-gallery-slider-nav' ) );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
@@ -1585,6 +1586,7 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 		// Nav use int values in order to have different parameters.
 		$image_params = array(
 			'alt'     => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+			/** This filter is documented in includes/wc-template-functions.php */
 			'loading' => ( $main_image <= apply_filters( 'woocommerce_product_thumbnails_columns', 4 ) ) ? null : 'lazy',
 			'class'   => 0 === $main_image ? 'flex-active' : '', // If is the first image set the flex-active class on init.
 		);

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1568,8 +1568,8 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $flexslider_nav || is_bool($main_image)  ? 'woocommerce_single' : $thumbnail_size );
 
 
-	// Gallery uses true false to indicate whether it is the main image
-	if (is_bool($main_image)) {
+	// Gallery uses true false to indicate whether it is the main image.
+	if ( is_bool( $main_image ) ) {
 		$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 		$image_params = array(
 			'title'                   => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
@@ -1582,11 +1582,11 @@ function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 			'loading'                 => esc_attr( $main_image ? 'eager' : 'lazy' ),
 		);
 	} else {
-		// Nav use int values in order to have different parameters
+		// Nav use int values in order to have different parameters.
 		$image_params = array(
-			'alt' => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
-			'loading' => ($main_image <= apply_filters( 'woocommerce_product_thumbnails_columns', 4 )) ? null : 'lazy',
-			'class' => $main_image === 0 ? 'flex-active'  : '', // if is the first image set the flex-active class on init
+			'alt'     => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+			'loading' => ( $main_image <= apply_filters( 'woocommerce_product_thumbnails_columns', 4 ) ) ? null : 'lazy',
+			'class'   => 0 === $main_image ? 'flex-active' : '', // If is the first image set the flex-active class on init.
 		);
 	}
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1559,35 +1559,88 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
  */
 function wc_get_gallery_image_html( $attachment_id, $main_image = false ) {
 	$flexslider        = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
-	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
-	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
-	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $main_image ? 'woocommerce_single' : $thumbnail_size );
+	$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', false );
 	$full_size         = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );
-	$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
 	$full_src          = wp_get_attachment_image_src( $attachment_id, $full_size );
 	$alt_text          = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-	$image             = wp_get_attachment_image(
+	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
+	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+	$image_size        = apply_filters( 'woocommerce_gallery_image_size', $flexslider || $flexslider_nav || is_bool($main_image)  ? 'woocommerce_single' : $thumbnail_size );
+
+	if (is_bool($main_image)) {
+		$thumbnail_src     = wp_get_attachment_image_src( $attachment_id, $thumbnail_size );
+		$image_params = array(
+			'title'                   => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+			'data-caption'            => _wp_specialchars( get_post_field( 'post_excerpt', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+			'data-src'                => esc_url( $full_src[0] ),
+			'data-large_image'        => esc_url( $full_src[0] ),
+			'data-large_image_width'  => esc_attr( $full_src[1] ),
+			'data-large_image_height' => esc_attr( $full_src[2] ),
+			'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
+			'loading'                 => esc_attr( $main_image ? 'eager' : 'lazy' ),
+		);
+	} else {
+		$image_size = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+		$image_params = array(
+			'alt' => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+			'loading' => ($main_image <= apply_filters( 'woocommerce_product_thumbnails_columns', 4 )) ? null : 'lazy',
+			'class' => $main_image === 0 ? 'flex-active'  : '', // if is the first image set the flex-active class on init
+		);
+	}
+
+	$image = wp_get_attachment_image(
 		$attachment_id,
 		$image_size,
 		false,
 		apply_filters(
 			'woocommerce_gallery_image_html_attachment_image_params',
-			array(
-				'title'                   => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
-				'data-caption'            => _wp_specialchars( get_post_field( 'post_excerpt', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
-				'data-src'                => esc_url( $full_src[0] ),
-				'data-large_image'        => esc_url( $full_src[0] ),
-				'data-large_image_width'  => esc_attr( $full_src[1] ),
-				'data-large_image_height' => esc_attr( $full_src[2] ),
-				'class'                   => esc_attr( $main_image ? 'wp-post-image' : '' ),
-			),
+			$image_params,
 			$attachment_id,
 			$image_size,
 			$main_image
 		)
 	);
 
-	return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	if (is_bool($main_image))
+		return '<div data-thumb="' . esc_url( $thumbnail_src[0] ) . '" data-thumb-alt="' . esc_attr( $alt_text ) . '" class="woocommerce-product-gallery__image"><a href="' . esc_url( $full_src[0] ) . '">' . $image . '</a></div>';
+	else
+		return '<li>' . $image . '</li>';
+}
+
+/**
+ * Get HTML for slider navigation.
+ *
+ * Hooks: woocommerce_gallery_thumbnail_size accept name based image sizes, or an array of width/height values.
+ * woocommerce_gallery_nav_image_html_attachment_image_params accept an array of attributes for nav items.
+ *
+ * @since 6.1.0
+ * @param int  $attachment_id Attachment ID.
+ * @return string
+ */
+function wc_get_gallery_nav_image_html( $attachment_id, $count = false ) {
+	$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_flexslider_nav_enabled', get_theme_support( 'wc-product-gallery-slider-nav' ) );
+	$gallery_thumbnail = wc_get_image_size( 'gallery_thumbnail' );
+	$thumbnail_size    = apply_filters( 'woocommerce_gallery_thumbnail_size', array( $gallery_thumbnail['width'], $gallery_thumbnail['height'] ) );
+	if ($flexslider_nav && $attachment_id){
+		$thumbnail = wp_get_attachment_image(
+			$attachment_id,
+			$thumbnail_size,
+			false,
+			apply_filters(
+				'woocommerce_gallery_nav_image_html_attachment_image_params',
+				array(
+					'title' => _wp_specialchars( get_post_field( 'post_title', $attachment_id ), ENT_QUOTES, 'UTF-8', true ),
+					'class' => $count === 0 ? 'flex-active' : null,
+				),
+				$attachment_id,
+				$thumbnail_size
+			)
+		);
+
+		return '<li>' . $thumbnail . '</li>';
+	}
+
+	return false;
 }
 
 if ( ! function_exists( 'woocommerce_output_product_data_tabs' ) ) {

--- a/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
@@ -170,7 +170,7 @@ a.button {
 	font-size: 1.2rem;
 	font-weight: 700;
 	letter-spacing: -0.02em;
-	z-index: 1;
+	z-index: 3;
 	border-radius: 50%;
 	text-align: center;
 	padding: 0.8rem;
@@ -307,10 +307,6 @@ a.button {
 		text-decoration: none;
 		color: #000;
 	}
-}
-
-.flex-viewport {
-	margin-bottom: 1.5em;
 }
 
 #main {
@@ -541,6 +537,21 @@ dl.variation,
 			padding-top: 0.5em;
 			margin-top: 3rem;
 		}
+
+		div.images {
+			.woocommerce-product-gallery__image:nth-child(n+2) {
+				width: 25%;
+				display: inline-block;
+			}
+
+			&.woocommerce-product-gallery--columns-3 .woocommerce-product-gallery__image:nth-child(n+2) {
+				width: 33.33%;
+			}
+
+			&.woocommerce-product-gallery--columns-5 .woocommerce-product-gallery__image:nth-child(n+2) {
+				width: 20%;
+			}
+		}
 	}
 
 	.single_add_to_cart_button {
@@ -685,6 +696,21 @@ a.reset_variations {
 		padding: 0;
 	}
 
+	&.woocommerce-product-gallery--custom-nav  {
+
+		.woocommerce-product-gallery__wrapper {
+			white-space: nowrap;
+			overflow: hidden;
+			line-height: 0;
+		}
+
+		.woocommerce-product-gallery__image {
+			display: inline-block;
+			width: 100%;
+			float: inherit;
+		}
+	}
+
 	.zoomImg {
 		background-color: #fff;
 		opacity: 0;
@@ -694,12 +720,9 @@ a.reset_variations {
 		border: 1px solid #f2f2f2;
 	}
 
-	.woocommerce-product-gallery__image:nth-child(n+2) {
-		width: 25%;
-		display: inline-block;
-	}
 
 	.flex-control-thumbs {
+		padding: 1.5em 0 0;
 
 		li {
 			list-style: none;

--- a/plugins/woocommerce/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce.scss
@@ -202,6 +202,14 @@ p.demo_store,
 				display: inline-block;
 			}
 
+			&.woocommerce-product-gallery--columns-3 .woocommerce-product-gallery__image:nth-child(n+2) {
+				width: 33.33%;
+			}
+
+			&.woocommerce-product-gallery--columns-5 .woocommerce-product-gallery__image:nth-child(n+2) {
+				width: 20%;
+			}
+
 			.woocommerce-product-gallery__trigger {
 				position: absolute;
 				top: 0.5em;
@@ -271,6 +279,10 @@ p.demo_store,
 
 		.woocommerce-product-gallery--columns-3 {
 
+			&.images .flex-control-thumbs li{
+				width:33.33%;
+			}
+
 			.flex-control-thumbs li:nth-child(3n+1) {
 				clear: left;
 			}
@@ -284,6 +296,10 @@ p.demo_store,
 		}
 
 		.woocommerce-product-gallery--columns-5 {
+
+			&.images .flex-control-thumbs li{
+				width:20%;
+			}
 
 			.flex-control-thumbs li:nth-child(5n+1) {
 				clear: left;

--- a/plugins/woocommerce/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/legacy/css/woocommerce.scss
@@ -210,6 +210,20 @@ p.demo_store,
 				width: 20%;
 			}
 
+			&.woocommerce-product-gallery.woocommerce-product-gallery--custom-nav  {
+
+				.woocommerce-product-gallery__wrapper {
+					white-space: nowrap;
+					overflow: hidden;
+					line-height: 0;
+				}
+
+				.woocommerce-product-gallery__image {
+					width: 100%;
+					display: inline-block;
+				}
+			}
+
 			.woocommerce-product-gallery__trigger {
 				position: absolute;
 				top: 0.5em;

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -951,8 +951,8 @@
 	    var $img = $(this).find('img').first();
 		$img
 		.data({
-			srcset: $img.srcset,
-			src: $img.src
+			src: $img.attr('src'),
+			srcset: $img.attr('srcset')
 		})
 		.removeAttr('src srcset')
 		.addClass('flexslider-deferred');

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -962,6 +962,7 @@
         sliderOffset = (reverse) ? slider.count - 1 - slider.currentSlide + slider.cloneOffset : slider.currentSlide + slider.cloneOffset;
         // VERTICAL:
         if (vertical && !carousel) {
+          slider.doMath();
           slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
           setTimeout(function(){
             slider.newSlides.css({"display": "block"});
@@ -969,20 +970,20 @@
             slider.setProps(sliderOffset * slider.h, "init");
           }, (type === "init") ? 100 : 0);
         } else {
-          slider.container.width((slider.count + slider.cloneCount) * 200 + "%");
-          slider.setProps(sliderOffset * slider.computedW, "init");
-          setTimeout(function(){
-          if(slider.vars.rtl){
-              slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
-           }
-            else{
-              slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
-            }
-            // SMOOTH HEIGHT:
-            if (slider.vars.smoothHeight) { methods.smoothHeight(); }
-          }, (type === "init") ? 100 : 0);
+			slider.doMath();
+			slider.container.css({"height": slider.h + slider.computedW / slider.count, "overflow":"hidden"});
+			if(slider.vars.rtl){
+				slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
+			} else {
+				slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
+			}
+			slider.container.css({"height": "","width": (slider.count + slider.cloneCount) * 200 + "%"});
+			slider.setProps(sliderOffset * slider.computedW, "init");
+			setTimeout(function(){
+				// SMOOTH HEIGHT:
+				if (slider.vars.smoothHeight) { methods.smoothHeight(); }
+			}, (type === "init") ? 100 : 0);
         }
-		slider.doMath();
       } else { // FADE:
         if(slider.vars.rtl){
           slider.slides.css({"width": "100%", "float": 'right', "marginLeft": "-100%", "position": "relative"});

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -965,7 +965,6 @@
           slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
           setTimeout(function(){
             slider.newSlides.css({"display": "block"});
-            slider.doMath();
             slider.viewport.height(slider.h);
             slider.setProps(sliderOffset * slider.h, "init");
           }, (type === "init") ? 100 : 0);
@@ -973,7 +972,6 @@
           slider.container.width((slider.count + slider.cloneCount) * 200 + "%");
           slider.setProps(sliderOffset * slider.computedW, "init");
           setTimeout(function(){
-            slider.doMath();
           if(slider.vars.rtl){
               slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
            }
@@ -984,6 +982,7 @@
             if (slider.vars.smoothHeight) { methods.smoothHeight(); }
           }, (type === "init") ? 100 : 0);
         }
+		slider.doMath();
       } else { // FADE:
         if(slider.vars.rtl){
           slider.slides.css({"width": "100%", "float": 'right', "marginLeft": "-100%", "position": "relative"});

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -987,15 +987,11 @@
 		  slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
 		  slider.setProps(sliderOffset * slider.h, "init");
         } else {
-		  if (type === "init") slider.container.css({"height": slider.h, "overflow":"hidden"});
-          if(slider.vars.rtl){
-            slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
-          } else {
-            slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
-          }
+		  if (type === "init") slider.viewport.css({"height": slider.h, "overflow-X":"hidden"});
+		  slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": slider.vars.rtl ? "right" : "left", "display": "block"});
+		  slider.container.css({"height": "","width": (slider.count + slider.cloneCount) * 200 + "%"});
+		  slider.setProps(sliderOffset * slider.computedW, "init");
 		  setTimeout(function(){
-			slider.container.css({"height": "","width": (slider.count + slider.cloneCount) * 200 + "%"});
-			slider.setProps(sliderOffset * slider.computedW, "init");
 			// SMOOTH HEIGHT:
 			if (slider.vars.smoothHeight) { methods.smoothHeight(); }
 		  }, (type === "init") ? 100 : 0);
@@ -1003,20 +999,19 @@
       } else { // FADE:
         if(slider.vars.rtl){
           slider.slides.css({"width": "100%", "float": 'right', "marginLeft": "-100%", "position": "relative"});
-        }
-        else{
+        } else{
           slider.slides.css({"width": "100%", "float": 'left', "marginRight": "-100%", "position": "relative"});
         }
         if (type === "init") {
           if (!touch) {
             //slider.slides.eq(slider.currentSlide).fadeIn(slider.vars.animationSpeed, slider.vars.easing);
-            if (slider.vars.fadeFirstSlide == false) {
-              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).css({"zIndex": 2}).css({"opacity": 1});
+            if (!slider.vars.fadeFirstSlide) {
+              slider.slides.css({ "opacity": 1, "display": "block", "zIndex": 1 });
             } else {
-              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).css({"zIndex": 2}).animate({"opacity": 1},slider.vars.animationSpeed,slider.vars.easing);
+              slider.slides.css({ "opacity": 0, "display": "block", "zIndex": 1 }).eq(slider.currentSlide).animate({"opacity": 1},slider.vars.animationSpeed,slider.vars.easing);
             }
           } else {
-            slider.slides.css({ "opacity": 0, "display": "block", "webkitTransition": "opacity " + slider.vars.animationSpeed / 1000 + "s ease", "zIndex": 1 }).eq(slider.currentSlide).css({ "opacity": 1, "zIndex": 2});
+            slider.slides.css({ "opacity": 0, "display": "block", "webkitTransition": "opacity " + slider.vars.fadeFirstSlide ? 1 : slider.vars.animationSpeed / 1000 + "s ease", "zIndex": 1 }).eq(slider.currentSlide).css({ "opacity": 1 });
           }
         }
         // SMOOTH HEIGHT:

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -965,12 +965,10 @@
         // VERTICAL:
         if (vertical && !carousel) {
           slider.doMath();
-          slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
-          setTimeout(function(){
-            slider.newSlides.css({"display": "block"});
-            slider.viewport.height(slider.h);
-            slider.setProps(sliderOffset * slider.h, "init");
-          }, (type === "init") ? 100 : 0);
+		  slider.viewport.height(slider.h);
+          slider.newSlides.css({"display": "block", "width": slider.computedW, "height": slider.computedW});
+		  slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
+		  slider.setProps(sliderOffset * slider.h, "init");
         } else {
 			slider.doMath();
 			slider.container.css({"height": slider.h + slider.computedW / slider.count, "overflow":"hidden"});

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -947,6 +947,16 @@
     };
 
     slider.setup = function(type) {
+	  slider.slides.slice(1).each( function () {
+	    var $img = $(this).find('img').first();
+		$img
+		.data({
+			srcset: $img.srcset,
+			src: $img.src
+		})
+		.removeAttr('src srcset')
+		.addClass('flexslider-deferred');
+      })
       // SLIDE:
       if (!fade) {
         var sliderOffset, arr;
@@ -1153,6 +1163,16 @@
     focused = false;
   }).on( 'focus', function ( e ) {
     focused = true;
+  }).on( 'load', function () {
+	  $('.woocommerce-product-gallery__wrapper .flexslider-deferred').each(function () {
+		  $(this)
+			  .prop({
+				  src: $(this).attr('data-src'),
+				  srcset: $(this).attr('data-srcset')
+			  })
+			  .removeAttr('data-src data-srcset loading')
+			  .removeClass('flex-deferred');
+	  })
   });
 
   //FlexSlider: Default Settings

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -624,12 +624,16 @@
             slider.setProps();
           }
           else if (vertical) { //VERTICAL:
-            slider.viewport.height(slider.h);
-            slider.setProps(slider.h, "setTotal");
+			slider.viewport.height(slider.computedW);
+			slider.newSlides.css({"width": slider.computedW, "height": slider.computedW});
+		    if (slider.vars.smoothHeight) {
+		    	methods.smoothHeight();
+		    }
+            slider.setProps(slider.computedW, "setTotal");
           } else {
             // SMOOTH HEIGHT:
-            if (slider.vars.smoothHeight) { methods.smoothHeight(); }
             slider.newSlides.width(slider.computedW);
+            if (slider.vars.smoothHeight) { methods.smoothHeight(); }
             slider.setProps(slider.computedW, "setTotal");
           }
         }
@@ -972,18 +976,18 @@
 		  slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
 		  slider.setProps(sliderOffset * slider.h, "init");
         } else {
-			slider.container.css({"height": slider.h, "overflow":"hidden"});
-			if(slider.vars.rtl){
-				slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
-			} else {
-				slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
-			}
+		  if (type === "init") slider.container.css({"height": slider.h, "overflow":"hidden"});
+          if(slider.vars.rtl){
+            slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
+          } else {
+            slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "left", "display": "block"});
+          }
+		  setTimeout(function(){
 			slider.container.css({"height": "","width": (slider.count + slider.cloneCount) * 200 + "%"});
 			slider.setProps(sliderOffset * slider.computedW, "init");
-			setTimeout(function(){
-				// SMOOTH HEIGHT:
-				if (slider.vars.smoothHeight) { methods.smoothHeight(); }
-			}, (type === "init") ? 100 : 0);
+			// SMOOTH HEIGHT:
+			if (slider.vars.smoothHeight) { methods.smoothHeight(); }
+		  }, (type === "init") ? 100 : 0);
         }
       } else { // FADE:
         if(slider.vars.rtl){

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -246,6 +246,8 @@
                 item = $('<img/>', {
                   onload: 'this.width = this.naturalWidth; this.height = this.naturalHeight',
                   src: slide.attr('data-thumb'),
+                  srcset: `${slide.attr('data-thumb')} ${Math.round(slider.itemW / slider.count)}w, ${slide.find('img').attr('src')} ${Math.round(slider.w)}w`,
+                  sizes: `(max-width: ${Math.round(slider.w)}px) ${Math.round(slider.itemW / slider.count)}px, ${Math.round(slider.w)}px`,
                   alt: slide.attr('alt')
                 })
               }

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -247,7 +247,7 @@
                   onload: 'this.width = this.naturalWidth; this.height = this.naturalHeight',
                   src: slide.attr('data-thumb'),
                   srcset: `${slide.attr('data-thumb')} ${Math.round(slider.itemW / slider.count)}w, ${slide.find('img').attr('src')} ${Math.round(slider.w)}w`,
-                  sizes: `(max-width: ${Math.round(slider.w)}px) ${Math.round(slider.itemW / slider.count)}px, ${Math.round(slider.w)}px`,
+                  sizes: `(max-width: ${Math.round(slider.w)}px) 100vw, ${Math.round(slider.w)}px`,
                   alt: slide.attr('alt')
                 })
               }

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -1171,7 +1171,7 @@
 				  srcset: $(this).attr('data-srcset')
 			  })
 			  .removeAttr('data-src data-srcset loading')
-			  .removeClass('flex-deferred');
+			  .removeClass('flexslider-deferred');
 	  })
   });
 

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -971,7 +971,7 @@
 		  slider.setProps(sliderOffset * slider.h, "init");
         } else {
 			slider.doMath();
-			slider.container.css({"height": slider.h + slider.computedW / slider.count, "overflow":"hidden"});
+			slider.container.css({"height": slider.h, "overflow":"hidden"});
 			if(slider.vars.rtl){
 				slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
 			} else {

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -50,6 +50,7 @@
         slider.slides = $(slider.vars.selector, slider);
         slider.container = $(slider.containerSelector, slider);
         slider.count = slider.slides.length;
+		slider.itemsPerRow = parseInt(el.dataset.columns);
         // SYNC:
         slider.syncExists = $(slider.vars.sync).length > 0;
         // SLIDE:
@@ -244,9 +245,10 @@
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if (slider.vars.controlNav === "thumbnails") {
                 item = $('<img/>', {
-                  onload: 'this.width = this.naturalWidth; this.height = this.naturalHeight',
+				  Width: slider.navItemSize,
+				  Height: slider.navItemSize,
                   src: slide.attr('data-thumb'),
-                  srcset: `${slide.attr('data-thumb')} ${Math.round(slider.itemW / slider.count)}w, ${slide.find('img').attr('src')} ${Math.round(slider.w)}w`,
+				  srcset: `${slide.attr('data-thumb')} ${Math.round( slider.w / slider.navItemSize )}w, ${slide.find('img').attr('src')} ${Math.round(slider.w)}w`,
                   sizes: `(max-width: ${Math.round(slider.w)}px) 100vw, ${Math.round(slider.w)}px`,
                   alt: slide.attr('alt')
                 })
@@ -962,15 +964,14 @@
         slider.newSlides = $(slider.vars.selector, slider);
 
         sliderOffset = (reverse) ? slider.count - 1 - slider.currentSlide + slider.cloneOffset : slider.currentSlide + slider.cloneOffset;
+        slider.doMath();
         // VERTICAL:
         if (vertical && !carousel) {
-          slider.doMath();
 		  slider.viewport.height(slider.h);
           slider.newSlides.css({"display": "block", "width": slider.computedW, "height": slider.computedW});
 		  slider.container.height((slider.count + slider.cloneCount) * 200 + "%").css("position", "absolute").width("100%");
 		  slider.setProps(sliderOffset * slider.h, "init");
         } else {
-			slider.doMath();
 			slider.container.css({"height": slider.h, "overflow":"hidden"});
 			if(slider.vars.rtl){
 				slider.newSlides.css({"width": slider.computedW, "marginRight" : slider.computedM, "float": "right", "display": "block"});
@@ -1024,7 +1025,8 @@
       if (slider.isFirefox) { slider.w = slider.width(); }
       slider.h = slide.height();
       slider.boxPadding = slide.outerWidth() - slide.width();
-
+	  slider.firstRowCount = slider.itemsPerRow > slider.count ? slider.itemsPerRow : Math.min(slider.itemsPerRow, slider.count);
+	  slider.navItemSize = Math.round(slider.w / slider.firstRowCount);
       // CAROUSEL:
       if (carousel) {
         slider.itemT = slider.vars.itemWidth + slideMargin;

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -634,7 +634,7 @@
       },
       smoothHeight: function(dur) {
         if (!vertical || fade) {
-          var $obj = (fade) ? slider : slider.viewport;
+          var $obj = (fade) ? slider.container : slider.viewport;
           (dur) ? $obj.animate({"height": slider.slides.eq(slider.animatingTo).innerHeight()}, dur) : $obj.innerHeight(slider.slides.eq(slider.animatingTo).innerHeight());
         }
       },

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -948,14 +948,16 @@
 
     slider.setup = function(type) {
 	  slider.slides.slice(1).each( function () {
-	    var $img = $(this).find('img').first();
-		$img
-		.data({
-			src: $img.attr('src'),
-			srcset: $img.attr('srcset')
-		})
-		.removeAttr('src srcset')
-		.addClass('flexslider-deferred');
+        if ( document.readyState !== 'complete' ) {
+          var $img = $(this).find('img').first()
+          $img
+            .data({
+              src: $img.attr('src'),
+              srcset: $img.attr('srcset')
+            })
+            .removeAttr('src srcset')
+            .addClass('flexslider-deferred');
+        }
       })
       // SLIDE:
       if (!fade) {
@@ -1163,16 +1165,16 @@
     focused = false;
   }).on( 'focus', function ( e ) {
     focused = true;
-  }).on( 'load', function () {
-	  $('.woocommerce-product-gallery__wrapper .flexslider-deferred').each(function () {
-		  $(this)
-			  .prop({
-				  src: $(this).attr('data-src'),
-				  srcset: $(this).attr('data-srcset')
-			  })
-			  .removeAttr('data-src data-srcset loading')
-			  .removeClass('flexslider-deferred');
-	  })
+  }).on('load', function () {
+    $('.woocommerce-product-gallery__wrapper .flexslider-deferred').each(function () {
+      $(this)
+        .prop({
+          src: $(this).attr('data-src'),
+          srcset: $(this).attr('data-srcset')
+        })
+        .removeAttr('data-src data-srcset loading')
+        .removeClass('flexslider-deferred');
+    })
   });
 
   //FlexSlider: Default Settings

--- a/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
+++ b/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js
@@ -243,7 +243,7 @@
               }
 
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
-              if (slider.vars.controlNav === "thumbnails") {
+              if (slider.vars.controlNav === "thumbnails" && slider.vars.manualControls === '') {
                 item = $('<img/>', {
 				  Width: slider.navItemSize,
 				  Height: slider.navItemSize,
@@ -252,7 +252,14 @@
                   sizes: `(max-width: ${Math.round(slider.w)}px) 100vw, ${Math.round(slider.w)}px`,
                   alt: slide.attr('alt')
                 })
-              }
+              } else {
+                item = $('<img/>', {
+                  Width: slider.navItemSize,
+                  Height: slider.navItemSize,
+                  src: slide.attr('data-thumb'),
+                  alt: slide.attr('alt')
+                })
+			  }
 
               if ( '' !== slide.attr( 'data-thumb-alt' ) ) {
                 item.attr( 'alt', slide.attr( 'data-thumb-alt' ) );
@@ -945,7 +952,11 @@
         var sliderOffset, arr;
 
         if (type === "init") {
-          slider.viewport = $('<div class="' + namespace + 'viewport"></div>').css({"overflow": "hidden", "position": "relative"}).appendTo(slider).append(slider.container);
+		  if (slider.vars.manualControls === '') {
+			  slider.viewport = $('<div class="' + namespace + 'viewport"></div>').css({"overflow": "hidden", "position": "relative"}).appendTo(slider).append(slider.container);
+		  } else {
+			  slider.viewport = $('<div class="' + namespace + 'viewport"></div>').css({"overflow": "hidden", "position": "relative"}).prependTo(slider).prepend(slider.container);
+		  }
           // INFINITE LOOP:
           slider.cloneCount = 0;
           slider.cloneOffset = 0;

--- a/plugins/woocommerce/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/legacy/js/frontend/single-product.js
@@ -98,8 +98,10 @@ jQuery( function( $ ) {
 
 		// Make this object available.
 		$target.data( 'product_gallery', this );
-		
-		if( this.$target.css( 'opacity' ) ) this.$target.css( 'opacity', 1 );
+
+		if ( this.$target.css( 'opacity' ) ) {
+			this.$target.css( 'opacity', 1 )
+		}
 
 		// Pick functionality to initialize...
 		this.flexslider_enabled = 'function' === typeof $.fn.flexslider && wc_single_product_params.flexslider_enabled;

--- a/plugins/woocommerce/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/legacy/js/frontend/single-product.js
@@ -93,7 +93,6 @@ jQuery( function( $ ) {
 
 		// No images? Abort.
 		if ( 0 === this.$images.length ) {
-			this.$target.css( 'opacity', 1 );
 			return;
 		}
 
@@ -129,8 +128,6 @@ jQuery( function( $ ) {
 		if ( this.flexslider_enabled ) {
 			this.initFlexslider( args.flexslider );
 			$target.on( 'woocommerce_gallery_reset_slide_position', this.onResetSlidePosition );
-		} else {
-			this.$target.css( 'opacity', 1 );
 		}
 
 		if ( this.zoom_enabled ) {
@@ -152,9 +149,6 @@ jQuery( function( $ ) {
 
 		var options = $.extend( {
 			selector: '.woocommerce-product-gallery__wrapper > .woocommerce-product-gallery__image',
-			start: function() {
-				$target.css( 'opacity', 1 );
-			},
 			after: function( slider ) {
 				gallery.initZoomForTarget( gallery.$images.eq( slider.currentSlide ) );
 			}

--- a/plugins/woocommerce/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/legacy/js/frontend/single-product.js
@@ -98,6 +98,8 @@ jQuery( function( $ ) {
 
 		// Make this object available.
 		$target.data( 'product_gallery', this );
+		
+		if( this.$target.css( 'opacity' ) ) this.$target.css( 'opacity', 1 );
 
 		// Pick functionality to initialize...
 		this.flexslider_enabled = 'function' === typeof $.fn.flexslider && wc_single_product_params.flexslider_enabled;

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -36,7 +36,7 @@ $wrapper_classes   = apply_filters(
 	)
 );
 ?>
-<div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
+<div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>">
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
 		if ( $post_thumbnail_id ) {

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -54,11 +54,13 @@ $wrapper_classes   = apply_filters(
 		do_action( 'woocommerce_product_thumbnails' );
 		?>
 	</figure>
-	<?php if ( $flexslider_nav && $post_thumbnail_id && $nav_thumbnails_ids = $product->get_gallery_image_ids() ) {
+	<?php
+	if ( $flexslider_nav && $post_thumbnail_id && $nav_thumbnails_ids = $product->get_gallery_image_ids() ) {
 		echo '<ol class="flex-control-nav flex-control-thumbs">';
 		foreach ( array_merge( array( $post_thumbnail_id ), $nav_thumbnails_ids ) as $count => $attachment_id ) {
 			echo apply_filters( 'woocommerce_single_product_image_nav_html', wc_get_gallery_image_html( $attachment_id, $count ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 		}
 		echo '</ol>';
-	} ?>
+	}
+	?>
 </div>

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -24,7 +24,15 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 
 global $product;
 
+/**
+ * Controls the number of thumbnail per row displayed by flexslider.
+ *
+ * @since 2.7.0
+ *
+ * @param int $count The number of thumbnails displayed.
+ */
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
+/** This filter is documented in includes/class-wc-frontend-scripts.php */
 $flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', get_theme_support( 'wc-product-gallery-slider-nav' ) );
 $post_thumbnail_id = $product->get_image_id();
 $wrapper_classes   = apply_filters(

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -25,6 +25,7 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
+$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', false );
 $post_thumbnail_id = $product->get_image_id();
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',
@@ -32,6 +33,7 @@ $wrapper_classes   = apply_filters(
 		'woocommerce-product-gallery',
 		'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
 		'woocommerce-product-gallery--columns-' . absint( $columns ),
+		$flexslider_nav ? 'woocommerce-product-gallery--custom-nav' : 'woocommerce-product-gallery--nav',
 		'images',
 	)
 );
@@ -52,4 +54,11 @@ $wrapper_classes   = apply_filters(
 		do_action( 'woocommerce_product_thumbnails' );
 		?>
 	</figure>
+	<?php if ( $flexslider_nav && $post_thumbnail_id && $nav_thumbnails_ids = $product->get_gallery_image_ids() ) {
+		echo '<ol class="flex-control-nav flex-control-thumbs">';
+		foreach ( array_merge( array( $post_thumbnail_id ), $nav_thumbnails_ids ) as $count => $attachment_id ) {
+			echo apply_filters( 'woocommerce_single_product_image_nav_html', wc_get_gallery_image_html( $attachment_id, $count ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
+		}
+		echo '</ol>';
+	} ?>
 </div>

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
-$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', false );
+$flexslider_nav    = (bool) apply_filters( 'woocommerce_single_product_nav_flexslider', get_theme_support( 'wc-product-gallery-slider-nav' ) );
 $post_thumbnail_id = $product->get_image_id();
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR aims to fix the performance issues of flexslider and re-enable some plugin options that had been removed such as fade or slide vertical.

**NEW**: `add_theme_support( 'wc-product-gallery-slider-nav' );`
this part is perhaps the best of the entire PR and ensures that the flexslider nav is generated by wordpress instead of flexslider. This reset the cls to zero because before we were waiting for jquery to load, then flexslider, then the nav was finally created. now it's different and the nav is created together with the page, allowing (when the theme is well configured) a cls of 0

**FIXED**: `add_filter( 'woocommerce_product_thumbnails_columns', function () { return 3; } );`
you can set any number of thumbnail for the flexslider nav, but this has to be fixed for all other templates twentytwentytwo, twentytwenty. I suggest to use the scss more effectively in this, because themes customized needs to be updated manually for each change. 

**FIXED**:  `add_filter( 'woocommerce_single_product_carousel_options', 'filter_single_product_carousel_options' );`
```
function filter_single_product_carousel_options( $options ) {
	//$options['direction'] = 'vertical';
	// $options['animation'] = 'fade';
	return $options;
}
```

Closes https://github.com/woocommerce/woocommerce/issues/30893
Closes https://github.com/woocommerce/woocommerce/issues/12253
Fix https://github.com/woocommerce/woocommerce/issues/14380#issuecomment-294142894
Follow-up https://github.com/woocommerce/woocommerce/issues/31418

This changes is by me and @Mte90 after a long series of tests and discussions on how to improve the flexslider. The suggestion to edit `.\templates\single-product\product-image.php` (and conseguently "wc_get_gallery_image_html") was suggested to me by @jeffstieler (because initially I was using custom templates for the nav)

### How to test the changes in this Pull Request:

1. You NEED to use a custom template (that uses woo.scss) OR twentytwentyone. this is mandatory because all the woo styles need to be fixed (few lines to add, but these bring the CLS to 0)
2. add `add_theme_support( 'wc-product-gallery-slider-nav' );` to your theme functions.php (optionally you can test the options mentioned before like fade or vertical scrolling)
3. Load the product page with the different options (with the gallery-slider-nav, without, with 3 - 4 - 5 thumbnails per row, vertical slider, fade slide and a combinations of theese)
4. You have to get results like below with "wc-product-gallery-slider-nav", CLS 0 is what we want :)

![flexslider](https://user-images.githubusercontent.com/8550908/168427340-e19a77b8-1e65-4aa7-8ab3-6e59bf65070c.gif)

---

**Main Changes recap:**
Enabling theme_support for `wc-product-gallery-slider-nav` will create a [real set of thumbnails](https://github.com/woocommerce/woocommerce/blob/b2392036eeee949ee7e7c2130578d38f237c8baf/plugins/woocommerce/templates/single-product/product-image.php#L28) below the gallery, using the same html and css classes as the one that creates flexslider, to use its style as far as possible. This will fix an issue with flexslider because currently it sets the width of the first image to 100% and the rest to 25% with css and then after jquery is loaded and flexslider has done its chores in the init, the gallery content is cloned and the nav is created (and a new css is applied to the gallery images)... how it work is long also to explain 😅 and is hidden by a fade-in effect! Anyway this is the main cause of the large amount of cls of the single product page!
In order to speedup the layout generation i've changed a bit the behaivour of [wc_get_gallery_image_html](https://github.com/woocommerce/woocommerce/blob/b2392036eeee949ee7e7c2130578d38f237c8baf/plugins/woocommerce/includes/wc-template-functions.php#L1560) to permit a double use: with bool for the main gallery and with int for the generated nav thumb.
I used one of the native functions of flexslider, the [custom navigation](https://github.com/woocommerce/woocommerce/blob/b2392036eeee949ee7e7c2130578d38f237c8baf/plugins/woocommerce/includes/class-wc-frontend-scripts.php#L495) to enable the "real" navigation, so on this side there are no major changes.

About Flexslider there are some of changes but the most important are about the [gallery size](https://github.com/woocommerce/woocommerce/blob/b2392036eeee949ee7e7c2130578d38f237c8baf/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js#L1000) and [deferring gallery images after the first one](https://github.com/woocommerce/woocommerce/blob/b2392036eeee949ee7e7c2130578d38f237c8baf/plugins/woocommerce/legacy/js/flexslider/jquery.flexslider.js#L950)

To get the best performance results also the css style needs to be changed a bit. This is already done for twentytwentyone.scss and woocommerce.scss style but needs to be replicated to the other customized styles. Or perhaps it would be better to modularize the flexslider style to be imported with scss, without having to do theme-by-theme fixes (as the fonts for example that are a single fonts.scss and then imported into all styles).