### PR TITLE
First pass: Twenty Twenty One notice styles. Closes #29560.

### DIFF
--- a/plugins/woocommerce/changelog/fix-29560-twentytwentyone-notices
+++ b/plugins/woocommerce/changelog/fix-29560-twentytwentyone-notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Improve Twenty Twenty One notice styles

--- a/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/legacy/css/twenty-twenty-one.scss
@@ -213,30 +213,16 @@ a.button {
 .woocommerce-message,
 .woocommerce-error,
 .woocommerce-info {
+	color: #000;
+	border-top: 3px solid $highlights-color;
 	margin-bottom: 2rem;
+	padding: 0;
 	margin-left: 0;
-	background: var(--global--color-background);
+	background: #eee;
 	font-size: 0.88889em;
 	font-family: $headings;
 	list-style: none;
 	overflow: hidden;
-}
-
-.woocommerce-message,
-.woocommerce-error li,
-.woocommerce-info {
-	padding: 1.5rem 3rem;
-	justify-content: space-between;
-	align-items: center;
-
-	.button {
-		order: 2;
-	}
-}
-
-.woocommerce-error {
-	color: #fff;
-	background: #b22222;
 
 	a {
 		color: #fff;
@@ -247,39 +233,34 @@ a.button {
 
 		&.button {
 			background: #111;
+			color: #fff;
 		}
 	}
 
-	> li {
-		margin: 0;
-	}
-}
-
-#main {
-
-	.woocommerce-error,
-	.woocommerce-info {
-		font-family: $headings;
-	}
 }
 
 .woocommerce-message,
+.woocommerce-error li,
 .woocommerce-info {
-	background: #eee;
-	color: #000;
-	border-top: 2px solid $highlights-color;
+	padding: 1.5rem 3rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 
-	a {
-		color: #444;
+	.button {
+		order: 2;
+	}
+}
 
-		&:hover {
-			color: #000;
-		}
+.woocommerce-info {
+	border-top-color: var( --wc-blue );
+}
 
-		&.button {
-			background: $highlights-color;
-			color: #f5efe0;
-		}
+.woocommerce-error {
+	border-top-color: #b22222;
+
+	> li {
+		margin: 0;
 	}
 }
 
@@ -617,10 +598,6 @@ dl.variation,
 		.button.disabled {
 			opacity: 0.2;
 		}
-	}
-
-	.woocommerce-message {
-		flex-direction: row-reverse;
 	}
 
 	.woocommerce-Tabs-panel--additional_information,
@@ -2937,14 +2914,6 @@ a.reset_variations {
 }
 
 .woocommerce {
-
-	.woocommerce-notices-wrapper {
-
-		& > * {
-			padding: 15px;
-			list-style: none;
-		}
-	}
 
 	.return-to-shop,
 	.wc-proceed-to-checkout {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Give twenty twenty one notice styles some attention... specifically so that the success and info notices look different.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29560.

### How to test the changes in this Pull Request:

Add some sample notices
```
add_action( 'woocommerce_before_main_content', 'test_notice_styles' );
function test_notice_styles() {
	if ( function_exists( 'wc_add_notice' ) ) {
		wc_add_notice( 'Error notice <a class="button">Do the thing</a>', 'error' );
		wc_add_notice( 'Another Error notice <a class="button">Do the other thing</a>', 'error' );
		wc_add_notice( 'Success notice <a class="button">Do the thing</a>', 'success' );
		wc_add_notice( 'Info notice <a class="button">Do the thing</a>', 'notice' );
	}
}
```

![image](https://user-images.githubusercontent.com/507025/172947230-a968579c-4dd4-408e-84c8-e0f2b3a4ced8.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.

@barryhughes These are quite similar to the Twenty Twenty PR except the success notice is using the Twenty Twenty One green color.
