### PR TITLE
Remove changelog file for cherry-picked PRs #33180 and #33300

### DIFF
--- a/plugins/woocommerce/changelog/fix-33179-check-type
+++ b/plugins/woocommerce/changelog/fix-33179-check-type
@@ -1,7 +1,0 @@
-Significance: patch
-Type: fix
-
-Add guard to avoid error when $block_templates is null.
-
-
-

--- a/plugins/woocommerce/changelog/fix-33295
+++ b/plugins/woocommerce/changelog/fix-33295
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add woo install timestamp to server experimental assignment requests #33300


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

This PR removes the changelog file for #33180 and #33300, as they are cherry-picked into the release branch by #33297.

### How to test the changes in this Pull Request:

1. Make sure that this PR removes the changelog file cherry-picked into the `release/6.6` branch by #33297.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
