### PR TITLE
Remove 6.6 changelog files

### DIFF
--- a/plugins/woocommerce/changelog/31477-remove-coupon-js
+++ b/plugins/woocommerce/changelog/31477-remove-coupon-js
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Ensure observers of the `removed_coupon_in_checkout` event can access the coupon code successfully.

--- a/plugins/woocommerce/changelog/add-32143-add-experimental-import-products
+++ b/plugins/woocommerce/changelog/add-32143-add-experimental-import-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add experimental import product task, which replaces the default add products task when selling elsewhere is selected during the OBW.

--- a/plugins/woocommerce/changelog/add-32156_preview-store-button
+++ b/plugins/woocommerce/changelog/add-32156_preview-store-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add Preview store button to Home screen #32739

--- a/plugins/woocommerce/changelog/add-32160-add-reminder-badge
+++ b/plugins/woocommerce/changelog/add-32160-add-reminder-badge
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adding badge to homescreen item on admin menu for setup tasks

--- a/plugins/woocommerce/changelog/add-32178
+++ b/plugins/woocommerce/changelog/add-32178
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add filtered tracks properties to client-side tracks #32690

--- a/plugins/woocommerce/changelog/add-32412-load-sample-products
+++ b/plugins/woocommerce/changelog/add-32412-load-sample-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add load sample products for experimental product task

--- a/plugins/woocommerce/changelog/add-32634-add-products-task
+++ b/plugins/woocommerce/changelog/add-32634-add-products-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add experimental add product for task list

--- a/plugins/woocommerce/changelog/add-32671
+++ b/plugins/woocommerce/changelog/add-32671
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add tracks to products list page #32949

--- a/plugins/woocommerce/changelog/add-32762
+++ b/plugins/woocommerce/changelog/add-32762
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add legal messaging on WCPay task and fix click behavior

--- a/plugins/woocommerce/changelog/add-32772-exp-product-tasks-feature-flag
+++ b/plugins/woocommerce/changelog/add-32772-exp-product-tasks-feature-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add experimental product task feature flag & experimental-products component

--- a/plugins/woocommerce/changelog/add-32789-add-experimental-import-products
+++ b/plugins/woocommerce/changelog/add-32789-add-experimental-import-products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add experimental import product task feature flag & experimental-import products component

--- a/plugins/woocommerce/changelog/add-32811-import-prdocuts-tracks
+++ b/plugins/woocommerce/changelog/add-32811-import-prdocuts-tracks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add track events for experimental import products task

--- a/plugins/woocommerce/changelog/add-32850-add-tiktok-plugin-to-the-marketing-task
+++ b/plugins/woocommerce/changelog/add-32850-add-tiktok-plugin-to-the-marketing-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add TikTok for Business plugin in the Marketing task #32850

--- a/plugins/woocommerce/changelog/add-32859-fashion-sample-products
+++ b/plugins/woocommerce/changelog/add-32859-fashion-sample-products
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add fashion sample products

--- a/plugins/woocommerce/changelog/add-32933_task_view_prop_experimental_products
+++ b/plugins/woocommerce/changelog/add-32933_task_view_prop_experimental_products
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Add
-
-Add task_view tracks prop for experimental products #32933

--- a/plugins/woocommerce/changelog/add-32944_experimental_products_tracks_events
+++ b/plugins/woocommerce/changelog/add-32944_experimental_products_tracks_events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Add
-
-Added events for experimental products page #32944

--- a/plugins/woocommerce/changelog/add-33022-add-explat-usage
+++ b/plugins/woocommerce/changelog/add-33022-add-explat-usage
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Add ExPlat usage.

--- a/plugins/woocommerce/changelog/add-33052_task_view_track_event_polling
+++ b/plugins/woocommerce/changelog/add-33052_task_view_track_event_polling
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Removed experimental product hook and instead poll the slot's fill for variant metadata. To be removed when experiment concludes! #33052

--- a/plugins/woocommerce/changelog/add-order-state-fields
+++ b/plugins/woocommerce/changelog/add-order-state-fields
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add the `is_editable`, `needs_payment`, and `needs_processing` boolean properties to order response objects in both v2 and v3 of the WC REST API.

