### PR TITLE
Update add product task to only show "subscriptions" product type for stores in the US

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
@@ -49,7 +49,9 @@ export const Products = () => {
 	} );
 
 	const productTypeListItems = useProductTypeListItems(
-		getProductTypes( [ 'subscription' ] ),
+		getProductTypes( {
+			exclude: [ 'subscription' ],
+		} ),
 		[],
 		{
 			onClick: recordCompletionTime,

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -70,7 +70,7 @@ export const Products = () => {
 		const country =
 			typeof settings.woocommerce_default_country === 'string'
 				? settings.woocommerce_default_country
-				: 'US';
+				: '';
 
 		return {
 			isStoreInUS: getCountryCode( country ) === 'US',

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -13,7 +13,8 @@ import { Button, Spinner } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { recordEvent } from '@woocommerce/tracks';
-
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -28,6 +29,7 @@ import { LoadSampleProductType } from './constants';
 import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
 import useRecordCompletionTime from '../use-record-completion-time';
+import { getCountryCode } from '~/dashboard/utils';
 
 const getOnboardingProductType = (): string[] => {
 	const onboardingData = getAdminSetting( 'onboarding' );
@@ -59,12 +61,31 @@ export const Products = () => {
 		experimentLayout,
 	] = useProductTaskExperiment();
 
+	const { isStoreInUS } = useSelect( ( select ) => {
+		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { general: settings = {} } = getSettings< {
+			general?: { [ key: string ]: unknown };
+		} >( 'general' );
+
+		const country =
+			typeof settings.woocommerce_default_country === 'string'
+				? settings.woocommerce_default_country
+				: 'US';
+
+		return {
+			isStoreInUS: getCountryCode( country ) === 'US',
+		};
+	} );
+
 	const surfacedProductTypeKeys = getSurfacedProductTypeKeys(
 		getOnboardingProductType()
 	);
 
 	const productTypes = useProductTypeListItems(
-		getProductTypes(),
+		// Subscriptions only in the US
+		getProductTypes( {
+			exclude: isStoreInUS ? [] : [ 'subscription' ],
+		} ),
 		surfacedProductTypeKeys
 	);
 	const { recordCompletionTime } = useRecordCompletionTime( 'products' );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -104,6 +104,46 @@ describe( 'Products', () => {
 		expect( queryByText( 'Subscription product' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'should not render subscriptions products type when store country is unknown', () => {
+		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
+			profile: {
+				product_types: [ 'subscriptions' ],
+			},
+		} ) );
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getSettings: () => ( {
+					general: {
+						woocommerce_default_country: undefined,
+					},
+				} ),
+			} ) )
+		);
+		const { queryByText } = render( <Products /> );
+
+		expect( queryByText( 'Subscription product' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render subscriptions products type when store is in the US', () => {
+		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
+			profile: {
+				product_types: [ 'subscriptions' ],
+			},
+		} ) );
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getSettings: () => ( {
+					general: {
+						woocommerce_default_country: 'US',
+					},
+				} ),
+			} ) )
+		);
+		const { queryByText } = render( <Products /> );
+
+		expect( queryByText( 'Subscription product' ) ).toBeInTheDocument();
+	} );
+
 	it( 'clicking on suggested product should fire event tasklist_product_template_selection with is_suggested:true and task_completion_time', () => {
 		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
 			profile: {

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -5,6 +5,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useProductTaskExperiment } from '@woocommerce/onboarding';
 import { recordEvent } from '@woocommerce/tracks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -44,6 +45,15 @@ jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
 describe( 'Products', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getSettings: () => ( {
+					general: {
+						woocommerce_default_country: 'US',
+					},
+				} ),
+			} ) )
+		);
 	} );
 
 	it( 'should render default products types when onboardingData.profile.productType is null', () => {
@@ -72,6 +82,26 @@ describe( 'Products', () => {
 		expect( queryByText( 'Digital product' ) ).toBeInTheDocument();
 		expect( queryByRole( 'menu' )?.childElementCount ).toBe( 1 );
 		expect( queryByText( 'View more product types' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not render subscriptions products type when store is not in the US', () => {
+		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
+			profile: {
+				product_types: [ 'subscriptions' ],
+			},
+		} ) );
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getSettings: () => ( {
+					general: {
+						woocommerce_default_country: 'GB',
+					},
+				} ),
+			} ) )
+		);
+		const { queryByText } = render( <Products /> );
+
+		expect( queryByText( 'Subscription product' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'clicking on suggested product should fire event tasklist_product_template_selection with is_suggested:true and task_completion_time', () => {

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/utils.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/utils.ts
@@ -11,7 +11,9 @@ describe( 'getProductTypes', () => {
 
 	it( 'should return the product types without excluded items', () => {
 		expect(
-			getProductTypes( [ 'external', 'digital' ] ).map( ( p ) => p.key )
+			getProductTypes( { exclude: [ 'external', 'digital' ] } ).map(
+				( p ) => p.key
+			)
 		).toEqual( [ 'physical', 'variable', 'subscription', 'grouped' ] );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/utils.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/utils.tsx
@@ -15,12 +15,19 @@ import {
 	defaultSurfacedProductTypes,
 } from './constants';
 
-export const getProductTypes = (
-	exclude: ProductTypeKey[] = []
-): ProductType[] =>
-	productTypes.filter(
+export const getProductTypes = ( {
+	exclude,
+}: {
+	exclude?: ProductTypeKey[];
+} = {} ): ProductType[] => {
+	if ( ! exclude ) {
+		return [ ...productTypes ];
+	}
+
+	return productTypes.filter(
 		( productType ) => ! exclude.includes( productType.key )
 	);
+};
 
 /**
  * Get key of surfaced product types by onboarding product types.

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/utils.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/utils.tsx
@@ -20,13 +20,13 @@ export const getProductTypes = ( {
 }: {
 	exclude?: ProductTypeKey[];
 } = {} ): ProductType[] => {
-	if ( ! exclude ) {
-		return [ ...productTypes ];
+	if ( exclude && exclude?.length > 0 ) {
+		return productTypes.filter(
+			( productType ) => ! exclude.includes( productType.key )
+		);
 	}
 
-	return productTypes.filter(
-		( productType ) => ! exclude.includes( productType.key )
-	);
+	return [ ...productTypes ];
 };
 
 /**

--- a/plugins/woocommerce/changelog/update-33062-subscriptions-product-type-only-in-the-us
+++ b/plugins/woocommerce/changelog/update-33062-subscriptions-product-type-only-in-the-us
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update add product task to only show "subscriptions" product type for stores in the US


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33062.

> Enable the Subscription product template only for merchants in the US both on the card and stack layout.

### How to test the changes in this Pull Request:

1. Make sure your site has `woocommerce_allow_tracking` option set to `yes`
2. Go to `Tools > WCA Test Helper > Experiments`
3. Enable treatment for `woocommerce_products_task_layout_stacked` 
4. Go to OBW
5. Set `Country` to the US
6. Select "Subscriptions" in the `Product Types` step.
7. Navigate to `WooCommerce > Home`
8. Go to "Add products" task
9. Observe that the subscriptions product type is shown
10. Go to `woocommmerce > Settings`
11. Change `Country / State` to another country.
12. Go back to "Add products" task
13. Observe that the subscriptions product type is hidden.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
