### PR TITLE
Fix Admin performance with a large # of zipcodes

### DIFF
--- a/plugins/woocommerce/changelog/update-33073-fix-admin-perf-issue-with-large-zipcodes
+++ b/plugins/woocommerce/changelog/update-33073-fix-admin-perf-issue-with-large-zipcodes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Uses WC_Data_Store directly to count the shipping zones to avoid any unncessary query to the D.B

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use WC_Data_Store;
 
 /**
  * Shipping Task
@@ -95,7 +96,7 @@ class Shipping extends Task {
 	 * @return bool
 	 */
 	public static function has_shipping_zones() {
-		return count( \WC_Shipping_Zones::get_zones() ) > 0;
+		return count( WC_Data_Store::load( 'shipping-zone' )->get_zones() ) > 0;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33073 .

This PR uses `count( WC_Data_Store::load( 'shipping-zone' )->get_zones() )` instead of `count( \WC_Shipping_Zones::get_zones() )` to avoid any unnecessary D.B operations that might slow down the performance when there is a large # of zipcodes.

`WC_Shipping_Zones::get_zones()` tries to get zone data, which is unnecessary to check # of zones.

```
$data_store = WC_Data_Store::load( 'shipping-zone' );
$raw_zones  = $data_store->get_zones();
$zones      = array();

foreach ( $raw_zones as $raw_zone ) {
	$zone                                = new WC_Shipping_Zone( $raw_zone );
	$zones[ $zone->get_id() ]            = $zone->get_data();
	$zones[ $zone->get_id() ]['zone_id'] = $zone->get_id();
	$zones[ $zone->get_id() ]['formatted_zone_location'] = $zone->get_formatted_location();
	$zones[ $zone->get_id() ]['shipping_methods']        = $zone->get_shipping_methods( false, $context );
}

return $zones;
```


Thanks, @barryhughes for the suggestion!

### How to test the changes in this Pull Request:

1. Checkout the trunk branch
2. Follow steps in https://github.com/woocommerce/woocommerce/issues/33073#issuecomment-1141603234
3. Try to access the admin area. You should notice slowness. 
4. Checkout this branch
5. Try to access the admin area again. It should be faster now.


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
