### PR TITLE
Turn on experimental-product-tour feature flag

### DIFF
--- a/plugins/woocommerce/changelog/update-turn-on-product-tour-feature-flag
+++ b/plugins/woocommerce/changelog/update-turn-on-product-tour-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Turn on experimental-product-tour feature flag

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -7,7 +7,7 @@
 		"experimental-products-task": true,
 		"experimental-import-products-task": true,
 		"experimental-fashion-sample-products": true,
-		"experimental-product-tour": false,
+		"experimental-product-tour": true,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": false,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -7,7 +7,7 @@
 		"experimental-products-task": true,
 		"experimental-import-products-task": true,
 		"experimental-fashion-sample-products": true,
-		"experimental-product-tour": false,
+		"experimental-product-tour": true,
 		"homescreen": true,
 		"marketing": true,
 		"minified-js": true,


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Turn on experimental-product-tour feature flag since we've wrapped the product tour feature under Explat logic

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to Tools > WCA Test Helper > Features
3. Observe that `experimental-product-tour` is enabled.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
