### PR TITLE
Fix low stock threshold input wrapper to clear on floating element

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -236,7 +236,7 @@ defined( 'ABSPATH' ) || exit;
 							'custom_attributes' => array(
 								'step' => 'any',
 							),
-							'wrapper_class' => 'form-row',
+							'wrapper_class' => 'form-row form-row-full',
 						)
 					);
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Low stock threshold input wrapper in admin variation product does not have clear property (e.g. form-row-full). Without clear property, the low stock threshold label filled up the space in between form-row-first and form-row-last classes (floating element).

<img width="945" alt="Screenshot 2022-05-22 at 2 15 07 PM" src="https://user-images.githubusercontent.com/9669062/169681668-da62928a-72a4-42c7-8257-fa353de268d1.png">

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?
