### PR TITLE
Cherry-pick 33194 into release/6.6

### DIFF
--- a/plugins/woocommerce/changelog/update-minimum-wp-version
+++ b/plugins/woocommerce/changelog/update-minimum-wp-version
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: This change just updates the plugin file, and we already have a changelog entry for the release of 6.0
+
+

--- a/plugins/woocommerce/changelog/update-minimum-wp-version
+++ b/plugins/woocommerce/changelog/update-minimum-wp-version
@@ -1,5 +1,0 @@
-Significance: patch
-Type: update
-Comment: This change just updates the plugin file, and we already have a changelog entry for the release of 6.0
-
-

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce
-Requires at least: 5.7
+Requires at least: 5.8
 Tested up to: 6.0
 Requires PHP: 7.0
 Stable tag: 6.5.1

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires at least: 5.7
+ * Requires at least: 5.8
  * Requires PHP: 7.2
  *
  * @package WooCommerce


### PR DESCRIPTION
This PR cherry-picks #33194 into the `release/6.6` branch.

Note: The commit handling the changelog for this is cherry-picked into `trunk` in #33213.