### PR TITLE
Wrap product task import around experiment

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/index.js
@@ -6,7 +6,7 @@ import { isProductTaskExperimentTreatment } from '@woocommerce/onboarding';
 /**
  * Internal dependencies
  */
-import { getAdminSetting } from '~/utils/admin-settings';
+import { isImportProductExperiment } from './product-task-experiment';
 
 import './PaymentGatewaySuggestions';
 import './shipping';
@@ -17,16 +17,10 @@ import './tax';
 import './woocommerce-payments';
 import './purchase';
 
-const onboardingData = getAdminSetting( 'onboarding' );
-
 const possiblyImportProductTaskExperiment = async () => {
 	const isExperiment = await isProductTaskExperimentTreatment();
 	if ( isExperiment ) {
-		if (
-			window.wcAdminFeatures[ 'experimental-import-products-task' ] &&
-			onboardingData?.profile?.selling_venues &&
-			onboardingData?.profile?.selling_venues !== 'no'
-		) {
+		if ( isImportProductExperiment() ) {
 			import( './experimental-import-products' );
 		} else {
 			import( './experimental-products' );

--- a/plugins/woocommerce-admin/client/tasks/fills/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/index.js
@@ -22,7 +22,15 @@ const onboardingData = getAdminSetting( 'onboarding' );
 const possiblyImportProductTaskExperiment = async () => {
 	const isExperiment = await isProductTaskExperimentTreatment();
 	if ( isExperiment ) {
-		import( './experimental-products' );
+		if (
+			window.wcAdminFeatures[ 'experimental-import-products-task' ] &&
+			onboardingData?.profile?.selling_venues &&
+			onboardingData?.profile?.selling_venues !== 'no'
+		) {
+			import( './experimental-import-products' );
+		} else {
+			import( './experimental-products' );
+		}
 	} else {
 		import( './products' );
 	}
@@ -30,14 +38,8 @@ const possiblyImportProductTaskExperiment = async () => {
 
 if (
 	window.wcAdminFeatures &&
-	window.wcAdminFeatures[ 'experimental-import-products-task' ] &&
-	onboardingData?.profile?.selling_venues &&
-	onboardingData?.profile?.selling_venues !== 'no'
-) {
-	import( './experimental-import-products' );
-} else if (
-	window.wcAdminFeatures &&
-	window.wcAdminFeatures[ 'experimental-products-task' ]
+	( window.wcAdminFeatures[ 'experimental-import-products-task' ] ||
+		window.wcAdminFeatures[ 'experimental-products-task' ] )
 ) {
 	possiblyImportProductTaskExperiment();
 } else {

--- a/plugins/woocommerce-admin/client/tasks/fills/product-task-experiment.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/product-task-experiment.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '~/utils/admin-settings';
+
+const onboardingData = getAdminSetting( 'onboarding' );
+
+export const isImportProductExperiment = () => {
+	return (
+		window?.wcAdminFeatures?.[ 'experimental-import-products-task' ] &&
+		onboardingData?.profile?.selling_venues &&
+		onboardingData?.profile?.selling_venues !== 'no'
+	);
+};

--- a/plugins/woocommerce/changelog/fix-wrap-import-products-under-experiment
+++ b/plugins/woocommerce/changelog/fix-wrap-import-products-under-experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update product import task to appear only under experiment


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Fixes import product task to only appear when either `woocommerce_products_task_layout_card` or `woocommerce_products_task_layout_stacked` experiment is treatment

### How to test the changes in this Pull Request:

1. Go to onboarding wizard's Business Features step
2. Set "Currently selling elsewhere" to "Yes, on other platform" and save
1. Install `WooCommerce Admin Test Helper`
3. Go to `Tools > WCA Test Helper > Features`
4. Enable `experimental-import-products-task`
2. Go to `Tools > WCA Test Helper > Experiments`
1. Enable treatment for either `woocommerce_products_task_layout_stacked` or `woocommerce_products_task_layout_card` **for frontend**
5. Go to the products task
6. Observe the import screen is displayed
1. Disable treatment for the experiment and refresh product task
2. Observe the old product task screen is displayed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
