### PR TITLE
Use term ID to query category IDs in analytics

### DIFF
--- a/plugins/woocommerce/changelog/fix-33141
+++ b/plugins/woocommerce/changelog/fix-33141
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use term ID to query category IDs in analytics #33164

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/DataStore.php
@@ -303,8 +303,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	protected function initialize_queries() {
 		global $wpdb;
 		$this->subquery = new SqlQuery( $this->context . '_subquery' );
-		$this->subquery->add_sql_clause( 'select', "{$wpdb->term_taxonomy}.term_taxonomy_id as category_id," );
+		$this->subquery->add_sql_clause( 'select', "{$wpdb->term_taxonomy}.term_id as category_id," );
 		$this->subquery->add_sql_clause( 'from', self::get_db_table_name() );
-		$this->subquery->add_sql_clause( 'group_by', "{$wpdb->term_taxonomy}.term_taxonomy_id" );
+		$this->subquery->add_sql_clause( 'group_by', "{$wpdb->term_taxonomy}.term_id" );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes querying of categories in analytics by using `term_id` instead of `term_taxonomy_id`.

cc @chihsuan to double check if there was a reason or edge case for using `term_taxonomy_id`.

Closes #33141, closes #32387, closes WOOPLUG-654

### How to test the changes in this Pull Request:

1. Create some categories
2. Place some orders with products in various categories
3. Navigate to Analytics->Categories
4. Make sure the categories and category names load as expected

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
