### PR TITLE
Preserve meta-data uniqueness

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -418,6 +418,7 @@ abstract class WC_Data {
 			array(
 				'key'   => $key,
 				'value' => $value,
+				'unique' => $unique,
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -411,9 +411,6 @@ abstract class WC_Data {
 		}
 
 		$this->maybe_read_meta_data();
-		if ( $unique ) {
-			$this->delete_meta_data( $key );
-		}
 		$this->meta_data[] = new WC_Meta_Data(
 			array(
 				'key'   => $key,

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -133,7 +133,7 @@ class WC_Data_Store_WP {
 	 * @return int meta ID
 	 */
 	public function add_meta( &$object, $meta ) {
-		return add_metadata( $this->meta_type, $object->get_id(), wp_slash( $meta->key ), is_string( $meta->value ) ? wp_slash( $meta->value ) : $meta->value, false );
+		return add_metadata( $this->meta_type, $object->get_id(), wp_slash( $meta->key ), is_string( $meta->value ) ? wp_slash( $meta->value ) : $meta->value, $meta->unique );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -133,7 +133,7 @@ class WC_Data_Store_WP {
 	 * @return int meta ID
 	 */
 	public function add_meta( &$object, $meta ) {
-		return add_metadata( $this->meta_type, $object->get_id(), wp_slash( $meta->key ), is_string( $meta->value ) ? wp_slash( $meta->value ) : $meta->value, $meta->unique );
+		return add_metadata( $this->meta_type, $object->get_id(), wp_slash( $meta->key ), is_string( $meta->value ) ? wp_slash( $meta->value ) : $meta->value, $meta->unique ?? false );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
@@ -161,7 +161,7 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 	/**
 	 * Tests uniqueness constraint for metadata.
 	 */
-	function test_metadata_uniqueness() {
+	public function test_metadata_uniqueness() {
 		$object    = new WC_Order();
 		$object_id = $object->save();
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
@@ -157,4 +157,30 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 		// clean
 		$object->delete();
 	}
+
+	/**
+	 * Tests uniqueness constraint for metadata.
+	 */
+	function test_metadata_uniqueness() {
+		$object    = new WC_Order();
+		$object_id = $object->save();
+
+		// Create another reference to the same order to simulate concurrent updates.
+		$order_dup = wc_get_order( $object_id );
+
+		// Simulate two "concurrent" processes adding metadata.
+		$object->add_meta_data( 'unique_meta_key', 'a_value', true );
+		$order_dup->add_meta_data( 'unique_meta_key', 'other_value', true );
+
+		$object->save_meta_data();
+		$order_dup->save_meta_data();
+
+		// Refresh metadata.
+		$object->read_meta_data( true );
+
+		$this->assertCount( 1, $object->get_meta( 'unique_meta_key', false ) );
+
+		$object->delete( true );
+	}
+
 }


### PR DESCRIPTION
A race condition can eventually duplicate meta-data.

See p81Rsd-QQ-p2