### PR TITLE
Fix space between logos in the payment banner experiment

### DIFF
--- a/plugins/woocommerce-admin/client/payments/payment-recommendations.scss
+++ b/plugins/woocommerce-admin/client/payments/payment-recommendations.scss
@@ -33,6 +33,7 @@
 
 	.woocommerce-recommended-payments-banner__footer_icon_container > svg {
 		height: 28px;
+		width: 51px;
 	}
 }
 

--- a/plugins/woocommerce/changelog/fix-33053-fix-logo-spacing
+++ b/plugins/woocommerce/changelog/fix-33053-fix-logo-spacing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Fix spacing between the Paymetn logo assets in the payment banner experiment.


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33053  .

This PR adjusts the space between payment logos in the payment banner experiment.

### How to test the changes in this Pull Request:

1. Follow test instructions on pbIJXs-1P0-p2
2. Make sure logos are aligned correctly.


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.