### PR TITLE
TimeInterval test fix expected 5 weeks instead of 6

### DIFF
--- a/plugins/woocommerce/changelog/fix-33036-failing-timeinterval-test
+++ b/plugins/woocommerce/changelog/fix-33036-failing-timeinterval-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix failing TimeInterval test

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-interval.php
@@ -621,7 +621,7 @@ class WC_Admin_Tests_Reports_Interval_Stats extends WC_Unit_Test_Case {
 				'intervals'  => array(
 					'hour'    => 31 * 24,
 					'day'     => 31,
-					'week'    => 6,
+					'week'    => 5,
 					'month'   => 1,
 					'quarter' => 1,
 					'year'    => 1,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a test error in https://github.com/woocommerce/woocommerce/pull/33036/. 

In October 2021, there should be only 5 weeks, but the existing test mistakenly validates for 6:

- 1 - 3
- 4 - 10
- 11 - 17
- 18 - 24
- 25 - 31

[DST for EST timezone](https://www.timeanddate.com/time/change/usa/new-york?year=2021) is not relevant for October

### How to test the changes in this Pull Request:

1. Make sure the test passes