### PR TITLE
Fix dashboard and analytics crashing

### DIFF
--- a/plugins/woocommerce/changelog/fix-32979-next_week_start-respects-timezone
+++ b/plugins/woocommerce/changelog/fix-32979-next_week_start-respects-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dashboard and analytics crashing with certain timezone configuration

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -330,12 +330,16 @@ class TimeInterval {
 	 */
 	public static function next_week_start( $datetime, $reversed = false ) {
 		$seven_days = new \DateInterval( 'P7D' );
-		$start_end  = get_weekstartend( $datetime->format( 'Y-m-d' ) );
+		// Default timezone set in wp-settings.php.
+		$default_timezone = new \DateTimeZone( date_default_timezone_get() );
+		// Timezone that the WP site uses in Settings > General.
+		$timezone   = $datetime->getTimezone();
+		$start_end_timestamp  = get_weekstartend( $datetime->setTimezone( $default_timezone )->format( 'Y-m-d' ) );
 
 		if ( $reversed ) {
-			return \DateTime::createFromFormat( 'U', $start_end['end'] )->sub( $seven_days );
+			return \DateTime::createFromFormat( 'U', $start_end_timestamp['end'] )->sub( $seven_days )->setTimezone( $timezone );
 		}
-		return \DateTime::createFromFormat( 'U', $start_end['start'] )->add( $seven_days );
+		return \DateTime::createFromFormat( 'U', $start_end_timestamp['start'] )->add( $seven_days )->setTimezone( $timezone );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php
@@ -331,16 +331,22 @@ class TimeInterval {
 	public static function next_week_start( $datetime, $reversed = false ) {
 		$seven_days = new \DateInterval( 'P7D' );
 		// Default timezone set in wp-settings.php.
-		$default_timezone = new \DateTimeZone( date_default_timezone_get() );
+		$default_timezone = date_default_timezone_get();
 		// Timezone that the WP site uses in Settings > General.
-		$timezone   = $datetime->getTimezone();
-		$start_end_timestamp  = get_weekstartend( $datetime->setTimezone( $default_timezone )->format( 'Y-m-d' ) );
-
+		$original_timezone = $datetime->getTimezone();
+		// @codingStandardsIgnoreStart
+		date_default_timezone_set( 'UTC' );
+		$start_end_timestamp  = get_weekstartend( $datetime->format( 'Y-m-d' ) );
+		date_default_timezone_set( $default_timezone );
+		// @codingStandardsIgnoreEnd
 		if ( $reversed ) {
-			return \DateTime::createFromFormat( 'U', $start_end_timestamp['end'] )->sub( $seven_days )->setTimezone( $timezone );
+			$result = \DateTime::createFromFormat( 'U', $start_end_timestamp['end'] )->sub( $seven_days );
+		} else {
+			$result = \DateTime::createFromFormat( 'U', $start_end_timestamp['start'] )->add( $seven_days );
 		}
-		return \DateTime::createFromFormat( 'U', $start_end_timestamp['start'] )->add( $seven_days )->setTimezone( $timezone );
+		return \DateTime::createFromFormat( 'Y-m-d H:i:s', $result->format( 'Y-m-d H:i:s' ), $original_timezone );
 	}
+
 
 	/**
 	 * Returns a new DateTime object representing the next month start, or previous month end if reversed.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -753,6 +753,28 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests when users manually set timezone by date_default_timezone_set in wp-settings.php.
+	 * Since we're using get_weekstartend, next_week_start should preemptively set
+	 * the date object with the default timezone.
+	 */
+	public function test_next_week_start_timezone_loop() {
+		$original_timezone = date_default_timezone_get();
+		// @codingStandardsIgnoreStart
+		date_default_timezone_set( 'Europe/Berlin' );
+		$start_datetime = new \DateTime( '01-05-2022 00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
+		$end_datetime = new \DateTime( '26-05-2022 00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
+		$week_count = 0;
+		do {
+			$start_datetime = TimeInterval::next_week_start( $start_datetime, false );
+			$week_count++;
+		} while ( $start_datetime <= $end_datetime && $week_count < 10 );
+		date_default_timezone_set( $original_timezone );
+		// @codingStandardsIgnoreEnd
+		// Value more than 5 should mean that loop would've never terminated.
+		$this->assertEquals( 5, $week_count );
+	}
+
+	/**
 	 * Test function that returns beginning of next week or previous week end if reversed, for weeks starting on Sunday.
 	 */
 	public function test_next_week_start_Sunday_based_week() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -753,6 +753,23 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests for the exact datetime returned by next_week_start to make sure it
+	 * returns the exact time and timezone with shifting timezones
+	 * between PHP settings and WordPress config.
+	 */
+	public function test_next_week_start_correct_timezone_calculation() {
+		$original_timezone = date_default_timezone_get();
+		// @codingStandardsIgnoreStart
+		date_default_timezone_set( 'UTC' );
+		$start_datetime = new \DateTime( '2022-05-02T00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
+		$next_week_datetime = TimeInterval::next_week_start( $start_datetime, false );
+		date_default_timezone_set( $original_timezone );
+		// @codingStandardsIgnoreEnd
+		$this->assertEquals( '2022-05-09T00:00:00', $next_week_datetime->format( TimeInterval::$iso_datetime_format ) );
+		$this->assertEquals( 'Europe/Berlin', $next_week_datetime->getTimezone()->getName() );
+	}
+
+	/**
 	 * Tests when users manually set timezone by date_default_timezone_set in wp-settings.php.
 	 * Since we're using get_weekstartend, next_week_start should preemptively set
 	 * the date object with the default timezone.
@@ -761,8 +778,8 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 		$original_timezone = date_default_timezone_get();
 		// @codingStandardsIgnoreStart
 		date_default_timezone_set( 'Europe/Berlin' );
-		$start_datetime = new \DateTime( '01-05-2022 00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
-		$end_datetime = new \DateTime( '26-05-2022 00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
+		$start_datetime = new \DateTime( '01-05-2022T00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
+		$end_datetime = new \DateTime( '26-05-2022T00:00:00', new \DateTimeZone( 'Europe/Berlin' ) );
 		$week_count = 0;
 		do {
 			$start_datetime = TimeInterval::next_week_start( $start_datetime, false );
@@ -770,7 +787,7 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 		} while ( $start_datetime <= $end_datetime && $week_count < 10 );
 		date_default_timezone_set( $original_timezone );
 		// @codingStandardsIgnoreEnd
-		// Value more than 5 should mean that loop would've never terminated.
+		// Value more than 5 should mean that loop never terminated.
 		$this->assertEquals( 5, $week_count );
 	}
 


### PR DESCRIPTION
Build: [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/8779476/woocommerce.zip)

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32979. 

`get_weekstartend` utilizes the function [`mktime`](https://www.php.net/manual/en/function.mktime.php) date format which is sensitive to the timezone configuration set by [`date_default_timezone_set`](https://www.php.net/manual/en/function.date-default-timezone-set.php).

This function inadvertently converts the date passed in our [call](https://github.com/woocommerce/woocommerce/blob/13fe9b49707afdb50387bece76d2f588c3f05164/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php#L333) to `get_weekstartend` without respecting its original timezone information. This would cause the date calculation to be inaccurate, i.e: returning last week when the correct value should be this week. Since the function is called from a [loop](https://github.com/woocommerce/woocommerce/blob/13fe9b49707afdb50387bece76d2f588c3f05164/plugins/woocommerce/src/Admin/API/Reports/TimeInterval.php#L247-L250), the function incorrectly returning previous week makes the loop runs indefinitely thus crashing sites.

The following is a minimal code to reproduce date miscalculation (You can put this in a PHP file in any WordPress base installation and run it with `php -f file.php`)
```php
<?php
require_once __DIR__ . '/wp-load.php';

date_default_timezone_set( 'Europe/Berlin' );
$start_date = \DateTime::createFromFormat( 'U', get_weekstartend( '2022-05-02' )['start'] );
echo $start_date->format( 'Y-m-d' ); // 2022-04-25, this is the previous week.
echo $start_date->add( new \DateInterval( 'P7D' ) )->format( 'Y-m-d' ); // 2022-05-02, after adding 7 days, it returns the same date we've supplied
```

### How to test the changes in this Pull Request:

1. In a fresh site with WooCommerce 6.5.1 installed, go to `Settings -> General` and change `Timezone` to `Berlin`
2. Download [this plugin](https://gist.github.com/ilyasfoo/dbac0430d2741071dc6a00772f651a27) by clicking "Download ZIP" on top right corner
3. Install & activate the plugin
5. Go to Products page and click on "Help" (top right) > Setup Wizard > disable task list. 
6. Go to WordPress dashboard
7. Observe the the dashboard loads without errors and "WooCommerce Status" widget is loaded successfully
8. Go to Analytics > Overview and make sure "Leaderboards" stats are able to load

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
