### PR TITLE
Add check for post_types key #33179

### DIFF
--- a/plugins/woocommerce/changelog/fix-33179-check-type
+++ b/plugins/woocommerce/changelog/fix-33179-check-type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This PR adds a check to be sure that we are checking an array. In this way, we can avoid a PHP warning.
+
+

--- a/plugins/woocommerce/changelog/fix-33179-check-type
+++ b/plugins/woocommerce/changelog/fix-33179-check-type
@@ -1,5 +1,7 @@
 Significance: patch
 Type: fix
-Comment: This PR adds a check to be sure that we are checking an array. In this way, we can avoid a PHP warning.
+
+Add guard to avoid error when $block_templates is null.
+
 
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -276,7 +276,7 @@ class WC_Admin_Meta_Boxes {
 				get_block_template( $theme . '//' . $template_key );
 
 			// If the block template has the product post type specified, include it.
-			if ( $block_template && in_array( 'product', $block_template->post_types ) ) {
+			if ( $block_template && is_array( $block_template->post_types ) && in_array( 'product', $block_template->post_types ) ) {
 				$filtered_templates[ $template_key ] = $template_name;
 			}
 		}


### PR DESCRIPTION
This PR adds a check to be sure that we are checking an array. In this way, we can avoid a PHP warning.
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33179.

### How to test the changes in this Pull Request:

Check out this branch.

1. Install and active `Quadrat` theme.
2. Go on the page for adding a product (`/wp-admin/post-new.php?post_type=product`)
3. Be sure that it is not raised the warning: `Warning: in_array() expects parameter 2 to be array, null given in /plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php on line 279`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
