### PR TITLE
[HACK week] Introduce experimental GraphQL and API endpoints for orders using COT

### DIFF
--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,6 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"psr/container": "1.0.0",
+		"webonyx/graphql-php": "^14.11",
 		"woocommerce/action-scheduler": "3.4.2",
 		"woocommerce/woocommerce-blocks": "7.6.0"
 	},

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac7396bfc3fa1d5a6f4d471c15f8a417",
+    "content-hash": "48993dce7d18468188f8089d1ac29ba2",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -638,6 +638,72 @@
                 }
             ],
             "time": "2022-03-04T08:16:47+00:00"
+        },
+        {
+            "name": "webonyx/graphql-php",
+            "version": "v14.11.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webonyx/graphql-php.git",
+                "reference": "6070542725b61fc7d0654a8a9855303e5e157434"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/6070542725b61fc7d0654a8a9855303e5e157434",
+                "reference": "6070542725b61fc7d0654a8a9855303e5e157434",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.3",
+                "doctrine/coding-standard": "^6.0",
+                "nyholm/psr7": "^1.2",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "0.12.82",
+                "phpstan/phpstan-phpunit": "0.12.18",
+                "phpstan/phpstan-strict-rules": "0.12.9",
+                "phpunit/phpunit": "^7.2 || ^8.5",
+                "psr/http-message": "^1.0",
+                "react/promise": "2.*",
+                "simpod/php-coveralls-mirror": "^3.0",
+                "squizlabs/php_codesniffer": "3.5.4"
+            },
+            "suggest": {
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "issues": "https://github.com/webonyx/graphql-php/issues",
+                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.6"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-04-13T16:25:32+00:00"
         },
         {
             "name": "woocommerce/action-scheduler",
@@ -3021,5 +3087,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/plugins/woocommerce/includes/class-wc-rest-authentication.php
+++ b/plugins/woocommerce/includes/class-wc-rest-authentication.php
@@ -556,6 +556,10 @@ class WC_REST_Authentication {
 	private function check_permissions( $method ) {
 		$permissions = $this->user->permissions;
 
+		if( $this->is_graphql_request() ) {
+			return 'POST' === $method;
+		}
+
 		switch ( $method ) {
 			case 'HEAD':
 			case 'GET':
@@ -579,6 +583,16 @@ class WC_REST_Authentication {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Is the current request a GraphQL API request?
+	 *
+	 * @return bool True if the current request is a GraphQL API request.
+	 */
+	private function is_graphql_request()
+	{
+		return StringUtil::ends_with( $_SERVER['PHP_SELF'], '/wc/v4/graphql' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DownloadPermissionsAdjuster;
+use Automattic\WooCommerce\Internal\GraphQL\GraphQLController;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as ProductDownloadDirectories;
@@ -227,6 +228,7 @@ final class WooCommerce {
 		wc_get_container()->get( RestockRefundedItemsAdjuster::class );
 		wc_get_container()->get( CustomOrdersTableController::class );
 		wc_get_container()->get( OptionSanitizer::class );
+		wc_get_container()->get( GraphQLController::class )->initialize();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -26,6 +26,21 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	protected $namespace = 'wc/v3';
 
 	/**
+	 * Retrieve an order by id, and display the execution time.
+	 *
+	 * @param int $id Id of the order to retrieve.
+	 * @return WP_Error|WP_REST_Response The retrieved order, or an error.
+	 */
+	public function get_order( int $id ) {
+		$start   = hrtime( true );
+		$result  = $this->get_item( array( 'id' => $id, 'context' => null, 'dp' => null ) );
+		$end     = hrtime( true );
+		$elapsed = ( $end - $start ) / 1e6;
+		echo "Time: $elapsed ms\n";
+		return $result;
+	}
+
+	/**
 	 * Calculate coupons.
 	 *
 	 * @throws WC_REST_Exception When fails to set any item.

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ExtendedContainer;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\COTMigrationServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\DownloadPermissionsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\AssignDefaultCategoryServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\GraphQLServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OrdersDataStoreServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OptionSanitizerServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ProductAttributesLookupServiceProvider;
@@ -53,6 +54,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 		RestockRefundedItemsAdjusterServiceProvider::class,
 		UtilsClassesServiceProvider::class,
 		COTMigrationServiceProvider::class,
+		GraphQLServiceProvider::class
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/GraphQLServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/GraphQLServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+use Automattic\WooCommerce\Internal\GraphQL\DateTimeType;
+use Automattic\WooCommerce\Internal\GraphQL\GraphQLController;
+use Automattic\WooCommerce\Internal\GraphQL\OrderAddressType;
+use Automattic\WooCommerce\Internal\GraphQL\OrderAddressTypeType;
+use Automattic\WooCommerce\Internal\GraphQL\OrderRetriever;
+use Automattic\WooCommerce\Internal\GraphQL\OrderType;
+use Automattic\WooCommerce\Internal\GraphQL\RootQueryType;
+
+/**
+ * Service provider for the classes in the Automattic\WooCommerce\Internal\GraphQL namespace.
+ */
+class GraphQLServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The classes/interfaces that are serviced by this service provider.
+	 *
+	 * @var array
+	 */
+	protected $provides = array(
+		GraphQLController::class,
+		OrderRetriever::class,
+		RootQueryType::class,
+		OrderType::class,
+		OrderAddressType::class,
+		OrderAddressTypeType::class,
+		DateTimeType::class
+	);
+
+	/**
+	 * Register the classes.
+	 */
+	public function register() {
+		$this->share( GraphQLController::class );
+		$this->share( OrderRetriever::class );
+		$this->share( RootQueryType::class );
+		$this->share( OrderType::class );
+		$this->share( OrderAddressType::class );
+		$this->share( OrderAddressTypeType::class );
+		$this->share( DateTimeType::class );
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/DateTimeType.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/DateTimeType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\ScalarType;
+
+/**
+ * Class to represent an ISO date and time as a GraphQL scalar type.
+ * Assumes that the dates are already represented in ISO format in the database,
+ * except that the 'T' is replaced with a space.
+ */
+class DateTimeType extends ScalarType {
+
+	public function serialize( $value ) {
+		return str_replace( ' ', 'T', $value );
+	}
+
+	public function parseValue( $value ) {
+		return str_replace( 'T', ' ', $value );
+	}
+
+	public function parseLiteral( Node $valueNode, ?array $variables = null ) {
+		if ( ! $valueNode instanceof StringValueNode ) {
+			throw new \Exception( 'Query error: Can only parse strings got: ' . $valueNode->kind, array( $valueNode ) );
+		}
+
+		return $valueNode->value;
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/GraphQLController.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/GraphQLController.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+use GraphQL\Executor\ExecutionResult;
+use GraphQL\GraphQL;
+use GraphQL\Language\Parser;
+use GraphQL\Language\Source;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Schema;
+use GraphQL\Validator\DocumentValidator;
+
+/**
+ * Main class to handle GraphQL requests  and execute GraphQL queries.
+ */
+class GraphQLController {
+
+	private static $container;
+
+	/**
+	 * Initialize the class, registering the API endpoints.
+	 *
+	 * @return void
+	 */
+	public function initialize() {
+		self::$container = wc_get_container();
+
+		add_action(
+			'rest_api_init',
+			function () {
+				register_rest_route(
+					'wc/v4',
+					'graphql',
+					array(
+						'methods'             => 'POST',
+						'callback'            => function( $request ) {
+							return self::handle_graphql_request( $request );
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				register_rest_route(
+					'wc/v4',
+					'orders/(?P<id>\d+)',
+					array(
+						'methods'             => 'GET',
+						'callback'            => function( $request ) {
+							return wc_get_container()->get( OrderRetriever::class )->retrieve_order( $request['id'] );
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+
+				register_rest_route(
+					'wc/v4',
+					'orders/(?P<order_id>\d+)/address/(?P<type>\w+)',
+					array(
+						'methods'             => 'GET',
+						'callback'            => function( $request ) {
+							return wc_get_container()->get( OrderRetriever::class )->retrieve_address( $request['order_id'], $request['type'] );
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Handle a GraphQL HTTP request.
+	 *
+	 * @param \WP_REST_Request $request The request to handle.
+	 * @return ExecutionResult|\WP_Error The request result or an error.
+	 */
+	private static function handle_graphql_request( \WP_REST_Request $request ) {
+		$input = json_decode( $request->get_body(), true );
+
+		$query           = $input['query'];
+		$variable_values = $input['variables'] ?? null;
+
+		$schema = new Schema(
+			array(
+				'query'      => self::$container->get( RootQueryType::class ),
+				'typeLoader' => function( $name ) {
+					return self::resolve_type( $name );
+				},
+			)
+		);
+
+		// The built-in field resolver takes in account both objects and arrays,
+		// this is a simplified version that handles arrays only.
+		$field_resolver = function( $objectValue, array $args, $context, ResolveInfo $info ) {
+			return $objectValue[ $info->fieldName ];
+		};
+
+		return GraphQL::executeQuery( $schema, $query, null, null, $variable_values, null, $field_resolver );
+	}
+
+	/**
+	 * Convert a GraphQL type into a full class name.
+	 *
+	 * @param string $name The GraphQL type name.
+	 * @return string The resulting full class name.
+	 * @throws \Exception Unknown type.
+	 */
+	public static function resolve_type( $name ) {
+		$full_name = __NAMESPACE__ . '\\' . $name . 'Type';
+		if ( self::$container->has( $full_name ) ) {
+			return self::$container->get( $full_name );
+		}
+
+		throw new \Exception( "There's no way to resolve the type '" . $name . "'." );
+	}
+
+	/**
+	 * Execute a GraphQL query displaying execution times.
+	 *
+	 * @param string $query The query to execute.
+	 * @param bool   $use_query_cache If true, use query caching.
+	 * @param bool   $force_query_caching If this and $use_query_cache are true, always assume the query isn't cached.
+	 * @return ExecutionResult The result of executing the query.
+	 * @throws \Exception Query execution failed.
+	 */
+	public static function execute_graphql_verbose( string $query, bool $use_query_cache, bool $force_query_caching ) {
+		echo "\n";
+
+		$schema = new Schema(
+			array(
+				'query'      => self::$container->get( RootQueryType::class ),
+				'typeLoader' => function( $name ) {
+					return self::resolve_type( $name );
+				},
+			)
+		);
+
+		// The built-in field resolver takes in account both objects and arrays,
+		// this is a simplified version that handles arrays only.
+		$field_resolver = function( $objectValue, array $args, $context, ResolveInfo $info ) {
+			return $objectValue[ $info->fieldName ];
+		};
+
+		$query_was_cached = false;
+		if ( $use_query_cache ) {
+			$query_hash      = md5( $query );
+			$query_cache_key = "graphql_query_$query_hash";
+
+			if ( $force_query_caching ) {
+				delete_transient( $query_cache_key );
+			}
+			$cached_query = self::run_measuring_time(
+				function() use ( $query_cache_key ) {
+					return get_transient( $query_cache_key );
+				},
+				'Get cached query'
+			);
+
+			if ( false === $cached_query ) {
+				echo "The parsed query wasn't cached.\n";
+				$parsed = self::run_measuring_time(
+					function() use ( $schema, $query ) {
+						$parsed            = Parser::parse( new Source( $query ?? '', 'GraphQL' ) );
+						$validation_errors = DocumentValidator::validate( $schema, $parsed );
+						if ( count( $validation_errors ) ) {
+							return new ExecutionResult( null, $validation_errors );
+						}
+						return $parsed;},
+					'Parse and validate query'
+				);
+
+				if ( $parsed instanceof ExecutionResult ) {
+					return $parsed;
+				}
+
+				$query = $parsed;
+
+				self::run_measuring_time(
+					function() use ( $query_cache_key, $query ) {
+						set_transient( $query_cache_key, $query, 60 );
+					},
+					'Set parsed query in cache'
+				);
+				echo "The parsed query has been cached.\n";
+			} else {
+				$query_was_cached = true;
+				$query            = $cached_query;
+			}
+		}
+
+		return self::run_measuring_time(
+			function() use ( $schema, $query, $field_resolver, $query_was_cached ) {
+				return GraphQL::executeQuery( $schema, $query, null, null, null, null, $field_resolver, $query_was_cached ? array() : null );
+			},
+			'Run query'
+		);
+	}
+
+	/**
+	 * Execute a GraphQL query and display the total execution time.
+	 *
+	 * @param string $query The query to execute.
+	 * @param bool   $use_query_cache If true, use query caching.
+	 * @param bool   $force_query_caching If this and $use_query_cache are true, always assume the query isn't cached.
+	 * @return ExecutionResult The result of executing the query.
+	 * @throws \Exception Query execution failed.
+	 */
+	public static function execute_graphql( string $query, bool $use_query_cache, bool $force_query_caching ) {
+		return self::run_measuring_time(
+			function() use ( $query, $use_query_cache, $force_query_caching ) {
+				return self::_execute_graphql( $query, $use_query_cache, $force_query_caching ); },
+			'Execution time'
+		);
+	}
+
+	private static function _execute_graphql( string $query, bool $use_query_cache, bool $force_query_caching ) {
+		$schema = new Schema(
+			array(
+				'query'      => self::$container->get( RootQueryType::class ),
+				'typeLoader' => function( $name ) {
+					return self::resolve_type( $name );
+				},
+			)
+		);
+
+		$query_was_cached = false;
+		if ( $use_query_cache ) {
+			$query_hash      = md5( $query );
+			$query_cache_key = "graphql_query_$query_hash";
+
+			if ( $force_query_caching ) {
+				delete_transient( $query_cache_key );
+			}
+			$cached_query = get_transient( $query_cache_key );
+
+			if ( false === $cached_query ) {
+				$query             = Parser::parse( new Source( $query ?? '', 'GraphQL' ) );
+				$validation_errors = DocumentValidator::validate( $schema, $query );
+				if ( count( $validation_errors ) ) {
+					return new ExecutionResult( null, $validation_errors );
+				}
+
+				set_transient( $query_cache_key, $query, 60 );
+			} else {
+				$query_was_cached = true;
+				$query            = $cached_query;
+			}
+		}
+
+		$field_resolver = function( $objectValue, array $args, $context, ResolveInfo $info ) {
+			return $objectValue[ $info->fieldName ];
+		};
+
+		return GraphQL::executeQuery(
+			$schema, $query,
+			null, null, null, null, $field_resolver,
+			// Validation rules to use, null means the default set:
+			$query_was_cached ? array() : null );
+	}
+
+	/**
+	 * Run some code and display the execution time.
+	 *
+	 * @param callable $callback The code to run.
+	 * @param string   $action Text to display before the measured time.
+	 * @return mixed The return value of the executed code.
+	 */
+	private static function run_measuring_time( callable $callback, string $action ) {
+		$start   = hrtime( true );
+		$result  = $callback();
+		$end     = hrtime( true );
+		$elapsed = ( $end - $start ) / 1e6;
+		echo "$action: $elapsed ms\n";
+		return $result;
+	}
+
+	/**
+	 * Retrieve an order together with its billing and shipping addresses, and display the total execution time.
+	 *
+	 * @param int $order_id The id of the order to retrieve.
+	 * @return mixed The retrieved order.
+	 */
+	public static function retrieve_order( int $order_id ) {
+		return self::run_measuring_time(
+			function() use ( $order_id ) {
+				$retriever = wc_get_container()->get( OrderRetriever::class );
+				return array(
+					'order'    => $retriever->retrieve_order( $order_id ),
+					'billing'  => $retriever->retrieve_address( $order_id, 'billing' ),
+					'shipping' => $retriever->retrieve_address( $order_id, 'shipping' ),
+				);
+			},
+			'Execution time'
+		);
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/OrderAddressType.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/OrderAddressType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Object type to represent an order address in GraphQL.
+ */
+class OrderAddressType extends ObjectType {
+
+	public function __construct() {
+		 $config = array(
+			 'fields' => array(
+				 'id'           => Type::nonNull( Type::int() ),
+				 'order_id'     => Type::nonNull( Type::int() ),
+				 'address_type' => wc_get_container()->get( OrderAddressTypeType::class ),
+				 'first_name'   => Type::string(),
+				 'last_name'    => Type::string(),
+				 'company'      => Type::string(),
+				 'address_1'    => Type::string(),
+				 'address_2'    => Type::string(),
+				 'city'         => Type::string(),
+				 'state'        => Type::string(),
+				 'postcode'     => Type::string(),
+				 'country'      => Type::string(),
+				 'email'        => Type::string(),
+				 'phone'        => Type::string(),
+			 ),
+		 );
+
+		 parent::__construct( $config );
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/OrderAddressTypeType.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/OrderAddressTypeType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+use GraphQL\Type\Definition\EnumType;
+
+/**
+ * Enumeration type to represent the order address types in GraphQL requests.
+ */
+class OrderAddressTypeType extends EnumType {
+
+	public function __construct() {
+		 $config = array(
+			 'name'        => 'OrderAddressType',
+			 'description' => 'Order address type',
+			 'values'      => array(
+				 'BILLING'  => 'billing',
+				 'SHIPPING' => 'shipping',
+			 ),
+		 );
+		 parent::__construct( $config );
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/OrderRetriever.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/OrderRetriever.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+/**
+ * Extremely simplified to retrieve orders and order addresses from the custom order tables.
+ */
+class OrderRetriever {
+
+	public function retrieve_order( int $id, array $fields = array( '*' ) ): array {
+		global $wpdb;
+
+		$fields = join( ',', $fields );
+		$sql    = "select $fields from {$wpdb->prefix}wc_orders where id=$id";
+
+		return $wpdb->get_row( $sql, ARRAY_A );
+	}
+
+	public function retrieve_address( int $order_id, string $address_type, array $fields = array( '*' ) ): array {
+		global $wpdb;
+
+		$fields = join( ',', $fields );
+		$sql    = $wpdb->prepare( "select $fields from {$wpdb->prefix}wc_order_addresses where order_id=$order_id and address_type=%s", $address_type );
+
+		return $wpdb->get_row( $sql, ARRAY_A );
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/OrderType.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/OrderType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Object type to represent an order in GraphQL.
+ */
+class OrderType extends ObjectType {
+
+	public function __construct() {
+		 $config = array(
+			 'description' => 'An order, no more, no less.',
+			 'fields'      => array(
+				 'id'               => Type::nonNull( Type::int() ),
+				 'status'           => Type::string(),
+				 'currency'         => Type::string(),
+				 'tax_amount'       => Type::float(),
+				 'billing_email'    => Type::string(),
+				 'date_created_gmt' => wc_get_container()->get( DateTimeType::class ),
+				 'date_updated_gmt' => wc_get_container()->get( DateTimeType::class ),
+				 'ip_address'       => Type::string(),
+				 'user_agent'       => Type::string(),
+				 'billing_address'  => wc_get_container()->get( OrderAddressType::class ),
+				 'shipping_address' => wc_get_container()->get( OrderAddressType::class ),
+			 ),
+		 );
+
+		 parent::__construct( $config );
+	}
+}

--- a/plugins/woocommerce/src/Internal/GraphQL/RootQueryType.php
+++ b/plugins/woocommerce/src/Internal/GraphQL/RootQueryType.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\GraphQL;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Object to represent the root GraphQL query.
+ */
+class RootQueryType extends ObjectType {
+
+	public function __construct() {
+		 $config = array(
+			 'fields' => array(
+
+				 'Order'        => array(
+					 'type'    => wc_get_container()->get( OrderType::class ),
+					 'args'    => array(
+						 'id' => Type::int(),
+					 ),
+					 'resolve' => function( $objectValue, $args, $context, ResolveInfo $info ) {
+						$order_id        = $args['id'];
+						$fields          = $info->getFieldSelection( 1 );
+						$retriever       = wc_get_container()->get( OrderRetriever::class );
+						$billing_address = $shipping_address = null;
+						if ( array_key_exists( 'billing_address', $fields ) ) {
+							$address_fields  = $fields['billing_address'];
+							$billing_address = $retriever->retrieve_address( $order_id, 'billing', array_keys( $address_fields ) );
+							unset( $fields['billing_address'] );
+						}
+						if ( array_key_exists( 'shipping_address', $fields ) ) {
+							$address_fields   = $fields['shipping_address'];
+							$shipping_address = $retriever->retrieve_address( $order_id, 'shipping', array_keys( $address_fields ) );
+							unset( $fields['shipping_address'] );
+						}
+						$order = empty( $fields ) ? array() : $retriever->retrieve_order( $args['id'], array_keys( $fields ) );
+						if ( $billing_address ) {
+							$order['billing_address'] = $billing_address;
+						}
+						if ( $shipping_address ) {
+							$order['shipping_address'] = $shipping_address;
+						}
+						return $order;
+					 },
+				 ),
+
+				 'OrderAddress' => array(
+					 'type'    => wc_get_container()->get( OrderAddressType::class ),
+					 'args'    => array(
+						 'order_id'     => Type::int(),
+						 'address_type' => wc_get_container()->get( OrderAddressTypeType::class ),
+					 ),
+					 'resolve' => function( $objectValue, $args, $context, ResolveInfo $info ) {
+						$fields = array_keys( $info->getFieldSelection() );
+						return wc_get_container()->get( OrderRetriever::class )->retrieve_address( $args['order_id'], $args['address_type'], $fields );
+					 },
+				 ),
+			 ),
+		 );
+		 parent::__construct( $config );
+	}
+}


### PR DESCRIPTION
This is the supporting code for the "REST API vs GraphQL performance" hack week project (p7bje6-4cp-p2).

The endpoints introduced are:

* `/wp-json/wc/v4/graphql`
* `/wp-json/wc/v4/orders/<id>`
* `/wp-json/wc/v4/orders/<id>/address/<type>`

Assumes that the custom order tables exist in the database. No permission or error checking is in place.