### PR TITLE
WooCommerce Plugin: Update Webpack to 5.x

### DIFF
--- a/plugins/woocommerce/changelog/update-webpack-5
+++ b/plugins/woocommerce/changelog/update-webpack-5
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update Webpack to 5.x

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -75,7 +75,7 @@
 		"prettier": "npm:wp-prettier@2.0.5",
 		"stylelint": "^13.8.0",
 		"typescript": "3.9.7",
-		"webpack": "4.44.2",
+		"webpack": "5.70.0",
 		"webpack-cli": "3.3.12",
 		"wp-textdomain": "1.0.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8874,473 +8874,7 @@ packages:
       node-gyp: 8.4.1
       read-package-json-fast: 2.0.3
     transitivePeerDependencies:
-<<<<<<< HEAD
       - supports-color
-=======
-      - supports-color
-    dev: true
-
-  /@nrwl/cli/13.3.4:
-    resolution: {integrity: sha512-x3IM9X/q5Yv54ZSr+GsIxa07GJt+hG7dOdjvAFBnixMWb3o4utOVrd6GusDrn2t0HhnCuzqLosFnk+gcOrL34w==}
-    hasBin: true
-    dependencies:
-      '@nrwl/tao': 13.3.4
-      chalk: 4.1.0
-      enquirer: 2.3.6
-      v8-compile-cache: 2.3.0
-      yargs: 15.4.1
-      yargs-parser: 20.0.0
-    dev: true
-
-  /@nrwl/cli/13.3.5:
-    resolution: {integrity: sha512-Cpa/DnsgcE7mLNOPXQbbN4wXBalvEi1TF+sPvTpGaRpy5FxEg6kTQ0C4oKiOGX97YkR1uy0OGVPpw2IKGzG2Ig==}
-    hasBin: true
-    dependencies:
-      '@nrwl/tao': 13.3.5
-      chalk: 4.1.0
-      enquirer: 2.3.6
-      v8-compile-cache: 2.3.0
-      yargs: 15.4.1
-      yargs-parser: 20.0.0
-    dev: true
-
-  /@nrwl/cypress/13.3.5_c038c1456e7bf90a94e00c2ec1748e38:
-    resolution: {integrity: sha512-m4n+NxNvmqj9nUdKXETI3pAFJCd1DJVHm7Jwf1L8sYFlxOAv8MaFEmrPjmx2qY8F5TUqWqG2BgRYwIx1ImIPkg==}
-    peerDependencies:
-      cypress: '>= 3 < 10'
-    peerDependenciesMeta:
-      cypress:
-        optional: true
-    dependencies:
-      '@cypress/webpack-preprocessor': 5.10.0_eab84302f28ca27d02fd15252916451f
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
-      '@nrwl/workspace': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
-      chalk: 4.1.0
-      enhanced-resolve: 5.8.3
-      fork-ts-checker-webpack-plugin: 6.2.10
-      rxjs: 6.6.7
-      ts-loader: 9.2.6_typescript@4.2.4+webpack@5.70.0
-      tsconfig-paths: 3.11.0
-      tsconfig-paths-webpack-plugin: 3.4.1
-      tslib: 2.3.1
-      webpack-node-externals: 3.0.0
-      yargs-parser: 20.0.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - '@types/react'
-      - babel-loader
-      - bufferutil
-      - canvas
-      - node-notifier
-      - prettier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-      - webpack
-    dev: true
-
-  /@nrwl/devkit/12.10.0:
-    resolution: {integrity: sha512-we0K5Hn48BXh77SV5GVSPfRJeIHNCVFSn+feLbnKz3G60Tk3wFEEFhDABA8cCfTKDxMESSjZoWBy4ZcVg0EX0g==}
-    dependencies:
-      '@nrwl/tao': 12.10.0
-      ejs: 3.1.6
-      ignore: 5.2.0
-      rxjs: 6.6.7
-      semver: 7.3.4
-      tslib: 2.3.1
-    dev: true
-
-  /@nrwl/devkit/13.3.5:
-    resolution: {integrity: sha512-QqCP81T1PmAQdVyX5roQwNMMkyp+Pqe79WU4r/Uln0DAEzb9BcTQE61TDgNIcdvMq7Ng6uxGWRnhK8XbdLNVtw==}
-    dependencies:
-      '@nrwl/tao': 13.3.5
-      ejs: 3.1.6
-      ignore: 5.1.9
-      rxjs: 6.6.7
-      semver: 7.3.4
-      tslib: 2.3.1
-    dev: true
-
-  /@nrwl/jest/13.3.5:
-    resolution: {integrity: sha512-psSpkw+ZzasVnHlJuoTuEDKvQ1O+ad7ND2a6ZSSJVPqxcB/sapikXJZjwKIYdGvl4LLQdfNAV1ioXSVP3Jl4sg==}
-    dependencies:
-      '@jest/reporters': 27.2.2
-      '@jest/test-result': 27.2.2
-      '@nrwl/devkit': 13.3.5
-      chalk: 4.1.0
-      identity-obj-proxy: 3.0.0
-      jest-config: 27.2.2
-      jest-resolve: 27.2.2
-      jest-util: 27.2.0
-      resolve.exports: 1.1.0
-      rxjs: 6.6.7
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - node-notifier
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
-  /@nrwl/jest/13.3.5_ts-node@9.1.1:
-    resolution: {integrity: sha512-psSpkw+ZzasVnHlJuoTuEDKvQ1O+ad7ND2a6ZSSJVPqxcB/sapikXJZjwKIYdGvl4LLQdfNAV1ioXSVP3Jl4sg==}
-    dependencies:
-      '@jest/reporters': 27.2.2
-      '@jest/test-result': 27.2.2
-      '@nrwl/devkit': 13.3.5
-      chalk: 4.1.0
-      identity-obj-proxy: 3.0.0
-      jest-config: 27.2.2_ts-node@9.1.1
-      jest-resolve: 27.2.2
-      jest-util: 27.2.0
-      resolve.exports: 1.1.0
-      rxjs: 6.6.7
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - node-notifier
-      - supports-color
-      - ts-node
-      - utf-8-validate
-    dev: true
-
-  /@nrwl/js/13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669:
-    resolution: {integrity: sha512-XqRvZbyBC4BAlG4V2QNjXb7t8PNgfuWs8km+/S82AYJebRdf17lR+ARm+qghVIc61fZThYSTu2Be2zDdzn8YZA==}
-    dependencies:
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/jest': 13.3.5_ts-node@9.1.1
-      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
-      '@nrwl/workspace': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
-      chalk: 4.1.0
-      js-tokens: 4.0.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - canvas
-      - node-notifier
-      - prettier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-    dev: true
-
-  /@nrwl/linter/13.3.5_ts-node@9.1.1+typescript@4.2.4:
-    resolution: {integrity: sha512-bNhwTFmxVWVtitirc+YGRc7XJvOx8m/rbvfKSVxv6l+q/udRxHcOH0jLlGraMYBohCw6T7NxgMR+BOEFr+u+5g==}
-    dependencies:
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/jest': 13.3.5_ts-node@9.1.1
-      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.2.4
-      eslint: 8.2.0
-      glob: 7.1.4
-      minimatch: 3.0.4
-      tmp: 0.2.1
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-    dev: true
-
-  /@nrwl/linter/13.3.5_typescript@4.2.4:
-    resolution: {integrity: sha512-bNhwTFmxVWVtitirc+YGRc7XJvOx8m/rbvfKSVxv6l+q/udRxHcOH0jLlGraMYBohCw6T7NxgMR+BOEFr+u+5g==}
-    dependencies:
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/jest': 13.3.5
-      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.2.4
-      eslint: 8.2.0
-      glob: 7.1.4
-      minimatch: 3.0.4
-      tmp: 0.2.1
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-    dev: true
-
-  /@nrwl/tao/12.10.0:
-    resolution: {integrity: sha512-YkdgTJJsDQlItVj25vW8zEen7BAra6i41Udd0v3CuxTSEXjJJnBD2KzEOGUxXS0gMg7+ILuw2rl9aOKu43TmVA==}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.0
-      enquirer: 2.3.6
-      fs-extra: 9.1.0
-      jsonc-parser: 3.0.0
-      nx: 12.10.0
-      rxjs: 6.6.7
-      rxjs-for-await: 0.0.2_rxjs@6.6.7
-      semver: 7.3.4
-      tmp: 0.2.1
-      tslib: 2.3.1
-      yargs-parser: 20.0.0
-    dev: true
-
-  /@nrwl/tao/13.3.4:
-    resolution: {integrity: sha512-ujwxGZcR3De8FSj8IjVSGmfZ2CQZfFzeV9QXU8DeiZ9J1ylWPwWpMIS3XVxZIpe7gR++XP4jbvFodKFQP7PzVQ==}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.0
-      enquirer: 2.3.6
-      fast-glob: 3.2.7
-      fs-extra: 9.1.0
-      ignore: 5.1.9
-      jsonc-parser: 3.0.0
-      nx: 13.3.4
-      rxjs: 6.6.7
-      rxjs-for-await: 0.0.2_rxjs@6.6.7
-      semver: 7.3.4
-      tmp: 0.2.1
-      tslib: 2.3.1
-      yargs-parser: 20.0.0
-    dev: true
-
-  /@nrwl/tao/13.3.5:
-    resolution: {integrity: sha512-OOoNrH9ELt7GwNnu34L4gGTWpX8N2F7v0H23I6tSM5Qj6KhIJ/DPxaedF9a6frUhewX1+iuvZ0rOD5/TWRUd2w==}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.0
-      enquirer: 2.3.6
-      fast-glob: 3.2.7
-      fs-extra: 9.1.0
-      ignore: 5.2.0
-      jsonc-parser: 3.0.0
-      nx: 13.3.5
-      rxjs: 6.6.7
-      rxjs-for-await: 0.0.2_rxjs@6.6.7
-      semver: 7.3.4
-      tmp: 0.2.1
-      tslib: 2.3.1
-      yargs-parser: 20.0.0
-    dev: true
-
-  /@nrwl/web/13.3.5_42cab1dece2b2240094de84cfd414406:
-    resolution: {integrity: sha512-3nrcxp6o/vR2ISwJfX3FhP2tMG24ZdYfvgo5OCbYRBhWCZ+40UqQ53J7i3XzYAR/JrN2f8nDjTci5i9QljDWtw==}
-    dependencies:
-      '@babel/core': 7.16.0
-      '@babel/plugin-proposal-class-properties': 7.16.0_@babel+core@7.16.0
-      '@babel/plugin-proposal-decorators': 7.16.4_@babel+core@7.16.0
-      '@babel/plugin-transform-regenerator': 7.16.0_@babel+core@7.16.0
-      '@babel/plugin-transform-runtime': 7.16.4_@babel+core@7.16.0
-      '@babel/preset-env': 7.16.11_@babel+core@7.16.0
-      '@babel/preset-typescript': 7.16.0_@babel+core@7.16.0
-      '@babel/runtime': 7.17.7
-      '@nrwl/cypress': 13.3.5_c038c1456e7bf90a94e00c2ec1748e38
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/jest': 13.3.5_ts-node@9.1.1
-      '@nrwl/js': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
-      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
-      '@nrwl/workspace': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.1_acddec6c34c518c147e4dc38c87b7252
-      '@rollup/plugin-babel': 5.3.0_@babel+core@7.16.0+rollup@2.60.0
-      '@rollup/plugin-commonjs': 20.0.0_rollup@2.60.0
-      '@rollup/plugin-image': 2.1.1_rollup@2.60.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.60.0
-      '@rollup/plugin-node-resolve': 13.0.6_rollup@2.60.0
-      autoprefixer: 10.4.0_postcss@8.3.0
-      babel-loader: 8.2.3_2126ca8a005869f6c62d5aa977e8d816
-      babel-plugin-const-enum: 1.2.0_@babel+core@7.16.0
-      babel-plugin-macros: 2.8.0
-      babel-plugin-transform-async-to-promises: 0.8.15
-      babel-plugin-transform-typescript-metadata: 0.3.2
-      browserslist: 4.18.1
-      bytes: 3.1.1
-      caniuse-lite: 1.0.30001280
-      chalk: 4.1.0
-      chokidar: 3.5.2
-      copy-webpack-plugin: 9.1.0_webpack@5.70.0
-      core-js: 3.21.1
-      css-loader: 6.7.1_webpack@5.70.0
-      css-minimizer-webpack-plugin: 3.1.3_webpack@5.70.0
-      enhanced-resolve: 5.8.3
-      file-loader: 6.2.0_webpack@5.70.0
-      fork-ts-checker-webpack-plugin: 6.2.10
-      fs-extra: 9.1.0
-      http-server: 0.12.3
-      identity-obj-proxy: 3.0.0
-      ignore: 5.1.9
-      less: 3.12.2
-      less-loader: 10.2.0_less@3.12.2+webpack@5.70.0
-      license-webpack-plugin: 2.3.15
-      loader-utils: 1.2.3
-      mini-css-extract-plugin: 2.4.4_webpack@5.70.0
-      open: 7.4.2
-      parse5: 4.0.0
-      parse5-html-rewriting-stream: 6.0.1
-      postcss: 8.3.0
-      postcss-import: 14.0.2_postcss@8.3.0
-      postcss-loader: 6.2.0_postcss@8.3.0+webpack@5.70.0
-      raw-loader: 4.0.2_webpack@5.70.0
-      react-refresh: 0.10.0
-      rimraf: 3.0.2
-      rollup: 2.60.0
-      rollup-plugin-copy: 3.4.0
-      rollup-plugin-peer-deps-external: 2.2.4_rollup@2.60.0
-      rollup-plugin-postcss: 4.0.1_postcss@8.3.0+ts-node@9.1.1
-      rollup-plugin-typescript2: 0.30.0_rollup@2.60.0+typescript@4.2.4
-      rxjs: 6.6.7
-      rxjs-for-await: 0.0.2_rxjs@6.6.7
-      sass: 1.49.9
-      sass-loader: 12.3.0_sass@1.49.9+webpack@5.70.0
-      semver: 7.3.4
-      source-map: 0.7.3
-      source-map-loader: 3.0.0_webpack@5.70.0
-      style-loader: 3.3.1_webpack@5.70.0
-      stylus: 0.55.0
-      stylus-loader: 6.2.0_stylus@0.55.0+webpack@5.70.0
-      terser: 4.3.8
-      terser-webpack-plugin: 5.2.5_webpack@5.70.0
-      ts-loader: 9.2.6_typescript@4.2.4+webpack@5.70.0
-      ts-node: 9.1.1_typescript@4.2.4
-      tsconfig-paths: 3.11.0
-      tsconfig-paths-webpack-plugin: 3.4.1
-      tslib: 2.3.1
-      webpack: 5.70.0
-      webpack-dev-server: 4.5.0_webpack@5.70.0
-      webpack-merge: 5.8.0
-      webpack-sources: 3.2.2
-      webpack-subresource-integrity: 1.5.2_webpack@5.70.0
-      worker-plugin: 3.2.0_webpack@5.70.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/babel__core'
-      - '@types/react'
-      - '@types/webpack'
-      - acorn
-      - bufferutil
-      - canvas
-      - clean-css
-      - csso
-      - cypress
-      - debug
-      - esbuild
-      - fibers
-      - html-webpack-plugin
-      - node-notifier
-      - node-sass
-      - prettier
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: true
-
-  /@nrwl/workspace/13.3.5_42cab1dece2b2240094de84cfd414406:
-    resolution: {integrity: sha512-2SU0uiplM0A7oxejDCsXftJkELyi00FYTIPq19oD+uVLUblWo2THIks9Zst7mjw1FMYu4PsCTLQAO2qpDnRmUA==}
-    peerDependencies:
-      prettier: ^2.3.0
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-    dependencies:
-      '@nrwl/cli': 13.3.5
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/jest': 13.3.5
-      '@nrwl/linter': 13.3.5_typescript@4.2.4
-      '@parcel/watcher': 2.0.4
-      chalk: 4.1.0
-      chokidar: 3.5.2
-      cosmiconfig: 4.0.0
-      dotenv: 10.0.0
-      enquirer: 2.3.6
-      figures: 3.2.0
-      flat: 5.0.2
-      fs-extra: 9.1.0
-      glob: 7.1.4
-      ignore: 5.1.9
-      ink: 3.2.0_react@17.0.2
-      ink-spinner: 4.0.3_ink@3.2.0+react@17.0.2
-      minimatch: 3.0.4
-      npm-run-all: 4.1.5
-      npm-run-path: 4.0.1
-      open: 7.4.2
-      prettier: /wp-prettier/2.2.1-beta-1
-      react: 17.0.2
-      rxjs: 6.6.7
-      semver: 7.3.4
-      strip-ansi: 6.0.0
-      tmp: 0.2.1
-      tslib: 2.3.1
-      yargs: 15.4.1
-      yargs-parser: 20.0.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - canvas
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-    dev: true
-
-  /@nrwl/workspace/13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669:
-    resolution: {integrity: sha512-2SU0uiplM0A7oxejDCsXftJkELyi00FYTIPq19oD+uVLUblWo2THIks9Zst7mjw1FMYu4PsCTLQAO2qpDnRmUA==}
-    peerDependencies:
-      prettier: ^2.3.0
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-    dependencies:
-      '@nrwl/cli': 13.3.5
-      '@nrwl/devkit': 13.3.5
-      '@nrwl/jest': 13.3.5_ts-node@9.1.1
-      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
-      '@parcel/watcher': 2.0.4
-      chalk: 4.1.0
-      chokidar: 3.5.2
-      cosmiconfig: 4.0.0
-      dotenv: 10.0.0
-      enquirer: 2.3.6
-      figures: 3.2.0
-      flat: 5.0.2
-      fs-extra: 9.1.0
-      glob: 7.1.4
-      ignore: 5.1.9
-      ink: 3.2.0_react@17.0.2
-      ink-spinner: 4.0.3_ink@3.2.0+react@17.0.2
-      minimatch: 3.0.4
-      npm-run-all: 4.1.5
-      npm-run-path: 4.0.1
-      open: 7.4.2
-      prettier: /wp-prettier/2.2.1-beta-1
-      react: 17.0.2
-      rxjs: 6.6.7
-      semver: 7.3.4
-      strip-ansi: 6.0.0
-      tmp: 0.2.1
-      tslib: 2.3.1
-      yargs: 15.4.1
-      yargs-parser: 20.0.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - canvas
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /@oclif/color/1.0.1:
@@ -12555,17 +12089,6 @@ packages:
     dependencies:
       '@types/estree': 0.0.51
       '@types/json-schema': 7.0.9
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /@types/estree/0.0.39:
-    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
-    dev: true
-
-  /@types/estree/0.0.50:
-    resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /@types/estree/0.0.51:
@@ -17131,24 +16654,6 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /babel-loader/8.2.3_2126ca8a005869f6c62d5aa977e8d816:
-    resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
-    engines: {node: '>= 8.9'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      webpack: '>=2'
-    dependencies:
-      '@babel/core': 7.16.0
-      find-cache-dir: 3.3.2
-      loader-utils: 1.4.0
-      make-dir: 3.1.0
-      schema-utils: 2.7.1
-      webpack: 5.70.0
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /babel-loader/8.2.3_b72fb7e629d39881e138edb6dcd0dfbe:
@@ -18129,6 +17634,18 @@ packages:
       node-releases: 2.0.2
       picocolors: 1.0.0
 
+  /browserslist/4.20.4:
+    resolution: {integrity: sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001352
+      electron-to-chromium: 1.4.151
+      escalade: 3.1.1
+      node-releases: 2.0.5
+      picocolors: 1.0.0
+    dev: true
+
   /bs-logger/0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
     engines: {node: '>= 6'}
@@ -18407,6 +17924,10 @@ packages:
 
   /caniuse-lite/1.0.30001317:
     resolution: {integrity: sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==}
+
+  /caniuse-lite/1.0.30001352:
+    resolution: {integrity: sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==}
+    dev: true
 
   /capture-exit/2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -18857,7 +18378,7 @@ packages:
     dev: true
 
   /clone-deep/0.2.4:
-    resolution: {integrity: sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=}
+    resolution: {integrity: sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       for-own: 0.1.5
@@ -19751,7 +19272,7 @@ packages:
     resolution: {integrity: sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==}
 
   /cwd/0.10.0:
-    resolution: {integrity: sha1-FyQAaUBXwioTsM8WFix+S3p/5Wc=}
+    resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
     engines: {node: '>=0.8'}
     dependencies:
       find-pkg: 0.1.2
@@ -20463,6 +19984,10 @@ packages:
   /electron-to-chromium/1.3.899:
     resolution: {integrity: sha512-w16Dtd2zl7VZ4N4Db+FIa7n36sgPGCKjrKvUUmp5ialsikvcQLjcJR9RWnlYNxIyEHLdHaoIZEqKsPxU9MdyBg==}
 
+  /electron-to-chromium/1.4.151:
+    resolution: {integrity: sha512-XaG2LpZi9fdiWYOqJh0dJy4SlVywCvpgYXhzOlZTp4JqSKqxn5URqOjbm9OMYB3aInA2GuHQiem1QUOc1yT0Pw==}
+    dev: true
+
   /electron-to-chromium/1.4.73:
     resolution: {integrity: sha512-RlCffXkE/LliqfA5m29+dVDPB2r72y2D2egMMfIy3Le8ODrxjuZNVo4NIC2yPL01N4xb4nZQLwzi6Z5tGIGLnA==}
 
@@ -20592,17 +20117,6 @@ packages:
       graceful-fs: 4.2.9
       memory-fs: 0.5.0
       tapable: 1.1.3
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /enhanced-resolve/5.8.3:
-    resolution: {integrity: sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      graceful-fs: 4.2.9
-      tapable: 2.2.1
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /enhanced-resolve/5.9.2:
@@ -20997,7 +20511,6 @@ packages:
       semver: 5.7.1
       webpack: 5.70.0_webpack-cli@4.9.2
     dev: true
-<<<<<<< HEAD
 
   /eslint-module-utils/2.7.3:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
@@ -21006,16 +20519,6 @@ packages:
       debug: 3.2.7
       find-up: 2.1.0
 
-=======
-
-  /eslint-module-utils/2.7.3:
-    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      debug: 3.2.7
-      find-up: 2.1.0
-
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /eslint-plugin-import/2.25.4:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
@@ -22258,7 +21761,7 @@ packages:
       to-regex: 3.0.2
 
   /expand-tilde/1.2.2:
-    resolution: {integrity: sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=}
+    resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
     engines: {node: '>=0.10.0'}
     dependencies:
       os-homedir: 1.0.2
@@ -22686,7 +22189,7 @@ packages:
     dev: true
 
   /find-file-up/0.1.3:
-    resolution: {integrity: sha1-z2gJG8+fMApA2kEbN9pczlovvqA=}
+    resolution: {integrity: sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==}
     engines: {node: '>=0.10.0'}
     dependencies:
       fs-exists-sync: 0.1.0
@@ -22697,7 +22200,7 @@ packages:
     dev: true
 
   /find-pkg/0.1.2:
-    resolution: {integrity: sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=}
+    resolution: {integrity: sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       find-file-up: 0.1.3
@@ -22903,7 +22406,7 @@ packages:
     dev: false
 
   /for-in/0.1.8:
-    resolution: {integrity: sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=}
+    resolution: {integrity: sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==}
     engines: {node: '>=0.10.0'}
 
   /for-in/1.0.2:
@@ -22911,7 +22414,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   /for-own/0.1.5:
-    resolution: {integrity: sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=}
+    resolution: {integrity: sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       for-in: 1.0.2
@@ -22945,28 +22448,6 @@ packages:
       semver: 5.7.1
       tapable: 1.1.3
       worker-rpc: 0.1.1
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /fork-ts-checker-webpack-plugin/6.2.10:
-    resolution: {integrity: sha512-HveFCHWSH2WlYU1tU3PkrupvW8lNFMTfH3Jk0TfC2mtktE9ibHGcifhCsCFvj+kqlDfNIlwmNLiNqR9jnSA7OQ==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    dependencies:
-      '@babel/code-frame': 7.16.0
-      '@types/json-schema': 7.0.9
-      chalk: 4.1.2
-      chokidar: 3.5.2
-      cosmiconfig: 6.0.0
-      deepmerge: 4.2.2
-      fs-extra: 9.1.0
-      glob: 7.2.0
-      memfs: 3.3.0
-      minimatch: 3.0.4
-      schema-utils: 2.7.0
-      semver: 7.3.5
-      tapable: 1.1.3
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /fork-ts-checker-webpack-plugin/6.5.0_10568ae13669cc833891d65cd6879aa0:
@@ -23199,7 +22680,7 @@ packages:
     dev: true
 
   /fs-exists-sync/0.1.0:
-    resolution: {integrity: sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=}
+    resolution: {integrity: sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==}
     engines: {node: '>=0.10.0'}
 
   /fs-extra/0.30.0:
@@ -23578,7 +23059,7 @@ packages:
     dev: true
 
   /global-modules/0.2.3:
-    resolution: {integrity: sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=}
+    resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       global-prefix: 0.1.5
@@ -23601,7 +23082,7 @@ packages:
     dev: true
 
   /global-prefix/0.1.5:
-    resolution: {integrity: sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=}
+    resolution: {integrity: sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       homedir-polyfill: 1.0.3
@@ -24534,28 +24015,6 @@ packages:
     resolution: {integrity: sha1-qVPKZwB4Zp3eFCzomUAbnW6F07Q=}
     dev: false
 
-<<<<<<< HEAD
-=======
-  /http-server/0.12.3:
-    resolution: {integrity: sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      basic-auth: 1.1.0
-      colors: 1.4.0
-      corser: 2.0.1
-      ecstatic: 3.3.2
-      http-proxy: 1.18.1
-      minimist: 1.2.5
-      opener: 1.5.2
-      portfinder: 1.0.28
-      secure-compare: 3.0.1
-      union: 0.5.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /http-signature/1.2.0:
     resolution: {integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
@@ -25475,7 +24934,7 @@ packages:
     dev: true
 
   /is-windows/0.2.0:
-    resolution: {integrity: sha1-3hqm1j6indJIc3tp8f+LgALSEIw=}
+    resolution: {integrity: sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==}
     engines: {node: '>=0.10.0'}
 
   /is-windows/1.0.2:
@@ -27991,7 +27450,7 @@ packages:
     dev: false
 
   /kind-of/2.0.1:
-    resolution: {integrity: sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=}
+    resolution: {integrity: sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-buffer: 1.1.6
@@ -28058,11 +27517,11 @@ packages:
     dev: true
 
   /lazy-cache/0.2.7:
-    resolution: {integrity: sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=}
+    resolution: {integrity: sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==}
     engines: {node: '>=0.10.0'}
 
   /lazy-cache/1.0.4:
-    resolution: {integrity: sha1-odePw6UEdMuAhF07O24dpJpEbo4=}
+    resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
     engines: {node: '>=0.10.0'}
 
   /lazy-universal-dotenv/3.0.1:
@@ -28105,16 +27564,6 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /license-webpack-plugin/2.3.15:
-    resolution: {integrity: sha512-reA0yvwvkkFMRsyqVikTcLGFXmgWKPVXrFaR3tRvAnFoZozM4zvwlNNQxuB5Il6fgTtS7nGkrIPm9xS2KZtu7g==}
-    dependencies:
-      '@types/webpack-sources': 0.1.9
-      webpack-sources: 1.4.3
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /liftoff/2.5.0:
@@ -28256,18 +27705,6 @@ packages:
   /loader-runner/4.2.0:
     resolution: {integrity: sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==}
     engines: {node: '>=6.11.5'}
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /loader-utils/1.2.3:
-    resolution: {integrity: sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      big.js: 5.2.2
-      emojis-list: 2.1.0
-      json5: 1.0.1
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /loader-utils/1.4.0:
@@ -28918,14 +28355,6 @@ packages:
     dependencies:
       errno: 0.1.8
       readable-stream: 2.3.7
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /memorystream/0.3.1:
-    resolution: {integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=}
-    engines: {node: '>= 0.10.0'}
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /meow/6.1.1:
@@ -29281,7 +28710,7 @@ packages:
       is-extendable: 1.0.1
 
   /mixin-object/2.0.1:
-    resolution: {integrity: sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=}
+    resolution: {integrity: sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       for-in: 0.1.8
@@ -29449,15 +28878,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-<<<<<<< HEAD
-=======
-
-  /native-request/1.1.0:
-    resolution: {integrity: sha512-uZ5rQaeRn15XmpgE0xoPL8YWqcX90VtCFglYwAgkvKM5e8fog+vePLAhHxuuv/gRkrQxIeh5U3q9sMNUrENqWw==}
-    requiresBuild: true
-    dev: true
-    optional: true
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
@@ -29652,6 +29072,10 @@ packages:
 
   /node-releases/2.0.2:
     resolution: {integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==}
+
+  /node-releases/2.0.5:
+    resolution: {integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==}
+    dev: true
 
   /node-stream-zip/1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
@@ -30887,21 +30311,6 @@ packages:
       htmlparser2: 3.10.1
       postcss: 7.0.39
       postcss-syntax: 0.36.2_postcss@7.0.39
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /postcss-import/14.0.2_postcss@8.3.0:
-    resolution: {integrity: sha512-BJ2pVK4KhUyMcqjuKs9RijV5tatNzNa73e/32aBVE/ejYPe37iH+6vAu9WvqUkB5OAYgLHzbSvzHnorybJCm9g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      postcss: 8.3.0
-      postcss-value-parser: 4.1.0
-      read-cache: 1.0.0
-      resolve: 1.20.0
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /postcss-less/3.1.4:
@@ -31248,37 +30657,15 @@ packages:
       postcss-value-parser: 3.3.1
       svgo: 1.3.2
 
-<<<<<<< HEAD
-=======
-  /postcss-svgo/5.0.3_postcss@8.3.0:
-    resolution: {integrity: sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      postcss: 8.3.0
-      postcss-value-parser: 4.2.0
-      svgo: 2.8.0
-    dev: true
-
-  /postcss-svgo/5.0.3_postcss@8.3.11:
-    resolution: {integrity: sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==}
-    engines: {node: ^10 || ^12 || >=14.0}
-    peerDependencies:
-      postcss: ^8.2.15
-    dependencies:
-      postcss: 8.3.11
-      postcss-value-parser: 4.2.0
-      svgo: 2.8.0
-    dev: true
-
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /postcss-syntax/0.36.2_postcss@7.0.39:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
     dependencies:
       postcss: 7.0.39
+      postcss-html: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
+      postcss-less: 3.1.4
+      postcss-scss: 2.1.1
     dev: true
 
   /postcss-unique-selectors/4.0.1:
@@ -33275,7 +32662,7 @@ packages:
       resolve-from: 5.0.0
 
   /resolve-dir/0.1.1:
-    resolution: {integrity: sha1-shklmlYC+sXFxJatiUpujMQwJh4=}
+    resolution: {integrity: sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       expand-tilde: 1.2.2
@@ -33746,22 +33133,6 @@ packages:
       safe-buffer: 5.1.1
     dev: true
 
-<<<<<<< HEAD
-=======
-  /serve-index/1.9.1:
-    resolution: {integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      accepts: 1.3.7
-      batch: 0.6.1
-      debug: 2.6.9
-      escape-html: 1.0.3
-      http-errors: 1.6.3
-      mime-types: 2.1.34
-      parseurl: 1.3.3
-    dev: true
-
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /serve-static/1.14.1:
     resolution: {integrity: sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==}
     engines: {node: '>= 0.8.0'}
@@ -33800,7 +33171,7 @@ packages:
       safe-buffer: 5.2.1
 
   /shallow-clone/0.1.2:
-    resolution: {integrity: sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=}
+    resolution: {integrity: sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extendable: 0.1.1
@@ -34835,37 +34206,6 @@ packages:
     resolution: {integrity: sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==}
     dev: false
 
-<<<<<<< HEAD
-=======
-  /stylus-loader/6.2.0_stylus@0.55.0+webpack@5.70.0:
-    resolution: {integrity: sha512-5dsDc7qVQGRoc6pvCL20eYgRUxepZ9FpeK28XhdXaIPP6kXr6nI1zAAKFQgP5OBkOfKaURp4WUpJzspg1f01Gg==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      stylus: '>=0.52.4'
-      webpack: ^5.0.0
-    dependencies:
-      fast-glob: 3.2.11
-      klona: 2.0.5
-      normalize-path: 3.0.0
-      stylus: 0.55.0
-      webpack: 5.70.0
-    dev: true
-
-  /stylus/0.55.0:
-    resolution: {integrity: sha512-MuzIIVRSbc8XxHH7FjkvWqkIcr1BvoMZoR/oFuAJDlh7VSaNJzrB4uJ38GRQa+mWjLXODAMzeDe0xi9GYbGwnw==}
-    hasBin: true
-    dependencies:
-      css: 3.0.0
-      debug: 3.1.0
-      glob: 7.2.0
-      mkdirp: 1.0.4
-      safer-buffer: 2.1.2
-      sax: 1.2.4
-      semver: 6.3.0
-      source-map: 0.7.3
-    dev: true
-
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /sugarss/2.0.0:
     resolution: {integrity: sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==}
     dependencies:
@@ -34906,7 +34246,7 @@ packages:
     engines: {node: '>=0.8.0'}
 
   /supports-color/3.2.3:
-    resolution: {integrity: sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=}
+    resolution: {integrity: sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==}
     engines: {node: '>=0.8.0'}
     dependencies:
       has-flag: 1.0.0
@@ -35316,41 +34656,6 @@ packages:
       source-map: 0.7.3
       source-map-support: 0.5.20
     dev: true
-<<<<<<< HEAD
-=======
-
-  /terser/5.10.0_acorn@7.4.1:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 7.4.1
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.20
-    dev: true
-
-  /terser/5.10.0_acorn@8.7.0:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 8.7.0
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.20
-    dev: true
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
 
   /test-exclude/5.2.3:
     resolution: {integrity: sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==}
@@ -36857,15 +36162,6 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
-<<<<<<< HEAD
-=======
-    dev: true
-
-  /wbuf/1.7.3:
-    resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
-    dependencies:
-      minimalistic-assert: 1.0.1
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /wcwidth/1.0.1:
@@ -36910,30 +36206,6 @@ packages:
       mkdirp: 0.5.5
       opener: 1.5.2
       ws: 6.2.2
-<<<<<<< HEAD
-    dev: true
-
-  /webpack-cli/3.3.12_webpack@4.44.2:
-    resolution: {integrity: sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==}
-    engines: {node: '>=6.11.5'}
-    hasBin: true
-    peerDependencies:
-      webpack: 4.x.x
-    dependencies:
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
-      enhanced-resolve: 4.5.0
-      findup-sync: 3.0.0
-      global-modules: 2.0.0
-      import-local: 2.0.0
-      interpret: 1.4.0
-      loader-utils: 1.4.0
-      supports-color: 6.1.0
-      v8-compile-cache: 2.3.0
-      webpack: 4.44.2_webpack-cli@3.3.12
-      yargs: 13.3.2
-=======
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /webpack-cli/3.3.12_webpack@4.46.0:
@@ -37135,48 +36407,6 @@ packages:
     resolution: {integrity: sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==}
     dev: true
 
-<<<<<<< HEAD
-  /webpack/4.44.2_webpack-cli@3.3.12:
-    resolution: {integrity: sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==}
-    engines: {node: '>=6.11.5'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-      webpack-command: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-      webpack-command:
-        optional: true
-    dependencies:
-      '@webassemblyjs/ast': 1.9.0
-      '@webassemblyjs/helper-module-context': 1.9.0
-      '@webassemblyjs/wasm-edit': 1.9.0
-      '@webassemblyjs/wasm-parser': 1.9.0
-      acorn: 6.4.2
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2_ajv@6.12.6
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 4.5.0
-      eslint-scope: 4.0.3
-      json-parse-better-errors: 1.0.2
-      loader-runner: 2.4.0
-      loader-utils: 1.4.0
-      memory-fs: 0.4.1
-      micromatch: 3.1.10
-      mkdirp: 0.5.5
-      neo-async: 2.6.2
-      node-libs-browser: 2.2.1
-      schema-utils: 1.0.0
-      tapable: 1.1.3
-      terser-webpack-plugin: 1.4.5_webpack@4.44.2
-      watchpack: 1.7.5
-      webpack-cli: 3.3.12_webpack@4.44.2
-      webpack-sources: 1.4.3
-    dev: true
-
-=======
->>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /webpack/4.46.0:
     resolution: {integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==}
     engines: {node: '>=6.11.5'}
@@ -37271,7 +36501,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.1
       acorn: 8.7.0
       acorn-import-assertions: 1.8.0_acorn@8.7.0
-      browserslist: 4.20.2
+      browserslist: 4.20.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.9.2
       es-module-lexer: 0.9.3
@@ -37311,7 +36541,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.1
       acorn: 8.7.0
       acorn-import-assertions: 1.8.0_acorn@8.7.0
-      browserslist: 4.20.2
+      browserslist: 4.20.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.9.2
       es-module-lexer: 0.9.3
@@ -37352,7 +36582,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.1
       acorn: 8.7.0
       acorn-import-assertions: 1.8.0_acorn@8.7.0
-      browserslist: 4.20.2
+      browserslist: 4.20.4
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.9.2
       es-module-lexer: 0.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1226,7 +1226,7 @@ importers:
       prettier: npm:wp-prettier@2.0.5
       stylelint: ^13.8.0
       typescript: 3.9.7
-      webpack: 4.44.2
+      webpack: 5.70.0
       webpack-cli: 3.3.12
       wp-textdomain: 1.0.1
     devDependencies:
@@ -1267,8 +1267,8 @@ importers:
       prettier: /wp-prettier/2.0.5
       stylelint: 13.13.1
       typescript: 3.9.7
-      webpack: 4.44.2_webpack-cli@3.3.12
-      webpack-cli: 3.3.12_webpack@4.44.2
+      webpack: 5.70.0_webpack-cli@3.3.12
+      webpack-cli: 3.3.12_webpack@5.70.0
       wp-textdomain: 1.0.1
 
   plugins/woocommerce-admin:
@@ -8874,7 +8874,473 @@ packages:
       node-gyp: 8.4.1
       read-package-json-fast: 2.0.3
     transitivePeerDependencies:
+<<<<<<< HEAD
       - supports-color
+=======
+      - supports-color
+    dev: true
+
+  /@nrwl/cli/13.3.4:
+    resolution: {integrity: sha512-x3IM9X/q5Yv54ZSr+GsIxa07GJt+hG7dOdjvAFBnixMWb3o4utOVrd6GusDrn2t0HhnCuzqLosFnk+gcOrL34w==}
+    hasBin: true
+    dependencies:
+      '@nrwl/tao': 13.3.4
+      chalk: 4.1.0
+      enquirer: 2.3.6
+      v8-compile-cache: 2.3.0
+      yargs: 15.4.1
+      yargs-parser: 20.0.0
+    dev: true
+
+  /@nrwl/cli/13.3.5:
+    resolution: {integrity: sha512-Cpa/DnsgcE7mLNOPXQbbN4wXBalvEi1TF+sPvTpGaRpy5FxEg6kTQ0C4oKiOGX97YkR1uy0OGVPpw2IKGzG2Ig==}
+    hasBin: true
+    dependencies:
+      '@nrwl/tao': 13.3.5
+      chalk: 4.1.0
+      enquirer: 2.3.6
+      v8-compile-cache: 2.3.0
+      yargs: 15.4.1
+      yargs-parser: 20.0.0
+    dev: true
+
+  /@nrwl/cypress/13.3.5_c038c1456e7bf90a94e00c2ec1748e38:
+    resolution: {integrity: sha512-m4n+NxNvmqj9nUdKXETI3pAFJCd1DJVHm7Jwf1L8sYFlxOAv8MaFEmrPjmx2qY8F5TUqWqG2BgRYwIx1ImIPkg==}
+    peerDependencies:
+      cypress: '>= 3 < 10'
+    peerDependenciesMeta:
+      cypress:
+        optional: true
+    dependencies:
+      '@cypress/webpack-preprocessor': 5.10.0_eab84302f28ca27d02fd15252916451f
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
+      '@nrwl/workspace': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
+      chalk: 4.1.0
+      enhanced-resolve: 5.8.3
+      fork-ts-checker-webpack-plugin: 6.2.10
+      rxjs: 6.6.7
+      ts-loader: 9.2.6_typescript@4.2.4+webpack@5.70.0
+      tsconfig-paths: 3.11.0
+      tsconfig-paths-webpack-plugin: 3.4.1
+      tslib: 2.3.1
+      webpack-node-externals: 3.0.0
+      yargs-parser: 20.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - '@types/react'
+      - babel-loader
+      - bufferutil
+      - canvas
+      - node-notifier
+      - prettier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+      - webpack
+    dev: true
+
+  /@nrwl/devkit/12.10.0:
+    resolution: {integrity: sha512-we0K5Hn48BXh77SV5GVSPfRJeIHNCVFSn+feLbnKz3G60Tk3wFEEFhDABA8cCfTKDxMESSjZoWBy4ZcVg0EX0g==}
+    dependencies:
+      '@nrwl/tao': 12.10.0
+      ejs: 3.1.6
+      ignore: 5.2.0
+      rxjs: 6.6.7
+      semver: 7.3.4
+      tslib: 2.3.1
+    dev: true
+
+  /@nrwl/devkit/13.3.5:
+    resolution: {integrity: sha512-QqCP81T1PmAQdVyX5roQwNMMkyp+Pqe79WU4r/Uln0DAEzb9BcTQE61TDgNIcdvMq7Ng6uxGWRnhK8XbdLNVtw==}
+    dependencies:
+      '@nrwl/tao': 13.3.5
+      ejs: 3.1.6
+      ignore: 5.1.9
+      rxjs: 6.6.7
+      semver: 7.3.4
+      tslib: 2.3.1
+    dev: true
+
+  /@nrwl/jest/13.3.5:
+    resolution: {integrity: sha512-psSpkw+ZzasVnHlJuoTuEDKvQ1O+ad7ND2a6ZSSJVPqxcB/sapikXJZjwKIYdGvl4LLQdfNAV1ioXSVP3Jl4sg==}
+    dependencies:
+      '@jest/reporters': 27.2.2
+      '@jest/test-result': 27.2.2
+      '@nrwl/devkit': 13.3.5
+      chalk: 4.1.0
+      identity-obj-proxy: 3.0.0
+      jest-config: 27.2.2
+      jest-resolve: 27.2.2
+      jest-util: 27.2.0
+      resolve.exports: 1.1.0
+      rxjs: 6.6.7
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - node-notifier
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /@nrwl/jest/13.3.5_ts-node@9.1.1:
+    resolution: {integrity: sha512-psSpkw+ZzasVnHlJuoTuEDKvQ1O+ad7ND2a6ZSSJVPqxcB/sapikXJZjwKIYdGvl4LLQdfNAV1ioXSVP3Jl4sg==}
+    dependencies:
+      '@jest/reporters': 27.2.2
+      '@jest/test-result': 27.2.2
+      '@nrwl/devkit': 13.3.5
+      chalk: 4.1.0
+      identity-obj-proxy: 3.0.0
+      jest-config: 27.2.2_ts-node@9.1.1
+      jest-resolve: 27.2.2
+      jest-util: 27.2.0
+      resolve.exports: 1.1.0
+      rxjs: 6.6.7
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - node-notifier
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /@nrwl/js/13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669:
+    resolution: {integrity: sha512-XqRvZbyBC4BAlG4V2QNjXb7t8PNgfuWs8km+/S82AYJebRdf17lR+ARm+qghVIc61fZThYSTu2Be2zDdzn8YZA==}
+    dependencies:
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/jest': 13.3.5_ts-node@9.1.1
+      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
+      '@nrwl/workspace': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
+      chalk: 4.1.0
+      js-tokens: 4.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - canvas
+      - node-notifier
+      - prettier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /@nrwl/linter/13.3.5_ts-node@9.1.1+typescript@4.2.4:
+    resolution: {integrity: sha512-bNhwTFmxVWVtitirc+YGRc7XJvOx8m/rbvfKSVxv6l+q/udRxHcOH0jLlGraMYBohCw6T7NxgMR+BOEFr+u+5g==}
+    dependencies:
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/jest': 13.3.5_ts-node@9.1.1
+      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.2.4
+      eslint: 8.2.0
+      glob: 7.1.4
+      minimatch: 3.0.4
+      tmp: 0.2.1
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - node-notifier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /@nrwl/linter/13.3.5_typescript@4.2.4:
+    resolution: {integrity: sha512-bNhwTFmxVWVtitirc+YGRc7XJvOx8m/rbvfKSVxv6l+q/udRxHcOH0jLlGraMYBohCw6T7NxgMR+BOEFr+u+5g==}
+    dependencies:
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/jest': 13.3.5
+      '@phenomnomnominal/tsquery': 4.1.1_typescript@4.2.4
+      eslint: 8.2.0
+      glob: 7.1.4
+      minimatch: 3.0.4
+      tmp: 0.2.1
+      tslib: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - node-notifier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /@nrwl/tao/12.10.0:
+    resolution: {integrity: sha512-YkdgTJJsDQlItVj25vW8zEen7BAra6i41Udd0v3CuxTSEXjJJnBD2KzEOGUxXS0gMg7+ILuw2rl9aOKu43TmVA==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.0
+      enquirer: 2.3.6
+      fs-extra: 9.1.0
+      jsonc-parser: 3.0.0
+      nx: 12.10.0
+      rxjs: 6.6.7
+      rxjs-for-await: 0.0.2_rxjs@6.6.7
+      semver: 7.3.4
+      tmp: 0.2.1
+      tslib: 2.3.1
+      yargs-parser: 20.0.0
+    dev: true
+
+  /@nrwl/tao/13.3.4:
+    resolution: {integrity: sha512-ujwxGZcR3De8FSj8IjVSGmfZ2CQZfFzeV9QXU8DeiZ9J1ylWPwWpMIS3XVxZIpe7gR++XP4jbvFodKFQP7PzVQ==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.0
+      enquirer: 2.3.6
+      fast-glob: 3.2.7
+      fs-extra: 9.1.0
+      ignore: 5.1.9
+      jsonc-parser: 3.0.0
+      nx: 13.3.4
+      rxjs: 6.6.7
+      rxjs-for-await: 0.0.2_rxjs@6.6.7
+      semver: 7.3.4
+      tmp: 0.2.1
+      tslib: 2.3.1
+      yargs-parser: 20.0.0
+    dev: true
+
+  /@nrwl/tao/13.3.5:
+    resolution: {integrity: sha512-OOoNrH9ELt7GwNnu34L4gGTWpX8N2F7v0H23I6tSM5Qj6KhIJ/DPxaedF9a6frUhewX1+iuvZ0rOD5/TWRUd2w==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.0
+      enquirer: 2.3.6
+      fast-glob: 3.2.7
+      fs-extra: 9.1.0
+      ignore: 5.2.0
+      jsonc-parser: 3.0.0
+      nx: 13.3.5
+      rxjs: 6.6.7
+      rxjs-for-await: 0.0.2_rxjs@6.6.7
+      semver: 7.3.4
+      tmp: 0.2.1
+      tslib: 2.3.1
+      yargs-parser: 20.0.0
+    dev: true
+
+  /@nrwl/web/13.3.5_42cab1dece2b2240094de84cfd414406:
+    resolution: {integrity: sha512-3nrcxp6o/vR2ISwJfX3FhP2tMG24ZdYfvgo5OCbYRBhWCZ+40UqQ53J7i3XzYAR/JrN2f8nDjTci5i9QljDWtw==}
+    dependencies:
+      '@babel/core': 7.16.0
+      '@babel/plugin-proposal-class-properties': 7.16.0_@babel+core@7.16.0
+      '@babel/plugin-proposal-decorators': 7.16.4_@babel+core@7.16.0
+      '@babel/plugin-transform-regenerator': 7.16.0_@babel+core@7.16.0
+      '@babel/plugin-transform-runtime': 7.16.4_@babel+core@7.16.0
+      '@babel/preset-env': 7.16.11_@babel+core@7.16.0
+      '@babel/preset-typescript': 7.16.0_@babel+core@7.16.0
+      '@babel/runtime': 7.17.7
+      '@nrwl/cypress': 13.3.5_c038c1456e7bf90a94e00c2ec1748e38
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/jest': 13.3.5_ts-node@9.1.1
+      '@nrwl/js': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
+      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
+      '@nrwl/workspace': 13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.1_acddec6c34c518c147e4dc38c87b7252
+      '@rollup/plugin-babel': 5.3.0_@babel+core@7.16.0+rollup@2.60.0
+      '@rollup/plugin-commonjs': 20.0.0_rollup@2.60.0
+      '@rollup/plugin-image': 2.1.1_rollup@2.60.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.60.0
+      '@rollup/plugin-node-resolve': 13.0.6_rollup@2.60.0
+      autoprefixer: 10.4.0_postcss@8.3.0
+      babel-loader: 8.2.3_2126ca8a005869f6c62d5aa977e8d816
+      babel-plugin-const-enum: 1.2.0_@babel+core@7.16.0
+      babel-plugin-macros: 2.8.0
+      babel-plugin-transform-async-to-promises: 0.8.15
+      babel-plugin-transform-typescript-metadata: 0.3.2
+      browserslist: 4.18.1
+      bytes: 3.1.1
+      caniuse-lite: 1.0.30001280
+      chalk: 4.1.0
+      chokidar: 3.5.2
+      copy-webpack-plugin: 9.1.0_webpack@5.70.0
+      core-js: 3.21.1
+      css-loader: 6.7.1_webpack@5.70.0
+      css-minimizer-webpack-plugin: 3.1.3_webpack@5.70.0
+      enhanced-resolve: 5.8.3
+      file-loader: 6.2.0_webpack@5.70.0
+      fork-ts-checker-webpack-plugin: 6.2.10
+      fs-extra: 9.1.0
+      http-server: 0.12.3
+      identity-obj-proxy: 3.0.0
+      ignore: 5.1.9
+      less: 3.12.2
+      less-loader: 10.2.0_less@3.12.2+webpack@5.70.0
+      license-webpack-plugin: 2.3.15
+      loader-utils: 1.2.3
+      mini-css-extract-plugin: 2.4.4_webpack@5.70.0
+      open: 7.4.2
+      parse5: 4.0.0
+      parse5-html-rewriting-stream: 6.0.1
+      postcss: 8.3.0
+      postcss-import: 14.0.2_postcss@8.3.0
+      postcss-loader: 6.2.0_postcss@8.3.0+webpack@5.70.0
+      raw-loader: 4.0.2_webpack@5.70.0
+      react-refresh: 0.10.0
+      rimraf: 3.0.2
+      rollup: 2.60.0
+      rollup-plugin-copy: 3.4.0
+      rollup-plugin-peer-deps-external: 2.2.4_rollup@2.60.0
+      rollup-plugin-postcss: 4.0.1_postcss@8.3.0+ts-node@9.1.1
+      rollup-plugin-typescript2: 0.30.0_rollup@2.60.0+typescript@4.2.4
+      rxjs: 6.6.7
+      rxjs-for-await: 0.0.2_rxjs@6.6.7
+      sass: 1.49.9
+      sass-loader: 12.3.0_sass@1.49.9+webpack@5.70.0
+      semver: 7.3.4
+      source-map: 0.7.3
+      source-map-loader: 3.0.0_webpack@5.70.0
+      style-loader: 3.3.1_webpack@5.70.0
+      stylus: 0.55.0
+      stylus-loader: 6.2.0_stylus@0.55.0+webpack@5.70.0
+      terser: 4.3.8
+      terser-webpack-plugin: 5.2.5_webpack@5.70.0
+      ts-loader: 9.2.6_typescript@4.2.4+webpack@5.70.0
+      ts-node: 9.1.1_typescript@4.2.4
+      tsconfig-paths: 3.11.0
+      tsconfig-paths-webpack-plugin: 3.4.1
+      tslib: 2.3.1
+      webpack: 5.70.0
+      webpack-dev-server: 4.5.0_webpack@5.70.0
+      webpack-merge: 5.8.0
+      webpack-sources: 3.2.2
+      webpack-subresource-integrity: 1.5.2_webpack@5.70.0
+      worker-plugin: 3.2.0_webpack@5.70.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/babel__core'
+      - '@types/react'
+      - '@types/webpack'
+      - acorn
+      - bufferutil
+      - canvas
+      - clean-css
+      - csso
+      - cypress
+      - debug
+      - esbuild
+      - fibers
+      - html-webpack-plugin
+      - node-notifier
+      - node-sass
+      - prettier
+      - sockjs-client
+      - supports-color
+      - type-fest
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+    dev: true
+
+  /@nrwl/workspace/13.3.5_42cab1dece2b2240094de84cfd414406:
+    resolution: {integrity: sha512-2SU0uiplM0A7oxejDCsXftJkELyi00FYTIPq19oD+uVLUblWo2THIks9Zst7mjw1FMYu4PsCTLQAO2qpDnRmUA==}
+    peerDependencies:
+      prettier: ^2.3.0
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      '@nrwl/cli': 13.3.5
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/jest': 13.3.5
+      '@nrwl/linter': 13.3.5_typescript@4.2.4
+      '@parcel/watcher': 2.0.4
+      chalk: 4.1.0
+      chokidar: 3.5.2
+      cosmiconfig: 4.0.0
+      dotenv: 10.0.0
+      enquirer: 2.3.6
+      figures: 3.2.0
+      flat: 5.0.2
+      fs-extra: 9.1.0
+      glob: 7.1.4
+      ignore: 5.1.9
+      ink: 3.2.0_react@17.0.2
+      ink-spinner: 4.0.3_ink@3.2.0+react@17.0.2
+      minimatch: 3.0.4
+      npm-run-all: 4.1.5
+      npm-run-path: 4.0.1
+      open: 7.4.2
+      prettier: /wp-prettier/2.2.1-beta-1
+      react: 17.0.2
+      rxjs: 6.6.7
+      semver: 7.3.4
+      strip-ansi: 6.0.0
+      tmp: 0.2.1
+      tslib: 2.3.1
+      yargs: 15.4.1
+      yargs-parser: 20.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - canvas
+      - node-notifier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+    dev: true
+
+  /@nrwl/workspace/13.3.5_e77b5b0640b6ec0ecc6c8e0dab0ec669:
+    resolution: {integrity: sha512-2SU0uiplM0A7oxejDCsXftJkELyi00FYTIPq19oD+uVLUblWo2THIks9Zst7mjw1FMYu4PsCTLQAO2qpDnRmUA==}
+    peerDependencies:
+      prettier: ^2.3.0
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+    dependencies:
+      '@nrwl/cli': 13.3.5
+      '@nrwl/devkit': 13.3.5
+      '@nrwl/jest': 13.3.5_ts-node@9.1.1
+      '@nrwl/linter': 13.3.5_ts-node@9.1.1+typescript@4.2.4
+      '@parcel/watcher': 2.0.4
+      chalk: 4.1.0
+      chokidar: 3.5.2
+      cosmiconfig: 4.0.0
+      dotenv: 10.0.0
+      enquirer: 2.3.6
+      figures: 3.2.0
+      flat: 5.0.2
+      fs-extra: 9.1.0
+      glob: 7.1.4
+      ignore: 5.1.9
+      ink: 3.2.0_react@17.0.2
+      ink-spinner: 4.0.3_ink@3.2.0+react@17.0.2
+      minimatch: 3.0.4
+      npm-run-all: 4.1.5
+      npm-run-path: 4.0.1
+      open: 7.4.2
+      prettier: /wp-prettier/2.2.1-beta-1
+      react: 17.0.2
+      rxjs: 6.6.7
+      semver: 7.3.4
+      strip-ansi: 6.0.0
+      tmp: 0.2.1
+      tslib: 2.3.1
+      yargs: 15.4.1
+      yargs-parser: 20.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - canvas
+      - node-notifier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /@oclif/color/1.0.1:
@@ -12089,6 +12555,17 @@ packages:
     dependencies:
       '@types/estree': 0.0.51
       '@types/json-schema': 7.0.9
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /@types/estree/0.0.39:
+    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    dev: true
+
+  /@types/estree/0.0.50:
+    resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==}
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /@types/estree/0.0.51:
@@ -12491,7 +12968,6 @@ packages:
       re-resizable: 4.11.0
     transitivePeerDependencies:
       - react
-      - react-dom
     dev: true
 
   /@types/wordpress__compose/4.0.1:
@@ -16655,6 +17131,24 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /babel-loader/8.2.3_2126ca8a005869f6c62d5aa977e8d816:
+    resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
+    engines: {node: '>= 8.9'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    dependencies:
+      '@babel/core': 7.16.0
+      find-cache-dir: 3.3.2
+      loader-utils: 1.4.0
+      make-dir: 3.1.0
+      schema-utils: 2.7.1
+      webpack: 5.70.0
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /babel-loader/8.2.3_b72fb7e629d39881e138edb6dcd0dfbe:
@@ -20098,6 +20592,17 @@ packages:
       graceful-fs: 4.2.9
       memory-fs: 0.5.0
       tapable: 1.1.3
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /enhanced-resolve/5.8.3:
+    resolution: {integrity: sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.9
+      tapable: 2.2.1
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /enhanced-resolve/5.9.2:
@@ -20492,6 +20997,7 @@ packages:
       semver: 5.7.1
       webpack: 5.70.0_webpack-cli@4.9.2
     dev: true
+<<<<<<< HEAD
 
   /eslint-module-utils/2.7.3:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
@@ -20500,6 +21006,16 @@ packages:
       debug: 3.2.7
       find-up: 2.1.0
 
+=======
+
+  /eslint-module-utils/2.7.3:
+    resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      debug: 3.2.7
+      find-up: 2.1.0
+
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /eslint-plugin-import/2.25.4:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
@@ -22429,6 +22945,28 @@ packages:
       semver: 5.7.1
       tapable: 1.1.3
       worker-rpc: 0.1.1
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /fork-ts-checker-webpack-plugin/6.2.10:
+    resolution: {integrity: sha512-HveFCHWSH2WlYU1tU3PkrupvW8lNFMTfH3Jk0TfC2mtktE9ibHGcifhCsCFvj+kqlDfNIlwmNLiNqR9jnSA7OQ==}
+    engines: {node: '>=10', yarn: '>=1.0.0'}
+    dependencies:
+      '@babel/code-frame': 7.16.0
+      '@types/json-schema': 7.0.9
+      chalk: 4.1.2
+      chokidar: 3.5.2
+      cosmiconfig: 6.0.0
+      deepmerge: 4.2.2
+      fs-extra: 9.1.0
+      glob: 7.2.0
+      memfs: 3.3.0
+      minimatch: 3.0.4
+      schema-utils: 2.7.0
+      semver: 7.3.5
+      tapable: 1.1.3
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /fork-ts-checker-webpack-plugin/6.5.0_10568ae13669cc833891d65cd6879aa0:
@@ -23996,6 +24534,28 @@ packages:
     resolution: {integrity: sha1-qVPKZwB4Zp3eFCzomUAbnW6F07Q=}
     dev: false
 
+<<<<<<< HEAD
+=======
+  /http-server/0.12.3:
+    resolution: {integrity: sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      basic-auth: 1.1.0
+      colors: 1.4.0
+      corser: 2.0.1
+      ecstatic: 3.3.2
+      http-proxy: 1.18.1
+      minimist: 1.2.5
+      opener: 1.5.2
+      portfinder: 1.0.28
+      secure-compare: 3.0.1
+      union: 0.5.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /http-signature/1.2.0:
     resolution: {integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
@@ -27545,6 +28105,16 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /license-webpack-plugin/2.3.15:
+    resolution: {integrity: sha512-reA0yvwvkkFMRsyqVikTcLGFXmgWKPVXrFaR3tRvAnFoZozM4zvwlNNQxuB5Il6fgTtS7nGkrIPm9xS2KZtu7g==}
+    dependencies:
+      '@types/webpack-sources': 0.1.9
+      webpack-sources: 1.4.3
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /liftoff/2.5.0:
@@ -27686,6 +28256,18 @@ packages:
   /loader-runner/4.2.0:
     resolution: {integrity: sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==}
     engines: {node: '>=6.11.5'}
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /loader-utils/1.2.3:
+    resolution: {integrity: sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 2.1.0
+      json5: 1.0.1
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /loader-utils/1.4.0:
@@ -28336,6 +28918,14 @@ packages:
     dependencies:
       errno: 0.1.8
       readable-stream: 2.3.7
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /memorystream/0.3.1:
+    resolution: {integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=}
+    engines: {node: '>= 0.10.0'}
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /meow/6.1.1:
@@ -28859,6 +29449,15 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+<<<<<<< HEAD
+=======
+
+  /native-request/1.1.0:
+    resolution: {integrity: sha512-uZ5rQaeRn15XmpgE0xoPL8YWqcX90VtCFglYwAgkvKM5e8fog+vePLAhHxuuv/gRkrQxIeh5U3q9sMNUrENqWw==}
+    requiresBuild: true
+    dev: true
+    optional: true
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
@@ -30288,6 +30887,21 @@ packages:
       htmlparser2: 3.10.1
       postcss: 7.0.39
       postcss-syntax: 0.36.2_postcss@7.0.39
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /postcss-import/14.0.2_postcss@8.3.0:
+    resolution: {integrity: sha512-BJ2pVK4KhUyMcqjuKs9RijV5tatNzNa73e/32aBVE/ejYPe37iH+6vAu9WvqUkB5OAYgLHzbSvzHnorybJCm9g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.3.0
+      postcss-value-parser: 4.1.0
+      read-cache: 1.0.0
+      resolve: 1.20.0
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /postcss-less/3.1.4:
@@ -30634,15 +31248,37 @@ packages:
       postcss-value-parser: 3.3.1
       svgo: 1.3.2
 
+<<<<<<< HEAD
+=======
+  /postcss-svgo/5.0.3_postcss@8.3.0:
+    resolution: {integrity: sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==}
+    engines: {node: ^10 || ^12 || >=14.0}
+    peerDependencies:
+      postcss: ^8.2.15
+    dependencies:
+      postcss: 8.3.0
+      postcss-value-parser: 4.2.0
+      svgo: 2.8.0
+    dev: true
+
+  /postcss-svgo/5.0.3_postcss@8.3.11:
+    resolution: {integrity: sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==}
+    engines: {node: ^10 || ^12 || >=14.0}
+    peerDependencies:
+      postcss: ^8.2.15
+    dependencies:
+      postcss: 8.3.11
+      postcss-value-parser: 4.2.0
+      svgo: 2.8.0
+    dev: true
+
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /postcss-syntax/0.36.2_postcss@7.0.39:
     resolution: {integrity: sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==}
     peerDependencies:
       postcss: '>=5.0.0'
     dependencies:
       postcss: 7.0.39
-      postcss-html: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
-      postcss-less: 3.1.4
-      postcss-scss: 2.1.1
     dev: true
 
   /postcss-unique-selectors/4.0.1:
@@ -33110,6 +33746,22 @@ packages:
       safe-buffer: 5.1.1
     dev: true
 
+<<<<<<< HEAD
+=======
+  /serve-index/1.9.1:
+    resolution: {integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      accepts: 1.3.7
+      batch: 0.6.1
+      debug: 2.6.9
+      escape-html: 1.0.3
+      http-errors: 1.6.3
+      mime-types: 2.1.34
+      parseurl: 1.3.3
+    dev: true
+
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /serve-static/1.14.1:
     resolution: {integrity: sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==}
     engines: {node: '>= 0.8.0'}
@@ -34183,6 +34835,37 @@ packages:
     resolution: {integrity: sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==}
     dev: false
 
+<<<<<<< HEAD
+=======
+  /stylus-loader/6.2.0_stylus@0.55.0+webpack@5.70.0:
+    resolution: {integrity: sha512-5dsDc7qVQGRoc6pvCL20eYgRUxepZ9FpeK28XhdXaIPP6kXr6nI1zAAKFQgP5OBkOfKaURp4WUpJzspg1f01Gg==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      stylus: '>=0.52.4'
+      webpack: ^5.0.0
+    dependencies:
+      fast-glob: 3.2.11
+      klona: 2.0.5
+      normalize-path: 3.0.0
+      stylus: 0.55.0
+      webpack: 5.70.0
+    dev: true
+
+  /stylus/0.55.0:
+    resolution: {integrity: sha512-MuzIIVRSbc8XxHH7FjkvWqkIcr1BvoMZoR/oFuAJDlh7VSaNJzrB4uJ38GRQa+mWjLXODAMzeDe0xi9GYbGwnw==}
+    hasBin: true
+    dependencies:
+      css: 3.0.0
+      debug: 3.1.0
+      glob: 7.2.0
+      mkdirp: 1.0.4
+      safer-buffer: 2.1.2
+      sax: 1.2.4
+      semver: 6.3.0
+      source-map: 0.7.3
+    dev: true
+
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /sugarss/2.0.0:
     resolution: {integrity: sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==}
     dependencies:
@@ -34447,24 +35130,6 @@ packages:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.2.0
 
-  /terser-webpack-plugin/1.4.5_webpack@4.44.2:
-    resolution: {integrity: sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==}
-    engines: {node: '>= 6.9.0'}
-    peerDependencies:
-      webpack: ^4.0.0
-    dependencies:
-      cacache: 12.0.4
-      find-cache-dir: 2.1.0
-      is-wsl: 1.1.0
-      schema-utils: 1.0.0
-      serialize-javascript: 4.0.0
-      source-map: 0.6.1
-      terser: 4.8.0
-      webpack: 4.44.2_webpack-cli@3.3.12
-      webpack-sources: 1.4.3
-      worker-farm: 1.7.0
-    dev: true
-
   /terser-webpack-plugin/1.4.5_webpack@4.46.0:
     resolution: {integrity: sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==}
     engines: {node: '>= 6.9.0'}
@@ -34651,6 +35316,41 @@ packages:
       source-map: 0.7.3
       source-map-support: 0.5.20
     dev: true
+<<<<<<< HEAD
+=======
+
+  /terser/5.10.0_acorn@7.4.1:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 7.4.1
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.20
+    dev: true
+
+  /terser/5.10.0_acorn@8.7.0:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 8.7.0
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.20
+    dev: true
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
 
   /test-exclude/5.2.3:
     resolution: {integrity: sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==}
@@ -36157,6 +36857,15 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.9
+<<<<<<< HEAD
+=======
+    dev: true
+
+  /wbuf/1.7.3:
+    resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
+    dependencies:
+      minimalistic-assert: 1.0.1
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /wcwidth/1.0.1:
@@ -36201,6 +36910,7 @@ packages:
       mkdirp: 0.5.5
       opener: 1.5.2
       ws: 6.2.2
+<<<<<<< HEAD
     dev: true
 
   /webpack-cli/3.3.12_webpack@4.44.2:
@@ -36222,6 +36932,8 @@ packages:
       v8-compile-cache: 2.3.0
       webpack: 4.44.2_webpack-cli@3.3.12
       yargs: 13.3.2
+=======
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
     dev: true
 
   /webpack-cli/3.3.12_webpack@4.46.0:
@@ -36423,6 +37135,7 @@ packages:
     resolution: {integrity: sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==}
     dev: true
 
+<<<<<<< HEAD
   /webpack/4.44.2_webpack-cli@3.3.12:
     resolution: {integrity: sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==}
     engines: {node: '>=6.11.5'}
@@ -36462,6 +37175,8 @@ packages:
       webpack-sources: 1.4.3
     dev: true
 
+=======
+>>>>>>> 0ebd018ef9 (update to Webpack 5.x)
   /webpack/4.46.0:
     resolution: {integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==}
     engines: {node: '>=6.11.5'}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In testing https://github.com/woocommerce/woocommerce/pull/33329,  a mismatched Webpack version between 4.x and 5.x declared by `wp-scripts` is somehow causing an error when running commands via NX. A bump of Webpack for WooCommerce fixes the problem.

### How to test the changes in this Pull Request:

1. `pnpm install`
2. `pnpm nx build woocommerce`
3. See no errors in the build

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
