### PR TITLE
Add "built by Woo" label to Pinterest

### DIFF
--- a/plugins/woocommerce/changelog/update-pinterest-built-by-woo
+++ b/plugins/woocommerce/changelog/update-pinterest-built-by-woo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add "built by Woo" label to Pinterest

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -105,7 +105,7 @@ class DefaultFreeExtensions {
 				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
-				'is_built_by_wc' => false,
+				'is_built_by_wc' => true,
 			],
 			'mailpoet'                          => [
 				'name'           => __( 'MailPoet', 'woocommerce' ),
@@ -462,7 +462,7 @@ class DefaultFreeExtensions {
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,
 			],
-			'tiktok-for-business'                            => [
+			'tiktok-for-business'               => [
 				'name'           => __( 'TikTok for WooCommerce', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/tiktok.svg', WC_PLUGIN_FILE ),
 				'description'    =>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33260

This PR adds "built by Woo" label to Pinterest.

### How to test the changes in this Pull Request:

1. Create a fresh site.
2. Make sure `woocommerce_show_marketplace_suggestions` is set to `no` in **wp_options** table.
3. Navigate to http://your-site/wp-admin/admin.php?page=wc-admin&task=marketing
4. Confirm the Pinterest has a "Built by WooCommerce" label

![Screen Shot 2022-05-31 at 16 11 14](https://user-images.githubusercontent.com/4344253/171125263-4610a581-b836-4a43-b4b4-4590712db47b.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
