### PR TITLE
Update ActionScheduler to 3.4.2

### DIFF
--- a/plugins/woocommerce/changelog/update-as-3.4.2
+++ b/plugins/woocommerce/changelog/update-as-3.4.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update ActionScheduler to 3.4.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"psr/container": "1.0.0",
-		"woocommerce/action-scheduler": "3.4.1",
+		"woocommerce/action-scheduler": "3.4.2",
 		"woocommerce/woocommerce-blocks": "7.6.0"
 	},
 	"require-dev": {

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e381a6654b1e65324831bf233b7f68b",
+    "content-hash": "ac7396bfc3fa1d5a6f4d471c15f8a417",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -641,16 +641,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "9ce261d7055650331d6d433c03bf188e6dd2b259"
+                "reference": "7d8e830b6387410ccf11708194d3836f01cb2942"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/9ce261d7055650331d6d433c03bf188e6dd2b259",
-                "reference": "9ce261d7055650331d6d433c03bf188e6dd2b259",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/7d8e830b6387410ccf11708194d3836f01cb2942",
+                "reference": "7d8e830b6387410ccf11708194d3836f01cb2942",
                 "shasum": ""
             },
             "require-dev": {
@@ -675,9 +675,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.4.1"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.4.2"
             },
-            "time": "2022-05-03T09:41:49+00:00"
+            "time": "2022-06-08T15:46:07+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the version of ActionScheduler included in core to 3.4.2.

### How to test the changes in this Pull Request:

1. Verify that the version was bumped to 3.4.2 and that that version appears correctly on the SSR.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
