### PR TITLE
Add extra hook in email setup_locale and restore_locale functions.

### DIFF
--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -322,7 +322,7 @@ class WC_Email extends WC_Settings_API {
 		/**
 		 * Filter the ability to switch email locale.
 		 *
-		 * @since 6.7.0
+		 * @since 6.8.0
 		 *
 		 * @param bool $default_value The default returned value.
 		 * @param WC_Email $this The WC_Email object.
@@ -342,7 +342,7 @@ class WC_Email extends WC_Settings_API {
 		/**
 		 * Filter the ability to restore email locale.
 		 *
-		 * @since 6.7.0
+		 * @since 6.8.0
 		 *
 		 * @param bool $default_value The default returned value.
 		 * @param WC_Email $this The WC_Email object.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -318,7 +318,7 @@ class WC_Email extends WC_Settings_API {
 	 * Set the locale to the store locale for customer emails to make sure emails are in the store language.
 	 */
 	public function setup_locale() {
-		if ( $this->is_customer_email() && apply_filters( 'woocommerce_email_setup_locale', true ) ) {
+		if ( apply_filters( 'woocommerce_allow_switching_email_locale', true, $this ) && $this->is_customer_email() && apply_filters( 'woocommerce_email_setup_locale', true ) ) {
 			wc_switch_to_site_locale();
 		}
 	}
@@ -327,7 +327,7 @@ class WC_Email extends WC_Settings_API {
 	 * Restore the locale to the default locale. Use after finished with setup_locale.
 	 */
 	public function restore_locale() {
-		if ( $this->is_customer_email() && apply_filters( 'woocommerce_email_restore_locale', true ) ) {
+		if ( apply_filters( 'woocommerce_allow_restoring_email_locale', true, $this ) && $this->is_customer_email() && apply_filters( 'woocommerce_email_restore_locale', true ) ) {
 			wc_restore_locale();
 		}
 	}

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -318,7 +318,18 @@ class WC_Email extends WC_Settings_API {
 	 * Set the locale to the store locale for customer emails to make sure emails are in the store language.
 	 */
 	public function setup_locale() {
-		if ( apply_filters( 'woocommerce_allow_switching_email_locale', true, $this ) && $this->is_customer_email() && apply_filters( 'woocommerce_email_setup_locale', true ) ) {
+
+		/**
+		 * Filter the ability to switch email locale.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param bool $default_value The default returned value.
+		 * @param WC_Email $this The WC_Email object.
+		 */
+		$switch_email_locale = apply_filters( 'woocommerce_allow_switching_email_locale', true, $this );
+
+		if ( $switch_email_locale && $this->is_customer_email() && apply_filters( 'woocommerce_email_setup_locale', true ) ) {
 			wc_switch_to_site_locale();
 		}
 	}
@@ -327,7 +338,18 @@ class WC_Email extends WC_Settings_API {
 	 * Restore the locale to the default locale. Use after finished with setup_locale.
 	 */
 	public function restore_locale() {
-		if ( apply_filters( 'woocommerce_allow_restoring_email_locale', true, $this ) && $this->is_customer_email() && apply_filters( 'woocommerce_email_restore_locale', true ) ) {
+
+		/**
+		 * Filter the ability to restore email locale.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param bool $default_value The default returned value.
+		 * @param WC_Email $this The WC_Email object.
+		 */
+		$restore_email_locale = apply_filters( 'woocommerce_allow_restoring_email_locale', true, $this );
+
+		if ( $restore_email_locale && $this->is_customer_email() && apply_filters( 'woocommerce_email_restore_locale', true ) ) {
 			wc_restore_locale();
 		}
 	}


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hello!

This is the TranslatePress development team.

We made a pull request for a change in your plugin code that would allow translating WooCommerce emails in the language of the customer and of the admin, respectively.

The change consists of adding an extra hook to the condition in the setup_locale() and restore_locale() functions in includes/emails/class-wc-email.php.

The desire behind this is to be able to control the execution and change the language accordingly by returning FALSE on the filter.

The reason we made the change by adding an extra hook and not using the already existing one was to be able to translate emails in the case they are sent to the admin as well (in the original code, because the existing hook comes second in an AND condition, the execution does not reach it in the case of emails sent to the admin).

By adding the new hook at the beginning of the condition, we make sure it is executed every time. Because of this, backwards compatibility is also ensured as there is no need to change the logic by reversing the order of the already existing conditions inside the IF.

As the change we propose is minor and safe to implement in your code, yet indeed very important for us, we hope you will consider approving it in the near future according to your schedule.

Thank you! 

Closes # .

### How to test the changes in this Pull Request:

1. Check that WooCommerce email functionality is not modified in any way by the changes.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
