### PR TITLE
Cleanup and fix translation path changes

### DIFF
--- a/plugins/woocommerce/changelog/dev-33226-cleanup-translation-path-fixes
+++ b/plugins/woocommerce/changelog/dev-33226-cleanup-translation-path-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Removed temporary codepath added in #32603 since translation paths have been updated #33226

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -43,40 +43,8 @@ class Translations {
 		// Handler for WooCommerce and WooCommerce Admin plugin activation.
 		add_action( 'woocommerce_activated_plugin', array( $this, 'potentially_generate_translation_strings' ) );
 		add_action( 'activated_plugin', array( $this, 'potentially_generate_translation_strings' ) );
-
-		// Adding this filter to adjust the path after woocommerce-admin was merged into woocommerce core.
-		// Remove after the translations strings have been updated to the new path (probably woocommerce 6.6).
-		add_filter( 'load_script_textdomain_relative_path', array( $this, 'adjust_script_path' ), 10, 2 );
 	}
 
-	/**
-	 * This filter is temporarily used to produce the correct i18n paths as they were moved in WC 6.5.
-	 *
-	 * @param string $relative Relative path to the script.
-	 * @param string $src      The script's source URL.
-	 */
-	public function adjust_script_path( $relative, $src ) {
-		// only rewrite the path if the translation file is from the old woocommerce-admin dist folder.
-		if ( false === strpos( $relative, 'assets/client/admin' ) ) {
-			return $relative;
-		}
-
-		// translation filenames are always based on the unminified path.
-		if ( substr( $relative, -7 ) === '.min.js' ) {
-			$relative = substr( $relative, 0, -7 ) . '.js';
-		}
-
-		$file_base = 'woocommerce-' . determine_locale(); // e.g woocommerce-fr_FR.
-		$md5_filename = $file_base . '-' . md5( $relative ) . '.json';
-
-		$languages_path = WP_LANG_DIR . '/plugins/'; // get path to translations folder.
-
-		if ( ! is_readable( $languages_path . $md5_filename ) ) {
-			return str_replace( 'assets/client/admin', 'packages/woocommerce-admin/dist', $relative );
-		} else {
-			return $relative;
-		}
-	}
 	/**
 	 * Generate a filename to cache translations from JS chunks.
 	 *
@@ -133,13 +101,8 @@ class Translations {
 
 			// Only combine "app" files (not scripts registered with WP).
 			if (
-				// paths for woocommerce < 6.5. can be removed from 6.6 onwards or when i18n json file names are updated.
-				false === strpos( $reference_file, 'dist/chunks/' ) &&
-				false === strpos( $reference_file, 'dist/app/index.js' ) &&
-
-				// paths for woocommerce >= 6.5 (post-merge of woocommerce-admin).
-				false === strpos( $reference_file, 'assets/admin/app/index.js' ) &&
-				false === strpos( $reference_file, 'assets/admin/chunks/' )
+				false === strpos( $reference_file, WC_ADMIN_DIST_JS_FOLDER . 'app/index.js' ) &&
+				false === strpos( $reference_file, WC_ADMIN_DIST_JS_FOLDER . 'chunks/' )
 			) {
 				continue;
 			}


### PR DESCRIPTION
Removed temporary codepath added in https://github.com/woocommerce/woocommerce/pull/32603  since translation paths have been updated

Also there was an error in that PR that causes translations to be broken for wc-admin related translations

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Install Woocommerce and set the site language to a language with good translation coverage such as French or German
2. Download the translation from the Dashboard > Updates menu
3. Check that translations are working, both in the onboarding wizard and analytics screens

![image](https://user-images.githubusercontent.com/27843274/170637577-868d7bf5-5565-449b-bef8-fc23f35cecd4.png)

![image](https://user-images.githubusercontent.com/27843274/170637637-f1b267a7-d3c4-40ba-bfc0-8682807f3b3b.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
