### PR TITLE
Fix warning on WC Pay subscriptions page with unset submenu item

### DIFF
--- a/plugins/woocommerce/changelog/fix-33298
+++ b/plugins/woocommerce/changelog/fix-33298
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a warning caused by an attempt to iterate over a submenu that may not exist on WC Pay subscriptions page.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -499,7 +499,7 @@ class TaskLists {
 
 		$tasks_count = self::setup_tasks_remaining();
 
-		if ( ! $tasks_count ) {
+		if ( ! $tasks_count || ! isset( $submenu['woocommerce'] ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/WcPaySubscriptionsPage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPaySubscriptionsPage.php
@@ -231,6 +231,9 @@ class WcPaySubscriptionsPage {
 		$wc_admin_menu           = array();
 		$subscriptions_menu_item = null;
 
+		if ( ! isset( $submenu['woocommerce'] ) ) {
+			return;
+		}
 		foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
 			$wc_admin_menu[ $key ] = $menu_item;
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes sure that the WooCommerce submenu exists prior to attempting to iterate over it. It doesn't exist when attempting to log in to wp-admin with a customer account, and this causes issues with the redirect for customer accounts to the my account page.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33298.

### How to test the changes in this Pull Request:

1. Create a customer account.
2.Attempt to login to /wp-admin with customer account.
3.Verify that you are redirected to the my account page.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
