### PR TITLE
Add total payments volume rule processor for inbox notifications

### DIFF
--- a/plugins/woocommerce/changelog/add-32910
+++ b/plugins/woocommerce/changelog/add-32910
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add total payments volume rule processor for inbox notifications #33192

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -356,7 +356,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				/**
 				 * Used to determine the separator for products and their variations titles.
 				 *
-				 * @since 6.6.0
+				 * @since 4.0.0
 				 */
 				$separator = apply_filters( 'woocommerce_product_variation_title_attributes_separator', ' - ', $variation );
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -592,6 +592,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$amount     = $wpdb->get_col( $query );
 		/* phpcs:enable */
 
-		return $amount[0] ? $amount[0] : 0;
+		return isset( $amount[0] ) && $amount[0] ? $amount[0] : 0;
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -353,6 +353,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			if ( $is_variation ) {
 				$variation = wc_get_product( $product_data['id'] );
+				/**
+				 * Used to determine the separator for products and their variations titles.
+				 *
+				 * @since 6.6.0
+				 */
 				$separator = apply_filters( 'woocommerce_product_variation_title_attributes_separator', ' - ', $variation );
 
 				if ( false === strpos( $product_data['name'], $separator ) ) {
@@ -554,5 +559,24 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->subquery = new SqlQuery( $this->context . '_subquery' );
 		$this->subquery->add_sql_clause( 'select', self::get_db_table_name() . '.order_id' );
 		$this->subquery->add_sql_clause( 'from', self::get_db_table_name() );
+	}
+
+	/**
+	 * Get total sales for a given number of days.
+	 *
+	 * @param int $days Number of days.
+	 * @return float
+	 */
+	public function get_total_sales( $days ) {
+		global $wpdb;
+
+		/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
+		$table_name = self::get_db_table_name();
+		$amount     = $wpdb->get_col(
+			"SELECT SUM( total_sales ) FROM {$table_name} WHERE date_created >= DATE_SUB( NOW(), INTERVAL ${days} DAY )"
+		);
+		/* phpcs:enable */
+
+		return $amount;
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -560,38 +560,4 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->subquery->add_sql_clause( 'select', self::get_db_table_name() . '.order_id' );
 		$this->subquery->add_sql_clause( 'from', self::get_db_table_name() );
 	}
-
-	/**
-	 * Get total sales for a given timeframe.
-	 *
-	 * @param int $start_date Start date.
-	 * @param int $end_date End date.
-	 * @return float
-	 */
-	public function get_total_sales( $start_date = null, $end_date = null ) {
-		global $wpdb;
-
-		$table_name    = self::get_db_table_name();
-		$where_clauses = array();
-
-		if ( $start_date ) {
-			$where_clauses[] = $wpdb->prepare( 'date_created >= %s', $start_date );
-		}
-
-		if ( $end_date ) {
-			$where_clauses[] = $wpdb->prepare( 'date_created <= %s', $end_date );
-		}
-
-		/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared */
-		$query = "SELECT SUM( total_sales ) FROM {$table_name}";
-
-		if ( ! empty( $where_clauses ) ) {
-			$query .= ' WHERE ' . implode( ' AND ', $where_clauses );
-		}
-
-		$amount     = $wpdb->get_col( $query );
-		/* phpcs:enable */
-
-		return isset( $amount[0] ) && $amount[0] ? $amount[0] : 0;
-	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -680,7 +680,7 @@ class TimeInterval {
 				case $current_month >= 10 && $current_month <= 12:
 					return array(
 						'start' => $current_year . '-07-01 00:00:00',
-						'end'   => $current_year . '-10-31 23:59:59',
+						'end'   => $current_year . '-09-31 23:59:59',
 					);
 			}
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -639,7 +639,7 @@ class TimeInterval {
 	 * @param DateTime|null $current_date DateTime of current date to compare.
 	 * @return array
 	 */
-	public function get_timeframe_dates( $timeframe, $current_date = null ) {
+	public static function get_timeframe_dates( $timeframe, $current_date = null ) {
 		if ( ! $current_date ) {
 			$current_date = new \DateTime();
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -631,4 +631,80 @@ class TimeInterval {
 
 		return true;
 	}
+
+	/**
+	 * Get dates from a timeframe string.
+	 *
+	 * @param int           $timeframe Timeframe to use.  One of: last_week|last_month|last_quarter|last_6_months|last_year.
+	 * @param DateTime|null $current_date DateTime of current date to compare.
+	 * @return array
+	 */
+	public function get_timeframe_dates( $timeframe, $current_date = null ) {
+		if ( ! $current_date ) {
+			$current_date = new \DateTime();
+		}
+		$current_year  = $current_date->format( 'Y' );
+		$current_month = $current_date->format( 'm' );
+
+		if ( 'last_week' === $timeframe ) {
+			return array(
+				'start' => $current_date->modify( 'last week monday' )->format( 'Y-m-d 00:00:00' ),
+				'end'   => $current_date->modify( 'this sunday' )->format( 'Y-m-d 23:59:59' ),
+			);
+		}
+
+		if ( 'last_month' === $timeframe ) {
+			return array(
+				'start' => $current_date->modify( 'first day of previous month' )->format( 'Y-m-d 00:00:00' ),
+				'end'   => $current_date->modify( 'last day of this month' )->format( 'Y-m-d 23:59:59' ),
+			);
+		}
+
+		if ( 'last_quarter' === $timeframe ) {
+			switch ( $current_month ) {
+				case $current_month >= 1 && $current_month <= 3:
+					return array(
+						'start' => ( $current_year - 1 ) . '-10-01 00:00:00',
+						'end'   => ( $current_year - 1 ) . '-12-31 23:59:59',
+					);
+				case $current_month >= 4 && $current_month <= 6:
+					return array(
+						'start' => $current_year . '-01-01 00:00:00',
+						'end'   => $current_year . '-03-31 23:59:59',
+					);
+				case $current_month >= 7 && $current_month <= 9:
+					return array(
+						'start' => $current_year . '-04-01 00:00:00',
+						'end'   => $current_year . '-06-30 23:59:59',
+					);
+				case $current_month >= 10 && $current_month <= 12:
+					return array(
+						'start' => $current_year . '-07-01 00:00:00',
+						'end'   => $current_year . '-10-31 23:59:59',
+					);
+			}
+		}
+
+		if ( 'last_6_months' === $timeframe ) {
+			if ( $current_month >= 1 && $current_month <= 6 ) {
+				return array(
+					'start' => ( $current_year - 1 ) . '-07-01 00:00:00',
+					'end'   => ( $current_year - 1 ) . '-12-31 23:59:59',
+				);
+			}
+			return array(
+				'start' => $current_year . '-01-01 00:00:00',
+				'end'   => $current_year . '-06-30 23:59:59',
+			);
+		}
+
+		if ( 'last_year' === $timeframe ) {
+			return array(
+				'start' => ( $current_year - 1 ) . '-01-01 00:00:00',
+				'end'   => ( $current_year - 1 ) . '-12-31 23:59:59',
+			);
+		}
+
+		return false;
+	}
 }

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/GetRuleProcessor.php
@@ -58,6 +58,8 @@ class GetRuleProcessor {
 				return new OptionRuleProcessor();
 			case 'wca_updated':
 				return new WooCommerceAdminUpdatedRuleProcessor();
+			case 'total_payments_value':
+				return new TotalPaymentsVolumeProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
@@ -409,6 +409,20 @@ actioned.
 }
 ```
 
+### Total Payments Value
+This passes when the total value of all payments for a given number of days
+compared to the provided value pass the operation test.
+
+```
+{
+	"type": "total_payments_value",
+	"days": "30",
+	"value": "actioned",
+	"operation": ">"
+}
+```
+`days`, `value`, and `operation` are all required.
+
 ### Option
 This passes when the option value matches the value using the operation.
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
@@ -410,18 +410,20 @@ actioned.
 ```
 
 ### Total Payments Value
-This passes when the total value of all payments for a given number of days
+This passes when the total value of all payments for a given timeframe
 compared to the provided value pass the operation test.
+
+`timeframe` can be one of `last_week`, `last_month`, `last_quarter`, `last_6_months`, `last_year`
 
 ```
 {
 	"type": "total_payments_value",
-	"days": "30",
+	"days": "last_month",
 	"value": "actioned",
 	"operation": ">"
 }
 ```
-`days`, `value`, and `operation` are all required.
+`timeframe`, `value`, and `operation` are all required.
 
 ### Option
 This passes when the option value matches the value using the operation.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Rule processor that passes when a store's payments volume exceeds a provided amount.
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as Orders;
+
+/**
+ * Rule processor that passes when a store's payments volume exceeds a provided amount.
+ */
+class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
+	/**
+	 * Compare against the store's total payments volume.
+	 *
+	 * @param object $rule         The rule being processed by this rule processor.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		$value = Orders::get_total_sales( $rule->days );
+
+		return ComparisonOperation::compare(
+			$value,
+			$rule->value,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->days ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->value ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
@@ -7,7 +7,7 @@ namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
+use Automattic\WooCommerce\Admin\API\Reports\Revenue\Query as RevenueQuery;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 
 /**
@@ -24,8 +24,16 @@ class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
 	 */
 	public function process( $rule, $stored_state ) {
 		$dates      = TimeInterval::get_timeframe_dates( $rule->timeframe );
-		$data_store = new OrdersDataStore();
-		$value      = $data_store->get_total_sales( $dates['start'], $dates['end'] );
+		$reports_revenue = new RevenueQuery(
+			array(
+				'before' => $dates['end'],
+				'after'  => $dates['start'],
+				'interval' => 'year',
+				'fields' => array( 'total_sales' ),
+			)
+		);
+		$report_data    = $reports_revenue->get_data();
+		$value          = $report_data->totals->total_sales;
 
 		return ComparisonOperation::compare(
 			$value,

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
@@ -7,7 +7,8 @@ namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as Orders;
+use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
+use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 
 /**
  * Rule processor that passes when a store's payments volume exceeds a provided amount.
@@ -22,7 +23,9 @@ class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$value = Orders::get_total_sales( $rule->timeframe );
+		$dates      = TimeInterval::get_timeframe_dates( $rule->timeframe );
+		$data_store = new OrdersDataStore();
+		$value      = $data_store->get_total_sales( $dates['start'], $dates['end'] );
 
 		return ComparisonOperation::compare(
 			$value,

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/TotalPaymentsVolumeProcessor.php
@@ -22,7 +22,7 @@ class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$value = Orders::get_total_sales( $rule->days );
+		$value = Orders::get_total_sales( $rule->timeframe );
 
 		return ComparisonOperation::compare(
 			$value,
@@ -39,7 +39,15 @@ class TotalPaymentsVolumeProcessor implements RuleProcessorInterface {
 	 * @return bool Pass/fail.
 	 */
 	public function validate( $rule ) {
-		if ( ! isset( $rule->days ) ) {
+		$allowed_timeframes = array(
+			'last_week',
+			'last_month',
+			'last_quarter',
+			'last_6_months',
+			'last_year',
+		);
+
+		if ( ! isset( $rule->timeframe ) || ! in_array( $rule->timeframe, $allowed_timeframes, true ) ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -1013,4 +1013,107 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 			TimeInterval::rest_validate_between_date_arg( array( '2019-01-01T00:00:00', '2019-01-15T00:00:00' ), null, 'param' )
 		);
 	}
+
+	/**
+	 * Test that we get the correct start and end times for "last_week" timeframes.
+	 */
+	public function test_timeframes_last_week() {
+		$datetime = new DateTime( '2022-05-26' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_week', $datetime );
+
+		$this->assertEquals( '2022-05-16 00:00:00', $dates['start'] );
+		$this->assertEquals( '2022-05-22 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2022-05-16' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_week', $datetime );
+
+		$this->assertEquals( '2022-05-09 00:00:00', $dates['start'] );
+		$this->assertEquals( '2022-05-15 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2022-01-02' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_week', $datetime );
+
+		$this->assertEquals( '2021-12-20 00:00:00', $dates['start'] );
+		$this->assertEquals( '2021-12-26 23:59:59', $dates['end'] );
+	}
+
+	/**
+	 * Test that we get the correct start and end times for "last_month" timeframes.
+	 */
+	public function test_timeframes_last_month() {
+		$datetime = new DateTime( '2022-05-26' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_month', $datetime );
+
+		$this->assertEquals( '2022-04-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2022-04-30 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2021-01-12' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_month', $datetime );
+
+		$this->assertEquals( '2020-12-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2020-12-31 23:59:59', $dates['end'] );
+	}
+
+	/**
+	 * Test that we get the correct start and end times for "last_quarter" timeframes.
+	 */
+	public function test_timeframes_last_quarter() {
+		$datetime = new DateTime( '2022-05-26' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_quarter', $datetime );
+
+		$this->assertEquals( '2022-01-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2022-03-31 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2022-01-12' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_quarter', $datetime );
+
+		$this->assertEquals( '2021-10-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2021-12-31 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2022-07-18' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_quarter', $datetime );
+
+		$this->assertEquals( '2022-04-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2022-06-30 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2022-11-07' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_quarter', $datetime );
+
+		$this->assertEquals( '2022-07-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2022-09-31 23:59:59', $dates['end'] );
+	}
+
+	/**
+	 * Test that we get the correct start and end times for "last_6_months" timeframes.
+	 */
+	public function test_timeframes_last_6_months() {
+		$datetime = new DateTime( '2022-05-26' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_6_months', $datetime );
+
+		$this->assertEquals( '2021-07-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2021-12-31 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2021-09-12' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_6_months', $datetime );
+
+		$this->assertEquals( '2021-01-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2021-06-30 23:59:59', $dates['end'] );
+	}
+
+	/**
+	 * Test that we get the correct start and end times for "last_year" timeframes.
+	 */
+	public function test_timeframes_last_year() {
+		$datetime = new DateTime( '2022-05-26' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_year', $datetime );
+
+		$this->assertEquals( '2021-01-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2021-12-31 23:59:59', $dates['end'] );
+
+		$datetime = new DateTime( '2021-09-12' );
+		$dates    = TimeInterval::get_timeframe_dates( 'last_year', $datetime );
+
+		$this->assertEquals( '2020-01-01 00:00:00', $dates['start'] );
+		$this->assertEquals( '2020-12-31 23:59:59', $dates['end'] );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -222,44 +222,4 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, $data->total );
 		$this->assertEquals( $order_2->get_id(), $data->data[0]['order_id'] );
 	}
-
-	/**
-	 * Test that we get the correct sales volume based on provided dates.
-	 */
-	public function test_total_sales_by_date() {
-		WC_Helper_Reports::reset_stats_dbs();
-
-		$simple_product = new WC_Product_Simple();
-		$simple_product->set_name( 'Simple Product' );
-		$simple_product->set_regular_price( 25 );
-		$simple_product->save();
-
-		$order_1 = WC_Helper_Order::create_order( 1, $simple_product );
-		$order_1->set_total( 25 );
-		$order_1->set_status( 'completed' );
-		$order_1->set_date_created( '2022-01-02T00:00' );
-		$order_1->save();
-
-		$order_2 = WC_Helper_Order::create_order( 1, $simple_product );
-		$order_2->set_total( 25 );
-		$order_2->set_status( 'completed' );
-		$order_2->set_date_created( '2022-03-24T00:00' );
-		$order_2->save();
-
-		$order_3 = WC_Helper_Order::create_order( 1, $simple_product );
-		$order_3->set_total( 25 );
-		$order_3->set_status( 'completed' );
-		$order_3->set_date_created( '2021-07-04T00:00' );
-		$order_3->save();
-
-		WC_Helper_Queue::run_all_pending();
-
-		$data_store  = new OrdersDataStore();
-		$total_sales = $data_store->get_total_sales();
-		$this->assertEquals( 75, $total_sales );
-		$total_sales = $data_store->get_total_sales( '2022-01-01T00:00', '2022-04-01T00:00' );
-		$this->assertEquals( 50, $total_sales );
-		$total_sales = $data_store->get_total_sales( '2021-01-01T00:00', '2021-12-01T23:59' );
-		$this->assertEquals( 25, $total_sales );
-	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -222,4 +222,44 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, $data->total );
 		$this->assertEquals( $order_2->get_id(), $data->data[0]['order_id'] );
 	}
+
+	/**
+	 * Test that we get the correct sales volume based on provided dates.
+	 */
+	public function test_total_sales_by_date() {
+		WC_Helper_Reports::reset_stats_dbs();
+
+		$simple_product = new WC_Product_Simple();
+		$simple_product->set_name( 'Simple Product' );
+		$simple_product->set_regular_price( 25 );
+		$simple_product->save();
+
+		$order_1 = WC_Helper_Order::create_order( 1, $simple_product );
+		$order_1->set_total( 25 );
+		$order_1->set_status( 'completed' );
+		$order_1->set_date_created( '2022-01-02T00:00' );
+		$order_1->save();
+
+		$order_2 = WC_Helper_Order::create_order( 1, $simple_product );
+		$order_2->set_total( 25 );
+		$order_2->set_status( 'completed' );
+		$order_2->set_date_created( '2022-03-24T00:00' );
+		$order_2->save();
+
+		$order_3 = WC_Helper_Order::create_order( 1, $simple_product );
+		$order_3->set_total( 25 );
+		$order_3->set_status( 'completed' );
+		$order_3->set_date_created( '2021-07-04T00:00' );
+		$order_3->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$data_store  = new OrdersDataStore();
+		$total_sales = $data_store->get_total_sales();
+		$this->assertEquals( 75, $total_sales );
+		$total_sales = $data_store->get_total_sales( '2022-01-01T00:00', '2022-04-01T00:00' );
+		$this->assertEquals( 50, $total_sales );
+		$total_sales = $data_store->get_total_sales( '2021-01-01T00:00', '2021-12-01T23:59' );
+		$this->assertEquals( 25, $total_sales );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a new rule processor so that notes can be added depending on the total sales volume for a given store.

Closes #32910  .

### How to test the changes in this Pull Request:

1. Add this snippet as a plugin:
```
function test_rind_rules( $specs, $id ) {
	if ( 'remote_inbox_notifications' !== $id ) {
		return $specs;
	}

	return array(
		(object) array(
			'slug' => 'wca-tpv-test',
			'type' => 'info',
			'icon' => 'info',
			'status' => 'unactioned',
			'is_snoozable' => false,
			'source' => 'test',
			'locales' => [
				(object) array(
					'locale' => 'en_US',
					'title' => 'Total payments volume',
					'content' => 'This should appear if total sales volume was greater than 100,000 last quarter'
				),
			],
			'rules' => array(
				(object) array(
					'type' => 'total_payments_value',
					'value' => 100000,
					'operation' => '>=',
					'timeframe' => 'last_quarter',
				),
			),
		)
	);
}

add_filter( 'data_source_poller_specs', 'test_rind_rules', 10, 2 );
```
2. Create a store with at least 100,000 sales in the last quarter (currency does not matter)
3. Optionally modify the above rules and use the various time frames (`last_week`, `last_month`, `last_quarter`, `last_6_months`, `last_year`)
4. Run the `wc_admin_daily` cron event
5. Check that the note was added if your rules pass

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