--- a/plugins/woocommerce/changelog/add-pay-for-order-express-checkout-action
+++ b/plugins/woocommerce/changelog/add-pay-for-order-express-checkout-action
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adds a `before_woocommerce_pay_form` action to the Pay for Order page.

--- a/plugins/woocommerce/changelog/add-product-stack
+++ b/plugins/woocommerce/changelog/add-product-stack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add experimental product stack component

--- a/plugins/woocommerce/changelog/add-support-select2-for-log_file-dropdown
+++ b/plugins/woocommerce/changelog/add-support-select2-for-log_file-dropdown
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add support for select2 for the log files dropdown

--- a/plugins/woocommerce/changelog/add-track_mini_cart_block
+++ b/plugins/woocommerce/changelog/add-track_mini_cart_block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Adds usage data for the Mini Cart Block to the WC Tracker snapshot.

--- a/plugins/woocommerce/changelog/add-view-more-product-type-track
+++ b/plugins/woocommerce/changelog/add-view-more-product-type-track
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add wcadmin_tasklist_view_more_product_types_click track event for add product task

--- a/plugins/woocommerce/changelog/add-wc-payment-gateways-banner
+++ b/plugins/woocommerce/changelog/add-wc-payment-gateways-banner
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Added react mount point in payment settings page for banner slotfill #32697

--- a/plugins/woocommerce/changelog/add-wctracker-dropins
+++ b/plugins/woocommerce/changelog/add-wctracker-dropins
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add dropins to WCTracker

--- a/plugins/woocommerce/changelog/api-28508-search-including-sku
+++ b/plugins/woocommerce/changelog/api-28508-search-including-sku
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adds  a `search_sku` parameter to the v3 products endpoint. Allows for partial match search of the product SKU field.

--- a/plugins/woocommerce/changelog/bump-wp-tested-to
+++ b/plugins/woocommerce/changelog/bump-wp-tested-to
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Bumps the WP version for the WP tested up to.

--- a/plugins/woocommerce/changelog/cot-32663
+++ b/plugins/woocommerce/changelog/cot-32663
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Modify migration to make cot.id === posts.id.

--- a/plugins/woocommerce/changelog/cot-32669
+++ b/plugins/woocommerce/changelog/cot-32669
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add `read` method to custom order table datastore.

--- a/plugins/woocommerce/changelog/cot-32917
+++ b/plugins/woocommerce/changelog/cot-32917
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-CLI support for running COT migrations (one way).

--- a/plugins/woocommerce/changelog/cot-backfill
+++ b/plugins/woocommerce/changelog/cot-backfill
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Implement backfill for wp_post and wp_postmeta table for custom tables.

--- a/plugins/woocommerce/changelog/cot-effectively_sync_posts_to_cot
+++ b/plugins/woocommerce/changelog/cot-effectively_sync_posts_to_cot
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Effectively synchronize orders from the posts table to the custom orders table.

--- a/plugins/woocommerce/changelog/cot-meta_migrations
+++ b/plugins/woocommerce/changelog/cot-meta_migrations
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Enable meta table to meta table migrations towards custom table project.

--- a/plugins/woocommerce/changelog/dev-32575-add-generic-fallback-image-payments-task
+++ b/plugins/woocommerce/changelog/dev-32575-add-generic-fallback-image-payments-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add fallback image for payments task gateway icons

--- a/plugins/woocommerce/changelog/dev-32635-implement-product-task-experiment
+++ b/plugins/woocommerce/changelog/dev-32635-implement-product-task-experiment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add ExPlat call for product task experiment

--- a/plugins/woocommerce/changelog/dev-32719-remove-wc-admin-set-up-additional-payment-types-note
+++ b/plugins/woocommerce/changelog/dev-32719-remove-wc-admin-set-up-additional-payment-types-note
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove wc-admin-set-up-additional-payment-types inbox note

--- a/plugins/woocommerce/changelog/dev-follow-up-product-task-experiment
+++ b/plugins/woocommerce/changelog/dev-follow-up-product-task-experiment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Moved out product task experiment hook to onboarding package, added ExPlat logic to backend calls

--- a/plugins/woocommerce/changelog/e2e-rep-gh-pages
+++ b/plugins/woocommerce/changelog/e2e-rep-gh-pages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-

