### PR TITLE
Adding context property to tasklist_view and task_click events

### DIFF
--- a/packages/js/data/src/onboarding/utils.ts
+++ b/packages/js/data/src/onboarding/utils.ts
@@ -6,11 +6,9 @@ import { TaskType } from './types';
 /**
  * Filters tasks to only visible tasks, taking in account snoozed tasks.
  */
-export function getVisibleTasks( tasks: TaskType[] ) {
-	const nowTimestamp = Date.now();
-	return tasks.filter(
+export const getVisibleTasks = ( tasks: TaskType[] ) =>
+	tasks.filter(
 		( task ) =>
 			! task.isDismissed &&
-			( ! task.isSnoozed || task.snoozedUntil < nowTimestamp )
+			( ! task.isSnoozed || task.snoozedUntil < Date.now() )
 	);
-}

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lazy, useState } from '@wordpress/element';
+import { lazy, useState, useContext, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
@@ -38,6 +38,7 @@ import { getUnapprovedReviews } from '../homescreen/activity-panel/reviews/utils
 import { ABBREVIATED_NOTIFICATION_SLOT_NAME } from './panels/inbox/abbreviated-notifications-panel';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { useActiveSetupTasklist } from '~/tasks';
+import { LayoutContext } from '~/layout';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -64,6 +65,11 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const hasExtendedNotifications = Boolean( fills?.length );
 	const { updateUserPreferences, ...userData } = useUserPreferences();
 	const activeSetupList = useActiveSetupTasklist();
+	const layoutContext = useContext( LayoutContext );
+	const updatedLayoutContext = useMemo(
+		() => layoutContext.getExtendedContext( 'activity-panel' ),
+		[ layoutContext ]
+	);
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
 		let trackData = {};
@@ -368,55 +374,57 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const showHelpHighlightTooltip = shouldShowHelpTooltip();
 
 	return (
-		<div>
-			<H id={ headerId } className="screen-reader-text">
-				{ __( 'Store Activity', 'woocommerce' ) }
-			</H>
-			<Section
-				component="aside"
-				id="woocommerce-activity-panel"
-				className="woocommerce-layout__activity-panel"
-				aria-labelledby={ headerId }
-			>
-				<Tabs
-					tabs={ tabs }
-					tabOpen={ isPanelOpen }
-					selectedTab={ currentTab }
-					onTabClick={ ( tab, tabOpen ) => {
-						if ( tab.onClick ) {
-							tab.onClick();
-							return;
-						}
+		<LayoutContext.Provider value={ updatedLayoutContext }>
+			<div>
+				<H id={ headerId } className="screen-reader-text">
+					{ __( 'Store Activity', 'woocommerce' ) }
+				</H>
+				<Section
+					component="aside"
+					id="woocommerce-activity-panel"
+					className="woocommerce-layout__activity-panel"
+					aria-labelledby={ headerId }
+				>
+					<Tabs
+						tabs={ tabs }
+						tabOpen={ isPanelOpen }
+						selectedTab={ currentTab }
+						onTabClick={ ( tab, tabOpen ) => {
+							if ( tab.onClick ) {
+								tab.onClick();
+								return;
+							}
 
-						togglePanel( tab, tabOpen );
-					} }
-				/>
-				<Panel
-					currentTab
-					isPanelOpen={ isPanelOpen }
-					isPanelSwitching={ isPanelSwitching }
-					tab={ find( getTabs(), { name: currentTab } ) }
-					content={ getPanelContent( currentTab ) }
-					closePanel={ () => closePanel() }
-					clearPanel={ () => clearPanel() }
-				/>
-			</Section>
-			{ showHelpHighlightTooltip ? (
-				<HighlightTooltip
-					delay={ 1000 }
-					useAnchor={ true }
-					title={ __( "We're here for help", 'woocommerce' ) }
-					content={ __(
-						'If you have any questions, feel free to explore the WooCommerce docs listed here.',
-						'woocommerce'
-					) }
-					closeButtonText={ __( 'Got it', 'woocommerce' ) }
-					id="activity-panel-tab-help"
-					onClose={ () => closedHelpPanelHighlight() }
-					onShow={ () => recordEvent( 'help_tooltip_view' ) }
-				/>
-			) : null }
-		</div>
+							togglePanel( tab, tabOpen );
+						} }
+					/>
+					<Panel
+						currentTab
+						isPanelOpen={ isPanelOpen }
+						isPanelSwitching={ isPanelSwitching }
+						tab={ find( getTabs(), { name: currentTab } ) }
+						content={ getPanelContent( currentTab ) }
+						closePanel={ () => closePanel() }
+						clearPanel={ () => clearPanel() }
+					/>
+				</Section>
+				{ showHelpHighlightTooltip ? (
+					<HighlightTooltip
+						delay={ 1000 }
+						useAnchor={ true }
+						title={ __( "We're here for help", 'woocommerce' ) }
+						content={ __(
+							'If you have any questions, feel free to explore the WooCommerce docs listed here.',
+							'woocommerce'
+						) }
+						closeButtonText={ __( 'Got it', 'woocommerce' ) }
+						id="activity-panel-tab-help"
+						onClose={ () => closedHelpPanelHighlight() }
+						onShow={ () => recordEvent( 'help_tooltip_view' ) }
+					/>
+				) : null }
+			</div>
+		</LayoutContext.Provider>
 	);
 };
 

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -12,6 +12,7 @@ import {
 	OPTIONS_STORE_NAME,
 	useUser,
 	useUserPreferences,
+	getVisibleTasks,
 } from '@woocommerce/data';
 import { getHistory } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
