### PR TITLE
Add script to get db schema from CLI

### DIFF
--- a/plugins/woocommerce/bin/get-schema.php
+++ b/plugins/woocommerce/bin/get-schema.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Helper methods for extracting database schema.
+ *
+ * @package WooCommerce
+ */
+
+// phpcs:disable PHPCompatibility.Classes.NewLateStaticBinding.OutsideClassScope
+/**
+ * Get database schema.
+ */
+function get_schema() {
+	$schema = function () {
+		return static::get_schema();
+	};
+
+	return $schema->call( new \WC_Install() );
+}
+
+echo( esc_sql( get_schema() ) );

--- a/plugins/woocommerce/bin/wc-get-schema.php
+++ b/plugins/woocommerce/bin/wc-get-schema.php
@@ -9,7 +9,7 @@
 /**
  * Get database schema.
  */
-function get_schema() {
+function wc_get_schema() {
 	$schema = function () {
 		return static::get_schema();
 	};
@@ -17,4 +17,4 @@ function get_schema() {
 	return $schema->call( new \WC_Install() );
 }
 
-echo( esc_sql( get_schema() ) );
+echo( esc_sql( wc_get_schema() ) );

--- a/plugins/woocommerce/changelog/add-schema-output
+++ b/plugins/woocommerce/changelog/add-schema-output
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add script to get database schema from CLI


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I'd like to be able to obtain the database schema from Github Actions using `wp-env`. `WC_Install` class provides a private function `get_schema` to return the schema, but the file nor the function is accessible from the command line.

https://github.com/woocommerce/woocommerce/blob/0b35ad678d463b547d7315fc060f9ab6908959a9/plugins/woocommerce/includes/class-wc-install.php#L995

The reason to do this is to programatically compare branchs' schemas to detect any changes and raise a notice if so. See issue [here](https://github.com/woocommerce/platform-private/issues/51) and PR [here](https://github.com/woocommerce/woocommerce/pull/33084).

I saw a workaround our tests were doing to obtain the schema. This PR creates a script to easily get the schema from a CLI environment. I'd like to know if this approach is above board. What are the reasons the function was made private? Would it be better to make the method public?

### How to test the changes in this Pull Request:

1. `cd plugins/woocommerce`
2. `wp-env run cli "wp eval-file 'wp-content/plugins/woocommerce/bin/get-schema.php'"`
3. See the schema string output.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
