### PR TITLE
Fix unresponsive clicks on product task card elements

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/card-layout.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/card-layout.scss
@@ -18,7 +18,7 @@
 		.woocommerce-list__item {
 			width: 217px;
 			height: 200px;
-			padding: 40px 24px;
+			align-items: stretch;
 		}
 
 		.woocommerce-list__item-after {
@@ -26,7 +26,7 @@
 		}
 
 		.woocommerce-list__item-inner {
-			padding: 0;
+			padding: 40px 24px;
 		}
 	}
 

--- a/plugins/woocommerce/changelog/fix-33232-fix-product-task-cards-click-unresponsive
+++ b/plugins/woocommerce/changelog/fix-33232-fix-product-task-cards-click-unresponsive
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix clicking on edges of product task cards


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33232. Adjusted some CSS to make sure the inner elements that listens to click event covers the whole element.

### How to test the changes in this Pull Request:

1. Install and activate the latest [WooCommerce Test Helper plugin](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/tag/v0.7.5)
1. Navigate to **Tools > WCA Test Helper > Experiments** and add `woocommerce_products_task_layout_card` to treatment
1. Make sure your site has woocommerce_allow_tracking option set to yes
1. Go to WooCommerce > Home > Add my products
2. Attempt to click on the edges of the card element and make sure it navigates to another page

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
