### PR TITLE
Update code freeze script exit code on failure

### DIFF
--- a/.github/workflows/scripts/release-code-freeze.php
+++ b/.github/workflows/scripts/release-code-freeze.php
@@ -20,14 +20,14 @@ $release_day_of_month = (int) date( 'j', $release_time );
 // If 26 days from now isn't the second Tuesday, then it's not code freeze day.
 if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
 	echo 'Info: Today is not the Thursday of the code freeze.' . PHP_EOL;
-	return;
+	exit( 1 );
 }
 
 $latest_version_with_release = get_latest_version_with_release();
 
 if ( empty( $latest_version_with_release ) ) {
 	echo '*** Error: Unable to get latest version with release' . PHP_EOL;
-	return;
+	exit( 1 );
 }
 
 // Because we go from 5.9 to 6.0, we can get the next major_minor by adding 0.1 and formatting appropriately.
@@ -60,6 +60,8 @@ if ( create_github_branch_from_branch( 'trunk', $release_branch_to_create ) ) {
 } else if ( '422' === $github_api_response_code ) {
 	// The release branch already existed when GitHub returns a 422 status.
 	echo "Notice: Unable to create {$release_branch_to_create} branch. Maybe it already exists? Skipping..." . PHP_EOL;
+	exit( 1 );
 } else {
 	echo "*** Error: Unable to create {$release_branch_to_create}" . PHP_EOL;
+	exit( 1 );
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the script to create the milestone and release branch such that it exits with a non-zero status code for failures, or if it's not the correct day for code freeze. This stops the action from continuing and running other jobs (namely, the Slack notification job).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Checkout the branch and run the following: `GITHUB_REPOSITORY=woocommerce/woocommerce TIME_OVERRIDE="2022-06-07" php .github/workflows/scripts/release-code-freeze.php && echo "success"`
2. Verify that "success" is not echoed. Prior to this PR, it would have been.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
