### PR TITLE
Try: Unfurl panels and hide ul tabs [DO NOT MERGE]

### DIFF
--- a/plugins/woocommerce/legacy/css/admin.scss
+++ b/plugins/woocommerce/legacy/css/admin.scss
@@ -4852,7 +4852,7 @@ img.help_tip {
 	.woocommerce_options_panel,
 	.wc-metaboxes-wrapper {
 		float: left;
-		width: 80%;
+		width: 100%;
 
 		.wc-radios {
 			display: block;
@@ -4869,6 +4869,10 @@ img.help_tip {
 			}
 		}
 	}
+
+	h2 {
+		font-weight: bold;
+	}
 }
 
 #woocommerce-product-data,
@@ -4880,6 +4884,7 @@ img.help_tip {
 	}
 
 	ul.wc-tabs {
+		display: none !important;
 		margin: 0;
 		width: 20%;
 		float: left;
@@ -5221,6 +5226,7 @@ img.help_tip {
 .woocommerce_options_panel {
 	min-height: 175px;
 	box-sizing: border-box;
+	display: block !important;
 
 	.downloadable_files {
 		padding: 0 9px 0 162px;

--- a/plugins/woocommerce/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/legacy/js/admin/meta-boxes.js
@@ -16,6 +16,16 @@ jQuery( function ( $ ) {
 
 	runTipTip();
 
+	function addPanelTitles() {
+		$( 'ul.wc-tabs a' ).each( function() {
+			const title = $( this ).text();
+			const panel = $( $( this ).attr( 'href' ) );
+			$( panel ).prepend( `<h2>${ title }</h2>` );
+		});
+	}
+
+	addPanelTitles();
+
 	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox > h3', function() {
 		var metabox = $( this ).parent( '.wc-metabox' );
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a spike to see what problems might arise from unfurling the product panel tabs on the product edit screen.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
