### PR TITLE
Add exporter instance parameter to `woocommerce_product_export_row_data` filter

### DIFF
--- a/plugins/woocommerce/changelog/add-33390
+++ b/plugins/woocommerce/changelog/add-33390
@@ -1,4 +1,4 @@
 Significance: minor
-Type: dev
+Type: tweak
 
-Add third parameter to woocommerce_product_export_row_data filter
+Add the `WC_Product_CSV_Exporter` object as a third parameter of the `woocommerce_product_export_row_data` filter.

--- a/plugins/woocommerce/changelog/add-33390
+++ b/plugins/woocommerce/changelog/add-33390
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add third parameter to woocommerce_product_export_row_data filter

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -254,7 +254,8 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		/**
 		 * Allow third-party plugins to filter the data in a single row of the exported CSV file.
 		 *
-		 * @since 6.7.0
+		 * @since 3.1.0
+		 *
 		 * @param array                   $row         An associative array with the data of a single row in the CSV file.
 		 * @param WC_Product              $product     The product object correspnding to the current row.
 		 * @param WC_Product_CSV_Exporter $exporter    The instance of the CSV exporter.

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -251,6 +251,14 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$this->prepare_attributes_for_export( $product, $row );
 		$this->prepare_meta_for_export( $product, $row );
 
+		/**
+		 * Allow third-party plugins to filter the data in a single row of the exported CSV file.
+		 *
+		 * @since 6.7.0
+		 * @param array                   $row         An associative array with the data of a single row in the CSV file.
+		 * @param WC_Product              $product     The product object correspnding to the current row.
+		 * @param WC_Product_CSV_Exporter $exporter    The instance of the CSV exporter.
+		 */
 		return apply_filters( 'woocommerce_product_export_row_data', $row, $product, $this );
 	}
 

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -250,7 +250,8 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$this->prepare_downloads_for_export( $product, $row );
 		$this->prepare_attributes_for_export( $product, $row );
 		$this->prepare_meta_for_export( $product, $row );
-		return apply_filters( 'woocommerce_product_export_row_data', $row, $product );
+
+		return apply_filters( 'woocommerce_product_export_row_data', $row, $product, $this );
 	}
 
 	/**


### PR DESCRIPTION
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding the `WC_Product_CSV_Exporter` instance as a third parameter of the `woocommerce_product_export_row_data` filter allows third-party plugins to make better use of the CSV exporting capability. A plugin might need to add custom columns based on some custom data attached to a product, in a similar way to how the `prepare_downloads_for_export` or `prepare_attributes_for_export` methods currently do. This is particularly useful for custom structured data with a dynamic number of items.

With the proposed change, it would be possible to do something like this:

```php
function my_export_row_data_callback( $row, $product, $exporter ) {
	// get some custom data that is stored as a serialized array in a single meta key
	$items = get_post_meta( $product->get_id(), 'some_custom_items', true );

	if ( is_array( $items ) ) {
		$i = 1;

		// get the current column names
		$column_names = $exporter->get_column_names();

		foreach ( $items as $item_id => $item_data ) {
			// adds new column names based on the retrieved data
			$column_names[ 'custom_items:id' . $i ]           = sprintf( __( 'Custom item %d ID' ), $i );
			$column_names[ 'custom_items:name' . $i ]         = sprintf( __( 'Custom item %d name' ), $i );
			$column_names[ 'custom_items:description' . $i ]  = sprintf( __( 'Custom item %d description' ), $i );
			$row[ 'custom_items:id' . $i ]                    = $item_id;
			$row[ 'custom_items:name' . $i ]                  = $item_data['name'];
			$row[ 'custom_items:description' . $i ]           = $item_data['description'];
			$i++;
		}

		// set the new column names
		$exporter->set_column_names( $column_names );
	}

	return $row;
}
```

which is not possible at the moment.

Although it is already possible to export any type of non-scalar data by using the `woocommerce_product_export_meta_value` filter (i.e. converting it to a scalar value), the proposed change would avoid the need to write structured data as a string, resulting in CSV files that are easier to read, manipulate and import.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
