### PR TITLE
Convert null and '' to 0 before verification.

### DIFF
--- a/plugins/woocommerce/changelog/fix-33147
+++ b/plugins/woocommerce/changelog/fix-33147
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Convert null and '' to 0 before verification to mimic $wpdb->prepare.

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -563,7 +563,7 @@ WHERE
 	private function validate_data( $value, string $type ) {
 		switch ( $type ) {
 			case 'decimal':
-				$value = (float) $value;
+				$value = wc_format_decimal( $value, false, true );
 				break;
 			case 'int':
 				$value = (int) $value;
@@ -778,6 +778,9 @@ WHERE $where_clause
 	 */
 	private function pre_process_row( $row, $schema, $alias, $destination_alias ) {
 		if ( in_array( $schema['type'], array( 'int', 'decimal' ), true ) ) {
+			if ( '' === $row[ $alias ] || null === $row[ $alias ] ) {
+				$row[ $alias ] = 0; // $wpdb->prepare forces empty values to 0.
+			}
 			$row[ $alias ]             = wc_format_decimal( $row[ $alias ], false, true );
 			$row[ $destination_alias ] = wc_format_decimal( $row[ $destination_alias ], false, true );
 		}

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
@@ -726,4 +726,22 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		return $wpdb_mock;
 	}
+
+	/**
+	 * Test that orders are migrated and verified without errors.
+	 */
+	public function test_verify_migrated_orders() {
+		$order = wc_get_order( OrderHelper::create_complex_wp_post_order() );
+		$this->clear_all_orders();
+
+		// Additional test to assert null values are converted properly.
+		delete_post_meta( $order->get_id(), '_cart_discount_tax' );
+
+		$this->assertEquals( '', get_post_meta( $order->get_id(), '_cart_discount_tax', true ) );
+
+		$this->sut->migrate_order( $order->get_id() );
+		$errors = $this->sut->verify_migrated_orders( array( $order->get_id() ) );
+
+		$this->assertEmpty( $errors );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During migration $wpdb->prepare would force null and empty values to be zero for %f placeholder. This was causing verification logic to fail, which is being addressed in this commit.

The alternative was to insert null values without running them via $wpdb->prepare, but that seemed less safer than converting to zero because it would have to done manually since $wpdb->prepare wouldn't support it.

Closes #33147 .

### How to test the changes in this Pull Request:

1. Drop and recreate custom order tables by going to WooCommerce > Status > Tools.
2. For any order, drop the meta value `_cart_discount_tax`, either directly, or by using `delete_post_meta( $order_id(), '_cart_discount_tax' );`
3. Run the migration and then verification via CLI. Check that there are no errors.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
