### PR TITLE
Analyzer CLI: De-asyncify methods not requiring async

### DIFF
--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -73,19 +73,19 @@ export default class Analyzer extends Command {
 	async run(): Promise< void > {
 		const { args, flags } = await this.parse( Analyzer );
 
-		await this.validateArgs( flags.source );
+		this.validateArgs( flags.source );
 
-		const patchContent = await generatePatch(
+		const patchContent = generatePatch(
 			flags.source,
 			args.compare,
 			flags.base,
 			( e: string ): void => this.error( e )
 		);
 
-		const pluginData = await this.getPluginData( flags.plugin );
+		const pluginData = this.getPluginData( flags.plugin );
 		this.log( `${ pluginData[ 1 ] } Version: ${ pluginData[ 0 ] }` );
 
-		await this.scanChanges( patchContent, pluginData[ 0 ], flags.output );
+		this.scanChanges( patchContent, pluginData[ 0 ], flags.output );
 	}
 
 	/**
@@ -93,7 +93,7 @@ export default class Analyzer extends Command {
 	 *
 	 * @param {string} source The GitHub repository we are merging.
 	 */
-	private async validateArgs( source: string ): Promise< void > {
+	private validateArgs( source: string ): void {
 		// We only support pulling from GitHub so the format needs to match that.
 		if ( ! source.match( /^[a-z0-9\-]+\/[a-z0-9\-]+$/ ) ) {
 			this.error(
@@ -106,9 +106,9 @@ export default class Analyzer extends Command {
 	 * Get plugin data
 	 *
 	 * @param {string} plugin Plugin slug.
-	 * @return {Promise<string[]>} Promise.
+	 * @return {string[]} Promise.
 	 */
-	private async getPluginData( plugin: string ): Promise< string[] > {
+	private getPluginData( plugin: string ): string[] {
 		/**
 		 * List of plugins from our monorepo.
 		 */
@@ -166,16 +166,16 @@ export default class Analyzer extends Command {
 	 * @param {string} version Current product version.
 	 * @param {string} output  Output style.
 	 */
-	private async scanChanges(
+	private scanChanges(
 		content: string,
 		version: string,
 		output: string
-	): Promise< void > {
-		const templates = await this.scanTemplates( content, version );
-		const hooks = await this.scanHooks( content, version, output );
+	): void {
+		const templates = this.scanTemplates( content, version );
+		const hooks = this.scanHooks( content, version, output );
 
 		if ( templates.size ) {
-			await printTemplateResults(
+			printTemplateResults(
 				templates,
 				output,
 				'TEMPLATE CHANGES',
@@ -186,11 +186,8 @@ export default class Analyzer extends Command {
 		}
 
 		if ( hooks.size ) {
-			await printHookResults(
-				hooks,
-				output,
-				'HOOKS',
-				( s: string ): void => this.log( s )
+			printHookResults( hooks, output, 'HOOKS', ( s: string ): void =>
+				this.log( s )
 			);
 		} else {
 			this.log( 'No new hooks found' );
@@ -204,10 +201,10 @@ export default class Analyzer extends Command {
 	 * @param {string} version Current product version.
 	 * @return {Promise<Map<string, string[]>>} Promise.
 	 */
-	private async scanTemplates(
+	private scanTemplates(
 		content: string,
 		version: string
-	): Promise< Map< string, string[] > > {
+	): Map< string, string[] > {
 		CliUx.ux.action.start( 'Scanning template changes' );
 
 		const report: Map< string, string[] > = new Map< string, string[] >();
@@ -261,11 +258,11 @@ export default class Analyzer extends Command {
 	 * @param {string} output  Output style.
 	 * @return {Promise<Map<string, Map<string, string[]>>>} Promise.
 	 */
-	private async scanHooks(
+	private scanHooks(
 		content: string,
 		version: string,
 		output: string
-	): Promise< Map< string, Map< string, string[] > > > {
+	): Map< string, Map< string, string[] > > {
 		CliUx.ux.action.start( 'Scanning for new hooks' );
 
 		const report: Map< string, Map< string, string[] > > = new Map<

--- a/tools/code-analyzer/src/git.ts
+++ b/tools/code-analyzer/src/git.ts
@@ -12,12 +12,12 @@ import { readFileSync } from 'fs';
  *
  * @param {string}   branch branch/commit hash.
  * @param {Function} error  error print method.
- * @return {Promise<boolean>} Promise.
+ * @return {boolean} Promise.
  */
-export const fetchBranch = async (
+export const fetchBranch = (
 	branch: string,
 	error: ( s: string ) => void
-): Promise< boolean > => {
+): boolean => {
 	CliUx.ux.action.start( `Fetching ${ branch }` );
 	const branches = execSync( 'git branch', {
 		encoding: 'utf-8',
@@ -37,6 +37,7 @@ export const fetchBranch = async (
 		execSync( `git branch ${ branch } origin/${ branch }` );
 	} catch ( e ) {
 		error( `Unable to fetch ${ branch }` );
+		return false;
 	}
 
 	CliUx.ux.action.stop();
@@ -50,22 +51,22 @@ export const fetchBranch = async (
  * @param {string}   compare Branch/commit hash to compare against the base.
  * @param {string}   base    Base branch/commit hash.
  * @param {Function} error   error print method.
- * @return {Promise<string>} Promise.
+ * @return {string} patch string.
  */
-export const generatePatch = async (
+export const generatePatch = (
 	source: string,
 	compare: string,
 	base: string,
 	error: ( s: string ) => void
-): Promise< string > => {
+): string => {
 	const filename = `${ source }-${ base }-${ compare }.patch`.replace(
 		/\//g,
 		'-'
 	);
 	const filepath = join( tmpdir(), filename );
 
-	await fetchBranch( base, error );
-	await fetchBranch( compare, error );
+	fetchBranch( base, error );
+	fetchBranch( compare, error );
 
 	CliUx.ux.action.start( 'Generating patch for ' + compare );
 

--- a/tools/code-analyzer/src/print.ts
+++ b/tools/code-analyzer/src/print.ts
@@ -6,12 +6,12 @@
  * @param {string}                title  Section title.
  * @param {Function}              log    print method.
  */
-export const printTemplateResults = async (
+export const printTemplateResults = (
 	data: Map< string, string[] >,
 	output: string,
 	title: string,
 	log: ( s: string ) => void
-): Promise< void > => {
+): void => {
 	if ( output === 'github' ) {
 		let opt = '\\n\\n### Template changes:';
 		for ( const [ key, value ] of data ) {
@@ -46,12 +46,12 @@ export const printTemplateResults = async (
  * @param {string}   title  Section title.
  * @param {Function} log    print method.
  */
-export const printHookResults = async (
+export const printHookResults = (
 	data: Map< string, Map< string, string[] > >,
 	output: string,
 	title: string,
 	log: ( s: string ) => void
-): Promise< void > => {
+): void => {
 	if ( output === 'github' ) {
 		let opt = '\\n\\n### New hooks:';
 		for ( const [ key, value ] of data ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Analyzer command was full of `aync` functions that didn't require it. This introduces complexity due to functions returning Promises when a normal return value would suffice. This PR remove all unnecessary `async` declarations.

### How to test the changes in this Pull Request:

1. Confirm the CLI still works by adding a test hook somewhere
```php
/**
* Test hook
*
* @since 6.6.0
*/
do_action( 'woocommerce_test_hook' );
```
2. Commit the code locally
3. Run the CLI tool to see the newly added hook picked up without error, `./tools/code-analyzer/bin/dev analyzer fix/analyzer-cli-deasyncify`
4. See the GH actions passing 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
