### PR TITLE
Add a new ArrayUtil::select method

### DIFF
--- a/plugins/woocommerce/changelog/add-array_util_select_method
+++ b/plugins/woocommerce/changelog/add-array_util_select_method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add a new ArrayUtil::select method

--- a/plugins/woocommerce/tests/php/src/Utilities/ArrayUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/ArrayUtilTest.php
@@ -168,4 +168,87 @@ class ArrayUtilTest extends \WC_Unit_Test_Case {
 		$actual = ArrayUtil::to_ranges_string( $input_array );
 		$this->assertEquals( $expected_string, $actual );
 	}
+
+	/**
+	 * @testdox `select` can be used to select a value from an array of arrays based on array key.
+	 */
+	public function test_select_for_arrays() {
+		$items = array(
+			array(
+				'foo' => 1,
+				'bar' => 2,
+			),
+			array(
+				'foo' => 3,
+				'bar' => 4,
+			),
+		);
+
+		$actual = ArrayUtil::select( $items, 'foo' );
+		$this->assertEquals( array( 1, 3 ), $actual, ArrayUtil::SELECT_BY_ARRAY_KEY );
+	}
+
+	/**
+	 * @testdox `select` can be used to select a value from an array of objects based on a method of the objects.
+	 */
+	public function test_select_for_object_methods() {
+		// phpcs:disable Squiz.Commenting
+		$items = array(
+			new class() {
+				public function get_id() {
+					return 1;
+				}
+			},
+			new class() {
+				public function get_id() {
+					return 2;
+				}
+			},
+		);
+		// phpcs:enable Squiz.Commenting
+
+		$actual = ArrayUtil::select( $items, 'get_id', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+		$this->assertEquals( array( 1, 2 ), $actual );
+	}
+
+	/**
+	 * @testdox `select` can be used to select a value from an array of objects based on a property of the objects.
+	 */
+	public function test_select_for_object_properties() {
+		// phpcs:disable Squiz.Commenting
+		$items = array(
+			new class() {
+				public $id = 1;
+			},
+			new class() {
+				public $id = 2;
+			},
+		);
+		// phpcs:enable Squiz.Commenting
+
+		$actual = ArrayUtil::select( $items, 'id', ArrayUtil::SELECT_BY_OBJECT_PROPERTY );
+		$this->assertEquals( array( 1, 2 ), $actual );
+	}
+
+	/**
+	 * @testdox `select` can be used to select a value from an array of objects with automatic selection of array key or object method/property.
+	 */
+	public function test_select_for_mixed() {
+		// phpcs:disable Squiz.Commenting
+		$items = array(
+			array( 'the_id' => 1 ),
+			new class() {
+				public $the_id = 2;
+			},
+			new class() {
+				public function the_id() {
+					return 3;
+				}
+			},
+		);
+		// phpcs:enable Squiz.Commenting
+
+		$actual = ArrayUtil::select( $items, 'the_id', ArrayUtil::SELECT_BY_AUTO );
+		$this->assertEquals( array( 1, 2, 3 ), $actual );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new method named `select` to the `ArrayUtil` class. This method is an utility layer on top of `array_map`, it will convert an array of arrays and/or objects into an array of single values obtained by picking array values by key, by picking object property values, or by executing object methods. See the unit tests for usage details.

### How to test the changes in this Pull Request:

Run the unit tests.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
