### PR TITLE
Adding the action to the Pay for Order shortcode

### DIFF
--- a/plugins/woocommerce/changelog/add-pay-for-order-express-checkout-action
+++ b/plugins/woocommerce/changelog/add-pay-for-order-express-checkout-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds a `before_woocommerce_pay_form` action to the Pay for Order page.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -183,11 +183,15 @@ class WC_Shortcode_Checkout {
 					current( $available_gateways )->set_current();
 				}
 
+				$order_button_text = apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) );
+
 				/**
 				 * Triggered right before the Pay for Order form, after validation of the order and customer.
 				 *
 				 * @param WC_Order $order             The order that is being paid for.
 				 * @param string   $order_button_text The text for the submit button.
+				 *
+				 * @since 6.6
 				 */
 				do_action( 'before_woocommerce_pay_form', $order, $order_button_text );
 
@@ -196,7 +200,7 @@ class WC_Shortcode_Checkout {
 					array(
 						'order'              => $order,
 						'available_gateways' => $available_gateways,
-						'order_button_text'  => apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) ),
+						'order_button_text'  => $order_button_text,
 					)
 				);
 

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -183,6 +183,14 @@ class WC_Shortcode_Checkout {
 					current( $available_gateways )->set_current();
 				}
 
+				/**
+				 * Triggered right before the Pay for Order form, after validation of the order and customer.
+				 *
+				 * @param WC_Order $order             The order that is being paid for.
+				 * @param string   $order_button_text The text for the submit button.
+				 */
+				do_action( 'before_woocommerce_pay_form', $order, $order_button_text );
+
 				wc_get_template(
 					'checkout/form-pay.php',
 					array(

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -195,12 +195,13 @@ class WC_Shortcode_Checkout {
 				/**
 				 * Triggered right before the Pay for Order form, after validation of the order and customer.
 				 *
-				 * @param WC_Order $order             The order that is being paid for.
-				 * @param string   $order_button_text The text for the submit button.
+				 * @param WC_Order $order              The order that is being paid for.
+				 * @param string   $order_button_text  The text for the submit button.
+				 * @param array    $available_gateways All available gateways.
 				 *
 				 * @since 6.6
 				 */
-				do_action( 'before_woocommerce_pay_form', $order, $order_button_text );
+				do_action( 'before_woocommerce_pay_form', $order, $order_button_text, $available_gateways );
 
 				wc_get_template(
 					'checkout/form-pay.php',

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -183,6 +183,13 @@ class WC_Shortcode_Checkout {
 					current( $available_gateways )->set_current();
 				}
 
+				/**
+				 * Allows the text of the submit button on the Pay for Order page to be changed.
+				 *
+				 * @param string $text The text of the button.
+				 *
+				 * @since 3.0.2
+				 */
 				$order_button_text = apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) );
 
 				/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a simple `before_woocommerce_pay_form` hook, which will allow payment gateways to display other payment options before the form on the Pay for Order page. This is useful in addition to the existing `before_woocommerce_pay` action, because at the point of execution, all checks and validation will have already passed.

### How to test the changes in this Pull Request:

Being just an action, this does not require any particular testing. There will be a Proof of Concept PR for WooCommerce Payments shortly, where this will be shown in action.

### Other information:

-  [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-  [x] Have you successfully run tests with your changes locally?
-  [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?