--- a/plugins/woocommerce/changelog/fix-27364-api-order-lineitem-image
+++ b/plugins/woocommerce/changelog/fix-27364-api-order-lineitem-image
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add an 'image_src' field to product line items returned by the orders endpoint (v2 and v3). This contains the URL of the main product image.

--- a/plugins/woocommerce/changelog/fix-29705-tests-install
+++ b/plugins/woocommerce/changelog/fix-29705-tests-install
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add basic pre-requisite checking to the test suite installation script.

--- a/plugins/woocommerce/changelog/fix-32016-shipping-zones-loop
+++ b/plugins/woocommerce/changelog/fix-32016-shipping-zones-loop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Allow removal of all zone regions from a shipping zone

--- a/plugins/woocommerce/changelog/fix-32028-settings-method-exists-fatal
+++ b/plugins/woocommerce/changelog/fix-32028-settings-method-exists-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix possible fatal error during install on PHP 8.x

--- a/plugins/woocommerce/changelog/fix-32149_mark_marketing_task_as_complete
+++ b/plugins/woocommerce/changelog/fix-32149_mark_marketing_task_as_complete
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Mark marketing task as complete when an extension is installed #32630

--- a/plugins/woocommerce/changelog/fix-32600-vietnam
+++ b/plugins/woocommerce/changelog/fix-32600-vietnam
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-For Vietnam, the second street address line should be displayed but not required.

--- a/plugins/woocommerce/changelog/fix-32705
+++ b/plugins/woocommerce/changelog/fix-32705
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixing bug on sectioned task list for tasks with actionUrl property

--- a/plugins/woocommerce/changelog/fix-32714_wcpay_blank_page
+++ b/plugins/woocommerce/changelog/fix-32714_wcpay_blank_page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Addressing issues with certain tasks in task list experiment leading to blank page. #32742

--- a/plugins/woocommerce/changelog/fix-32720_progress-header-title
+++ b/plugins/woocommerce/changelog/fix-32720_progress-header-title
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix progress header title #32786

--- a/plugins/woocommerce/changelog/fix-32733-database-errors
+++ b/plugins/woocommerce/changelog/fix-32733-database-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix database errors after deleting WC Admin standalone plugin while WC 6.5 is active

--- a/plugins/woocommerce/changelog/fix-32745_task_list_experiment_1_tracks
+++ b/plugins/woocommerce/changelog/fix-32745_task_list_experiment_1_tracks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix event names for tracks in new Task List. #32759

--- a/plugins/woocommerce/changelog/fix-32751-remove-wcpay-in-core-experiment-request
+++ b/plugins/woocommerce/changelog/fix-32751-remove-wcpay-in-core-experiment-request
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Remove `woocommerce_payments_menu_promo_nz_ie` experiment request

--- a/plugins/woocommerce/changelog/fix-32754-inactive-downloads
+++ b/plugins/woocommerce/changelog/fix-32754-inactive-downloads
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: We're adding extra protections to a newly introduced feature; a further changelog entry is not needed.
-
-

--- a/plugins/woocommerce/changelog/fix-32761-exp2-task-no-padding
+++ b/plugins/woocommerce/changelog/fix-32761-exp2-task-no-padding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix no padding between the task section and things to do next in experiment 2

--- a/plugins/woocommerce/changelog/fix-32797-wca-fatal
+++ b/plugins/woocommerce/changelog/fix-32797-wca-fatal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix fatal errors when activated alongside WooCommerce Admin plugin

--- a/plugins/woocommerce/changelog/fix-32802_update_copy_and_illustrations
+++ b/plugins/woocommerce/changelog/fix-32802_update_copy_and_illustrations
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update illustrations and copy of new task list. #32805

--- a/plugins/woocommerce/changelog/fix-32863-get-option-deprecated-notices
+++ b/plugins/woocommerce/changelog/fix-32863-get-option-deprecated-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix get_options function deprecation notice

--- a/plugins/woocommerce/changelog/fix-32896_two_tasklists
+++ b/plugins/woocommerce/changelog/fix-32896_two_tasklists
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Update finish setup button logic to adhere to new Task List data structure. #32926

--- a/plugins/woocommerce/changelog/fix-32956-notice-on-empty-product-page
+++ b/plugins/woocommerce/changelog/fix-32956-notice-on-empty-product-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix notice on emptry product page

