### PR TITLE
Allow filtering of cookie flags, which enables setting of samesite

### DIFF
--- a/plugins/woocommerce/changelog/cookie-options
+++ b/plugins/woocommerce/changelog/cookie-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Introduce new hook `woocommerce_set_cookie_options` to exercise more control over cookie options.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1053,26 +1053,24 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = 
 	}
 
 	if ( ! headers_sent() ) {
+		$options = apply_filters(
+			'woocommerce_set_cookie_options',
+			array(
+				'expires' => $expire,
+				'secure' => $secure,
+				'path' => COOKIEPATH ? COOKIEPATH : '/',
+				'domain' => COOKIE_DOMAIN,
+				'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ),
+			),
+			$name,
+			$value
+		);
 		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
-			setcookie(
-				$name,
-				$value,
-				apply_filters(
-					'woocommerce_set_cookie_options',
-					array(
-						'expires' => $expire,
-						'secure' => $secure,
-						'path' => COOKIEPATH ? COOKIEPATH : '/',
-						COOKIE_DOMAIN,
-						'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ),
-					),
-					$name,
-					$value
-				)
-			);
+			setcookie( $name, $value, $options );
 		} else {
-			setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
-		}	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
+			setcookie( $name, $value, $options['expires'], $options['path'], $options['domain'], $options['secure'], $options['httponly'] );
+		}
+	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine
 	}

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1053,8 +1053,26 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = 
 	}
 
 	if ( ! headers_sent() ) {
-		setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
-	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
+		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
+			setcookie(
+				$name,
+				$value,
+				apply_filters(
+					'woocommerce_set_cookie_options',
+					array(
+						'expires' => $expire,
+						'secure' => $secure,
+						'path' => COOKIEPATH ? COOKIEPATH : '/',
+						COOKIE_DOMAIN,
+						'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ),
+					),
+					$name,
+					$value
+				)
+			);
+		} else {
+			setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
+		}	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine
 	}

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1048,23 +1048,58 @@ function wc_print_js() {
  * @param  bool    $httponly Whether the cookie is only accessible over HTTP, not scripting languages like JavaScript. @since 3.6.0.
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
-	if ( ! apply_filters( 'woocommerce_set_cookie_enabled', true, $name ,$value, $expire, $secure ) ) {
+	/**
+	 * Controls whether the cookie should be set via wc_setcookie().
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param bool    $set_cookie_enabled If wc_setcookie() should set the cookie.
+	 * @param string  $name               Cookie name.
+	 * @param string  $value              Cookie value.
+	 * @param integer $expire             When the cookie should expire.
+	 * @param bool    $secure             If the cookie should only be served over HTTPS.
+	 */
+	if ( ! apply_filters( 'woocommerce_set_cookie_enabled', true, $name, $value, $expire, $secure ) ) {
 		return;
 	}
 
 	if ( ! headers_sent() ) {
+		/**
+		 * Controls the options to be specified when setting the cookie.
+		 *
+		 * @see   https://www.php.net/manual/en/function.setcookie.php
+		 * @since 6.7.0
+		 *
+		 * @param array  $cookie_options Cookie options.
+		 * @param string $name           Cookie name.
+		 * @param string $value          Cookie value.
+		 */
 		$options = apply_filters(
 			'woocommerce_set_cookie_options',
 			array(
-				'expires' => $expire,
-				'secure' => $secure,
-				'path' => COOKIEPATH ? COOKIEPATH : '/',
-				'domain' => COOKIE_DOMAIN,
+				'expires'  => $expire,
+				'secure'   => $secure,
+				'path'     => COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => COOKIE_DOMAIN,
+				/**
+				 * Controls whether the cookie should only be accessible via the HTTP protocol, or if it should also be
+				 * accessible to Javascript.
+				 *
+				 * @see   https://www.php.net/manual/en/function.setcookie.php
+				 * @since 3.3.0
+				 *
+				 * @param bool   $httponly If the cookie should only be accessible via the HTTP protocol.
+				 * @param string $name     Cookie name.
+				 * @param string $value    Cookie value.
+				 * @param int    $expire   When the cookie should expire.
+				 * @param bool   $secure   If the cookie should only be served over HTTPS.
+				 */
 				'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ),
 			),
 			$name,
 			$value
 		);
+
 		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
 			setcookie( $name, $value, $options );
 		} else {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add `woocommerce_set_cookie_options` filter, allowing `setcookie()` options to be filtered.

This is a followup to the https://github.com/woocommerce/woocommerce/pull/28105 and https://github.com/woocommerce/woocommerce/pull/31019 pull requests by @DavidAnderson684 

It incorporates the changes requested by @barryhughes

Looking to get this feature implemented so I made the additions here which allow the filter to work under all PHP versions

Closes #28106 .

### How to test the changes in this Pull Request:

1. Put items in cart.
2. Verify in your browser that valid set-cookie headers exist in the HTTP response.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
