### PR TITLE
[DO NOT MERGE] Example of detabbing the product data box

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -6,6 +6,7 @@
  *
  * @package  WooCommerce\Admin\Meta Boxes
  * @version  3.0.0
+ * @phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -34,17 +35,26 @@ class WC_Meta_Box_Product_Data {
 	}
 
 	/**
+	 * Output one tab
+	 *
+	 * @param String | Array $tab Either the path to the include file for the tab or an array with an 'include' parameter.
+	 */
+	private static function output_tab( $tab ) {
+		global $post, $thepostid, $product_object;
+		$tab_path = is_array( $tab ) ? $tab['include'] : $tab;
+
+		if ( ! empty( $tab_path ) && file_exists( $tab_path ) ) {
+			include $tab['include'];
+		}
+	}
+
+	/**
 	 * Show tab content/settings.
 	 */
 	private static function output_tabs() {
-		global $post, $thepostid, $product_object;
-
-		include __DIR__ . '/views/html-product-data-general.php';
-		include __DIR__ . '/views/html-product-data-inventory.php';
-		include __DIR__ . '/views/html-product-data-shipping.php';
-		include __DIR__ . '/views/html-product-data-linked-products.php';
-		include __DIR__ . '/views/html-product-data-attributes.php';
-		include __DIR__ . '/views/html-product-data-advanced.php';
+		foreach ( self::get_product_data_tabs() as $tab ) {
+			self::output_tab( $tab );
+		}
 	}
 
 	/**
@@ -88,30 +98,35 @@ class WC_Meta_Box_Product_Data {
 					'target'   => 'general_product_data',
 					'class'    => array( 'hide_if_grouped' ),
 					'priority' => 10,
+					'include' => __DIR__ . '/views/html-product-data-general.php',
 				),
 				'inventory'      => array(
 					'label'    => __( 'Inventory', 'woocommerce' ),
 					'target'   => 'inventory_product_data',
 					'class'    => array( 'show_if_simple', 'show_if_variable', 'show_if_grouped', 'show_if_external' ),
 					'priority' => 20,
+					'include' => __DIR__ . '/views/html-product-data-inventory.php',
 				),
 				'shipping'       => array(
 					'label'    => __( 'Shipping', 'woocommerce' ),
 					'target'   => 'shipping_product_data',
 					'class'    => array( 'hide_if_virtual', 'hide_if_grouped', 'hide_if_external' ),
 					'priority' => 30,
+					'include' => __DIR__ . '/views/html-product-data-shipping.php',
 				),
 				'linked_product' => array(
 					'label'    => __( 'Linked Products', 'woocommerce' ),
 					'target'   => 'linked_product_data',
 					'class'    => array(),
 					'priority' => 40,
+					'include' => __DIR__ . '/views/html-product-data-linked-products.php',
 				),
 				'attribute'      => array(
 					'label'    => __( 'Attributes', 'woocommerce' ),
 					'target'   => 'product_attributes',
 					'class'    => array(),
 					'priority' => 50,
+					'include' => __DIR__ . '/views/html-product-data-attributes.php',
 				),
 				'variations'     => array(
 					'label'    => __( 'Variations', 'woocommerce' ),
@@ -124,6 +139,7 @@ class WC_Meta_Box_Product_Data {
 					'target'   => 'advanced_product_data',
 					'class'    => array(),
 					'priority' => 70,
+					'include' => __DIR__ . '/views/html-product-data-advanced.php',
 				),
 			)
 		);

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -3,6 +3,7 @@
  * Product data meta box.
  *
  * @package WooCommerce\Admin
+ * @phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -37,21 +38,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</label>
 		<?php endforeach; ?>
 	</span>
+	
+	<?php if ( true ) : ?>
+		<dl class="product_data_cards wc-cards">
+			<?php foreach ( self::get_product_data_tabs() as $key => $tab_data ) : ?>
+				<dt class="clear <?php echo esc_attr( $key ); ?>_options_label <?php echo esc_attr( $key ); ?>_card_label <?php echo esc_attr( isset( $tab_data['class'] ) ? implode( ' ', (array) $tab_data['class'] ) : '' ); ?>">
+					<span><?php echo esc_html( $tab_data['label'] ); ?></span>
+				</dt>
+				<dd class="<?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_card <?php echo esc_attr( isset( $tab_data['class'] ) ? implode( ' ', (array) $tab_data['class'] ) : '' ); ?>">
+					<?php self::output_tab( $tab_data ); ?>
+				</dd>
+			<?php endforeach; ?>
+		</dl>
+	<?php else : ?>
+		<ul class="product_data_tabs wc-tabs">
+			<?php foreach ( self::get_product_data_tabs() as $key => $tab_data ) : ?>
+				<li class="<?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_tab <?php echo esc_attr( isset( $tab_data['class'] ) ? implode( ' ', (array) $tab_data['class'] ) : '' ); ?>">
+					<a href="#<?php echo esc_attr( $tab_data['target'] ); ?>"><span><?php echo esc_html( $tab_data['label'] ); ?></span></a>
+				</li>
+			<?php endforeach; ?>
+			<?php do_action( 'woocommerce_product_write_panel_tabs' ); ?>
+		</ul>
 
-	<ul class="product_data_tabs wc-tabs">
-		<?php foreach ( self::get_product_data_tabs() as $key => $tab ) : ?>
-			<li class="<?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_tab <?php echo esc_attr( isset( $tab['class'] ) ? implode( ' ', (array) $tab['class'] ) : '' ); ?>">
-				<a href="#<?php echo esc_attr( $tab['target'] ); ?>"><span><?php echo esc_html( $tab['label'] ); ?></span></a>
-			</li>
-		<?php endforeach; ?>
-		<?php do_action( 'woocommerce_product_write_panel_tabs' ); ?>
-	</ul>
-
-	<?php
-		self::output_tabs();
-		self::output_variations();
-		do_action( 'woocommerce_product_data_panels' );
-		wc_do_deprecated_action( 'woocommerce_product_write_panels', array(), '2.6', 'Use woocommerce_product_data_panels action instead.' );
-	?>
+		<?php
+			self::output_tabs();
+			self::output_variations();
+			do_action( 'woocommerce_product_data_panels' );
+			wc_do_deprecated_action( 'woocommerce_product_write_panels', array(), '2.6', 'Use woocommerce_product_data_panels action instead.' );
+		?>
+	<?php endif; ?>
 	<div class="clear"></div>
 </div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -45,11 +45,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<dt class="clear <?php echo esc_attr( $key ); ?>_options_label <?php echo esc_attr( $key ); ?>_card_label <?php echo esc_attr( isset( $tab_data['class'] ) ? implode( ' ', (array) $tab_data['class'] ) : '' ); ?>">
 					<span><?php echo esc_html( $tab_data['label'] ); ?></span>
 				</dt>
-				<dd class="<?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_card <?php echo esc_attr( isset( $tab_data['class'] ) ? implode( ' ', (array) $tab_data['class'] ) : '' ); ?>">
+				<dd class="card <?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_card <?php echo esc_attr( isset( $tab_data['class'] ) ? implode( ' ', (array) $tab_data['class'] ) : '' ); ?>">
 					<?php self::output_tab( $tab_data ); ?>
 				</dd>
 			<?php endforeach; ?>
 		</dl>
+		<script type="text/javascript">
+			for (let hiddenCard of document.querySelectorAll( '.product_data_cards .card > .hidden' ) ) {
+				hiddenCard.classList.remove( 'hidden' );
+			}
+		</script>
 	<?php else : ?>
 		<ul class="product_data_tabs wc-tabs">
 			<?php foreach ( self::get_product_data_tabs() as $key => $tab_data ) : ?>


### PR DESCRIPTION
Compare and contrast with the mostly-css approach in @joshuatf 's PR #33409 .

This is a PHP-first stab at flattening out the tabs from the product data meta box. It's not polished, or even done (it totally ignores hooks!), but it's a sketch.

As I see it, the pros of a php-first approach are mostly about consistency for developers, e.g. we probably shouldn't keep calling things "tabs" and then make a bunch of display-layer changes that cause them to behave in a non-tab-like* manner. The cons are obvious: it dramatically increases the surface area where extensions and edge cases can break the page.

*: We shouldn't call them "cards" either; that also implies they won't all be visible.

