### PR TITLE
Fixes for the WP CLI Updater

### DIFF
--- a/plugins/woocommerce/changelog/fix-33262-wp-cli-updates
+++ b/plugins/woocommerce/changelog/fix-33262-wp-cli-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes for the WP CLI updates

--- a/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
@@ -63,10 +63,6 @@ class WC_CLI_Update_Command {
 
 		foreach ( $callbacks_to_run as $update_callback ) {
 			call_user_func( $update_callback );
-			$result = false;
-			while ( $result ) {
-				$result = (bool) call_user_func( $update_callback );
-			}
 			$update_count ++;
 			$progress->tick();
 		}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
@@ -71,6 +71,7 @@ class WC_CLI_Update_Command {
 			$progress->tick();
 		}
 
+		WC_Install::update_db_version();
 		$progress->finish();
 
 		WC_Admin_Notices::remove_notice( 'update', true );

--- a/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-update-command.php
@@ -21,7 +21,7 @@ class WC_CLI_Update_Command {
 	 * Registers the update command.
 	 */
 	public static function register_commands() {
-		WP_CLI::add_command( 'wc update', array( 'WC_CLI_Update_Command', 'update' ) );
+		WC()->call_static( WP_CLI::class, 'add_command', 'wc update', array( 'WC_CLI_Update_Command', 'update' ) );
 	}
 
 	/**
@@ -51,15 +51,28 @@ class WC_CLI_Update_Command {
 		if ( empty( $callbacks_to_run ) ) {
 			// Ensure DB version is set to the current WC version to match WP-Admin update routine.
 			WC_Install::update_db_version();
-			/* translators: %s Database version number */
-			WP_CLI::success( sprintf( __( 'No updates required. Database version is %s', 'woocommerce' ), get_option( 'woocommerce_db_version' ) ) );
+
+			WC()->call_static(
+				WP_CLI::class,
+				'success',
+				/* translators: %s Database version number */
+				sprintf( __( 'No updates required. Database version is %s', 'woocommerce' ), get_option( 'woocommerce_db_version' ) )
+			);
 			return;
 		}
 
-		/* translators: 1: Number of database updates 2: List of update callbacks */
-		WP_CLI::log( sprintf( __( 'Found %1$d updates (%2$s)', 'woocommerce' ), count( $callbacks_to_run ), implode( ', ', $callbacks_to_run ) ) );
+		WC()->call_static(
+			WP_CLI::class,
+			'log',
+			/* translators: 1: Number of database updates 2: List of update callbacks */
+			sprintf( __( 'Found %1$d updates (%2$s)', 'woocommerce' ), count( $callbacks_to_run ), implode( ', ', $callbacks_to_run ) )
+		);
 
-		$progress = \WP_CLI\Utils\make_progress_bar( __( 'Updating database', 'woocommerce' ), count( $callbacks_to_run ) ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+		$progress = WC()->call_function(
+			'WP_CLI\Utils\make_progress_bar',
+			__( 'Updating database', 'woocommerce' ),
+			count( $callbacks_to_run ) // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+		);
 
 		foreach ( $callbacks_to_run as $update_callback ) {
 			call_user_func( $update_callback );
@@ -72,7 +85,11 @@ class WC_CLI_Update_Command {
 
 		WC_Admin_Notices::remove_notice( 'update', true );
 
-		/* translators: 1: Number of database updates performed 2: Database version number */
-		WP_CLI::success( sprintf( __( '%1$d update functions completed. Database version is %2$s', 'woocommerce' ), absint( $update_count ), get_option( 'woocommerce_db_version' ) ) );
+		WC()->call_static(
+			WP_CLI::class,
+			'success',
+			/* translators: 1: Number of database updates performed 2: Database version number */
+			sprintf( __( '%1$d update functions completed. Database version is %2$s', 'woocommerce' ), absint( $update_count ), get_option( 'woocommerce_db_version' ) )
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
+++ b/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Tests for the `wp wc update` WP CLI command.
+ */
+class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
+	/**
+	 * @var array
+	 */
+	private $db_updates_original_value;
+
+	/**
+	 * @var ReflectionProperty
+	 */
+	private $db_updates_property;
+
+	/**
+	 * Load the WC_CLI_Update_Command class definition.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once dirname( WC_PLUGIN_FILE ) . '/includes/cli/class-wc-cli-update-command.php';
+	}
+
+	/**
+	 * Make WP_Install::$db_updates readable and capture the original value.
+	 */
+	public function set_up() {
+		$this->db_updates_property = new ReflectionProperty( WC_Install::class, 'db_updates' );
+		$this->db_updates_property->setAccessible( true );
+		$this->db_updates_original_value = $this->db_updates_property->getValue();
+	}
+
+	/**
+	 * Restore WP_Install::$db_updates to its earlier state.
+	 */
+	public function tear_down() {
+		$this->db_updates_property->setValue( $this->db_updates_original_value );
+		$this->db_updates_property->setAccessible( false );
+	}
+
+	/**
+	 * @testdox After `wp wc update` has run, the `woocommerce_db_option` should be left at the expected value.
+	 */
+	public function test_db_version_is_updated_if_have_callbacks() {
+		$this->mock_wp_cli();
+
+		// Overwrite with some alternative update callbacks.
+		$this->db_updates_property->setValue(
+			array(
+				'5.0.0' => function () {},
+				'6.0.0' => function () {},
+			)
+		);
+
+		update_option( 'woocommerce_db_version', '4.0.0' );
+		$sut = new WC_CLI_Update_Command();
+		$sut->update();
+
+		$this->assertEquals(
+			WC()->version,
+			get_option( 'woocommerce_db_version' ),
+			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the current `WC()->version` property.'
+		);
+	}
+
+	/**
+	 * @testdox After `wp wc update` has run, the `woocommerce_db_option` should be left at the expected value (even if no update callbacks were executed)
+	 */
+	public function test_db_version_is_updated_if_no_callbacks() {
+		$this->mock_wp_cli();
+
+		// Overwrite with some alternative update callbacks.
+		$this->db_updates_property->setValue( array() );
+
+		update_option( 'woocommerce_db_version', '4.0.0' );
+		$sut = new WC_CLI_Update_Command();
+		$sut->update();
+
+		$this->assertEquals(
+			WC()->version,
+			get_option( 'woocommerce_db_version' ),
+			'After applying updates via WP CLI, the `woocommerce_db_version` option should match the current `WC()->version` property.'
+		);
+	}
+
+	/**
+	 * Mock WP_CLI and related functionality.
+	 */
+	private function mock_wp_cli() {
+		parent::set_up();
+
+		$this->register_legacy_proxy_static_mocks(
+			array(
+				WP_CLI::class => array(
+					'log'     => function () {},
+					'success' => function () {},
+				),
+			)
+		);
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'WP_CLI\Utils\make_progress_bar' => function () {
+					return new class() {
+						/**
+						 * Stub, implemented so that calls to WP CLI methods do not break the tests.
+						 */
+						public function finish() {}
+
+						/**
+						 * Stub, implemented so that calls to WP CLI methods do not break the tests.
+						 */
+						public function tick() {}
+					};
+				},
+			)
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tidies the `wp wc update` command:

- Removes unexecutable code (closes #31214).
- Updates the `woocommerce_db_version` option after executing any/all callbacks, for parity with the web/queue-based update flow (closes #33262).

### How to test the changes in this Pull Request:

Using WP CLI:

1. Set the relevant plugin version options to an earlier version. Let's use 6.4.0:
    1. `wp option set woocommerce_version 6.4.0`
    2. `wp option set woocommerce_db_version 6.4.0`
3. Run updates via WP CLI: `wp wc update`
4. Command should be successful and should indicate that the db version is now `6.6.0` (or some higher value, depending on which release cycle we're in the middle of at time of testing, etc).
5. Verify you see `6.6.0` (or later) by using:
    1. `wp option get woocommerce_version`
    2. `wp option get woocommerce_db_version`

Web/queue-based (this functionality should not have changed, so we're just testing as a confidence measure to ensure there are no unexpected glitches introduced by accident):

1. Update the database options to an earlier version, just as you did in the previous set of instructions.
2. Visit a WooCommerce admin screen, you should see a banner inviting you to update. Do it!
3. Give time for the update to complete ... eventually, it should be finished and you should see a new admin notice indicating as much
4. Verify the `woocommerce_*_version` option values just as you did in the earlier steps.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
