### PR TITLE
Wrap product spotlight tour under ExPlat logic

### DIFF
--- a/plugins/woocommerce/changelog/add-33162-experiment-logic
+++ b/plugins/woocommerce/changelog/add-33162-experiment-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Wrap spotlight product tour under experiment logic

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
@@ -43,6 +43,22 @@ class WC_Admin_Pointers {
 	}
 
 	/**
+	 * Check if product tour experiment is treatment.
+	 *
+	 * @return bool
+	 */
+	public static function is_experiment_product_tour() {
+		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
+		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
+		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
+			$anon_id,
+			'woocommerce',
+			$allow_tracking
+		);
+		return $abtest->get_variation( 'woocommerce_products_tour' ) === 'treatment';
+	}
+
+	/**
 	 * Pointers for creating a product.
 	 */
 	public function create_product_tutorial() {
@@ -54,6 +70,7 @@ class WC_Admin_Pointers {
 
 		if (
 			Features::is_enabled( 'experimental-product-tour' ) &&
+			self::is_experiment_product_tour() &&
 			isset( $_GET['spotlight'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			isset( $wp_post_types )
 		) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
@@ -70,9 +70,9 @@ class WC_Admin_Pointers {
 
 		if (
 			Features::is_enabled( 'experimental-product-tour' ) &&
-			self::is_experiment_product_tour() &&
 			isset( $_GET['spotlight'] ) && // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			isset( $wp_post_types )
+			isset( $wp_post_types ) &&
+			self::is_experiment_product_tour()
 		) {
 			$labels          = $wp_post_types['product']->labels;
 			$labels->add_new = __( 'Enable guided mode', 'woocommerce' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33162.

Wraps the product spotlight tour under ExPlat logic.

### How to test the changes in this Pull Request:

1. Install and activate [WCA Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/download/v0.7.6/woocommerce-admin-test-helper.zip)
1. Go to Tools > WCA Test Helper > Features
2. Enable `experimental-product-tour`
1. Go to Tools > WCA Test Helper > Experiments
1. Add `woocommerce_products_tour` to treatment
1. Go to WooCommerce > Home
1. Click on "Add My Products" > Start with a template
3. Select physical products and click "Go"
4. Observe the spotlight feature as per screenshot

<img width="769" alt="image" src="https://user-images.githubusercontent.com/3747241/172780033-1380b970-6b7b-4631-9a7f-007bb776cc37.png">


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
