### PR TITLE
Make sure payment gateway title is a string before sanitizing

### DIFF
--- a/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
+++ b/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure payment gateway title is a string before sanitizing

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -305,7 +305,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_title() {
-		$title = wc_get_container()->get( HtmlSanitizer::class )->sanitize( $this->title, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
+		$title = wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $this->title, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 		return apply_filters( 'woocommerce_gateway_title', $title, $this->id );
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -868,8 +868,8 @@ abstract class WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function validate_safe_text_field( string $key, string $value ): string {
-		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
+	public function validate_safe_text_field( string $key, $value ): string {
+		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -868,7 +868,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function validate_safe_text_field( string $key, $value ): string {
+	public function validate_safe_text_field( string $key, ?string $value ): string {
 		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR casts the gateway title to `string` before passing it through our new sanitizing methods to prevent possible fatal errors due to a type mismatch.
This seems very unlikely to happen (with only one gateway detected so far that is affected).

### How to test the changes in this Pull Request:

1. Check out the latest `trunk`.
2. Install and activate the ["Paytm Payments"](https://wordpress.org/plugins/paytm-payments/) plugin.
3. Go to WC > Settings > Payments.
4. You'll get a fatal error.
5. Check out this branch. 
6. No fatal error on WC > Settings > Payments.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
