### PR TITLE
Add `tasklist_cancel_load_sample_products_click` event track for product task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/index.tsx
@@ -95,9 +95,12 @@ export const Products = () => {
 			) : (
 				isConfirmingLoadSampleProducts && (
 					<LoadSampleProductConfirmModal
-						onCancel={ () =>
-							setIsConfirmingLoadSampleProducts( false )
-						}
+						onCancel={ () => {
+							setIsConfirmingLoadSampleProducts( false );
+							recordEvent(
+								'tasklist_cancel_load_sample_products_click'
+							);
+						} }
 						onImport={ () => {
 							setIsConfirmingLoadSampleProducts( false );
 							loadSampleProduct();

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-import-products/test/index.tsx
@@ -165,5 +165,8 @@ describe( 'Products', () => {
 
 		userEvent.click( getByRole( 'button', { name: 'Cancel' } ) );
 		expect( queryByText( confirmModalText ) ).not.toBeInTheDocument();
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'tasklist_cancel_load_sample_products_click'
+		);
 	} );
 } );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/index.tsx
@@ -189,9 +189,12 @@ export const Products = () => {
 					) : (
 						isConfirmingLoadSampleProducts && (
 							<LoadSampleProductConfirmModal
-								onCancel={ () =>
-									setIsConfirmingLoadSampleProducts( false )
-								}
+								onCancel={ () => {
+									setIsConfirmingLoadSampleProducts( false );
+									recordEvent(
+										'tasklist_cancel_load_sample_products_click'
+									);
+								} }
 								onImport={ () => {
 									setIsConfirmingLoadSampleProducts( false );
 									loadSampleProduct();

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -292,6 +292,9 @@ describe( 'Products', () => {
 
 		userEvent.click( getByRole( 'button', { name: 'Cancel' } ) );
 		expect( queryByText( confirmModalText ) ).not.toBeInTheDocument();
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'tasklist_cancel_load_sample_products_click'
+		);
 	} );
 
 	it( 'should show spinner when layout experiment is loading', async () => {

--- a/plugins/woocommerce/changelog/add-event-track-cancel-load-sample-product
+++ b/plugins/woocommerce/changelog/add-event-track-cancel-load-sample-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tasklist_cancel_load_sample_products_click event track for product task


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33201.

Add event tracking for load sample product confirmation modal. Event fired when a user clicks the load sample products cancel button.

### How to test the changes in this Pull Request:

1. Install `WooCommerce Admin Test Helper`
2. Go to `Tools > WCA Test Helper`
3. Click `Experiments`
4. Toggle `woocommerce_products_task_layout_stacked` to set you to the treatment group.
5. Go to `Woocommerce > Home`
6. Click "Add my products"
7. Enable track logging `localStorage.setItem( 'debug', 'wc-admin:*' );`
8. Click `View more product types`
9. Click `Load Sample Products`
10. Click `Cancel` button
11. It should record a  `wcadmin_tasklist_cancel_load_sample_products_click` event.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
