### PR TITLE
Include screenreader text for the regular & discounted price.

### DIFF
--- a/plugins/woocommerce/changelog/fix-accessible-sale-price
+++ b/plugins/woocommerce/changelog/fix-accessible-sale-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure original and sale prace accessible to screen readers on Product page.

--- a/plugins/woocommerce/changelog/fix-accessible-sale-price
+++ b/plugins/woocommerce/changelog/fix-accessible-sale-price
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Ensure original and sale prace accessible to screen readers on Product page.
+Ensure original and sale price accessible to screen readers on Product page.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1272,9 +1272,9 @@ function wc_format_stock_quantity_for_display( $stock_quantity, $product ) {
  * @return string
  */
 function wc_format_sale_price( $regular_price, $sale_price ) {
-	$price  = '<span class="screen-reader-text">' . __( 'Previous price:', 'woocommerce' ) . '</span>';
+	$price  = '<span class="screen-reader-text">' . esc_html__( 'Previous price:', 'woocommerce' ) . '</span>';
 	$price .= '<del>' . ( is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price ) . '</del>';
-	$price .= '<span class="screen-reader-text">' . __( 'Discounted price:', 'woocommerce' ) . '</span>';
+	$price .= '<span class="screen-reader-text">' . esc_html__( 'Discounted price:', 'woocommerce' ) . '</span>';
 	$price .= '<ins>' . ( is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price ) . '</ins>';
 	return apply_filters( 'woocommerce_format_sale_price', $price, $regular_price, $sale_price );
 }

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -351,9 +351,9 @@ function wc_format_localized_price( $value ) {
  * @return string
  */
 function wc_format_localized_decimal( $value ) {
-	$locale = localeconv();
+	$locale        = localeconv();
 	$decimal_point = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
-	$decimal = ( ! empty( wc_get_price_decimal_separator() ) ) ? wc_get_price_decimal_separator() : $decimal_point;
+	$decimal       = ( ! empty( wc_get_price_decimal_separator() ) ) ? wc_get_price_decimal_separator() : $decimal_point;
 	return apply_filters( 'woocommerce_format_localized_decimal', str_replace( '.', $decimal, strval( $value ) ), $value );
 }
 
@@ -1272,7 +1272,10 @@ function wc_format_stock_quantity_for_display( $stock_quantity, $product ) {
  * @return string
  */
 function wc_format_sale_price( $regular_price, $sale_price ) {
-	$price = '<del aria-hidden="true">' . ( is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price ) . '</del> <ins>' . ( is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price ) . '</ins>';
+	$price  = '<span class="screen-reader-text">' . __( 'Previous price:', 'woocommerce' ) . '</span>';
+	$price .= '<del>' . ( is_numeric( $regular_price ) ? wc_price( $regular_price ) : $regular_price ) . '</del>';
+	$price .= '<span class="screen-reader-text">' . __( 'Discounted price:', 'woocommerce' ) . '</span>';
+	$price .= '<ins>' . ( is_numeric( $sale_price ) ? wc_price( $sale_price ) : $sale_price ) . '</ins>';
 	return apply_filters( 'woocommerce_format_sale_price', $price, $regular_price, $sale_price );
 }
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Include screenreader text for the regular & discounted price. Using the same markup & language as in the woocommerce-blocks ProductPrice component:

https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/base/components/product-price/index.tsx

Closes #31099 .

### How to test the changes in this Pull Request:

1. Ensure that a Product is on sale.
2. On this products item page, read the sale and discounted prices with a screen reader. Both should be read out.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
