### PR TITLE
Update onboarding email marketing checkbox default to false

### DIFF
--- a/packages/js/admin-e2e-tests/changelog/update-marketing-checkbox
+++ b/packages/js/admin-e2e-tests/changelog/update-marketing-checkbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update email marketing checkbox assertion.

--- a/packages/js/admin-e2e-tests/src/sections/onboarding/StoreDetailsSection.ts
+++ b/packages/js/admin-e2e-tests/src/sections/onboarding/StoreDetailsSection.ts
@@ -79,8 +79,8 @@ export class StoreDetailsSection extends BasePage {
 				config.get( 'addresses.admin.store.email' )
 		);
 
-		// Verify that checkbox next to "Get tips, product updates and inspiration straight to your mailbox" is selected
-		await this.checkMarketingCheckbox( true );
+		// Verify that the marketing checkbox is opt-in by default (WordPress.org Plugin Review Team requirement).
+		await this.checkMarketingCheckbox( false );
 	}
 
 	async fillAddress( address: string ): Promise< void > {

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -523,6 +523,8 @@ export default compose(
 			city: settings.woocommerce_store_city || '',
 			countryState,
 			postCode: settings.woocommerce_store_postcode || '',
+
+			// By default, the marketing checkbox should be unticked by default to comply with WordPress.org plugin review guidelines.
 			isAgreeMarketing:
 				typeof profileItems.is_agree_marketing === 'boolean'
 					? profileItems.is_agree_marketing

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -526,7 +526,7 @@ export default compose(
 			isAgreeMarketing:
 				typeof profileItems.is_agree_marketing === 'boolean'
 					? profileItems.is_agree_marketing
-					: true,
+					: false,
 			storeEmail:
 				typeof profileItems.store_email === 'string'
 					? profileItems.store_email

--- a/plugins/woocommerce/changelog/fix-onboarding-email-optin
+++ b/plugins/woocommerce/changelog/fix-onboarding-email-optin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update email marketing checkbox to be unticked by default.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33289. This PR makes the email marketing checkbox "Get tips, product updates etc" opt-in by default.

![image](https://user-images.githubusercontent.com/9312929/173020675-ef0b4eeb-5b95-4407-9412-4cac259936f6.png)




### How to test the changes in this Pull Request:

1. On a fresh install, start the onboarding wizard.
2. See that the marketing checkbox is not ticked by default

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
