### PR TITLE
Settings: fix Tracks event when enabling/disabling advanced features settings.

### DIFF
--- a/plugins/woocommerce/changelog/fix-advanced-feature-tracks
+++ b/plugins/woocommerce/changelog/fix-advanced-feature-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Settings: fix Tracks event when enabling/disabling advanced features settings. #33305

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -78,7 +78,24 @@ class WC_Settings_Tracking {
 			return;
 		}
 
+		// This is not used for site option storing/updates,
+		// which are yes/no *_enabled*.
+		// It is merely setting up $this->updated_options[] array
+		// with property names used in tracking events.
+		if ( 'woocommerce_analytics_enabled' === $option_name && 'no' === $new_value ) {
+			$option_name = 'woocommerce_analytics_disabled';
+		}
+		if ( 'woocommerce_navigation_enabled' === $option_name && 'no' === $new_value ) {
+			$option_name = 'woocommerce_navigation_disabled';
+		}
 		$this->updated_options[] = $option_name;
+
+		/**
+		 * Fire recording Tracks events.
+		 *
+		 * @since 2.4.0
+		 */
+		do_action( 'woocommerce_update_options' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -78,24 +78,7 @@ class WC_Settings_Tracking {
 			return;
 		}
 
-		// This is not used for site option storing/updates,
-		// which are yes/no *_enabled*.
-		// It is merely setting up $this->updated_options[] array
-		// with property names used in tracking events.
-		if ( 'woocommerce_analytics_enabled' === $option_name && 'no' === $new_value ) {
-			$option_name = 'woocommerce_analytics_disabled';
-		}
-		if ( 'woocommerce_navigation_enabled' === $option_name && 'no' === $new_value ) {
-			$option_name = 'woocommerce_navigation_disabled';
-		}
 		$this->updated_options[] = $option_name;
-
-		/**
-		 * Fire recording Tracks events.
-		 *
-		 * @since 2.4.0
-		 */
-		do_action( 'woocommerce_update_options' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
@@ -24,11 +24,19 @@ class Init {
 	const TOGGLE_OPTION_NAME = 'woocommerce_navigation_enabled';
 
 	/**
+	 * Determines if the feature has been toggled on or off.
+	 *
+	 * @var boolean
+	 */
+	protected static $is_updated = false;
+
+	/**
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_settings_features', array( $this, 'add_feature_toggle' ) );
 		add_action( 'update_option_' . self::TOGGLE_OPTION_NAME, array( $this, 'reload_page_on_toggle' ), 10, 2 );
+		add_action( 'woocommerce_settings_saved', array( $this, 'maybe_reload_page' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_opt_out_scripts' ) );
 
 		if ( Features::is_enabled( 'navigation' ) ) {
@@ -115,10 +123,19 @@ class Init {
 			update_option( 'woocommerce_navigation_show_opt_out', 'yes' );
 		}
 
-		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-			wp_safe_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ) );
-			exit();
+		self::$is_updated = true;
+	}
+
+	/**
+	 * Reload the page if the setting has been updated.
+	 */
+	public static function maybe_reload_page() {
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) || ! self::$is_updated ) {
+			return;
 		}
+
+		wp_safe_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		exit();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Track events of user actions enabling/disabling the navigation and analytics settings (WooCommerce - Settings - Advanced - Features) is not recording any data atm, while we need it for usage statistics.

Here, we fix the event `wcadmin_settings_change` with **property** `settings` of ` woocommerce_navigation_enabled`/` woocommerce_analytics_enabled` to fire on checkbox settings changes.
The corresponding **options** are `woocommerce_navigation_enabled` and `woocommerce_navigation_disabled` with yes/no values.

In a follow up we will expand the event schema to distinguish enable/disable actions.
Closes #33128, closes #32294, closes WOOPLUG-642

### How to test the changes in this Pull Request:

1. go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. enable/disable de settings
3. verify in Tracks that the appropriate event was fired
<img width="1263" alt="Screenshot 2022-06-03 at 11 28 59" src="https://user-images.githubusercontent.com/13561163/171828504-ca322f49-b919-4084-8efe-c9aa6cd9c57d.png">
Note: for testing in a set-up where `userid = null`, the events will show as rejected in Tracks live

4. verify that the relevant option value is set correctly

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
