### PR TITLE
Fix janky product task items on hover

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/cards.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/cards.scss
@@ -14,7 +14,7 @@
 	.woocommerce-list__item {
 		float: left;
 		border-radius: 3px;
-		border: 1px solid #dcdcde;
+		border: 1.5px solid #dcdcde;
 		width: 263px;
 		height: 226px;
 		text-align: center;

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/card-layout.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/card-layout.scss
@@ -31,7 +31,7 @@
 	}
 
 	.woocommerce-products-list__item-load-sample-product {
-		border: 1px dashed #dcdcde;
+		border: 1.5px dashed #dcdcde;
 
 		.woocommerce-list__item-before {
 			background-color: $gray-100;

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.scss
@@ -15,7 +15,7 @@
 	.woocommerce-list__item {
 		margin-top: 8px;
 		border-radius: 3px;
-		border: 1px solid #dcdcde;
+		border: 1.5px solid #dcdcde;
 
 		&:hover {
 			background-color: #fff;

--- a/plugins/woocommerce/changelog/fix-janky-hover-on-product-task
+++ b/plugins/woocommerce/changelog/fix-janky-hover-on-product-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix janky border on hover product task items


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes janky/jumpy look when hovering product task items:

**Before:**
<img src="https://cdn-std.droplr.net/files/acc_1119691/n8ocZ9" width="500">

**After:**
<img src="https://cdn-std.droplr.net/files/acc_1119691/brBa0N" width="500">

### How to test the changes in this Pull Request:


**Prerequisite**
1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-products-task`
2. Go to `Tools > WCA Test Helper > Experiments`
1. Enable treatment for either `woocommerce_products_task_layout_stacked` or `woocommerce_products_task_layout_card` **for frontend**
2. Go to WooCommerce > Product task
3. Hover over items and observe it isn't jumpy as per screenshot

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
