### PR TITLE
Correct CLIRunner translations

### DIFF
--- a/plugins/woocommerce/changelog/update-fix-CLIRunner-translations
+++ b/plugins/woocommerce/changelog/update-fix-CLIRunner-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update CLI messages in COT migration to be more clear.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -122,7 +122,12 @@ class CLIRunner {
 			WP_CLI::log(
 				sprintf(
 					/* Translators: %1$d is the number of orders to be migrated. */
-					_n( 'There is %1$d order to be migrated.', 'There are %1$d orders to be migrated.', $order_count, 'woocommerce' ),
+					_n(
+						'There is %1$d order to be migrated.',
+						'There are %1$d orders to be migrated.',
+						$order_count,
+						'woocommerce'
+					),
 					$order_count
 				)
 			);
@@ -182,7 +187,7 @@ class CLIRunner {
 
 			WP_CLI::debug(
 				sprintf(
-					/* Translators: %1$d is the batch number, %2$d is the batch size. */
+					/* Translators: %1$d is the batch number and %2$d is the batch size. */
 					__( 'Beginning batch #%1$d (%2$d orders/batch).', 'woocommerce' ),
 					$batch_count,
 					$batch_size
@@ -198,8 +203,8 @@ class CLIRunner {
 
 			WP_CLI::debug(
 				sprintf(
-					// Translators: %1$d is the batch number, %2$f is time taken to process batch.
-					__( 'Batch %1$d (%2$d orders) completed in %3$f seconds', 'woocommerce' ),
+					// Translators: %1$d is the batch number, %2$d is the number of processed orders and %3$d is the execution time in seconds.
+					__( 'Batch %1$d (%2$d orders) completed in %3$d seconds', 'woocommerce' ),
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
@@ -229,8 +234,13 @@ class CLIRunner {
 
 		return WP_CLI::success(
 			sprintf(
-				/* Translators: %1$d is the number of migrated orders. */
-				_n( '%1$d order was migrated, in %2$f seconds', '%1$d orders were migrated in %2$f seconds', $processed, 'woocommerce' ),
+				/* Translators: %1$d is the number of migrated orders and %2$d is the execution time in seconds. */
+				_n(
+					'%1$d order was migrated in %2$d seconds.',
+					'%1$d orders were migrated in %2$d seconds.',
+					$processed,
+					'woocommerce'
+				),
 				$processed,
 				$total_time
 			)
@@ -347,7 +357,7 @@ class CLIRunner {
 			WP_CLI::debug(
 				sprintf(
 				// Translators: %1$d is the batch number, %2$f is time taken to process batch.
-					__( 'Batch %1$d (%2$d orders) completed in %3$f seconds', 'woocommerce' ),
+					__( 'Batch %1$d (%2$d orders) completed in %3$f seconds.', 'woocommerce' ),
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
@@ -370,8 +380,8 @@ class CLIRunner {
 				sprintf(
 					/* Translators: %1$d is the number of migrated orders and %2$f is time taken */
 					_n(
-						'%1$d order was verified in %2$f seconds.',
-						'%1$d orders were verified in %2$f seconds.',
+						'%1$d order was verified in %2$d seconds.',
+						'%1$d orders were verified in %2$d seconds.',
 						$processed,
 						'woocommerce'
 					),
@@ -384,17 +394,29 @@ class CLIRunner {
 
 			return WP_CLI::error(
 				sprintf(
-					/* Translators: %1$d is the number of migrated orders, %2$f is time taken, %3$d is number of errors and $4%s is formatted array of order ids. */
-					_n(
-						'%1$d order was verified in %2$f seconds. %3$d error(s) found: %4$s. Please review above errors.',
-						'%1$d orders were verified in %2$f seconds. %3$d error(s) found: %4$s. Please review above errors.',
+					'%1$s %2$s',
+					sprintf(
+						/* Translators: %1$d is the number of migrated orders and %2$d is the execution time in seconds. */
+						_n(
+							'%1$d order was verified in %2$d seconds.',
+							'%1$d orders were verified in %2$d seconds.',
+							$processed,
+							'woocommerce'
+						),
 						$processed,
-						'woocommerce'
+						$total_time,
 					),
-					$processed,
-					$total_time,
-					count( $failed_ids ),
-					$errors
+					sprintf(
+						/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
+						_n(
+							'%1$d error found: %2$s. Please review the error above.',
+							'%1$d errors found: %2$s. Please review the errors above.',
+							count( $failed_ids ),
+							'woocommerce'
+						),
+						count( $failed_ids ),
+						$errors
+					)
 				)
 			);
 		}
@@ -422,7 +444,12 @@ class CLIRunner {
 			WP_CLI::log(
 				sprintf(
 					/* Translators: %1$d is the number of orders to be verified. */
-					_n( 'There is %1$d order to be verified.', 'There are %1$d orders to be verified.', $order_count, 'woocommerce' ),
+					_n(
+						'There is %1$d order to be verified.',
+						'There are %1$d orders to be verified.',
+						$order_count,
+						'woocommerce'
+					),
 					$order_count
 				)
 			);

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -356,8 +356,8 @@ class CLIRunner {
 
 			WP_CLI::debug(
 				sprintf(
-				// Translators: %1$d is the batch number, %2$f is time taken to process batch.
-					__( 'Batch %1$d (%2$d orders) completed in %3$f seconds.', 'woocommerce' ),
+					/* Translators: %1$d is the batch number, %2$d is time taken to process batch. */
+					__( 'Batch %1$d (%2$d orders) completed in %3$d seconds.', 'woocommerce' ),
 					$batch_count,
 					count( $order_ids ),
 					$batch_total_time
@@ -378,7 +378,7 @@ class CLIRunner {
 		if ( 0 === count( $failed_ids ) ) {
 			return WP_CLI::success(
 				sprintf(
-					/* Translators: %1$d is the number of migrated orders and %2$f is time taken */
+					/* Translators: %1$d is the number of migrated orders and %2$d is time taken. */
 					_n(
 						'%1$d order was verified in %2$d seconds.',
 						'%1$d orders were verified in %2$d seconds.',
@@ -404,7 +404,7 @@ class CLIRunner {
 							'woocommerce'
 						),
 						$processed,
-						$total_time,
+						$total_time
 					),
 					sprintf(
 						/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

While working on new translations of the WooCommerce plugin, I noticed some incorrect translation strings, inconsistent translator comments and incorrect placeholder formats.

Below, I've explained all changes in detail as a review.

### How to test the changes in this Pull Request:

1. Look up the changed strings.
2. Verify that all strings end with a full stop.
3. Verify that the number of orders is shown as an integer instead of a float.
4. Verify that the execution time in seconds is shown as an integer instead of a float.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.