### PR TITLE
Fix continue button is enabled when email is null in setup wizard

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -231,6 +231,16 @@ export class StoreDetails extends Component {
 			errors.storeEmail = __( 'Invalid email address', 'woocommerce' );
 		}
 
+		if (
+			values.isAgreeMarketing &&
+			( ! values.storeEmail || ! values.storeEmail.trim().length )
+		) {
+			errors.storeEmail = __(
+				'Please enter your email address to subscribe',
+				'woocommerce'
+			);
+		}
+
 		return errors;
 	}
 
@@ -373,16 +383,6 @@ export class StoreDetails extends Component {
 									autoComplete="email"
 									{ ...getInputProps( 'storeEmail' ) }
 								/>
-								{ values.isAgreeMarketing &&
-									( ! values.storeEmail ||
-										! values.storeEmail.trim().length ) && (
-										<div className="woocommerce-profile-wizard__store-details-error">
-											{ __(
-												'Please enter your email address to subscribe',
-												'woocommerce'
-											) }
-										</div>
-									) }
 								<FlexItem>
 									<div className="woocommerce-profile-wizard__newsletter-signup">
 										<CheckboxControl

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
@@ -40,6 +40,37 @@ describe( 'StoreDetails', () => {
 		} );
 	} );
 	describe( 'Email validation test cases', () => {
+		test( 'should fail email validation and disable continue button when isAgreeMarketing is true and email is empty', async () => {
+			const container = render(
+				<StoreDetails
+					{ ...testProps }
+					initialValues={ {
+						addressLine1: 'address1',
+						addressLine2: 'address2',
+						city: 'city',
+						countryState: 'state',
+						postCode: '123',
+						isAgreeMarketing: true,
+						storeEmail: 'wordpress@example.com',
+					} }
+				/>
+			);
+			const emailInput = container.getByLabelText( 'Email address' );
+			await userEvent.clear( emailInput );
+			userEvent.tab();
+			expect(
+				container.queryByText(
+					'Please enter your email address to subscribe'
+				)
+			).toBeInTheDocument();
+
+			expect(
+				container.queryByRole( 'button', {
+					name: 'Continue',
+				} ).disabled
+			).toBe( true );
+		} );
+
 		// test cases taken from wordpress php is_email test cases
 		// https://github.com/WordPress/wordpress-develop/blob/2648a5f984b8abf06872151898e3a61d3458a628/tests/phpunit/tests/formatting/isEmail.php
 		test.each( [

--- a/plugins/woocommerce/changelog/fix-32588-continue-button-is-enabled-when-email-is-null
+++ b/plugins/woocommerce/changelog/fix-32588-continue-button-is-enabled-when-email-is-null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix continue button is enabled even when email is null in setup wizard


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32588.

This PR fixes the issue such that if the newsletter signup checkbox is checked AND the email text box is empty, we disable the Continue button.

### How to test the changes in this Pull Request:

1. Go to the Setup Wizard
2. Fill in details like Address, Country, City, and Postcode
3. Check the `Get tips, product updates and inspiration straight to your mailbox. checkbox`
4. Ensure the email textbox is empty
5. Observe that "Please enter your email address to subscribe" error is displayed, and "Continue" button is disabled.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
