### PR TITLE
Make the option 'woocommerce_tracker_ua' load on demand.

### DIFF
--- a/plugins/woocommerce/changelog/update-31881-lazyload-ua-option
+++ b/plugins/woocommerce/changelog/update-31881-lazyload-ua-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Make the option 'woocommerce_tracker_ua' load on demand.

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -862,7 +862,7 @@ function wc_maybe_store_user_agent( $user_login, $user ) {
 	if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) && user_can( $user, 'manage_woocommerce' ) ) {
 		$admin_user_agents   = array_filter( (array) get_option( 'woocommerce_tracker_ua', array() ) );
 		$admin_user_agents[] = wc_get_user_agent();
-		update_option( 'woocommerce_tracker_ua', array_unique( $admin_user_agents ) );
+		update_option( 'woocommerce_tracker_ua', array_unique( $admin_user_agents ), false );
 	}
 }
 add_action( 'wp_login', 'wc_maybe_store_user_agent', 10, 2 );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31881 .

### How to test the changes in this Pull Request:

1. Drop the option from the database 
2. Logging into the WordPress admin area
3. Ensure that the database entry for the option is marked as lazy-loading

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
