### PR TITLE
Add initial tracking for categories, tags, and attribute product pages

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/add-term-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/add-term-tracking/index.js
@@ -4,31 +4,40 @@
 import { recordEvent } from '@woocommerce/tracks';
 
 const addNewTag = document.querySelector( '#addtag #submit' );
-const actionButtons = document.querySelectorAll( '.row-actions span' );
+
+function actionButtonEventHandler( event ) {
+	const actionClass = event.target.parentElement.classList[ 0 ];
+
+	const actions = {
+		edit: 'edit',
+		inline: 'quick_edit',
+		delete: 'delete',
+		view: 'preview',
+	};
+
+	if ( ! actions[ actionClass ] ) {
+		return;
+	}
+
+	recordEvent( 'product_attributes_term_list_action_click', {
+		selected_action: actions[ actionClass ],
+	} );
+}
+
+function addActionButtonListeners() {
+	const actionButtons = document.querySelectorAll( '.row-actions span' );
+	actionButtons.forEach( ( button ) => {
+		button.removeEventListener( 'click', actionButtonEventHandler );
+		button.addEventListener( 'click', actionButtonEventHandler );
+	} );
+}
+addActionButtonListeners();
 
 addNewTag?.addEventListener( 'click', function () {
 	recordEvent( 'product_attributes_add_term', {
 		page: 'tags',
 	} );
-} );
-
-actionButtons.forEach( ( button ) => {
-	button.addEventListener( 'click', function ( event ) {
-		const actionClass = event.target.parentElement.classList[ 0 ];
-
-		const actions = {
-			edit: 'edit',
-			inline: 'quick_edit',
-			delete: 'delete',
-			view: 'preview',
-		};
-
-		if ( ! actions[ actionClass ] ) {
-			return;
-		}
-
-		recordEvent( 'product_attributes_term_list_action_click', {
-			selected_action: actions[ actionClass ],
-		} );
-	} );
+	setTimeout( () => {
+		addActionButtonListeners();
+	}, 1000 );
 } );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/add-term-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/add-term-tracking/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+const addNewTag = document.querySelector( '#addtag #submit' );
