### PR TITLE
Add/32676 category and tag tracks within products screen

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/global.d.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/global.d.ts
@@ -1,1 +1,1 @@
-declare const productScreen: string;
+declare const productScreen: { name: string };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
@@ -13,6 +13,6 @@ const initTracks = () => {
 	initProductScreenTracks();
 };
 
-if ( productScreen === 'edit' ) {
+if ( productScreen && productScreen.name === 'edit' ) {
 	initTracks();
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-new.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-new.ts
@@ -12,7 +12,7 @@ const initTracks = () => {
 	recordEvent( 'product_add_view' );
 };
 
-if ( productScreen === 'new' ) {
+if ( productScreen && productScreen.name === 'new' ) {
 	initTracks();
 	initProductScreenTracks();
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/products-list.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/products-list.ts
@@ -153,6 +153,6 @@ const initTracks = () => {
 	} );
 };
 
-if ( productScreen === 'list' ) {
+if ( productScreen && productScreen.name === 'list' ) {
 	initTracks();
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -279,25 +279,28 @@ export const initProductScreenTracks = () => {
 
 	document
 		.querySelector( '.add_attribute' )
-		?.addEventListener( 'click', ( event ) => {
-			recordEvent( 'product_attributes_add', {
-				page: 'product',
-				enable_archive: '',
-				default_sort_order: '',
-			} );
+		?.addEventListener( 'click', () => {
 			setTimeout( () => {
 				addNewAttributeTermTracks();
 			}, 1000 );
 		} );
 
+	const attributesCount = document.querySelectorAll(
+		'.woocommerce_attribute'
+	).length;
+
 	document
 		.querySelector( '.save_attributes' )
-		?.addEventListener( 'click', ( event ) => {
-			recordEvent( 'product_attributes_save', {
-				page: 'product',
-				attributes_count: document.querySelectorAll(
-					'.woocommerce_attribute'
-				).length,
-			} );
+		?.addEventListener( 'click', () => {
+			const newAttributesCount = document.querySelectorAll(
+				'.woocommerce_attribute'
+			).length;
+			if ( newAttributesCount > attributesCount ) {
+				recordEvent( 'product_attributes_add', {
+					page: 'product',
+					enable_archive: '',
+					default_sort_order: '',
+				} );
+			}
 		} );
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -193,4 +193,111 @@ export const initProductScreenTracks = () => {
 				checkbox: ( event.target as HTMLInputElement ).checked,
 			} );
 		} );
+
+	// Product tags
+
+	document
+		.querySelector( '.tagadd' )
+		?.addEventListener( 'click', ( event ) => {
+			const tagInput = document.querySelector< HTMLInputElement >(
+				'#new-tag-product_tag'
+			);
+			if ( tagInput && tagInput.value && tagInput.value.length > 0 ) {
+				recordEvent( 'product_tags_add', {
+					page: 'product',
+					tag_string_length: tagInput.value.length,
+					tag_list_size:
+						( document.querySelector( '.tagchecklist' )?.children
+							.length || 0 ) + 1,
+					most_used: false,
+				} );
+			}
+		} );
+
+	function addMostUsedTagEventListener( event: Event ) {
+		recordEvent( 'product_tags_add', {
+			page: 'product',
+			tag_string_length: ( event.target as HTMLAnchorElement ).textContent
+				?.length,
+			tag_list_size:
+				( document.querySelector( '.tagchecklist' )?.children.length ||
+					0 ) + 1,
+			most_used: true,
+		} );
+	}
+
+	function addMostUsedTagsTracks() {
+		const tagCloudLinks = document.querySelectorAll(
+			'#tagcloud-product_tag .tag-cloud-link'
+		);
+		tagCloudLinks.forEach( ( button ) => {
+			button.removeEventListener( 'click', addMostUsedTagEventListener );
+			button.addEventListener( 'click', addMostUsedTagEventListener );
+		} );
+	}
+
+	function waitUntilMostUsedTagsIsPresent( func: () => void, tries = 0 ) {
+		if ( tries > 6 ) {
+			return;
+		}
+		setTimeout( () => {
+			const tagCloudContainer = document.querySelector(
+				'#tagcloud-product_tag'
+			);
+			if ( tagCloudContainer ) {
+				func();
+			} else {
+				waitUntilMostUsedTagsIsPresent( func, ++tries );
+			}
+		}, 500 );
+	}
+
+	document
+		.querySelector( '.tagcloud-link' )
+		?.addEventListener( 'click', () => {
+			waitUntilMostUsedTagsIsPresent( addMostUsedTagsTracks );
+		} );
+
+	// Attribute tracks.
+
+	function addNewTermEventHandler() {
+		recordEvent( 'product_attributes_add_term', {
+			page: 'product',
+		} );
+	}
+
+	function addNewAttributeTermTracks() {
+		const addNewTermButtons = document.querySelectorAll(
+			'.woocommerce_attribute .add_new_attribute'
+		);
+		addNewTermButtons.forEach( ( button ) => {
+			button.removeEventListener( 'click', addNewTermEventHandler );
+			button.addEventListener( 'click', addNewTermEventHandler );
+		} );
+	}
+	addNewAttributeTermTracks();
+
+	document
+		.querySelector( '.add_attribute' )
+		?.addEventListener( 'click', ( event ) => {
+			recordEvent( 'product_attributes_add', {
+				page: 'product',
+				enable_archive: '',
+				default_sort_order: '',
+			} );
+			setTimeout( () => {
+				addNewAttributeTermTracks();
+			}, 1000 );
+		} );
+
+	document
+		.querySelector( '.save_attributes' )
+		?.addEventListener( 'click', ( event ) => {
+			recordEvent( 'product_attributes_save', {
+				page: 'product',
+				attributes_count: document.querySelectorAll(
+					'.woocommerce_attribute'
+				).length,
+			} );
+		} );
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Recursive function that waits up to 3 seconds until an element is found, then calls the callback.
+ *
+ * @param {string} query query of the element.
+ * @param {Function} func callback called when element is found.
+ * @param {number} tries used internally to limit the number of tries.
+ */
+export function waitUntilElementIsPresent(
+	query: string,
+	func: () => void,
+	tries = 0
+) {
+	if ( tries > 6 ) {
+		return;
+	}
+	setTimeout( () => {
+		const element = document.querySelector( query );
+		if ( element ) {
+			func();
+		} else {
+			waitUntilElementIsPresent( query, func, ++tries );
+		}
+	}, 500 );
+}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -192,7 +192,7 @@ class WC_Products_Tracking {
 	 * @param int $category_id Category ID.
 	 */
 	public function track_product_category_created( $category_id ) {
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		// Only track category creation from the edit product screen or the
 		// category management screen (which both occur via AJAX).
 		if (
@@ -208,11 +208,21 @@ class WC_Products_Tracking {
 			return;
 		}
 
-		$category   = get_term( $category_id, 'product_cat' );
+		$category = get_term( $category_id, 'product_cat' );
+		$parent_category = $category->parent > 0 ? 'Other' : 'None';
+		if ( $category->parent > 0 ) {
+			$parent = get_term( $category_id, 'product_cat' );
+			if ( 'uncategorized' === $parent->name ) {
+				$parent_category = 'Uncategorized';
+			}
+		}
 		$properties = array(
-			'category_id' => $category_id,
-			'parent_id'   => $category->parent,
-			'page'        => ( 'add-tag' === $_POST['action'] ) ? 'categories' : 'product',
+			'category_id'     => $category_id,
+			'parent_id'       => $category->parent,
+			'parent_category' => $parent_category,
+			'page'            => ( 'add-tag' === $_POST['action'] ) ? 'categories' : 'product',
+			'display_type'    => isset( $_POST['display_type'] ) ? wp_unslash( $_POST['display_type'] ) : '',
+			'image'           => isset( $_POST['product_cat_thumbnail_id'] ) && '' !== $_POST['product_cat_thumbnail_id'] ? 'Yes' : 'No',
 		);
 		// phpcs:enable
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -208,7 +208,7 @@ class WC_Products_Tracking {
 			return;
 		}
 
-		$category = get_term( $category_id, 'product_cat' );
+		$category        = get_term( $category_id, 'product_cat' );
 		$parent_category = $category->parent > 0 ? 'Other' : 'None';
 		if ( $category->parent > 0 ) {
 			$parent = get_term( $category_id, 'product_cat' );
@@ -286,6 +286,12 @@ class WC_Products_Tracking {
 			true
 		);
 
-		wp_localize_script( 'wc-admin-product-tracking', 'productScreen', $product_screen );
+		wp_localize_script(
+			'wc-admin-product-tracking',
+			'productScreen',
+			array(
+				'name' => $product_screen,
+			)
+		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add tracks on the product editing and creation page for tags and attributes.
This is currently branched off of #33120, please look at the commits I made in the diff ([link](https://github.com/woocommerce/woocommerce/pull/33121/files/e946306585eafe9c9f0ce400a55299482f0ce54a..327c4f6d564bdf02649c022c696e4a18d1962ac0))

Closes #32676  .

### How to test the changes in this Pull Request:

1. Go to the product creation or edit page
2. And have tracks output enabled in your console: `localStorage.setItem( 'debug', 'wc-admin:*' );`
3. Click on the **Attributes** tab and select an attribute from the dropdown and click `Add`
4. Try adding a new term if you selected a none custom attribute, this should trigger the `wcadmin_product_attributes_add_term` track with the page param set to `product`
5. Click **Save attributes**, this should trigger a `wcadmin_product_attributes_add` with the page param set to `product`.

Testing product tags
1. Add a new tag on the right side (**product tags**), this should output the `wcadmin_product_tags_add` track.
2. Now click on **Choose from the most used tags** and add some of those tags, this should also trigger the `wcadmin_product_tags_add` track. Check if the extra params make sense for this.

Testing product categories
1. Add a new category on the right side (**product categories**), this should output the `wcadmin_product_category_add` track. This is triggered on the back-end, so you did have to have the [WooCommerce Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper) enabled and look at the track logs under **WooCommerce > Status > Logs** for that day.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