@@ -151,6 +152,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		const setupList = getTaskList( activeSetupList );
 
 		const isSetupTaskListHidden = setupList?.isHidden;
+		const setupVisibleTasks = getVisibleTasks( setupList?.tasks || [] );
 		const extendedTaskList = getTaskList( 'extended' );
 
 		const thingsToDoCount = getThingsToDoNextCount( extendedTaskList );
@@ -168,8 +170,8 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			),
 			setupTaskListComplete: setupList?.isComplete,
 			setupTaskListHidden: isSetupTaskListHidden,
-			setupTasksCount: setupList?.tasks.length,
-			setupTasksCompleteCount: setupList?.tasks.filter(
+			setupTasksCount: setupVisibleTasks.length,
+			setupTasksCompleteCount: setupVisibleTasks.filter(
 				( task ) => task.isComplete
 			).length,
 			isCompletedTask: Boolean(

--- a/plugins/woocommerce-admin/client/activity-panel/panels/setup-tasks/setup-tasks-panel.tsx
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/setup-tasks/setup-tasks-panel.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import Tasks from '~/tasks';
+import { Tasks } from '~/tasks';
 
 type QueryTypeProps = {
 	query: {

--- a/plugins/woocommerce-admin/client/activity-panel/panels/setup-tasks/setup-tasks-panel.tsx
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/setup-tasks/setup-tasks-panel.tsx
@@ -12,7 +12,7 @@ type QueryTypeProps = {
 export const SetupTasksPanel = ( { query }: QueryTypeProps ) => {
 	return (
 		<div className="woocommerce-setup-panel">
-			<Tasks query={ query } context="sidebar" />
+			<Tasks query={ query } />
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/activity-panel/panels/setup-tasks/setup-tasks-panel.tsx
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/setup-tasks/setup-tasks-panel.tsx
@@ -12,7 +12,7 @@ type QueryTypeProps = {
 export const SetupTasksPanel = ( { query }: QueryTypeProps ) => {
 	return (
 		<div className="woocommerce-setup-panel">
-			<Tasks query={ query } />
+			<Tasks query={ query } context="sidebar" />
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/activity-panel/setup-progress.js
+++ b/plugins/woocommerce-admin/client/activity-panel/setup-progress.js
@@ -1,21 +1,45 @@
-export const SetupProgress = () => (
+export const SetupProgress = ( {
+	setupTasksComplete,
+	setupCompletePercent,
+} ) => (
 	<svg
 		className="woocommerce-layout__activity-panel-tab-icon setup-progress"
-		width="18"
-		height="18"
 		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
 	>
 		<path
-			d="M12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20Z"
+			d="M 11.985 22.747 C 17.878 22.747 22.655 17.924 22.655 11.974 C 22.655 6.022 17.878 1.197 11.985 1.197 C 6.09 1.197 1.312 6.022 1.312 11.974 C 1.312 17.924 6.09 22.747 11.985 22.747 Z"
 			stroke="#DCDCDE"
-			strokeWidth="2"
+			strokewidth="2"
+			fill="currentColor"
 		/>
 		<path
 			d="M4 12V12C4 16.4183 7.58172 20 12 20V20C16.4183 20 20 16.4183 20 12V12C20 7.58172 16.4183 4 12 4V4"
-			strokeWidth="2"
-			strokeLinecap="round"
+			strokewidth="2"
+			strokelinecap="round"
+		/>
+		<path
+			className="setup-progress-slice"
+			transform="matrix(-0.034188, 0, 0, 0.034134, 37.882862, -8.768827)"
+			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
+			fill={ setupTasksComplete > 0 ? 'currentColor' : 'white' }
+		/>
+		<path
+			className="setup-progress-slice"
+			transform="matrix(-0.034188, 0, 0, -0.034134, 37.878132, 32.640987)"
+			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
+			fill={ setupCompletePercent >= 50 ? 'currentColor' : 'white' }
+		/>
+		<path
+			className="setup-progress-slice"
+			transform="matrix(0.034188, 0, 0, -0.034134, -13.99084, 32.643505)"
+			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
+			fill={ setupCompletePercent >= 75 ? 'currentColor' : 'white' }
+		/>
+		<path
+			className="setup-progress-slice"
+			transform="matrix(0.034188, 0, 0, 0.034134, -13.986106, -8.771348)"
+			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
+			fill="white"
 		/>
 	</svg>
 );

--- a/plugins/woocommerce-admin/client/activity-panel/setup-progress.js
+++ b/plugins/woocommerce-admin/client/activity-panel/setup-progress.js
@@ -4,40 +4,33 @@ export const SetupProgress = ( {
 } ) => (
 	<svg
 		className="woocommerce-layout__activity-panel-tab-icon setup-progress"
-		viewBox="0 0 24 24"
+		viewBox="0 0 25 25"
 	>
 		<path
-			d="M 11.985 22.747 C 17.878 22.747 22.655 17.924 22.655 11.974 C 22.655 6.022 17.878 1.197 11.985 1.197 C 6.09 1.197 1.312 6.022 1.312 11.974 C 1.312 17.924 6.09 22.747 11.985 22.747 Z"
-			stroke="#DCDCDE"
-			strokewidth="2"
-			fill="currentColor"
-		/>
-		<path
-			d="M4 12V12C4 16.4183 7.58172 20 12 20V20C16.4183 20 20 16.4183 20 12V12C20 7.58172 16.4183 4 12 4V4"
-			strokewidth="2"
-			strokelinecap="round"
+			className="setup-progress-ring"
+			d="M 12.476 23.237 C 18.369 23.237 23.146 18.414 23.146 12.464 C 23.146 6.512 18.369 1.687 12.476 1.687 C 6.581 1.687 1.803 6.512 1.803 12.464 C 1.803 18.414 6.581 23.237 12.476 23.237 Z"
 		/>
 		<path
 			className="setup-progress-slice"
-			transform="matrix(-0.034188, 0, 0, 0.034134, 37.882862, -8.768827)"
+			transform="matrix(-0.034188, 0, 0, 0.034134, 38.373184, -8.278505)"
 			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
 			fill={ setupTasksComplete > 0 ? 'currentColor' : 'white' }
 		/>
 		<path
 			className="setup-progress-slice"
-			transform="matrix(-0.034188, 0, 0, -0.034134, 37.878132, 32.640987)"
+			transform="matrix(-0.034188, 0, 0, -0.034134, 38.368454, 33.13131)"
 			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
 			fill={ setupCompletePercent >= 50 ? 'currentColor' : 'white' }
 		/>
 		<path
 			className="setup-progress-slice"
-			transform="matrix(0.034188, 0, 0, -0.034134, -13.99084, 32.643505)"
+			transform="matrix(0.034188, 0, 0, -0.034134, -13.500516, 33.133827)"
 			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
 			fill={ setupCompletePercent >= 75 ? 'currentColor' : 'white' }
 		/>
 		<path
 			className="setup-progress-slice"
-			transform="matrix(0.034188, 0, 0, 0.034134, -13.986106, -8.771348)"
+			transform="matrix(0.034188, 0, 0, 0.034134, -13.495783, -8.281025)"
 			d="M 522 607 A 237 237 0 0 1 759 370 L 759 607 Z"
 			fill="white"
 		/>

--- a/plugins/woocommerce-admin/client/activity-panel/style.scss
+++ b/plugins/woocommerce-admin/client/activity-panel/style.scss
@@ -204,16 +204,15 @@
 	}
 	transform: translateX(100%);
 	@include activity-panel-slide();
-	position: fixed;
+	position: absolute;
 	right: 0;
-	top: #{$header-height + $adminbar-height-mobile};
+	top: 100%;
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: auto;
 
 	@include breakpoint( '>782px' ) {
 		height: calc(100vh - #{$header-height + $adminbar-height});
-		top: #{$header-height + $adminbar-height};
 	}
 	.has-woocommerce-navigation & {
 		height: calc(100vh - #{$header-height});

--- a/plugins/woocommerce-admin/client/activity-panel/style.scss
+++ b/plugins/woocommerce-admin/client/activity-panel/style.scss
@@ -69,8 +69,6 @@
 		outline: none;
 		cursor: pointer;
 		background-color: $studio-white;
-		max-width: min-content;
-		min-width: 80px;
 		width: 100%;
 		height: $header-height;
 		color: $gray-700;

--- a/plugins/woocommerce-admin/client/activity-panel/style.scss
+++ b/plugins/woocommerce-admin/client/activity-panel/style.scss
@@ -28,13 +28,6 @@
 				stroke: currentColor;
 			}
 		}
-
-		// custom progress icon, requires specific coloring
-		&.setup-progress {
-			path:first-child {
-				stroke: '#DCDCDE';
-			}
-		}
 	}
 
 	.woocommerce-layout__homescreen-display-options {

--- a/plugins/woocommerce-admin/client/activity-panel/style.scss
+++ b/plugins/woocommerce-admin/client/activity-panel/style.scss
@@ -28,6 +28,14 @@
 				stroke: currentColor;
 			}
 		}
+
+		.setup-progress-slice {
+			stroke: none;
+		}
+
+		.setup-progress-ring {
+			stroke-width: 2px;
+		}
 	}
 
 	.woocommerce-layout__homescreen-display-options {

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -44,7 +44,9 @@ import { getAdminSetting } from '~/utils/admin-settings';
 import { ProgressTitle } from '../task-lists';
 
 const Tasks = lazy( () =>
-	import( /* webpackChunkName: "tasks" */ '../tasks' )
+	import( /* webpackChunkName: "tasks" */ '../tasks' ).then( ( module ) => ( {
+		default: module.Tasks,
+	} ) )
 );
 
 const TwoColumnTasks = lazy( () =>

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -4,7 +4,7 @@
 import { SlotFillProvider } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { Component, lazy, Suspense } from '@wordpress/element';
+import { Component, lazy, Suspense, createContext } from '@wordpress/element';
 import {
 	unstable_HistoryRouter as HistoryRouter,
 	Route,
@@ -15,7 +15,7 @@ import {
 } from 'react-router-dom';
 import { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import { get, isFunction, identity } from 'lodash';
+import { get, isFunction, identity, memoize } from 'lodash';
 import { parse } from 'qs';
 import { getHistory, getQuery } from '@woocommerce/navigation';
 import {
@@ -49,6 +49,20 @@ const WCPayUsageModal = lazy( () =>
 	import(
 		/* webpackChunkName: "wcpay-usage-modal" */ '../tasks/fills/PaymentGatewaySuggestions/components/WCPay/UsageModal'
 	)
+);
+
+const LayoutContextPrototype = {
+	getExtendedContext( newItem ) {
+		return { ...this, path: [ ...this.path, newItem ] };
+	},
+	toString() {
+		return this.path.join( '/' );
+	},
+	path: [],
+};
+
+export const LayoutContext = createContext(
+	LayoutContextPrototype.getExtendedContext( 'root' )
 );
 
 export class PrimaryLayout extends Component {
@@ -111,6 +125,13 @@ const LayoutSwitchWrapper = ( props ) => {
 };
 
 class _Layout extends Component {
+	memoizedLayoutContext = memoize( ( page ) =>
+		LayoutContextPrototype.getExtendedContext(
+			page?.breadcrumbs[ page.breadcrumbs.length - 1 ].toLowerCase() ||
+				'page'
+		)
+	);
+
 	componentDidMount() {
 		this.recordPageViewTrack();
 	}
@@ -195,38 +216,45 @@ class _Layout extends Component {
 		const query = this.getQuery( location && location.search );
 
 		return (
-			<SlotFillProvider>
-				<div className="woocommerce-layout">
-					<Header
-						sections={
-							isFunction( breadcrumbs )
-								? breadcrumbs( this.props )
-								: breadcrumbs
-						}
-						isEmbedded={ isEmbedded }
-						query={ query }
-					/>
-					<TransientNotices />
-					{ ! isEmbedded && (
-						<PrimaryLayout>
-							<div className="woocommerce-layout__main">
-								<Controller { ...restProps } query={ query } />
-							</div>
-						</PrimaryLayout>
-					) }
+			<LayoutContext.Provider
+				value={ this.memoizedLayoutContext( page ) }
+			>
+				<SlotFillProvider>
+					<div className="woocommerce-layout">
+						<Header
+							sections={
+								isFunction( breadcrumbs )
+									? breadcrumbs( this.props )
+									: breadcrumbs
+							}
+							isEmbedded={ isEmbedded }
+							query={ query }
+						/>
+						<TransientNotices />
+						{ ! isEmbedded && (
+							<PrimaryLayout>
+								<div className="woocommerce-layout__main">
+									<Controller
+										{ ...restProps }
+										query={ query }
+									/>
+								</div>
+							</PrimaryLayout>
+						) }
 
-					{ isEmbedded && this.isWCPaySettingsPage() && (
-						<Suspense fallback={ null }>
-							<WCPayUsageModal />
-						</Suspense>
+						{ isEmbedded && this.isWCPaySettingsPage() && (
+							<Suspense fallback={ null }>
+								<WCPayUsageModal />
+							</Suspense>
+						) }
+					</div>
+					<PluginArea scope="woocommerce-admin" />
+					{ window.wcAdminFeatures.navigation && (
+						<PluginArea scope="woocommerce-navigation" />
 					) }
-				</div>
-				<PluginArea scope="woocommerce-admin" />
-				{ window.wcAdminFeatures.navigation && (
-					<PluginArea scope="woocommerce-navigation" />
-				) }
-				<PluginArea scope="woocommerce-tasks" />
-			</SlotFillProvider>
+					<PluginArea scope="woocommerce-tasks" />
+				</SlotFillProvider>
+			</LayoutContext.Provider>
 		);
 	}
 }

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -127,7 +127,7 @@ const LayoutSwitchWrapper = ( props ) => {
 class _Layout extends Component {
 	memoizedLayoutContext = memoize( ( page ) =>
 		LayoutContextPrototype.getExtendedContext(
-			page?.breadcrumbs[ page.breadcrumbs.length - 1 ].toLowerCase() ||
+			page?.breadcrumbs[ page.breadcrumbs.length - 1 ]?.toLowerCase() ||
 				'page'
 		)
 	);

--- a/plugins/woocommerce-admin/client/tasks/index.ts
+++ b/plugins/woocommerce-admin/client/tasks/index.ts
@@ -1,11 +1,10 @@
 /**
  * Internal dependencies
  */
-import { Tasks } from './tasks';
 import './fills';
 import './deprecated-tasks';
 
+export * from './tasks';
 export * from './placeholder';
 export * from './reminder-bar';
 export * from './hooks/useActiveSetupList';
-export default Tasks;

--- a/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
@@ -3,11 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	ONBOARDING_STORE_NAME,
-	OPTIONS_STORE_NAME,
-	TaskListType,
-} from '@woocommerce/data';
+import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { Link } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';

--- a/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/plugins/woocommerce-admin/client/tasks/reminder-bar/reminder-bar.tsx
@@ -3,7 +3,12 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import {
+	ONBOARDING_STORE_NAME,
+	OPTIONS_STORE_NAME,
+	TaskType,
+	getVisibleTasks,
+} from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { Link } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
@@ -108,15 +113,10 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 			REMINDER_BAR_HIDDEN_OPTION,
 		] );
 
-		const visibleTasks =
-			taskList?.tasks.filter(
-				( task ) =>
-					! task.isDismissed &&
-					( ! task.isSnoozed || task.snoozedUntil < Date.now() )
-			) || [];
+		const visibleTasks = getVisibleTasks( taskList?.tasks || [] );
 
 		const completedTasks =
-			visibleTasks?.filter( ( task ) => task.isComplete ) || [];
+			visibleTasks.filter( ( task: TaskType ) => task.isComplete ) || [];
 
 		const isResolved = taskListIsResolved && optionIsResolved;
 

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -26,6 +26,7 @@ export type TaskListItemProps = {
 	task: TaskType & {
 		onClick?: () => void;
 	};
+	context?: string;
 };
 
 export const TaskListItem: React.FC< TaskListItemProps > = ( {
@@ -33,6 +34,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	isExpanded = false,
 	setExpandedTask,
 	task,
+	context,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 
@@ -117,6 +119,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const trackClick = () => {
 		recordEvent( 'tasklist_click', {
 			task_name: id,
+			context,
 		} );
 
 		if ( ! isComplete ) {

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -10,13 +10,14 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { TaskItem, useSlot } from '@woocommerce/experimental';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
 
 /**
  * Internal dependencies
  */
+import { TasksContext } from '~/tasks';
 import './task-list.scss';
 
 export type TaskListItemProps = {
@@ -26,7 +27,6 @@ export type TaskListItemProps = {
 	task: TaskType & {
 		onClick?: () => void;
 	};
-	context?: string;
 };
 
 export const TaskListItem: React.FC< TaskListItemProps > = ( {
@@ -34,9 +34,9 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	isExpanded = false,
 	setExpandedTask,
 	task,
-	context,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
+	const { context } = useContext( TasksContext );
 
 	const {
 		dismissTask,

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -17,7 +17,7 @@ import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
 /**
  * Internal dependencies
  */
-import { TasksContext } from '~/tasks';
+import { LayoutContext } from '~/layout';
 import './task-list.scss';
 
 export type TaskListItemProps = {
@@ -36,7 +36,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	task,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { context } = useContext( TasksContext );
+	const layoutContext = useContext( LayoutContext );
 
 	const {
 		dismissTask,
@@ -119,7 +119,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const trackClick = () => {
 		recordEvent( 'tasklist_click', {
 			task_name: id,
-			context,
+			context: layoutContext.toString(),
 		} );
 
 		if ( ! isComplete ) {

--- a/plugins/woocommerce-admin/client/tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list.tsx
@@ -30,6 +30,7 @@ export type TaskListProps = TaskListType & {
 	twoColumns?: boolean;
 	keepCompletedTaskList?: 'yes' | 'no';
 	cesHeader?: boolean;
+	context?: string;
 };
 
 export const TaskList: React.FC< TaskListProps > = ( {
@@ -41,6 +42,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	isExpandable = false,
 	displayProgressHeader = false,
 	query,
+	context,
 } ) => {
 	const { profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
@@ -64,6 +66,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordEvent( eventPrefix + 'view', {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
+			context,
 		} );
 	};
 
@@ -104,6 +107,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 			isExpandable={ isExpandable }
 			task={ task }
 			setExpandedTask={ setExpandedTask }
+			context={ context }
 		/>
 	) );
 

--- a/plugins/woocommerce-admin/client/tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState, useContext } from '@wordpress/element';
 import { Card, CardHeader } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Badge } from '@woocommerce/components';
@@ -21,6 +21,7 @@ import { TaskListItem } from './task-list-item';
 import { TaskListMenu } from './task-list-menu';
 import './task-list.scss';
 import { ProgressHeader } from '~/task-lists/progress-header';
+import { TasksContext } from '~/tasks';
 
 export type TaskListProps = TaskListType & {
 	query: {
@@ -30,7 +31,6 @@ export type TaskListProps = TaskListType & {
 	twoColumns?: boolean;
 	keepCompletedTaskList?: 'yes' | 'no';
 	cesHeader?: boolean;
-	context?: string;
 };
 
 export const TaskList: React.FC< TaskListProps > = ( {
@@ -42,7 +42,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	isExpandable = false,
 	displayProgressHeader = false,
 	query,
-	context,
 } ) => {
 	const { profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
@@ -53,6 +52,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	} );
 	const prevQueryRef = useRef( query );
 	const visibleTasks = getVisibleTasks( tasks );
+	const { context } = useContext( TasksContext );
 
 	const incompleteTasks = tasks.filter(
 		( task ) => ! task.isComplete && ! task.isDismissed
@@ -107,7 +107,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 			isExpandable={ isExpandable }
 			task={ task }
 			setExpandedTask={ setExpandedTask }
-			context={ context }
 		/>
 	) );
 

--- a/plugins/woocommerce-admin/client/tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list.tsx
@@ -21,7 +21,7 @@ import { TaskListItem } from './task-list-item';
 import { TaskListMenu } from './task-list-menu';
 import './task-list.scss';
 import { ProgressHeader } from '~/task-lists/progress-header';
-import { TasksContext } from '~/tasks';
+import { LayoutContext } from '~/layout';
 
 export type TaskListProps = TaskListType & {
 	query: {
@@ -52,7 +52,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	} );
 	const prevQueryRef = useRef( query );
 	const visibleTasks = getVisibleTasks( tasks );
-	const { context } = useContext( TasksContext );
+	const layoutContext = useContext( LayoutContext );
 
 	const incompleteTasks = tasks.filter(
 		( task ) => ! task.isComplete && ! task.isDismissed
@@ -66,7 +66,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordEvent( eventPrefix + 'view', {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
-			context,
+			context: layoutContext.toString(),
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -159,12 +159,9 @@ export const Tasks: React.FC< TasksProps > = ( {
 						? id.endsWith( 'two_column' )
 						: ! id.endsWith( 'two_column' )
 				)
+				.filter( ( { isVisible } ) => isVisible )
 				.map( ( taskList: TaskListType ) => {
-					const { id, isHidden, isVisible, isToggleable } = taskList;
-
-					if ( ! isVisible ) {
-						return null;
-					}
+					const { id, isHidden, isToggleable } = taskList;
 
 					const TaskListComponent = getTaskListComponent( id );
 					return (

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -4,7 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { check } from '@wordpress/icons';
-import { Fragment, useEffect } from '@wordpress/element';
+import {
+	Fragment,
+	useEffect,
+	createContext,
+	useState,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	ONBOARDING_STORE_NAME,
@@ -35,6 +40,14 @@ export type TasksProps = {
 	query: { task?: string };
 	context?: string;
 };
+
+export type TasksContextProps = {
+	context: string;
+};
+
+export const TasksContext = createContext< TasksContextProps >( {
+	context: '',
+} );
 
 function getTaskListComponent( taskListId: string ) {
 	switch ( taskListId ) {
@@ -70,6 +83,9 @@ export const Tasks: React.FC< TasksProps > = ( {
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
 		'woocommerce_tasklist_progression'
 	);
+	const [ tasksContext ] = useState( {
+		context,
+	} );
 
 	const { isResolving, taskLists } = useSelect(
 		( select: WCDataSelector ) => {
@@ -152,7 +168,7 @@ export const Tasks: React.FC< TasksProps > = ( {
 	}
 
 	return (
-		<>
+		<TasksContext.Provider value={ tasksContext }>
 			{ taskLists
 				.filter( ( { id }: TaskListType ) =>
 					experimentAssignment?.variationName === 'treatment'
@@ -173,7 +189,6 @@ export const Tasks: React.FC< TasksProps > = ( {
 								}
 								query={ query }
 								twoColumns={ false }
-								context={ context }
 								{ ...taskList }
 							/>
 							{ isToggleable && (
@@ -204,6 +219,6 @@ export const Tasks: React.FC< TasksProps > = ( {
 						</Fragment>
 					);
 				} ) }
-		</>
+		</TasksContext.Provider>
 	);
 };

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -33,6 +33,7 @@ import { SectionedTaskListPlaceholder } from '~/two-column-tasks/sectioned-task-
 
 export type TasksProps = {
 	query: { task?: string };
+	context?: string;
 };
 
 function getTaskListComponent( taskListId: string ) {
@@ -59,7 +60,10 @@ function getTaskListPlaceholderComponent(
 	}
 }
 
-export const Tasks: React.FC< TasksProps > = ( { query } ) => {
+export const Tasks: React.FC< TasksProps > = ( {
+	query,
+	context = 'homescreen',
+} ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
@@ -172,6 +176,7 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 								}
 								query={ query }
 								twoColumns={ false }
+								context={ context }
 								{ ...taskList }
 							/>
 							{ isToggleable && (

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -175,7 +175,7 @@ export const Tasks: React.FC< TasksProps > = ( {
 						? id.endsWith( 'two_column' )
 						: ! id.endsWith( 'two_column' )
 				)
-				.filter( ( { isVisible } ) => isVisible )
+				.filter( ( { isVisible }: TaskListType ) => isVisible )
 				.map( ( taskList: TaskListType ) => {
 					const { id, isHidden, isToggleable } = taskList;
 

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -4,12 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { check } from '@wordpress/icons';
-import {
-	Fragment,
-	useEffect,
-	createContext,
-	useState,
-} from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	ONBOARDING_STORE_NAME,
@@ -41,14 +36,6 @@ export type TasksProps = {
 	context?: string;
 };
 
-export type TasksContextProps = {
-	context: string;
-};
-
-export const TasksContext = createContext< TasksContextProps >( {
-	context: '',
-} );
-
 function getTaskListComponent( taskListId: string ) {
 	switch ( taskListId ) {
 		case 'setup_experiment_1':
@@ -73,19 +60,13 @@ function getTaskListPlaceholderComponent(
 	}
 }
 
-export const Tasks: React.FC< TasksProps > = ( {
-	query,
-	context = 'homescreen',
-} ) => {
+export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
 		'woocommerce_tasklist_progression'
 	);
-	const [ tasksContext ] = useState( {
-		context,
-	} );
 
 	const { isResolving, taskLists } = useSelect(
 		( select: WCDataSelector ) => {
@@ -168,7 +149,7 @@ export const Tasks: React.FC< TasksProps > = ( {
 	}
 
 	return (
-		<TasksContext.Provider value={ tasksContext }>
+		<>
 			{ taskLists
 				.filter( ( { id }: TaskListType ) =>
 					experimentAssignment?.variationName === 'treatment'
@@ -219,6 +200,6 @@ export const Tasks: React.FC< TasksProps > = ( {
 						</Fragment>
 					);
 				} ) }
-		</TasksContext.Provider>
+		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -144,6 +144,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
+			context: '',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -166,6 +167,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'extended_tasklist_view', {
+			context: '',
 			number_tasks: 0,
 			store_connected: null,
 		} );

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -144,7 +144,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
-			context: '',
+			context: 'root',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -167,7 +167,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'extended_tasklist_view', {
-			context: '',
+			context: 'root',
 			number_tasks: 0,
 			store_connected: null,
 		} );

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -37,6 +37,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	sections,
 	displayProgressHeader,
 	cesHeader = true,
+	context,
 } ) => {
 	const { profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
@@ -64,6 +65,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		recordEvent( `${ eventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
+			context,
 		} );
 	};
 
@@ -191,6 +193,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 												key={ task.id }
 												task={ task }
 												eventPrefix={ eventPrefix }
+												context={ context }
 											/>
 										)
 									) }

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -20,7 +20,7 @@ import { ProgressHeader } from '~/task-lists/progress-header';
 import { SectionPanelTitle } from './section-panel-title';
 import { TaskListItem } from './task-list-item';
 import { TaskListCompletedHeader } from './completed-header';
-import { TasksContext } from '~/tasks';
+import { LayoutContext } from '~/layout';
 
 type PanelBodyProps = Omit< PanelBody.Props, 'title' | 'onToggle' > & {
 	title: string | React.ReactNode | undefined;
@@ -52,7 +52,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	const [ openPanel, setOpenPanel ] = useState< string | null >(
 		sections?.find( ( section ) => ! section.isComplete )?.id || null
 	);
-	const { context } = useContext( TasksContext );
+	const layoutContext = useContext( LayoutContext );
 
 	const prevQueryRef = useRef( query );
 
@@ -66,7 +66,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 		recordEvent( `${ eventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
-			context,
+			context: layoutContext.toString(),
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/sectioned-task-list.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState, useContext } from '@wordpress/element';
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, getVisibleTasks } from '@woocommerce/data';
@@ -20,6 +20,7 @@ import { ProgressHeader } from '~/task-lists/progress-header';
 import { SectionPanelTitle } from './section-panel-title';
 import { TaskListItem } from './task-list-item';
 import { TaskListCompletedHeader } from './completed-header';
+import { TasksContext } from '~/tasks';
 
 type PanelBodyProps = Omit< PanelBody.Props, 'title' | 'onToggle' > & {
 	title: string | React.ReactNode | undefined;
@@ -37,7 +38,6 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	sections,
 	displayProgressHeader,
 	cesHeader = true,
-	context,
 } ) => {
 	const { profileItems } = useSelect( ( select ) => {
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
@@ -52,6 +52,7 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 	const [ openPanel, setOpenPanel ] = useState< string | null >(
 		sections?.find( ( section ) => ! section.isComplete )?.id || null
 	);
+	const { context } = useContext( TasksContext );
 
 	const prevQueryRef = useRef( query );
 
@@ -193,7 +194,6 @@ export const SectionedTaskList: React.FC< TaskListProps > = ( {
 												key={ task.id }
 												task={ task }
 												eventPrefix={ eventPrefix }
-												context={ context }
 											/>
 										)
 									) }

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import {
 	ONBOARDING_STORE_NAME,
-	OPTIONS_STORE_NAME,
 	TaskType,
 	useUserPreferences,
 } from '@woocommerce/data';
@@ -19,11 +18,13 @@ import classnames from 'classnames';
 export type TaskListItemProps = {
 	task: TaskType;
 	eventPrefix?: string;
+	context?: string;
 };
 
 export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	task,
 	eventPrefix,
+	context,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 
@@ -68,6 +69,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const trackClick = () => {
 		recordEvent( `${ eventPrefix }click`, {
 			task_name: task.id,
+			context,
 		} );
 
 		if ( ! task.isComplete ) {

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -10,21 +10,24 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { TaskItem, useSlot } from '@woocommerce/experimental';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import { TasksContext } from '~/tasks';
+
 export type TaskListItemProps = {
 	task: TaskType;
 	eventPrefix?: string;
-	context?: string;
 };
 
 export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	task,
 	eventPrefix,
-	context,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 
@@ -35,6 +38,8 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		snoozeTask,
 		undoSnoozeTask,
 	} = useDispatch( ONBOARDING_STORE_NAME );
+
+	const { context } = useContext( TasksContext );
 
 	const slot = useSlot(
 		`woocommerce_onboarding_task_list_item_${ task.id }`

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -18,7 +18,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { TasksContext } from '~/tasks';
+import { LayoutContext } from '~/layout';
 
 export type TaskListItemProps = {
 	task: TaskType;
@@ -39,7 +39,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		undoSnoozeTask,
 	} = useDispatch( ONBOARDING_STORE_NAME );
 
-	const { context } = useContext( TasksContext );
+	const layoutContext = useContext( LayoutContext );
 
 	const slot = useSlot(
 		`woocommerce_onboarding_task_list_item_${ task.id }`
@@ -74,7 +74,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const trackClick = () => {
 		recordEvent( `${ eventPrefix }click`, {
 			task_name: task.id,
-			context,
+			context: layoutContext.toString(),
 		} );
 
 		if ( ! task.isComplete ) {

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -35,7 +35,7 @@ import TaskListCompleted from './completed';
 import { ProgressHeader } from '~/task-lists/progress-header';
 import { TaskListItemTwoColumn } from './task-list-item-two-column';
 import { TaskListCompletedHeader } from './completed-header';
-import { TasksContext } from '~/tasks';
+import { LayoutContext } from '~/layout';
 
 export type TaskListProps = TaskListType & {
 	eventName?: string;
@@ -78,7 +78,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	} >( {} );
 	const [ activeTaskId, setActiveTaskId ] = useState( '' );
 	const [ showDismissModal, setShowDismissModal ] = useState( false );
-	const { context } = useContext( TasksContext );
+	const layoutContext = useContext( LayoutContext );
 
 	const prevQueryRef = useRef( query );
 
@@ -91,7 +91,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordEvent( `${ listEventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
-			context,
+			context: layoutContext.toString(),
 		} );
 	};
 
@@ -188,7 +188,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	const trackClick = ( task: TaskType ) => {
 		recordEvent( `${ listEventPrefix }click`, {
 			task_name: task.id,
-			context,
+			context: layoutContext.toString(),
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -37,6 +37,7 @@ export type TaskListProps = TaskListType & {
 		task?: string;
 	};
 	cesHeader?: boolean;
+	context?: string;
 };
 
 export const TaskList: React.FC< TaskListProps > = ( {
@@ -50,6 +51,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	isComplete,
 	displayProgressHeader,
 	cesHeader = true,
+	context,
 } ) => {
 	const listEventPrefix = eventName ? eventName + '_' : eventPrefix;
 	const { profileItems } = useSelect( ( select: WCDataSelector ) => {
@@ -83,6 +85,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordEvent( `${ listEventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
+			context,
 		} );
 	};
 
@@ -179,6 +182,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	const trackClick = ( task: TaskType ) => {
 		recordEvent( `${ listEventPrefix }click`, {
 			task_name: task.id,
+			context,
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useState, createElement } from '@wordpress/element';
+import {
+	useEffect,
+	useRef,
+	useState,
+	createElement,
+	useContext,
+} from '@wordpress/element';
 import { Button, Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EllipsisMenu } from '@woocommerce/components';
@@ -29,6 +35,7 @@ import TaskListCompleted from './completed';
 import { ProgressHeader } from '~/task-lists/progress-header';
 import { TaskListItemTwoColumn } from './task-list-item-two-column';
 import { TaskListCompletedHeader } from './completed-header';
+import { TasksContext } from '~/tasks';
 
 export type TaskListProps = TaskListType & {
 	eventName?: string;
@@ -37,7 +44,6 @@ export type TaskListProps = TaskListType & {
 		task?: string;
 	};
 	cesHeader?: boolean;
-	context?: string;
 };
 
 export const TaskList: React.FC< TaskListProps > = ( {
@@ -51,7 +57,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	isComplete,
 	displayProgressHeader,
 	cesHeader = true,
-	context,
 } ) => {
 	const listEventPrefix = eventName ? eventName + '_' : eventPrefix;
 	const { profileItems } = useSelect( ( select: WCDataSelector ) => {
@@ -73,6 +78,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	} >( {} );
 	const [ activeTaskId, setActiveTaskId ] = useState( '' );
 	const [ showDismissModal, setShowDismissModal ] = useState( false );
+	const { context } = useContext( TasksContext );
 
 	const prevQueryRef = useRef( query );
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -148,6 +148,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
+			context: '',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -170,6 +171,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
+			context: '',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -193,6 +195,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'extended_tasklist_view', {
+			context: '',
 			number_tasks: 0,
 			store_connected: null,
 		} );

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -148,7 +148,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
-			context: '',
+			context: 'root',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -171,7 +171,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
-			context: '',
+			context: 'root',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -195,7 +195,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'extended_tasklist_view', {
-			context: '',
+			context: 'root',
 			number_tasks: 0,
 			store_connected: null,
 		} );

--- a/plugins/woocommerce/changelog/add-33284-task-sidebar-tracks
+++ b/plugins/woocommerce/changelog/add-33284-task-sidebar-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding property to tasks tracks events to indicate context.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -171,7 +171,7 @@ class TaskList {
 	 * @return bool
 	 */
 	public function is_visible() {
-		if ( ! $this->visible ) {
+		if ( ! $this->visible || ! count( $this->get_viewable_tasks() ) > 0 ) {
 			return false;
 		}
 		return ! $this->is_hidden();

--- a/plugins/woocommerce/tests/legacy/unit-tests/payment-tokens/payment-tokens.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/payment-tokens/payment-tokens.php
@@ -104,7 +104,6 @@ class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 	 * Test getting a customers default token, when there no token is expictly set.
 	 * This should be the "first created".
 	 * @see WC_Payment_Token::create()
-	 * @group failing
 	 * @since 2.6.0
 	 */
 	public function test_wc_get_customer_default_token_returns_first_created_when_no_default_token_set() {

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
@@ -8,6 +8,7 @@
 require_once __DIR__ . '/test-task.php';
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 
 /**
  * class WC_Admin_Tests_OnboardingTasks_TaskList
@@ -89,6 +90,13 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 	 * Tests that lists can be hidden.
 	 */
 	public function test_visible() {
+		$this->assertFalse( $this->list->is_visible() );
+		$this->list->add_task(
+			new TestTask(
+				new TaskList(),
+				array( 'id' => 'my-task' )
+			)
+		);
 		$this->assertTrue( $this->list->is_visible() );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding the `context` property to the `wcadmin_tasklist_view` and `wcadmin_tasklist_click` tracks events, indicating if the tasklist was in the sidebar or homescreen.

I also took the liberty of fixing a couple bugs I came across involving the ActionPanel being displayed incorrectly when the reminder bar was visible, and the `wcadmin_tasklist_view` event being fired for lists that were not visible since they had no tasks.

Closes #33284  .

### How to test the changes in this Pull Request:

1. Checkout branch on fresh site, no need to complete OBW.
2. Go to a screen where the reminder bar is present (ie Customers) and click "Finish Setup." Ensure that the top of the panel aligns correctly with the header. 
3. Enable tracks logging in your browser console with `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
4. When you load the Homescreen, ensure that the `wcadmin_extended_tasklist_view` is NOT fired since it's not visible.
5. View Homescreen, and look for the `wcadmin_tasklist_view` event logged in your console. Ensure it has the `context` property with a value of `homescreen`.
6. Click on one of the tasks, and look for the `wcadmin_tasklist_click` event in your console. Ensure it also has the `context` property with a value of `homescreen`.
7. Now navigate away from the homescreen to another page with the "Finish Setup" button in the activity panel. (ie Customers or Orders)
8. Click the "Finish Setup" button to bring out the tasks sidebar. 
9. You should now see the `wcadmin_tasklist_view` event fire again. Ensure that it has a `context` property of `sidebar`.
10. Click on a task, and look for the `wcadmin_tasklist_click` event again. Ensure that it also has a `context` property of `sidebar`.
11. Using the WCA Test Helper plugin, enable the `woocommerce_tasklist_setup_experiment_1_*` experiment and do steps 4-8 again. 
12. Using the WCA Test Helper plugin, enable the `woocommerce_tasklist_setup_experiment_2_*` experiment and do steps 4-8 again. 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
