### PR TITLE
Add Slack notification for code freeze

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -33,3 +33,45 @@ jobs:
         run: php release-code-freeze.php
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-slack:
+    name: "Sends code freeze notification to Slack"
+    runs-on: ubuntu-20.04
+    needs: maybe-create-next-milestone-and-release-branch
+    steps:
+      - name: Get outgoing release version
+        uses: actions/github-script@v6
+        id: outgoing
+        with:
+          script: |
+              const latest = await github.rest.repos.getLatestRelease({
+                owner: 'woocommerce',
+                repo: 'woocommerce'
+              });
+
+              let version = parseFloat( latest.data.tag_name ) + 0.1;
+              version = parseFloat( version ).toPrecision( 2 );
+
+              return version;
+      - name: Get next release version
+        uses: actions/github-script@v6
+        id: next
+        with:
+          script: |
+              const latest = await github.rest.repos.getLatestRelease({
+                owner: 'woocommerce',
+                repo: 'woocommerce'
+              });
+
+              let version = parseFloat( latest.data.tag_name ) + 0.2;
+              version = parseFloat( version ).toPrecision( 2 );
+
+              return version;
+      - name: Slack
+        uses: archive/github-actions-slack@v2.0.0
+        id: notify
+        with:
+         slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+         slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
+         slack-text: ":warning-8c: ${{ steps.outgoing.outputs.result }} Code Freeze :ice_cube:
+The automation to cut the release branch for ${{ steps.outgoing.outputs.result }} has run. Any PRs that were not already merged will be a part of ${{ steps.next.outputs.result }} by default. If you have something that needs to make ${{ steps.outgoing.outputs.result }} that hasn't yet been merged, please see the <${{ secrets.FG_LINK }}/code-freeze-for-woocommerce-core-release/|fieldguide page for the code freeze>."


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a Slack notification whenever the code freeze action is triggered. It will ping the release channel.


### How to test the changes in this Pull Request:

I am not able to test this live until it is merged and when the code freeze triggers. However you can test it with your repo.

1. Create a private repo on your own org. Add a workflow to `/.github/workflows`.
```
name: Slack
on:
  push:
    branches: ["trunk", "main"]
  workflow_dispatch:
jobs:
  slack:
    runs-on: ubuntu-20.04
    steps:
      - name: Get outgoing release version
        uses: actions/github-script@v6
        id: outgoing
        with:
          script: |
              const latest = await github.rest.repos.getLatestRelease({
                owner: 'woocommerce',
                repo: 'woocommerce'
              });

              let version = parseFloat( latest.data.tag_name ) + 0.1;
              version = parseFloat( version ).toPrecision( 2 );

              return version;
      - name: Get next release version
        uses: actions/github-script@v6
        id: next
        with:
          script: |
              const latest = await github.rest.repos.getLatestRelease({
                owner: 'woocommerce',
                repo: 'woocommerce'
              });

              let version = parseFloat( latest.data.tag_name ) + 0.2;
              version = parseFloat( version ).toPrecision( 2 );

              return version;
      - name: Slack
        uses: archive/github-actions-slack@v2.0.0
        id: notify
        with:
         slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
         slack-channel: ${{ secrets.WOO_RELEASE_SLACK_CHANNEL }}
         slack-text: ":warning-8c: ${{steps.outgoing.outputs.result}} Code Freeze :ice_cube:
The automation to cut the release branch for ${{steps.outgoing.outputs.result}} has run. Any PRs that were not already merged will be a part of ${{steps.next.outputs.result}} by default. If you have something that needs to make ${{steps.outgoing.outputs.result}} that hasn't yet been merged, please see the <${{ secrets.FG_LINK }}/code-freeze-for-woocommerce-core-release/|fieldguide page for the code freeze>."
```
2. Create a private Slack channel. Right click on the channel and click on "Channel Details". Note the channel ID at the bottom. Save that information.
3. Create two action secrets on your private repo. `CODE_FREEZE_BOT_TOKEN` and `WOO_RELEASE_SLACK_CHANNEL`. You can get the bot token from the Slack APP you were invited to from your email. For the Slack channel, use the channel ID you saved from step 2.
4. Now commit and push your changes you did in step 1 to your private repo. This should set off the action.
5. Go to your actions and make sure the action ran successfully.
6. Now go check the private Slack channel you created in step 2 and see the code freeze notification.

### Other information:

After merge, I have to invite the bot to the release channel.

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
