### PR TITLE
Orders API: Add decimal-place formatting to tax totals in order line items

### DIFF
--- a/plugins/woocommerce/changelog/fix-33143-line-item-tax-precision
+++ b/plugins/woocommerce/changelog/fix-33143-line-item-tax-precision
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add decimal-place formatting to tax totals in the orders API response line items. Affects both v2 and v3 of the API.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -242,10 +242,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			$taxes = array();
 
 			foreach ( $data['taxes']['total'] as $tax_rate_id => $tax ) {
+				$subtotal = isset( $data['taxes']['subtotal'][ $tax_rate_id ] ) ? $data['taxes']['subtotal'][ $tax_rate_id ] : '';
+
 				$taxes[] = array(
 					'id'       => $tax_rate_id,
-					'total'    => $tax,
-					'subtotal' => isset( $data['taxes']['subtotal'][ $tax_rate_id ] ) ? $data['taxes']['subtotal'][ $tax_rate_id ] : '',
+					'total'    => wc_format_decimal( $tax, $this->request['dp'] ),
+					'subtotal' => $subtotal ? wc_format_decimal( $subtotal, $this->request['dp'] ) : $subtotal,
 				);
 			}
 			$data['taxes'] = $taxes;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This addresses part of the issue described in https://github.com/woocommerce/woocommerce/issues/33143 by ensuring that `line_items[].taxes.total` and `line_items[].taxes.subtotal` have the same decimal precision as other currency values returned in order responses. The third field, `line_items[].price`, cannot similarly be addressed here because it requires a type change in the API schema.

I note that there are a few other issues in this repo related to rounding of tax totals and subtotals (#31076, #32783, #29688), so I'm not sure if this is actually the right move here. Is this a case where we should check the `woocommerce_tax_round_at_subtotal` option before applying decimal precision?

### How to test the changes in this Pull Request:

1. Create a product with a price of `741.93`.
2. Set up a 2% tax rate.
3. Create a new order with the product in it.
4. Retrieve the order via the `wc/v3/orders` API endpoint. The response should include `line_items[].taxes.total` and `line_items[].taxes.subtotal`, which should both have a formatted number string with too many decimal points (`14.8386`).
5. Now apply this patch and retry the request. The two values should now be rounded to two decimal points (`14.84`)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
