### PR TITLE
Add: temporary workaround to add experiment metadata for task_view

### DIFF
--- a/packages/js/onboarding/changelog/add-33052_task_view_track_event_polling
+++ b/packages/js/onboarding/changelog/add-33052_task_view_track_event_polling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Removed experimental product hook and instead poll the slot's fill for variant metadata. To be removed when experiment concludes! #33052

--- a/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
+++ b/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
@@ -64,7 +64,7 @@ const pollForExperimentalVariant = ( id, count ) => {
 	} else if ( experimentalVariant ) {
 		trackView( id, experimentalVariant );
 	} else {
-		setTimeout( () => pollForExperimentalVariant( id ), 200 );
+		setTimeout( () => pollForExperimentalVariant( id, count + 1 ), 200 );
 	}
 };
 

--- a/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
+++ b/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
@@ -56,16 +56,22 @@ const WooOnboardingTask = ( { id, variant, ...props } ) => {
 	return <Fill name={ 'woocommerce_onboarding_task_' + id } { ...props } />;
 };
 
+// We need this here just in case the experiment assignment takes awhile to load, so that we don't fire trackView with a blank experimentalVariant
+// Remove all of the code in this file related to experiments and variants when the product task experiment concludes and never speak of the existence of this code to anyone
+const pollForExperimentalVariant = ( id ) => {
+	if ( experimentalVariant ) {
+		trackView( id, experimentalVariant );
+	} else {
+		setTimeout( () => pollForExperimentalVariant( id ), 200 );
+	}
+};
+
 WooOnboardingTask.Slot = ( { id, fillProps } ) => {
 	// The Slot is a React component and this hook works as expected.
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	useEffect( () => {
 		if ( id === 'products' ) {
-			setTimeout(
-				// call trackView with a small delay to ensure the experimentalVariant variable is loaded
-				() => trackView( id, experimentalVariant ),
-				200
-			);
+			pollForExperimentalVariant( id );
 		} else {
 			trackView( id );
 		}

--- a/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
+++ b/packages/js/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
@@ -58,8 +58,10 @@ const WooOnboardingTask = ( { id, variant, ...props } ) => {
 
 // We need this here just in case the experiment assignment takes awhile to load, so that we don't fire trackView with a blank experimentalVariant
 // Remove all of the code in this file related to experiments and variants when the product task experiment concludes and never speak of the existence of this code to anyone
-const pollForExperimentalVariant = ( id ) => {
-	if ( experimentalVariant ) {
+const pollForExperimentalVariant = ( id, count ) => {
+	if ( count > 20 ) {
+		trackView( id, 'experiment_timed_out' ); // if we can't fetch experiment after 4 seconds, give up
+	} else if ( experimentalVariant ) {
 		trackView( id, experimentalVariant );
 	} else {
 		setTimeout( () => pollForExperimentalVariant( id ), 200 );
@@ -71,7 +73,7 @@ WooOnboardingTask.Slot = ( { id, fillProps } ) => {
 	// eslint-disable-next-line react-hooks/rules-of-hooks
 	useEffect( () => {
 		if ( id === 'products' ) {
-			pollForExperimentalVariant( id );
+			pollForExperimentalVariant( id, 0 );
 		} else {
 			trackView( id );
 		}

--- a/packages/js/onboarding/src/components/WooOnboardingTask/index.js
+++ b/packages/js/onboarding/src/components/WooOnboardingTask/index.js
@@ -1,2 +1,1 @@
 export * from './WooOnboardingTask';
-export * from './use-product-layout-experiment';

--- a/packages/js/onboarding/src/index.js
+++ b/packages/js/onboarding/src/index.js
@@ -11,8 +11,4 @@ export { default as WCPayLogo } from './images/wcpay-logo';
 export { WooPaymentGatewaySetup } from './components/WooPaymentGatewaySetup';
 export { WooPaymentGatewayConfigure } from './components/WooPaymentGatewayConfigure';
 export { WooOnboardingTaskListItem } from './components/WooOnboardingTaskListItem';
-export {
-	WooOnboardingTask,
-	useProductTaskExperiment,
-	isProductTaskExperimentTreatment,
-} from './components/WooOnboardingTask';
+export { WooOnboardingTask } from './components/WooOnboardingTask';

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
@@ -92,8 +92,7 @@ registerPlugin( 'wc-admin-onboarding-task-products', {
 	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
 	scope: 'woocommerce-tasks',
 	render: () => (
-		// @ts-expect-error WooOnboardingTask is a pure JS component.
-		<WooOnboardingTask id="products">
+		<WooOnboardingTask id="products" variant="import">
 			<Products />
 		</WooOnboardingTask>
 	),

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import {
 	WooOnboardingTask,
-	useProductTaskExperiment,
 } from '@woocommerce/onboarding';
 import { Text } from '@woocommerce/experimental';
 import { registerPlugin } from '@wordpress/plugins';
@@ -30,6 +29,7 @@ import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
 import useRecordCompletionTime from '../use-record-completion-time';
 import { getCountryCode } from '~/dashboard/utils';
+import {useProductTaskExperiment} from "./use-product-layout-experiment";
 
 const getOnboardingProductType = (): string[] => {
 	const onboardingData = getAdminSetting( 'onboarding' );
@@ -56,10 +56,10 @@ const ViewControlButton: React.FC< {
 
 export const Products = () => {
 	const [ isExpanded, setIsExpanded ] = useState< boolean >( false );
-	const [
-		isLoadingExperiment,
+	const { 
+		isLoading: isLoadingExperiment,
 		experimentLayout,
-	] = useProductTaskExperiment();
+	 } = useProductTaskExperiment();
 
 	const { isStoreInUS } = useSelect( ( select ) => {
 		const { getSettings } = select( SETTINGS_STORE_NAME );
@@ -99,7 +99,7 @@ export const Products = () => {
 					recordCompletionTime();
 				},
 			} ) ),
-		[ recordCompletionTime ]
+		[ recordCompletionTime, productTypes ]
 	);
 
 	const {
@@ -135,7 +135,7 @@ export const Products = () => {
 	}, [
 		surfacedProductTypeKeys,
 		isExpanded,
-		productTypes,
+		productTypesWithTimeRecord,
 		experimentLayout,
 		loadSampleProduct,
 	] );
@@ -187,13 +187,21 @@ export const Products = () => {
 	);
 };
 
+const ExperimentalProductsFill = () => {
+	const { 
+		isLoading,
+		experimentLayout,
+	 } = useProductTaskExperiment();
+
+	return isLoading ? null : (
+		<WooOnboardingTask id="products" variant={ experimentLayout }>
+			<Products />
+		</WooOnboardingTask>
+	);
+};
+
 registerPlugin( 'wc-admin-onboarding-task-products', {
 	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
 	scope: 'woocommerce-tasks',
-	render: () => (
-		// @ts-expect-error WooOnboardingTask is a pure JS component.
-		<WooOnboardingTask id="products">
-			<Products />
-		</WooOnboardingTask>
-	),
+	render: () => <ExperimentalProductsFill />,
 } );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	WooOnboardingTask,
-} from '@woocommerce/onboarding';
+import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { Text } from '@woocommerce/experimental';
 import { registerPlugin } from '@wordpress/plugins';
 import { useMemo, useState } from '@wordpress/element';
@@ -29,7 +27,7 @@ import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
 import useRecordCompletionTime from '../use-record-completion-time';
 import { getCountryCode } from '~/dashboard/utils';
-import {useProductTaskExperiment} from "./use-product-layout-experiment";
+import { useProductTaskExperiment } from './use-product-layout-experiment';
 
 const getOnboardingProductType = (): string[] => {
 	const onboardingData = getAdminSetting( 'onboarding' );
@@ -56,10 +54,10 @@ const ViewControlButton: React.FC< {
 
 export const Products = () => {
 	const [ isExpanded, setIsExpanded ] = useState< boolean >( false );
-	const { 
+	const {
 		isLoading: isLoadingExperiment,
 		experimentLayout,
-	 } = useProductTaskExperiment();
+	} = useProductTaskExperiment();
 
 	const { isStoreInUS } = useSelect( ( select ) => {
 		const { getSettings } = select( SETTINGS_STORE_NAME );
@@ -188,10 +186,7 @@ export const Products = () => {
 };
 
 const ExperimentalProductsFill = () => {
-	const { 
-		isLoading,
-		experimentLayout,
-	 } = useProductTaskExperiment();
+	const { isLoading, experimentLayout } = useProductTaskExperiment();
 
 	return isLoading ? null : (
 		<WooOnboardingTask id="products" variant={ experimentLayout }>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -3,7 +3,6 @@
  */
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useProductTaskExperiment } from '@woocommerce/onboarding';
 import { recordEvent } from '@woocommerce/tracks';
 import { useSelect } from '@wordpress/data';
 
@@ -13,6 +12,7 @@ import { useSelect } from '@wordpress/data';
 import { Products } from '../';
 import { defaultSurfacedProductTypes, productTypes } from '../constants';
 import { getAdminSetting } from '~/utils/admin-settings';
+import { useProductTaskExperiment } from '../use-product-layout-experiment';
 
 jest.mock( '@wordpress/data', () => ( {
 	...jest.requireActual( '@wordpress/data' ),

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -23,8 +23,11 @@ jest.mock( '~/utils/admin-settings', () => ( {
 	getAdminSetting: jest.fn(),
 } ) );
 
-jest.mock( '@woocommerce/onboarding', () => ( {
-	useProductTaskExperiment: jest.fn().mockReturnValue( [ false, 'stacked' ] ),
+jest.mock( '../use-product-layout-experiment', () => ( {
+	useProductTaskExperiment: jest.fn().mockReturnValue( {
+		isLoading: false,
+		experimentLayout: 'stacked',
+	} ),
 } ) );
 
 jest.mock( '../use-create-product-by-type', () => ( {
@@ -263,10 +266,12 @@ describe( 'Products', () => {
 	} );
 
 	it( 'should show spinner when layout experiment is loading', async () => {
-		( useProductTaskExperiment as jest.Mock ).mockImplementation( () => [
-			true,
-			'card',
-		] );
+		( useProductTaskExperiment as jest.Mock ).mockImplementation( () => {
+			return {
+				isLoading: true,
+				experimentLayout: 'card',
+			};
+		} );
 		const { container } = render( <Products /> );
 		expect(
 			container.getElementsByClassName( 'components-spinner' )
@@ -274,10 +279,12 @@ describe( 'Products', () => {
 	} );
 
 	it( 'should render card layout when experiment is assigned', async () => {
-		( useProductTaskExperiment as jest.Mock ).mockImplementation( () => [
-			false,
-			'card',
-		] );
+		( useProductTaskExperiment as jest.Mock ).mockImplementation( () => {
+			return {
+				isLoading: false,
+				experimentLayout: 'card',
+			};
+		} );
 		const { container } = render( <Products /> );
 		expect(
 			container.getElementsByClassName(
@@ -287,10 +294,12 @@ describe( 'Products', () => {
 	} );
 
 	it( 'should render stacked layout when experiment is assigned', async () => {
-		( useProductTaskExperiment as jest.Mock ).mockImplementation( () => [
-			false,
-			'stacked',
-		] );
+		( useProductTaskExperiment as jest.Mock ).mockImplementation( () => {
+			return {
+				isLoading: false,
+				experimentLayout: 'stacked',
+			};
+		} );
 		const { container } = render( <Products /> );
 		expect(
 			container.getElementsByClassName( 'woocommerce-products-stack' )

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
@@ -38,7 +38,7 @@ export const useProductTaskExperiment = () => {
 		} );
 	}, [ setExperimentLayout ] );
 
-	return [ isLoading, experimentLayout ];
+	return { isLoading, experimentLayout };
 };
 
 export default useProductTaskExperiment;

--- a/plugins/woocommerce-admin/client/tasks/fills/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/index.js
@@ -1,13 +1,8 @@
 /**
- * External dependencies
- */
-import { isProductTaskExperimentTreatment } from '@woocommerce/onboarding';
-
-/**
  * Internal dependencies
  */
+import { isProductTaskExperimentTreatment } from './experimental-products/use-product-layout-experiment';
 import { isImportProductExperiment } from './product-task-experiment';
-
 import './PaymentGatewaySuggestions';
 import './shipping';
 import './Marketing';

--- a/plugins/woocommerce-admin/client/tasks/fills/product-task-experiment.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/product-task-experiment.js
@@ -5,6 +5,9 @@ import { getAdminSetting } from '~/utils/admin-settings';
 
 const onboardingData = getAdminSetting( 'onboarding' );
 
+/**
+ * Returns true if the merchant has indicated that they have another online shop while filling out the OBW
+ */
 export const isImportProductExperiment = () => {
 	return (
 		window?.wcAdminFeatures?.[ 'experimental-import-products-task' ] &&

--- a/plugins/woocommerce-admin/client/tasks/fills/products/products.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/products.js
@@ -166,7 +166,7 @@ const Products = () => {
 registerPlugin( 'wc-admin-onboarding-task-products', {
 	scope: 'woocommerce-tasks',
 	render: () => (
-		<WooOnboardingTask id="products">
+		<WooOnboardingTask id="products" variant="control">
 			<Products />
 		</WooOnboardingTask>
 	),

--- a/plugins/woocommerce/changelog/add-33052_task_view_track_event_polling
+++ b/plugins/woocommerce/changelog/add-33052_task_view_track_event_polling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Removed experimental product hook and instead poll the slot's fill for variant metadata. To be removed when experiment concludes! #33052


### PR DESCRIPTION
Moved some things around so that it's possible to track experiment metadata for task_view.
Not ideal design but due to sunk costs and the temporary nature of experiments, this has been implemented.
To be removed by conclusion of experiment, approx woocommerce-core 6.7

This changeset adds a mechanism for the task_view slotfill's fills to pass data about which variant is loaded by means of a shared variable that is populated only by 'products' fills. 

The "variant" key in wcadmin_task_view event can take the possible values of "control", "card", "stacked", "import", "experiment_timed_out". 

The only new instance is "experiment_timed_out" if for whatever reason it is unable to retrieve the experiment assignment, in which case the rendering should show the control version.


### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:
Same as in https://github.com/woocommerce/woocommerce/pull/32944 with the addition of the import task as well. There should be no outward changes.

The import task flow can be triggered by indicating that you have an existing store while filling out the OBW.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
