### PR TITLE
Remove two-col task list experiments

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -49,16 +49,6 @@ const Tasks = lazy( () =>
 	} ) )
 );
 
-const TwoColumnTasks = lazy( () =>
-	import( /* webpackChunkName: "two-column-tasks" */ '../two-column-tasks' )
-);
-
-const TwoColumnTasksExtended = lazy( () =>
-	import(
-		/* webpackChunkName: "two-column-tasks-extended" */ '../two-column-tasks/extended-task'
-	)
-);
-
 export const Layout = ( {
 	defaultHomescreenLayout,
 	isBatchUpdating,
@@ -80,44 +70,8 @@ export const Layout = ( {
 	const isDashboardShown = ! query.task;
 	const activeSetupTaskList = useActiveSetupTasklist();
 
-	const {
-		isLoadingExperimentAssignment,
-		isLoadingTwoColExperimentAssignment,
-		experimentAssignment,
-		twoColExperimentAssignment,
-	} = {
-		isLoadingExperimentAssignment: false,
-		isLoadingTwoColExperimentAssignment: false,
-		experimentAssignment: null,
-		twoColExperimentAssignment: null,
-	};
-
-	const isRunningTwoColumnExperiment =
-		twoColExperimentAssignment?.variationName === 'treatment';
-
-	// New TaskList UI is enabled when either experiment is treatment.
-	const isRunningTaskListExperiment =
-		experimentAssignment?.variationName === 'treatment' ||
-		isRunningTwoColumnExperiment;
-
-	// Override defaultHomescreenLayout if store is in the experiment.
-	const defaultHomescreenLayoutOverride = () => {
-		if (
-			isLoadingExperimentAssignment ||
-			isLoadingTwoColExperimentAssignment
-		) {
-			return defaultHomescreenLayout; // Experiments are still loading, don't override.
-		}
-
-		if ( ! isRunningTaskListExperiment ) {
-			return defaultHomescreenLayout; // Not in the experiment, don't override.
-		}
-
-		return isRunningTwoColumnExperiment ? 'two_columns' : 'single_column';
-	};
-
 	const twoColumns =
-		( userPrefs.homepage_layout || defaultHomescreenLayoutOverride() ) ===
+		( userPrefs.homepage_layout || defaultHomescreenLayout ) ===
 			'two_columns' && hasTwoColumnContent;
 
 	if ( isBatchUpdating && ! showInbox ) {
@@ -144,23 +98,16 @@ export const Layout = ( {
 		return (
 			<>
 				<Column shouldStick={ shouldStickColumns }>
-					{ ! isLoadingExperimentAssignment &&
-						! isLoadingTwoColExperimentAssignment &&
-						! isRunningTaskListExperiment &&
-						! isLoadingTaskLists &&
-						! showingProgressHeader && (
-							<ActivityHeader
-								className="your-store-today"
-								title={ __(
-									'Your store today',
-									'woocommerce'
-								) }
-								subtitle={ __(
-									"To do's, tips, and insights for your business",
-									'woocommerce'
-								) }
-							/>
-						) }
+					{ ! isLoadingTaskLists && ! showingProgressHeader && (
+						<ActivityHeader
+							className="your-store-today"
+							title={ __( 'Your store today', 'woocommerce' ) }
+							subtitle={ __(
+								"To do's, tips, and insights for your business",
+								'woocommerce'
+							) }
+						/>
+					) }
 					{ <ActivityPanel /> }
 					{ hasTaskList && renderTaskList() }
 					<InboxPanel />
@@ -174,33 +121,6 @@ export const Layout = ( {
 	};
 
 	const renderTaskList = () => {
-		if ( twoColumns && isRunningTaskListExperiment ) {
-			return (
-				// When running the two-column experiment, we still need to render
-				// the component in the left column for the extended task list.
-				<Suspense fallback={ null }>
-					<TwoColumnTasksExtended query={ query } />
-				</Suspense>
-			);
-		} else if (
-			! twoColumns &&
-			isRunningTaskListExperiment &&
-			! isLoadingExperimentAssignment
-		) {
-			return (
-				<Suspense fallback={ null }>
-					<>
-						<TwoColumnTasks
-							query={ query }
-							userPreferences={ userPrefs }
-							twoColumns={ twoColumns }
-						/>
-						<TwoColumnTasksExtended query={ query } />
-					</>
-				</Suspense>
-			);
-		}
-
 		return (
 			<Suspense fallback={ <TasksPlaceholder query={ query } /> }>
 				{ activeSetupTaskList &&
@@ -215,15 +135,6 @@ export const Layout = ( {
 
 	return (
 		<>
-			{ twoColumns && isRunningTaskListExperiment && (
-				<Suspense fallback={ null }>
-					<TwoColumnTasks
-						query={ query }
-						userPreferences={ userPrefs }
-						twoColumns={ twoColumns }
-					/>
-				</Suspense>
-			) }
 			<div
 				className={ classnames( 'woocommerce-homescreen', {
 					'two-columns': twoColumns,

--- a/plugins/woocommerce/changelog/update-32415-remove-task-list-ui-experiments
+++ b/plugins/woocommerce/changelog/update-32415-remove-task-list-ui-experiments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Removed two-col task list expierments code


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32415 

This PR removes the two-col task list experiments code.

### How to test the changes in this Pull Request:

Not much to test, other than making sure the changes did not remove unrelated codes and the default task list works as expected.

Navigate to `WooCommerce -> Home` and make sure the default task list is rendered.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
