### PR TITLE
Update method for getting Reports API cache version number

### DIFF
--- a/plugins/woocommerce/changelog/fix-33315-stats-cache-ttl
+++ b/plugins/woocommerce/changelog/fix-33315-stats-cache-ttl
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change invalidation and TTL of the analytics cache for better cache resilience

--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -29,7 +29,7 @@ class Cache {
 	 * Get cache version number.
 	 *
 	 * This is based on WC_Cache_Helper::get_transient_version, but rounds the Unix timestamp to the nearest
-	 * increment to buffer the caching a bit.
+	 * increment to rate-limit cache invalidations.
 	 *
 	 * @param bool $refresh True to generate a new value.
 	 *

--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -84,7 +84,7 @@ class Cache {
 			'value'   => $value,
 		);
 
-		$result = set_transient( $key, $transient_value, WEEK_IN_SECONDS );
+		$result = set_transient( $key, $transient_value, DAY_IN_SECONDS );
 
 		return $result;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -42,7 +42,7 @@ class Cache {
 		if ( false === $transient_value || true === $refresh ) {
 			// Round to the nearest $minutes increment.
 			$minutes = 10;
-			$transient_value = (string) round( time() / MINUTE_IN_SECONDS * $minutes ) * ( MINUTE_IN_SECONDS * $minutes );
+			$transient_value = (string) round( time() / ( MINUTE_IN_SECONDS * $minutes ) ) * ( MINUTE_IN_SECONDS * $minutes );
 
 			set_transient( $transient_name, $transient_value );
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -84,7 +84,7 @@ class Cache {
 			'value'   => $value,
 		);
 
-		$result = set_transient( $key, $transient_value, DAY_IN_SECONDS );
+		$result = set_transient( $key, $transient_value, HOUR_IN_SECONDS );
 
 		return $result;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -22,18 +22,32 @@ class Cache {
 	 * Invalidate cache.
 	 */
 	public static function invalidate() {
-		\WC_Cache_Helper::get_transient_version( self::VERSION_OPTION, true );
+		self::get_version( true );
 	}
 
 	/**
 	 * Get cache version number.
 	 *
+	 * This is based on WC_Cache_Helper::get_transient_version, but rounds the Unix timestamp to the nearest
+	 * increment to buffer the caching a bit.
+	 *
+	 * @param bool $refresh True to generate a new value.
+	 *
 	 * @return string
 	 */
-	public static function get_version() {
-		$version = \WC_Cache_Helper::get_transient_version( self::VERSION_OPTION );
+	public static function get_version( $refresh = false ) {
+		$transient_name  = self::VERSION_OPTION . '-transient-version';
+		$transient_value = get_transient( $transient_name );
 
-		return $version;
+		if ( false === $transient_value || true === $refresh ) {
+			// Round to the nearest $minutes increment.
+			$minutes = 10;
+			$transient_value = (string) round( time() / MINUTE_IN_SECONDS * $minutes ) * ( MINUTE_IN_SECONDS * $minutes );
+
+			set_transient( $transient_name, $transient_value );
+		}
+
+		return $transient_value;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -221,6 +221,7 @@ class DataStore extends SqlQuery {
 		if ( true === $this->debug_cache ) {
 			$this->debug_cache_data['should_use_cache']    = $this->should_use_cache();
 			$this->debug_cache_data['force_cache_refresh'] = $this->force_cache_refresh;
+			$this->debug_cache_data['cache_version']       = Cache::get_version();
 			$this->debug_cache_data['cache_hit']           = false;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Changes the frequency at which the Reports API cache can be invalidated via the cache version number to be at most once every 10 minutes, instead of with every change to the store.
* Changes the TTL of Reports API cache entries so that they expire after an hour instead of after a week.

The goal of these changes is to increase the chance that a request to the Reports API for store stats will result in a cache hit, thus avoiding expensive, slow queries. The reason for _lowering_ the TTL is so that if multiple store changes are made within the new 10-minute frequency window, the cache data will only be stale for up to an hour. With #33325 users will be able to refresh entries in the cache manually if they think something is stale.

Closes #33315 

### How to test the changes in this Pull Request:

1. Using Insomnia, create an order by posting to `wp-json/wc/v3/orders`.
2. Also using Insomnia, hit the order stats endpoint (`wp-json/wc-analytics/reports/orders/stats`). Use `before` and `after` values that encompass the current day, e.g. `after: 2022-06-14 00:00:00`, `before: 2022-06-15 23:59:59`. Also include the `_envelope` parameter so you can get debugging info about the cache.
3. You should see that the stats include the new order. If you repeat the stats request, the `cache_debug` info should show a `cache_hit` set to true, along with the current `cache_version` value.
4. If you now create another order (you can just repeat the previous order creation request) and then send a new stats request, the stats should _not_ update and the cache version should remain the same (unless you created the second order right after the boundary when the version would round to the next 10-minute increment).
5. Wait 10 minutes, then check the stats again. It should still not be updated.
6. Now after this wait, create another order, and check stats again. I have found that it may take up to a minute after creating the order for the stats to refresh, but they should now update if you keep hitting the stats endpoint.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
