### PR TITLE
Remove changelog files for PRs cherry-picked into 6.6-RC1

### DIFF
--- a/plugins/woocommerce/changelog/dev-33226-cleanup-translation-path-fixes
+++ b/plugins/woocommerce/changelog/dev-33226-cleanup-translation-path-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Removed temporary codepath added in #32603 since translation paths have been updated #33226

--- a/plugins/woocommerce/changelog/fix-32979-next_week_start-respects-timezone
+++ b/plugins/woocommerce/changelog/fix-32979-next_week_start-respects-timezone
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix dashboard and analytics crashing with certain timezone configuration

--- a/plugins/woocommerce/changelog/fix-33232-fix-product-task-cards-click-unresponsive
+++ b/plugins/woocommerce/changelog/fix-33232-fix-product-task-cards-click-unresponsive
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix clicking on edges of product task cards


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR deletes the changelog files from the PRs that were cherry-picked into 6.6-RC1 via #33242

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
