### PR TITLE
Fix the styling of the frame in the Leaderboard section of Analytics.

### DIFF
--- a/plugins/woocommerce-admin/client/dashboard/leaderboards/index.js
+++ b/plugins/woocommerce-admin/client/dashboard/leaderboards/index.js
@@ -122,16 +122,21 @@ const Leaderboards = ( props ) => {
 						hiddenBlocks,
 						onToggleHiddenBlock,
 					} ) }
-					<SelectControl
-						className="woocommerce-dashboard__dashboard-leaderboards__select"
-						label={ __( 'Rows per table', 'woocommerce' ) }
-						value={ rowsPerTable }
-						options={ Array.from( { length: 20 }, ( v, key ) => ( {
-							v: key + 1,
-							label: key + 1,
-						} ) ) }
-						onChange={ setRowsPerTable }
-					/>
+					<MenuItem>
+						<SelectControl
+							className="woocommerce-dashboard__dashboard-leaderboards__select"
+							label={ __( 'Rows per table', 'woocommerce' ) }
+							value={ rowsPerTable }
+							options={ Array.from(
+								{ length: 20 },
+								( v, key ) => ( {
+									v: key + 1,
+									label: key + 1,
+								} )
+							) }
+							onChange={ setRowsPerTable }
+						/>
+					</MenuItem>
 					<Controls
 						onToggle={ onToggle }
 						onMove={ onMove }

--- a/plugins/woocommerce/changelog/fix-leaderboard-menu-styling
+++ b/plugins/woocommerce/changelog/fix-leaderboard-menu-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the styling of the frame in the Leaderboard section of Analytics. #33163


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Correct the styling in the dropdown menu item.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #https://github.com/woocommerce/woocommerce/issues/32186 

### How to test the changes in this Pull Request:
1. Go to Analytics -> Leaderboards -> Ellipsis Menu -> Rows per table
2. Verify the layout:
<img width="212" alt="Screenshot 2022-05-23 at 16 41 54" src="https://user-images.githubusercontent.com/13561163/169856363-d1829357-d7b3-443c-a2c7-82f45de239e2.png">