--- a/plugins/woocommerce/changelog/fix-32962_fatal_error_wc_admin_conflict
+++ b/plugins/woocommerce/changelog/fix-32962_fatal_error_wc_admin_conflict
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix issue where FeaturePlugin class caused a conflict with older WooCommerce Admin versions. #32966

--- a/plugins/woocommerce/changelog/fix-32962_multisite_disable
+++ b/plugins/woocommerce/changelog/fix-32962_multisite_disable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Make sure WooCommerce Admin is also being disabled on multi sites. #32981

--- a/plugins/woocommerce/changelog/fix-33053-fix-logo-spacing
+++ b/plugins/woocommerce/changelog/fix-33053-fix-logo-spacing
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Fix spacing between the Paymetn logo assets in the payment banner experiment.

--- a/plugins/woocommerce/changelog/fix-33055-skip-payment-welcome-screen-for-wcpay-setup
+++ b/plugins/woocommerce/changelog/fix-33055-skip-payment-welcome-screen-for-wcpay-setup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Skip payment welcome screen for wc pay banner experiment

--- a/plugins/woocommerce/changelog/fix-33083-fix-broken-events-tracking-assignment-to-const
+++ b/plugins/woocommerce/changelog/fix-33083-fix-broken-events-tracking-assignment-to-const
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed broken event tracking by correcting 'const' to 'let' from a previous commit #33083

--- a/plugins/woocommerce/changelog/fix-650-update-routines
+++ b/plugins/woocommerce/changelog/fix-650-update-routines
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Omitting a changelog entry, because we're correcting an unreleased oversight.
-
-

--- a/plugins/woocommerce/changelog/fix-admin-payment-type
+++ b/plugins/woocommerce/changelog/fix-admin-payment-type
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix typescript type errors in react admin `payments` & `payment-welcome`

--- a/plugins/woocommerce/changelog/fix-admin-remaining-task-types
+++ b/plugins/woocommerce/changelog/fix-admin-remaining-task-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix remaining typescript type errors in react admin

--- a/plugins/woocommerce/changelog/fix-admin-task-types
+++ b/plugins/woocommerce/changelog/fix-admin-task-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix typescript type errors in react admin ./client/tasks/task & ./client/tasks/tests

--- a/plugins/woocommerce/changelog/fix-admin-two-column-tasks-types
+++ b/plugins/woocommerce/changelog/fix-admin-two-column-tasks-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix typescript type errors in react admin ./client/two-column/tasks

