### PR TITLE
Update changelogger validation to only affect PRs against trunk

### DIFF
--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,5 +1,7 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on: pull_request
+  branches:
+    - trunk
 concurrency:
   group: changelogger-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,7 +1,8 @@
 name: Run lint checks potentially affecting projects across the monorepo
-on: pull_request
-  branches:
-    - trunk
+on:
+  pull_request:
+    branches:
+      - 'trunk'
 concurrency:
   group: changelogger-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the changelogger validation to only affect PRs against trunk. The motivation for this change is that it allows for PRs against a feature-branch without requiring a changelog entry, or PRs against a release branch (which often build the changelog) without requiring a changelog entry.

### How to test the changes in this Pull Request:

1. Fork repo.
2. Enable actions in your fork.
3. Merge this PR to `trunk` in your fork.
4. Create a PR against a branch other than `trunk` without creating a changelog entry. Verify that the action isn't run.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
