### PR TITLE
Fix product tour TypeError when reading innerHTML

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tour/use-product-step-change.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tour/use-product-step-change.ts
@@ -22,14 +22,15 @@ const getInputValue = ( id: string ) => {
 };
 
 const getTinyMceValue = ( id: string ) => {
-	const iframe = document.querySelector( id ) as HTMLIFrameElement;
-	return ( iframe?.contentWindow?.document.querySelector(
+	const iframe = document.querySelector< HTMLIFrameElement >( id );
+	const tinymce = iframe?.contentWindow?.document.querySelector< HTMLElement >(
 		'#tinymce'
-	) as HTMLElement ).innerHTML;
+	);
+	return tinymce?.innerHTML || '';
 };
 
 const getTextareaValue = ( id: string ) => {
-	return ( document.querySelector( id ) as HTMLTextAreaElement ).value;
+	return document.querySelector< HTMLTextAreaElement >( id )?.value || '';
 };
 
 const getProductDescriptionValue = ( isContentEditorTmceActive: boolean ) => {
@@ -48,29 +49,28 @@ const getProductShortDescriptionValue = (
 
 const getProductImageValue = () => {
 	return (
-		( document.querySelector(
-			'#set-post-thumbnail img'
-		) as HTMLImageElement )?.src || ''
+		document.querySelector< HTMLImageElement >( '#set-post-thumbnail img' )
+			?.src || ''
 	);
 };
 
 // Parses categories into a string of true/false. Should be enough to catch any change.
 const getProductCategoriesValue = () => {
 	return Array.from(
-		document.querySelectorAll(
+		document.querySelectorAll< HTMLInputElement >(
 			'#product_cat-all #product_catchecklist input'
 		)
 	)
-		.map( ( x ) => ( x as HTMLInputElement ).checked )
+		.map( ( x ) => x.checked )
 		.join( ',' );
 };
 
 // Parses all tags as string of tags separated by comma.
 const getProductTagsValue = () => {
-	return Array.from( document.querySelectorAll( '#product_tag li' ) )
-		.map(
-			( x ) => ( ( x as HTMLLIElement ).lastChild as Text ).textContent
-		)
+	return Array.from(
+		document.querySelectorAll< HTMLLIElement >( '#product_tag li' )
+	)
+		.map( ( x ) => ( x.lastChild as Text ).textContent )
 		.join( ',' );
 };
 
@@ -87,7 +87,6 @@ export const useProductStepChange = () => {
 	const { isTmce: isExcerptEditorTmceActive } = useActiveEditorType( {
 		editorWrapSelector: '#wp-excerpt-wrap',
 	} );
-
 	const [ initialValues, setInitialValues ] = useState<
 		Partial< Record< ProductTourStepName, string > >
 	>( {} );

--- a/plugins/woocommerce/changelog/fix-tour-kit-undefined-error
+++ b/plugins/woocommerce/changelog/fix-tour-kit-undefined-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product tour TypeError when reading innerHTML


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a Uncaught TypeError:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'innerHTML')
    at getTinyMceValue (product-tour.js?ver=6.7.0:93:220)
```

It seems that `#tinymce` is loaded after we call `getTinyMceValue`. This only happens

- when a user uses the text editor by default
- the first time that a user switches editor to TinyMce



I think a way to fix it is to use MutationObserver, but I don't think it's worth it. So just check the type and return an empty string if it's undefined.

I also changed all `document.querySelector... as ...;` to `document.querySelector<...>` to avoid null exceptions.


### How to test the changes in this Pull Request:

1. Install and activate [WCA Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/download/v0.7.6/woocommerce-admin-test-helper.zip)
2. Go to Tools > WCA Test Helper > Features
3. Enable `experimental-product-tour`
4. Go to Tools > WCA Test Helper > Experiments
5. Add `woocommerce_products_tour` to treatment
6. Go to WooCommerce > Home > Add my products > Start with a template > Physical product
7. Observe that spotlight tour is displayed and dismiss it.
9. Switch to the **text** tab for product description
10. Reload the page
11. Observe that spotlight tour is displayed again
12. Click "next" button
13. Switch to the **Visual** tab
14. Observe that the spotlight tour is still shown and no typeError in dev tools.

 
### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
