### PR TITLE
[COT] Implement create() method in COT datastore

### DIFF
--- a/plugins/woocommerce/changelog/add-32670-cot-data-store-create
+++ b/plugins/woocommerce/changelog/add-32670-cot-data-store-create
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Implement `create()` in COT datastore.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -339,6 +339,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'post_status'   => $this->get_post_status( $order ),
 				'post_parent'   => $order->get_parent_id(),
 				'post_excerpt'  => $this->get_post_excerpt( $order ),
+				'post_type'     => 'shop_order',
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -339,7 +339,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'post_status'   => $this->get_post_status( $order ),
 				'post_parent'   => $order->get_parent_id(),
 				'post_excerpt'  => $this->get_post_excerpt( $order ),
-				'post_type'     => 'shop_order',
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -950,12 +950,12 @@ LEFT JOIN {$operational_data_clauses['join']}
 		/**
 		 * Allow third parties to include rows that need to be inserted/updated in custom tables when persisting an order.
 		 *
-		 * @param array Array of rows to be inserted/updated when persisting an order. Each entry should be an array with
-		 *              keys 'table', 'data' (the row), 'format' (row format), 'where' and 'where_format'.
-		 * @param \WC_Order The order object.
-		 * @param string The context of the operation: 'create' or 'update'.
-		 *
 		 * @since 6.8.0
+		 *
+		 * @param array      Array of rows to be inserted/updated when persisting an order. Each entry should be an array with
+		 *                   keys 'table', 'data' (the row), 'format' (row format), 'where' and 'where_format'.
+		 * @param \WC_Order  The order object.
+		 * @param string     The context of the operation: 'create' or 'update'.
 		 */
 		$ext_rows = apply_filters( 'woocommerce_orders_table_datastore_extra_db_rows_for_order', array(), $order, $context );
 
@@ -1035,9 +1035,11 @@ LEFT JOIN {$operational_data_clauses['join']}
 
 		/**
 		 * Fires when a new order is created.
+		 *
+		 * @since 2.7.0
+		 *
 		 * @param int       Order ID.
 		 * @param \WC_Order Order object.
-		 * @since 2.7.0
 		 */
 		do_action( 'woocommerce_new_order', $order->get_id(), $order );
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -823,6 +823,8 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 *
 	 * @param \WC_Order $order        The order.
 	 * @throws \Exception If order data is not valid.