--- a/plugins/woocommerce/changelog/fix-admin-types
+++ b/plugins/woocommerce/changelog/fix-admin-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Add @types/* & declare TS modules to fix admin TS errors

--- a/plugins/woocommerce/changelog/fix-change-tiktok-icon
+++ b/plugins/woocommerce/changelog/fix-change-tiktok-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update TikTok onboarding icon

--- a/plugins/woocommerce/changelog/fix-client-shipping-typescritp-errors
+++ b/plugins/woocommerce/changelog/fix-client-shipping-typescritp-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Fix typescript type errors in react admin ./client/shipping

--- a/plugins/woocommerce/changelog/fix-core-build-scripts
+++ b/plugins/woocommerce/changelog/fix-core-build-scripts
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Standardize WooCommerce build scripts

--- a/plugins/woocommerce/changelog/fix-download-file-warnings
+++ b/plugins/woocommerce/changelog/fix-download-file-warnings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Improves a newly added feature, so a further changelog entry is not required.
-
-

--- a/plugins/woocommerce/changelog/fix-download_dir_table_key
+++ b/plugins/woocommerce/changelog/fix-download_dir_table_key
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Specify a maximum index size for the URL column in the Download Directories table.

--- a/plugins/woocommerce/changelog/fix-e2e-tests
+++ b/plugins/woocommerce/changelog/fix-e2e-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Related to QOL
-
-

--- a/plugins/woocommerce/changelog/fix-email-template--path
+++ b/plugins/woocommerce/changelog/fix-email-template--path
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Update path to email template for analytics report.

--- a/plugins/woocommerce/changelog/fix-errors-flash-messaging
+++ b/plugins/woocommerce/changelog/fix-errors-flash-messaging
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Changes to reduce the risk of admin error messages being discarded prematurely.

--- a/plugins/woocommerce/changelog/fix-exclude-drafts-in-reports
+++ b/plugins/woocommerce/changelog/fix-exclude-drafts-in-reports
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Don't include draft orders in reports

--- a/plugins/woocommerce/changelog/fix-hook_removal_from_32460
+++ b/plugins/woocommerce/changelog/fix-hook_removal_from_32460
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: This fixes a bug that was introduced in a PR targetting the same Woo version.
-
-

--- a/plugins/woocommerce/changelog/fix-janky-hover-on-product-task
+++ b/plugins/woocommerce/changelog/fix-janky-hover-on-product-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix janky border on hover product task items

--- a/plugins/woocommerce/changelog/fix-json-formatting
+++ b/plugins/woocommerce/changelog/fix-json-formatting
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: This is a JSON formatting change.
-
-

--- a/plugins/woocommerce/changelog/fix-mini_cart_block-tests-failing
+++ b/plugins/woocommerce/changelog/fix-mini_cart_block-tests-failing
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Check WP version 5.9 before adding mini_cart_block to WC Tracker

--- a/plugins/woocommerce/changelog/fix-nested-link-in-products-import-task
+++ b/plugins/woocommerce/changelog/fix-nested-link-in-products-import-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Change product import task items to use onClick for link

--- a/plugins/woocommerce/changelog/fix-product_attributes_lookup_table_update
+++ b/plugins/woocommerce/changelog/fix-product_attributes_lookup_table_update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Product attributes lookup table is now properly updated on WooCommerce upgrade and when using REST API batch endpoints

--- a/plugins/woocommerce/changelog/fix-products-api-method-visibility
+++ b/plugins/woocommerce/changelog/fix-products-api-method-visibility
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Changelog added in #32046, which has not yet been released, and this simply fixes a bug from that.

--- a/plugins/woocommerce/changelog/fix-remove-deactivate-wcadmin-note
+++ b/plugins/woocommerce/changelog/fix-remove-deactivate-wcadmin-note
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add wc-admin-deactivate-plugin to list of obselete notes so it gets deleted on upgrade

--- a/plugins/woocommerce/changelog/fix-sanitize-notes-order-by
+++ b/plugins/woocommerce/changelog/fix-sanitize-notes-order-by
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Sanitize order and orderby args in get_notes and lookup_notes. #32614

--- a/plugins/woocommerce/changelog/fix-standardize-lint-woocommerce-plugin
+++ b/plugins/woocommerce/changelog/fix-standardize-lint-woocommerce-plugin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Standardize lint scripts: Add lint:fix

--- a/plugins/woocommerce/changelog/fix-starter-pack-monorepo
+++ b/plugins/woocommerce/changelog/fix-starter-pack-monorepo
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Update create-extension script to function in the monorepo.

--- a/plugins/woocommerce/changelog/fix-storybook-location
+++ b/plugins/woocommerce/changelog/fix-storybook-location
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Move Storybook to better monorepo location

--- a/plugins/woocommerce/changelog/fix-task-list-style-conflict
+++ b/plugins/woocommerce/changelog/fix-task-list-style-conflict
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix setup task list style conflict #32704

--- a/plugins/woocommerce/changelog/fix-tax_data_rounded_on_save
+++ b/plugins/woocommerce/changelog/fix-tax_data_rounded_on_save
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Display the raw 6 decimal place tax data while editing line item

--- a/plugins/woocommerce/changelog/fix-update-wcpay-banner-tos-link
+++ b/plugins/woocommerce/changelog/fix-update-wcpay-banner-tos-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix payment settings banner tos link

--- a/plugins/woocommerce/changelog/fix-woocommerce-admin-build
+++ b/plugins/woocommerce/changelog/fix-woocommerce-admin-build
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: This is a developer tooling change
-
-

--- a/plugins/woocommerce/changelog/fix-wp-admin-scripts-type
+++ b/plugins/woocommerce/changelog/fix-wp-admin-scripts-type
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Fix typescript type errors in react admin ./client/wp-admin-scripts

--- a/plugins/woocommerce/changelog/fix-wrap-import-products-under-experiment
+++ b/plugins/woocommerce/changelog/fix-wrap-import-products-under-experiment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update product import task to appear only under experiment

--- a/plugins/woocommerce/changelog/issue-32843
+++ b/plugins/woocommerce/changelog/issue-32843
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add 'recorded_sales' meta to operational data table.

--- a/plugins/woocommerce/changelog/move-DatabaseUtil-class-to-proper-directory
+++ b/plugins/woocommerce/changelog/move-DatabaseUtil-class-to-proper-directory
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Move the file for the DatabaseUtil class to the proper directory according to its namespace.

--- a/plugins/woocommerce/changelog/patch-8
+++ b/plugins/woocommerce/changelog/patch-8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Prevent errors and log a warning in the event the WP Filesystem cannot be initialized while updating the geoloc database.

--- a/plugins/woocommerce/changelog/performance-merchant-view-coupons
+++ b/plugins/woocommerce/changelog/performance-merchant-view-coupons
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: No entry needed because this change only added a new performance test.
-
-

--- a/plugins/woocommerce/changelog/pr-31788
+++ b/plugins/woocommerce/changelog/pr-31788
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add formatting rules for Latvian postcodes.

--- a/plugins/woocommerce/changelog/pr-32577
+++ b/plugins/woocommerce/changelog/pr-32577
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add exception handling to serialize when seriliazing context.

--- a/plugins/woocommerce/changelog/pr-32743
+++ b/plugins/woocommerce/changelog/pr-32743
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Also allow getting category ID as option ID instead of term slug in wc-enhanced-select.

--- a/plugins/woocommerce/changelog/pr-32747
+++ b/plugins/woocommerce/changelog/pr-32747
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add check for $wp_query before calling is_cart to prevent doing_it_wrong notice.

--- a/plugins/woocommerce/changelog/pr-32886-update-sniffs
+++ b/plugins/woocommerce/changelog/pr-32886-update-sniffs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Updates the WC sniffs version to latest.

--- a/plugins/woocommerce/changelog/pr-32980
+++ b/plugins/woocommerce/changelog/pr-32980
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Revert 30204 for Indian pincode to "PIN Code"

--- a/plugins/woocommerce/changelog/prep-post-6.5.1
+++ b/plugins/woocommerce/changelog/prep-post-6.5.1
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
- Updates the stable tag and changelog from 6.5.1 release.

--- a/plugins/woocommerce/changelog/refactor-standardize-postinstall
+++ b/plugins/woocommerce/changelog/refactor-standardize-postinstall
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Tooling change
-
-

--- a/plugins/woocommerce/changelog/remove-admin-tests-folder
+++ b/plugins/woocommerce/changelog/remove-admin-tests-folder
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Simply remove woocommerce-admin tests folder
-
-

--- a/plugins/woocommerce/changelog/remove-post_id-from-orders-table
+++ b/plugins/woocommerce/changelog/remove-post_id-from-orders-table
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Remove the post_id column from the orders table, and adjust the SQL queries that count/get out of sync orders accordingly.

--- a/plugins/woocommerce/changelog/update-32410-deprecated-wca-classes-have-wca-versions
+++ b/plugins/woocommerce/changelog/update-32410-deprecated-wca-classes-have-wca-versions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Use the core version for the @deprecated tags in WCA

--- a/plugins/woocommerce/changelog/update-32410-use-the-core-version-for-deprecated-tags
+++ b/plugins/woocommerce/changelog/update-32410-use-the-core-version-for-deprecated-tags
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Use the core version for the @deprecated tags

--- a/plugins/woocommerce/changelog/update-32451-wcpay-task-display-logic
+++ b/plugins/woocommerce/changelog/update-32451-wcpay-task-display-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Change WCPayments task display logic

--- a/plugins/woocommerce/changelog/update-32508_pnpx_deprecated
+++ b/plugins/woocommerce/changelog/update-32508_pnpx_deprecated
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Updating instance of now-deprecated pnpx to pnpm dlx/exec

--- a/plugins/woocommerce/changelog/update-32716-explat-api-requests
+++ b/plugins/woocommerce/changelog/update-32716-explat-api-requests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Add safeguards to ensure ExPlat API requests are valid

--- a/plugins/woocommerce/changelog/update-32911-remove-explat-calls-for-headercard-exp
+++ b/plugins/woocommerce/changelog/update-32911-remove-explat-calls-for-headercard-exp
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Remove ExPlat calls for woocommerce_tasklist_progression_headercard_2col_2022_05 and woocommerce_tasklist_progression_headercard_2022_05

--- a/plugins/woocommerce/changelog/update-33056-update-the-wcpay-description
+++ b/plugins/woocommerce/changelog/update-33056-update-the-wcpay-description
@@ -1,5 +1,0 @@
-Significance: minor
-Type: update
-
-Payment banner experiment: update the description and make the button to redirect the users to the WC Pay connect page when the WC Pay is
-already installed

--- a/plugins/woocommerce/changelog/update-33062-subscriptions-product-type-only-in-the-us
+++ b/plugins/woocommerce/changelog/update-33062-subscriptions-product-type-only-in-the-us
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update add product task to only show "subscriptions" product type for stores in the US

--- a/plugins/woocommerce/changelog/update-admin-tsconfig-config
+++ b/plugins/woocommerce/changelog/update-admin-tsconfig-config
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Update woo admin ts config to have an isolated TS environment

--- a/plugins/woocommerce/changelog/update-api-system-status-performance
+++ b/plugins/woocommerce/changelog/update-api-system-status-performance
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Fix system status API requests that only query some fields

--- a/plugins/woocommerce/changelog/update-bash-zip
+++ b/plugins/woocommerce/changelog/update-bash-zip
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Updating scripts to use pnpm/Nx commands

--- a/plugins/woocommerce/changelog/update-center-view-more-button
+++ b/plugins/woocommerce/changelog/update-center-view-more-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Center experimental products view more button

--- a/plugins/woocommerce/changelog/update-convert-woo-tracks-to-ts
+++ b/plugins/woocommerce/changelog/update-convert-woo-tracks-to-ts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove woo tracks type declaration from woo admin ./cleint.

--- a/plugins/woocommerce/changelog/update-eable-feature-flags-for-product-task
+++ b/plugins/woocommerce/changelog/update-eable-feature-flags-for-product-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Enable feature flags for add product task

--- a/plugins/woocommerce/changelog/update-k6-merch-wc-home-assert
+++ b/plugins/woocommerce/changelog/update-k6-merch-wc-home-assert
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: updating performance test request
-
-

--- a/plugins/woocommerce/changelog/update-memoize-one
+++ b/plugins/woocommerce/changelog/update-memoize-one
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove `memoize-one` from woo admin dependency

--- a/plugins/woocommerce/changelog/update-react-dates
+++ b/plugins/woocommerce/changelog/update-react-dates
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove `react-dates` from woo admin dependency

--- a/plugins/woocommerce/changelog/update-refactor-and-improve-tests-payments-task
+++ b/plugins/woocommerce/changelog/update-refactor-and-improve-tests-payments-task
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Refactor and improve tests payments task

--- a/plugins/woocommerce/changelog/update-system-status-report
+++ b/plugins/woocommerce/changelog/update-system-status-report
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Add status of admin items to system status report

--- a/plugins/woocommerce/changelog/update-task-completion-time
+++ b/plugins/woocommerce/changelog/update-task-completion-time
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update to record completion time in time frame format

--- a/plugins/woocommerce/changelog/update-woo-data-types
+++ b/plugins/woocommerce/changelog/update-woo-data-types
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix react admin ./client type errors after updating @woocommerce/data types

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Woo Blocks 7.3.0 & 7.4.1

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.3
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update to WooCommerce Blocks 7.4.3

--- a/plugins/woocommerce/changelog/use-configured-decimal-separator-for-product-weight-and-dimensions
+++ b/plugins/woocommerce/changelog/use-configured-decimal-separator-for-product-weight-and-dimensions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use the configured decimal separator to format product weight and dimensions

--- a/plugins/woocommerce/changelog/wcpay-subscriptions-menu-item-experiment
+++ b/plugins/woocommerce/changelog/wcpay-subscriptions-menu-item-experiment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a WooCommerce > Subscriptions menu item for eligible stores to offer WC Payments Subscriptions functionality


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR cherry-picks the commit that removes 6.6 (and previous changelog files) from #33148

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Verify that the changelog files being removed come from #33148 (check that the same number of files are removed)

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
