### PR TITLE
[redux] Coerce variable type of form field argument 'class' in woocommerce_form_field()

### DIFF
--- a/plugins/woocommerce/changelog/hahn208-master
+++ b/plugins/woocommerce/changelog/hahn208-master
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Allow strings to be passed as 'class' arg to '`woocommerce_form_field()`

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2760,6 +2760,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		$args = wp_parse_args( $args, $defaults );
 		$args = apply_filters( 'woocommerce_form_field_args', $args, $key, $value );
 
+		if ( is_string( $args['class'] ) ) {
+			$args['class'] = array( $args['class'] );
+		}
+
 		if ( $args['required'] ) {
 			$args['class'][] = 'validate-required';
 			$required        = '&nbsp;<abbr class="required" title="' . esc_attr__( 'required', 'woocommerce' ) . '">*</abbr>';


### PR DESCRIPTION
Originally submitted in #28730. Submitting again because the original fork is no longer available.

> ### All Submissions:
> 
> * [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
> * [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
> * [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
> 
> ### Changes proposed in this Pull Request:
> 
> If a non-array value (eg empty string) is supplied as the `class` in the arguments collection a fatal error is thrown. Other arguments in the `woocommerce_form_field` method have the type validated (eg label_class), so it makes sense to do a check on the class property as well.
> 
> ### How to test the changes in this Pull Request:
> 
> Add the following code as a theme or plugin snippet:
> ```
> add_filter(
>   'woocommerce_form_field_args' ,
>   function($args, $key, $value)
>   {
>     $args['class'] = 'my-class';
>     return $args;
>   },
>   10,
>   3
> );
> ```
> At current, the filter will result in the following error when $args['required'] is true:
> PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /woocommerce/includes/wc-template-functions.php:2688
> 
> ### Other information:
> 
> * [x] Have you added an explanation of what your changes do and why you'd like us to include them?
> * [x] Have you written new tests for your changes, as applicable?
> * [x] Have you successfully run tests with your changes locally?
> 
> ### Changelog entry
> 
> Coerced variable type of form field argument 'class' from String to Array in woocommerce_form_field()
