### PR TITLE
Fix completed card button

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -54,6 +54,10 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	const [ openPanel, setOpenPanel ] = useState< string | null >(
 		sections?.find( ( section ) => ! section.isComplete )?.id || null
 	);
+	const [
+		isCompletedCardVisible,
+		setIsCompletedCardVisible,
+	] = useState< boolean >( true );
 
 	const prevQueryRef = useRef( query );
 
@@ -96,6 +100,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		updateOptions( {
 			...updateOptionsParams,
 		} );
+		setIsCompletedCardVisible( false );
 	};
 
 	let selectedHeaderCard = visibleTasks.find(
@@ -117,7 +122,11 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
 
-	if ( isComplete && keepCompletedTaskList !== 'yes' ) {
+	if (
+		isComplete &&
+		keepCompletedTaskList !== 'yes' &&
+		isCompletedCardVisible
+	) {
 		return (
 			<>
 				{ cesHeader ? (

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -50,14 +50,13 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 			profileItems: getProfileItems(),
 		};
 	} );
-	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
+	const {
+		hideTaskList,
+		keepCompletedTaskList: keepCompletedTasks,
+	} = useDispatch( ONBOARDING_STORE_NAME );
 	const [ openPanel, setOpenPanel ] = useState< string | null >(
 		sections?.find( ( section ) => ! section.isComplete )?.id || null
 	);
-	const [
-		isCompletedCardVisible,
-		setIsCompletedCardVisible,
-	] = useState< boolean >( true );
 
 	const prevQueryRef = useRef( query );
 
@@ -93,14 +92,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	};
 
 	const keepTasks = () => {
-		const updateOptionsParams = {
-			woocommerce_task_list_keep_completed: 'yes',
-		};
-
-		updateOptions( {
-			...updateOptionsParams,
-		} );
-		setIsCompletedCardVisible( false );
+		keepCompletedTasks( id );
 	};
 
 	let selectedHeaderCard = visibleTasks.find(
@@ -122,11 +114,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
 
-	if (
-		isComplete &&
-		keepCompletedTaskList !== 'yes' &&
-		isCompletedCardVisible
-	) {
+	if ( isComplete && keepCompletedTaskList !== 'yes' ) {
 		return (
 			<>
 				{ cesHeader ? (


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the button `Show setup task list` in the completed setup card. 

Closes #33211.

### How to test the changes in this Pull Request:

1. Start with a fresh install
2. Install and activate the latest [WooCommerce Test Helper plugin](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/tag/v0.7.4)
3. Navigate to **Tools > WCA Test Helper > Experiments** and toggle `woocommerce_tasklist_setup_experiment_2_2022_*` to treatment.
4. Finish all the tasks.
5. The message `You've completed store setup` will be visible.
6. Select `Show setup task list` in the kebab menu. 
7. The setup task list should be visible now.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
