### PR TITLE
Add cache refreshing/debugging mechanisms to Report API endpoints

### DIFF
--- a/plugins/woocommerce/changelog/fix-33221-force-cache-refresh
+++ b/plugins/woocommerce/changelog/fix-33221-force-cache-refresh
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a new collection parameter, force_cache_refresh, to Reports API endpoints which will cause the current request to bypass the cache, re-run the queries for the requested data, and overwrite the previous cache entry with the new results.

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -41,18 +41,19 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                      = array();
-		$args['before']            = $request['before'];
-		$args['after']             = $request['after'];
-		$args['interval']          = $request['interval'];
-		$args['page']              = $request['page'];
-		$args['per_page']          = $request['per_page'];
-		$args['orderby']           = $request['orderby'];
-		$args['order']             = $request['order'];
-		$args['extended_info']     = $request['extended_info'];
-		$args['category_includes'] = (array) $request['categories'];
-		$args['status_is']         = (array) $request['status_is'];
-		$args['status_is_not']     = (array) $request['status_is_not'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['interval']            = $request['interval'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['extended_info']       = $request['extended_info'];
+		$args['category_includes']   = (array) $request['categories'];
+		$args['status_is']           = (array) $request['status_is'];
+		$args['status_is_not']       = (array) $request['status_is_not'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -314,6 +315,12 @@ class Controller extends ReportsController implements ExportableInterface {
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -40,15 +40,16 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                  = array();
-		$args['before']        = $request['before'];
-		$args['after']         = $request['after'];
-		$args['page']          = $request['page'];
-		$args['per_page']      = $request['per_page'];
-		$args['orderby']       = $request['orderby'];
-		$args['order']         = $request['order'];
-		$args['coupons']       = (array) $request['coupons'];
-		$args['extended_info'] = $request['extended_info'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['coupons']             = (array) $request['coupons'];
+		$args['extended_info']       = $request['extended_info'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 		return $args;
 	}
 
@@ -284,6 +285,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -41,17 +41,18 @@ class Controller extends \WC_REST_Reports_Controller {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args              = array();
-		$args['before']    = $request['before'];
-		$args['after']     = $request['after'];
-		$args['interval']  = $request['interval'];
-		$args['page']      = $request['page'];
-		$args['per_page']  = $request['per_page'];
-		$args['orderby']   = $request['orderby'];
-		$args['order']     = $request['order'];
-		$args['coupons']   = (array) $request['coupons'];
-		$args['segmentby'] = $request['segmentby'];
-		$args['fields']    = $request['fields'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['interval']            = $request['interval'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['coupons']             = (array) $request['coupons'];
+		$args['segmentby']           = $request['segmentby'];
+		$args['fields']              = $request['fields'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -359,6 +360,12 @@ class Controller extends \WC_REST_Reports_Controller {
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -78,6 +78,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$args['last_order_after']    = $request['last_order_after'];
 		$args['customers']           = $request['customers'];
 		$args['users']               = $request['users'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = TimeInterval::normalize_between_params( $request, $between_params_numeric, false );
@@ -583,6 +584,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'items'             => array(
 				'type' => 'integer',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
@@ -64,6 +64,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$args['last_order_after']    = $request['last_order_after'];
 		$args['customers']           = $request['customers'];
 		$args['fields']              = $request['fields'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = TimeInterval::normalize_between_params( $request, $between_params_numeric, false );
@@ -384,6 +385,12 @@ class Controller extends \WC_REST_Reports_Controller {
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -227,7 +227,7 @@ class DataStore extends SqlQuery {
 		if ( $this->should_use_cache() && false === $this->force_cache_refresh ) {
 			$cached_data = Cache::get( $cache_key );
 
-			$cache_hit = ! ! $cached_data;
+			$cache_hit = false !== $cached_data;
 			if ( true === $this->debug_cache ) {
 				$this->debug_cache_data['cache_hit'] = $cache_hit;
 			}

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -142,7 +142,7 @@ class DataStore extends SqlQuery {
 		// See https://querymonitor.com/blog/2021/05/debugging-wordpress-rest-api-requests/
 		if ( isset( $_GET['_envelope'] ) ) {
 			$this->debug_cache = true;
-			add_filter( 'rest_envelope_response', array( $this, 'add_debug_cache_to_envelope' ), 999 );
+			add_filter( 'rest_envelope_response', array( $this, 'add_debug_cache_to_envelope' ), 999, 2 );
 		}
 	}
 
@@ -259,11 +259,16 @@ class DataStore extends SqlQuery {
 	/**
 	 * Add cache debugging information to an enveloped API response.
 	 *
-	 * @param array $envelope
+	 * @param array             $envelope
+	 * @param \WP_REST_Response $response
 	 *
 	 * @return array
 	 */
-	public function add_debug_cache_to_envelope( $envelope ) {
+	public function add_debug_cache_to_envelope( $envelope, $response ) {
+		if ( 0 !== strncmp( '/wc-analytics', $response->get_matched_route(), 13 ) ) {
+			return $envelope;
+		}
+
 		if ( ! empty( $this->debug_cache_data ) ) {
 			$envelope['debug_cache'] = $this->debug_cache_data;
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
@@ -369,7 +369,6 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-
 		$params['ip_address_excludes'] = array(
 			'description'       => __( 'Limit response to objects that don\'t have a specified ip address.', 'woocommerce' ),
 			'type'              => 'array',
@@ -377,6 +376,12 @@ class Controller extends ReportsController implements ExportableInterface {
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -56,6 +56,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$args['ip_address_includes'] = (array) $request['ip_address_includes'];
 		$args['ip_address_excludes'] = (array) $request['ip_address_excludes'];
 		$args['fields']              = $request['fields'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -376,6 +377,12 @@ class Controller extends \WC_REST_Reports_Controller {
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -41,31 +41,32 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                       = array();
-		$args['before']             = $request['before'];
-		$args['after']              = $request['after'];
-		$args['page']               = $request['page'];
-		$args['per_page']           = $request['per_page'];
-		$args['orderby']            = $request['orderby'];
-		$args['order']              = $request['order'];
-		$args['product_includes']   = (array) $request['product_includes'];
-		$args['product_excludes']   = (array) $request['product_excludes'];
-		$args['variation_includes'] = (array) $request['variation_includes'];
-		$args['variation_excludes'] = (array) $request['variation_excludes'];
-		$args['coupon_includes']    = (array) $request['coupon_includes'];
-		$args['coupon_excludes']    = (array) $request['coupon_excludes'];
-		$args['tax_rate_includes']  = (array) $request['tax_rate_includes'];
-		$args['tax_rate_excludes']  = (array) $request['tax_rate_excludes'];
-		$args['status_is']          = (array) $request['status_is'];
-		$args['status_is_not']      = (array) $request['status_is_not'];
-		$args['customer_type']      = $request['customer_type'];
-		$args['extended_info']      = $request['extended_info'];
-		$args['refunds']            = $request['refunds'];
-		$args['match']              = $request['match'];
-		$args['order_includes']     = $request['order_includes'];
-		$args['order_excludes']     = $request['order_excludes'];
-		$args['attribute_is']       = (array) $request['attribute_is'];
-		$args['attribute_is_not']   = (array) $request['attribute_is_not'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['product_includes']    = (array) $request['product_includes'];
+		$args['product_excludes']    = (array) $request['product_excludes'];
+		$args['variation_includes']  = (array) $request['variation_includes'];
+		$args['variation_excludes']  = (array) $request['variation_excludes'];
+		$args['coupon_includes']     = (array) $request['coupon_includes'];
+		$args['coupon_excludes']     = (array) $request['coupon_excludes'];
+		$args['tax_rate_includes']   = (array) $request['tax_rate_includes'];
+		$args['tax_rate_excludes']   = (array) $request['tax_rate_excludes'];
+		$args['status_is']           = (array) $request['status_is'];
+		$args['status_is_not']       = (array) $request['status_is_not'];
+		$args['customer_type']       = $request['customer_type'];
+		$args['extended_info']       = $request['extended_info'];
+		$args['refunds']             = $request['refunds'];
+		$args['match']               = $request['match'];
+		$args['order_includes']      = $request['order_includes'];
+		$args['order_excludes']      = $request['order_excludes'];
+		$args['attribute_is']        = (array) $request['attribute_is'];
+		$args['attribute_is_not']    = (array) $request['attribute_is_not'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -477,6 +478,12 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'array',
 			),
 			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -67,7 +67,6 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		$args['category_includes']   = (array) $request['categories'];
 		$args['segmentby']           = $request['segmentby'];
 		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-		$args['debug_cache']         = $request['debug_cache'];
 
 		// For backwards compatibility, `customer` is aliased to `customer_type`.
 		if ( empty( $request['customer_type'] ) && ! empty( $request['customer'] ) ) {
@@ -100,10 +99,6 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		foreach ( $report_data->intervals as $interval_data ) {
 			$item                    = $this->prepare_item_for_response( $interval_data, $request );
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
-		}
-
-		if ( isset( $report_data->debug_cache ) ) {
-			$out_data['debug_cache'] = $report_data->debug_cache;
 		}
 
 		$response = rest_ensure_response( $out_data );
@@ -578,12 +573,6 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		);
 		$params['force_cache_refresh'] = array(
 			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['debug_cache']         = array(
-			'description'       => __( 'Include cache debugging info in the response.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -40,32 +40,34 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                       = array();
-		$args['before']             = $request['before'];
-		$args['after']              = $request['after'];
-		$args['interval']           = $request['interval'];
-		$args['page']               = $request['page'];
-		$args['per_page']           = $request['per_page'];
-		$args['orderby']            = $request['orderby'];
-		$args['order']              = $request['order'];
-		$args['fields']             = $request['fields'];
-		$args['match']              = $request['match'];
-		$args['status_is']          = (array) $request['status_is'];
-		$args['status_is_not']      = (array) $request['status_is_not'];
-		$args['product_includes']   = (array) $request['product_includes'];
-		$args['product_excludes']   = (array) $request['product_excludes'];
-		$args['variation_includes'] = (array) $request['variation_includes'];
-		$args['variation_excludes'] = (array) $request['variation_excludes'];
-		$args['coupon_includes']    = (array) $request['coupon_includes'];
-		$args['coupon_excludes']    = (array) $request['coupon_excludes'];
-		$args['tax_rate_includes']  = (array) $request['tax_rate_includes'];
-		$args['tax_rate_excludes']  = (array) $request['tax_rate_excludes'];
-		$args['customer_type']      = $request['customer_type'];
-		$args['refunds']            = $request['refunds'];
-		$args['attribute_is']       = (array) $request['attribute_is'];
-		$args['attribute_is_not']   = (array) $request['attribute_is_not'];
-		$args['category_includes']  = (array) $request['categories'];
-		$args['segmentby']          = $request['segmentby'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['interval']            = $request['interval'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['fields']              = $request['fields'];
+		$args['match']               = $request['match'];
+		$args['status_is']           = (array) $request['status_is'];
+		$args['status_is_not']       = (array) $request['status_is_not'];
+		$args['product_includes']    = (array) $request['product_includes'];
+		$args['product_excludes']    = (array) $request['product_excludes'];
+		$args['variation_includes']  = (array) $request['variation_includes'];
+		$args['variation_excludes']  = (array) $request['variation_excludes'];
+		$args['coupon_includes']     = (array) $request['coupon_includes'];
+		$args['coupon_excludes']     = (array) $request['coupon_excludes'];
+		$args['tax_rate_includes']   = (array) $request['tax_rate_includes'];
+		$args['tax_rate_excludes']   = (array) $request['tax_rate_excludes'];
+		$args['customer_type']       = $request['customer_type'];
+		$args['refunds']             = $request['refunds'];
+		$args['attribute_is']        = (array) $request['attribute_is'];
+		$args['attribute_is_not']    = (array) $request['attribute_is_not'];
+		$args['category_includes']   = (array) $request['categories'];
+		$args['segmentby']           = $request['segmentby'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
+		$args['debug_cache']         = $request['debug_cache'];
 
 		// For backwards compatibility, `customer` is aliased to `customer_type`.
 		if ( empty( $request['customer_type'] ) && ! empty( $request['customer'] ) ) {
@@ -98,6 +100,10 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		foreach ( $report_data->intervals as $interval_data ) {
 			$item                    = $this->prepare_item_for_response( $interval_data, $request );
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
+		}
+
+		if ( isset( $report_data->debug_cache ) ) {
+			$out_data['debug_cache'] = $report_data->debug_cache;
 		}
 
 		$response = rest_ensure_response( $out_data );
@@ -569,6 +575,18 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['debug_cache']         = array(
+			'description'       => __( 'Include cache debugging info in the response.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -284,7 +284,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'category_includes' => array(),
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
-		$query_args = $this->parse_cache_options( $query_args );
 		$this->normalize_timezones( $query_args, $defaults );
 
 		/*
@@ -414,8 +413,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$this->set_cached_data( $cache_key, $data );
 		}
-
-		$this->maybe_add_cache_debug_data( $data, $query_args );
 
 		return $data;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -284,6 +284,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'category_includes' => array(),
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
+		$query_args = $this->parse_cache_options( $query_args );
 		$this->normalize_timezones( $query_args, $defaults );
 
 		/*
@@ -413,6 +414,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$this->set_cached_data( $cache_key, $data );
 		}
+
+		$this->maybe_add_cache_debug_data( $data, $query_args );
 
 		return $data;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -345,6 +345,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 
 		return $params;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -425,6 +425,12 @@ class Controller extends \WC_REST_Reports_Controller {
 				'type' => 'string',
 			),
 		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 
 		return $params;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -47,16 +47,17 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args              = array();
-		$args['before']    = $request['before'];
-		$args['after']     = $request['after'];
-		$args['interval']  = $request['interval'];
-		$args['page']      = $request['page'];
-		$args['per_page']  = $request['per_page'];
-		$args['orderby']   = $request['orderby'];
-		$args['order']     = $request['order'];
-		$args['segmentby'] = $request['segmentby'];
-		$args['fields']    = $request['fields'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['interval']            = $request['interval'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['segmentby']           = $request['segmentby'];
+		$args['fields']              = $request['fields'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -433,6 +434,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				'coupon',
 				'customer_type', // new vs returning.
 			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -45,14 +45,15 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args             = array();
-		$args['before']   = $request['before'];
-		$args['after']    = $request['after'];
-		$args['page']     = $request['page'];
-		$args['per_page'] = $request['per_page'];
-		$args['orderby']  = $request['orderby'];
-		$args['order']    = $request['order'];
-		$args['taxes']    = $request['taxes'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['taxes']               = $request['taxes'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -288,6 +289,12 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -69,17 +69,18 @@ class Controller extends \WC_REST_Reports_Controller {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args              = array();
-		$args['before']    = $request['before'];
-		$args['after']     = $request['after'];
-		$args['interval']  = $request['interval'];
-		$args['page']      = $request['page'];
-		$args['per_page']  = $request['per_page'];
-		$args['orderby']   = $request['orderby'];
-		$args['order']     = $request['order'];
-		$args['taxes']     = (array) $request['taxes'];
-		$args['segmentby'] = $request['segmentby'];
-		$args['fields']    = $request['fields'];
+		$args                        = array();
+		$args['before']              = $request['before'];
+		$args['after']               = $request['after'];
+		$args['interval']            = $request['interval'];
+		$args['page']                = $request['page'];
+		$args['per_page']            = $request['per_page'];
+		$args['orderby']             = $request['orderby'];
+		$args['order']               = $request['order'];
+		$args['taxes']               = (array) $request['taxes'];
+		$args['segmentby']           = $request['segmentby'];
+		$args['fields']              = $request['fields'];
+		$args['force_cache_refresh'] = $request['force_cache_refresh'];
 
 		return $args;
 	}
@@ -395,6 +396,12 @@ class Controller extends \WC_REST_Reports_Controller {
 			'items'             => array(
 				'type' => 'string',
 			),
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -398,6 +398,12 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 
 		return $params;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -476,6 +476,12 @@ class Controller extends \WC_REST_Reports_Controller {
 			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 
 		return $params;
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new collection parameter to all Reports API endpoints that utilize caching, `force_cache_refresh`, which will cause the current request to bypass the cache, re-run the queries for the requested data, and overwrite the previous cache entry with the new results.

Note that this doesn't invalidate the entire cache, only the entry for the particular set of collection parameters and values specified in the request.

This also adds a way to include debugging information related to the cache in the API response. Modeled after the way the Query Monitor plugin [adds such information](https://querymonitor.com/blog/2021/05/debugging-wordpress-rest-api-requests/), you can get this by including an `_envelope` parameter in your API request. The debugging info includes whether the cache has been disabled via filter (`should_use_cache`), whether the `force_cache_refresh` parameter was used, whether the returned data was a `cache_hit` or not, and an array of the query parameters that were actually used to create the cache key.

Closes #33221 

### How to test the changes in this Pull Request:

1. Using an API client like Insomnia, choose one of the WC Analytics API endpoints that this PR updates, and send a request to it. It's best to include the `before` and `after` parameters when making these requests so that you get a consistent time range. Otherwise it defaults to the current second, and you'll never get a cache hit.
2. Now make the request again, but include the `_envelope` parameter. The response should be an object with `body`, `status`, and `headers` properties, along with a new `debug_cache` property.
3. Make this same request a couple of times so you can see that `debug_cache.cache_hit` is set to `true`.
4. Now add the `force_cache_refresh` parameter to the request, with its value set to `true`. With this request, `debug_cache` should show that `cache_hit` is now false.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
