### PR TITLE
Fix PHP notice when `woocommerce_admin_disabled` filter is used

### DIFF
--- a/plugins/woocommerce/changelog/fix-33086-admin-disable-filter-notice
+++ b/plugins/woocommerce/changelog/fix-33086-admin-disable-filter-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix notice on woocommerce_admin_disabled filter enabled

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -345,7 +345,9 @@ class Loader {
 				$group_settings   = $setting_options->get_group_settings( $group );
 				$preload_settings = [];
 				foreach ( $group_settings as $option ) {
-					$preload_settings[ $option['id'] ] = $option['value'];
+					if ( array_key_exists( 'id', $option ) && array_key_exists( 'value', $option ) ) {
+						$preload_settings[ $option['id'] ] = $option['value'];
+					}
 				}
 				$settings['preloadSettings'][ $group ] = $preload_settings;
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -159,7 +159,9 @@ class Settings {
 				$group_settings   = $setting_options->get_group_settings( $group );
 				$preload_settings = [];
 				foreach ( $group_settings as $option ) {
-					$preload_settings[ $option['id'] ] = $option['value'];
+					if ( array_key_exists( 'id', $option ) && array_key_exists( 'value', $option ) ) {
+						$preload_settings[ $option['id'] ] = $option['value'];
+					}
 				}
 				$settings['preloadSettings'][ $group ] = $preload_settings;
 			}


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Closes #33086.

This PR adds a simple check to prevent PHP notice on uninitialized array elements.

### How to test the changes in this Pull Request:

1. Make sure PHP & WordPress debugging is enabled
2. Navigate to WooCommerce > Home
3. Open `wp-content/debug.log`
4. Observe no "Undefined index" notice appear.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
