### PR TITLE
Fix nested link in products import task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/importTypes.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/importTypes.tsx
@@ -18,16 +18,16 @@ export const importTypes = [
 			'woocommerce'
 		),
 		before: <PageIcon />,
-		href: getAdminLink(
-			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
-		),
-		onClick: () =>
-			recordEvent( 'tasklist_add_product', { method: 'import' } ),
+		onClick: () => {
+			recordEvent( 'tasklist_add_product', { method: 'import' } );
+			window.location.href = getAdminLink(
+				'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
+			);
+		},
 	},
 	{
 		key: 'from-cart2cart' as const,
 		title: __( 'FROM CART2CART', 'woocommerce' ),
-		href: 'https://woocommerce.com/products/cart2cart/?utm_medium=product',
 		content: interpolateComponents( {
 			mixedString: __(
 				'Migrate all store data like products, customers, and orders in no time with this 3rd party plugin. {{link}}Learn more{{/link}}',
@@ -35,12 +35,22 @@ export const importTypes = [
 			),
 			components: {
 				link: (
-					<ExternalLink href="https://woocommerce.com/products/cart2cart/?utm_medium=product"></ExternalLink>
+					<ExternalLink
+						href="https://woocommerce.com/products/cart2cart/?utm_medium=product"
+						onClickCapture={ ( e ) => e.preventDefault() }
+					></ExternalLink>
 				),
 			},
 		} ),
 		before: <ReblogIcon />,
-		onClick: () =>
-			recordEvent( 'tasklist_add_product', { method: 'migrate' } ),
+		onClick: () => {
+			recordEvent( 'tasklist_add_product', { method: 'migrate' } );
+			window
+				.open(
+					'https://woocommerce.com/products/cart2cart/?utm_medium=product',
+					'_blank'
+				)
+				?.focus();
+		},
 	},
 ];

--- a/plugins/woocommerce/changelog/fix-nested-link-in-products-import-task
+++ b/plugins/woocommerce/changelog/fix-nested-link-in-products-import-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Change product import task items to use onClick for link


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to https://github.com/woocommerce/woocommerce/pull/33052#pullrequestreview-976270141. Fixes warning where `<a>` element was nested in products import task.

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/3747241/168991235-58e02ec1-adf9-4d6b-8684-92e706e4edfc.png">


### How to test the changes in this Pull Request:

1. In Onboarding Wizard's Business Features step, select "Yes, on other platforms"
2. Open developer console
3. Go to products task, observe no warning related to `<a>` element nested in console
4. Try clicking on the csv import, make sure tracking works as usual and link works
5. Try clicking on the cart2cart button, make sure tracking works and the **link opens up in a new tab**

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
