### PR TITLE
fix: broken event tracking due to assignment to const

### DIFF
--- a/plugins/woocommerce/changelog/fix-33083-fix-broken-events-tracking-assignment-to-const
+++ b/plugins/woocommerce/changelog/fix-33083-fix-broken-events-tracking-assignment-to-const
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed broken event tracking by correcting 'const' to 'let' from a previous commit #33083

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -81,7 +81,7 @@ class WC_Site_Tracking {
 				}
 
 				const eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
-				const eventProperties = properties || {};
+				let eventProperties = properties || {};
 				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties ); ?> };
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Change in #32690 resulted in broken events tracking, due to a change from 'var' to 'const'

Changed 'const' to 'let' 


### How to test the changes in this Pull Request:

1. Install WooCommerce
2. Attempt to skip OBW, and accept tracking when the modal pops up
3. No error should occur

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
