### PR TITLE
Update woocommerce-admin `test:watch` command

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -49,7 +49,7 @@
 		"test:help": "wp-scripts test-unit-js --help",
 		"test:packages": "pnpm run --filter ../../packages/js/ --filter !api-core-tests test",
 		"test:update-snapshots": "pnpm run test:client -- --updateSnapshot && pnpm run --filter @woocommerce/components test:update-snapshots",
-		"test:watch": "tsc --build || concurrently \"pnpm run test:client -- --watch\" \"pnpm run:packages -- test:nobuild --parallel -- --watch\"",
+		"test:watch": "pnpm run test:client -- --watch",
 		"ts:check": "tsc --build ./tsconfig.json --pretty",
 		"ts:check:watch": "npm run ts:check -- --watch"
 	},

--- a/plugins/woocommerce/changelog/dev-update-test-watch-command
+++ b/plugins/woocommerce/changelog/dev-update-test-watch-command
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update woocommerce-admin "test:watch" command


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

context: p1653516285015389-slack-CBKK5KM41

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix the command and update to only watch admin ./client folder

### How to test the changes in this Pull Request:

1. Run `pnpm nx test:watch woocommerce-admin` 
2. Should re-run the test when changing a test case

We could also run`pnpm test:watch ./client/tasks/fills/experimental-import-products` command in `plugins/woocommerce-admin` for watching a subfolder.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.