### PR TITLE
Update product task experiment names

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
@@ -8,8 +8,8 @@ type Layout = 'control' | 'card' | 'stacked';
 
 export const getProductLayoutExperiment = async (): Promise< Layout > => {
 	const [ cardAssignment, stackedAssignment ] = await Promise.all( [
-		loadExperimentAssignment( `woocommerce_products_task_layout_card` ),
-		loadExperimentAssignment( `woocommerce_products_task_layout_stacked` ),
+		loadExperimentAssignment( `woocommerce_products_task_layout_card_v2` ),
+		loadExperimentAssignment( `woocommerce_products_task_layout_stacked_v2` ),
 	] );
 	// This logic may look flawed as in both looks like they can be assigned treatment at the same time,
 	// but in backend we segment the experiments by store country, so it will never be.

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
@@ -9,7 +9,9 @@ type Layout = 'control' | 'card' | 'stacked';
 export const getProductLayoutExperiment = async (): Promise< Layout > => {
 	const [ cardAssignment, stackedAssignment ] = await Promise.all( [
 		loadExperimentAssignment( `woocommerce_products_task_layout_card_v2` ),
-		loadExperimentAssignment( `woocommerce_products_task_layout_stacked_v2` ),
+		loadExperimentAssignment(
+			`woocommerce_products_task_layout_stacked_v2`
+		),
 	] );
 	// This logic may look flawed as in both looks like they can be assigned treatment at the same time,
 	// but in backend we segment the experiments by store country, so it will never be.

--- a/plugins/woocommerce/changelog/tweak-update-product-task-experiment-names
+++ b/plugins/woocommerce/changelog/tweak-update-product-task-experiment-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update product task experiment names

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -368,8 +368,8 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			'woocommerce',
 			$allow_tracking
 		);
-		return $abtest->get_variation( 'woocommerce_products_task_layout_stacked' ) === 'treatment' ||
-			$abtest->get_variation( 'woocommerce_products_task_layout_card' ) === 'treatment';
+		return $abtest->get_variation( 'woocommerce_products_task_layout_stacked_v2' ) === 'treatment' ||
+			$abtest->get_variation( 'woocommerce_products_task_layout_card_v2' ) === 'treatment';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates product task experiment names due to the previous experiment had to be cancelled.

### How to test the changes in this Pull Request:

**Test using WCA Test helper**
1. Install and activate the latest [WooCommerce Test Helper plugin](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/tag/v0.7.5)
1. Navigate to **Tools > WCA Test Helper > Experiments** and add `woocommerce_products_task_layout_card_v2` to treatment
1. Make sure your site has woocommerce_allow_tracking option set to yes
1. Go to WooCommerce > Home > Add my products
2. Observe the experiment card screen

**Test using bookmarklet**
1. Navigate to **Tools > WCA Test Helper > Experiments** and delete `woocommerce_products_task_layout_card_v2` from treatment
2. Apply `woocommerce_products_task_layout_stacked_v2` treatment bookmarklet
1. Go to WooCommerce > Home > Add my products
2. Observe the experiment stacked screen

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
