### PR TITLE
Check results of calling WP_Filesystem()

### DIFF
--- a/plugins/woocommerce/changelog/patch-8
+++ b/plugins/woocommerce/changelog/patch-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent errors and log a warning in the event the WP Filesystem cannot be initialized while updating the geoloc database.

--- a/plugins/woocommerce/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/plugins/woocommerce/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -168,7 +168,10 @@ class WC_Integration_MaxMind_Geolocation extends WC_Integration {
 	public function update_database( $new_database_path = null ) {
 		// Allow us to easily interact with the filesystem.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
+		if ( ! WP_Filesystem() ) {
+			wc_get_logger()->notice( __( 'Failed to initialise WC_Filesystem API', 'woocommerce' ) );
+			return;
+		}
 		global $wp_filesystem;
 
 		// Remove any existing archives to comply with the MaxMind TOS.

--- a/plugins/woocommerce/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/plugins/woocommerce/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -169,7 +169,7 @@ class WC_Integration_MaxMind_Geolocation extends WC_Integration {
 		// Allow us to easily interact with the filesystem.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		if ( ! WP_Filesystem() ) {
-			wc_get_logger()->notice( __( 'Failed to initialise WC_Filesystem API', 'woocommerce' ) );
+			wc_get_logger()->warning( __( 'Failed to initialise WC_Filesystem API while trying to update the MaxMind Geolocation database.', 'woocommerce' ) );
 			return;
 		}
 		global $wp_filesystem;


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Contrary to https://codex.wordpress.org/Filesystem_API, woocommerce/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php does not check the result of calling the function WP_Filesystem() prior to attempting to call methods on the global `$wp_filesystem`. Consequently, the call to `$wp_filesystem->exists()` can result in an uncaught exception (seen on my systems) instead of cleanly handling the failure to access the filesystem.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
