### PR TITLE
Remove obselete experiment calls

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/stats-overview/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/stats-overview/index.js
@@ -16,7 +16,6 @@ import { useUserPreferences, PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
-import { Experiment } from '@woocommerce/explat';
 
 /**
  * Internal dependencies
@@ -34,6 +33,12 @@ const { performanceIndicators = [] } = getAdminSetting( 'dataEndpoints', {
 const stats = performanceIndicators.filter( ( indicator ) => {
 	return DEFAULT_STATS.includes( indicator.stat );
 } );
+
+const HeaderText = () => (
+	<Text variant="title.small" size="20" lineHeight="28px">
+		{ __( 'Stats overview', 'woocommerce' ) }
+	</Text>
+);
 
 export const StatsOverview = () => {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
@@ -65,24 +70,13 @@ export const StatsOverview = () => {
 		( item ) => ! hiddenStats.includes( item.stat )
 	);
 
-	const HeaderText = (
-		<Text variant="title.small" size="20" lineHeight="28px">
-			{ __( 'Stats overview', 'woocommerce' ) }
-		</Text>
-	);
-
 	return (
 		<Card
 			size="large"
 			className="woocommerce-stats-overview woocommerce-homescreen-card"
 		>
 			<CardHeader size="medium">
-				<Experiment
-					name="woocommerce_test_experiment"
-					defaultExperience={ HeaderText }
-					treatmentExperience={ HeaderText }
-					loadingExperience={ HeaderText }
-				/>
+				<HeaderText />
 				<EllipsisMenu
 					label={ __(
 						'Choose which values to display',

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { MenuGroup, MenuItem } from '@wordpress/components';
 import { check } from '@wordpress/icons';
-import { Fragment, useEffect, useState } from '@wordpress/element';
+import { Fragment, useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	ONBOARDING_STORE_NAME,
@@ -13,7 +13,6 @@ import {
 	TaskType,
 	WCDataSelector,
 } from '@woocommerce/data';
-import { useExperiment } from '@woocommerce/explat';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -64,9 +63,6 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
-		'woocommerce_tasklist_progression'
-	);
 
 	const { isResolving, taskLists } = useSelect(
 		( select: WCDataSelector ) => {
@@ -144,17 +140,11 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		);
 	}
 
-	if ( isLoadingExperiment ) {
-		return <TaskListPlaceholderComponent query={ query } />;
-	}
-
 	return (
 		<>
 			{ taskLists
-				.filter( ( { id }: TaskListType ) =>
-					experimentAssignment?.variationName === 'treatment'
-						? id.endsWith( 'two_column' )
-						: ! id.endsWith( 'two_column' )
+				.filter(
+					( { id }: TaskListType ) => ! id.endsWith( 'two_column' )
 				)
 				.filter( ( { isVisible }: TaskListType ) => isVisible )
 				.map( ( taskList: TaskListType ) => {
@@ -164,10 +154,7 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 					return (
 						<Fragment key={ id }>
 							<TaskListComponent
-								isExpandable={
-									experimentAssignment?.variationName ===
-									'treatment'
-								}
+								isExpandable={ false }
 								query={ query }
 								twoColumns={ false }
 								{ ...taskList }

--- a/plugins/woocommerce-admin/client/tasks/test/tasks.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/tasks.test.tsx
@@ -75,10 +75,6 @@ describe( 'Task', () => {
 				{ id: 'extended', isVisible: true, tasks: [] },
 			],
 		} ) );
-		( useExperiment as jest.Mock ).mockImplementation( () => [
-			false,
-			'control',
-		] );
 	} );
 
 	afterEach( () => {
@@ -125,19 +121,6 @@ describe( 'Task', () => {
 		( useSelect as jest.Mock ).mockImplementation( () => ( {
 			isResolving: true,
 		} ) );
-		const { queryByText } = render(
-			<div>
-				<Tasks query={ {} } />
-			</div>
-		);
-		expect( queryByText( 'task-placeholder' ) ).toBeInTheDocument();
-	} );
-
-	it( 'should render the placeholder if isLoadingExperiment is true', () => {
-		( useExperiment as jest.Mock ).mockImplementation( () => [
-			true,
-			'control',
-		] );
 		const { queryByText } = render(
 			<div>
 				<Tasks query={ {} } />


### PR DESCRIPTION
Closes #33429.

Removes obsolete experiments and defaults to control experience.

### How to test the changes in this Pull Request:

1. Make sure homescreen renders properly. To be specific, the tasklist and "Stats overview" components.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