+const actionButtons = document.querySelectorAll( '.row-actions span' );
+
+addNewTag?.addEventListener( 'click', function () {
+	recordEvent( 'product_attributes_add_term', {
+		page: 'tags',
+	} );
+} );
+
+actionButtons.forEach( ( button ) => {
+	button.addEventListener( 'click', function ( event ) {
+		const actionClass = event.target.parentElement.classList[ 0 ];
+
+		const actions = {
+			edit: 'edit',
+			inline: 'quick_edit',
+			delete: 'delete',
+			view: 'preview',
+		};
+
+		if ( ! actions[ actionClass ] ) {
+			return;
+		}
+
+		recordEvent( 'product_attributes_term_list_action_click', {
+			selected_action: actions[ actionClass ],
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/attributes-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/attributes-tracking/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+const addNewAttribute = document.querySelector( '[name="add_new_attribute"]' );
+const saveAttribute = document.querySelector( '[name="save_attribute"]' );
+const actionButtons = document.querySelectorAll( '.row-actions span a' );
+const configureTerms = document.querySelectorAll( '.configure-terms' );
+
+addNewAttribute?.addEventListener( 'click', function () {
+	const archiveInput = document.querySelector( '#attribute_public' );
+	const sortOrder = document.querySelector( '#attribute_orderby' );
+	recordEvent( 'product_attributes_add', {
+		enable_archive: archiveInput?.checked ? 'yes' : 'no',
+		default_sort_order: sortOrder?.value,
+		page: 'attributes',
+	} );
+} );
+
+saveAttribute?.addEventListener( 'click', function () {
+	const archiveInput = document.querySelector( '#attribute_public' );
+	const sortOrder = document.querySelector( '#attribute_orderby' );
+	recordEvent( 'product_attributes_update', {
+		enable_archive: archiveInput?.checked ? 'yes' : 'no',
+		default_sort_order: sortOrder?.value,
+		page: 'attributes',
+	} );
+} );
+
+actionButtons.forEach( ( button ) => {
+	button.addEventListener( 'click', function ( event ) {
+		const actionClass = event.target.parentElement.classList[ 0 ];
+
+		const actions = {
+			edit: 'edit',
+			delete: 'delete',
+		};
+
+		if ( ! actions[ actionClass ] ) {
+			return;
+		}
+
+		recordEvent( 'product_attributes_' + actions[ actionClass ], {
+			page: 'attributes',
+		} );
+	} );
+} );
+
+configureTerms.forEach( ( button ) => {
+	button.addEventListener( 'click', function () {
+		recordEvent( 'product_attributes_configure_terms', {
+			page: 'attributes',
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/category-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/category-tracking/index.js
@@ -20,8 +20,8 @@ function actionButtonEventHandler( event ) {
 		return;
 	}
 
-	recordEvent( 'product_category_list_action_click', {
-		selected_action: actions[ actionClass ],
+	recordEvent( 'product_category_manage', {
+		option_selected: actions[ actionClass ],
 	} );
 }
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/category-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/category-tracking/index.js
@@ -3,26 +3,39 @@
  */
 import { recordEvent } from '@woocommerce/tracks';
 
-const actionButtons = document.querySelectorAll( '.row-actions span' );
+const addNewCategory = document.querySelector( '#addtag #submit' );
 
-actionButtons.forEach( ( button ) => {
-	button.addEventListener( 'click', function ( event ) {
-		const actionClass = event.target.parentElement.classList[ 0 ];
+function actionButtonEventHandler( event ) {
+	const actionClass = event.target.parentElement.classList[ 0 ];
 
-		const actions = {
-			edit: 'edit',
-			inline: 'quick_edit',
-			delete: 'delete',
-			view: 'preview',
-			make_default: 'make_default',
-		};
+	const actions = {
+		edit: 'edit',
+		inline: 'quick_edit',
+		delete: 'delete',
+		view: 'preview',
+		make_default: 'make_default',
+	};
 
-		if ( ! actions[ actionClass ] ) {
-			return;
-		}
+	if ( ! actions[ actionClass ] ) {
+		return;
+	}
 
-		recordEvent( 'product_category_list_action_click', {
-			selected_action: actions[ actionClass ],
-		} );
+	recordEvent( 'product_category_list_action_click', {
+		selected_action: actions[ actionClass ],
 	} );
+}
+
+function addActionButtonListeners() {
+	const actionButtons = document.querySelectorAll( '.row-actions span' );
+	actionButtons.forEach( ( button ) => {
+		button.removeEventListener( 'click', actionButtonEventHandler );
+		button.addEventListener( 'click', actionButtonEventHandler );
+	} );
+}
+addActionButtonListeners();
+
+addNewCategory?.addEventListener( 'click', function () {
+	setTimeout( () => {
+		addActionButtonListeners();
+	}, 1000 );
 } );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/category-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/category-tracking/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+const actionButtons = document.querySelectorAll( '.row-actions span' );
+
+actionButtons.forEach( ( button ) => {
+	button.addEventListener( 'click', function ( event ) {
+		const actionClass = event.target.parentElement.classList[ 0 ];
+
+		const actions = {
+			edit: 'edit',
+			inline: 'quick_edit',
+			delete: 'delete',
+			view: 'preview',
+			make_default: 'make_default',
+		};
+
+		if ( ! actions[ actionClass ] ) {
+			return;
+		}
+
+		recordEvent( 'product_category_list_action_click', {
+			selected_action: actions[ actionClass ],
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks';
+
+const addNewAttribute = document.querySelector( '#addtag #submit' );
+const actionButtons = document.querySelectorAll( '.row-actions span' );
+
+addNewAttribute?.addEventListener( 'click', function () {
+	const archiveInput = document.querySelector( '#attribute_public' );
+	const sortOrder = document.querySelector( '#attribute_orderby' );
+	recordEvent( 'product_tags_add', {
+		enable_archive: archiveInput?.checked ? 'yes' : 'no',
+		default_sort_order: sortOrder?.value,
+		page: 'attributes',
+	} );
+} );
+
+actionButtons.forEach( ( button ) => {
+	button.addEventListener( 'click', function ( event ) {
+		const actionClass = event.target.parentElement.classList[ 0 ];
+
+		const actions = {
+			edit: 'edit',
+			inline: 'quick_edit',
+			delete: 'delete',
+			view: 'preview',
+		};
+
+		if ( ! actions[ actionClass ] ) {
+			return;
+		}
+
+		recordEvent( 'product_tags_list_action_click', {
+			selected_action: actions[ actionClass ],
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
@@ -4,7 +4,34 @@
 import { recordEvent } from '@woocommerce/tracks';
 
 const addNewAttribute = document.querySelector( '#addtag #submit' );
-const actionButtons = document.querySelectorAll( '.row-actions span' );
+
+function actionButtonEventHandler( event ) {
+	const actionClass = event.target.parentElement.classList[ 0 ];
+
+	const actions = {
+		edit: 'edit',
+		inline: 'quick_edit',
+		delete: 'delete',
+		view: 'preview',
+	};
+
+	if ( ! actions[ actionClass ] ) {
+		return;
+	}
+
+	recordEvent( 'product_tags_list_action_click', {
+		selected_action: actions[ actionClass ],
+	} );
+}
+
+function addActionButtonListeners() {
+	const actionButtons = document.querySelectorAll( '.row-actions span' );
+	actionButtons.forEach( ( button ) => {
+		button.removeEventListener( 'click', actionButtonEventHandler );
+		button.addEventListener( 'click', actionButtonEventHandler );
+	} );
+}
+addActionButtonListeners();
 
 addNewAttribute?.addEventListener( 'click', function () {
 	const archiveInput = document.querySelector( '#attribute_public' );
@@ -14,25 +41,7 @@ addNewAttribute?.addEventListener( 'click', function () {
 		default_sort_order: sortOrder?.value,
 		page: 'attributes',
 	} );
-} );
-
-actionButtons.forEach( ( button ) => {
-	button.addEventListener( 'click', function ( event ) {
-		const actionClass = event.target.parentElement.classList[ 0 ];
-
-		const actions = {
-			edit: 'edit',
-			inline: 'quick_edit',
-			delete: 'delete',
-			view: 'preview',
-		};
-
-		if ( ! actions[ actionClass ] ) {
-			return;
-		}
-
-		recordEvent( 'product_tags_list_action_click', {
-			selected_action: actions[ actionClass ],
-		} );
-	} );
+	setTimeout( () => {
+		addActionButtonListeners();
+	}, 1000 );
 } );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
@@ -34,11 +34,7 @@ function addActionButtonListeners() {
 addActionButtonListeners();
 
 addNewTag?.addEventListener( 'click', function () {
-	const archiveInput = document.querySelector( '#attribute_public' );
-	const sortOrder = document.querySelector( '#attribute_orderby' );
 	recordEvent( 'product_tags_add', {
-		enable_archive: archiveInput?.checked ? 'yes' : 'no',
-		default_sort_order: sortOrder?.value,
 		page: 'attributes',
 	} );
 	setTimeout( () => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/tags-tracking/index.js
@@ -3,7 +3,7 @@
  */
 import { recordEvent } from '@woocommerce/tracks';
 
-const addNewAttribute = document.querySelector( '#addtag #submit' );
+const addNewTag = document.querySelector( '#addtag #submit' );
 
 function actionButtonEventHandler( event ) {
 	const actionClass = event.target.parentElement.classList[ 0 ];
@@ -33,7 +33,7 @@ function addActionButtonListeners() {
 }
 addActionButtonListeners();
 
-addNewAttribute?.addEventListener( 'click', function () {
+addNewTag?.addEventListener( 'click', function () {
 	const archiveInput = document.querySelector( '#attribute_public' );
 	const sortOrder = document.querySelector( '#attribute_orderby' );
 	recordEvent( 'product_tags_add', {

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -50,6 +50,10 @@ const wpAdminScripts = [
 	'payment-method-promotions',
 	'onboarding-load-sample-products-notice',
 	'product-tracking',
+	'add-term-tracking',
+	'attributes-tracking',
+	'category-tracking',
+	'tags-tracking',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/add-32676_category_and_tag_tracks
+++ b/plugins/woocommerce/changelog/add-32676_category_and_tag_tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add wpAdmin scripts for tracking actions in the category, tags, and attribute pages. #33118

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -23,6 +23,7 @@ class WC_Products_Tracking {
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'wp_after_insert_post', array( $this, 'track_product_published' ), 10, 4 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
+		add_action( 'edited_product_cat', array( $this, 'track_product_category_updated' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_product_tracking_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_attribute_tracking_scripts' ) );
@@ -232,7 +233,27 @@ class WC_Products_Tracking {
 	}
 
 	/**
-	 * Get the product screen name if current hook and page is a products type page.
+	 * Send a Tracks event when a product category is updated.
+	 *
+	 * @param int $category_id Category ID.
+	 */
+	public function track_product_category_updated( $category_id ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// Only track category creation from the edit product screen or the
+		// category management screen (which both occur via AJAX).
+		if (
+			empty( $_POST['action'] ) ||
+			( 'editedtag' !== $_POST['action'] && 'inline-save-tax' !== $_POST['action'] )
+		) {
+			return;
+		}
+		// phpcs:enable
+
+		WC_Tracks::record_event( 'product_category_update' );
+	}
+
+	/**
+	 * Adds the tracking scripts for product filtering actions.
 	 *
 	 * @param string $hook Hook of the current page.
 	 * @return string|boolean

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -24,7 +24,9 @@ class WC_Products_Tracking {
 		add_action( 'wp_after_insert_post', array( $this, 'track_product_published' ), 10, 4 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_tracking_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_product_tracking_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_attribute_tracking_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_tag_tracking_scripts' ) );
 	}
 
 	/**
@@ -269,7 +271,7 @@ class WC_Products_Tracking {
 	 *
 	 * @param string $hook Page hook.
 	 */
-	public function possibly_add_tracking_scripts( $hook ) {
+	public function possibly_add_product_tracking_scripts( $hook ) {
 		$product_screen = $this->get_product_screen( $hook );
 		if ( ! $product_screen ) {
 			return;
@@ -292,6 +294,100 @@ class WC_Products_Tracking {
 			array(
 				'name' => $product_screen,
 			)
+		);
+	}
+
+	/**
+	 * Adds the tracking scripts for product attributes filtering actions.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function possibly_add_attribute_tracking_scripts( $hook ) {
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		if (
+			'edit.php' !== $hook ||
+			! isset( $_GET['page'] ) ||
+			'product_attributes' !== wp_unslash( $_GET['page'] )
+		) {
+			return;
+		}
+		// phpcs:enable
+
+		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'attributes-tracking' );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'wc-admin-attributes-tracking',
+			WCAdminAssets::get_url( 'wp-admin-scripts/attributes-tracking', 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			WCAdminAssets::get_file_version( 'js' ),
+			true
+		);
+	}
+
+	/**
+	 * Adds the tracking scripts for tags and categories filtering actions.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function possibly_add_tag_tracking_scripts( $hook ) {
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		if (
+			'edit-tags.php' !== $hook ||
+			! isset( $_GET['post_type'] ) ||
+			'product' !== wp_unslash( $_GET['post_type'] )
+		) {
+			return;
+		}
+		// phpcs:enable
+
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if (
+			isset( $_GET['taxonomy'] ) &&
+			'product_tag' === wp_unslash( $_GET['taxonomy'] )
+		) {
+			// phpcs:enable
+			$tags_script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'tags-tracking' );
+			$tags_script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $tags_script_assets_filename;
+
+			wp_enqueue_script(
+				'wc-admin-tags-tracking',
+				WCAdminAssets::get_url( 'wp-admin-scripts/tags-tracking', 'js' ),
+				array_merge( array( WC_ADMIN_APP ), $tags_script_assets ['dependencies'] ),
+				WCAdminAssets::get_file_version( 'js' ),
+				true
+			);
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if (
+			isset( $_GET['taxonomy'] ) &&
+			'product_cat' === wp_unslash( $_GET['taxonomy'] )
+		) {
+			// phpcs:enable
+			$category_script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'category-tracking' );
+			$category_script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $category_script_assets_filename;
+
+			wp_enqueue_script(
+				'wc-admin-category-tracking',
+				WCAdminAssets::get_url( 'wp-admin-scripts/category-tracking', 'js' ),
+				array_merge( array( WC_ADMIN_APP ), $category_script_assets ['dependencies'] ),
+				WCAdminAssets::get_file_version( 'js' ),
+				true
+			);
+			return;
+		}
+
+		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'add-term-tracking' );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'wc-admin-add-term-tracking',
+			WCAdminAssets::get_url( 'wp-admin-scripts/add-term-tracking', 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			WCAdminAssets::get_file_version( 'js' ),
+			true
 		);
 	}
 }

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -305,7 +305,7 @@ class WC_Products_Tracking {
 	public function possibly_add_attribute_tracking_scripts( $hook ) {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
 		if (
-			'edit.php' !== $hook ||
+			'product_page_product_attributes' !== $hook ||
 			! isset( $_GET['page'] ) ||
 			'product_attributes' !== wp_unslash( $_GET['page'] )
 		) {

--- a/plugins/woocommerce/legacy/js/admin/term-ordering.js
+++ b/plugins/woocommerce/legacy/js/admin/term-ordering.js
@@ -14,6 +14,10 @@ jQuery( function( $ ) {
 		term_id_selector = '.check-column input';
 	}
 
+	// Stand-in wcTracks.recordEvent in case tracks is not available (for any reason).
+	window.wcTracks = window.wcTracks || {};
+	window.wcTracks.recordEvent = window.wcTracks.recordEvent  || function() { };
+
 	$( table_selector ).find( '.column-handle' ).show();
 
 	$.wc_add_missing_sort_handles = function() {
@@ -96,6 +100,13 @@ jQuery( function( $ ) {
 				$( table_selector ).sortable( 'cancel' );
 				return;
 			}
+
+			window.wcTracks.recordEvent( 'product_attributes_ordering_term', {
+				is_category:
+					woocommerce_term_ordering_params.taxonomy === 'product_cat'
+						? 'yes'
+						: 'no',
+			} );
 
 			// Show Spinner
 			ui.item.find( '.check-column input' ).hide();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds tracks to the products attributes, tags, and categories pages.

Mostly addresses #32676 , the only think missing is tracking the attributes/terms added/created in the product page, this will be done in a separate PR.

### How to test the changes in this Pull Request:
*see original issue for more context on the attributes.

1.  Open your browser console and run `localStorage.setItem( 'debug', 'wc-admin:*' );`
2.  Navigate to **Products > Attributes** and check out these actions and events:
     - Add attribute - `wcadmin_product_attributes_add`, should contain attributes - page, enable_archive, default_sort_order
     - Attribute edit and delete clicks (they show up when hovering over them within the list) - `wcadmin_product_attributes_edit` & `wcadmin_product_attributes_delete`
     - Within attribute edit hit update - `wcadmin_product_attributes_update` attributes - page, enable_archive, default_sort_order
     - Configure terms - `wcadmin_product_attributes_configure_terms`
     - Within configure terms
          - Add new term - `wcadmin_product_attributes_add_term`
          - Term list actions - `wcadmin_product_attributes_term_list_action_click`, attributes: `selected_action`
          - Re order terms - `wcadmin_product_attributes_ordering_term`, attributes: `is_category` (**note:** this is not showing in the console for me, I had to look for the `t.gif` request and look at the payload to see if it was triggered)
3.  Navigate to **Products > Tags** and check out these actions and events:
     - Add tag - `wcadmin_product_tags_add`, attributes: `page`
     - Actions within tags list (on hover) - `wcadmin_product_tags_list_action_click`, attributes: `selected_action`
4. Navigate to **Products > Categories** and check out these actions and events:
     - Add new Category - `wcadmin_product_category_add` (this one already existed and is being triggered on the back-end, you can check that by going to **WooCommerce > Status > Logs** and looking for the latest `tracks-2022...` log (if you have the WooCommerce Admin test helper enabled.
     - Category list actions - `wcadmin_product_category_manage`, attributes - `option_selected`
     - Re order categories - `wcadmin_product_attributes_ordering_term`, attributes: `is_category` (**note:** this is not showing in the console for me, I had to look for the `t.gif` request and look at the payload to see if it was triggered)
     - Updating a category - `wcadmin_product_category_update` will be triggered from PHP, so use the logs to test.
6.  Navigate to non-product pages and make sure the `product-tracking` script is not loaded on those pages by viewing the page's source code.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Have you created a changelog file by running `pnpm nx affected --target=changelog`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
