### PR TITLE
Tweak tour kit gap between content and controls

### DIFF
--- a/packages/js/components/changelog/tweak-tour-kit-gap-between-content-and-controls
+++ b/packages/js/components/changelog/tweak-tour-kit-gap-between-content-and-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak tour kit gap between content and controls

--- a/packages/js/components/src/tour-kit/style.scss
+++ b/packages/js/components/src/tour-kit/style.scss
@@ -32,6 +32,10 @@
 		margin: 4px 0 0;
 	}
 
+	.components-card-header {
+		padding-bottom: 0;
+	}
+
 	.woocommerce-tour-kit-step-controls__close-btn {
 		height: 16px;
 		min-width: 16px;

--- a/plugins/woocommerce/changelog/fix-tour-kit-gap-between-content-and-controls
+++ b/plugins/woocommerce/changelog/fix-tour-kit-gap-between-content-and-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak tour-kit gap between content and controls

--- a/plugins/woocommerce/changelog/fix-tour-kit-gap-between-content-and-controls
+++ b/plugins/woocommerce/changelog/fix-tour-kit-gap-between-content-and-controls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Tweak tour-kit gap between content and controls


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Close  https://github.com/woocommerce/woocommerce/issues/33399

This PR updates the tour-kit component to reduce the gap between content and controls

Before:
![Screen Shot 2022-06-13 at 11 04 46](https://user-images.githubusercontent.com/4344253/173272212-3462ef59-e3ee-4182-b4be-ba9185786d0f.png)

After:
![Screen Shot 2022-06-13 at 11 04 38](https://user-images.githubusercontent.com/4344253/173272218-aee15242-bb15-43e3-bf37-54a6a021f668.png)


### How to test the changes in this Pull Request:

1. Run `pnpm install`
2. Run `pnpm nx build @woocommerce/components`
3. Run `pnpm storybook`
4. Go to http://localhost:6007/
5. Find Tour-kit component
6. Confirm the gap between content and controls is smaller

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.