### PR TITLE
Fix explat fetchExperimentAssignment response

### DIFF
--- a/packages/js/explat/changelog/fix-explat-fetch-assignment
+++ b/packages/js/explat/changelog/fix-explat-fetch-assignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fetchExperimentAssignment response

--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -89,11 +89,12 @@ export const fetchExperimentAssignment = async ( {
 		);
 	}
 
-	return await window.fetch(
+	const response = await window.fetch(
 		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ stringify(
 			queryParams
 		) }`
 	);
+	return await response.json();
 };
 
 export const fetchExperimentAssignmentWithAuth = async ( {

--- a/packages/js/explat/src/test/assignment-test.js
+++ b/packages/js/explat/src/test/assignment-test.js
@@ -65,6 +65,26 @@ describe( 'fetchExperimentAssignment', () => {
 		} );
 		await expect( fetchPromise ).rejects.toThrowError();
 	} );
+
+	it( 'should return .json response', async () => {
+		const data = {
+			variations: { woocommerce_test: null },
+			ttl: 60,
+			debug: { backend_aa_result: 'request not sampled' },
+		};
+		window.fetch.mockImplementation( () =>
+			Promise.resolve( {
+				json: () => Promise.resolve( data ),
+				status: 200,
+			} )
+		);
+
+		const assignment = await fetchExperimentAssignment( {
+			experimentName: 'woocommerce_test',
+			anonId: '1234',
+		} );
+		await expect( assignment ).toEqual( data );
+	} );
 } );
 
 describe( 'fetchExperimentAssignmentWithAuth', () => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the `Invalid FetchExperimentAssignmentResponse` error.

![Screen Shot 2022-06-15 at 09 16 50](https://user-images.githubusercontent.com/4344253/173715705-a75e11f2-786d-4739-9811-da31519ed96c.png)


### How to test the changes in this Pull Request:

1. Clear local experiment caches (`window.localStorage.clear()` or Go to `Application` tab to only clear experiment caches)
2. Open dev tools
3. Go to `Woocommerce > Home`
4. Observe the page is loaded without `[ExPlat]  Invalid FetchExperimentAssignmentResponse` errors

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
