### PR TITLE
Add woo install timestamp to server experimental assignment requests

### DIFF
--- a/plugins/woocommerce/changelog/fix-33295
+++ b/plugins/woocommerce/changelog/fix-33295
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add woo install timestamp to server experimental assignment requests #33300

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -20,6 +20,7 @@ namespace WooCommerce\Admin;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 use Automattic\Jetpack\Connection\Client as Jetpack_Connection_client;
+use Automattic\WooCommerce\Admin\WCAdminHelper;
 
 /**
  * This class provides an interface to the Explat A/B tests.
@@ -184,10 +185,12 @@ final class Experimental_Abtest {
 
 		// Make the request to the WP.com API.
 		$args = array(
-			'experiment_name'  => $test_name,
-			'anon_id'          => rawurlencode( $this->anon_id ),
-			'woo_country_code' => rawurlencode( get_option( 'woocommerce_default_country', 'US:CA' ) ),
+			'experiment_name'               => $test_name,
+			'anon_id'                       => rawurlencode( $this->anon_id ),
+			'woo_country_code'              => rawurlencode( get_option( 'woocommerce_default_country', 'US:CA' ) ),
+			'woo_wcadmin_install_timestamp' => rawurlencode( get_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION ) ),
 		);
+
 		/**
 		 * Get additional request args.
 		 *


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes (part of) #33295 .

### How to test the changes in this Pull Request:

1. Create a new site
2. Add this as a plugin:
```
add_filter( 'pre_http_request', function( $bool, $parsed_args, $url ) {
	$logger = wc_get_logger();
	$logger->debug( $url );
	$logger->debug(
		$url,
		array( 'source' => 'experiments' )
	);
	return $bool;
}, 10, 3 );
```
3. Visit the homepage
4. Visit the logs page `wp-admin/admin.php?page=wc-status&tab=logs`
5. Check the `experiments-*` log
6. See that `woo_wcadmin_install_timestamp` is in the URL with the correct timestamp


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
