### PR TITLE
Add charset collation to COT database schema

### DIFF
--- a/plugins/woocommerce/changelog/cot-add-collation-to-schema
+++ b/plugins/woocommerce/changelog/cot-add-collation-to-schema
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add charset collation to COT tables.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -819,6 +819,10 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 * @return string
 	 */
 	public function get_database_schema() {
+		global $wpdb;
+
+		$collate = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+
 		$orders_table_name           = $this->get_orders_table_name();
 		$addresses_table_name        = $this->get_addresses_table_name();
 		$operational_data_table_name = $this->get_operational_data_table_name();
@@ -845,7 +849,7 @@ CREATE TABLE $orders_table_name (
 	KEY status (status),
 	KEY date_created (date_created_gmt),
 	KEY customer_id_billing_email (customer_id, billing_email)
-);
+) $collate;
 CREATE TABLE $addresses_table_name (
 	id bigint(20) unsigned auto_increment primary key,
 	order_id bigint(20) unsigned NOT NULL,
@@ -863,7 +867,7 @@ CREATE TABLE $addresses_table_name (
 	phone varchar(100) null,
 	KEY order_id (order_id),
 	KEY address_type_order_id (address_type, order_id)
-);
+) $collate;
 CREATE TABLE $operational_data_table_name (
 	id bigint(20) unsigned auto_increment primary key,
 	order_id bigint(20) unsigned NULL,
@@ -885,14 +889,14 @@ CREATE TABLE $operational_data_table_name (
 	recorded_sales tinyint(1) NULL,
 	KEY order_id (order_id),
 	KEY order_key (order_key)
-);
+) $collate;
 CREATE TABLE $meta_table (
 	id bigint(20) unsigned auto_increment primary key,
 	order_id bigint(20) unsigned null,
 	meta_key varchar(255),
 	meta_value text null,
 	KEY meta_key_value (meta_key, meta_value(100))
-);
+) $collate;
 ";
 
 		return $sql;


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
COT database schema doesn't set the charset collation as our routines usually do.

This might be related to #33146 and why certain characters were not being migrated correctly.

### How to test the changes in this Pull Request:

1. Enable the COT feature if necessary.
2. If necessary, create the COT tables: go to WC > Status> Tools and click "Create the custom orders tables".
3. Check the charset info on your existing WP tables and compare it with the newly created tables. For example, compare `wp_postmeta` with `wp_wc_orders` (WP) by running an SQL command such as this:

   ```sql
   SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_COLLATION  FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME IN ('wp_wc_orders', 'wp_postmeta' );
   ```
4. Check out this branch.
5. Go to WC > Status > Tools and click "Delete the custom orders tables".
6. Repeat steps 2-3 and confirm that the charset now matches that of the WP tables.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
