### PR TITLE
Fix setup wizard click button loading state

### DIFF
--- a/packages/js/e2e-utils/changelog/fix-33172-setup-wizard-click-button-loading-state
+++ b/packages/js/e2e-utils/changelog/fix-33172-setup-wizard-click-button-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tests to check usage button loading state

--- a/packages/js/e2e-utils/src/components.js
+++ b/packages/js/e2e-utils/src/components.js
@@ -129,6 +129,12 @@ const completeOnboardingWizard = async () => {
 		expect( continueButtons ).toHaveLength( 1 );
 
 		await continueButtons[ 0 ].click();
+		await expect( page ).toMatchElement(
+			'.woocommerce-usage-modal__actions button.is-secondary.is-busy'
+		);
+		await expect( page ).not.toMatchElement(
+			'.woocommerce-usage-modal__actions button.is-primary:disabled'
+		);
 	}
 	await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
@@ -17,6 +17,7 @@ class UsageModal extends Component {
 		this.state = {
 			isLoadingScripts: false,
 			isRequestStarted: false,
+			selectedAction: null,
 		};
 	}
 
@@ -131,7 +132,7 @@ class UsageModal extends Component {
 			acceptActionText = __( 'Yes, count me in!', 'woocommerce' ),
 		} = this.props;
 
-		const { isRequestStarted } = this.state;
+		const { isRequestStarted, selectedAction } = this.state;
 		const isBusy = isRequestStarted && isRequesting;
 
 		return (
@@ -148,19 +149,23 @@ class UsageModal extends Component {
 					<div className="woocommerce-usage-modal__actions">
 						<Button
 							isSecondary
-							isBusy={ isBusy }
-							onClick={ () =>
-								this.updateTracking( { allowTracking: false } )
-							}
+							isBusy={ isBusy && selectedAction === 'dismiss' }
+							disabled={ isBusy && selectedAction === 'accept' }
+							onClick={ () => {
+								this.setState( { selectedAction: 'dismiss' } );
+								this.updateTracking( { allowTracking: false } );
+							} }
 						>
 							{ dismissActionText }
 						</Button>
 						<Button
 							isPrimary
-							isBusy={ isBusy }
-							onClick={ () =>
-								this.updateTracking( { allowTracking: true } )
-							}
+							isBusy={ isBusy && selectedAction === 'accept' }
+							disabled={ isBusy && selectedAction === 'dismiss' }
+							onClick={ () => {
+								this.setState( { selectedAction: 'accept' } );
+								this.updateTracking( { allowTracking: true } );
+							} }
 						>
 							{ acceptActionText }
 						</Button>

--- a/plugins/woocommerce/changelog/fix-33172-setup-wizard-click-button-loading-state
+++ b/plugins/woocommerce/changelog/fix-33172-setup-wizard-click-button-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix setup wizard usage button loading state


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33172.

This PR fixes the issue that clicking on the "No thanks" button shouldn't have the loading state on  "Yes, count me in!" button.

Before
![Screen Shot 2022-06-09 at 11 39 41](https://user-images.githubusercontent.com/4344253/172759262-aa02152d-dbce-40d9-a7c6-abacbf458b27.png)




After
![Screen Shot 2022-06-09 at 11 38 00](https://user-images.githubusercontent.com/4344253/172759105-30c26284-27d4-4e31-99d8-fef65702b4ec.png)


### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to OBW
3. Skip setup wizard
4. Click the first button `No thanks`
5. Observe that only `No thanks` button is loading and "Yes, count me in!" button is disabled.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
