### PR TITLE
Deprecate wcAdminAssetUrl and WC_ADMIN_IMAGES_FOLDER_URL

### DIFF
--- a/plugins/woocommerce-admin/client/shipping/woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/woocommerce-services-item.tsx
@@ -13,13 +13,11 @@ import { getAdminLink } from '@woocommerce/settings';
  */
 import './woocommerce-services-item.scss';
 import WooIcon from './woo-icon.svg';
-import { getAdminSetting } from '../utils/admin-settings';
 
 const WooCommerceServicesItem: React.FC< {
 	pluginsBeingSetup: Array< string >;
 	onSetupClick: ( slugs: string[] ) => PromiseLike< void >;
 } > = ( { onSetupClick, pluginsBeingSetup } ) => {
-	const wcAdminAssetUrl = getAdminSetting( 'wcAdminAssetUrl', '' );
 	const { createSuccessNotice } = useDispatch( 'core/notices' );
 
 	const isSiteConnectedToJetpack = useSelect( ( select ) =>

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -11,6 +11,7 @@ import { get, isArray } from 'lodash';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -19,9 +20,8 @@ import '../style.scss';
 import DismissModal from '../dismiss-modal';
 import SetupNotice, { setupErrorTypes } from '../setup-notice';
 import { getWcsAssets, acceptWcsTos } from '../wcs-api';
-import { getAdminSetting } from '~/utils/admin-settings';
 
-const wcAdminAssetUrl = getAdminSetting( 'wcAdminAssetUrl', '' );
+const wcAssetUrl = getSetting( 'wcAssetUrl', '' );
 const wcsPluginSlug = 'woocommerce-services';
 
 export class ShippingBanner extends Component {
@@ -399,7 +399,7 @@ export class ShippingBanner extends Component {
 				<div className="wc-admin-shipping-banner-container">
 					<img
 						className="wc-admin-shipping-banner-illustration"
-						src={ wcAdminAssetUrl + '/shippingillustration.svg' }
+						src={ wcAssetUrl + 'images/shippingillustration.svg' }
 						alt={ __( 'Shipping ', 'woocommerce' ) }
 					/>
 					<div className="wc-admin-shipping-banner-blob">

--- a/plugins/woocommerce/changelog/update-32491-deprecate-wcadminasseturl
+++ b/plugins/woocommerce/changelog/update-32491-deprecate-wcadminasseturl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Deprecate wcAdminAssetUrl and WC_ADMIN_IMAGES_FOLDER_URL

--- a/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
+++ b/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php
@@ -110,7 +110,22 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_DIST_JS_FOLDER', 'assets/client/admin/' );
 		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'assets/client/admin/' );
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_PLUGIN_FILE );
-		$this->define( 'WC_ADMIN_IMAGES_FOLDER_URL', plugins_url( 'assets/images', WC_PLUGIN_FILE ) );
+
+		/**
+		 * Define the WC Admin Images Folder URL.
+		 *
+		 * @deprecated 6.7.0
+		 * @var string
+		 */
+		if ( ! defined( 'WC_ADMIN_IMAGES_FOLDER_URL' ) ) {
+			/**
+			 * Define the WC Admin Images Folder URL.
+			 *
+			 * @deprecated 6.7.0
+			 * @var string
+			 */
+			define( 'WC_ADMIN_IMAGES_FOLDER_URL', plugins_url( 'assets/images', WC_PLUGIN_FILE ) );
+		}
 
 		/**
 		 * Define the current WC Admin version.

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -121,7 +121,7 @@ class Settings {
 			$settings['orderStatuses'] = self::get_order_statuses( wc_get_order_statuses() );
 			$settings['stockStatuses'] = self::get_order_statuses( wc_get_product_stock_status_options() );
 			$settings['currency']      = self::get_currency_settings();
-			$settings['locale']        = [
+			$settings['locale']        = array(
 				'siteLocale'    => isset( $settings['siteLocale'] )
 					? $settings['siteLocale']
 					: get_locale(),
@@ -131,7 +131,7 @@ class Settings {
 				'weekdaysShort' => isset( $settings['l10n']['weekdaysShort'] )
 					? $settings['l10n']['weekdaysShort']
 					: array_values( $wp_locale->weekday_abbrev ),
-			];
+			);
 		}
 
 		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array() );
@@ -157,7 +157,7 @@ class Settings {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
 				$group_settings   = $setting_options->get_group_settings( $group );
-				$preload_settings = [];
+				$preload_settings = array();
 				foreach ( $group_settings as $option ) {
 					if ( array_key_exists( 'id', $option ) && array_key_exists( 'value', $option ) ) {
 						$preload_settings[ $option['id'] ] = $option['value'];
@@ -178,9 +178,12 @@ class Settings {
 		$settings['manageStock']          = get_option( 'woocommerce_manage_stock' );
 		$settings['commentModeration']    = get_option( 'comment_moderation' );
 		$settings['notifyLowStockAmount'] = get_option( 'woocommerce_notify_low_stock_amount' );
-		// @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired,
-		// and `wcAssetUrl` can be used in its place throughout the codebase.
-		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', dirname( __DIR__ ) . '/woocommerce-admin.php' );
+
+		/**
+		 * @deprecated 6.7.0
+		 * @var string
+		 */
+		$settings['wcAdminAssetUrl'] = WC_ADMIN_IMAGES_FOLDER_URL;
 		$settings['wcVersion']       = WC_VERSION;
 		$settings['siteUrl']         = site_url();
 		$settings['shopUrl']         = get_permalink( wc_get_page_id( 'shop' ) );
@@ -204,7 +207,7 @@ class Settings {
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$settings['dataEndpoints'] = isset( $settings['dataEndpoints'] )
 				? $settings['dataEndpoints']
-				: [];
+				: array();
 			foreach ( $preload_data_endpoints as $key => $endpoint ) {
 				// Handle error case: rest_do_request() doesn't guarantee success.
 				if ( empty( $preload_data[ $endpoint ] ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -90,6 +90,7 @@ class Settings {
 	public static function get_currency_settings() {
 		$code = get_woocommerce_currency();
 
+		//phpcs:ignore
 		return apply_filters(
 			'wc_currency_settings',
 			array(
@@ -134,6 +135,7 @@ class Settings {
 			);
 		}
 
+		//phpcs:ignore
 		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array() );
 		if ( class_exists( 'Jetpack' ) ) {
 			$preload_data_endpoints['jetpackStatus'] = '/jetpack/v4/connection';
@@ -145,6 +147,7 @@ class Settings {
 			);
 		}
 
+		//phpcs:ignore
 		$preload_options = apply_filters( 'woocommerce_admin_preload_options', array() );
 		if ( ! empty( $preload_options ) ) {
 			foreach ( $preload_options as $option ) {
@@ -152,6 +155,7 @@ class Settings {
 			}
 		}
 
+		//phpcs:ignore
 		$preload_settings = apply_filters( 'woocommerce_admin_preload_settings', array() );
 		if ( ! empty( $preload_settings ) ) {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
@@ -180,6 +184,9 @@ class Settings {
 		$settings['notifyLowStockAmount'] = get_option( 'woocommerce_notify_low_stock_amount' );
 
 		/**
+		 * Deprecate wcAdminAssetUrl as we no longer need it after The Merge.
+		 * Use wcAssetUrl instead.
+		 *
 		 * @deprecated 6.7.0
 		 * @var string
 		 */
@@ -202,6 +209,7 @@ class Settings {
 		// E.g An extension that added statuses is now inactive or removed.
 		$settings['unregisteredOrderStatuses'] = $this->get_unregistered_order_statuses();
 		// The separator used for attributes found in Variation titles.
+		//phpcs:ignore
 		$settings['variationTitleAttributesSeparator'] = apply_filters( 'woocommerce_product_variation_title_attributes_separator', ' - ', new \WC_Product() );
 
 		if ( ! empty( $preload_data_endpoints ) ) {


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #32491

This PR changes the following items.

1. Fixes the incorrect return value from `wcAdminAssetUrl`
2. Deprecate [WC_ADMIN_IMAGES_FOLDER_URL](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/FeaturePlugin.php#L113) and [$settings['wcAdminAssetUrl']](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/Settings.php#L183)
3. Remove unused `wcAdminAssetUrl` variable
4. Replaces `wcAdminAssetUrl` with `wcAssetUrl`

### How to test the changes in this Pull Request:

**Testing wcAdminAssetUrl**

1. Open browser inspector and navigate to `WooCommerce -> Home`
2. Console log `wcSettings.admin.wcAdminAssetUrl` and make sure the return value is `http://your-domain/wp-content/plugins/woocommerce/assets/images`

**Testing shipping-banner changes**

1. Open https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php#L38 and add `return true` at the first line of `should_show_meta_box` method.
2. Open https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php#L98 and change `$this->count_shippable_items( $order )` line to `1` so that it doesn't call the function.
3. Go to `Products -> Add New`
4. You should see a meta box (screenshot 1)
5. Make sure the image is displayed correctly.

### Screenshots
![Screen Shot 2022-06-01 at 6 50 42 PM](https://user-images.githubusercontent.com/4723145/171530139-3353fd2e-f800-4ac7-bd80-0fb3ef06e28b.jpg)

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
