### PR TITLE
follow up to #33182 swap .woocommerce-info and .woocommerce-message colors in twenty twenty

### DIFF
--- a/plugins/woocommerce/changelog/fix-33182-twenty-twenty
+++ b/plugins/woocommerce/changelog/fix-33182-twenty-twenty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Swap info and message notice colors in Twenty-Twenty

--- a/plugins/woocommerce/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty.scss
@@ -224,7 +224,7 @@ a.button {
 	}
 }
 
-.woocommerce-message {
+.woocommerce-info {
 	border-color: var( --wc-blue );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

swap .woocommerce-info and .woocommerce-message colors in twenty twenty

@barryhughes I had the success and notices swapped in my `wc_add_notice` test.. so had the colors inverted. the info notice should now be blue.

### How to test the changes in this Pull Request:

```
add_action( 'woocommerce_before_main_content', 'test_notice_styles' );
function test_notice_styles() {
	if ( function_exists( 'wc_add_notice' ) ) {
		wc_add_notice( 'Error notice <a class="button">Do the thing</a>', 'error' );
		wc_add_notice( 'Success notice <a class="button">Do the thing</a>', 'success' );
		wc_add_notice( 'Info notice <a class="button">Do the thing</a>', 'notice' );
	}
}
```

follow up to #33182