+	 *
+	 * @since 6.8.0
 	 */
 	protected function persist_order_to_db( &$order ) {
 		global $wpdb;
@@ -879,8 +881,10 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 * @param boolean   $only_changes Whether to consider only changes in the order for generating the rows.
 	 * @return array
 	 * @throws \Exception When invalid data is found for the given context.
+	 *
+	 * @since 6.8.0
 	 */
-	private function get_db_rows_for_order( $order, $context = 'create', $only_changes = false ): array {
+	protected function get_db_rows_for_order( $order, $context = 'create', $only_changes = false ): array {
 		$result = array();
 
 		// wc_orders.
@@ -951,7 +955,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		 * @param \WC_Order The order object.
 		 * @param string The context of the operation: 'create' or 'update'.
 		 *
-		 * @since x.y.z
+		 * @since 6.8.0
 		 */
 		$ext_rows = apply_filters( 'woocommerce_orders_table_datastore_extra_db_rows_for_order', array(), $order, $context );
 
@@ -967,8 +971,10 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 * @param array     $column_mapping Table column mapping.
 	 * @param bool      $only_changes   Whether to consider only changes in the order object or all fields.
 	 * @return array
+	 *
+	 * @since 6.8.0
 	 */
-	private function get_db_row_from_order( $order, $column_mapping, $only_changes = false ) {
+	protected function get_db_row_from_order( $order, $column_mapping, $only_changes = false ) {
 		$changes = $only_changes ? $order->get_changes() : array_merge( $order->get_data(), $order->get_changes() );
 
 		// XXX: manually persist some of the properties until the datastore/property design is finalized.
@@ -1002,6 +1008,8 @@ LEFT JOIN {$operational_data_clauses['join']}
 	//phpcs:disable Squiz.Commenting, Generic.Commenting
 
 	/**
+	 * Method to create an order in the database.
+	 *
 	 * @param \WC_Order $order
 	 */
 	public function create( &$order ) {
@@ -1333,7 +1341,7 @@ CREATE TABLE $meta_table (
 	 *
 	 * @return array List of keys.
 	 */
-	private static function get_internal_data_store_keys() {
+	protected function get_internal_data_store_keys() {
 		// XXX: Finalize design -- will these be turned into props?
 		return array(
 			'order_stock_reduced',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -839,7 +839,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 				)
 			);
 
-			if ( ! $post_id || is_wp_error( $post_id ) ) {
+			if ( ! $post_id ) {
 				throw new \Exception( __( 'Could not create order in posts table.', 'woocommerce' ) );
 			}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -994,8 +994,6 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 * @param \WC_Order $order
 	 */
 	public function update( &$order ) {
-		global $wpdb;
-
 		// Before updating, ensure date paid is set if missing.
 		if (
 			! $order->get_date_paid( 'edit' )

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -849,12 +849,12 @@ LEFT JOIN {$operational_data_clauses['join']}
 
 		if ( $row ) {
 			$db_updates[] = array(
-				'table'          => self::get_orders_table_name(),
-				'pk_table'       => true,
-				'data'           => $row['data'],
-				'format'         => $row['format'],
-				'where'          => $is_new_record ? null : array( 'id' => $order_id ),
-				'where_format'   => $is_new_record ? null : '%d',
+				'table'        => self::get_orders_table_name(),
+				'pk_table'     => true,
+				'data'         => $row['data'],
+				'format'       => $row['format'],
+				'where'        => $is_new_record ? null : array( 'id' => $order_id ),
+				'where_format' => $is_new_record ? null : '%d',
 			);
 		}
 
@@ -882,8 +882,11 @@ LEFT JOIN {$operational_data_clauses['join']}
 					'table'        => self::get_addresses_table_name(),
 					'data'         => $row['data'],
 					'format'       => $row['format'],
-					'where'        => $is_new_record ? null : array( 'order_id' => $order_id, 'address_type' => $address_type ),
-					'where_format' => $is_new_record ? null : array( '%d', '%s' )
+					'where'        => $is_new_record ? null : array(
+						'order_id'     => $order_id,
+						'address_type' => $address_type,
+					),
+					'where_format' => $is_new_record ? null : array( '%d', '%s' ),
 				);
 			}
 		}
@@ -906,6 +909,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 			}
 
 			if ( false === $result ) {
+				// translators: %s is a table name.
 				throw new \Exception( sprintf( __( 'Could not persist order to database table "%s".', 'woocommerce' ), $update['table'] ) );
 			}
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -318,7 +318,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		),
 		'order_stock_reduced'         => array(
 			'type' => 'bool',
-			'name' => 'stock_reduced',
+			'name' => 'order_stock_reduced',
 		),
 		'date_paid_gmt'               => array(
 			'type' => 'date',
@@ -539,7 +539,28 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	public function set_stock_reduced( $order, $set, $save = true ) {
 		// XXX implement $save = true.
 		$order = is_numeric( $order ) ? wc_get_order( $order ) : $order;
-		return $order->update_meta_data( '_order_stock_reduced', wc_string_to_bool( $set ) );
+		return $order->update_meta_data( '_order_stock_reduced', wc_bool_to_string( $set ) );
+	}
+
+	/**
+	 * Helper getter for `order_stock_reduced`.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return bool Whether stock was reduced.
+	 */
+	private function get_order_stock_reduced( $order ) {
+		return $this->get_stock_reduced( $order );
+	}
+
+	/**
+	 * Helper setter for `order_stock_reduced`.
+	 *
+	 * @param \WC_Order $order Order ID or order object.
+	 * @param bool      $set Whether stock was reduced.
+	 * @param bool      $save Whether to persist changes to db immediately or not.
+	 */
+	private function set_order_stock_reduced( $order, $set, $save = true ) {
+		return $this->set_stock_reduced( $order, $set, $save );
 	}
 
 	//phpcs:disable Squiz.Commenting, Generic.Commenting

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -38,7 +38,6 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 	 */
 	public function register() {
 		$this->share( OrdersTableDataStoreMeta::class );
-		$this->share( OrdersTableDataStoreHelper::class );
 
 		$this->share( OrdersTableDataStore::class )->addArguments( array( OrdersTableDataStoreMeta::class, DatabaseUtil::class ) );
 		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, PostsToOrdersMigrationController::class ) );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -196,6 +196,100 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests create() on the COT datastore.
+	 */
+	public function test_cot_datastore_create() {
+		$order = new WC_Order();
+		$this->switch_data_store( $order, $this->sut );
+
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+
+		$order->set_status( 'pending' );
+		$order->set_created_via( 'unit-tests' );
+		$order->set_currency( 'COP' );
+		$order->set_customer_ip_address( '127.0.0.1' );
+
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 2,
+				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 2 ) ),
+				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 2 ) ),
+			)
+		);
+
+		$order->add_item( $item );
+
+		$order->set_billing_first_name( 'Jeroen' );
+		$order->set_billing_last_name( 'Sormani' );
+		$order->set_billing_company( 'WooCompany' );
+		$order->set_billing_address_1( 'WooAddress' );
+		$order->set_billing_address_2( '' );
+		$order->set_billing_city( 'WooCity' );
+		$order->set_billing_state( 'NY' );
+		$order->set_billing_postcode( '123456' );
+		$order->set_billing_country( 'US' );
+		$order->set_billing_email( 'admin@example.org' );
+		$order->set_billing_phone( '555-32123' );
+
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$order->set_payment_method( $payment_gateways['bacs'] );
+
+		$order->set_shipping_total( 5.0 );
+		$order->set_discount_total( 0.0 );
+		$order->set_discount_tax( 0.0 );
+		$order->set_cart_tax( 0.0 );
+		$order->set_shipping_tax( 0.0 );
+		$order->set_total( 25.0 );
+		$order->save();
+
+		$order->get_data_store()->set_stock_reduced( $order, true, false );
+
+		$order->update_meta_data( 'my_meta', rand( 0, 255 ) );
+
+		$order_id = $order->save();
+
+		$this->assertIsInteger( $order_id );
+		$this->assertLessThan( $order_id, 0 );
+
+		wp_cache_flush();
+
+		// Read the order again (fresh).
+		$r_order = new WC_Order();
+		$r_order->set_id( $order_id );
+		$this->switch_data_store( $r_order, $this->sut );
+		$this->sut->read( $r_order );
+
+		// Compare some of the prop/meta values to those that should've been persisted.
+		$props_to_compare = array(
+			'status',
+			'created_via',
+			'currency',
+			'customer_ip_address',
+			'billing_first_name',
+			'billing_last_name',
+			'billing_company',
+			'billing_address_1',
+			'billing_city',
+			'billing_state',
+			'billing_postcode',
+			'billing_country',
+			'billing_email',
+			'billing_phone',
+			'shipping_total',
+			'total',
+		);
+
+		foreach ( $props_to_compare as $prop ) {
+			$this->assertEquals( $order->{"get_$prop"}( 'edit' ), $r_order->{"get_$prop"}( 'edit' ) );
+		}
+
+		$this->assertEquals( $order->get_meta( 'my_meta', true, 'edit' ), $r_order->get_meta( 'my_meta', true, 'edit' ) );
+		$this->assertEquals( $this->sut->get_stock_reduced( $order ), $this->sut->get_stock_reduced( $r_order ) );
+	}
+
+	/**
 	 * Helper function to delete all meta for post.
 	 *
 	 * @param int $post_id Post ID to delete data for.


### PR DESCRIPTION
### Description
This PR implements the `create()` method in the COT datastore, allowing new orders to be persisted to the database by calling `$order->save()`.

It enhances the functionality first introduced in #33026.

Some additions in this PR:

- Reworked some of the logic that persists data into the database to simplify it.
- Overrides and makes use of `update_post_meta()` to sync metadata with some COT fields.
   This also improves backwards compatibility because metadata can be accessed and directly updated for fields like `order_stock_reduced` and it'd get persisted to the correct table.
- Added unit test `test_cot_datastore_create` which creates an order from scratch, reads it fresh from the database and compares values with expected ones.

#### ⚠️ For discussion
- This PR still treats some props (such as `order_stock_reduced`) as a special case, as those haven't been turned into `WC_Order` properties yet. This works fine, but it's worth mentioning, this is still in the COT blockers list for discussion.
- The `create()` method in this datastore behaves as in current data stores in the sense that it  determines whether a record is new or not based on whether it has an ID or not.
   The current CPT datastore, for example, doesn't allow you to insert a record with a pre-defined ID, but we might need this for the COT datastore in order to reuse IDs from the `wp_posts` table, as long as that's necessary.
   I mostly focused on getting the basics working and feature parity with the CPT datastore, but I can work on that functionality if we need at this point (maybe in a different PR?). It wouldn't be too difficult to add it IMO.

Closes #32670.

### Testing
1. Enable the COT feature and make sure the COT datastore is configured as the order datastore. 
  This can be achieved programmatically (if necessary) with code like this:
   ```php
   add_filter(
       'woocommerce_order_data_store',
       function ( $default_data_store ) {
 	      return wc_get_container()->get( 'Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore' );
      },
       999,
       1
   );
   ```
2. Via custom code, try to create a new order with some properties/metadata/etc. For example:
   ```php
   $order = new WC_Order();
   $order->set_status( 'on-hold' );
   $order->set_created_via( 'php-code' );
   $order->set_currency( get_woocommerce_currency() );
   $order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
   $order->set_customer_user_agent( wc_get_user_agent() );
   $order->set_billing_first_name( 'Albert' );
   $order->set_billing_last_name( 'Einstein' );
   $order->set_billing_email( 'albert.einstein@example.org' );
   $order->set_billing_address_1( 'Woo Street' );
   $order->set_billing_city( 'WooCity' );
   $order->set_billing_country( 'US' );
   $order->set_shipping_first_name( 'Elsa' );
   $order->set_shipping_last_name( 'Einstein' );
   $order->set_shipping_address_1( 'Woo Street' );
   $order->set_shipping_city( 'WooCity' );
   $order->set_shipping_country( 'US' );
   
   $order->get_data_store()->set_stock_reduced( $order, true, false );
   
   $payment_gateways = WC()->payment_gateways->payment_gateways();
   $order->set_payment_method( $payment_gateways['bacs'] );
   
   $order->set_shipping_total( 2.5 );
   $order->set_total( 12.5 );
   
   $order->save();
   ```
4. Confirm that tables `wc_orders`, `wc_order_operational_data`, `wc_order_addresses` and `wc_orders_meta` now have the data for the new order.