### PR TITLE
Fix: error when creating products via REST API v1

### DIFF
--- a/plugins/woocommerce/changelog/fix-error-when-creating-products-via-rest-api-v1
+++ b/plugins/woocommerce/changelog/fix-error-when-creating-products-via-rest-api-v1
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Changelog already added (see fix-product_attributes_lookup_table_update), the intention is for this to ship in the same release.
+
+

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -647,11 +647,11 @@ class LookupDataStore {
 	 * Handler for the woocommerce_rest_insert_product hook.
 	 * Needed to update the lookup table when the REST API batch insert/update endpoints are used.
 	 *
-	 * @param WP_Post          $product The post representing the created or updated product.
+	 * @param \WP_Post         $product The post representing the created or updated product.
 	 * @param \WP_REST_Request $request The REST request that caused the hook to be fired.
 	 * @return void
 	 */
-	private function on_product_created_or_updated_via_rest_api( WP_Post $product, \WP_REST_Request $request ): void {
+	private function on_product_created_or_updated_via_rest_api( \WP_Post $product, \WP_REST_Request $request ): void {
 		if ( StringUtil::ends_with( $request->get_route(), '/batch' ) ) {
 			$this->on_product_changed( $product->ID );
 		}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This bug was introduced in https://github.com/woocommerce/woocommerce/pull/32893.

There was a missing root namespace indicator for the first parameter of `LookupDataStore::on_product_created_or_updated_via_rest_api`. This was causing an error when creating products via the REST API v1 endpoints.

### How to test the changes in this Pull Request:

Same testing instructions of https://github.com/woocommerce/woocommerce/pull/32893, but focusing on the v1 API.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
