### PR TITLE
Updated assertion for k6 merchant wc home request

### DIFF
--- a/plugins/woocommerce/changelog/update-k6-merch-wc-home-assert
+++ b/plugins/woocommerce/changelog/update-k6-merch-wc-home-assert
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: updating performance test request
+
+

--- a/plugins/woocommerce/tests/performance/requests/merchant/home-wc-admin.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/home-wc-admin.js
@@ -46,7 +46,7 @@ export function homeWCAdmin() {
 		check(response, {
 			"is status 200": (r) => r.status === 200,
 			"body contains: current page is 'Home'": (response) =>
-				response.body.includes('aria-current="page">Home</a>'),
+				response.body.includes('>Home</h1>'),
 		});
 
 		// Correlate nonce values for use in subsequent requests.

--- a/plugins/woocommerce/tests/performance/requests/merchant/home-wc-admin.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/home-wc-admin.js
@@ -46,7 +46,7 @@ export function homeWCAdmin() {
 		check(response, {
 			"is status 200": (r) => r.status === 200,
 			"body contains: current page is 'Home'": (response) =>
-				response.body.includes('>Home</h1>'),
+				response.body.includes('aria-current="page">Home'),
 		});
 
 		// Correlate nonce values for use in subsequent requests.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Changes included in https://github.com/woocommerce/woocommerce/pull/32611 for https://github.com/woocommerce/woocommerce/issues/32160 resulted in the WooCommerce > Home menu element changing to include an additional `<span>` element with a badge.

The existing k6 merchant request for `wp-admin/admin.php?page=wc-admin` used this menu element to assert we had the correct request response. The aforementioned change therefore caused this assertion to fail. 

This PR updates the assertion to not include the closing link tag, this means the request will be able to assert with the badge change but also will still be able to assert ok on older versions without the badge change.

### How to test the changes in this Pull Request:

1. Checkout this branch and build WooCommerce
run
```
nvm use
pnpm install
pnpm nx composer-install woocommerce
pnpm nx build woocommerce
```

2. Build local test environment
change directory to `plugins/woocommerce/tests/e2e/docker`
run `cp init-sample-products.sh initialize.sh`  to use the Docker Initialization Script that will set up a shop with sample products imported and the shop settings (payment method, permalinks, address etc) needed for the tests already set.
run `pnpm exec wc-e2e docker:up`

3. Install k6 and run test
run `brew install k6`
[For other platforms please see the k6 installation guide.](https://k6.io/docs/getting-started/installation/)
change directory to `plugins/woocommerce/tests/performance`
Run merchant tests with 
`k6 run tests/simple-all-merchant-requests.js`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
