### PR TITLE
Fix broken design of Single Product template in block themes when product had no reviews or additional info

### DIFF
--- a/plugins/woocommerce/changelog/fix-33304-single-product-no-reviews-block-themes
+++ b/plugins/woocommerce/changelog/fix-33304-single-product-no-reviews-block-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix broken design of Single Product template in block themes when product had no reviews or additional info

--- a/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-two.scss
@@ -253,6 +253,7 @@ $tt2-gray: #f7f7f7;
 
 	div.product {
 		position: relative;
+		overflow: auto;
 
 		> span.onsale {
 			position: absolute;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add `overflow: auto` to `div.product` in Single Product template in TT2, forcing the `div` to "occupy" the necessary height, so the footer doesn't collapse.

The issue affects all block theme, but currently we don't have a CSS file specific to block themes, so I'm applying the fix only on TT2, for now. @frontdevde is working on extracting some parts of TT2's stylesheet into a block-specific stylesheet.

Closes #33304.

### How to test the changes in this Pull Request:

1. Create a new product and make sure it has no description, no reviews and no additional information.
2. With [TT2 theme](https://wordpress.org/themes/twentytwentytwo/), visit that product in the frontend.
3. Verify the footer doesn't render on top of the single product template.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/171817337-6b7aaeb0-2c36-4ca0-a6e0-5f29e78644ed.png) | ![imatge](https://user-images.githubusercontent.com/3616980/171842549-c1a2f187-bc40-4936-9df1-9040538f1009.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
