### PR TITLE
Update the CI workflow to include WP 5.9 and 5.8 matching our L-2 support policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
         include:
           - wp: nightly
             php: '7.4'
-          - wp: '5.8'
+          - wp: '5.9'
             php: 7.2
-          - wp: '5.7'
+          - wp: '5.8'
             php: 7.2
     services:
       database:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -22,9 +22,9 @@ jobs:
         include:
           - wp: nightly
             php: '7.4'
-          - wp: '5.8'
+          - wp: '5.9'
             php: 7.2
-          - wp: '5.7'
+          - wp: '5.8'
             php: 7.2
     services:
       database:


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the CI workflow to include PHP versions matching our L-2 support policy for WordPress releases now that WordPress 6.0 has been released.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Spot-check the changes, and once merged, verify that the workflows for 5.8 and 5.9 run, and that the workflow for 5.7 no longer runs.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
