### PR TITLE
Add inbox WP admin link support for remote inbox notifications

### DIFF
--- a/plugins/woocommerce/changelog/add-32129_remove_inbox_wp_admin_link_support
+++ b/plugins/woocommerce/changelog/add-32129_remove_inbox_wp_admin_link_support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support to remote inbox notification actions to link to other wp-admin pages. #33237

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -101,7 +101,10 @@ class SpecRunner {
 		}
 
 		if ( isset( $action->url_is_admin_query ) && $action->url_is_admin_query ) {
-			return wc_admin_url( $action->url );
+			if ( strpos( $action->url, '&path' ) === 0 ) {
+				return wc_admin_url( $action->url );
+			}
+			return admin_url( $action->url );
 		}
 
 		return $action->url;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/spec-runner.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/spec-runner.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Spec runner tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
+
+/**
+ * class WC_Admin_Tests_RemoteInboxNotifications_SpecRunner
+ */
+class WC_Admin_Tests_RemoteInboxNotifications_SpecRunner extends WC_Unit_Test_Case {
+
+	/**
+	 * Build up a spec given the supplied parameters.
+	 *
+	 * @param string $url url for the action.
+	 * @param bool   $url_is_admin_query is_admin_query boolean for the action.
+	 *
+	 * @return object The spec object.
+	 */
+	private function get_spec( $url, $url_is_admin_query ) {
+		return json_decode(
+			'{
+				"slug": "test",
+				"status": "unactioned",
+				"type": "info",
+				"locales": [{
+					"locale": "en_US",
+					"title": "Title",
+					"content": "Content"
+				}],
+				"rules": [],
+				"actions": [ {
+					"name": "test-action",
+	 				"locales": [
+	 				{
+						"locale": "en_US",
+						"label": "Action label"
+					}],
+					"url": "' . $url . '",
+					"url_is_admin_query": ' . ( $url_is_admin_query ? 'true' : 'false' ) . ',
+					"status": "unactioned"
+				}]
+			}'
+		);
+	}
+
+	/**
+	 * Tests get_url function with wp-admin url
+	 *
+	 * @group fast
+	 */
+	public function test_get_url_with_wp_admin_url() {
+		$spec = $this->get_spec( 'plugins.php', true );
+		SpecRunner::run_spec( $spec, RemoteInboxNotificationsEngine::get_stored_state() );
+		$note   = Notes::get_note_by_name( $spec->slug );
+		$action = $note->get_action( 'test-action' );
+		$this->assertEquals( admin_url( 'plugins.php' ), $action->query );
+	}
+
+	/**
+	 * Tests get url function with WooCommerce Admin url.
+	 *
+	 * @group fast
+	 */
+	public function test_get_url_with_wc_admin_url() {
+		$spec = $this->get_spec( '&path=wc-addons', true );
+		SpecRunner::run_spec( $spec, RemoteInboxNotificationsEngine::get_stored_state() );
+		$note   = Notes::get_note_by_name( $spec->slug );
+		$action = $note->get_action( 'test-action' );
+		$this->assertEquals( wc_admin_url( '&path=wc-addons' ), $action->query );
+	}
+
+	/**
+	 * Tests get url with external url.
+	 *
+	 * @group fast
+	 */
+	public function test_get_url_with_external_url() {
+		$spec = $this->get_spec( 'http://test.com', false );
+		SpecRunner::run_spec( $spec, RemoteInboxNotificationsEngine::get_stored_state() );
+		$note   = Notes::get_note_by_name( $spec->slug );
+		$action = $note->get_action( 'test-action' );
+		$this->assertEquals( 'http://test.com', $action->query );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Make use of `admin_url` by default for action urls, and only use `wc_admin_url` when the url starts with `&path`.

This would mean that this might break on older versions of WC, so whomever adds a new note will have to add this condition (other suggestions are welcome):
```
{
"type": "plugin_version",
"plugin": "woocommerce",
"operator": ">=",
"version": "6.5"
}
```

Closes #32129  .

### How to test the changes in this Pull Request:

1. Load this branch and have WooCommerce Admin Test Helper installed, but on this branch: https://github.com/woocommerce/woocommerce-admin-test-helper/pull/48 (as there is a bug, if you could review those changes at the same time that would be fantastic :) )
2. Create a `mu-plugin` if you don't have one already and add this filter to it:
```
function add_datasource_remote_inbox_notifications( $data_sources, $id ) {
	if ( "remote_inbox_notifications" === $id ) {
		$data_sources[] = "https://gist.githubusercontent.com/louwie17/bd6f9fb6e0dec763f3dd9ed204924689/raw/a89ef9651aa0ab6cf3c636a4ea4a348f3c0b6734/inbox-notifications.json";
	}
	return $data_sources;
}
add_filter( 'data_source_poller_data_sources', 'add_datasource_remote_inbox_notifications', 10, 2 );
```
This add's this [gist](https://gist.github.com/louwie17/bd6f9fb6e0dec763f3dd9ed204924689) to the remote inbox notifications that will add 3 new notes.
3. Go to **Tools > WCA Test Helper > Tools** and trigger the `wc_admin_daily_job`
4. Go to **WooCommerce > Home** and 4 new notes should be present (**Navigate to plugins**, **Where did this note come from?**, **Navigate to add products**, and **Navigate to onboarding** )
5. Click on the action of each of them, and they should all direct correctly to it's designated location (as implied by the title and description). The **Navigate to add products** and the **Navigate to plugins** are the notes that contains the Admin url, see line 24 and 147 in [the Gist](https://gist.github.com/louwie17/bd6f9fb6e0dec763f3dd9ed204924689#file-inbox-notifications-json) ). 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
