### PR TITLE
Redirect users to the WC Pay connect page if the WC Pay is already installed

### DIFF
--- a/plugins/woocommerce-admin/client/payments/payment-recommendations.scss
+++ b/plugins/woocommerce-admin/client/payments/payment-recommendations.scss
@@ -12,8 +12,11 @@
 	}
 
 	.woocommerce-recommended-payments-banner__text_container {
-		width: 40%;
+		width: 46%;
 		margin-inline: 24px;
+		a {
+			margin-top: 0;
+		}
 
 		* {
 			margin-block: 1rem;

--- a/plugins/woocommerce-admin/client/payments/payment-settings-banner.tsx
+++ b/plugins/woocommerce-admin/client/payments/payment-settings-banner.tsx
@@ -14,6 +14,8 @@ import { useSelect } from '@wordpress/data';
 import { useExperiment } from '@woocommerce/explat';
 import { getAdminLink } from '@woocommerce/settings';
 import moment from 'moment';
+import interpolateComponents from '@automattic/interpolate-components';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -35,6 +37,7 @@ import {
 import WCPayBannerImage from './wcpay-banner-image';
 import './payment-recommendations.scss';
 import { isWcPaySupported } from './utils';
+import { getAdminSetting } from '~/utils/admin-settings';
 
 export const PaymentMethodsIcons = () => (
 	<div className="woocommerce-recommended-payments-banner__footer_icon_container">
@@ -55,8 +58,10 @@ export const PaymentMethodsIcons = () => (
 
 const WcPayBanner = () => {
 	const WC_PAY_SETUP_URL = getAdminLink(
-		'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments'
+		'admin.php?wcpay-connect=1&_wpnonce=' +
+			getAdminSetting( 'wcpay_welcome_page_connect_nonce' )
 	);
+
 	return (
 		<Card size="medium" className="woocommerce-recommended-payments-banner">
 			<CardBody className="woocommerce-recommended-payments-banner__body">
@@ -85,10 +90,32 @@ const WcPayBanner = () => {
 						size="12"
 						lineHeight="16px"
 					>
-						{ __(
-							'By using WooCommerce Payments you agree to be bound by our Terms of Service and acknowledge that you have read our Privacy Policy',
-							'woocommerce'
-						) }
+						{ interpolateComponents( {
+							mixedString: __(
+								'By using WooCommerce Payments you agree to be bound by our {{tosLink}}Terms of Service{{/tosLink}} and acknowledge that you have read our {{privacyLink}}Privacy Policy{{/privacyLink}} ',
+								'woocommerce'
+							),
+							components: {
+								tosLink: (
+									<Link
+										href="https://woocommerce.com/posts/terms-of-service-update/"
+										type="external"
+										target="_blank"
+									>
+										<></>
+									</Link>
+								),
+								privacyLink: (
+									<Link
+										href="https://automattic.com/privacy/"
+										type="external"
+										target="_blank"
+									>
+										<></>
+									</Link>
+								),
+							},
+						} ) }
 					</Text>
 					<Button href={ WC_PAY_SETUP_URL } isPrimary>
 						{ __( 'Get started', 'woocommerce' ) }

--- a/plugins/woocommerce/changelog/update-33056-update-the-wcpay-description
+++ b/plugins/woocommerce/changelog/update-33056-update-the-wcpay-description
@@ -1,0 +1,5 @@
+Significance: minor
+Type: update
+
+Payment banner experiment: update the description and make the button to redirect the users to the WC Pay connect page when the WC Pay is
+already installed


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #33056  .

This PR updates the description of the WC Pay and redirect the users to the WC Pay connect page upon clicking `Get started` button when the WC Pay is already installed.

### How to test the changes in this Pull Request:

1. Follow test instructions in pbIJXs-1P0-p2
2. Confirm the updated description.
3. Confirm the button redirects you to the WC Pay connect page.

### Screenshots

![Screen Shot 2022-05-16 at 3 14 05 PM](https://user-images.githubusercontent.com/4723145/168691069-e7220fc4-c1d9-46c8-9477-ea841d7c7e3d.jpg)

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.