### PR TITLE
Final public method for abstract class

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -163,7 +163,7 @@ abstract class WC_Data {
 	 * @since  3.0.0
 	 * @return object
 	 */
-	public function get_data_store() {
+	final public function get_data_store() {
 		return $this->data_store;
 	}
 
@@ -173,7 +173,7 @@ abstract class WC_Data {
 	 * @since  2.6.0
 	 * @return int
 	 */
-	public function get_id() {
+	final public function get_id() {
 		return $this->id;
 	}
 
@@ -184,7 +184,7 @@ abstract class WC_Data {
 	 * @param  bool $force_delete Should the date be deleted permanently.
 	 * @return bool result
 	 */
-	public function delete( $force_delete = false ) {
+	final public function delete( $force_delete = false ) {
 		if ( $this->data_store ) {
 			$this->data_store->delete( $this, array( 'force_delete' => $force_delete ) );
 			$this->set_id( 0 );
@@ -199,7 +199,7 @@ abstract class WC_Data {
 	 * @since  2.6.0
 	 * @return int
 	 */
-	public function save() {
+	final public function save() {
 		if ( ! $this->data_store ) {
 			return $this->get_id();
 		}
@@ -245,7 +245,7 @@ abstract class WC_Data {
 	 * @since  2.6.0
 	 * @return array
 	 */
-	public function get_data() {
+	final public function get_data() {
 		return array_merge( array( 'id' => $this->get_id() ), $this->data, array( 'meta_data' => $this->get_meta_data() ) );
 	}
 
@@ -255,7 +255,7 @@ abstract class WC_Data {
 	 * @since   3.0.0
 	 * @return array
 	 */
-	public function get_data_keys() {
+	final public function get_data_keys() {
 		return array_keys( $this->data );
 	}
 
@@ -265,7 +265,7 @@ abstract class WC_Data {
 	 * @since  3.0.0
 	 * @return array
 	 */
-	public function get_extra_data_keys() {
+	final public function get_extra_data_keys() {
 		return array_keys( $this->extra_data );
 	}
 
@@ -286,7 +286,7 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 * @return array of objects.
 	 */
-	public function get_meta_data() {
+	final public function get_meta_data() {
 		$this->maybe_read_meta_data();
 		return array_values( array_filter( $this->meta_data, array( $this, 'filter_null_meta' ) ) );
 	}
@@ -325,7 +325,7 @@ abstract class WC_Data {
 	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return mixed
 	 */
-	public function get_meta( $key = '', $single = true, $context = 'view' ) {
+	final public function get_meta( $key = '', $single = true, $context = 'view' ) {
 		if ( $this->is_internal_meta_key( $key ) ) {
 			$function = 'get_' . ltrim( $key, '_' );
 
@@ -362,7 +362,7 @@ abstract class WC_Data {
 	 * @param  string $key Meta Key.
 	 * @return boolean
 	 */
-	public function meta_exists( $key = '' ) {
+	final public function meta_exists( $key = '' ) {
 		$this->maybe_read_meta_data();
 		$array_keys = wp_list_pluck( $this->get_meta_data(), 'key' );
 		return in_array( $key, $array_keys, true );
@@ -374,7 +374,7 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 * @param array $data Key/Value pairs.
 	 */
-	public function set_meta_data( $data ) {
+	final public function set_meta_data( $data ) {
 		if ( ! empty( $data ) && is_array( $data ) ) {
 			$this->maybe_read_meta_data();
 			foreach ( $data as $meta ) {
@@ -401,7 +401,7 @@ abstract class WC_Data {
 	 * @param string|array $value Meta value.
 	 * @param bool         $unique Should this be a unique key?.
 	 */
-	public function add_meta_data( $key, $value, $unique = false ) {
+	final public function add_meta_data( $key, $value, $unique = false ) {
 		if ( $this->is_internal_meta_key( $key ) ) {
 			$function = 'set_' . ltrim( $key, '_' );
 
@@ -431,7 +431,7 @@ abstract class WC_Data {
 	 * @param  string|array $value Meta value.
 	 * @param  int          $meta_id Meta ID.
 	 */
-	public function update_meta_data( $key, $value, $meta_id = 0 ) {
+	final public function update_meta_data( $key, $value, $meta_id = 0 ) {
 		if ( $this->is_internal_meta_key( $key ) ) {
 			$function = 'set_' . ltrim( $key, '_' );
 
@@ -480,7 +480,7 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 * @param string $key Meta key.
 	 */
-	public function delete_meta_data( $key ) {
+	final public function delete_meta_data( $key ) {
 		$this->maybe_read_meta_data();
 		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'key' ), $key, true );
 
@@ -497,7 +497,7 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 * @param int $mid Meta ID.
 	 */
-	public function delete_meta_data_by_mid( $mid ) {
+	final public function delete_meta_data_by_mid( $mid ) {
 		$this->maybe_read_meta_data();
 		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'id' ), (int) $mid, true );
 
@@ -526,7 +526,7 @@ abstract class WC_Data {
 	 *
 	 * @return string
 	 */
-	public function get_meta_cache_key() {
+	final public function get_meta_cache_key() {
 		if ( ! $this->get_id() ) {
 			wc_doing_it_wrong( 'get_meta_cache_key', 'ID needs to be set before fetching a cache key.', '4.7.0' );
 			return false;
@@ -544,7 +544,7 @@ abstract class WC_Data {
 	 *
 	 * @return string Meta cache key.
 	 */
-	public static function generate_meta_cache_key( $id, $cache_group ) {
+	final public static function generate_meta_cache_key( $id, $cache_group ) {
 		return WC_Cache_Helper::get_cache_prefix( $cache_group ) . WC_Cache_Helper::get_cache_prefix( 'object_' . $id ) . 'object_meta_' . $id;
 	}
 
@@ -556,7 +556,7 @@ abstract class WC_Data {
 	 * @param array  $raw_meta_data_collection Array of objects of { object_id => array( meta_row_1, meta_row_2, ... }.
 	 * @param string $cache_group              Name of cache group.
 	 */
-	public static function prime_raw_meta_data_cache( $raw_meta_data_collection, $cache_group ) {
+	final public static function prime_raw_meta_data_cache( $raw_meta_data_collection, $cache_group ) {
 		foreach ( $raw_meta_data_collection as $object_id => $raw_meta_data_array ) {
 			$cache_key = self::generate_meta_cache_key( $object_id, $cache_group );
 			wp_cache_set( $cache_key, $raw_meta_data_array, $cache_group );
@@ -570,7 +570,7 @@ abstract class WC_Data {
 	 * @since 2.6.0
 	 * @param bool $force_read True to force a new DB read (and update cache).
 	 */
-	public function read_meta_data( $force_read = false ) {
+	final public function read_meta_data( $force_read = false ) {
 		$this->meta_data = array();
 		$cache_loaded    = false;
 
@@ -619,7 +619,7 @@ abstract class WC_Data {
 	 *
 	 * @since 2.6.0
 	 */
-	public function save_meta_data() {
+	final public function save_meta_data() {
 		if ( ! $this->data_store || is_null( $this->meta_data ) ) {
 			return;
 		}
@@ -651,7 +651,7 @@ abstract class WC_Data {
 	 * @since 3.0.0
 	 * @param int $id ID.
 	 */
-	public function set_id( $id ) {
+	final public function set_id( $id ) {
 		$this->id = absint( $id );
 	}
 
@@ -660,7 +660,7 @@ abstract class WC_Data {
 	 *
 	 * @since 3.0.0
 	 */
-	public function set_defaults() {
+	final public function set_defaults() {
 		$this->data    = $this->default_data;
 		$this->changes = array();
 		$this->set_object_read( false );
@@ -672,7 +672,7 @@ abstract class WC_Data {
 	 * @since 3.0.0
 	 * @param boolean $read Should read?.
 	 */
-	public function set_object_read( $read = true ) {
+	final public function set_object_read( $read = true ) {
 		$this->object_read = (bool) $read;
 	}
 
@@ -682,7 +682,7 @@ abstract class WC_Data {
 	 * @since  3.0.0
 	 * @return boolean
 	 */
-	public function get_object_read() {
+	final public function get_object_read() {
 		return (bool) $this->object_read;
 	}
 
@@ -697,7 +697,7 @@ abstract class WC_Data {
 	 *
 	 * @return bool|WP_Error
 	 */
-	public function set_props( $props, $context = 'set' ) {
+	final public function set_props( $props, $context = 'set' ) {
 		$errors = false;
 
 		foreach ( $props as $prop => $value ) {
@@ -752,7 +752,7 @@ abstract class WC_Data {
 	 * @since 3.0.0
 	 * @return array
 	 */
-	public function get_changes() {
+	final public function get_changes() {
 		return $this->changes;
 	}
 
@@ -761,7 +761,7 @@ abstract class WC_Data {
 	 *
 	 * @since 3.0.0
 	 */
-	public function apply_changes() {
+	final public function apply_changes() {
 		$this->data    = array_replace_recursive( $this->data, $this->changes ); // @codingStandardsIgnoreLine
 		$this->changes = array();
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-deprecated-hooks.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-deprecated-hooks.php
@@ -55,7 +55,7 @@ abstract class WC_Deprecated_Hooks {
 	 * @param  string $new_hook New hook name.
 	 * @return array
 	 */
-	public function get_old_hooks( $new_hook ) {
+	final public function get_old_hooks( $new_hook ) {
 		$old_hooks = isset( $this->deprecated_hooks[ $new_hook ] ) ? $this->deprecated_hooks[ $new_hook ] : array();
 		$old_hooks = is_array( $old_hooks ) ? $old_hooks : array( $old_hooks );
 
@@ -65,7 +65,7 @@ abstract class WC_Deprecated_Hooks {
 	/**
 	 * If the hook is Deprecated, call the old hooks here.
 	 */
-	public function maybe_handle_deprecated_hook() {
+	final public function maybe_handle_deprecated_hook() {
 		$new_hook          = current_filter();
 		$old_hooks         = $this->get_old_hooks( $new_hook );
 		$new_callback_args = func_get_args();

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-integration.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-integration.php
@@ -52,7 +52,7 @@ abstract class WC_Integration extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_method_title() {
+	final public function get_method_title() {
 		return apply_filters( 'woocommerce_integration_title', $this->method_title, $this );
 	}
 
@@ -61,14 +61,14 @@ abstract class WC_Integration extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_method_description() {
+	final public function get_method_description() {
 		return apply_filters( 'woocommerce_integration_description', $this->method_description, $this );
 	}
 
 	/**
 	 * Output the gateway settings screen.
 	 */
-	public function admin_options() {
+	final public function admin_options() {
 		echo '<h2>' . esc_html( $this->get_method_title() ) . '</h2>';
 		echo wp_kses_post( wpautop( $this->get_method_description() ) );
 		echo '<div><input type="hidden" name="section" value="' . esc_attr( $this->id ) . '" /></div>';
@@ -78,7 +78,7 @@ abstract class WC_Integration extends WC_Settings_API {
 	/**
 	 * Init settings for gateways.
 	 */
-	public function init_settings() {
+	final public function init_settings() {
 		parent::init_settings();
 		$this->enabled = ! empty( $this->settings['enabled'] ) && 'yes' === $this->settings['enabled'] ? 'yes' : 'no';
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-object-query.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-object-query.php
@@ -40,7 +40,7 @@ abstract class WC_Object_Query {
 	 *
 	 * @return array
 	 */
-	public function get_query_vars() {
+	final public function get_query_vars() {
 		return $this->query_vars;
 	}
 
@@ -51,7 +51,7 @@ abstract class WC_Object_Query {
 	 * @param mixed  $default Default value if query variable is not set.
 	 * @return mixed Query variable value if set, otherwise default.
 	 */
-	public function get( $query_var, $default = '' ) {
+	final public function get( $query_var, $default = '' ) {
 		if ( isset( $this->query_vars[ $query_var ] ) ) {
 			return $this->query_vars[ $query_var ];
 		}
@@ -64,7 +64,7 @@ abstract class WC_Object_Query {
 	 * @param string $query_var Query variable to set.
 	 * @param mixed  $value Value to set for query variable.
 	 */
-	public function set( $query_var, $value ) {
+	final public function set( $query_var, $value ) {
 		$this->query_vars[ $query_var ] = $value;
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -122,7 +122,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return string
 	 */
-	public function get_type() {
+	final public function get_type() {
 		return 'shop_order';
 	}
 
@@ -132,7 +132,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 3.0.0
 	 * @return array
 	 */
-	public function get_data() {
+	final public function get_data() {
 		return array_merge(
 			array(
 				'id' => $this->get_id(),
@@ -169,7 +169,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 3.0.0
 	 * @return int order ID
 	 */
-	public function save() {
+	final public function save() {
 		if ( ! $this->data_store ) {
 			return $this->get_id();
 		}
@@ -284,7 +284,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return integer
 	 */
-	public function get_parent_id( $context = 'view' ) {
+	final public function get_parent_id( $context = 'view' ) {
 		return $this->get_prop( 'parent_id', $context );
 	}
 
@@ -294,7 +294,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_currency( $context = 'view' ) {
+	final public function get_currency( $context = 'view' ) {
 		return $this->get_prop( 'currency', $context );
 	}
 
@@ -304,7 +304,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_version( $context = 'view' ) {
+	final public function get_version( $context = 'view' ) {
 		return $this->get_prop( 'version', $context );
 	}
 
@@ -314,7 +314,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return bool
 	 */
-	public function get_prices_include_tax( $context = 'view' ) {
+	final public function get_prices_include_tax( $context = 'view' ) {
 		return $this->get_prop( 'prices_include_tax', $context );
 	}
 
@@ -324,7 +324,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return WC_DateTime|NULL object if the date is set or null if there is no date.
 	 */
-	public function get_date_created( $context = 'view' ) {
+	final public function get_date_created( $context = 'view' ) {
 		return $this->get_prop( 'date_created', $context );
 	}
 
@@ -334,7 +334,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return WC_DateTime|NULL object if the date is set or null if there is no date.
 	 */
-	public function get_date_modified( $context = 'view' ) {
+	final public function get_date_modified( $context = 'view' ) {
 		return $this->get_prop( 'date_modified', $context );
 	}
 
@@ -344,7 +344,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_status( $context = 'view' ) {
+	final public function get_status( $context = 'view' ) {
 		$status = $this->get_prop( 'status', $context );
 
 		if ( empty( $status ) && 'view' === $context ) {
@@ -360,7 +360,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_discount_total( $context = 'view' ) {
+	final public function get_discount_total( $context = 'view' ) {
 		return $this->get_prop( 'discount_total', $context );
 	}
 
@@ -370,7 +370,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_discount_tax( $context = 'view' ) {
+	final public function get_discount_tax( $context = 'view' ) {
 		return $this->get_prop( 'discount_tax', $context );
 	}
 
@@ -380,7 +380,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_shipping_total( $context = 'view' ) {
+	final public function get_shipping_total( $context = 'view' ) {
 		return $this->get_prop( 'shipping_total', $context );
 	}
 
@@ -390,7 +390,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return string
 	 */
-	public function get_shipping_tax( $context = 'view' ) {
+	final public function get_shipping_tax( $context = 'view' ) {
 		return $this->get_prop( 'shipping_tax', $context );
 	}
 
@@ -400,7 +400,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return float
 	 */
-	public function get_cart_tax( $context = 'view' ) {
+	final public function get_cart_tax( $context = 'view' ) {
 		return $this->get_prop( 'cart_tax', $context );
 	}
 
@@ -410,7 +410,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return float
 	 */
-	public function get_total( $context = 'view' ) {
+	final public function get_total( $context = 'view' ) {
 		return $this->get_prop( 'total', $context );
 	}
 
@@ -420,7 +420,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return float
 	 */
-	public function get_total_tax( $context = 'view' ) {
+	final public function get_total_tax( $context = 'view' ) {
 		return $this->get_prop( 'total_tax', $context );
 	}
 
@@ -436,7 +436,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  bool $ex_tax Show discount excl any tax.
 	 * @return float
 	 */
-	public function get_total_discount( $ex_tax = true ) {
+	final public function get_total_discount( $ex_tax = true ) {
 		if ( $ex_tax ) {
 			$total_discount = $this->get_discount_total();
 		} else {
@@ -450,7 +450,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return float
 	 */
-	public function get_subtotal() {
+	final public function get_subtotal() {
 		$subtotal = NumberUtil::round( $this->get_cart_subtotal_for_order(), wc_get_price_decimals() );
 		return apply_filters( 'woocommerce_order_get_subtotal', (float) $subtotal, $this );
 	}
@@ -460,7 +460,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return array
 	 */
-	public function get_tax_totals() {
+	final public function get_tax_totals() {
 		$tax_totals = array();
 
 		foreach ( $this->get_items( 'tax' ) as $key => $tax ) {
@@ -503,7 +503,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $context View or edit context.
 	 * @return int
 	 */
-	public function get_user_id( $context = 'view' ) {
+	final public function get_user_id( $context = 'view' ) {
 		return 0;
 	}
 
@@ -512,7 +512,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return WP_User|false
 	 */
-	public function get_user() {
+	final public function get_user() {
 		return false;
 	}
 
@@ -534,7 +534,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param int $value Value to set.
 	 * @throws WC_Data_Exception Exception thrown if parent ID does not exist or is invalid.
 	 */
-	public function set_parent_id( $value ) {
+	final public function set_parent_id( $value ) {
 		if ( $value && ( $value === $this->get_id() || ! wc_get_order( $value ) ) ) {
 			$this->error( 'order_invalid_parent_id', __( 'Invalid parent ID', 'woocommerce' ) );
 		}
@@ -548,7 +548,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $new_status Status to change the order to. No internal wc- prefix is required.
 	 * @return array details of change
 	 */
-	public function set_status( $new_status ) {
+	final public function set_status( $new_status ) {
 		$old_status = $this->get_status();
 		$new_status = 'wc-' === substr( $new_status, 0, 3 ) ? substr( $new_status, 3 ) : $new_status;
 
@@ -581,7 +581,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_version( $value ) {
+	final public function set_version( $value ) {
 		$this->set_prop( 'version', $value );
 	}
 
@@ -591,7 +591,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_currency( $value ) {
+	final public function set_currency( $value ) {
 		if ( $value && ! in_array( $value, array_keys( get_woocommerce_currencies() ), true ) ) {
 			$this->error( 'order_invalid_currency', __( 'Invalid currency code', 'woocommerce' ) );
 		}
@@ -604,7 +604,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param bool $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_prices_include_tax( $value ) {
+	final public function set_prices_include_tax( $value ) {
 		$this->set_prop( 'prices_include_tax', (bool) $value );
 	}
 
@@ -614,7 +614,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string|integer|null $date UTC timestamp, or ISO 8601 DateTime. If the DateTime string has no timezone or offset, WordPress site timezone will be assumed. Null if there is no date.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_date_created( $date = null ) {
+	final public function set_date_created( $date = null ) {
 		$this->set_date_prop( 'date_created', $date );
 	}
 
@@ -624,7 +624,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string|integer|null $date UTC timestamp, or ISO 8601 DateTime. If the DateTime string has no timezone or offset, WordPress site timezone will be assumed. Null if there is no date.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_date_modified( $date = null ) {
+	final public function set_date_modified( $date = null ) {
 		$this->set_date_prop( 'date_modified', $date );
 	}
 
@@ -634,7 +634,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_discount_total( $value ) {
+	final public function set_discount_total( $value ) {
 		$this->set_prop( 'discount_total', wc_format_decimal( $value, false, true ) );
 	}
 
@@ -644,7 +644,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_discount_tax( $value ) {
+	final public function set_discount_tax( $value ) {
 		$this->set_prop( 'discount_tax', wc_format_decimal( $value, false, true ) );
 	}
 
@@ -654,7 +654,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_shipping_total( $value ) {
+	final public function set_shipping_total( $value ) {
 		$this->set_prop( 'shipping_total', wc_format_decimal( $value, false, true ) );
 	}
 
@@ -664,7 +664,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_shipping_tax( $value ) {
+	final public function set_shipping_tax( $value ) {
 		$this->set_prop( 'shipping_tax', wc_format_decimal( $value, false, true ) );
 		$this->set_total_tax( (float) $this->get_cart_tax() + (float) $this->get_shipping_tax() );
 	}
@@ -675,7 +675,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $value Value to set.
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_cart_tax( $value ) {
+	final public function set_cart_tax( $value ) {
 		$this->set_prop( 'cart_tax', wc_format_decimal( $value, false, true ) );
 		$this->set_total_tax( (float) $this->get_cart_tax() + (float) $this->get_shipping_tax() );
 	}
@@ -700,7 +700,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return bool|void
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
-	public function set_total( $value, $deprecated = '' ) {
+	final public function set_total( $value, $deprecated = '' ) {
 		if ( $deprecated ) {
 			wc_deprecated_argument( 'total_type', '3.0', 'Use dedicated total setter methods instead.' );
 			return $this->legacy_set_total( $value, $deprecated );
@@ -722,7 +722,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @param string $type Order item type. Default null.
 	 */
-	public function remove_order_items( $type = null ) {
+	final public function remove_order_items( $type = null ) {
 		if ( ! empty( $type ) ) {
 			$this->data_store->delete_items( $this, $type );
 
@@ -763,7 +763,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string|array $types Types of line items to get (array or string).
 	 * @return WC_Order_Item[]
 	 */
-	public function get_items( $types = 'line_item' ) {
+	final public function get_items( $types = 'line_item' ) {
 		$items = array();
 		$types = array_filter( (array) $types );
 
@@ -805,7 +805,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since  3.7.0
 	 * @return WC_Order_Item_Coupon[]
 	 */
-	public function get_coupons() {
+	final public function get_coupons() {
 		return $this->get_items( 'coupon' );
 	}
 
@@ -814,7 +814,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return WC_Order_item_Fee[]
 	 */
-	public function get_fees() {
+	final public function get_fees() {
 		return $this->get_items( 'fee' );
 	}
 
@@ -823,7 +823,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return WC_Order_Item_Tax[]
 	 */
-	public function get_taxes() {
+	final public function get_taxes() {
 		return $this->get_items( 'tax' );
 	}
 
@@ -832,7 +832,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return WC_Order_Item_Shipping[]
 	 */
-	public function get_shipping_methods() {
+	final public function get_shipping_methods() {
 		return $this->get_items( 'shipping' );
 	}
 
@@ -841,7 +841,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return string
 	 */
-	public function get_shipping_method() {
+	final public function get_shipping_method() {
 		$names = array();
 		foreach ( $this->get_shipping_methods() as $shipping_method ) {
 			$names[] = $shipping_method->get_name();
@@ -855,7 +855,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 3.7.0
 	 * @return array
 	 */
-	public function get_coupon_codes() {
+	final public function get_coupon_codes() {
 		$coupon_codes = array();
 		$coupons      = $this->get_items( 'coupon' );
 
@@ -873,7 +873,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $item_type Item type to lookup.
 	 * @return int|string
 	 */
-	public function get_item_count( $item_type = '' ) {
+	final public function get_item_count( $item_type = '' ) {
 		$items = $this->get_items( empty( $item_type ) ? 'line_item' : $item_type );
 		$count = 0;
 
@@ -892,7 +892,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  bool $load_from_db Prior to 3.2 this item was loaded direct from WC_Order_Factory, not this object. This param is here for backwards compatibility with that. If false, uses the local items variable instead.
 	 * @return WC_Order_Item|false
 	 */
-	public function get_item( $item_id, $load_from_db = true ) {
+	final public function get_item( $item_id, $load_from_db = true ) {
 		if ( $load_from_db ) {
 			return WC_Order_Factory::get_order_item( $item_id );
 		}
@@ -946,7 +946,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param int $item_id Item ID to delete.
 	 * @return false|void
 	 */
-	public function remove_item( $item_id ) {
+	final public function remove_item( $item_id ) {
 		$item      = $this->get_item( $item_id, false );
 		$items_key = $item ? $this->get_items_key( $item ) : false;
 
@@ -966,7 +966,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param WC_Order_Item $item Order item object (product, shipping, fee, coupon, tax).
 	 * @return false|void
 	 */
-	public function add_item( $item ) {
+	final public function add_item( $item ) {
 		$items_key = $this->get_items_key( $item );
 
 		if ( ! $items_key ) {
@@ -1000,7 +1000,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @param string $billing_email Billing email of order.
 	 */
-	public function hold_applied_coupons( $billing_email ) {
+	final public function hold_applied_coupons( $billing_email ) {
 		$held_keys          = array();
 		$held_keys_for_user = array();
 		$error              = null;
@@ -1120,7 +1120,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string|WC_Coupon $raw_coupon Coupon code or object.
 	 * @return true|WP_Error True if applied, error if not.
 	 */
-	public function apply_coupon( $raw_coupon ) {
+	final public function apply_coupon( $raw_coupon ) {
 		if ( is_a( $raw_coupon, 'WC_Coupon' ) ) {
 			$coupon = $raw_coupon;
 		} elseif ( is_string( $raw_coupon ) ) {
@@ -1203,7 +1203,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  string $code Coupon code.
 	 * @return void
 	 */
-	public function remove_coupon( $code ) {
+	final public function remove_coupon( $code ) {
 		$coupons = $this->get_items( 'coupon' );
 
 		// Remove the coupon line.
@@ -1224,7 +1224,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @since 3.2.0
 	 */
-	public function recalculate_coupons() {
+	final public function recalculate_coupons() {
 		// Reset line item totals.
 		foreach ( $this->get_items() as $item ) {
 			$item->set_total( $item->get_subtotal() );
@@ -1388,7 +1388,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  array      $args Args for the added product.
 	 * @return int
 	 */
-	public function add_product( $product, $qty = 1, $args = array() ) {
+	final public function add_product( $product, $qty = 1, $args = array() ) {
 		if ( $product ) {
 			$order = ArrayUtil::get_value_or_default( $args, 'order' );
 			$total = wc_get_price_excluding_tax(
@@ -1457,7 +1457,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param WC_Payment_Token $token Payment token object.
 	 * @return boolean|int The new token ID or false if it failed.
 	 */
-	public function add_payment_token( $token ) {
+	final public function add_payment_token( $token ) {
 		if ( empty( $token ) || ! ( $token instanceof WC_Payment_Token ) ) {
 			return false;
 		}
@@ -1476,7 +1476,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.6
 	 * @return array An array of payment token objects
 	 */
-	public function get_payment_tokens() {
+	final public function get_payment_tokens() {
 		return $this->data_store->get_payment_token_ids( $this );
 	}
 
@@ -1495,7 +1495,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.2
 	 * @return float
 	 */
-	public function calculate_shipping() {
+	final public function calculate_shipping() {
 		$shipping_total = 0;
 
 		foreach ( $this->get_shipping_methods() as $shipping ) {
@@ -1514,7 +1514,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.6.3
 	 * @return array
 	 */
-	public function get_items_tax_classes() {
+	final public function get_items_tax_classes() {
 		$found_tax_classes = array();
 
 		foreach ( $this->get_items() as $item ) {
@@ -1586,7 +1586,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @param array $args Added in 3.0.0 to pass things like location.
 	 */
-	public function calculate_taxes( $args = array() ) {
+	final public function calculate_taxes( $args = array() ) {
 		do_action( 'woocommerce_order_before_calculate_taxes', $args, $this );
 
 		$calculate_tax_for  = $this->get_tax_location( $args );
@@ -1624,7 +1624,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return float Fee total.
 	 */
-	public function get_total_fees() {
+	final public function get_total_fees() {
 		return array_reduce(
 			$this->get_fees(),
 			function( $carry, $item ) {
@@ -1636,7 +1636,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Update tax lines for the order based on the line item taxes themselves.
 	 */
-	public function update_taxes() {
+	final public function update_taxes() {
 		$cart_taxes     = array();
 		$shipping_taxes = array();
 		$existing_taxes = $this->get_taxes();
@@ -1729,7 +1729,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param  bool $and_taxes Calc taxes if true.
 	 * @return float calculated grand total.
 	 */
-	public function calculate_totals( $and_taxes = true ) {
+	final public function calculate_totals( $and_taxes = true ) {
 		do_action( 'woocommerce_order_before_calculate_totals', $and_taxes, $this );
 
 		$fees_total        = 0;
@@ -1798,7 +1798,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param bool   $round (default: true).
 	 * @return float
 	 */
-	public function get_item_subtotal( $item, $inc_tax = false, $round = true ) {
+	final public function get_item_subtotal( $item, $inc_tax = false, $round = true ) {
 		$subtotal = 0;
 
 		if ( is_callable( array( $item, 'get_subtotal' ) ) && $item->get_quantity() ) {
@@ -1822,7 +1822,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param bool   $round (default: true).
 	 * @return float
 	 */
-	public function get_line_subtotal( $item, $inc_tax = false, $round = true ) {
+	final public function get_line_subtotal( $item, $inc_tax = false, $round = true ) {
 		$subtotal = 0;
 
 		if ( is_callable( array( $item, 'get_subtotal' ) ) ) {
@@ -1846,7 +1846,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param bool   $round (default: true).
 	 * @return float
 	 */
-	public function get_item_total( $item, $inc_tax = false, $round = true ) {
+	final public function get_item_total( $item, $inc_tax = false, $round = true ) {
 		$total = 0;
 
 		if ( is_callable( array( $item, 'get_total' ) ) && $item->get_quantity() ) {
@@ -1870,7 +1870,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param bool   $round (default: true).
 	 * @return float
 	 */
-	public function get_line_total( $item, $inc_tax = false, $round = true ) {
+	final public function get_line_total( $item, $inc_tax = false, $round = true ) {
 		$total = 0;
 
 		if ( is_callable( array( $item, 'get_total' ) ) ) {
@@ -1891,7 +1891,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param bool  $round (default: true).
 	 * @return float
 	 */
-	public function get_item_tax( $item, $round = true ) {
+	final public function get_item_tax( $item, $round = true ) {
 		$tax = 0;
 
 		if ( is_callable( array( $item, 'get_total_tax' ) ) && $item->get_quantity() ) {
@@ -1908,7 +1908,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param mixed $item Item to get total from.
 	 * @return float
 	 */
-	public function get_line_tax( $item ) {
+	final public function get_line_tax( $item ) {
 		return apply_filters( 'woocommerce_order_amount_line_tax', is_callable( array( $item, 'get_total_tax' ) ) ? wc_round_tax_total( $item->get_total_tax() ) : 0, $item, $this );
 	}
 
@@ -1919,7 +1919,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $tax_display Incl or excl tax display mode.
 	 * @return string
 	 */
-	public function get_formatted_line_subtotal( $item, $tax_display = '' ) {
+	final public function get_formatted_line_subtotal( $item, $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 
 		if ( 'excl' === $tax_display ) {
@@ -1944,7 +1944,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @return string
 	 */
-	public function get_formatted_order_total() {
+	final public function get_formatted_order_total() {
 		$formatted_total = wc_price( $this->get_total(), array( 'currency' => $this->get_currency() ) );
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this );
 	}
@@ -1956,7 +1956,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $tax_display (default: the tax_display_cart value).
 	 * @return string
 	 */
-	public function get_subtotal_to_display( $compound = false, $tax_display = '' ) {
+	final public function get_subtotal_to_display( $compound = false, $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 		$subtotal    = $this->get_cart_subtotal_for_order();
 
@@ -2005,7 +2005,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $tax_display Excl or incl tax display mode.
 	 * @return string
 	 */
-	public function get_shipping_to_display( $tax_display = '' ) {
+	final public function get_shipping_to_display( $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 
 		if ( 0 < abs( (float) $this->get_shipping_total() ) ) {
@@ -2047,7 +2047,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $tax_display Excl or incl tax display mode.
 	 * @return string
 	 */
-	public function get_discount_to_display( $tax_display = '' ) {
+	final public function get_discount_to_display( $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 		return apply_filters( 'woocommerce_order_discount_to_display', wc_price( $this->get_total_discount( 'excl' === $tax_display && 'excl' === get_option( 'woocommerce_tax_display_cart' ) ), array( 'currency' => $this->get_currency() ) ), $this );
 	}
@@ -2165,7 +2165,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param mixed $tax_display Excl or incl tax display mode.
 	 * @return array
 	 */
-	public function get_order_item_totals( $tax_display = '' ) {
+	final public function get_order_item_totals( $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
 		$total_rows  = array();
 
@@ -2194,7 +2194,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param array|string $status Status to check.
 	 * @return bool
 	 */
-	public function has_status( $status ) {
+	final public function has_status( $status ) {
 		return apply_filters( 'woocommerce_order_has_status', ( is_array( $status ) && in_array( $this->get_status(), $status, true ) ) || $this->get_status() === $status, $this, $status );
 	}
 
@@ -2204,7 +2204,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $method_id Method ID to check.
 	 * @return bool
 	 */
-	public function has_shipping_method( $method_id ) {
+	final public function has_shipping_method( $method_id ) {
 		foreach ( $this->get_shipping_methods() as $shipping_method ) {
 			if ( strpos( $shipping_method->get_method_id(), $method_id ) === 0 ) {
 				return true;
@@ -2219,7 +2219,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @since 2.5.0
 	 * @return bool
 	 */
-	public function has_free_item() {
+	final public function has_free_item() {
 		foreach ( $this->get_items() as $item ) {
 			if ( ! $item->get_total() ) {
 				return true;

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -154,7 +154,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return array
 	 */
-	public function get_tokens() {
+	final public function get_tokens() {
 		if ( count( $this->tokens ) > 0 ) {
 			return $this->tokens;
 		}
@@ -171,7 +171,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_method_title() {
+	final public function get_method_title() {
 		return apply_filters( 'woocommerce_gateway_method_title', $this->method_title, $this );
 	}
 
@@ -180,14 +180,14 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_method_description() {
+	final public function get_method_description() {
 		return apply_filters( 'woocommerce_gateway_method_description', $this->method_description, $this );
 	}
 
 	/**
 	 * Output the gateway settings screen.
 	 */
-	public function admin_options() {
+	final public function admin_options() {
 		echo '<h2>' . esc_html( $this->get_method_title() );
 		wc_back_link( __( 'Return to payments', 'woocommerce' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
 		echo '</h2>';
@@ -198,7 +198,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	/**
 	 * Init settings for gateways.
 	 */
-	public function init_settings() {
+	final public function init_settings() {
 		parent::init_settings();
 		$this->enabled = ! empty( $this->settings['enabled'] ) && 'yes' === $this->settings['enabled'] ? 'yes' : 'no';
 	}
@@ -212,7 +212,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 3.4.0
 	 * @return bool
 	 */
-	public function needs_setup() {
+	final public function needs_setup() {
 		return false;
 	}
 
@@ -222,7 +222,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param WC_Order|null $order Order object.
 	 * @return string
 	 */
-	public function get_return_url( $order = null ) {
+	final public function get_return_url( $order = null ) {
 		if ( $order ) {
 			$return_url = $order->get_checkout_order_received_url();
 		} else {
@@ -238,7 +238,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param  WC_Order $order the order object.
 	 * @return string transaction URL, or empty string.
 	 */
-	public function get_transaction_url( $order ) {
+	final public function get_transaction_url( $order ) {
 
 		$return_url     = '';
 		$transaction_id = $order->get_transaction_id();
@@ -280,7 +280,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return bool
 	 */
-	public function is_available() {
+	final public function is_available() {
 		$is_available = ( 'yes' === $this->enabled );
 
 		if ( WC()->cart && 0 < $this->get_order_total() && 0 < $this->max_amount && $this->max_amount < $this->get_order_total() ) {
@@ -295,7 +295,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return bool
 	 */
-	public function has_fields() {
+	final public function has_fields() {
 		return (bool) $this->has_fields;
 	}
 
@@ -304,7 +304,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_title() {
+	final public function get_title() {
 		$title = wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $this->title, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 		return apply_filters( 'woocommerce_gateway_title', $title, $this->id );
 	}
@@ -314,7 +314,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_description() {
+	final public function get_description() {
 		return apply_filters( 'woocommerce_gateway_description', $this->description, $this->id );
 	}
 
@@ -323,7 +323,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_icon() {
+	final public function get_icon() {
 
 		$icon = $this->icon ? '<img src="' . WC_HTTPS::force_https_url( $this->icon ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
 
@@ -336,7 +336,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 3.9.0
 	 * @return string
 	 */
-	public function get_pay_button_id() {
+	final public function get_pay_button_id() {
 		return sanitize_html_class( $this->pay_button_id );
 	}
 
@@ -345,7 +345,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * Set this as the current gateway.
 	 */
-	public function set_current() {
+	final public function set_current() {
 		$this->chosen = true;
 	}
 
@@ -363,7 +363,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param int $order_id Order ID.
 	 * @return array
 	 */
-	public function process_payment( $order_id ) {
+	final public function process_payment( $order_id ) {
 		return array();
 	}
 
@@ -378,7 +378,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param  string     $reason Refund reason.
 	 * @return boolean True or false based on success, or a WP_Error object.
 	 */
-	public function process_refund( $order_id, $amount = null, $reason = '' ) {
+	final public function process_refund( $order_id, $amount = null, $reason = '' ) {
 		return false;
 	}
 
@@ -389,7 +389,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @return bool
 	 */
-	public function validate_fields() {
+	final public function validate_fields() {
 		return true;
 	}
 
@@ -397,7 +397,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * If There are no payment fields show the description if set.
 	 * Override this in your gateway if you have some.
 	 */
-	public function payment_fields() {
+	final public function payment_fields() {
 		$description = $this->get_description();
 		if ( $description ) {
 			echo wpautop( wptexturize( $description ) ); // @codingStandardsIgnoreLine.
@@ -418,7 +418,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return bool True if the gateway supports the feature, false otherwise.
 	 * @since 1.5.7
 	 */
-	public function supports( $feature ) {
+	final public function supports( $feature ) {
 		return apply_filters( 'woocommerce_payment_gateway_supports', in_array( $feature, $this->supports ), $feature, $this );
 	}
 
@@ -430,7 +430,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param  WC_Order $order Order object.
 	 * @return bool If false, the automatic refund button is hidden in the UI.
 	 */
-	public function can_refund_order( $order ) {
+	final public function can_refund_order( $order ) {
 		return $order && $this->supports( 'refunds' );
 	}
 
@@ -440,7 +440,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param  array $args Arguments.
 	 * @param  array $fields Fields.
 	 */
-	public function credit_card_form( $args = array(), $fields = array() ) {
+	final public function credit_card_form( $args = array(), $fields = array() ) {
 		wc_deprecated_function( 'credit_card_form', '2.6', 'WC_Payment_Gateway_CC->form' );
 		$cc_form           = new WC_Payment_Gateway_CC();
 		$cc_form->id       = $this->id;
@@ -453,7 +453,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @since 2.6.0
 	 */
-	public function tokenization_script() {
+	final public function tokenization_script() {
 		wp_enqueue_script(
 			'woocommerce-tokenization-form',
 			plugins_url( '/assets/js/frontend/tokenization-form' . ( Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min' ) . '.js', WC_PLUGIN_FILE ),
@@ -476,7 +476,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @since 2.6.0
 	 */
-	public function saved_payment_methods() {
+	final public function saved_payment_methods() {
 		$html = '<ul class="woocommerce-SavedPaymentMethods wc-saved-payment-methods" data-count="' . esc_attr( count( $this->get_tokens() ) ) . '">';
 
 		foreach ( $this->get_tokens() as $token ) {
@@ -496,7 +496,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param  WC_Payment_Token $token Payment Token.
 	 * @return string Generated payment method HTML
 	 */
-	public function get_saved_payment_method_option_html( $token ) {
+	final public function get_saved_payment_method_option_html( $token ) {
 		$html = sprintf(
 			'<li class="woocommerce-SavedPaymentMethods-token">
 				<input id="wc-%1$s-payment-token-%2$s" type="radio" name="wc-%1$s-payment-token" value="%2$s" style="width:auto;" class="woocommerce-SavedPaymentMethods-tokenInput" %4$s />
@@ -517,7 +517,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @since 2.6.0
 	 */
-	public function get_new_payment_method_option_html() {
+	final public function get_new_payment_method_option_html() {
 		$label = apply_filters( 'woocommerce_payment_gateway_get_new_payment_method_option_html_label', $this->new_method_label ? $this->new_method_label : __( 'Use a new payment method', 'woocommerce' ), $this );
 		$html  = sprintf(
 			'<li class="woocommerce-SavedPaymentMethods-new">
@@ -536,7 +536,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 *
 	 * @since 2.6.0
 	 */
-	public function save_payment_method_checkbox() {
+	final public function save_payment_method_checkbox() {
 		$html = sprintf(
 			'<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
 				<input id="wc-%1$s-new-payment-method" name="wc-%1$s-new-payment-method" type="checkbox" value="true" style="width:auto;" />
@@ -555,7 +555,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @since 3.2.0 Included here from 3.2.0, but supported from 3.0.0.
 	 * @return array
 	 */
-	public function add_payment_method() {
+	final public function add_payment_method() {
 		return array(
 			'result'   => 'failure',
 			'redirect' => wc_get_endpoint_url( 'payment-methods' ),

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-token.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-token.php
@@ -93,7 +93,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @param  string $context Context in which to call this.
 	 * @return string Raw token
 	 */
-	public function get_token( $context = 'view' ) {
+	final public function get_token( $context = 'view' ) {
 		return $this->get_prop( 'token', $context );
 	}
 
@@ -105,7 +105,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @param  string $deprecated Deprecated since WooCommerce 3.0.
 	 * @return string Payment Token Type (CC, eCheck)
 	 */
-	public function get_type( $deprecated = '' ) {
+	final public function get_type( $deprecated = '' ) {
 		return $this->type;
 	}
 
@@ -117,7 +117,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @param  string $deprecated Deprecated since WooCommerce 3.0.
 	 * @return string
 	 */
-	public function get_display_name( $deprecated = '' ) {
+	final public function get_display_name( $deprecated = '' ) {
 		return $this->get_type();
 	}
 
@@ -128,7 +128,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @param  string $context In what context to execute this.
 	 * @return int User ID if this token is associated with a user or 0 if no user is associated
 	 */
-	public function get_user_id( $context = 'view' ) {
+	final public function get_user_id( $context = 'view' ) {
 		return $this->get_prop( 'user_id', $context );
 	}
 
@@ -139,7 +139,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @param  string $context In what context to execute this.
 	 * @return string Gateway ID
 	 */
-	public function get_gateway_id( $context = 'view' ) {
+	final public function get_gateway_id( $context = 'view' ) {
 		return $this->get_prop( 'gateway_id', $context );
 	}
 
@@ -150,7 +150,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @param  string $context In what context to execute this.
 	 * @return string Gateway ID
 	 */
-	public function get_is_default( $context = 'view' ) {
+	final public function get_is_default( $context = 'view' ) {
 		return $this->get_prop( 'is_default', $context );
 	}
 
@@ -166,7 +166,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @since 2.6.0
 	 * @param string $token Payment token.
 	 */
-	public function set_token( $token ) {
+	final public function set_token( $token ) {
 		$this->set_prop( 'token', $token );
 	}
 
@@ -176,7 +176,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @since 2.6.0
 	 * @param int $user_id User ID.
 	 */
-	public function set_user_id( $user_id ) {
+	final public function set_user_id( $user_id ) {
 		$this->set_prop( 'user_id', absint( $user_id ) );
 	}
 
@@ -186,7 +186,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @since 2.6.0
 	 * @param string $gateway_id Gateway ID.
 	 */
-	public function set_gateway_id( $gateway_id ) {
+	final public function set_gateway_id( $gateway_id ) {
 		$this->set_prop( 'gateway_id', $gateway_id );
 	}
 
@@ -196,7 +196,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @since 2.6.0
 	 * @param boolean $is_default True or false.
 	 */
-	public function set_default( $is_default ) {
+	final public function set_default( $is_default ) {
 		$this->set_prop( 'is_default', (bool) $is_default );
 	}
 
@@ -212,7 +212,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @since 2.6.0
 	 * @return boolean True if the token is default
 	 */
-	public function is_default() {
+	final public function is_default() {
 		return (bool) $this->get_prop( 'is_default', 'view' );
 	}
 
@@ -222,7 +222,7 @@ abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 	 * @since 2.6.0
 	 * @return boolean True if the passed data is valid
 	 */
-	public function validate() {
+	final public function validate() {
 		$token = $this->get_prop( 'token', 'edit' );
 		if ( empty( $token ) ) {
 			return false;

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-privacy.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-privacy.php
@@ -80,7 +80,7 @@ abstract class WC_Abstract_Privacy {
 	/**
 	 * Adds the privacy message on WC privacy page.
 	 */
-	public function add_privacy_message() {
+	final public function add_privacy_message() {
 		if ( function_exists( 'wp_add_privacy_policy_content' ) ) {
 			$content = $this->get_privacy_message();
 
@@ -96,7 +96,7 @@ abstract class WC_Abstract_Privacy {
 	 *
 	 * @return string
 	 */
-	public function get_privacy_message() {
+	final public function get_privacy_message() {
 		return '';
 	}
 
@@ -106,7 +106,7 @@ abstract class WC_Abstract_Privacy {
 	 * @param array $exporters List of exporter callbacks.
 	 * @return array
 	 */
-	public function register_exporters( $exporters = array() ) {
+	final public function register_exporters( $exporters = array() ) {
 		foreach ( $this->exporters as $id => $exporter ) {
 			$exporters[ $id ] = $exporter;
 		}
@@ -119,7 +119,7 @@ abstract class WC_Abstract_Privacy {
 	 * @param array $erasers List of eraser callbacks.
 	 * @return array
 	 */
-	public function register_erasers( $erasers = array() ) {
+	final public function register_erasers( $erasers = array() ) {
 		foreach ( $this->erasers as $id => $eraser ) {
 			$erasers[ $id ] = $eraser;
 		}
@@ -135,7 +135,7 @@ abstract class WC_Abstract_Privacy {
 	 *
 	 * @return array
 	 */
-	public function add_exporter( $id, $name, $callback ) {
+	final public function add_exporter( $id, $name, $callback ) {
 		$this->exporters[ $id ] = array(
 			'exporter_friendly_name' => $name,
 			'callback'               => $callback,
@@ -152,7 +152,7 @@ abstract class WC_Abstract_Privacy {
 	 *
 	 * @return array
 	 */
-	public function add_eraser( $id, $name, $callback ) {
+	final public function add_eraser( $id, $name, $callback ) {
 		$this->erasers[ $id ] = array(
 			'eraser_friendly_name' => $name,
 			'callback'             => $callback,

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-session.php
@@ -42,12 +42,12 @@ abstract class WC_Session {
 	 *
 	 * @since 3.3.0
 	 */
-	public function init() {}
+	final public function init() {}
 
 	/**
 	 * Cleanup session data. Extended by child classes.
 	 */
-	public function cleanup_sessions() {}
+	final public function cleanup_sessions() {}
 
 	/**
 	 * Magic get method.
@@ -98,7 +98,7 @@ abstract class WC_Session {
 	 * @param mixed  $default used if the session variable isn't set.
 	 * @return array|string value of session variable
 	 */
-	public function get( $key, $default = null ) {
+	final public function get( $key, $default = null ) {
 		$key = sanitize_key( $key );
 		return isset( $this->_data[ $key ] ) ? maybe_unserialize( $this->_data[ $key ] ) : $default;
 	}
@@ -109,7 +109,7 @@ abstract class WC_Session {
 	 * @param string $key Key to set.
 	 * @param mixed  $value Value to set.
 	 */
-	public function set( $key, $value ) {
+	final public function set( $key, $value ) {
 		if ( $value !== $this->get( $key ) ) {
 			$this->_data[ sanitize_key( $key ) ] = maybe_serialize( $value );
 			$this->_dirty                        = true;
@@ -121,7 +121,7 @@ abstract class WC_Session {
 	 *
 	 * @return int
 	 */
-	public function get_customer_id() {
+	final public function get_customer_id() {
 		return $this->_customer_id;
 	}
 }

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -63,7 +63,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @return array of options
 	 */
-	public function get_form_fields() {
+	final public function get_form_fields() {
 		return apply_filters( 'woocommerce_settings_api_form_fields_' . $this->id, array_map( array( $this, 'set_defaults' ), $this->form_fields ) );
 	}
 
@@ -83,7 +83,7 @@ abstract class WC_Settings_API {
 	/**
 	 * Output the admin options table.
 	 */
-	public function admin_options() {
+	final public function admin_options() {
 		echo '<table class="form-table">' . $this->generate_settings_html( $this->get_form_fields(), false ) . '</table>'; // WPCS: XSS ok.
 	}
 
@@ -94,7 +94,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @since  1.0.0
 	 */
-	public function init_form_fields() {}
+	final public function init_form_fields() {}
 
 	/**
 	 * Return the name of the option in the WP DB.
@@ -102,7 +102,7 @@ abstract class WC_Settings_API {
 	 * @since 2.6.0
 	 * @return string
 	 */
-	public function get_option_key() {
+	final public function get_option_key() {
 		return $this->plugin_id . $this->id . '_settings';
 	}
 
@@ -112,7 +112,7 @@ abstract class WC_Settings_API {
 	 * @param  array $field Field key.
 	 * @return string
 	 */
-	public function get_field_type( $field ) {
+	final public function get_field_type( $field ) {
 		return empty( $field['type'] ) ? 'text' : $field['type'];
 	}
 
@@ -122,7 +122,7 @@ abstract class WC_Settings_API {
 	 * @param  array $field Field key.
 	 * @return string
 	 */
-	public function get_field_default( $field ) {
+	final public function get_field_default( $field ) {
 		return empty( $field['default'] ) ? '' : $field['default'];
 	}
 
@@ -134,7 +134,7 @@ abstract class WC_Settings_API {
 	 * @param array  $post_data Posted data.
 	 * @return string
 	 */
-	public function get_field_value( $key, $field, $post_data = array() ) {
+	final public function get_field_value( $key, $field, $post_data = array() ) {
 		$type      = $this->get_field_type( $field );
 		$field_key = $this->get_field_key( $key );
 		$post_data = empty( $post_data ) ? $_POST : $post_data; // WPCS: CSRF ok, input var ok.
@@ -163,7 +163,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @param array $data Posted data.
 	 */
-	public function set_post_data( $data = array() ) {
+	final public function set_post_data( $data = array() ) {
 		$this->data = $data;
 	}
 
@@ -172,7 +172,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @return array
 	 */
-	public function get_post_data() {
+	final public function get_post_data() {
 		if ( ! empty( $this->data ) && is_array( $this->data ) ) {
 			return $this->data;
 		}
@@ -187,7 +187,7 @@ abstract class WC_Settings_API {
 	 * @param mixed  $value Value to set.
 	 * @return bool was anything saved?
 	 */
-	public function update_option( $key, $value = '' ) {
+	final public function update_option( $key, $value = '' ) {
 		if ( empty( $this->settings ) ) {
 			$this->init_settings();
 		}
@@ -203,7 +203,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @return bool was anything saved?
 	 */
-	public function process_admin_options() {
+	final public function process_admin_options() {
 		$this->init_settings();
 
 		$post_data = $this->get_post_data();
@@ -228,21 +228,21 @@ abstract class WC_Settings_API {
 	 *
 	 * @param string $error Error message.
 	 */
-	public function add_error( $error ) {
+	final public function add_error( $error ) {
 		$this->errors[] = $error;
 	}
 
 	/**
 	 * Get admin error messages.
 	 */
-	public function get_errors() {
+	final public function get_errors() {
 		return $this->errors;
 	}
 
 	/**
 	 * Display admin error messages.
 	 */
-	public function display_errors() {
+	final public function display_errors() {
 		if ( $this->get_errors() ) {
 			echo '<div id="woocommerce_errors" class="error notice is-dismissible">';
 			foreach ( $this->get_errors() as $error ) {
@@ -262,7 +262,7 @@ abstract class WC_Settings_API {
 	 * @since 1.0.0
 	 * @uses get_option(), add_option()
 	 */
-	public function init_settings() {
+	final public function init_settings() {
 		$this->settings = get_option( $this->get_option_key(), null );
 
 		// If there are no settings defined, use defaults.
@@ -281,7 +281,7 @@ abstract class WC_Settings_API {
 	 * @param  mixed  $empty_value Value when empty.
 	 * @return string The value specified for the option or a default value for the option.
 	 */
-	public function get_option( $key, $empty_value = null ) {
+	final public function get_option( $key, $empty_value = null ) {
 		if ( empty( $this->settings ) ) {
 			$this->init_settings();
 		}
@@ -305,7 +305,7 @@ abstract class WC_Settings_API {
 	 * @param  string $key Field key.
 	 * @return string
 	 */
-	public function get_field_key( $key ) {
+	final public function get_field_key( $key ) {
 		return $this->plugin_id . $this->id . '_' . $key;
 	}
 
@@ -320,7 +320,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @uses   method_exists()
 	 */
-	public function generate_settings_html( $form_fields = array(), $echo = true ) {
+	final public function generate_settings_html( $form_fields = array(), $echo = true ) {
 		if ( empty( $form_fields ) ) {
 			$form_fields = $this->get_form_fields();
 		}
@@ -365,7 +365,7 @@ abstract class WC_Settings_API {
 	 * @param  array $data Data for the tooltip.
 	 * @return string
 	 */
-	public function get_tooltip_html( $data ) {
+	final public function get_tooltip_html( $data ) {
 		if ( true === $data['desc_tip'] ) {
 			$tip = $data['description'];
 		} elseif ( ! empty( $data['desc_tip'] ) ) {
@@ -383,7 +383,7 @@ abstract class WC_Settings_API {
 	 * @param  array $data Data for the description.
 	 * @return string
 	 */
-	public function get_description_html( $data ) {
+	final public function get_description_html( $data ) {
 		if ( true === $data['desc_tip'] ) {
 			$description = '';
 		} elseif ( ! empty( $data['desc_tip'] ) ) {
@@ -403,7 +403,7 @@ abstract class WC_Settings_API {
 	 * @param  array $data Field data.
 	 * @return string
 	 */
-	public function get_custom_attribute_html( $data ) {
+	final public function get_custom_attribute_html( $data ) {
 		$custom_attributes = array();
 
 		if ( ! empty( $data['custom_attributes'] ) && is_array( $data['custom_attributes'] ) ) {
@@ -423,7 +423,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_text_html( $key, $data ) {
+	final public function generate_text_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -466,7 +466,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_price_html( $key, $data ) {
+	final public function generate_price_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -509,7 +509,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_decimal_html( $key, $data ) {
+	final public function generate_decimal_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -552,7 +552,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_password_html( $key, $data ) {
+	final public function generate_password_html( $key, $data ) {
 		$data['type'] = 'password';
 		return $this->generate_text_html( $key, $data );
 	}
@@ -565,7 +565,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_color_html( $key, $data ) {
+	final public function generate_color_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -609,7 +609,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_textarea_html( $key, $data ) {
+	final public function generate_textarea_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -652,7 +652,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_checkbox_html( $key, $data ) {
+	final public function generate_checkbox_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -700,7 +700,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_select_html( $key, $data ) {
+	final public function generate_select_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -757,7 +757,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_multiselect_html( $key, $data ) {
+	final public function generate_multiselect_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title'             => '',
@@ -818,7 +818,7 @@ abstract class WC_Settings_API {
 	 * @since  1.0.0
 	 * @return string
 	 */
-	public function generate_title_html( $key, $data ) {
+	final public function generate_title_html( $key, $data ) {
 		$field_key = $this->get_field_key( $key );
 		$defaults  = array(
 			'title' => '',
@@ -849,7 +849,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_text_field( $key, $value ) {
+	final public function validate_text_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		return wp_kses_post( trim( stripslashes( $value ) ) );
 	}
@@ -868,7 +868,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function validate_safe_text_field( string $key, ?string $value ): string {
+	final public function validate_safe_text_field( string $key, ?string $value ): string {
 		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 	}
 
@@ -881,7 +881,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_price_field( $key, $value ) {
+	final public function validate_price_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		return ( '' === $value ) ? '' : wc_format_decimal( trim( stripslashes( $value ) ) );
 	}
@@ -895,7 +895,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_decimal_field( $key, $value ) {
+	final public function validate_decimal_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		return ( '' === $value ) ? '' : wc_format_decimal( trim( stripslashes( $value ) ) );
 	}
@@ -907,7 +907,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_password_field( $key, $value ) {
+	final public function validate_password_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		return trim( stripslashes( $value ) );
 	}
@@ -919,7 +919,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_textarea_field( $key, $value ) {
+	final public function validate_textarea_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		return wp_kses(
 			trim( stripslashes( $value ) ),
@@ -946,7 +946,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_checkbox_field( $key, $value ) {
+	final public function validate_checkbox_field( $key, $value ) {
 		return ! is_null( $value ) ? 'yes' : 'no';
 	}
 
@@ -957,7 +957,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string
 	 */
-	public function validate_select_field( $key, $value ) {
+	final public function validate_select_field( $key, $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		return wc_clean( stripslashes( $value ) );
 	}
@@ -969,7 +969,7 @@ abstract class WC_Settings_API {
 	 * @param  string $value Posted Value.
 	 * @return string|array
 	 */
-	public function validate_multiselect_field( $key, $value ) {
+	final public function validate_multiselect_field( $key, $value ) {
 		return is_array( $value ) ? array_map( 'wc_clean', array_map( 'stripslashes', $value ) ) : '';
 	}
 
@@ -979,7 +979,7 @@ abstract class WC_Settings_API {
 	 * @deprecated 2.6.0 No longer used.
 	 * @param array $form_fields Array of fields.
 	 */
-	public function validate_settings_fields( $form_fields = array() ) {
+	final public function validate_settings_fields( $form_fields = array() ) {
 		wc_deprecated_function( 'validate_settings_fields', '2.6' );
 	}
 
@@ -990,7 +990,7 @@ abstract class WC_Settings_API {
 	 * @param  array $value Value to format.
 	 * @return array
 	 */
-	public function format_settings( $value ) {
+	final public function format_settings( $value ) {
 		wc_deprecated_function( 'format_settings', '2.6' );
 		return $value;
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
@@ -151,7 +151,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param string $feature The name of a feature to test support for.
 	 * @return bool True if the shipping method supports the feature, false otherwise.
 	 */
-	public function supports( $feature ) {
+	final public function supports( $feature ) {
 		return apply_filters( 'woocommerce_shipping_method_supports', in_array( $feature, $this->supports ), $feature, $this );
 	}
 
@@ -160,14 +160,14 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 *
 	 * @param array $package Package array.
 	 */
-	public function calculate_shipping( $package = array() ) {}
+	final public function calculate_shipping( $package = array() ) {}
 
 	/**
 	 * Whether or not we need to calculate tax on top of the shipping rate.
 	 *
 	 * @return boolean
 	 */
-	public function is_taxable() {
+	final public function is_taxable() {
 		return wc_tax_enabled() && 'taxable' === $this->tax_status && ( WC()->customer && ! WC()->customer->get_is_vat_exempt() );
 	}
 
@@ -177,7 +177,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return boolean
 	 */
-	public function is_enabled() {
+	final public function is_enabled() {
 		return 'yes' === $this->enabled;
 	}
 
@@ -187,7 +187,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return int
 	 */
-	public function get_instance_id() {
+	final public function get_instance_id() {
 		return $this->instance_id;
 	}
 
@@ -197,7 +197,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return string
 	 */
-	public function get_method_title() {
+	final public function get_method_title() {
 		return apply_filters( 'woocommerce_shipping_method_title', $this->method_title, $this );
 	}
 
@@ -207,7 +207,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return string
 	 */
-	public function get_method_description() {
+	final public function get_method_description() {
 		return apply_filters( 'woocommerce_shipping_method_description', $this->method_description, $this );
 	}
 
@@ -216,7 +216,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_title() {
+	final public function get_title() {
 		return apply_filters( 'woocommerce_shipping_method_title', $this->title, $this->id );
 	}
 
@@ -227,7 +227,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param array $package Package array.
 	 * @return array
 	 */
-	public function get_rates_for_package( $package ) {
+	final public function get_rates_for_package( $package ) {
 		$this->rates = array();
 		if ( $this->is_available( $package ) && ( empty( $package['ship_via'] ) || in_array( $this->id, $package['ship_via'] ) ) ) {
 			$this->calculate_shipping( $package );
@@ -243,7 +243,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param string $suffix Suffix.
 	 * @return string
 	 */
-	public function get_rate_id( $suffix = '' ) {
+	final public function get_rate_id( $suffix = '' ) {
 		$rate_id = array( $this->id );
 
 		if ( $this->instance_id ) {
@@ -262,7 +262,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 *
 	 * @param array $args Arguments (default: array()).
 	 */
-	public function add_rate( $args = array() ) {
+	final public function add_rate( $args = array() ) {
 		$args = apply_filters(
 			'woocommerce_shipping_method_add_rate_args',
 			wp_parse_args(
@@ -374,7 +374,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param array $package Package.
 	 * @return bool
 	 */
-	public function is_available( $package ) {
+	final public function is_available( $package ) {
 		$available = $this->is_enabled();
 
 		// Country availability (legacy, for non-zone based methods).
@@ -405,7 +405,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param float        $total Total.
 	 * @return float
 	 */
-	public function get_fee( $fee, $total ) {
+	final public function get_fee( $fee, $total ) {
 		if ( strstr( $fee, '%' ) ) {
 			$fee = ( $total / 100 ) * str_replace( '%', '', $fee );
 		}
@@ -420,7 +420,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 *
 	 * @return bool
 	 */
-	public function has_settings() {
+	final public function has_settings() {
 		return $this->instance_id ? $this->supports( 'instance-settings' ) : $this->supports( 'settings' );
 	}
 
@@ -429,7 +429,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function get_admin_options_html() {
+	final public function get_admin_options_html() {
 		if ( $this->instance_id ) {
 			$settings_html = $this->generate_settings_html( $this->get_instance_form_fields(), false );
 		} else {
@@ -442,7 +442,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	/**
 	 * Output the shipping settings screen.
 	 */
-	public function admin_options() {
+	final public function admin_options() {
 		if ( ! $this->instance_id ) {
 			echo '<h2>' . esc_html( $this->get_method_title() ) . '</h2>';
 		}
@@ -459,7 +459,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param  mixed  $empty_value Empty value.
 	 * @return mixed  The value specified for the option or a default value for the option.
 	 */
-	public function get_option( $key, $empty_value = null ) {
+	final public function get_option( $key, $empty_value = null ) {
 		// Instance options take priority over global options.
 		if ( $this->instance_id && array_key_exists( $key, $this->get_instance_form_fields() ) ) {
 			return $this->get_instance_option( $key, $empty_value );
@@ -477,7 +477,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param  mixed  $empty_value Empty value.
 	 * @return mixed  The value specified for the option or a default value for the option.
 	 */
-	public function get_instance_option( $key, $empty_value = null ) {
+	final public function get_instance_option( $key, $empty_value = null ) {
 		if ( empty( $this->instance_settings ) ) {
 			$this->init_instance_settings();
 		}
@@ -503,7 +503,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return array
 	 */
-	public function get_instance_form_fields() {
+	final public function get_instance_form_fields() {
 		return apply_filters( 'woocommerce_shipping_instance_form_fields_' . $this->id, array_map( array( $this, 'set_defaults' ), $this->instance_form_fields ) );
 	}
 
@@ -513,7 +513,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return string
 	 */
-	public function get_instance_option_key() {
+	final public function get_instance_option_key() {
 		return $this->instance_id ? $this->plugin_id . $this->id . '_' . $this->instance_id . '_settings' : '';
 	}
 
@@ -522,7 +522,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 *
 	 * @since 2.6.0
 	 */
-	public function init_instance_settings() {
+	final public function init_instance_settings() {
 		$this->instance_settings = get_option( $this->get_instance_option_key(), null );
 
 		// If there are no settings defined, use defaults.
@@ -540,7 +540,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @since 2.6.0
 	 * @return bool was anything saved?
 	 */
-	public function process_admin_options() {
+	final public function process_admin_options() {
 		if ( ! $this->instance_id ) {
 			return parent::process_admin_options();
 		}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-widget.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-widget.php
@@ -80,7 +80,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * @param  array $args Arguments.
 	 * @return bool true if the widget is cached otherwise false
 	 */
-	public function get_cached_widget( $args ) {
+	final public function get_cached_widget( $args ) {
 		// Don't get cache if widget_id doesn't exists.
 		if ( empty( $args['widget_id'] ) ) {
 			return false;
@@ -107,7 +107,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * @param  string $content Content.
 	 * @return string the content that was cached
 	 */
-	public function cache_widget( $args, $content ) {
+	final public function cache_widget( $args, $content ) {
 		// Don't set any cache if widget_id doesn't exist.
 		if ( empty( $args['widget_id'] ) ) {
 			return $content;
@@ -129,7 +129,7 @@ abstract class WC_Widget extends WP_Widget {
 	/**
 	 * Flush the cache.
 	 */
-	public function flush_widget_cache() {
+	final public function flush_widget_cache() {
 		foreach ( array( 'https', 'http' ) as $scheme ) {
 			wp_cache_delete( $this->get_widget_id_for_cache( $this->widget_id, $scheme ), 'widget' );
 		}
@@ -159,7 +159,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * @param array $args Arguments.
 	 * @param array $instance Instance.
 	 */
-	public function widget_start( $args, $instance ) {
+	final public function widget_start( $args, $instance ) {
 		echo $args['before_widget']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		$title = apply_filters( 'widget_title', $this->get_instance_title( $instance ), $instance, $this->id_base );
@@ -174,7 +174,7 @@ abstract class WC_Widget extends WP_Widget {
 	 *
 	 * @param  array $args Arguments.
 	 */
-	public function widget_end( $args ) {
+	final public function widget_end( $args ) {
 		echo $args['after_widget']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}
 
@@ -186,7 +186,7 @@ abstract class WC_Widget extends WP_Widget {
 	 * @param  array $old_instance Old instance.
 	 * @return array
 	 */
-	public function update( $new_instance, $old_instance ) {
+	final public function update( $new_instance, $old_instance ) {
 
 		$instance = $old_instance;
 
@@ -242,7 +242,7 @@ abstract class WC_Widget extends WP_Widget {
 	 *
 	 * @param array $instance Instance.
 	 */
-	public function form( $instance ) {
+	final public function form( $instance ) {
 
 		if ( empty( $this->settings ) ) {
 			return;

--- a/plugins/woocommerce/includes/abstracts/class-wc-background-process.php
+++ b/plugins/woocommerce/includes/abstracts/class-wc-background-process.php
@@ -158,7 +158,7 @@ abstract class WC_Background_Process extends WP_Background_Process {
 	 * @param array $schedules Schedules.
 	 * @return array
 	 */
-	public function schedule_cron_healthcheck( $schedules ) {
+	final public function schedule_cron_healthcheck( $schedules ) {
 		$interval = apply_filters( $this->identifier . '_cron_interval', 5 );
 
 		if ( property_exists( $this, 'cron_interval' ) ) {
@@ -180,7 +180,7 @@ abstract class WC_Background_Process extends WP_Background_Process {
 	 *
 	 * @return WC_Background_Process
 	 */
-	public function delete_all_batches() {
+	final public function delete_all_batches() {
 		global $wpdb;
 
 		$table  = $wpdb->options;
@@ -203,7 +203,7 @@ abstract class WC_Background_Process extends WP_Background_Process {
 	 *
 	 * Stop processing queue items, clear cronjob and delete all batches.
 	 */
-	public function kill_process() {
+	final public function kill_process() {
 		if ( ! $this->is_queue_empty() ) {
 			$this->delete_all_batches();
 			wp_clear_scheduled_hook( $this->cron_hook_identifier );

--- a/plugins/woocommerce/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
+++ b/plugins/woocommerce/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
@@ -58,7 +58,7 @@ abstract class WC_Admin_List_Table {
 	 *
 	 * @param string $which String which tablenav is being shown.
 	 */
-	public function maybe_render_blank_state( $which ) {
+	final public function maybe_render_blank_state( $which ) {
 		global $post_type;
 
 		if ( $post_type === $this->list_table_type && 'bottom' === $which ) {
@@ -89,7 +89,7 @@ abstract class WC_Admin_List_Table {
 	 * @param  array $post_types Array of post types supporting view mode.
 	 * @return array             Array of post types supporting view mode, without this type.
 	 */
-	public function disable_view_mode( $post_types ) {
+	final public function disable_view_mode( $post_types ) {
 		unset( $post_types[ $this->list_table_type ] );
 		return $post_types;
 	}
@@ -97,7 +97,7 @@ abstract class WC_Admin_List_Table {
 	/**
 	 * See if we should render search filters or not.
 	 */
-	public function restrict_manage_posts() {
+	final public function restrict_manage_posts() {
 		global $typenow;
 
 		if ( $this->list_table_type === $typenow ) {
@@ -111,7 +111,7 @@ abstract class WC_Admin_List_Table {
 	 * @param array $query_vars Query vars.
 	 * @return array
 	 */
-	public function request_query( $query_vars ) {
+	final public function request_query( $query_vars ) {
 		global $typenow;
 
 		if ( $this->list_table_type === $typenow ) {
@@ -143,7 +143,7 @@ abstract class WC_Admin_List_Table {
 	 * @param WP_Post $post Current post object.
 	 * @return array
 	 */
-	public function row_actions( $actions, $post ) {
+	final public function row_actions( $actions, $post ) {
 		if ( $this->list_table_type === $post->post_type ) {
 			return $this->get_row_actions( $actions, $post );
 		}
@@ -168,7 +168,7 @@ abstract class WC_Admin_List_Table {
 	 * @param object $screen Current screen.
 	 * @return array
 	 */
-	public function default_hidden_columns( $hidden, $screen ) {
+	final public function default_hidden_columns( $hidden, $screen ) {
 		if ( isset( $screen->id ) && 'edit-' . $this->list_table_type === $screen->id ) {
 			$hidden = array_merge( $hidden, $this->define_hidden_columns() );
 		}
@@ -182,7 +182,7 @@ abstract class WC_Admin_List_Table {
 	 * @param  string $screen_id Current screen ID.
 	 * @return string
 	 */
-	public function list_table_primary_column( $default, $screen_id ) {
+	final public function list_table_primary_column( $default, $screen_id ) {
 		if ( 'edit-' . $this->list_table_type === $screen_id && $this->get_primary_column() ) {
 			return $this->get_primary_column();
 		}
@@ -213,7 +213,7 @@ abstract class WC_Admin_List_Table {
 	 * @param array $columns Existing columns.
 	 * @return array
 	 */
-	public function define_sortable_columns( $columns ) {
+	final public function define_sortable_columns( $columns ) {
 		return $columns;
 	}
 
@@ -223,7 +223,7 @@ abstract class WC_Admin_List_Table {
 	 * @param array $columns Existing columns.
 	 * @return array
 	 */
-	public function define_columns( $columns ) {
+	final public function define_columns( $columns ) {
 		return $columns;
 	}
 
@@ -233,7 +233,7 @@ abstract class WC_Admin_List_Table {
 	 * @param array $actions Existing actions.
 	 * @return array
 	 */
-	public function define_bulk_actions( $actions ) {
+	final public function define_bulk_actions( $actions ) {
 		return $actions;
 	}
 
@@ -250,7 +250,7 @@ abstract class WC_Admin_List_Table {
 	 * @param string $column Column ID to render.
 	 * @param int    $post_id Post ID being shown.
 	 */
-	public function render_columns( $column, $post_id ) {
+	final public function render_columns( $column, $post_id ) {
 		$this->prepare_row_data( $post_id );
 
 		if ( ! $this->object ) {
@@ -270,7 +270,7 @@ abstract class WC_Admin_List_Table {
 	 * @param  array  $ids         List of ids.
 	 * @return string
 	 */
-	public function handle_bulk_actions( $redirect_to, $action, $ids ) {
+	final public function handle_bulk_actions( $redirect_to, $action, $ids ) {
 		return esc_url_raw( $redirect_to );
 	}
 }

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-page.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * @since 3.0.0
 		 * @return string
 		 */
-		public function get_id() {
+		final public function get_id() {
 			return $this->id;
 		}
 
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 * @since 3.0.0
 		 * @return string
 		 */
-		public function get_label() {
+		final public function get_label() {
 			return $this->label;
 		}
 
@@ -68,7 +68,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 *
 		 * @return mixed
 		 */
-		public function add_settings_page( $pages ) {
+		final public function add_settings_page( $pages ) {
 			$pages[ $this->id ] = $this->label;
 
 			return $pages;
@@ -93,7 +93,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 *
 		 * @return array Settings array, each item being an associative array representing a setting.
 		 */
-		public function get_settings() {
+		final public function get_settings() {
 			$section_id = 0 === func_num_args() ? '' : func_get_arg( 0 );
 			return $this->get_settings_for_section( $section_id );
 		}
@@ -151,7 +151,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		 *
 		 * @return array
 		 */
-		public function get_sections() {
+		final public function get_sections() {
 			$sections = $this->get_own_sections();
 			return apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
 		}
@@ -176,7 +176,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		/**
 		 * Output sections.
 		 */
-		public function output_sections() {
+		final public function output_sections() {
 			global $current_section;
 
 			$sections = $this->get_sections();
@@ -203,7 +203,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		/**
 		 * Output the HTML for the settings.
 		 */
-		public function output() {
+		final public function output() {
 			global $current_section;
 
 			// We can't use "get_settings_for_section" here
@@ -216,7 +216,7 @@ if ( ! class_exists( 'WC_Settings_Page', false ) ) :
 		/**
 		 * Save settings and trigger the 'woocommerce_update_options_'.id action.
 		 */
-		public function save() {
+		final public function save() {
 			$this->save_settings_for_current_section();
 			$this->do_update_options_action();
 		}

--- a/plugins/woocommerce/includes/class-wc-log-levels.php
+++ b/plugins/woocommerce/includes/class-wc-log-levels.php
@@ -78,7 +78,7 @@ abstract class WC_Log_Levels {
 	 * @param string $level Log level.
 	 * @return bool True if $level is a valid level.
 	 */
-	public static function is_valid_level( $level ) {
+	final public static function is_valid_level( $level ) {
 		return array_key_exists( strtolower( $level ), self::$level_to_severity );
 	}
 
@@ -88,7 +88,7 @@ abstract class WC_Log_Levels {
 	 * @param string $level Log level, options: emergency|alert|critical|error|warning|notice|info|debug.
 	 * @return int 100 (debug) - 800 (emergency) or 0 if not recognized
 	 */
-	public static function get_level_severity( $level ) {
+	final public static function get_level_severity( $level ) {
 		return self::is_valid_level( $level ) ? self::$level_to_severity[ strtolower( $level ) ] : 0;
 	}
 
@@ -98,7 +98,7 @@ abstract class WC_Log_Levels {
 	 * @param int $severity Severity level.
 	 * @return bool|string False if not recognized. Otherwise string representation of level.
 	 */
-	public static function get_severity_level( $severity ) {
+	final public static function get_severity_level( $severity ) {
 		if ( ! array_key_exists( $severity, self::$severity_to_level ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -55,7 +55,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 *
 	 * @param WC_Order $order Order object.
 	 */
-	public function create( &$order ) {
+	final public function create( &$order ) {
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
 		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
 		if ( ! $order->get_date_created( 'edit' ) ) {
@@ -97,7 +97,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 *
 	 * @throws Exception If passed order is invalid.
 	 */
-	public function read( &$order ) {
+	final public function read( &$order ) {
 		$order->set_defaults();
 		$post_object = get_post( $order->get_id() );
 		if ( ! $order->get_id() || ! $post_object || ! in_array( $post_object->post_type, wc_get_order_types(), true ) ) {
@@ -132,7 +132,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 *
 	 * @param WC_Order $order Order object.
 	 */
-	public function update( &$order ) {
+	final public function update( &$order ) {
 		$order->save_meta_data();
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
 
@@ -183,7 +183,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 *
 	 * @return void
 	 */
-	public function delete( &$order, $args = array() ) {
+	final public function delete( &$order, $args = array() ) {
 		$id   = $order->get_id();
 		$args = wp_parse_args(
 			$args,
@@ -368,7 +368,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @param  string   $type Order item type.
 	 * @return array
 	 */
-	public function read_items( $order, $type ) {
+	final public function read_items( $order, $type ) {
 		global $wpdb;
 
 		// Get from cache if available.
@@ -403,7 +403,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @param WC_Order $order Order object.
 	 * @param string   $type Order item type. Default null.
 	 */
-	public function delete_items( $order, $type = null ) {
+	final public function delete_items( $order, $type = null ) {
 		global $wpdb;
 		if ( ! empty( $type ) ) {
 			$wpdb->query( $wpdb->prepare( "DELETE FROM itemmeta USING {$wpdb->prefix}woocommerce_order_itemmeta itemmeta INNER JOIN {$wpdb->prefix}woocommerce_order_items items WHERE itemmeta.order_item_id = items.order_item_id AND items.order_id = %d AND items.order_item_type = %s", $order->get_id(), $type ) );
@@ -421,7 +421,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @param WC_Order $order Order object.
 	 * @return array
 	 */
-	public function get_payment_token_ids( $order ) {
+	final public function get_payment_token_ids( $order ) {
 		$token_ids = array_filter( (array) get_post_meta( $order->get_id(), '_payment_tokens', true ) );
 		return $token_ids;
 	}
@@ -432,7 +432,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 * @param WC_Order $order Order object.
 	 * @param array    $token_ids Payment token ids.
 	 */
-	public function update_payment_token_ids( $order, $token_ids ) {
+	final public function update_payment_token_ids( $order, $token_ids ) {
 		update_post_meta( $order->get_id(), '_payment_tokens', $token_ids );
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -40,7 +40,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 * @since 3.0.0
 	 * @param WC_Order_Item $item Order item object.
 	 */
-	public function create( &$item ) {
+	final public function create( &$item ) {
 		global $wpdb;
 
 		$wpdb->insert(
@@ -66,7 +66,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 * @since 3.0.0
 	 * @param WC_Order_Item $item Order item object.
 	 */
-	public function update( &$item ) {
+	final public function update( &$item ) {
 		global $wpdb;
 
 		$changes = $item->get_changes();
@@ -98,7 +98,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 * @param WC_Order_Item $item Order item object.
 	 * @param array         $args Array of args to pass to the delete method.
 	 */
-	public function delete( &$item, $args = array() ) {
+	final public function delete( &$item, $args = array() ) {
 		if ( $item->get_id() ) {
 			global $wpdb;
 			do_action( 'woocommerce_before_delete_order_item', $item->get_id() );
@@ -118,7 +118,7 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 *
 	 * @throws Exception If invalid order item.
 	 */
-	public function read( &$item ) {
+	final public function read( &$item ) {
 		global $wpdb;
 
 		$item->set_defaults();
@@ -151,14 +151,14 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 	 * @since 3.0.0
 	 * @param WC_Order_Item $item Order item object.
 	 */
-	public function save_item_data( &$item ) {}
+	final public function save_item_data( &$item ) {}
 
 	/**
 	 * Clear meta cache.
 	 *
 	 * @param WC_Order_Item $item Order item object.
 	 */
-	public function clear_cache( &$item ) {
+	final public function clear_cache( &$item ) {
 		wp_cache_delete( 'item-' . $item->get_id(), 'order-items' );
 		wp_cache_delete( 'order-items-' . $item->get_order_id(), 'orders' );
 		wp_cache_delete( $item->get_id(), $this->meta_type . '_meta' );

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
@@ -61,7 +61,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return string
 	 */
-	public function get_headers_row_file() {
+	final public function get_headers_row_file() {
 
 		$file = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
 
@@ -78,7 +78,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return string
 	 */
-	public function get_file() {
+	final public function get_file() {
 		$file = '';
 		if ( @file_exists( $this->get_file_path() ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 			$file = @file_get_contents( $this->get_file_path() ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.WP.AlternativeFunctions.file_system_read_file_get_contents
@@ -94,7 +94,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 *
 	 * @since 3.1.0
 	 */
-	public function export() {
+	final public function export() {
 		$this->send_headers();
 		$this->send_content( $this->get_headers_row_file() . $this->get_file() );
 		@unlink( $this->get_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged
@@ -107,7 +107,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 *
 	 * @since 3.1.0
 	 */
-	public function generate_file() {
+	final public function generate_file() {
 		if ( 1 === $this->get_page() ) {
 			@unlink( $this->get_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged,
 
@@ -153,7 +153,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return int
 	 */
-	public function get_page() {
+	final public function get_page() {
 		return $this->page;
 	}
 
@@ -163,7 +163,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @param int $page Page Nr.
 	 */
-	public function set_page( $page ) {
+	final public function set_page( $page ) {
 		$this->page = absint( $page );
 	}
 
@@ -173,7 +173,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return int
 	 */
-	public function get_total_exported() {
+	final public function get_total_exported() {
 		return ( ( $this->get_page() - 1 ) * $this->get_limit() ) + $this->exported_row_count;
 	}
 
@@ -183,7 +183,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return int
 	 */
-	public function get_percent_complete() {
+	final public function get_percent_complete() {
 		return $this->total_rows ? (int) floor( ( $this->get_total_exported() / $this->total_rows ) * 100 ) : 100;
 	}
 }

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
@@ -89,7 +89,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return array
 	 */
-	public function get_column_names() {
+	final public function get_column_names() {
 		return apply_filters( "woocommerce_{$this->export_type}_export_column_names", $this->column_names, $this );
 	}
 
@@ -99,7 +99,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @param array $column_names Column names array.
 	 */
-	public function set_column_names( $column_names ) {
+	final public function set_column_names( $column_names ) {
 		$this->column_names = array();
 
 		foreach ( $column_names as $column_id => $column_name ) {
@@ -113,7 +113,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return array
 	 */
-	public function get_columns_to_export() {
+	final public function get_columns_to_export() {
 		return $this->columns_to_export;
 	}
 
@@ -123,7 +123,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.9.0
 	 * @return string
 	 */
-	public function get_delimiter() {
+	final public function get_delimiter() {
 		return apply_filters( "woocommerce_{$this->export_type}_export_delimiter", $this->delimiter );
 	}
 
@@ -133,7 +133,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @param array $columns Columns array.
 	 */
-	public function set_columns_to_export( $columns ) {
+	final public function set_columns_to_export( $columns ) {
 		$this->columns_to_export = array_map( 'wc_clean', $columns );
 	}
 
@@ -144,7 +144,7 @@ abstract class WC_CSV_Exporter {
 	 * @param  string $column_id ID of the column being exported.
 	 * @return boolean
 	 */
-	public function is_column_exporting( $column_id ) {
+	final public function is_column_exporting( $column_id ) {
 		$column_id         = strstr( $column_id, ':' ) ? current( explode( ':', $column_id ) ) : $column_id;
 		$columns_to_export = $this->get_columns_to_export();
 
@@ -165,7 +165,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return array
 	 */
-	public function get_default_column_names() {
+	final public function get_default_column_names() {
 		return array();
 	}
 
@@ -174,7 +174,7 @@ abstract class WC_CSV_Exporter {
 	 *
 	 * @since 3.1.0
 	 */
-	public function export() {
+	final public function export() {
 		$this->prepare_data_to_export();
 		$this->send_headers();
 		$this->send_content( chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers() . $this->get_csv_data() );
@@ -186,7 +186,7 @@ abstract class WC_CSV_Exporter {
 	 *
 	 * @since 3.1.0
 	 */
-	public function send_headers() {
+	final public function send_headers() {
 		if ( function_exists( 'gc_enable' ) ) {
 			gc_enable(); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.gc_enableFound
 		}
@@ -210,7 +210,7 @@ abstract class WC_CSV_Exporter {
 	 *
 	 * @param  string $filename Filename to export to.
 	 */
-	public function set_filename( $filename ) {
+	final public function set_filename( $filename ) {
 		$this->filename = sanitize_file_name( str_replace( '.csv', '', $filename ) . '.csv' );
 	}
 
@@ -219,7 +219,7 @@ abstract class WC_CSV_Exporter {
 	 *
 	 * @return string
 	 */
-	public function get_filename() {
+	final public function get_filename() {
 		return sanitize_file_name( apply_filters( "woocommerce_{$this->export_type}_export_get_filename", $this->filename ) );
 	}
 
@@ -229,7 +229,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @param string $csv_data All CSV content.
 	 */
-	public function send_content( $csv_data ) {
+	final public function send_content( $csv_data ) {
 		echo $csv_data; // @codingStandardsIgnoreLine
 	}
 
@@ -327,7 +327,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return int
 	 */
-	public function get_limit() {
+	final public function get_limit() {
 		return apply_filters( "woocommerce_{$this->export_type}_export_batch_limit", $this->limit, $this );
 	}
 
@@ -337,7 +337,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @param int $limit Limit to export.
 	 */
-	public function set_limit( $limit ) {
+	final public function set_limit( $limit ) {
 		$this->limit = absint( $limit );
 	}
 
@@ -347,7 +347,7 @@ abstract class WC_CSV_Exporter {
 	 * @since 3.1.0
 	 * @return int
 	 */
-	public function get_total_exported() {
+	final public function get_total_exported() {
 		return $this->exported_row_count;
 	}
 
@@ -367,7 +367,7 @@ abstract class WC_CSV_Exporter {
 	 * @param string $data CSV field to escape.
 	 * @return string
 	 */
-	public function escape_data( $data ) {
+	final public function escape_data( $data ) {
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
 		if ( in_array( mb_substr( $data, 0, 1 ), $active_content_triggers, true ) ) {
@@ -384,7 +384,7 @@ abstract class WC_CSV_Exporter {
 	 * @param  string $data Data to format.
 	 * @return string
 	 */
-	public function format_data( $data ) {
+	final public function format_data( $data ) {
 		if ( ! is_scalar( $data ) ) {
 			if ( is_a( $data, 'WC_Datetime' ) ) {
 				$data = $data->date( 'Y-m-d G:i:s' );
@@ -413,7 +413,7 @@ abstract class WC_CSV_Exporter {
 	 * @param  string $taxonomy Taxonomy name.
 	 * @return string
 	 */
-	public function format_term_ids( $term_ids, $taxonomy ) {
+	final public function format_term_ids( $term_ids, $taxonomy ) {
 		$term_ids = wp_parse_id_list( $term_ids );
 
 		if ( ! count( $term_ids ) ) {

--- a/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
+++ b/plugins/woocommerce/includes/import/abstract-wc-product-importer.php
@@ -94,7 +94,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_raw_keys() {
+	final public function get_raw_keys() {
 		return $this->raw_keys;
 	}
 
@@ -103,7 +103,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_mapped_keys() {
+	final public function get_mapped_keys() {
 		return ! empty( $this->mapped_keys ) ? $this->mapped_keys : $this->raw_keys;
 	}
 
@@ -112,7 +112,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_raw_data() {
+	final public function get_raw_data() {
 		return $this->raw_data;
 	}
 
@@ -121,7 +121,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_parsed_data() {
+	final public function get_parsed_data() {
 		/**
 		 * Filter product importer parsed data.
 		 *
@@ -136,7 +136,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_params() {
+	final public function get_params() {
 		return $this->params;
 	}
 
@@ -145,7 +145,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return int
 	 */
-	public function get_file_position() {
+	final public function get_file_position() {
 		return $this->file_position;
 	}
 
@@ -154,7 +154,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 *
 	 * @return int
 	 */
-	public function get_percent_complete() {
+	final public function get_percent_complete() {
 		$size = filesize( $this->file );
 		if ( ! $size ) {
 			return 0;
@@ -554,7 +554,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @return int
 	 * @throws Exception If attachment cannot be loaded.
 	 */
-	public function get_attachment_id_from_url( $url, $product_id ) {
+	final public function get_attachment_id_from_url( $url, $product_id ) {
 		if ( empty( $url ) ) {
 			return 0;
 		}
@@ -646,7 +646,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @return int
 	 * @throws Exception If taxonomy cannot be loaded.
 	 */
-	public function get_attribute_taxonomy_id( $raw_name ) {
+	final public function get_attribute_taxonomy_id( $raw_name ) {
 		global $wpdb, $wc_product_attributes;
 
 		// These are exported as labels, so convert the label to a name if possible first.

--- a/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php
+++ b/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php
@@ -24,7 +24,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function add_coupon( $code = array(), $discount = 0, $discount_tax = 0 ) {
+	final public function add_coupon( $code = array(), $discount = 0, $discount_tax = 0 ) {
 		wc_deprecated_function( 'WC_Order::add_coupon', '3.0', 'a new WC_Order_Item_Coupon object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Coupon();
@@ -48,7 +48,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function add_tax( $tax_rate_id, $tax_amount = 0, $shipping_tax_amount = 0 ) {
+	final public function add_tax( $tax_rate_id, $tax_amount = 0, $shipping_tax_amount = 0 ) {
 		wc_deprecated_function( 'WC_Order::add_tax', '3.0', 'a new WC_Order_Item_Tax object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Tax();
@@ -71,7 +71,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function add_shipping( $shipping_rate ) {
+	final public function add_shipping( $shipping_rate ) {
 		wc_deprecated_function( 'WC_Order::add_shipping', '3.0', 'a new WC_Order_Item_Shipping object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Shipping();
@@ -102,7 +102,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param  object $fee Fee data.
 	 * @return int         Updated order item ID.
 	 */
-	public function add_fee( $fee ) {
+	final public function add_fee( $fee ) {
 		wc_deprecated_function( 'WC_Order::add_fee', '3.0', 'a new WC_Order_Item_Fee object and add to order with WC_Order::add_item()' );
 
 		$item = new WC_Order_Item_Fee();
@@ -133,7 +133,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int updated order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function update_product( $item, $product, $args ) {
+	final public function update_product( $item, $product, $args ) {
 		wc_deprecated_function( 'WC_Order::update_product', '3.0', 'an interaction with the WC_Order_Item_Product class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
@@ -182,7 +182,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int updated order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function update_coupon( $item, $args ) {
+	final public function update_coupon( $item, $args ) {
 		wc_deprecated_function( 'WC_Order::update_coupon', '3.0', 'an interaction with the WC_Order_Item_Coupon class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
@@ -221,7 +221,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int updated order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function update_shipping( $item, $args ) {
+	final public function update_shipping( $item, $args ) {
 		wc_deprecated_function( 'WC_Order::update_shipping', '3.0', 'an interaction with the WC_Order_Item_Shipping class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
@@ -258,7 +258,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int updated order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function update_fee( $item, $args ) {
+	final public function update_fee( $item, $args ) {
 		wc_deprecated_function( 'WC_Order::update_fee', '3.0', 'an interaction with the WC_Order_Item_Fee class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
@@ -289,7 +289,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @return int updated order item ID
 	 * @throws WC_Data_Exception
 	 */
-	public function update_tax( $item, $args ) {
+	final public function update_tax( $item, $args ) {
 		wc_deprecated_function( 'WC_Order::update_tax', '3.0', 'an interaction with the WC_Order_Item_Tax class' );
 		if ( is_numeric( $item ) ) {
 			$item = $this->get_item( $item );
@@ -316,7 +316,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param object $item
 	 * @return WC_Product|bool
 	 */
-	public function get_product_from_item( $item ) {
+	final public function get_product_from_item( $item ) {
 		wc_deprecated_function( 'WC_Abstract_Legacy_Order::get_product_from_item', '4.4.0', '$item->get_product()' );
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$product = $item->get_product();
@@ -331,7 +331,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param array $address Address data.
 	 * @param string $type billing or shipping.
 	 */
-	public function set_address( $address, $type = 'billing' ) {
+	final public function set_address( $address, $type = 'billing' ) {
 		foreach ( $address as $key => $value ) {
 			update_post_meta( $this->get_id(), "_{$type}_" . $key, $value );
 			if ( is_callable( array( $this, "set_{$type}_{$key}" ) ) ) {
@@ -346,7 +346,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param string $total_type
 	 * @return bool
 	 */
-	public function legacy_set_total( $amount, $total_type = 'total' ) {
+	final public function legacy_set_total( $amount, $total_type = 'total' ) {
 		if ( ! in_array( $total_type, array( 'shipping', 'tax', 'shipping_tax', 'total', 'cart_discount', 'cart_discount_tax' ) ) ) {
 			return false;
 		}
@@ -468,7 +468,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 *
 	 * @return array of meta data.
 	 */
-	public function has_meta( $order_item_id ) {
+	final public function has_meta( $order_item_id ) {
 		global $wpdb;
 
 		wc_deprecated_function( 'WC_Order::has_meta( $order_item_id )', '3.0', 'WC_Order_item::get_meta_data' );
@@ -482,7 +482,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Display meta data belonging to an item.
 	 * @param  array $item
 	 */
-	public function display_item_meta( $item ) {
+	final public function display_item_meta( $item ) {
 		wc_deprecated_function( 'WC_Order::display_item_meta', '3.0', 'wc_display_item_meta' );
 		$product   = $item->get_product();
 		$item_meta = new WC_Order_Item_Meta( $item, $product );
@@ -493,7 +493,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Display download links for an order item.
 	 * @param  array $item
 	 */
-	public function display_item_downloads( $item ) {
+	final public function display_item_downloads( $item ) {
 		wc_deprecated_function( 'WC_Order::display_item_downloads', '3.0', 'wc_display_item_downloads' );
 		$product   = $item->get_product();
 
@@ -520,7 +520,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param  int $download_id
 	 * @return string
 	 */
-	public function get_download_url( $product_id, $download_id ) {
+	final public function get_download_url( $product_id, $download_id ) {
 		wc_deprecated_function( 'WC_Order::get_download_url', '3.0', 'WC_Order_Item_Product::get_item_download_url' );
 		return add_query_arg( array(
 			'download_file' => $product_id,
@@ -536,7 +536,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param  array $item
 	 * @return array
 	 */
-	public function get_item_downloads( $item ) {
+	final public function get_item_downloads( $item ) {
 		wc_deprecated_function( 'WC_Order::get_item_downloads', '3.0', 'WC_Order_Item_Product::get_item_downloads' );
 
 		if ( ! $item instanceof WC_Order_Item ) {
@@ -563,7 +563,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @deprecated 3.0.0 since this is an alias only.
 	 * @return float
 	 */
-	public function get_total_shipping() {
+	final public function get_total_shipping() {
 		return $this->get_shipping_total();
 	}
 
@@ -575,7 +575,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param bool $single (default: false)
 	 * @return array|string
 	 */
-	public function get_item_meta( $order_item_id, $key = '', $single = false ) {
+	final public function get_item_meta( $order_item_id, $key = '', $single = false ) {
 		wc_deprecated_function( 'WC_Order::get_item_meta', '3.0', 'wc_get_order_item_meta' );
 		return get_metadata( 'order_item', $order_item_id, $key, $single );
 	}
@@ -586,7 +586,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param mixed $order_item_id
 	 * @return array of objects
 	 */
-	public function get_item_meta_array( $order_item_id ) {
+	final public function get_item_meta_array( $order_item_id ) {
 		wc_deprecated_function( 'WC_Order::get_item_meta_array', '3.0', 'WC_Order_Item::get_meta_data() (note the format has changed)' );
 		$item            = $this->get_item( $order_item_id );
 		$meta_data       = $item->get_meta_data();
@@ -605,7 +605,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @deprecated 3.7.0 - Replaced with better named method to reflect the actual data being returned.
 	 * @return array
 	 */
-	public function get_used_coupons() {
+	final public function get_used_coupons() {
 		wc_deprecated_function( 'get_used_coupons', '3.7', 'WC_Abstract_Order::get_coupon_codes' );
 		return $this->get_coupon_codes();
 	}
@@ -617,7 +617,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param array $item before expansion.
 	 * @return array
 	 */
-	public function expand_item_meta( $item ) {
+	final public function expand_item_meta( $item ) {
 		wc_deprecated_function( 'WC_Order::expand_item_meta', '3.0' );
 		return $item;
 	}
@@ -646,7 +646,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param int $id (default: 0).
 	 * @return bool
 	 */
-	public function get_order( $id = 0 ) {
+	final public function get_order( $id = 0 ) {
 		wc_deprecated_function( 'WC_Order::get_order', '3.0' );
 
 		if ( ! $id ) {
@@ -668,7 +668,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @deprecated 3.0
 	 * @param mixed $result
 	 */
-	public function populate( $result ) {
+	final public function populate( $result ) {
 		wc_deprecated_function( 'WC_Order::populate', '3.0' );
 		$this->set_id( $result->ID );
 		$this->set_object_read( false );
@@ -680,7 +680,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @deprecated 3.0.0 Moved to event handler.
 	 * @param string $note (default: '') Optional note to add.
 	 */
-	public function cancel_order( $note = '' ) {
+	final public function cancel_order( $note = '' ) {
 		wc_deprecated_function( 'WC_Order::cancel_order', '3.0', 'WC_Order::update_status' );
 		WC()->session->set( 'order_awaiting_payment', false );
 		$this->update_status( 'cancelled', $note );
@@ -690,7 +690,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Record sales.
 	 * @deprecated 3.0.0
 	 */
-	public function record_product_sales() {
+	final public function record_product_sales() {
 		wc_deprecated_function( 'WC_Order::record_product_sales', '3.0', 'wc_update_total_sales_counts' );
 		wc_update_total_sales_counts( $this->get_id() );
 	}
@@ -699,7 +699,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Increase applied coupon counts.
 	 * @deprecated 3.0.0
 	 */
-	public function increase_coupon_usage_counts() {
+	final public function increase_coupon_usage_counts() {
 		wc_deprecated_function( 'WC_Order::increase_coupon_usage_counts', '3.0', 'wc_update_coupon_usage_counts' );
 		wc_update_coupon_usage_counts( $this->get_id() );
 	}
@@ -708,7 +708,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Decrease applied coupon counts.
 	 * @deprecated 3.0.0
 	 */
-	public function decrease_coupon_usage_counts() {
+	final public function decrease_coupon_usage_counts() {
 		wc_deprecated_function( 'WC_Order::decrease_coupon_usage_counts', '3.0', 'wc_update_coupon_usage_counts' );
 		wc_update_coupon_usage_counts( $this->get_id() );
 	}
@@ -717,7 +717,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Reduce stock levels for all line items in the order.
 	 * @deprecated 3.0.0
 	 */
-	public function reduce_order_stock() {
+	final public function reduce_order_stock() {
 		wc_deprecated_function( 'WC_Order::reduce_order_stock', '3.0', 'wc_reduce_stock_levels' );
 		wc_reduce_stock_levels( $this->get_id() );
 	}
@@ -730,7 +730,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param $new_stock
 	 * @param $qty_ordered
 	 */
-	public function send_stock_notifications( $product, $new_stock, $qty_ordered ) {
+	final public function send_stock_notifications( $product, $new_stock, $qty_ordered ) {
 		wc_deprecated_function( 'WC_Order::send_stock_notifications', '3.0' );
 	}
 
@@ -740,7 +740,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * @param array $args Items args.
 	 * @return string
 	 */
-	public function email_order_items_table( $args = array() ) {
+	final public function email_order_items_table( $args = array() ) {
 		wc_deprecated_function( 'WC_Order::email_order_items_table', '3.0', 'wc_get_email_order_items' );
 		return wc_get_email_order_items( $this, $args );
 	}
@@ -749,7 +749,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * Get currency.
 	 * @deprecated 3.0.0
 	 */
-	public function get_order_currency() {
+	final public function get_order_currency() {
 		wc_deprecated_function( 'WC_Order::get_order_currency', '3.0', 'WC_Order::get_currency' );
 		return apply_filters( 'woocommerce_get_order_currency', $this->get_currency(), $this );
 	}

--- a/plugins/woocommerce/includes/legacy/abstract-wc-legacy-payment-token.php
+++ b/plugins/woocommerce/includes/legacy/abstract-wc-legacy-payment-token.php
@@ -22,7 +22,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 *
 	 * @param string Payment Token Type (CC, eCheck)
 	 */
-	public function set_type( $type ) {
+	final public function set_type( $type ) {
 		wc_deprecated_function( 'WC_Payment_Token::set_type', '3.0.0', 'Type cannot be overwritten.' );
 	}
 
@@ -32,7 +32,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 *
 	 * @param int $token_id
 	 */
-	public function read( $token_id ) {
+	final public function read( $token_id ) {
 		wc_deprecated_function( 'WC_Payment_Token::read', '3.0.0', 'a new token class initialized with an ID.' );
 		$this->set_id( $token_id );
 		$data_store = WC_Data_Store::load( 'payment-token' );
@@ -43,7 +43,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 * Update a token.
 	 * @deprecated 3.0.0 - Use ::save instead.
 	 */
-	public function update() {
+	final public function update() {
 		wc_deprecated_function( 'WC_Payment_Token::update', '3.0.0', 'WC_Payment_Token::save instead.' );
 		$data_store = WC_Data_Store::load( 'payment-token' );
 		try {
@@ -57,7 +57,7 @@ abstract class WC_Legacy_Payment_Token extends WC_Data {
 	 * Create a token.
 	 * @deprecated 3.0.0 - Use ::save instead.
 	 */
-	public function create() {
+	final public function create() {
 		wc_deprecated_function( 'WC_Payment_Token::create', '3.0.0', 'WC_Payment_Token::save instead.' );
 		$data_store = WC_Data_Store::load( 'payment-token' );
 		try {

--- a/plugins/woocommerce/includes/legacy/abstract-wc-legacy-product.php
+++ b/plugins/woocommerce/includes/legacy/abstract-wc-legacy-product.php
@@ -160,7 +160,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return array
 	 */
-	public function get_variation_default_attributes() {
+	final public function get_variation_default_attributes() {
 		wc_deprecated_function( 'WC_Product_Variable::get_variation_default_attributes', '3.0', 'WC_Product::get_default_attributes' );
 		return apply_filters( 'woocommerce_product_default_attributes', $this->get_default_attributes(), $this );
 	}
@@ -171,7 +171,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return array
 	 */
-	public function get_gallery_attachment_ids() {
+	final public function get_gallery_attachment_ids() {
 		wc_deprecated_function( 'WC_Product::get_gallery_attachment_ids', '3.0', 'WC_Product::get_gallery_image_ids' );
 		return $this->get_gallery_image_ids();
 	}
@@ -186,7 +186,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 *
 	 * @return int
 	 */
-	public function set_stock( $amount = null, $mode = 'set' ) {
+	final public function set_stock( $amount = null, $mode = 'set' ) {
 		wc_deprecated_function( 'WC_Product::set_stock', '3.0', 'wc_update_product_stock' );
 		return wc_update_product_stock( $this, $amount, $mode );
 	}
@@ -198,7 +198,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param int $amount Amount to reduce by. Default: 1
 	 * @return int new stock level
 	 */
-	public function reduce_stock( $amount = 1 ) {
+	final public function reduce_stock( $amount = 1 ) {
 		wc_deprecated_function( 'WC_Product::reduce_stock', '3.0', 'wc_update_product_stock' );
 		return wc_update_product_stock( $this, $amount, 'decrease' );
 	}
@@ -210,7 +210,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param int $amount Amount to increase by. Default 1.
 	 * @return int new stock level
 	 */
-	public function increase_stock( $amount = 1 ) {
+	final public function increase_stock( $amount = 1 ) {
 		wc_deprecated_function( 'WC_Product::increase_stock', '3.0', 'wc_update_product_stock' );
 		return wc_update_product_stock( $this, $amount, 'increase' );
 	}
@@ -220,7 +220,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 *
 	 * @deprecated 3.0.0 Sync is done automatically on read/save, so calling this should not be needed any more.
 	 */
-	public function check_stock_status() {
+	final public function check_stock_status() {
 		wc_deprecated_function( 'WC_Product::check_stock_status', '3.0' );
 	}
 
@@ -232,7 +232,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 *
 	 * @return array
 	 */
-	public function get_related( $limit = 5 ) {
+	final public function get_related( $limit = 5 ) {
 		wc_deprecated_function( 'WC_Product::get_related', '3.0', 'wc_get_related_products' );
 		return wc_get_related_products( $this->get_id(), $limit );
 	}
@@ -271,7 +271,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param mixed $child_id
 	 * @return WC_Product|WC_Product|WC_Product_variation
 	 */
-	public function get_child( $child_id ) {
+	final public function get_child( $child_id ) {
 		wc_deprecated_function( 'WC_Product::get_child', '3.0', 'wc_get_product' );
 		return wc_get_product( $child_id );
 	}
@@ -282,7 +282,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return string
 	 */
-	public function get_price_html_from_text() {
+	final public function get_price_html_from_text() {
 		wc_deprecated_function( 'WC_Product::get_price_html_from_text', '3.0', 'wc_get_price_html_from_text' );
 		return wc_get_price_html_from_text();
 	}
@@ -295,7 +295,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param  mixed $to String or float to wrap with 'to' text
 	 * @return string
 	 */
-	public function get_price_html_from_to( $from, $to ) {
+	final public function get_price_html_from_to( $from, $to ) {
 		wc_deprecated_function( 'WC_Product::get_price_html_from_to', '3.0', 'wc_format_sale_price' );
 		return apply_filters( 'woocommerce_get_price_html_from_to', wc_format_sale_price( $from, $to ), $from, $to, $this );
 	}
@@ -304,7 +304,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * Lists a table of attributes for the product page.
 	 * @deprecated 3.0.0 Use wc_display_product_attributes instead.
 	 */
-	public function list_attributes() {
+	final public function list_attributes() {
 		wc_deprecated_function( 'WC_Product::list_attributes', '3.0', 'wc_display_product_attributes' );
 		wc_display_product_attributes( $this );
 	}
@@ -317,7 +317,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param  string $price to calculate, left blank to just use get_price()
 	 * @return string
 	 */
-	public function get_price_including_tax( $qty = 1, $price = '' ) {
+	final public function get_price_including_tax( $qty = 1, $price = '' ) {
 		wc_deprecated_function( 'WC_Product::get_price_including_tax', '3.0', 'wc_get_price_including_tax' );
 		return wc_get_price_including_tax( $this, array( 'qty' => $qty, 'price' => $price ) );
 	}
@@ -330,7 +330,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param  integer $qty   passed on to get_price_including_tax() or get_price_excluding_tax()
 	 * @return string
 	 */
-	public function get_display_price( $price = '', $qty = 1 ) {
+	final public function get_display_price( $price = '', $qty = 1 ) {
 		wc_deprecated_function( 'WC_Product::get_display_price', '3.0', 'wc_get_price_to_display' );
 		return wc_get_price_to_display( $this, array( 'qty' => $qty, 'price' => $price ) );
 	}
@@ -344,7 +344,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param  string $price to calculate, left blank to just use get_price()
 	 * @return string
 	 */
-	public function get_price_excluding_tax( $qty = 1, $price = '' ) {
+	final public function get_price_excluding_tax( $qty = 1, $price = '' ) {
 		wc_deprecated_function( 'WC_Product::get_price_excluding_tax', '3.0', 'wc_get_price_excluding_tax' );
 		return wc_get_price_excluding_tax( $this, array( 'qty' => $qty, 'price' => $price ) );
 	}
@@ -355,7 +355,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @param mixed $price
 	 */
-	public function adjust_price( $price ) {
+	final public function adjust_price( $price ) {
 		wc_deprecated_function( 'WC_Product::adjust_price', '3.0', 'WC_Product::set_price / WC_Product::get_price' );
 		$this->data['price'] = $this->data['price'] + $price;
 	}
@@ -369,7 +369,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param string $after (default: '').
 	 * @return string
 	 */
-	public function get_categories( $sep = ', ', $before = '', $after = '' ) {
+	final public function get_categories( $sep = ', ', $before = '', $after = '' ) {
 		wc_deprecated_function( 'WC_Product::get_categories', '3.0', 'wc_get_product_category_list' );
 		return wc_get_product_category_list( $this->get_id(), $sep, $before, $after );
 	}
@@ -383,7 +383,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param string $after (default: '').
 	 * @return array
 	 */
-	public function get_tags( $sep = ', ', $before = '', $after = '' ) {
+	final public function get_tags( $sep = ', ', $before = '', $after = '' ) {
 		wc_deprecated_function( 'WC_Product::get_tags', '3.0', 'wc_get_product_tag_list' );
 		return wc_get_product_tag_list( $this->get_id(), $sep, $before, $after );
 	}
@@ -394,7 +394,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return WP_Post
 	 */
-	public function get_post_data() {
+	final public function get_post_data() {
 		wc_deprecated_function( 'WC_Product::get_post_data', '3.0', 'get_post' );
 
 		// In order to keep backwards compatibility it's required to use the parent data for variations.
@@ -413,7 +413,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return int
 	 */
-	public function get_parent() {
+	final public function get_parent() {
 		wc_deprecated_function( 'WC_Product::get_parent', '3.0', 'WC_Product::get_parent_id' );
 		return apply_filters( 'woocommerce_product_parent', absint( $this->get_post_data()->post_parent ), $this );
 	}
@@ -424,7 +424,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return array
 	 */
-	public function get_upsells() {
+	final public function get_upsells() {
 		wc_deprecated_function( 'WC_Product::get_upsells', '3.0', 'WC_Product::get_upsell_ids' );
 		return apply_filters( 'woocommerce_product_upsell_ids', $this->get_upsell_ids(), $this );
 	}
@@ -435,7 +435,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return array
 	 */
-	public function get_cross_sells() {
+	final public function get_cross_sells() {
 		wc_deprecated_function( 'WC_Product::get_cross_sells', '3.0', 'WC_Product::get_cross_sell_ids' );
 		return apply_filters( 'woocommerce_product_crosssell_ids', $this->get_cross_sell_ids(), $this );
 	}
@@ -446,7 +446,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return bool
 	 */
-	public function has_default_attributes() {
+	final public function has_default_attributes() {
 		wc_deprecated_function( 'WC_Product_Variable::has_default_attributes', '3.0', 'a check against WC_Product::get_default_attributes directly' );
 		if ( ! $this->get_default_attributes() ) {
 			return true;
@@ -460,7 +460,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return int
 	 */
-	public function get_variation_id() {
+	final public function get_variation_id() {
 		wc_deprecated_function( 'WC_Product::get_variation_id', '3.0', 'WC_Product::get_id(). It will always be the variation ID if this is a variation.' );
 		return $this->get_id();
 	}
@@ -471,7 +471,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return string
 	 */
-	public function get_variation_description() {
+	final public function get_variation_description() {
 		wc_deprecated_function( 'WC_Product::get_variation_description', '3.0', 'WC_Product::get_description()' );
 		return $this->get_description();
 	}
@@ -482,7 +482,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return boolean
 	 */
-	public function has_all_attributes_set() {
+	final public function has_all_attributes_set() {
 		wc_deprecated_function( 'WC_Product::has_all_attributes_set', '3.0', 'an array filter on get_variation_attributes for a quick solution.' );
 		$set = true;
 
@@ -502,7 +502,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return bool
 	 */
-	public function parent_is_visible() {
+	final public function parent_is_visible() {
 		wc_deprecated_function( 'WC_Product::parent_is_visible', '3.0' );
 		return $this->is_visible();
 	}
@@ -513,7 +513,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return int
 	 */
-	public function get_total_stock() {
+	final public function get_total_stock() {
 		wc_deprecated_function( 'WC_Product::get_total_stock', '3.0', 'get_stock_quantity on each child. Beware of performance issues in doing so.' );
 		if ( sizeof( $this->get_children() ) > 0 ) {
 			$total_stock = max( 0, $this->get_stock_quantity() );
@@ -539,7 +539,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 *
 	 * @return string
 	 */
-	public function get_formatted_variation_attributes( $flat = false ) {
+	final public function get_formatted_variation_attributes( $flat = false ) {
 		wc_deprecated_function( 'WC_Product::get_formatted_variation_attributes', '3.0', 'wc_get_formatted_variation' );
 		return wc_get_formatted_variation( $this, $flat );
 	}
@@ -551,7 +551,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 *
 	 * @param int $product_id
 	 */
-	public function variable_product_sync( $product_id = 0 ) {
+	final public function variable_product_sync( $product_id = 0 ) {
 		wc_deprecated_function( 'WC_Product::variable_product_sync', '3.0' );
 		if ( empty( $product_id ) ) {
 			$product_id = $this->get_id();
@@ -569,7 +569,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param $product
 	 * @param bool $children
 	 */
-	public static function sync_attributes( $product, $children = false ) {
+	final public static function sync_attributes( $product, $children = false ) {
 		if ( ! is_a( $product, 'WC_Product' ) ) {
 			$product = wc_get_product( $product );
 		}
@@ -617,7 +617,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 *
 	 * @param array $match_attributes
 	 */
-	public function get_matching_variation( $match_attributes = array() ) {
+	final public function get_matching_variation( $match_attributes = array() ) {
 		wc_deprecated_function( 'WC_Product::get_matching_variation', '3.0', 'Product data store find_matching_product_variation' );
 		$data_store = WC_Data_Store::load( 'product' );
 		return $data_store->find_matching_product_variation( $this, $match_attributes );
@@ -628,7 +628,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0 Unused.
 	 * @return bool
 	 */
-	public function enable_dimensions_display() {
+	final public function enable_dimensions_display() {
 		wc_deprecated_function( 'WC_Product::enable_dimensions_display', '3.0' );
 		return apply_filters( 'wc_product_enable_dimensions_display', true ) && ( $this->has_dimensions() || $this->has_weight() || $this->child_has_weight() || $this->child_has_dimensions() );
 	}
@@ -640,7 +640,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @param string $rating (default: '')
 	 * @return string
 	 */
-	public function get_rating_html( $rating = null ) {
+	final public function get_rating_html( $rating = null ) {
 		wc_deprecated_function( 'WC_Product::get_rating_html', '3.0', 'wc_get_rating_html' );
 		return wc_get_rating_html( $rating );
 	}
@@ -651,7 +651,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @param  int $post_id
 	 */
-	public static function sync_average_rating( $post_id ) {
+	final public static function sync_average_rating( $post_id ) {
 		wc_deprecated_function( 'WC_Product::sync_average_rating', '3.0', 'WC_Comments::get_average_rating_for_product or leave to CRUD.' );
 		// See notes in https://github.com/woocommerce/woocommerce/pull/22909#discussion_r262393401.
 		// Sync count first like in the original method https://github.com/woocommerce/woocommerce/blob/2.6.0/includes/abstracts/abstract-wc-product.php#L1101-L1128.
@@ -666,7 +666,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @param  int $post_id
 	 */
-	public static function sync_rating_count( $post_id ) {
+	final public static function sync_rating_count( $post_id ) {
 		wc_deprecated_function( 'WC_Product::sync_rating_count', '3.0', 'WC_Comments::get_rating_counts_for_product or leave to CRUD.' );
 		$counts     = WC_Comments::get_rating_counts_for_product( wc_get_product( $post_id ) );
 		update_post_meta( $post_id, '_wc_rating_count', $counts );
@@ -678,7 +678,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 * @deprecated 3.0.0
 	 * @return array
 	 */
-	public function get_files() {
+	final public function get_files() {
 		wc_deprecated_function( 'WC_Product::get_files', '3.0', 'WC_Product::get_downloads' );
 		return $this->get_downloads();
 	}
@@ -686,7 +686,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	/**
 	 * @deprecated 3.0.0 Sync is taken care of during save - no need to call this directly.
 	 */
-	public function grouped_product_sync() {
+	final public function grouped_product_sync() {
 		wc_deprecated_function( 'WC_Product::grouped_product_sync', '3.0' );
 	}
 }

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-cart.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-cart.php
@@ -105,7 +105,7 @@ abstract class WC_Legacy_Cart {
 	 * @param string $name Property name.
 	 * @return mixed
 	 */
-	public function &__get( $name ) {
+	final public function &__get( $name ) {
 		$value = '';
 
 		switch ( $name ) {
@@ -271,19 +271,19 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Methods moved to session class in 3.2.0.
 	 */
-	public function get_cart_from_session() { $this->session->get_cart_from_session(); }
-	public function maybe_set_cart_cookies() { $this->session->maybe_set_cart_cookies(); }
-	public function set_session() { $this->session->set_session(); }
-	public function get_cart_for_session() { return $this->session->get_cart_for_session(); }
-	public function persistent_cart_update() { $this->session->persistent_cart_update(); }
-	public function persistent_cart_destroy() { $this->session->persistent_cart_destroy(); }
+	final public function get_cart_from_session() { $this->session->get_cart_from_session(); }
+	final public function maybe_set_cart_cookies() { $this->session->maybe_set_cart_cookies(); }
+	final public function set_session() { $this->session->set_session(); }
+	final public function get_cart_for_session() { return $this->session->get_cart_for_session(); }
+	final public function persistent_cart_update() { $this->session->persistent_cart_update(); }
+	final public function persistent_cart_destroy() { $this->session->persistent_cart_destroy(); }
 
 	/**
 	 * Get the total of all cart discounts.
 	 *
 	 * @return float
 	 */
-	public function get_cart_discount_total() {
+	final public function get_cart_discount_total() {
 		return $this->get_discount_total();
 	}
 
@@ -292,7 +292,7 @@ abstract class WC_Legacy_Cart {
 	 *
 	 * @return float
 	 */
-	public function get_cart_discount_tax_total() {
+	final public function get_cart_discount_tax_total() {
 		return $this->get_discount_tax();
 	}
 
@@ -302,7 +302,7 @@ abstract class WC_Legacy_Cart {
 	 * @param string $coupon_code
 	 * @return bool	True if the coupon is applied, false if it does not exist or cannot be applied.
 	 */
-	public function add_discount( $coupon_code ) {
+	final public function add_discount( $coupon_code ) {
 		return $this->apply_coupon( $coupon_code );
 	}
 	/**
@@ -310,7 +310,7 @@ abstract class WC_Legacy_Cart {
 	 *
 	 * @deprecated 3.2.0 Taxes are never calculated if customer is tax except making this function unused.
 	 */
-	public function remove_taxes() {
+	final public function remove_taxes() {
 		wc_deprecated_function( 'WC_Cart::remove_taxes', '3.2', '' );
 	}
 	/**
@@ -318,7 +318,7 @@ abstract class WC_Legacy_Cart {
 	 *
 	 * @deprecated 3.2.0 Session is loaded via hooks rather than directly.
 	 */
-	public function init() {
+	final public function init() {
 		wc_deprecated_function( 'WC_Cart::init', '3.2', '' );
 		$this->get_cart_from_session();
 	}
@@ -332,7 +332,7 @@ abstract class WC_Legacy_Cart {
 	 * @param bool  $add_totals Legacy.
 	 * @return float price
 	 */
-	public function get_discounted_price( $values, $price, $add_totals = false ) {
+	final public function get_discounted_price( $values, $price, $add_totals = false ) {
 		wc_deprecated_function( 'WC_Cart::get_discounted_price', '3.2', '' );
 
 		$cart_item_key = $values['key'];
@@ -347,7 +347,7 @@ abstract class WC_Legacy_Cart {
 	 * @deprecated 2.5.0 in favor to wc_get_cart_url()
 	 * @return string url to page
 	 */
-	public function get_cart_url() {
+	final public function get_cart_url() {
 		wc_deprecated_function( 'WC_Cart::get_cart_url', '2.5', 'wc_get_cart_url' );
 		return wc_get_cart_url();
 	}
@@ -358,7 +358,7 @@ abstract class WC_Legacy_Cart {
 	 * @deprecated 2.5.0 in favor to wc_get_checkout_url()
 	 * @return string url to page
 	 */
-	public function get_checkout_url() {
+	final public function get_checkout_url() {
 		wc_deprecated_function( 'WC_Cart::get_checkout_url', '2.5', 'wc_get_checkout_url' );
 		return wc_get_checkout_url();
 	}
@@ -369,7 +369,7 @@ abstract class WC_Legacy_Cart {
 	 * @deprecated 2.5.0 in favor to wc_ship_to_billing_address_only()
 	 * @return bool
 	 */
-	public function ship_to_billing_address_only() {
+	final public function ship_to_billing_address_only() {
 		wc_deprecated_function( 'WC_Cart::ship_to_billing_address_only', '2.5', 'wc_ship_to_billing_address_only' );
 		return wc_ship_to_billing_address_only();
 	}
@@ -380,7 +380,7 @@ abstract class WC_Legacy_Cart {
 	 * @deprecated 2.5.0
 	 * @return bool
 	 */
-	public function coupons_enabled() {
+	final public function coupons_enabled() {
 		wc_deprecated_function( 'WC_Legacy_Cart::coupons_enabled', '2.5.0', 'wc_coupons_enabled' );
 		return wc_coupons_enabled();
 	}
@@ -391,7 +391,7 @@ abstract class WC_Legacy_Cart {
 	 * @deprecated 2.3.0 Order discounts (after tax) removed in 2.3 so multiple methods for discounts are no longer required.
 	 * @return mixed formatted price or false if there are none.
 	 */
-	public function get_discounts_before_tax() {
+	final public function get_discounts_before_tax() {
 		wc_deprecated_function( 'get_discounts_before_tax', '2.3', 'get_total_discount' );
 		if ( $this->get_cart_discount_total() ) {
 			$discounts_before_tax = wc_price( $this->get_cart_discount_total() );
@@ -407,7 +407,7 @@ abstract class WC_Legacy_Cart {
 	 * @deprecated 2.3.0 Order discounts (after tax) removed in 2.3.
 	 * @return int
 	 */
-	public function get_order_discount_total() {
+	final public function get_order_discount_total() {
 		wc_deprecated_function( 'get_order_discount_total', '2.3' );
 		return 0;
 	}
@@ -419,7 +419,7 @@ abstract class WC_Legacy_Cart {
 	 * @param $values
 	 * @param $price
 	 */
-	public function apply_cart_discounts_after_tax( $values, $price ) {
+	final public function apply_cart_discounts_after_tax( $values, $price ) {
 		wc_deprecated_function( 'apply_cart_discounts_after_tax', '2.3' );
 	}
 
@@ -431,7 +431,7 @@ abstract class WC_Legacy_Cart {
 	 * @param $values
 	 * @param $price
 	 */
-	public function apply_product_discounts_after_tax( $values, $price ) {
+	final public function apply_product_discounts_after_tax( $values, $price ) {
 		wc_deprecated_function( 'apply_product_discounts_after_tax', '2.3' );
 	}
 
@@ -440,7 +440,7 @@ abstract class WC_Legacy_Cart {
 	 *
 	 * @deprecated 2.3.0 Coupons can not be applied after tax.
 	 */
-	public function get_discounts_after_tax() {
+	final public function get_discounts_after_tax() {
 		wc_deprecated_function( 'get_discounts_after_tax', '2.3' );
 	}
 }

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-coupon.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-coupon.php
@@ -141,7 +141,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 * @param  string|array $array
 	 * @return array
 	 */
-	public function format_array( $array ) {
+	final public function format_array( $array ) {
 		wc_deprecated_function( 'WC_Coupon::format_array', '3.0' );
 		if ( ! is_array( $array ) ) {
 			if ( is_serialized( $array ) ) {
@@ -159,7 +159,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 *
 	 * @return bool
 	 */
-	public function apply_before_tax() {
+	final public function apply_before_tax() {
 		wc_deprecated_function( 'WC_Coupon::apply_before_tax', '3.0' );
 		return true;
 	}
@@ -169,7 +169,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 *
 	 * @return bool
 	 */
-	public function enable_free_shipping() {
+	final public function enable_free_shipping() {
 		wc_deprecated_function( 'WC_Coupon::enable_free_shipping', '3.0', 'WC_Coupon::get_free_shipping' );
 		return $this->get_free_shipping();
 	}
@@ -179,7 +179,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 *
 	 * @return bool
 	 */
-	public function exclude_sale_items() {
+	final public function exclude_sale_items() {
 		wc_deprecated_function( 'WC_Coupon::exclude_sale_items', '3.0', 'WC_Coupon::get_exclude_sale_items' );
 		return $this->get_exclude_sale_items();
 	}
@@ -189,7 +189,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 *
 	 * @param string $used_by Either user ID or billing email
 	 */
-	public function inc_usage_count( $used_by = '' ) {
+	final public function inc_usage_count( $used_by = '' ) {
 		$this->increase_usage_count( $used_by );
 	}
 
@@ -198,7 +198,7 @@ abstract class WC_Legacy_Coupon extends WC_Data {
 	 *
 	 * @param string $used_by Either user ID or billing email
 	 */
-	public function dcr_usage_count( $used_by = '' ) {
+	final public function dcr_usage_count( $used_by = '' ) {
 		$this->decrease_usage_count( $used_by );
 	}
 }

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-customer.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-customer.php
@@ -97,7 +97,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	 * @param string $postcode (default: '')
 	 * @param string $city (default: '')
 	 */
-	public function set_location( $country, $state, $postcode = '', $city = '' ) {
+	final public function set_location( $country, $state, $postcode = '', $city = '' ) {
 		$this->set_billing_location( $country, $state, $postcode, $city );
 		$this->set_shipping_location( $country, $state, $postcode, $city );
 	}
@@ -106,7 +106,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	 * Get default country for a customer.
 	 * @return string
 	 */
-	public function get_default_country() {
+	final public function get_default_country() {
 		wc_deprecated_function( 'WC_Customer::get_default_country', '3.0', 'wc_get_customer_default_location' );
 		$default = wc_get_customer_default_location();
 		return $default['country'];
@@ -116,7 +116,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	 * Get default state for a customer.
 	 * @return string
 	 */
-	public function get_default_state() {
+	final public function get_default_state() {
 		wc_deprecated_function( 'WC_Customer::get_default_state', '3.0', 'wc_get_customer_default_location' );
 		$default = wc_get_customer_default_location();
 		return $default['state'];
@@ -125,7 +125,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	/**
 	 * Set customer address to match shop base address.
 	 */
-	public function set_to_base() {
+	final public function set_to_base() {
 		wc_deprecated_function( 'WC_Customer::set_to_base', '3.0', 'WC_Customer::set_billing_address_to_base' );
 		$this->set_billing_address_to_base();
 	}
@@ -133,7 +133,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	/**
 	 * Set customer shipping address to base address.
 	 */
-	public function set_shipping_to_base() {
+	final public function set_shipping_to_base() {
 		wc_deprecated_function( 'WC_Customer::set_shipping_to_base', '3.0', 'WC_Customer::set_shipping_address_to_base' );
 		$this->set_shipping_address_to_base();
 	}
@@ -142,7 +142,7 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	 * Calculated shipping.
 	 * @param boolean $calculated
 	 */
-	public function calculated_shipping( $calculated = true ) {
+	final public function calculated_shipping( $calculated = true ) {
 		wc_deprecated_function( 'WC_Customer::calculated_shipping', '3.0', 'WC_Customer::set_calculated_shipping' );
 		$this->set_calculated_shipping( $calculated );
 	}
@@ -150,14 +150,14 @@ abstract class WC_Legacy_Customer extends WC_Data {
 	/**
 	 * Set default data for a customer.
 	 */
-	public function set_default_data() {
+	final public function set_default_data() {
 		wc_deprecated_function( 'WC_Customer::set_default_data', '3.0' );
 	}
 
 	/**
 	 * Save data function.
 	 */
-	public function save_data() {
+	final public function save_data() {
 		$this->save();
 	}
 

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-shipping-zone.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-shipping-zone.php
@@ -18,7 +18,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 * @return int|null Null if the zone does not exist. 0 is the default zone.
 	 * @deprecated 3.0
 	 */
-	public function get_zone_id() {
+	final public function get_zone_id() {
 		wc_deprecated_function( 'WC_Shipping_Zone::get_zone_id', '3.0', 'WC_Shipping_Zone::get_id' );
 		return $this->get_id();
 	}
@@ -29,7 +29,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 *
 	 * @param int $zone_id
 	 */
-	public function read( $zone_id ) {
+	final public function read( $zone_id ) {
 		wc_deprecated_function( 'WC_Shipping_Zone::read', '3.0', 'a shipping zone initialized with an ID.' );
 		$this->set_id( $zone_id );
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
@@ -40,7 +40,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 * Update a zone.
 	 * @deprecated 3.0.0 - Use ::save instead.
 	 */
-	public function update() {
+	final public function update() {
 		wc_deprecated_function( 'WC_Shipping_Zone::update', '3.0', 'WC_Shipping_Zone::save instead.' );
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		try {
@@ -54,7 +54,7 @@ abstract class WC_Legacy_Shipping_Zone extends WC_Data {
 	 * Create a zone.
 	 * @deprecated 3.0.0 - Use ::save instead.
 	 */
-	public function create() {
+	final public function create() {
 		wc_deprecated_function( 'WC_Shipping_Zone::create', '3.0', 'WC_Shipping_Zone::save instead.' );
 		$data_store = WC_Data_Store::load( 'shipping-zone' );
 		try {

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-webhook.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-webhook.php
@@ -107,7 +107,7 @@ abstract class WC_Legacy_Webhook extends WC_Data {
 	 * @since      2.2
 	 * @return     null|WP_Post
 	 */
-	public function get_post_data() {
+	final public function get_post_data() {
 		wc_deprecated_function( 'WC_Webhook::get_post_data', '3.2' );
 
 		return null;
@@ -120,7 +120,7 @@ abstract class WC_Legacy_Webhook extends WC_Data {
 	 * @since      2.2.0
 	 * @param      string $status Status to set.
 	 */
-	public function update_status( $status ) {
+	final public function update_status( $status ) {
 		wc_deprecated_function( 'WC_Webhook::update_status', '3.2', 'WC_Webhook::set_status' );
 
 		$this->set_status( $status );

--- a/plugins/woocommerce/includes/libraries/wp-async-request.php
+++ b/plugins/woocommerce/includes/libraries/wp-async-request.php
@@ -67,7 +67,7 @@ abstract class WP_Async_Request {
 	 *
 	 * @return $this
 	 */
-	public function data( $data ) {
+	final public function data( $data ) {
 		$this->data = $data;
 
 		return $this;
@@ -78,7 +78,7 @@ abstract class WP_Async_Request {
 	 *
 	 * @return array|WP_Error
 	 */
-	public function dispatch() {
+	final public function dispatch() {
 		$url  = add_query_arg( $this->get_query_args(), $this->get_query_url() );
 		$args = $this->get_post_args();
 
@@ -138,7 +138,7 @@ abstract class WP_Async_Request {
 	 *
 	 * Check for correct nonce and pass to handler.
 	 */
-	public function maybe_handle() {
+	final public function maybe_handle() {
 		// Don't lock up other requests while processing
 		session_write_close();
 

--- a/plugins/woocommerce/includes/libraries/wp-background-process.php
+++ b/plugins/woocommerce/includes/libraries/wp-background-process.php
@@ -68,7 +68,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @access public
 	 * @return void
 	 */
-	public function dispatch() {
+	final public function dispatch() {
 		// Schedule the cron healthcheck.
 		$this->schedule_event();
 
@@ -83,7 +83,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 *
 	 * @return $this
 	 */
-	public function push_to_queue( $data ) {
+	final public function push_to_queue( $data ) {
 		$this->data[] = $data;
 
 		return $this;
@@ -94,7 +94,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 *
 	 * @return $this
 	 */
-	public function save() {
+	final public function save() {
 		$key = $this->generate_key();
 
 		if ( ! empty( $this->data ) ) {
@@ -112,7 +112,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 *
 	 * @return $this
 	 */
-	public function update( $key, $data ) {
+	final public function update( $key, $data ) {
 		if ( ! empty( $data ) ) {
 			update_site_option( $key, $data );
 		}
@@ -127,7 +127,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 *
 	 * @return $this
 	 */
-	public function delete( $key ) {
+	final public function delete( $key ) {
 		delete_site_option( $key );
 
 		return $this;
@@ -156,7 +156,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Checks whether data exists within the queue and that
 	 * the process is not already running.
 	 */
-	public function maybe_handle() {
+	final public function maybe_handle() {
 		// Don't lock up other requests while processing
 		session_write_close();
 
@@ -410,7 +410,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * @param mixed $schedules Schedules.
 	 * @return mixed
 	 */
-	public function schedule_cron_healthcheck( $schedules ) {
+	final public function schedule_cron_healthcheck( $schedules ) {
 		$interval = apply_filters( $this->identifier . '_cron_interval', 5 );
 
 		if ( property_exists( $this, 'cron_interval' ) ) {
@@ -432,7 +432,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Restart the background process if not already running
 	 * and data exists in the queue.
 	 */
-	public function handle_cron_healthcheck() {
+	final public function handle_cron_healthcheck() {
 		if ( $this->is_process_running() ) {
 			// Background process already running.
 			exit;
@@ -475,7 +475,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	 * Stop processing queue items, clear cronjob and delete batch.
 	 *
 	 */
-	public function cancel_process() {
+	final public function cancel_process() {
 		if ( ! $this->is_queue_empty() ) {
 			$batch = $this->get_batch();
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -99,7 +99,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 *
 	 * @return array Endpoint arguments.
 	 */
-	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
+	final public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 
 		$endpoint_args = parent::get_endpoint_args_for_item_schema( $method );
 
@@ -206,7 +206,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array Of WP_Error or WP_REST_Response.
 	 */
-	public function batch_items( $request ) {
+	final public function batch_items( $request ) {
 		/**
 		 * REST Server
 		 *
@@ -326,7 +326,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array  $setting Setting.
 	 * @return string
 	 */
-	public function validate_setting_text_field( $value, $setting ) {
+	final public function validate_setting_text_field( $value, $setting ) {
 		$value = is_null( $value ) ? '' : $value;
 		return wp_kses_post( trim( stripslashes( $value ) ) );
 	}
@@ -339,7 +339,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array  $setting Setting.
 	 * @return string|WP_Error
 	 */
-	public function validate_setting_select_field( $value, $setting ) {
+	final public function validate_setting_select_field( $value, $setting ) {
 		if ( array_key_exists( $value, $setting['options'] ) ) {
 			return $value;
 		} else {
@@ -355,7 +355,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array $setting Setting.
 	 * @return array|WP_Error
 	 */
-	public function validate_setting_multiselect_field( $values, $setting ) {
+	final public function validate_setting_multiselect_field( $values, $setting ) {
 		if ( empty( $values ) ) {
 			return array();
 		}
@@ -382,7 +382,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array $setting Setting.
 	 * @return string|WP_Error
 	 */
-	public function validate_setting_image_width_field( $values, $setting ) {
+	final public function validate_setting_image_width_field( $values, $setting ) {
 		if ( ! is_array( $values ) ) {
 			return new WP_Error( 'rest_setting_value_invalid', __( 'An invalid setting value was passed.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
@@ -408,7 +408,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array  $setting Setting.
 	 * @return string|WP_Error
 	 */
-	public function validate_setting_radio_field( $value, $setting ) {
+	final public function validate_setting_radio_field( $value, $setting ) {
 		return $this->validate_setting_select_field( $value, $setting );
 	}
 
@@ -420,7 +420,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array  $setting Setting.
 	 * @return string|WP_Error
 	 */
-	public function validate_setting_checkbox_field( $value, $setting ) {
+	final public function validate_setting_checkbox_field( $value, $setting ) {
 		if ( in_array( $value, array( 'yes', 'no' ) ) ) {
 			return $value;
 		} elseif ( empty( $value ) ) {
@@ -439,7 +439,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param array  $setting Setting.
 	 * @return string
 	 */
-	public function validate_setting_textarea_field( $value, $setting ) {
+	final public function validate_setting_textarea_field( $value, $setting ) {
 		$value = is_null( $value ) ? '' : $value;
 		return wp_kses(
 			trim( stripslashes( $value ) ),
@@ -480,7 +480,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 *
 	 * @return array
 	 */
-	public function get_public_batch_schema() {
+	final public function get_public_batch_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'batch',
@@ -526,7 +526,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return array Fields to be included in the response.
 	 */
-	public function get_fields_for_response( $request ) {
+	final public function get_fields_for_response( $request ) {
 		// From xdebug profiling, this method could take upto 25% of request time in index calls.
 		// Cache it and make sure _fields was cached on current request object!
 		// TODO: Submit this caching behavior in core.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -49,7 +49,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_item_permissions_check( $request ) {
+	final public function get_item_permissions_check( $request ) {
 		$object = $this->get_object( (int) $request['id'] );
 
 		if ( $object && 0 !== $object->get_id() && ! wc_rest_check_post_permissions( $this->post_type, 'read', $object->get_id() ) ) {
@@ -65,7 +65,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function update_item_permissions_check( $request ) {
+	final public function update_item_permissions_check( $request ) {
 		$object = $this->get_object( (int) $request['id'] );
 
 		if ( $object && 0 !== $object->get_id() && ! wc_rest_check_post_permissions( $this->post_type, 'edit', $object->get_id() ) ) {
@@ -81,7 +81,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return bool|WP_Error
 	 */
-	public function delete_item_permissions_check( $request ) {
+	final public function delete_item_permissions_check( $request ) {
 		$object = $this->get_object( (int) $request['id'] );
 
 		if ( $object && 0 !== $object->get_id() && ! wc_rest_check_post_permissions( $this->post_type, 'delete', $object->get_id() ) ) {
@@ -133,7 +133,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function get_item( $request ) {
+	final public function get_item( $request ) {
 		$object = $this->get_object( (int) $request['id'] );
 
 		if ( ! $object || 0 === $object->get_id() ) {
@@ -182,7 +182,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function create_item( $request ) {
+	final public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
 			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
@@ -228,7 +228,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function update_item( $request ) {
+	final public function update_item( $request ) {
 		$object = $this->get_object( (int) $request['id'] );
 
 		if ( ! $object || 0 === $object->get_id() ) {
@@ -375,7 +375,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function get_items( $request ) {
+	final public function get_items( $request ) {
 		$query_args = $this->prepare_objects_query( $request );
 		if ( is_wp_error( current( $query_args ) ) ) {
 			return current( $query_args );
@@ -438,7 +438,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function delete_item( $request ) {
+	final public function delete_item( $request ) {
 		$force  = (bool) $request['force'];
 		$object = $this->get_object( (int) $request['id'] );
 		$result = false;
@@ -515,7 +515,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @param array  $fields  List of fields to fetch.
 	 * @return array Data fetched from getters.
 	 */
-	public function fetch_fields_using_getters( $object, $context, $fields ) {
+	final public function fetch_fields_using_getters( $object, $context, $fields ) {
 		$data = array();
 		foreach ( $fields as $field ) {
 			if ( method_exists( $this, "api_get_$field" ) ) {
@@ -550,7 +550,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 *
 	 * @return array
 	 */
-	public function get_collection_params() {
+	final public function get_collection_params() {
 		$params                       = array();
 		$params['context']            = $this->get_context_param();
 		$params['context']['default'] = 'view';

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php
@@ -52,7 +52,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_items_permissions_check( $request ) {
+	final public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( $this->post_type, 'read' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
@@ -66,7 +66,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function create_item_permissions_check( $request ) {
+	final public function create_item_permissions_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( $this->post_type, 'create' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
@@ -80,7 +80,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_item_permissions_check( $request ) {
+	final public function get_item_permissions_check( $request ) {
 		$post = get_post( (int) $request['id'] );
 
 		if ( $post && ! wc_rest_check_post_permissions( $this->post_type, 'read', $post->ID ) ) {
@@ -96,7 +96,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function update_item_permissions_check( $request ) {
+	final public function update_item_permissions_check( $request ) {
 		$post = get_post( (int) $request['id'] );
 
 		if ( $post && ! wc_rest_check_post_permissions( $this->post_type, 'edit', $post->ID ) ) {
@@ -112,7 +112,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return bool|WP_Error
 	 */
-	public function delete_item_permissions_check( $request ) {
+	final public function delete_item_permissions_check( $request ) {
 		$post = get_post( (int) $request['id'] );
 
 		if ( $post && ! wc_rest_check_post_permissions( $this->post_type, 'delete', $post->ID ) ) {
@@ -129,7 +129,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 *
 	 * @return boolean|WP_Error
 	 */
-	public function batch_items_permissions_check( $request ) {
+	final public function batch_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( $this->post_type, 'batch' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_batch', __( 'Sorry, you are not allowed to batch manipulate this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
@@ -143,7 +143,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function get_item( $request ) {
+	final public function get_item( $request ) {
 		$id   = (int) $request['id'];
 		$post = get_post( $id );
 
@@ -169,7 +169,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function create_item( $request ) {
+	final public function create_item( $request ) {
 		if ( ! empty( $request['id'] ) ) {
 			/* translators: %s: post type */
 			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
@@ -250,7 +250,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function update_item( $request ) {
+	final public function update_item( $request ) {
 		$id   = (int) $request['id'];
 		$post = get_post( $id );
 
@@ -304,7 +304,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function get_items( $request ) {
+	final public function get_items( $request ) {
 		$args                         = array();
 		$args['offset']               = $request['offset'];
 		$args['order']                = $request['order'];
@@ -412,7 +412,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function delete_item( $request ) {
+	final public function delete_item( $request ) {
 		$id    = (int) $request['id'];
 		$force = (bool) $request['force'];
 		$post  = get_post( $id );
@@ -615,7 +615,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 	 *
 	 * @return array
 	 */
-	public function get_collection_params() {
+	final public function get_collection_params() {
 		$params = parent::get_collection_params();
 
 		$params['context']['default'] = 'view';

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zones-controller-base.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zones-controller-base.php
@@ -56,7 +56,7 @@ abstract class WC_REST_Shipping_Zones_Controller_Base extends WC_REST_Controller
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_items_permissions_check( $request ) {
+	final public function get_items_permissions_check( $request ) {
 		if ( ! wc_shipping_enabled() ) {
 			return new WP_Error( 'rest_no_route', __( 'Shipping is disabled.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
@@ -74,7 +74,7 @@ abstract class WC_REST_Shipping_Zones_Controller_Base extends WC_REST_Controller
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function create_item_permissions_check( $request ) {
+	final public function create_item_permissions_check( $request ) {
 		if ( ! wc_shipping_enabled() ) {
 			return new WP_Error( 'rest_no_route', __( 'Shipping is disabled.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
@@ -92,7 +92,7 @@ abstract class WC_REST_Shipping_Zones_Controller_Base extends WC_REST_Controller
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function update_items_permissions_check( $request ) {
+	final public function update_items_permissions_check( $request ) {
 		if ( ! wc_shipping_enabled() ) {
 			return new WP_Error( 'rest_no_route', __( 'Shipping is disabled.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
@@ -110,7 +110,7 @@ abstract class WC_REST_Shipping_Zones_Controller_Base extends WC_REST_Controller
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function delete_items_permissions_check( $request ) {
+	final public function delete_items_permissions_check( $request ) {
 		if ( ! wc_shipping_enabled() ) {
 			return new WP_Error( 'rest_no_route', __( 'Shipping is disabled.', 'woocommerce' ), array( 'status' => 404 ) );
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -41,7 +41,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	/**
 	 * Register the routes for terms.
 	 */
-	public function register_routes() {
+	final public function register_routes() {
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
@@ -132,7 +132,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_items_permissions_check( $request ) {
+	final public function get_items_permissions_check( $request ) {
 		$permissions = $this->check_permissions( $request, 'read' );
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
@@ -151,7 +151,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function create_item_permissions_check( $request ) {
+	final public function create_item_permissions_check( $request ) {
 		$permissions = $this->check_permissions( $request, 'create' );
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
@@ -170,7 +170,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function get_item_permissions_check( $request ) {
+	final public function get_item_permissions_check( $request ) {
 		$permissions = $this->check_permissions( $request, 'read' );
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
@@ -189,7 +189,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function update_item_permissions_check( $request ) {
+	final public function update_item_permissions_check( $request ) {
 		$permissions = $this->check_permissions( $request, 'edit' );
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
@@ -208,7 +208,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function delete_item_permissions_check( $request ) {
+	final public function delete_item_permissions_check( $request ) {
 		$permissions = $this->check_permissions( $request, 'delete' );
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
@@ -227,7 +227,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return boolean|WP_Error
 	 */
-	public function batch_items_permissions_check( $request ) {
+	final public function batch_items_permissions_check( $request ) {
 		$permissions = $this->check_permissions( $request, 'batch' );
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
@@ -275,7 +275,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function get_items( $request ) {
+	final public function get_items( $request ) {
 		$taxonomy      = $this->get_taxonomy( $request );
 		$prepared_args = array(
 			'exclude'    => $request['exclude'],
@@ -385,7 +385,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Request|WP_Error
 	 */
-	public function create_item( $request ) {
+	final public function create_item( $request ) {
 		$taxonomy = $this->get_taxonomy( $request );
 		$name     = $request['name'];
 		$args     = array();
@@ -460,7 +460,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Request|WP_Error
 	 */
-	public function get_item( $request ) {
+	final public function get_item( $request ) {
 		$taxonomy = $this->get_taxonomy( $request );
 		$term     = get_term( (int) $request['id'], $taxonomy );
 
@@ -479,7 +479,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Request|WP_Error
 	 */
-	public function update_item( $request ) {
+	final public function update_item( $request ) {
 		$taxonomy      = $this->get_taxonomy( $request );
 		$term          = get_term( (int) $request['id'], $taxonomy );
 		$schema        = $this->get_item_schema();
@@ -539,7 +539,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function delete_item( $request ) {
+	final public function delete_item( $request ) {
 		$taxonomy = $this->get_taxonomy( $request );
 		$force    = isset( $request['force'] ) ? (bool) $request['force'] : false;
 
@@ -700,7 +700,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 	 *
 	 * @return array
 	 */
-	public function get_collection_params() {
+	final public function get_collection_params() {
 		$params = parent::get_collection_params();
 
 		$params['context']['default'] = 'view';

--- a/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/AbstractServiceProvider.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/AbstractServiceProvider.php
@@ -21,7 +21,7 @@ abstract class AbstractServiceProvider implements ServiceProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function provides(string $alias) : bool
+    final public function provides(string $alias) : bool
     {
         return in_array($alias, $this->provides, true);
     }
@@ -29,7 +29,7 @@ abstract class AbstractServiceProvider implements ServiceProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function setIdentifier(string $id) : ServiceProviderInterface
+    final public function setIdentifier(string $id) : ServiceProviderInterface
     {
         $this->identifier = $id;
 
@@ -39,7 +39,7 @@ abstract class AbstractServiceProvider implements ServiceProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getIdentifier() : string
+    final public function getIdentifier() : string
     {
         return $this->identifier ?? get_class($this);
     }

--- a/plugins/woocommerce/src/Admin/API/Reports/Query.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Query.php
@@ -17,7 +17,7 @@ abstract class Query extends \WC_Object_Query {
 	 *
 	 * @return array|object of WC_Product objects
 	 */
-	public function get_data() {
+	final public function get_data() {
 		/* translators: %s: Method name */
 		return new \WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be overridden in subclass.", 'woocommerce' ), __METHOD__ ), array( 'status' => 405 ) );
 	}

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -103,7 +103,7 @@ abstract class DataSourcePoller {
 	 *
 	 * @return array list of specs.
 	 */
-	public function get_specs_from_data_sources() {
+	final public function get_specs_from_data_sources() {
 		$specs = get_transient( $this->args['transient_name'] );
 
 		if ( false === $specs || ! is_array( $specs ) || 0 === count( $specs ) ) {
@@ -119,7 +119,7 @@ abstract class DataSourcePoller {
 	 *
 	 * @return bool Whether any specs were read.
 	 */
-	public function read_specs_from_data_sources() {
+	final public function read_specs_from_data_sources() {
 		$specs        = array();
 		$data_sources = apply_filters( self::FILTER_NAME, $this->data_sources, $this->id );
 
@@ -145,7 +145,7 @@ abstract class DataSourcePoller {
 	 *
 	 * @return bool success of failure of transient deletion.
 	 */
-	public function delete_specs_transient() {
+	final public function delete_specs_transient() {
 		return delete_transient( $this->args['transient_name'] );
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -111,7 +111,7 @@ abstract class Task {
 	 *
 	 * @return string
 	 */
-	public function get_parent_id() {
+	final public function get_parent_id() {
 		if ( ! $this->task_list ) {
 			return '';
 		}
@@ -123,7 +123,7 @@ abstract class Task {
 	 *
 	 * @return array
 	 */
-	public function get_parent_options() {
+	final public function get_parent_options() {
 		if ( ! $this->task_list ) {
 			return array();
 		}
@@ -136,7 +136,7 @@ abstract class Task {
 	 * @param string $option_name name of custom option.
 	 * @return mixed|null
 	 */
-	public function get_parent_option( $option_name ) {
+	final public function get_parent_option( $option_name ) {
 		if ( $this->task_list && isset( $this->task_list->options[ $option_name ] ) ) {
 			return $this->task_list->options[ $option_name ];
 		}
@@ -150,7 +150,7 @@ abstract class Task {
 	 * @param string $event_name Event name.
 	 * @return string
 	 */
-	public function prefix_event( $event_name ) {
+	final public function prefix_event( $event_name ) {
 		if ( ! $this->task_list ) {
 			return '';
 		}
@@ -162,7 +162,7 @@ abstract class Task {
 	 *
 	 * @return string
 	 */
-	public function get_additional_info() {
+	final public function get_additional_info() {
 		return '';
 	}
 
@@ -171,7 +171,7 @@ abstract class Task {
 	 *
 	 * @return mixed
 	 */
-	public function get_additional_data() {
+	final public function get_additional_data() {
 		return null;
 	}
 
@@ -180,7 +180,7 @@ abstract class Task {
 	 *
 	 * @return string
 	 */
-	public function get_level() {
+	final public function get_level() {
 		return 3;
 	}
 
@@ -189,7 +189,7 @@ abstract class Task {
 	 *
 	 * @return string
 	 */
-	public function get_action_label() {
+	final public function get_action_label() {
 		return __( "Let's go", 'woocommerce' );
 	}
 
@@ -198,7 +198,7 @@ abstract class Task {
 	 *
 	 * @return string
 	 */
-	public function get_action_url() {
+	final public function get_action_url() {
 		return null;
 	}
 
@@ -207,7 +207,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_dismissable() {
+	final public function is_dismissable() {
 		return false;
 	}
 
@@ -216,7 +216,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_dismissed() {
+	final public function is_dismissed() {
 		if ( ! $this->is_dismissable() ) {
 			return false;
 		}
@@ -231,7 +231,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function dismiss() {
+	final public function dismiss() {
 		if ( ! $this->is_dismissable() ) {
 			return false;
 		}
@@ -252,7 +252,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function undo_dismiss() {
+	final public function undo_dismiss() {
 		$dismissed = get_option( self::DISMISSED_OPTION, array() );
 		$dismissed = array_diff( $dismissed, array( $this->get_id() ) );
 		$update    = update_option( self::DISMISSED_OPTION, $dismissed );
@@ -269,7 +269,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_snoozeable() {
+	final public function is_snoozeable() {
 		return false;
 	}
 
@@ -278,7 +278,7 @@ abstract class Task {
 	 *
 	 * @return string
 	 */
-	public function get_snoozed_until() {
+	final public function get_snoozed_until() {
 		$snoozed_tasks = get_option( self::SNOOZED_OPTION, array() );
 		if ( isset( $snoozed_tasks[ $this->get_id() ] ) ) {
 			return $snoozed_tasks[ $this->get_id() ];
@@ -292,7 +292,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_snoozed() {
+	final public function is_snoozed() {
 		if ( ! $this->is_snoozeable() ) {
 			return false;
 		}
@@ -308,7 +308,7 @@ abstract class Task {
 	 * @param string $duration Duration to snooze. day|hour|week.
 	 * @return bool
 	 */
-	public function snooze( $duration = 'day' ) {
+	final public function snooze( $duration = 'day' ) {
 		if ( ! $this->is_snoozeable() ) {
 			return false;
 		}
@@ -332,7 +332,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function undo_snooze() {
+	final public function undo_snooze() {
 		$snoozed = get_option( self::SNOOZED_OPTION, array() );
 		unset( $snoozed[ $this->get_id() ] );
 		$update = update_option( self::SNOOZED_OPTION, $snoozed );
@@ -349,7 +349,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function has_previously_completed() {
+	final public function has_previously_completed() {
 		$complete = get_option( self::COMPLETED_OPTION, array() );
 		return in_array( $this->get_id(), $complete, true );
 	}
@@ -357,7 +357,7 @@ abstract class Task {
 	/**
 	 * Track task completion if task is viewable.
 	 */
-	public function possibly_track_completion() {
+	final public function possibly_track_completion() {
 		if ( ! $this->is_complete() ) {
 			return;
 		}
@@ -375,7 +375,7 @@ abstract class Task {
 	/**
 	 * Set this as the active task across page loads.
 	 */
-	public function set_active() {
+	final public function set_active() {
 		if ( $this->is_complete() ) {
 			return;
 		}
@@ -390,7 +390,7 @@ abstract class Task {
 	/**
 	 * Check if this is the active task.
 	 */
-	public function is_active() {
+	final public function is_active() {
 		return get_transient( self::ACTIVE_TASK_TRANSIENT ) === $this->get_id();
 	}
 
@@ -399,7 +399,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function can_view() {
+	final public function can_view() {
 		return true;
 	}
 
@@ -408,7 +408,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_disabled() {
+	final public function is_disabled() {
 		return false;
 	}
 
@@ -417,7 +417,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_complete() {
+	final public function is_complete() {
 		return self::is_actioned();
 	}
 
@@ -426,7 +426,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_visited() {
+	final public function is_visited() {
 		$user_id       = get_current_user_id();
 		$response      = WCAdminUser::get_user_data_field( $user_id, 'task_list_tracked_started_tasks' );
 		$tracked_tasks = $response ? json_decode( $response, true ) : array();
@@ -439,7 +439,7 @@ abstract class Task {
 	 *
 	 * @return array
 	 */
-	public function get_json() {
+	final public function get_json() {
 		$this->possibly_track_completion();
 
 		return array(
@@ -473,7 +473,7 @@ abstract class Task {
 	 * @param array $data Data to convert.
 	 * @return object
 	 */
-	public static function convert_object_to_camelcase( $data ) {
+	final public static function convert_object_to_camelcase( $data ) {
 		if ( ! is_array( $data ) ) {
 			return $data;
 		}
@@ -493,7 +493,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function mark_actioned() {
+	final public function mark_actioned() {
 		$actioned = get_option( self::ACTIONED_OPTION, array() );
 
 		$actioned[] = $this->get_id();
@@ -511,7 +511,7 @@ abstract class Task {
 	 *
 	 * @return bool
 	 */
-	public function is_actioned() {
+	final public function is_actioned() {
 		return self::is_task_actioned( $this->get_id() );
 	}
 
@@ -521,7 +521,7 @@ abstract class Task {
 	 * @param string $id Task ID.
 	 * @return bool
 	 */
-	public static function is_task_actioned( $id ) {
+	final public static function is_task_actioned( $id ) {
 		$actioned = get_option( self::ACTIONED_OPTION, array() );
 		return in_array( $id, $actioned, true );
 	}
@@ -534,7 +534,7 @@ abstract class Task {
 	 * @param array $sort_by list of columns with sort order.
 	 * @return int
 	 */
-	public static function sort( $a, $b, $sort_by = array() ) {
+	final public static function sort( $a, $b, $sort_by = array() ) {
 		$result = 0;
 		foreach ( $sort_by as $data ) {
 			$key   = $data['key'];

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -605,7 +605,7 @@ WHERE
 	 *
 	 * @return array List of IDs along with columns that failed to migrate.
 	 */
-	public function verify_migrated_data( array $source_ids ) : array {
+	final public function verify_migrated_data( array $source_ids ) : array {
 		global $wpdb;
 		$query = $this->build_verification_query( $source_ids );
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $query should already be prepared.

--- a/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
@@ -95,7 +95,7 @@ abstract class TableMigrator {
 	 * @param array $entity_ids Order ids to migrate.
 	 * @return array An array containing the keys 'errors' (array of strings) and 'exception' (exception object or null).
 	 */
-	public function process_migration_batch_for_ids( array $entity_ids ): array {
+	final public function process_migration_batch_for_ids( array $entity_ids ): array {
 		$this->clear_errors();
 		$exception = null;
 

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/ImportScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/ImportScheduler.php
@@ -32,7 +32,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 * @internal
 	 * @return bool
 	 */
-	public static function is_importing() {
+	final public static function is_importing() {
 		$pending_jobs = self::queue()->search(
 			array(
 				'status'   => 'pending',
@@ -62,7 +62,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 * @internal
 	 * @retun array
 	 */
-	public static function get_batch_sizes() {
+	final public static function get_batch_sizes() {
 		return array_merge(
 			self::get_scheduler_batch_sizes(),
 			array(
@@ -81,7 +81,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 * @internal
 	 * @return array
 	 */
-	public static function get_scheduler_actions() {
+	final public static function get_scheduler_actions() {
 		return array(
 			'import_batch_init' => 'wc-admin_import_batch_init_' . static::$name,
 			'import_batch'      => 'wc-admin_import_batch_' . static::$name,
@@ -98,7 +98,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 * @param integer|boolean $days Number of days to import.
 	 * @param boolean         $skip_existing Skip exisiting records.
 	 */
-	public static function import_batch_init( $days, $skip_existing ) {
+	final public static function import_batch_init( $days, $skip_existing ) {
 		$batch_size = static::get_batch_size( 'import' );
 		$items      = static::get_items( 1, 1, $days, $skip_existing );
 
@@ -120,7 +120,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 * @param bool     $skip_existing Skip exisiting records.
 	 * @return void
 	 */
-	public static function import_batch( $batch_number, $days, $skip_existing ) {
+	final public static function import_batch( $batch_number, $days, $skip_existing ) {
 		$batch_size = static::get_batch_size( 'import' );
 
 		$properties = array(
@@ -154,7 +154,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 *
 	 * @internal
 	 */
-	public static function delete_batch_init() {
+	final public static function delete_batch_init() {
 		global $wpdb;
 		$batch_size = static::get_batch_size( 'delete' );
 		$count      = static::get_total_imported();
@@ -174,7 +174,7 @@ abstract class ImportScheduler implements ImportInterface {
 	 * @internal
 	 * @return void
 	 */
-	public static function delete_batch() {
+	final public static function delete_batch() {
 		wc_admin_record_tracks_event( 'delete_import_data_job_start', array( 'type' => static::$name ) );
 
 		$batch_size = static::get_batch_size( 'delete' );

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -56,7 +56,7 @@ abstract class CustomMetaDataStore {
 	 * @param  WC_Data $object WC_Data object.
 	 * @return array
 	 */
-	public function read_meta( &$object ) {
+	final public function read_meta( &$object ) {
 		global $wpdb;
 
 		$db_info = $this->get_db_info();
@@ -79,7 +79,7 @@ abstract class CustomMetaDataStore {
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing at least ->id).
 	 */
-	public function delete_meta( &$object, $meta ) {
+	final public function delete_meta( &$object, $meta ) {
 		global $wpdb;
 
 		if ( ! isset( $meta->id ) ) {
@@ -99,7 +99,7 @@ abstract class CustomMetaDataStore {
 	 * @param  stdClass $meta (containing ->key and ->value).
 	 * @return int meta ID
 	 */
-	public function add_meta( &$object, $meta ) {
+	final public function add_meta( &$object, $meta ) {
 		global $wpdb;
 
 		if ( ! is_a( $meta, 'WC_Meta_Data' ) ) {
@@ -132,7 +132,7 @@ abstract class CustomMetaDataStore {
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->id, ->key and ->value).
 	 */
-	public function update_meta( &$object, $meta ) {
+	final public function update_meta( &$object, $meta ) {
 		global $wpdb;
 
 		if ( ! isset( $meta->id ) || empty( $meta->key ) ) {
@@ -165,7 +165,7 @@ abstract class CustomMetaDataStore {
 	 * @param int $meta_id Meta ID.
 	 * @return object|bool Metadata object or FALSE if not found.
 	 */
-	public function get_metadata_by_id( $meta_id ) {
+	final public function get_metadata_by_id( $meta_id ) {
 		global $wpdb;
 
 		if ( ! is_numeric( $meta_id ) || floor( $meta_id ) != $meta_id ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison

--- a/plugins/woocommerce/tests/legacy/includes/wp-http-testcase.php
+++ b/plugins/woocommerce/tests/legacy/includes/wp-http-testcase.php
@@ -134,7 +134,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	/**
 	 * @since 1.3.0
 	 */
-	public static function setUpBeforeClass(): void {
+	final public static function setUpBeforeClass(): void {
 
 		if ( ! self::$did_init ) {
 			self::init();
@@ -146,7 +146,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	/**
 	 * @since 1.3.1
 	 */
-	public static function tearDownAfterClass(): void {
+	final public static function tearDownAfterClass(): void {
 
 		self::save_cache();
 
@@ -158,7 +158,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since 1.0.0
 	 */
-	public function setUp(): void {
+	final public function setUp(): void {
 
 		parent::setUp();
 
@@ -176,7 +176,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since 1.0.0
 	 */
-	public function tearDown(): void {
+	final public function tearDown(): void {
 
 		parent::tearDown();
 
@@ -202,7 +202,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	 *
 	 * @return mixed A response, or false.
 	 */
-	public function http_request_listner( $preempt, $request, $url ) {
+	final public function http_request_listner( $preempt, $request, $url ) {
 
 		$this->http_requests[] = array(
 			'url'     => $url,
@@ -329,7 +329,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since 1.1.0
 	 */
-	public static function init() {
+	final public static function init() {
 
 		self::load_env( 'HOST' );
 		self::load_env( 'USE_CACHING', true );
@@ -422,7 +422,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since 1.1.0
 	 */
-	public static function save_cache() {
+	final public static function save_cache() {
 
 		if ( ! self::$cache_changed ) {
 			return;

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
@@ -59,7 +59,7 @@ abstract class AbstractRestApiTest extends WC_REST_Unit_Test_Case {
 	 *
 	 * @param object $factory Factory object.
 	 */
-	public static function wpSetUpBeforeClass( $factory ) {
+	final public static function wpSetUpBeforeClass( $factory ) {
 		self::$user = $factory->user->create(
 			array(
 				'role' => 'administrator',
@@ -70,7 +70,7 @@ abstract class AbstractRestApiTest extends WC_REST_Unit_Test_Case {
 	/**
 	 * Setup test class.
 	 */
-	public function setUp(): void {
+	final public function setUp(): void {
 		parent::setUp();
 		wp_set_current_user( self::$user );
 	}
@@ -78,7 +78,7 @@ abstract class AbstractRestApiTest extends WC_REST_Unit_Test_Case {
 	/**
 	 * Test route registration.
 	 */
-	public function test_register_routes() {
+	final public function test_register_routes() {
 		$actual_routes   = $this->server->get_routes();
 		$expected_routes = $this->routes;
 
@@ -92,7 +92,7 @@ abstract class AbstractRestApiTest extends WC_REST_Unit_Test_Case {
 	 *
 	 * @return void
 	 */
-	public function test_schema_properties() {
+	final public function test_schema_properties() {
 		$request    = new \WP_REST_Request( 'OPTIONS', $this->routes[0] );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-unit-test-case.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-unit-test-case.php
@@ -18,7 +18,7 @@ abstract class WC_Settings_Unit_Test_Case extends WC_Unit_Test_Case {
 	 *
 	 * @return array|null The setting, or null if no setting exists in the supplied array with the supplied identifier.
 	 */
-	public function setting_by_id( $settings, $id ) {
+	final public function setting_by_id( $settings, $id ) {
 		foreach ( $settings as $setting ) {
 			if ( $id === $setting['id'] ) {
 				return $setting;
@@ -36,7 +36,7 @@ abstract class WC_Settings_Unit_Test_Case extends WC_Unit_Test_Case {
 	 *
 	 * @return array The transformed settings.
 	 */
-	public function get_ids_and_types( $settings ) {
+	final public function get_ids_and_types( $settings ) {
 		$settings_ids_and_types = array();
 		foreach ( $settings as $setting ) {
 			$id   = array_key_exists( 'id', $setting ) ? $setting['id'] : null;


### PR DESCRIPTION
All public methods of abstract classes should be final. Enforce API encapsulation in an inheritance architecture. If you want to override a method, use the Template method pattern.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
