### PR TITLE
Add individual analytics leaderboard endpoints

### DIFF
--- a/plugins/woocommerce/changelog/add-individual-analytics-leaderboards
+++ b/plugins/woocommerce/changelog/add-individual-analytics-leaderboards
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add individual analytics leaderboard endpoints.

--- a/plugins/woocommerce/src/Admin/API/Leaderboards.php
+++ b/plugins/woocommerce/src/Admin/API/Leaderboards.php
@@ -55,6 +55,19 @@ class Leaderboards extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/allowed',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_allowed_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_allowed_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/(?P<leaderboard>\w+)',
 			array(
 				'args' => array(
@@ -70,19 +83,6 @@ class Leaderboards extends \WC_REST_Data_Controller {
 					'args'                => $this->get_collection_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/allowed',
-			array(
-				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_allowed_items' ),
-					'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_allowed_item_schema' ),
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Admin/API/Leaderboards.php
+++ b/plugins/woocommerce/src/Admin/API/Leaderboards.php
@@ -53,7 +53,7 @@ class Leaderboards extends \WC_REST_Data_Controller {
 			)
 		);
 
-		foreach( [ 'customers', 'coupons', 'categories', 'products' ] as $endpoint ) {
+		foreach ( [ 'customers', 'coupons', 'categories', 'products' ] as $endpoint ) {
 			register_rest_route(
 				$this->namespace,
 				'/' . $this->rest_base . '/' . $endpoint,
@@ -386,10 +386,10 @@ class Leaderboards extends \WC_REST_Data_Controller {
 	public function get_items( $request ) {
 		$persisted_query = json_decode( $request['persisted_query'], true );
 
-		// Check which group (or all the leaderboards) we're requesting
+		// Check which group (or all the leaderboards) we're requesting.
 		$parts = explode( '/', $request->get_route() );
 		$endpoint = end( $parts );
-		switch( $endpoint ) {
+		switch ( $endpoint ) {
 			case 'leaderboards':
 				$leaderboards = $this->get_leaderboards( $request['per_page'], $request['after'], $request['before'], $persisted_query );
 				break;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/leaderboards.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/leaderboards.php
@@ -46,6 +46,62 @@ class WC_Admin_Tests_API_Leaderboards extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the customers leaderboard are returned by the endpoint.
+	 */
+	public function test_get_leaderboards_customers() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/customers' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'customers', $data[0]['id'] );
+	}
+
+	/**
+	 * Test that the coupons leaderboard are returned by the endpoint.
+	 */
+	public function test_get_leaderboards_coupons() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/coupons' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'coupons', $data[0]['id'] );
+	}
+
+	/**
+	 * Test that the categories leaderboard are returned by the endpoint.
+	 */
+	public function test_get_leaderboards_categories() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/categories' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'categories', $data[0]['id'] );
+	}
+
+	/**
+	 * Test that the products leaderboard are returned by the endpoint.
+	 */
+	public function test_get_leaderboards_products() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/products' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'products', $data[0]['id'] );
+	}
+
+	/**
 	 * Test reports schema.
 	 */
 	public function test_schema() {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Register routes for each of the individual leaderboards.

These leaderboards can be pretty expensive to generate. If you only need
to data from one of them, it can be a pretty significant performance
boost to avoid generating all the leaderboards.

### How to test the changes in this Pull Request:

1. GET /wc-analytics/leaderboards. Ensure all 4 groups (products, customers, coupons, categories) are in the response.
2. GET /wc-analytics/leaderboards/products. Ensure only the products group is in the response.
3. GET /wc-analytics/leaderboards/customers. Ensure only the customers group is in the response.
4. GET /wc-analytics/leaderboards/coupons. Ensure only the coupons group is in the response.
5. GET /wc-analytics/leaderboards/categories. Ensure only the categories group is in the response.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
