### PR TITLE
Add view more product type click event track for the add product task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -12,6 +12,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -147,7 +148,14 @@ export const Products = () => {
 						) }
 						<ViewControlButton
 							isExpanded={ isExpanded }
-							onClick={ () => setIsExpanded( ! isExpanded ) }
+							onClick={ () => {
+								if ( ! isExpanded ) {
+									recordEvent(
+										'tasklist_view_more_product_types_click'
+									);
+								}
+								setIsExpanded( ! isExpanded );
+							} }
 						/>
 						<Footer />
 					</div>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -128,11 +128,15 @@ describe( 'Products', () => {
 
 		expect( recordEvent ).toHaveBeenNthCalledWith(
 			1,
+			'tasklist_view_more_product_types_click'
+		);
+		expect( recordEvent ).toHaveBeenNthCalledWith(
+			2,
 			'tasklist_product_template_selection',
 			{ is_suggested: false, product_type: 'grouped' }
 		);
 		expect( recordEvent ).toHaveBeenNthCalledWith(
-			2,
+			3,
 			'task_completion_time',
 			{ task_name: 'products', time: '0-2s' }
 		);

--- a/plugins/woocommerce/changelog/add-view-more-product-type-track
+++ b/plugins/woocommerce/changelog/add-view-more-product-type-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add wcadmin_tasklist_view_more_product_types_click track event for add product task


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33057.

Add `wcadmin_tasklist_view_more_product_types_click` track event 

> % of users that clicks on view more product types - https://github.com/woocommerce/woocommerce/issues/32633#issue-1205317143

### How to test the changes in this Pull Request:


**Prerequisite**
1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper > Features`
3. Enable `experimental-products-task`
4. Make sure your site has `woocommerce_allow_tracking` option set to `yes`

**Testing**

1. Go to `Tools > WCA Test Helper > Experiments`
2. Enable treatment for either `woocommerce_products_task_layout_stacked` for frontend.
3. Go to Products task
4. Enable track logging `localStorage.setItem( 'debug', 'wc-admin:*' );`
5. Click `View more product types`
6. It should trigger a `wcadmin_tasklist_view_more_product_types_click` track


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
