### PR TITLE
Updated @automattic/tour-kit to 1.1.1 which has live resize functionality

### DIFF
--- a/packages/js/components/changelog/add-tour-kit-live-resize
+++ b/packages/js/components/changelog/add-tour-kit-live-resize
@@ -1,0 +1,4 @@
+Significance: minor 
+Type: add
+
+Updated @automattic/tour-kit to 1.1.1 which has live resize functionality 

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "^2.1.1",
 		"@automattic/interpolate-components": "^1.2.0",
-		"@automattic/tour-kit": "^1.0.0",
+		"@automattic/tour-kit": "^1.1.1",
 		"@woocommerce/csv-export": "workspace:*",
 		"@woocommerce/currency": "workspace:*",
 		"@woocommerce/data": "workspace:*",

--- a/packages/js/components/src/tour-kit/index.tsx
+++ b/packages/js/components/src/tour-kit/index.tsx
@@ -3,7 +3,7 @@
  */
 
 import { createElement } from '@wordpress/element';
-import TourKit, { TourStepRenderer } from '@automattic/tour-kit';
+import TourKit, { TourStepRenderer, Options } from '@automattic/tour-kit';
 
 /**
  * Internal dependencies
@@ -15,8 +15,18 @@ interface Props {
 	config: WooConfig;
 }
 
-const defaultOptions = {
-	effects: { spotlight: {}, arrowIndicator: true },
+const defaultOptions: Options = {
+	effects: {
+		spotlight: {
+			interactivity: { enabled: true, rootElementSelector: '#wpwrap' },
+		},
+		arrowIndicator: true,
+		liveResize: {
+			mutation: true,
+			resize: true,
+			rootElementSelector: '#wpwrap',
+		},
+	},
 };
 
 const WooTourKit: React.FunctionComponent< Props > = ( { config } ) => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tour/index.tsx
@@ -48,6 +48,11 @@ const getTourConfig = ( {
 					behavior: 'auto',
 					block: 'center',
 				},
+				liveResize: {
+					mutation: true,
+					resize: true,
+					rootElementSelector: '#wpwrap',
+				},
 			},
 			popperModifiers: [
 				{

--- a/plugins/woocommerce/changelog/add-tour-kit-live-resize
+++ b/plugins/woocommerce/changelog/add-tour-kit-live-resize
@@ -1,0 +1,4 @@
+Significance: minor 
+Type: add
+
+Updated @automattic/tour-kit to 1.1.1 which has live resize functionality 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
     specifiers:
       '@automattic/calypso-color-schemes': ^2.1.1
       '@automattic/interpolate-components': ^1.2.0
-      '@automattic/tour-kit': ^1.0.0
+      '@automattic/tour-kit': ^1.1.1
       '@babel/core': ^7.17.5
       '@babel/runtime': ^7.17.2
       '@storybook/addon-actions': ^6.4.0
@@ -280,7 +280,7 @@ importers:
     dependencies:
       '@automattic/calypso-color-schemes': 2.1.1
       '@automattic/interpolate-components': 1.2.1
-      '@automattic/tour-kit': 1.0.0_535ee2ac29d7af3b13ff2600d9b8992f
+      '@automattic/tour-kit': 1.1.1_535ee2ac29d7af3b13ff2600d9b8992f
       '@woocommerce/csv-export': link:../csv-export
       '@woocommerce/currency': link:../currency
       '@woocommerce/data': link:../data
@@ -1945,8 +1945,8 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /@automattic/tour-kit/1.0.0_535ee2ac29d7af3b13ff2600d9b8992f:
-    resolution: {integrity: sha512-md3VLtvCMR8lMqKJ+JH4YDQnN9VA5acCUGxeMWyyledu06cBU/Ki2Gyw3XTPz0IRO78n4dXFpFHR4sezfHDJcA==}
+  /@automattic/tour-kit/1.1.1_535ee2ac29d7af3b13ff2600d9b8992f:
+    resolution: {integrity: sha512-qC15YGZZW5VUhvl47y9C+aN0q0QIejP9g9pFZ9M3PRRgaZcXx00+ZrL1Ngg0+V9eS5io5OZcji3D8OU6i48t/w==}
     peerDependencies:
       '@wordpress/data': ^6.1.5
       react: ^17.0.2
@@ -1968,6 +1968,7 @@ packages:
       '@wordpress/primitives': 3.8.0
       '@wordpress/react-i18n': 3.8.0
       classnames: 2.3.1
+      debug: 4.3.4
       react-popper: 2.2.5_@popperjs+core@2.11.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -12703,6 +12704,7 @@ packages:
       re-resizable: 4.11.0
     transitivePeerDependencies:
       - react
+      - react-dom
     dev: true
 
   /@types/wordpress__compose/4.0.1:
@@ -25159,7 +25161,7 @@ packages:
       '@automattic/interpolate-components': 1.2.1
       '@babel/runtime': 7.17.7
       '@tannin/sprintf': 1.2.0
-      '@wordpress/compose': 5.2.1
+      '@wordpress/compose': 5.8.0
       debug: 4.3.4
       events: 3.3.0
       hash.js: 1.1.7
@@ -25180,7 +25182,7 @@ packages:
       '@automattic/interpolate-components': 1.2.1_react@17.0.2
       '@babel/runtime': 7.17.7
       '@tannin/sprintf': 1.2.0
-      '@wordpress/compose': 5.2.1_react@17.0.2
+      '@wordpress/compose': 5.8.0_react@17.0.2
       debug: 4.3.4
       events: 3.3.0
       hash.js: 1.1.7
@@ -25993,7 +25995,7 @@ packages:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
 
   /isarray/2.0.1:
-    resolution: {integrity: sha512-c2cu3UxbI+b6kR3fy0nRnAhodsvR9dx7U5+znCOzdj6IfP3upFURTr0Xl5BlQZNKZjEtxrmVyfSdeE3O57smoQ==}
+    resolution: {integrity: sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=}
     dev: false
 
   /isarray/2.0.5:
@@ -34986,7 +34988,7 @@ packages:
     dev: true
 
   /seed-random/2.2.0:
-    resolution: {integrity: sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=}
+    resolution: {integrity: sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==}
     dev: false
 
   /select/1.1.2:
@@ -36805,7 +36807,7 @@ packages:
     dev: true
 
   /through/2.3.8:
-    resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   /through2/2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -37825,7 +37827,7 @@ packages:
     dev: true
 
   /uppercamelcase/1.1.0:
-    resolution: {integrity: sha1-Mk2YprOvx+iolT4QZBUJsOTiP5c=}
+    resolution: {integrity: sha512-C7YEMvhgrvTEKEEVqA7LXNID/1TvvIwYZqNIKLquS6y/MGSkRQAav9LnTTILlC1RqUM8eTVBOe1U/fnB652PRA==}
     dependencies:
       camelcase: 1.2.1
     dev: false
@@ -39034,7 +39036,7 @@ packages:
     dev: true
 
   /wp-error/1.3.0:
-    resolution: {integrity: sha1-cgJHqjJkJJkcWHdcsv7cm/2IVCA=}
+    resolution: {integrity: sha512-6Mn8fIBgWYgKJveRpB5oR+T9JEXxUawq5Om35ZE0yvCh5p3SQ+2OCH+KH39k0ZMxvNh9CI7LyfihtQH6itHbdQ==}
     dependencies:
       builtin-status-codes: 2.0.0
       uppercamelcase: 1.1.0
@@ -39242,7 +39244,7 @@ packages:
     dev: false
 
   /xmlhttprequest-ssl/1.5.5:
-    resolution: {integrity: sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=}
+    resolution: {integrity: sha512-/bFPLUgJrfGUL10AIv4Y7/CUt6so9CLtB/oFxQSHseSDNNCdC6vwwKEqwLN6wNPBg9YWXAiMu8jkf6RPRS/75Q==}
     engines: {node: '>=0.4.0'}
     dev: false
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds live resize functionality to the tour kit spotlight so that it follows the referenced element even when it moves or resizes.

### How to test the changes in this Pull Request:
Same as https://github.com/woocommerce/woocommerce/pull/33268

1. Install and activate [WCA Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/download/v0.7.6/woocommerce-admin-test-helper.zip)
1. Go to Tools > WCA Test Helper > Features
2. Enable `experimental-product-tour`
1. Go to Tools > WCA Test Helper > Experiments
1. Add `woocommerce_products_tour` to treatment
1. Go to WooCommerce > Home
1. Click on "Add My Products" > Start with a template
3. Select physical products and click "Go"
4. Click Next button
5. Observe the spotlight feature as per recording

https://user-images.githubusercontent.com/27843274/174014964-983b908b-8482-4852-ba73-da6c2e808780.mp4

Notice that at the start of the recording I insert an element before the spotlit input field and the spotlight moves along with it. Previously that would not have updated. This also applies to notices that show up after the page has loaded.

The snippet I used to add a `<p>` element before the spotlit element looks like this:
`document.querySelector("input.wp-tour-kit-spotlit").parentElement.insertBefore(document.createElement("p", "a"), document.querySelector("input.wp-tour-kit-spotlit"))`


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
