### PR TITLE
Analyzer CLI: Allow commit hashes for comparisons

### DIFF
--- a/tools/code-analyzer/src/git.ts
+++ b/tools/code-analyzer/src/git.ts
@@ -46,7 +46,9 @@ export const fetchBranch = (
 		// Create branch.
 		execSync( `git branch ${ branch } origin/${ branch }` );
 	} catch ( e ) {
-		error( `Unable to fetch ${ branch }` );
+		error(
+			`Unable to fetch ${ branch }. Supply a valid branch name or commit hash.`
+		);
 		return false;
 	}
 

--- a/tools/code-analyzer/src/git.ts
+++ b/tools/code-analyzer/src/git.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs';
 /**
  * Internal dependencies
  */
-import { startWPEnv, stopWPEnv } from './utils';
+import { startWPEnv, stopWPEnv, isValidCommitHash } from './utils';
 
 /**
  * Fetch branches from origin.
@@ -32,6 +32,11 @@ export const fetchBranch = (
 
 	if ( branchExistsLocally ) {
 		CliUx.ux.action.stop();
+		return true;
+	}
+
+	if ( isValidCommitHash( branch ) ) {
+		// The hash is valid and available in history. No need to fetch anything.
 		return true;
 	}
 

--- a/tools/code-analyzer/src/utils.ts
+++ b/tools/code-analyzer/src/utils.ts
@@ -175,6 +175,12 @@ export const stopWPEnv = ( error: ( s: string ) => void ): boolean => {
 	}
 };
 
+/**
+ * Check if branch string is actually a commit hash and exists in git history.
+ *
+ * @param {string } branch branch name or commit hash.
+ * @return {boolean} If string is valid commit hash.
+ */
 export const isValidCommitHash = ( branch: string ): boolean => {
 	try {
 		// See if hash is valid and exists in the history.

--- a/tools/code-analyzer/src/utils.ts
+++ b/tools/code-analyzer/src/utils.ts
@@ -174,3 +174,16 @@ export const stopWPEnv = ( error: ( s: string ) => void ): boolean => {
 		return false;
 	}
 };
+
+export const isValidCommitHash = ( branch: string ): boolean => {
+	try {
+		// See if hash is valid and exists in the history.
+		execSync( `git show -s ${ branch }`, {
+			encoding: 'utf-8',
+		} );
+		return true;
+	} catch ( e ) {
+		// git show -s produces an error if the string is not a valid hash.
+		return false;
+	}
+};


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fetching a branch was erroring out when a commit hash was supplied as an argument in the Analyzer CLI tool. This PR checks if the argument is a valid commit hash in the commit history. If so, skips fetching anything as code is already available.

### How to test the changes in this Pull Request:

1. Choose two commit hashes to compare against
2. Run the analyzer, making sure the `-b` argument is the earlier commit. Otherwise there won't be a diff to compare against. Here is an example that produces an output. Pull the latest from `trunk` to ensure you have these commits available locally.
```
./tools/code-analyzer/bin/dev analyzer 17d9e8072d0cb52d051a3c32ab2957519f9c1a25 -b 21f7cea2b6ab1a268c137dcf761c4df721f1ec0b
```
3. Try an invalid commit hash and see an error produced.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
