### PR TITLE
Include Tracks indicator property for block editor on product update.

### DIFF
--- a/plugins/woocommerce/changelog/add-block-editor-edit-tracks
+++ b/plugins/woocommerce/changelog/add-block-editor-edit-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Include Tracks indicator property for block editor on product update. #33321

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -137,12 +137,12 @@ class WC_Products_Tracking {
 				var hasRecordedEvent = false;
 				var isBlockEditor = false;
 
-				$( '#publish' ).on( 'click', function() {
+				function sendTracks() {
 					if ( hasRecordedEvent ) {
 						return;
 					}
-					
-					if ( $( '.block-editor' )[0] ) {
+
+					if (  $( '.block-editor' ) && $( '.block-editor' )[0] ) {
 						 isBlockEditor = true;
 					}
 
@@ -174,7 +174,15 @@ class WC_Products_Tracking {
 
 					window.wcTracks.recordEvent( 'product_update', properties );
 					hasRecordedEvent = true;
-				} );
+				};
+
+				if ( $( '#publish' ) ) {
+					$( '#publish' ).on( 'click', sendTracks);
+					return;
+				}
+
+				$( '.editor-post-publish-button' ).on( 'click', sendTracks);
+
 			}
 			"
 		);

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -152,7 +152,7 @@ class WC_Products_Tracking {
 					var properties = {
 						attributes:				$( '.woocommerce_attribute' ).length,
 						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
-						'cross-sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
+						'cross_sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
 						description:			description_value.length ? 'Yes' : 'No',
 						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
 						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -135,10 +135,15 @@ class WC_Products_Tracking {
 			if ( $( 'h1.wp-heading-inline' ).text().trim() === '" . __( 'Edit product', 'woocommerce' ) . "') {
 				var initialStockValue = $( '#_stock' ).val();
 				var hasRecordedEvent = false;
+				var isBlockEditor = false;
 
 				$( '#publish' ).on( 'click', function() {
 					if ( hasRecordedEvent ) {
 						return;
+					}
+					
+					if ( $( '.block-editor' )[0] ) {
+						 isBlockEditor = true;
 					}
 
 					var tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
@@ -151,6 +156,7 @@ class WC_Products_Tracking {
 						description:			description_value.length ? 'Yes' : 'No',
 						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
 						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
+						is_block_editor:		isBlockEditor,
 						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
 						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
 						menu_order:				$( '#menu_order' ).val() ? 'Yes' : 'No',

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -142,7 +142,7 @@ class WC_Products_Tracking {
 						return;
 					}
 
-					if (  $( '.block-editor' ) && $( '.block-editor' )[0] ) {
+					if ( $( '.block-editor' ).length !== 0 && $( '.block-editor' )[0] ) {
 						 isBlockEditor = true;
 					}
 
@@ -176,7 +176,7 @@ class WC_Products_Tracking {
 					hasRecordedEvent = true;
 				};
 
-				if ( $( '#publish' ) ) {
+				if ( $( '#publish' ).length !== 0 ) {
 					$( '#publish' ).on( 'click', sendTracks);
 					return;
 				}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -136,57 +136,58 @@ class WC_Products_Tracking {
 				var initialStockValue = $( '#_stock' ).val();
 				var hasRecordedEvent = false;
 				var isBlockEditor = false;
+				var child_element = '#publish';
 
 				if ( $( '.block-editor' ).length !== 0 && $( '.block-editor' )[0] ) {
 	    			isBlockEditor = true;
 				}
 
-				if ( ! isBlockEditor & hasRecordedEvent) {
-                	return;
-            	}
+				if ( isBlockEditor ) {
+					child_element = '.editor-post-publish-button';
+				}
 
-       			var description_value  = '';
-     			var tagsText = '';
-     			var currentStockValue = $( '#_stock' ).val();
+				$( '#wpwrap' ).on( 'click', child_element, function() {
+					if ( ! isBlockEditor && hasRecordedEvent) {
+						return;
+					}
 
-           		if ( ! isBlockEditor ) {
-              		tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
-             		description_value  = $( '#content' ).is( ':visible' ) ? $( '#content' ).val() : tinymce.get( 'content' ).getContent();
-             	}
+					var description_value  = '';
+					var tagsText = '';
+					var currentStockValue = $( '#_stock' ).val();
 
-				var properties = {
-					attributes:				$( '.woocommerce_attribute' ).length,
-					categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
-					'cross_sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
-					description:			description_value.length ? 'Yes' : 'No',
-					enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
-					is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
-					is_block_editor:		isBlockEditor,
-					is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
-					manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
-					menu_order:				$( '#menu_order' ).val() ? 'Yes' : 'No',
-					product_gallery:		$( '#product_images_container .product_images > li' ).length,
-					product_image:			$( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
-					product_type:			$( '#product-type' ).val(),
-					purchase_note:			$( '#_purchase_note' ).val().length ? 'yes' : 'no',
-					sale_price:				$( '#_sale_price' ).val() ? 'yes' : 'no',
-					short_description:		$( '#excerpt' ).val().length ? 'yes' : 'no',
-					stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
-					tags:					tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
-					upsells:				$( '#upsell_ids option' ).length ? 'Yes' : 'No',
-					weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
-				};
+					if ( ! isBlockEditor ) {
+						tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
+						description_value  = $( '#content' ).is( ':visible' ) ? $( '#content' ).val() : tinymce.get( 'content' ).getContent();
+					} else {
+						description_value  = $( '.block-editor-rich-text__editable' ).text();
+					}
 
-          		if ( ! isBlockEditor ) {
-          			$( '#publish' ).on( 'click', function() {
-          			   window.wcTracks.recordEvent( 'product_update', properties );
-					});
-          			hasRecordedEvent = true;
-          		} else {
-					$( '#wpwrap' ).on( 'click', '.editor-post-publish-button', function() {
-          			   window.wcTracks.recordEvent( 'product_update', properties );
-					});
-          		};
+					var properties = {
+						attributes:				$( '.woocommerce_attribute' ).length,
+						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
+						'cross_sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
+						description:			description_value.length ? 'Yes' : 'No',
+						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
+						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
+						is_block_editor:		isBlockEditor,
+						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
+						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
+						menu_order:				$( '#menu_order' ).val() ? 'Yes' : 'No',
+						product_gallery:		$( '#product_images_container .product_images > li' ).length,
+						product_image:			$( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
+						product_type:			$( '#product-type' ).val(),
+						purchase_note:			$( '#_purchase_note' ).val().length ? 'yes' : 'no',
+						sale_price:				$( '#_sale_price' ).val() ? 'yes' : 'no',
+						short_description:		$( '#excerpt' ).val().length ? 'yes' : 'no',
+						stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
+						tags:					tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
+						upsells:				$( '#upsell_ids option' ).length ? 'Yes' : 'No',
+						weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
+					};
+
+					window.wcTracks.recordEvent( 'product_update', properties );
+					hasRecordedEvent = true;
+				} );
 			}
 			"
 		);

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -134,7 +134,6 @@ class WC_Products_Tracking {
 			"
 			if ( $( 'h1.wp-heading-inline' ).text().trim() === '" . __( 'Edit product', 'woocommerce' ) . "') {
 				var initialStockValue = $( '#_stock' ).val();
-				var hasRecordedEvent = false;
 				var isBlockEditor = false;
 				var child_element = '#publish';
 
@@ -147,10 +146,6 @@ class WC_Products_Tracking {
 				}
 
 				$( '#wpwrap' ).on( 'click', child_element, function() {
-					if ( ! isBlockEditor && hasRecordedEvent) {
-						return;
-					}
-
 					var description_value  = '';
 					var tagsText = '';
 					var currentStockValue = $( '#_stock' ).val();
@@ -166,7 +161,7 @@ class WC_Products_Tracking {
 						attributes:				$( '.woocommerce_attribute' ).length,
 						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
 						'cross_sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
-						description:			description_value.length ? 'Yes' : 'No',
+						description:			description_value.trim() !== '' ? 'Yes' : 'No',
 						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
 						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
 						is_block_editor:		isBlockEditor,
@@ -184,9 +179,7 @@ class WC_Products_Tracking {
 						upsells:				$( '#upsell_ids option' ).length ? 'Yes' : 'No',
 						weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
 					};
-
 					window.wcTracks.recordEvent( 'product_update', properties );
-					hasRecordedEvent = true;
 				} );
 			}
 			"

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -137,52 +137,72 @@ class WC_Products_Tracking {
 				var hasRecordedEvent = false;
 				var isBlockEditor = false;
 
-				function sendTracks() {
-					if ( hasRecordedEvent ) {
-						return;
-					}
-
-					if ( $( '.block-editor' ).length !== 0 && $( '.block-editor' )[0] ) {
-						 isBlockEditor = true;
-					}
-
-					var tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
-					var currentStockValue = $( '#_stock' ).val();
-					var description_value  = $( '#content' ).is( ':visible' ) ? $( '#content' ).val() : tinymce.get( 'content' ).getContent();
-					var properties = {
-						attributes:				$( '.woocommerce_attribute' ).length,
-						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
-						'cross_sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
-						description:			description_value.length ? 'Yes' : 'No',
-						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
-						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
-						is_block_editor:		isBlockEditor,
-						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
-						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
-						menu_order:				$( '#menu_order' ).val() ? 'Yes' : 'No',
-						product_gallery:		$( '#product_images_container .product_images > li' ).length,
-						product_image:			$( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
-						product_type:			$( '#product-type' ).val(),
-						purchase_note:			$( '#_purchase_note' ).val().length ? 'yes' : 'no',
-						sale_price:				$( '#_sale_price' ).val() ? 'yes' : 'no',
-						short_description:		$( '#excerpt' ).val().length ? 'yes' : 'no',
-						stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
-						tags:					tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
-						upsells:				$( '#upsell_ids option' ).length ? 'Yes' : 'No',
-						weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
-					};
-
-					window.wcTracks.recordEvent( 'product_update', properties );
-					hasRecordedEvent = true;
-				};
-
-				if ( $( '#publish' ).length !== 0 ) {
-					$( '#publish' ).on( 'click', sendTracks);
-					return;
+				if ( $( '.block-editor' ).length !== 0 && $( '.block-editor' )[0] ) {
+	    			isBlockEditor = true;
 				}
 
-				$( '.editor-post-publish-button' ).on( 'click', sendTracks);
+				if ( ! isBlockEditor & hasRecordedEvent) {
+                	return;
+            	}
 
+       			var description_value  = '';
+     			var tagsText = '';
+     			var currentStockValue = $( '#_stock' ).val();
+
+           		if ( ! isBlockEditor ) {
+              		tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
+             		description_value  = $( '#content' ).is( ':visible' ) ? $( '#content' ).val() : tinymce.get( 'content' ).getContent();
+             	}
+
+				var properties = {
+					attributes:				$( '.woocommerce_attribute' ).length,
+					categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
+					'cross_sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
+					description:			description_value.length ? 'Yes' : 'No',
+					enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
+					is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
+					is_block_editor:		isBlockEditor,
+					is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
+					manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
+					menu_order:				$( '#menu_order' ).val() ? 'Yes' : 'No',
+					product_gallery:		$( '#product_images_container .product_images > li' ).length,
+					product_image:			$( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
+					product_type:			$( '#product-type' ).val(),
+					purchase_note:			$( '#_purchase_note' ).val().length ? 'yes' : 'no',
+					sale_price:				$( '#_sale_price' ).val() ? 'yes' : 'no',
+					short_description:		$( '#excerpt' ).val().length ? 'yes' : 'no',
+					stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
+					tags:					tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
+					upsells:				$( '#upsell_ids option' ).length ? 'Yes' : 'No',
+					weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
+				};
+
+				function waitUntilElementExists( element, callback, limit ) {
+          			if ( $( element ).length > 0 ) {
+          				callback();
+          				return;
+          				}
+          			if ( limit < 1 ) {
+          				return;
+          			}
+          			setTimeout( function() {
+          				limit = limit || 10;
+          				waitUntilElementExists( element, callback, --limit );
+          				}, 500 );
+          		};
+
+          		if ( ! isBlockEditor ) {
+          			$( '#publish' ).on( 'click', function() {
+          				window.wcTracks.recordEvent( 'product_update', properties );
+          				});
+          			hasRecordedEvent = true;
+          		} else {
+					waitUntilElementExists( '.editor-post-publish-button', function() {
+          			$( '.editor-post-publish-button' ).on( 'click', function() {
+          				window.wcTracks.recordEvent( 'product_update', properties );
+          				}););
+          			});
+          		}
 			}
 			"
 		);

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -144,6 +144,7 @@ class WC_Products_Tracking {
 				if ( ! isBlockEditor & hasRecordedEvent) {
                 	return;
             	}
+          		console.log(isBlockEditor);
 
        			var description_value  = '';
      			var tagsText = '';
@@ -177,32 +178,16 @@ class WC_Products_Tracking {
 					weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
 				};
 
-				function waitUntilElementExists( element, callback, limit ) {
-          			if ( $( element ).length > 0 ) {
-          				callback();
-          				return;
-          				}
-          			if ( limit < 1 ) {
-          				return;
-          			}
-          			setTimeout( function() {
-          				limit = limit || 10;
-          				waitUntilElementExists( element, callback, --limit );
-          				}, 500 );
-          		};
-
           		if ( ! isBlockEditor ) {
           			$( '#publish' ).on( 'click', function() {
-          				window.wcTracks.recordEvent( 'product_update', properties );
-          				});
+          			   window.wcTracks.recordEvent( 'product_update', properties );
+					});
           			hasRecordedEvent = true;
           		} else {
-					waitUntilElementExists( '.editor-post-publish-button', function() {
-          			$( '.editor-post-publish-button' ).on( 'click', function() {
-          				window.wcTracks.recordEvent( 'product_update', properties );
-          				}););
-          			});
-          		}
+					$( '#wpwrap' ).on( 'click', '.editor-post-publish-button', function() {
+          			   window.wcTracks.recordEvent( 'product_update', properties );
+					});
+          		};
 			}
 			"
 		);

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -144,7 +144,6 @@ class WC_Products_Tracking {
 				if ( ! isBlockEditor & hasRecordedEvent) {
                 	return;
             	}
-          		console.log(isBlockEditor);
 
        			var description_value  = '';
      			var tagsText = '';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding an` isBlockEditor` prop to the `wcadmin_product_update` Tracks event. 
Reason: count of block usage for product management. 


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


part 1 of https://github.com/woocommerce/woocommerce/issues/33294

### How to test the changes in this Pull Request:

1. On a site with a block editing enabled when editing products (e.g. Blooms), edit and update a product
2. verify that the Track event `wcadmin_product_update`  has the `isBlockEditor` property.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
