### PR TITLE
REP: Update publish-test-reports if condition

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -171,7 +171,7 @@ jobs:
 
     publish-test-reports:
         name: Publish test reports
-        if: ${{ always() }}
+        if: always() && (contains( needs.*.result, 'success' ) || contains( needs.*.result, 'failure' ))
         runs-on: ubuntu-18.04
         needs: [api-tests-run, e2e-tests-run, k6-tests-run]
         env:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce-quality#276.

This PR replaces the `if` condition in the job [`Publish test reports`](https://github.com/woocommerce/woocommerce/blob/31922c1da9a40cd7fbed21864acb4252102aa757/.github/workflows/pr-build-and-e2e-tests.yml#L172) so that it would only run when at least one of the API, E2E, and k6 tests were completed, regardless of whether they passed or failed. This fix will prevent the job from running when none of the tests ran (when they're cancelled or skipped).

### How to test the changes in this Pull Request:

#### Scenario where all the 3 tests were cancelled
1. Create a PR that's based off of this one.
2. Push any kind of minor change to your PR, like maybe a minor edit in one of the README's.
3. Navigate to the `Checks` tab of your PR, and go to the `Run tests against PR` workflow.
4. When the E2E, API, and k6 tests started to run, cancel the workflow.
5. Verify that the `Publish test reports` job was skipped, like so:
    <img width="647" alt="Screen Shot 2022-05-18 at 2 06 44 PM" src="https://user-images.githubusercontent.com/4509348/168968889-86edecdd-ee77-46de-848d-74e2c198daca.png">

#### Scenario where at least one of the three tests passed, and the others were cancelled
1. Continuing from the steps above, rerun the `Run tests against PR` workflow, but this time let the `Runs API tests` job to finish (it should pass). 
2. Cancel the workflow even if the E2E and k6 tests are still in progress.
3. Verify that the `Publish test reports` job was successfully run:
    <img width="648" alt="Screen Shot 2022-05-18 at 2 21 36 PM" src="https://user-images.githubusercontent.com/4509348/168971020-c0a3a3bd-eea1-411f-85ae-ca58215c2ec5.png">

#### Scenario where at least one of the three tests failed, and the others were cancelled
1. Edit one of the API Core Tests to make it fail. For example, you may edit this line
    https://github.com/woocommerce/woocommerce/blob/31922c1da9a40cd7fbed21864acb4252102aa757/packages/js/api-core-tests/tests/shipping/shipping-zones.test.js#L87
    With a failing assertion, like `expect( body ).toHaveLength( 100 );`
1. Push this change to your PR.
2. Wait for the `Runs API tests` job to finish (it should fail this time).
3. Cancel the workflow while E2E and k6 tests are still running.
4. Verify that the `Publish test reports` job was successfully run.




### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.