### PR TITLE
Improve unit testing infrastructure

### DIFF
--- a/plugins/woocommerce/changelog/improve-unit-testing-infrastructure
+++ b/plugins/woocommerce/changelog/improve-unit-testing-infrastructure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add a mechanism to mock globals and a DynamicDecorator class.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -186,6 +186,11 @@ final class WooCommerce {
 	 * @since 3.6.0
 	 */
 	public function on_plugins_loaded() {
+		/**
+		 * Action to signal that WooCommerce has finished loading.
+		 *
+		 * @since 3.6.0
+		 */
 		do_action( 'woocommerce_loaded' );
 	}
 
@@ -251,6 +256,12 @@ final class WooCommerce {
 					'source' => 'fatal-errors',
 				)
 			);
+
+			/**
+			 * Action triggered when there are errors during shutdown.
+			 *
+			 * @since 3.2.0
+			 */
 			do_action( 'woocommerce_shutdown_error', $error );
 		}
 	}
@@ -339,7 +350,10 @@ final class WooCommerce {
 		$rest_prefix         = trailingslashit( rest_get_url_prefix() );
 		$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) ); // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		return apply_filters( 'woocommerce_is_rest_api_request', $is_rest_api_request );
+		/**
+		 * Filter to specify if the current request is a REST API request.
+		 */
+		return apply_filters( 'woocommerce_is_rest_api_request', $is_rest_api_request ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
@@ -613,8 +627,10 @@ final class WooCommerce {
 	 * Init WooCommerce when WordPress Initialises.
 	 */
 	public function init() {
-		// Before init action.
-		do_action( 'before_woocommerce_init' );
+		/**
+		 * Action triggered before WooCommerce initialization begins.
+		 */
+		do_action( 'before_woocommerce_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		// Set up localisation.
 		$this->load_plugin_textdomain();
@@ -635,8 +651,10 @@ final class WooCommerce {
 
 		$this->load_webhooks();
 
-		// Init action.
-		do_action( 'woocommerce_init' );
+		/**
+		 * Action triggered after WooCommerce initialization finishes.
+		 */
+		do_action( 'woocommerce_init' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
@@ -650,7 +668,11 @@ final class WooCommerce {
 	 */
 	public function load_plugin_textdomain() {
 		$locale = determine_locale();
-		$locale = apply_filters( 'plugin_locale', $locale, 'woocommerce' );
+
+		/**
+		 * Filter to adjust the WooCommerce locale to use for translations.
+		 */
+		$locale = apply_filters( 'plugin_locale', $locale, 'woocommerce' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		unload_textdomain( 'woocommerce' );
 		load_textdomain( 'woocommerce', WP_LANG_DIR . '/woocommerce/woocommerce-' . $locale . '.mo' );
@@ -738,7 +760,10 @@ final class WooCommerce {
 	 * @return string
 	 */
 	public function template_path() {
-		return apply_filters( 'woocommerce_template_path', 'woocommerce/' );
+		/**
+		 * Filter to adjust the base templates path.
+		 */
+		return apply_filters( 'woocommerce_template_path', 'woocommerce/' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
@@ -774,7 +799,10 @@ final class WooCommerce {
 			$api_request_url = add_query_arg( 'wc-api', $request, trailingslashit( home_url( '', $scheme ) ) );
 		}
 
-		return esc_url_raw( apply_filters( 'woocommerce_api_request_url', $api_request_url, $request, $ssl ) );
+		/**
+		 * Filter to adjust the url of an incoming API request.
+		 */
+		return esc_url_raw( apply_filters( 'woocommerce_api_request_url', $api_request_url, $request, $ssl ) );  // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
@@ -824,8 +852,10 @@ final class WooCommerce {
 	 * @return void
 	 */
 	public function initialize_session() {
-		// Session class, handles session data for users - can be overwritten if custom handler is needed.
-		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+		/**
+		 * Filter to overwrite the session class that handles session data for users.
+		 */
+		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		if ( is_null( $this->session ) || ! $this->session instanceof $session_class ) {
 			$this->session = new $session_class();
 			$this->session->init();
@@ -1015,5 +1045,15 @@ final class WooCommerce {
 	 */
 	public function get_instance_of( string $class_name, ...$args ) {
 		return wc_get_container()->get( LegacyProxy::class )->get_instance_of( $class_name, ...$args );
+	}
+
+	/**
+	 * Gets the value of a global.
+	 *
+	 * @param string $global_name The name of the global to get the value for.
+	 * @return mixed The value of the global.
+	 */
+	public function get_global( string $global_name ) {
+		return wc_get_container()->get( LegacyProxy::class )->get_global( $global_name );
 	}
 }

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -32,7 +32,7 @@ class PostsToOrdersMigrationController {
 	/**
 	 * The source name to use for logs.
 	 */
-	private const LOGS_SOURCE_NAME = 'posts-to-orders-migration';
+	public const LOGS_SOURCE_NAME = 'posts-to-orders-migration';
 
 	/**
 	 * PostsToOrdersMigrationController constructor.
@@ -67,6 +67,8 @@ class PostsToOrdersMigrationController {
 	 * @param array $order_post_ids List of post IDs of the orders to migrate.
 	 */
 	public function migrate_orders( array $order_post_ids ): void {
+		$this->error_logger = WC()->call_function( 'wc_get_logger' );
+
 		foreach ( $this->all_migrators as $migrator ) {
 			$this->do_orders_migration_step( $migrator, $order_post_ids );
 		}
@@ -83,7 +85,7 @@ class PostsToOrdersMigrationController {
 	private function do_orders_migration_step( object $migration_class, array $order_post_ids ): void {
 		$result = $migration_class->process_migration_batch_for_ids( $order_post_ids );
 
-		$errors    = $result['errors'];
+		$errors    = array_unique( $result['errors'] );
 		$exception = $result['exception'];
 		if ( null === $exception && empty( $errors ) ) {
 			return;
@@ -110,7 +112,7 @@ class PostsToOrdersMigrationController {
 				array(
 					'source'    => self::LOGS_SOURCE_NAME,
 					'ids'       => $order_post_ids,
-					'exception' => $exception,
+					'error    ' => $error,
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
@@ -57,7 +57,7 @@ abstract class TableMigrator {
 	 * @return mixed Whatever $wpdb->query returns.
 	 */
 	protected function db_query( string $query ) {
-		global $wpdb;
+		$wpdb = WC()->get_global( 'wpdb' );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( $query );
@@ -77,7 +77,7 @@ abstract class TableMigrator {
 	 * @return mixed Whatever $wpdb->get_results returns.
 	 */
 	protected function db_get_results( string $query = null, string $output = OBJECT ) {
-		global $wpdb;
+		$wpdb = WC()->get_global( 'wpdb' );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->get_results( $query, $output );

--- a/plugins/woocommerce/src/Proxies/LegacyProxy.php
+++ b/plugins/woocommerce/src/Proxies/LegacyProxy.php
@@ -96,4 +96,14 @@ class LegacyProxy {
 	public function call_static( $class_name, $method_name, ...$parameters ) {
 		return call_user_func_array( "$class_name::$method_name", $parameters );
 	}
+
+	/**
+	 * Get the value of a global.
+	 *
+	 * @param string $global_name The name of the global to get the value for.
+	 * @return mixed The value of the global.
+	 */
+	public function get_global( string $global_name ) {
+		return $GLOBALS[ $global_name ];
+	}
 }

--- a/plugins/woocommerce/src/Utilities/StringUtil.php
+++ b/plugins/woocommerce/src/Utilities/StringUtil.php
@@ -57,4 +57,20 @@ final class StringUtil {
 
 		return strcasecmp( $string, $ends_with ) === 0;
 	}
+
+	/**
+	 * Checks if one string is contained into another at any position.
+	 *
+	 * @param string $string The string we want to check.
+	 * @param string $contained The string we're looking for inside $string.
+	 * @param bool   $case_sensitive Indicates whether the comparison should be case-sensitive.
+	 * @return bool True if $contained is contained inside $string, false otherwise.
+	 */
+	public static function contains( string $string, string $contained, bool $case_sensitive = true ): bool {
+		if ( $case_sensitive ) {
+			return false !== strpos( $string, $contained );
+		} else {
+			return false !== stripos( $string, $contained );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/Tools/DynamicDecorator.php
+++ b/plugins/woocommerce/tests/Tools/DynamicDecorator.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * DynamicDecorator class file.
+ *
+ * @package WooCommerce\Testing\Tools
+ */
+
+namespace Automattic\WooCommerce\Testing\Tools;
+
+/**
+ * A class that allows to dynamically decorate an arbitrary object by selectively replace its public members,
+ * the decorator class can then be used as a replacement of the original object; invocations to non replaced members
+ * will be redirected to the decorated object. This is useful in the context of unit testing, especially when
+ * using mocks.
+ */
+class DynamicDecorator {
+
+	/**
+	 * The object being decorated.
+	 *
+	 * @var object
+	 */
+	public $decorated_object;
+
+	/**
+	 * This property is not used by the decorator itself, but may be optionally used by callers
+	 * in order to keep state information between member invocations, especially when using callbacks.
+	 *
+	 * @var mixed
+	 */
+	public $decorator_state;
+
+	/**
+	 * Replacement values or callbacks for property reads.
+	 *
+	 * @var array
+	 */
+	private $property_get_replacements = array();
+
+	/**
+	 * Replacement callbacks for property writes.
+	 *
+	 * @var array
+	 */
+	private $property_set_replacements = array();
+
+	/**
+	 * Replacement callbacks for methods.
+	 *
+	 * @var array
+	 */
+	private $method_replacements = array();
+
+	/**
+	 * Creates a new instance of the class.
+	 *
+	 * @param object $decorated_object Object that will be decorated.
+	 * @param mixed  $initial_state Initial value for the $decorator_state variable.
+	 */
+	public function __construct( object $decorated_object, $initial_state = null ) {
+		$this->decorated_object = $decorated_object;
+		$this->decorator_state  = $initial_state;
+	}
+
+	/**
+	 * Register a replacement value or callback to be used when a given property of the decorated object is read.
+	 *
+	 * If a callback is passed, it will be executed and its return value will be use as the value
+	 * read from the property. The callback must accept one argument: the decorator instance itself.
+	 *
+	 * If anything else is passed, then the supplied value will be directly used as the value read from the property.
+	 *
+	 * @param string         $property_name The name of the property to replace in the decorated object.
+	 * @param mixed|callable $replacement Either a value, or a callback accepting one argument (the decorator instance itself).
+	 * @return void
+	 */
+	public function register_property_get_replacement( string $property_name, $replacement ): void {
+		$this->property_get_replacements[ $property_name ] = $replacement;
+	}
+
+	/**
+	 * Register a replacement callback to be used when a given property of the decorated object is written.
+	 *
+	 * The return value from the callback will be executed instead of the property being set in the decorated object.
+	 * The callback must accept two argument: the decorator instance itself, and the value being set.
+	 *
+	 * @param string   $property_name The name of the property to replace in the decorated object.
+	 * @param callable $replacement A callback accepting two arguments (the decorator instance itself and the value being set).
+	 * @return void
+	 */
+	public function register_property_set_replacement( string $property_name, callable $replacement ) {
+		$this->property_set_replacements[ $property_name ] = $replacement;
+	}
+
+	/**
+	 * Register a replacement callback to be used when a given method is invoked in the decorated object.
+	 *
+	 * The callback will be executed in place of the actual method. The callback will receive the decorator
+	 * instance itself as the first argument, and then the rest of the arguments passed to the invoked method
+	 * in the same order. So e.g. for a method "foobar($a, $b, $c)" the callback will receive
+	 * ($decorator_instance, $a, $b, $c).
+	 *
+	 * @param string   $method_name The name of the method to replace in the decorated object.
+	 * @param callable $replacement A callback accepting as many argument as the replaced method plus one.
+	 * @return void
+	 */
+	public function register_method_replacement( string $method_name, callable $replacement ) {
+		$this->method_replacements[ $method_name ] = $replacement;
+	}
+
+	/**
+	 * Removes all the registered property and method replacements.
+	 *
+	 * @return void
+	 */
+	public function reset_replacements() {
+		$this->property_get_replacements = array();
+		$this->property_set_replacements = array();
+		$this->method_replacements       = array();
+	}
+
+	/**
+	 * Handle a method invocation, uses the registered replacement if available or redirects the call to the decorated object.
+	 *
+	 * @param string $name Method name.
+	 * @param array  $arguments Arguments for the method.
+	 * @return mixed Return value from either the replacement or the original method invocation.
+	 */
+	public function __call( $name, $arguments ) {
+		if ( array_key_exists( $name, $this->method_replacements ) ) {
+			array_unshift( $arguments, $this );
+			return call_user_func_array( $this->method_replacements[ $name ], $arguments );
+		} else {
+			return call_user_func_array( array( $this->decorated_object, $name ), $arguments );
+		}
+	}
+
+	/**
+	 * Handle a property read, uses the registered replacement if available or redirects the read to the decorated object.
+	 *
+	 * @param string $name Property name.
+	 * @return mixed Registered replacement value, return value from the registered replacement method, or value read from the decorated object.
+	 */
+	public function __get( $name ) {
+		if ( ! array_key_exists( $name, $this->property_get_replacements ) ) {
+			return $this->decorated_object->$name;
+		}
+
+		$replacement = $this->property_get_replacements[ $name ];
+		if ( is_callable( $replacement ) ) {
+			return $replacement( $this );
+		} else {
+			return $replacement;
+		}
+	}
+
+	/**
+	 * Handle a property write, uses the registered replacement if available or redirects the read to the decorated object.
+	 *
+	 * @param string $name Property name.
+	 * @param mixed  $value Value to set.
+	 * @return void
+	 */
+	public function __set( $name, $value ) {
+		if ( array_key_exists( $name, $this->property_set_replacements ) ) {
+			$this->property_set_replacements[ $name ]( $this, $value );
+		} else {
+			$this->decorated_object->$name = $value;
+		}
+	}
+}

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
@@ -255,6 +255,15 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	}
 
 	/**
+	 * Register the global mocks to use in the mockable LegacyProxy.
+	 *
+	 * @param array $mocks An associative array where keys are global names and values are the replacements for each global.
+	 */
+	public function register_legacy_proxy_global_mocks( array $mocks ) {
+		wc_get_container()->get( LegacyProxy::class )->register_global_mocks( $mocks );
+	}
+
+	/**
 	 * Asserts that a certain callable output is equivalent to a given piece of HTML.
 	 *
 	 * "Equivalent" means that the string representations of the HTML pieces are equal

--- a/plugins/woocommerce/tests/php/src/Proxies/DynamicDecoratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/DynamicDecoratorTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * DynamicDecorator class file
+ */
+
+namespace Automattic\WooCommerce\Tests\Proxies;
+
+use Automattic\WooCommerce\Testing\Tools\DynamicDecorator;
+use Automattic\WooCommerce\Tests\Proxies\ExampleClasses\ClassWithReplaceableMembers;
+
+/**
+ * Tests for DynamicDecorator
+ */
+class DynamicDecoratorTest extends \WC_Unit_Test_Case {
+	/**
+	 * The system under test.
+	 *
+	 * @var DynamicDecorator
+	 */
+	private $sut;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		$this->sut = new DynamicDecorator( new ClassWithReplaceableMembers() );
+	}
+
+	/**
+	 * @testdox A decorator with no replacements bypass all method invocations and property access to the decorated object.
+	 *
+	 * @return void
+	 */
+	public function test_decorator_with_no_actual_replacements() {
+		$this->assertEquals( 'Initial value of $some_property', $this->sut->some_property );
+
+		$this->sut->some_property = 'foobar';
+		$this->assertEquals( 'foobar', $this->sut->some_property );
+
+		$expected = '$some_method invoked with $a=1234, $b=foobar';
+		$actual   = $this->sut->some_method( 1234, 'foobar' );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox A replacement callback for a method receives the decorator instance and then the parameters of the original method.
+	 *
+	 * @return void
+	 */
+	public function test_method_replacement() {
+		$this->sut->register_method_replacement(
+			'some_method',
+			function( $decorator, $a, $b ) {
+				return "Replacement method invoked with \$a=$a, \$b=$b, " . $decorator->decorated_object->some_other_property;
+			}
+		);
+
+		$expected = 'Replacement method invoked with $a=1234, $b=foobar, hello';
+		$actual   = $this->sut->some_method( 1234, 'foobar' );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox A property read can be replaced with a fixed value.
+	 *
+	 * @return void
+	 */
+	public function test_property_get_replacement_with_value() {
+		$this->sut->register_property_get_replacement( 'some_property', 'replacement value' );
+
+		$this->assertEquals( 'replacement value', $this->sut->some_property );
+	}
+
+	/**
+	 * @testdox A property read can be replaced with a callback that receives the decorator instance as the only parameter.
+	 *
+	 * @return void
+	 */
+	public function test_property_get_replacement_with_callback() {
+		$this->sut->register_property_get_replacement(
+			'some_property',
+			function( $decorator ) {
+				return 'replacement value, ' . $decorator->decorated_object->some_other_property;
+			}
+		);
+
+		$this->assertEquals( 'replacement value, hello', $this->sut->some_property );
+	}
+
+	/**
+	 * @testdox A property write can be replaced with a callback that receives the decorator instance and the value being set as parameters.
+	 *
+	 * @return void
+	 */
+	public function test_property_set_replacement() {
+		$this->sut->register_property_set_replacement(
+			'some_property',
+			function( $decorator, $value ) {
+				$decorator->decorated_object->some_property = $decorator->decorated_object->some_other_property . ', ' . $value;
+			}
+		);
+
+		$this->sut->some_property = 'foobar';
+
+		$this->assertEquals( 'hello, foobar', $this->sut->some_property );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Proxies/ExampleClasses/ClassWithReplaceableMembers.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/ExampleClasses/ClassWithReplaceableMembers.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * ClassWithReplaceableMembers class file
+ */
+
+namespace Automattic\WooCommerce\Tests\Proxies\ExampleClasses;
+
+/**
+ * An example class with members that can be replaceable using the DynamicDecorator class.
+ */
+class ClassWithReplaceableMembers {
+	// phpcs:disable Squiz.Commenting
+
+	public $some_property;
+
+	public $some_other_property = 'hello';
+
+	public function __construct() {
+		$this->some_property = 'Initial value of $some_property';
+	}
+
+	public function some_method( $a, $b ) {
+		return "\$some_method invoked with \$a=$a, \$b=$b";
+	}
+
+	// phpcs:enable Squiz.Commenting
+}

--- a/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
@@ -95,4 +95,14 @@ class LegacyProxyTest extends \WC_Unit_Test_Case {
 		$result = $this->sut->call_static( DependencyClass::class, 'concat', 'foo', 'bar', 'fizz' );
 		$this->assertEquals( 'Parts: foo, bar, fizz', $result );
 	}
+
+	/**
+	 * @testdox 'get_global' can be used to get the value of a global.
+	 */
+	public function get_global_can_be_used_to_get_the_value_of_a_global() {
+		global $wpdb;
+
+		$result = $this->sut->get_global( 'wpdb' );
+		$this->assertEquals( $result, $wpdb );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Proxies/MockableLegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/MockableLegacyProxyTest.php
@@ -160,7 +160,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox
+	 * @testdox 'register_static_mocks' throws an exception if invalid parameters are supplied.
 	 *
 	 * @dataProvider data_provider_for_test_register_function_mocks_throws_if_invalid_parameters_supplied
 	 *
@@ -194,6 +194,38 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'get_global' works as in LegacyProxy if no global replacements are registered.
+	 */
+	public function test_get_global_works_as_regular_legacy_proxy_if_no_mocks_registered() {
+		global $wpdb;
+
+		$result = $this->sut->get_global( 'wpdb' );
+		$this->assertEquals( $wpdb, $result );
+	}
+
+	/**
+	 * @testdox 'get_global' can be used to reigster replacements for globals.
+	 */
+	public function test_register_global_mocks_can_be_used_to_replace_globals() {
+		$replacement_wpdb = new \stdClass();
+
+		$this->sut->register_global_mocks( array( 'wpdb' => $replacement_wpdb ) );
+
+		$result = $this->sut->get_global( 'wpdb' );
+		$this->assertEquals( $replacement_wpdb, $result );
+	}
+
+	/**
+	 * @testdox 'register_global_mocks' throws if invalid parameters are supplied.
+	 */
+	public function test_register_global_mocks_throws_if_invalid_parameters_are_supplied() {
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'MockableLegacyProxy::register_global_mocks: $mocks must be an associative array of global_name => value.' );
+
+		$this->sut->register_global_mocks( array( 1234 => new \stdClass() ) );
+	}
+
+	/**
 	 * @testdox 'reset' can be used to revert the instance to its original state, in which nothing is mocked.
 	 */
 	public function test_reset_can_be_used_to_unregister_all_mocks() {
@@ -217,10 +249,13 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 			)
 		);
 
+		$this->sut->register_global_mocks( array( 'wpdb' => new \stdClass() ) );
+
 		$this->sut->reset();
 
 		$this->test_call_function_works_as_regular_legacy_proxy_if_no_mocks_registered();
 		$this->test_call_static_works_as_regular_legacy_proxy_if_no_mocks_registered();
 		$this->test_call_static_works_as_regular_legacy_proxy_if_no_mocks_registered();
+		$this->test_get_global_works_as_regular_legacy_proxy_if_no_mocks_registered();
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/StringUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/StringUtilTest.php
@@ -48,4 +48,20 @@ class StringUtilTest extends \WC_Unit_Test_Case {
 		$this->assertTrue( StringUtil::ends_with( 'test', 'ST', false ) );
 		$this->assertTrue( StringUtil::ends_with( ' foo bar', ' BAR', false ) );
 	}
+
+	/**
+	 * @return void 'contains' should check whether one string contains another.
+	 */
+	public function test_contains() {
+		$this->assertFalse( StringUtil::contains( 'foobar', 'fizzbuzz' ) );
+		$this->assertFalse( StringUtil::contains( 'foobar', 'fizzbuzz', true ) );
+		$this->assertFalse( StringUtil::contains( 'foobar', 'fizzbuzz', false ) );
+
+		$this->assertFalse( StringUtil::contains( 'foobar', 'BA' ) );
+		$this->assertFalse( StringUtil::contains( 'foobar', 'BA', true ) );
+		$this->assertTrue( StringUtil::contains( 'foobar', 'ba' ) );
+		$this->assertTrue( StringUtil::contains( 'foobar', 'ba', true ) );
+
+		$this->assertTrue( StringUtil::contains( 'foobar', 'BA', false ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request improves the unit testing infrastructure by adding two new mechanisms:

* A way to mock global variables using the `LegacyProxy`. If you use `WC()->get_global('name')` from within the code to be tested instead of simply referencing the global, then you'll be able to do `$this->register_legacy_proxy_global_mocks( array( 'name' => $mock_value ) )` from within your unit tests.
* A new `DynamicDecorator` class. It wraps an arbitrary object and has methods to replace method calls and property read/writes; the decorator instance is then used in place of the original object.

As a "proof of concept" (but it's actual production code) unit tests are also added for the functionality that was introduced in https://github.com/woocommerce/woocommerce/pull/33034. A decorator for `$wpdb` is created that artificially introduces database errors and exceptions, and then `LegacyProxy` is used to replace the global `$wpdb` with the decorator.

**Note for reviewers:** The actual change in `class-woocommerce.php` is the introduction of the `get_global` method, everything else are adjustments to make the code sniffer happy.

### How to test the changes in this Pull Request:

Run the unit tests introduced in the pull request.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
