### PR TITLE
Add confirmation dialog for load sample products

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.scss
@@ -1,0 +1,15 @@
+.woocommerce-products-load-sample-product-confirm-modal {
+	.components-truncate.components-text.woocommerce-confirmation-modal__message {
+		color: $studio-gray-60;
+	}
+
+	.woocommerce-confirmation-modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: $gap;
+
+		button {
+			margin-left: $gap;
+		}
+	}
+}

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
@@ -22,12 +22,13 @@ export const LoadSampleProductConfirmModal: React.VFC< Props > = ( {
 	return (
 		<Modal
 			className="woocommerce-products-load-sample-product-confirm-modal"
-			title="Load sample products"
+			title={ __( 'Load sample products', 'woocommerce' ) }
 			onRequestClose={ onCancel }
 		>
 			<Text className="woocommerce-confirmation-modal__message">
 				{ __(
-					"We'll import images from woocommerce.com to set up your sample products."
+					"We'll import images from woocommerce.com to set up your sample products.",
+					'woocommerce'
 				) }
 			</Text>
 			<div className="woocommerce-confirmation-modal-actions">

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
@@ -32,10 +32,10 @@ export const LoadSampleProductConfirmModal: React.VFC< Props > = ( {
 			</Text>
 			<div className="woocommerce-confirmation-modal-actions">
 				<Button isSecondary onClick={ onCancel }>
-					{ __( 'Cancel' ) }
+					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>
 				<Button isPrimary onClick={ onImport }>
-					{ __( 'Import sample products' ) }
+					{ __( 'Import sample products', 'woocommerce' ) }
 				</Button>
 			</div>
 		</Modal>

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
+
+/**
+ * Internal dependencies
+ */
+import './load-sample-product-confirm-modal.scss';
+
+type Props = {
+	onCancel: () => void;
+	onOK: () => void;
+};
+
+export const LoadSampleProductConfirmModal: React.VFC< Props > = ( {
+	onCancel,
+	onOK,
+} ) => {
+	return (
+		<Modal
+			className="woocommerce-products-load-sample-product-confirm-modal"
+			overlayClassName="woocommerce-products-load-sample-product-confirm-modal-overlay"
+			title="Load sample products"
+			onRequestClose={ onCancel }
+		>
+			<Text className="woocommerce-confirmation-modal__message">
+				{ __(
+					"We'll import images from woocommerce.com to set up your sample products."
+				) }
+			</Text>
+			<div className="woocommerce-confirmation-modal-actions">
+				<Button isSecondary onClick={ onCancel }>
+					{ __( 'Cancel' ) }
+				</Button>
+				<Button isPrimary onClick={ onOK }>
+					{ __( 'Import sample products' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default LoadSampleProductConfirmModal;

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
@@ -12,17 +12,16 @@ import './load-sample-product-confirm-modal.scss';
 
 type Props = {
 	onCancel: () => void;
-	onOK: () => void;
+	onImport: () => void;
 };
 
 export const LoadSampleProductConfirmModal: React.VFC< Props > = ( {
 	onCancel,
-	onOK,
+	onImport,
 } ) => {
 	return (
 		<Modal
 			className="woocommerce-products-load-sample-product-confirm-modal"
-			overlayClassName="woocommerce-products-load-sample-product-confirm-modal-overlay"
 			title="Load sample products"
 			onRequestClose={ onCancel }
 		>
@@ -35,7 +34,7 @@ export const LoadSampleProductConfirmModal: React.VFC< Props > = ( {
 				<Button isSecondary onClick={ onCancel }>
 					{ __( 'Cancel' ) }
 				</Button>
-				<Button isPrimary onClick={ onOK }>
+				<Button isPrimary onClick={ onImport }>
 					{ __( 'Import sample products' ) }
 				</Button>
 			</div>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
@@ -21,11 +21,16 @@ import useProductTypeListItems from '../experimental-products/use-product-types-
 import { getProductTypes } from '../experimental-products/utils';
 import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
+import LoadSampleProductConfirmModal from '../components/load-sample-product-confirm-modal';
 import useRecordCompletionTime from '../use-record-completion-time';
 
 export const Products = () => {
 	const [ showStacks, setStackVisibility ] = useState< boolean >( false );
 	const { recordCompletionTime } = useRecordCompletionTime( 'products' );
+	const [
+		isConfirmingLoadSampleProducts,
+		setIsConfirmingLoadSampleProducts,
+	] = useState( false );
 
 	const importTypesWithTimeRecord = useMemo(
 		() =>
@@ -61,7 +66,9 @@ export const Products = () => {
 	const StacksComponent = (
 		<Stacks
 			items={ productTypeListItems }
-			onClickLoadSampleProduct={ loadSampleProduct }
+			onClickLoadSampleProduct={ () =>
+				setIsConfirmingLoadSampleProducts( true )
+			}
 		/>
 	);
 
@@ -83,7 +90,21 @@ export const Products = () => {
 				</Button>
 				{ showStacks && StacksComponent }
 			</div>
-			{ isLoadingSampleProducts && <LoadSampleProductModal /> }
+			{ isLoadingSampleProducts ? (
+				<LoadSampleProductModal />
+			) : (
+				isConfirmingLoadSampleProducts && (
+					<LoadSampleProductConfirmModal
+						onCancel={ () =>
+							setIsConfirmingLoadSampleProducts( false )
+						}
+						onImport={ () => {
+							setIsConfirmingLoadSampleProducts( false );
+							loadSampleProduct();
+						} }
+					/>
+				)
+			) }
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -25,6 +25,7 @@ import CardLayout from './card-layout';
 import { LoadSampleProductType } from './constants';
 import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
+import LoadSampleProductConfirmModal from '../components/load-sample-product-confirm-modal';
 import useRecordCompletionTime from '../use-record-completion-time';
 import { getCountryCode } from '~/dashboard/utils';
 import { useProductTaskExperiment } from './use-product-layout-experiment';
@@ -54,6 +55,10 @@ const ViewControlButton: React.FC< {
 
 export const Products = () => {
 	const [ isExpanded, setIsExpanded ] = useState< boolean >( false );
+	const [
+		isConfirmingLoadSampleProducts,
+		setIsConfirmingLoadSampleProducts,
+	] = useState( false );
 	const {
 		isLoading: isLoadingExperiment,
 		experimentLayout,
@@ -125,7 +130,7 @@ export const Products = () => {
 			if ( experimentLayout === 'card' ) {
 				surfacedProductTypes.push( {
 					...LoadSampleProductType,
-					onClick: loadSampleProduct,
+					onClick: () => setIsConfirmingLoadSampleProducts( true ),
 				} );
 			}
 		}
@@ -135,7 +140,6 @@ export const Products = () => {
 		isExpanded,
 		productTypesWithTimeRecord,
 		experimentLayout,
-		loadSampleProduct,
 	] );
 
 	return (
@@ -159,7 +163,9 @@ export const Products = () => {
 						{ experimentLayout === 'stacked' ? (
 							<Stack
 								items={ visibleProductTypes }
-								onClickLoadSampleProduct={ loadSampleProduct }
+								onClickLoadSampleProduct={ () =>
+									setIsConfirmingLoadSampleProducts( true )
+								}
 								showOtherOptions={ isExpanded }
 							/>
 						) : (
@@ -178,7 +184,21 @@ export const Products = () => {
 						/>
 						<Footer />
 					</div>
-					{ isLoadingSampleProducts && <LoadSampleProductModal /> }
+					{ isLoadingSampleProducts ? (
+						<LoadSampleProductModal />
+					) : (
+						isConfirmingLoadSampleProducts && (
+							<LoadSampleProductConfirmModal
+								onCancel={ () =>
+									setIsConfirmingLoadSampleProducts( false )
+								}
+								onImport={ () => {
+									setIsConfirmingLoadSampleProducts( false );
+									loadSampleProduct();
+								} }
+							/>
+						)
+					) }
 				</>
 			) }
 		</div>

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/stack.tsx
@@ -64,7 +64,6 @@ const Stack: React.FC< StackProps > = ( {
 									href=""
 									type="wc-admin"
 									onClick={ () => {
-										recordCompletionTime();
 										onClickLoadSampleProduct();
 										return false;
 									} }

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/stack.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/stack.tsx
@@ -70,12 +70,6 @@ describe( 'Stack', () => {
 			getByRole( 'link', { name: 'Load Sample Products' } )
 		);
 		await waitFor( () => expect( onClickLoadSampleProduct ).toBeCalled() );
-
-		expect( recordEvent ).toHaveBeenNthCalledWith(
-			1,
-			'task_completion_time',
-			{ task_name: 'products', time: '0-2s' }
-		);
 	} );
 
 	it( 'should fire the tasklist_add_product and task_completion_time events when the "Start Blank" link is clicked', async () => {

--- a/plugins/woocommerce/changelog/update-33167-add-confirmation-for-load-sample-products
+++ b/plugins/woocommerce/changelog/update-33167-add-confirmation-for-load-sample-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add confirmation dialog before loading the sample products


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33167.

This PR adds a confirmation dialog before loading sample products

**Acceptance Criteria**
- Add a confirmation dialog before loading the sample products stating `"We'll import images from woocommerce.com to set up your sample products."`
- Buttons should be `"Import sample products"` (primary) and `"Cancel"` (secondary).

![Screen Shot 2022-05-24 at 15 47 40](https://user-images.githubusercontent.com/4344253/169977721-9c1a40e4-4985-43dd-882b-30196feb25c1.png)


### How to test the changes in this Pull Request:

Make sure your site has the `woocommerce_allow_tracking` option set to yes

**Test load sample product - stack layout**

1. Go to Tools > WCA Test Helper > Experiments
2. Enable treatment for `woocommerce_products_task_layout_stacked`
3. Make sure there are no products in store (if there are in trash, empty them)
4. Navigate to `WooCommerce > Home`
5. Go to "Add products" task
6. Click `View more product types`
7. Click `Load sample products`
8. Observe that a confirmation dialog  is displayed
9. Click `Import sample products` button
10. Confirm that it loads the sample products
11. Go back to "Add products" task
12. Repeat 6~8 but click the `Cancel` button instead.
13. Confirm that the confirmation dialog is hidden


**Test load sample product - card layout**

1. Go to Tools > WCA Test Helper > Experiments
2. Enable treatment for `woocommerce_products_task_layout_card`
3. Make sure there are no products in store (if there are in trash, empty them)
4. Navigate to `WooCommerce > Home`
5. Go to "Add products" task
6. Click `View more product types`
7. Click the `CAN’T DECIDE?` card
8. Observe that a confirmation dialog  is displayed
9. Click `Import sample products` button
10. Confirm that it loads the sample products
11. Go back to "Add products" task
12. Repeat 6~8 but click the `Cancel` button instead.
13. Confirm that the confirmation dialog is hidden


**Test load sample product - import product view**

1. Go to Tools > WCA Test Helper > Experiments
2. Enable treatment for either `woocommerce_products_task_layout_stacked` or `woocommerce_products_task_layout_card`
3. Make sure there are no products in store (if there are in trash, empty them)
4. Go to OBW
5. Choose `Yes, on another platform` on the Business Details step
6. Navigate to `WooCommerce > Home`
7. Go to "Add products" task
8. Click `Or add your products from scratch`
9. Click the `Import sample products` button
10. Observe that a confirmation dialog  is displayed
11. Click `Import sample products` button
12. Confirm that it loads the sample products
13. Go back to "Add products" task
14. Repeat 6~8 but click the `Cancel` button instead.
15. Confirm that the confirmation dialog is hidden

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
