### PR TITLE
Static lambda

### DIFF
--- a/plugins/woocommerce-beta-tester/api/api.php
+++ b/plugins/woocommerce-beta-tester/api/api.php
@@ -1,11 +1,11 @@
 <?php
 function register_woocommerce_admin_test_helper_rest_route( $route, $callback, $additional_options = array() ) {
-    add_action( 'rest_api_init', function() use ( $route, $callback, $additional_options ) {
+    add_action( 'rest_api_init', static function() use ( $route, $callback, $additional_options ) {
 
     	$default_options = array(
 		    'methods'  => 'POST',
 		    'callback' => $callback,
-		    'permission_callback' => function( $request ) {
+		    'permission_callback' => static function( $request ) {
 			    if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
 				    return new \WP_Error(
 					    'woocommerce_rest_cannot_edit',

--- a/plugins/woocommerce-beta-tester/api/api/api.php
+++ b/plugins/woocommerce-beta-tester/api/api/api.php
@@ -1,11 +1,11 @@
 <?php
 function register_woocommerce_admin_test_helper_rest_route( $route, $callback, $additional_options = array() ) {
-    add_action( 'rest_api_init', function() use ( $route, $callback, $additional_options ) {
+    add_action( 'rest_api_init', static function() use ( $route, $callback, $additional_options ) {
 
     	$default_options = array(
 		    'methods'  => 'POST',
 		    'callback' => $callback,
-		    'permission_callback' => function( $request ) {
+		    'permission_callback' => static function( $request ) {
 			    if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
 				    return new \WP_Error(
 					    'woocommerce_rest_cannot_edit',

--- a/plugins/woocommerce-beta-tester/api/api/options/rest-api.php
+++ b/plugins/woocommerce-beta-tester/api/api/options/rest-api.php
@@ -43,7 +43,7 @@ register_woocommerce_admin_test_helper_rest_route(
 function wca_test_helper_delete_option( $request ) {
 	global $wpdb;
 	$option_names = explode( ',', $request->get_param( 'option_names' ) );
-    $option_names = array_map( function( $option_name ) {
+    $option_names = array_map( static function( $option_name ) {
         return "'" . $option_name . "'";
     }, $option_names );
 

--- a/plugins/woocommerce-beta-tester/api/api/rest-api-filters/hook.php
+++ b/plugins/woocommerce-beta-tester/api/api/rest-api-filters/hook.php
@@ -23,13 +23,13 @@ function array_dot_set( &$array, $key, $value ) {
 
 add_filter(
     'rest_request_after_callbacks',
-    function ( $response, array $handler, \WP_REST_Request $request ) use ( $filters ) {
+    static function ( $response, array $handler, \WP_REST_Request $request ) use ( $filters ) {
         if (! $response instanceof  \WP_REST_Response ) {
             return $response;
         }
         $route = $request->get_route();
         $filters = array_filter(
-            $filters, function ( $filter ) use ( $request, $route ) {
+            $filters, static function ( $filter ) use ( $request, $route ) {
                 if ($filter['enabled'] && $filter['endpoint'] == $route ) {
                     return true;
                 }

--- a/plugins/woocommerce-beta-tester/api/api/rest-api-filters/rest-api-filters.php
+++ b/plugins/woocommerce-beta-tester/api/api/rest-api-filters/rest-api-filters.php
@@ -62,7 +62,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
         $replacement = $request->get_param('replacement');
 
         self::update(
-            function ( $filters ) use (
+            static function ( $filters ) use (
                 $endpoint,
                 $dot_notation,
                 $replacement
@@ -87,7 +87,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
 
     public static function delete( $request ) {
         self::update(
-            function ( $filters ) use ( $request ) {
+            static function ( $filters ) use ( $request ) {
                 array_splice($filters, $request->get_param('index'), 1);
                 return $filters;
             }
@@ -98,7 +98,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
 
     public static function toggle( $request ) {
         self::update(
-            function ( $filters ) use ( $request ) {
+            static function ( $filters ) use ( $request ) {
                 $index = $request->get_param('index');
                 $filters[$index]['enabled'] = !$filters[$index]['enabled'];
                 return $filters;

--- a/plugins/woocommerce-beta-tester/api/api/tools/trigger-cron-job.php
+++ b/plugins/woocommerce-beta-tester/api/api/tools/trigger-cron-job.php
@@ -66,7 +66,7 @@ function trigger_selected_cron( $request ) {
 				return $scheduled;
 			}
 
-			add_filter( 'cron_request', function( array $cron_request ) {
+			add_filter( 'cron_request', static function( array $cron_request ) {
 				$cron_request['url'] = add_query_arg( 'run-cron', 1, $cron_request['url'] );
 				return $cron_request;
 			} );

--- a/plugins/woocommerce-beta-tester/api/options/rest-api.php
+++ b/plugins/woocommerce-beta-tester/api/options/rest-api.php
@@ -43,7 +43,7 @@ register_woocommerce_admin_test_helper_rest_route(
 function wca_test_helper_delete_option( $request ) {
 	global $wpdb;
 	$option_names = explode( ',', $request->get_param( 'option_names' ) );
-    $option_names = array_map( function( $option_name ) {
+    $option_names = array_map( static function( $option_name ) {
         return "'" . $option_name . "'";
     }, $option_names );
 

--- a/plugins/woocommerce-beta-tester/api/rest-api-filters/hook.php
+++ b/plugins/woocommerce-beta-tester/api/rest-api-filters/hook.php
@@ -23,13 +23,13 @@ function array_dot_set( &$array, $key, $value ) {
 
 add_filter(
     'rest_request_after_callbacks',
-    function ( $response, array $handler, \WP_REST_Request $request ) use ( $filters ) {
+    static function ( $response, array $handler, \WP_REST_Request $request ) use ( $filters ) {
         if (! $response instanceof  \WP_REST_Response ) {
             return $response;
         }
         $route = $request->get_route();
         $filters = array_filter(
-            $filters, function ( $filter ) use ( $request, $route ) {
+            $filters, static function ( $filter ) use ( $request, $route ) {
                 if ($filter['enabled'] && $filter['endpoint'] == $route ) {
                     return true;
                 }

--- a/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
+++ b/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
@@ -62,7 +62,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
         $replacement = $request->get_param('replacement');
 
         self::update(
-            function ( $filters ) use (
+            static function ( $filters ) use (
                 $endpoint,
                 $dot_notation,
                 $replacement
@@ -87,7 +87,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
 
     public static function delete( $request ) {
         self::update(
-            function ( $filters ) use ( $request ) {
+            static function ( $filters ) use ( $request ) {
                 array_splice($filters, $request->get_param('index'), 1);
                 return $filters;
             }
@@ -98,7 +98,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
 
     public static function toggle( $request ) {
         self::update(
-            function ( $filters ) use ( $request ) {
+            static function ( $filters ) use ( $request ) {
                 $index = $request->get_param('index');
                 $filters[$index]['enabled'] = !$filters[$index]['enabled'];
                 return $filters;

--- a/plugins/woocommerce-beta-tester/api/tools/trigger-cron-job.php
+++ b/plugins/woocommerce-beta-tester/api/tools/trigger-cron-job.php
@@ -66,7 +66,7 @@ function trigger_selected_cron( $request ) {
 				return $scheduled;
 			}
 
-			add_filter( 'cron_request', function( array $cron_request ) {
+			add_filter( 'cron_request', static function( array $cron_request ) {
 				$cron_request['url'] = add_query_arg( 'run-cron', 1, $cron_request['url'] );
 				return $cron_request;
 			} );

--- a/plugins/woocommerce-beta-tester/plugin.php
+++ b/plugins/woocommerce-beta-tester/plugin.php
@@ -1,11 +1,11 @@
 <?php
-add_action( 'admin_menu', function() {
+add_action( 'admin_menu', static function() {
 	add_management_page(
 		'WooCommerce Admin Test Helper',
 		'WCA Test Helper',
 		'install_plugins',
 		'woocommerce-admin-test-helper',
-		function() {
+		static function() {
 			?><div id="woocommerce-admin-test-helper-app-root"></div><?php
 		}
 	);
@@ -15,7 +15,7 @@ add_action( 'wp_loaded', function() {
 	require( 'api/api.php' );
 } );
 
-add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) {
+add_filter( 'woocommerce_admin_get_feature_config', static function( $feature_config ) {
     $custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
     foreach ( $custom_feature_values as $feature => $value ) {
         if ( isset(  $feature_config[$feature] ) ) {

--- a/plugins/woocommerce/bin/wc-get-schema.php
+++ b/plugins/woocommerce/bin/wc-get-schema.php
@@ -10,7 +10,7 @@
  * Get database schema.
  */
 function wc_get_schema() {
-	$schema = function () {
+	$schema = static function () {
 		return static::get_schema();
 	};
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -791,7 +791,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	protected function get_values_for_total( $field ) {
 		$items = array_map(
-			function ( $item ) use ( $field ) {
+			static function ( $item ) use ( $field ) {
 				return wc_add_number_precision( $item[ $field ], false );
 			},
 			array_values( $this->get_items() )
@@ -1627,7 +1627,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	public function get_total_fees() {
 		return array_reduce(
 			$this->get_fees(),
-			function( $carry, $item ) {
+			static function( $carry, $item ) {
 				return $carry + $item->get_total();
 			}
 		);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		public function get_completed_tasks_count() {
 			$completed_tasks = array_filter(
 				$this->get_tasks(),
-				function( $task ) {
+				static function( $task ) {
 					return $task->is_complete();
 				}
 			);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-duplicate-product.php
@@ -140,7 +140,7 @@ class WC_Admin_Duplicate_Product {
 				'woocommerce_duplicate_product_exclude_meta',
 				array(),
 				array_map(
-					function ( $datum ) {
+					static function ( $datum ) {
 						return $datum->key;
 					},
 					$product->get_meta_data()

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -323,7 +323,7 @@ class WC_Admin_Menus {
 			// need an extra step to remove the menu entry for the menu post type.
 			add_action(
 				'admin_init',
-				function () {
+				static function () {
 					remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
 				}
 			);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -53,7 +53,7 @@ class WC_Admin_Taxonomies {
 		add_action( 'create_term', array( $this, 'create_term' ), 5, 3 );
 		add_action(
 			'delete_product_cat',
-			function() {
+			static function() {
 				wc_get_container()->get( AssignDefaultCategory::class )->schedule_action();
 			}
 		);

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -209,7 +209,7 @@ class WC_Helper_Updater {
 		*/
 		$active_for_translations = array_filter(
 			$active_woo_plugins,
-			function( $plugin ) use ( $plugins ) {
+			static function( $plugin ) use ( $plugins ) {
 				return apply_filters( 'woocommerce_translations_updates_for_' . $plugins[ $plugin ]['slug'], false );
 			}
 		);

--- a/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
+++ b/plugins/woocommerce/includes/blocks/class-wc-blocks-utils.php
@@ -52,7 +52,7 @@ class WC_Blocks_Utils {
 		return array_values(
 			array_filter(
 				$page_blocks,
-				function ( $block ) use ( $block_name ) {
+				static function ( $block ) use ( $block_name ) {
 					return ( $block_name === $block['blockName'] );
 				}
 			)

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -308,7 +308,7 @@ class WC_CLI_REST_Command {
 			}
 			usort(
 				$performed_queries,
-				function( $a, $b ) {
+				static function( $a, $b ) {
 					if ( $a[1] === $b[1] ) {
 						return 0;
 					}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-runner.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-runner.php
@@ -235,7 +235,7 @@ class WC_CLI_Runner {
 
 			$before_invoke = null;
 			if ( empty( $command_args['when'] ) && \WP_CLI::get_config( 'debug' ) ) {
-				$before_invoke = function() {
+				$before_invoke = static function() {
 					wc_maybe_define_constant( 'SAVEQUERIES', true );
 				};
 			}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-tool-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-tool-command.php
@@ -85,7 +85,7 @@ class WC_CLI_Tool_Command {
 
 			$before_invoke = null;
 			if ( empty( $command_args['when'] ) && WP_CLI::get_config( 'debug' ) ) {
-				$before_invoke = function() {
+				$before_invoke = static function() {
 					wc_maybe_define_constant( 'SAVEQUERIES', true );
 				};
 			}

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1057,7 +1057,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		);
 		$order_refunds = array_reduce(
 			$refunds,
-			function ( $order_refunds_array, WC_Order_Refund $refund ) {
+			static function ( $order_refunds_array, WC_Order_Refund $refund ) {
 				if ( ! isset( $order_refunds_array[ $refund->get_parent_id() ] ) ) {
 					$order_refunds_array[ $refund->get_parent_id() ] = array();
 				}
@@ -1099,7 +1099,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			}
 		}
 		$cache_keys     = array_map(
-			function ( $order_id ) {
+			static function ( $order_id ) {
 				return 'order-items-' . $order_id;
 			},
 			$order_ids
@@ -1127,7 +1127,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		$order_items_for_all_orders = array_reduce(
 			$order_items,
-			function ( $order_items_collection, $order_item ) {
+			static function ( $order_items_collection, $order_item ) {
 				if ( ! isset( $order_items_collection[ $order_item->order_id ] ) ) {
 					$order_items_collection[ $order_item->order_id ] = array();
 				}
@@ -1186,7 +1186,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		);
 		$raw_meta_data_collection = array_reduce(
 			$raw_meta_data_array,
-			function ( $collection, $raw_meta_data ) {
+			static function ( $collection, $raw_meta_data ) {
 				if ( ! isset( $collection[ $raw_meta_data->object_id ] ) ) {
 					$collection[ $raw_meta_data->object_id ] = array();
 				}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -270,7 +270,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			$order_item_name   = $data['name'];
 			$data['meta_data'] = array_filter(
 				$data['meta_data'],
-				function( $meta ) use ( $product, $order_item_name ) {
+				static function( $meta ) use ( $product, $order_item_name ) {
 					$display_value = wp_kses_post( rawurldecode( (string) $meta->value ) );
 
 					// Skip items with values already in the product details area of the product name.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -44,7 +44,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		add_action( 'switch_theme', array( __CLASS__, 'clean_theme_cache' ) );
 		add_action(
 			'upgrader_process_complete',
-			function( $upgrader, $extra ) {
+			static function( $upgrader, $extra ) {
 				if ( ! $extra || ! $extra['type'] ) {
 					return;
 				}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -578,7 +578,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		// Return the list of all requested fields which appear in the schema.
 		$this->_fields = array_reduce(
 			$requested_fields,
-			function( $response_fields, $field ) use ( $fields ) {
+			static function( $response_fields, $field ) use ( $fields ) {
 				if ( in_array( $field, $fields, true ) ) {
 					$response_fields[] = $field;
 					return $response_fields;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -45,7 +45,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		$current_order_coupons      = array_values( $order->get_coupons() );
 		$current_order_coupon_codes = array_map(
-			function( $coupon ) {
+			static function( $coupon ) {
 				return $coupon->get_code();
 			},
 			$current_order_coupons

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -163,7 +163,7 @@ function wc_tokenize_path( $path, $path_tokens ) {
 	// Order most to least specific so that the token can encompass as much of the path as possible.
 	uasort(
 		$path_tokens,
-		function ( $a, $b ) {
+		static function ( $a, $b ) {
 			$a = strlen( $a );
 			$b = strlen( $b );
 
@@ -1871,7 +1871,7 @@ function wc_asort_by_locale( &$data, $locale = '' ) {
 
 	array_walk(
 		$data,
-		function ( &$value ) {
+		static function ( &$value ) {
 			$value = remove_accents( html_entity_decode( $value ) );
 		}
 	);

--- a/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site-installer.php
+++ b/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site-installer.php
@@ -557,7 +557,7 @@ class WC_WCCOM_Site_Installer {
 
 		$related_plugins = array_filter(
 			$plugins,
-			function( $key ) use ( $plugin_folder ) {
+			static function( $key ) use ( $plugin_folder ) {
 				return strpos( $key, $plugin_folder . '/' ) === 0;
 			},
 			ARRAY_FILTER_USE_KEY

--- a/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
+++ b/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
@@ -62,7 +62,7 @@ class WC_WCCOM_Site {
 		} else {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
-				function() {
+				static function() {
 					return new WP_Error(
 						WC_REST_WCCOM_Site_Installer_Errors::NO_ACCESS_TOKEN_CODE,
 						WC_REST_WCCOM_Site_Installer_Errors::NO_ACCESS_TOKEN_MESSAGE,
@@ -80,7 +80,7 @@ class WC_WCCOM_Site {
 		} else {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
-				function() {
+				static function() {
 					return new WP_Error(
 						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_CODE,
 						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_MESSAGE,
@@ -97,7 +97,7 @@ class WC_WCCOM_Site {
 		if ( empty( $site_auth['access_token'] ) ) {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
-				function() {
+				static function() {
 					return new WP_Error(
 						WC_REST_WCCOM_Site_Installer_Errors::SITE_NOT_CONNECTED_CODE,
 						WC_REST_WCCOM_Site_Installer_Errors::SITE_NOT_CONNECTED_MESSAGE,
@@ -111,7 +111,7 @@ class WC_WCCOM_Site {
 		if ( ! hash_equals( $access_token, $site_auth['access_token'] ) ) {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
-				function() {
+				static function() {
 					return new WP_Error(
 						WC_REST_WCCOM_Site_Installer_Errors::INVALID_TOKEN_CODE,
 						WC_REST_WCCOM_Site_Installer_Errors::INVALID_TOKEN_MESSAGE,
@@ -127,7 +127,7 @@ class WC_WCCOM_Site {
 		if ( ! self::verify_wccom_request( $body, $signature, $site_auth['access_token_secret'] ) ) {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
-				function() {
+				static function() {
 					return new WP_Error(
 						WC_REST_WCCOM_Site_Installer_Errors::REQUEST_VERIFICATION_FAILED_CODE,
 						WC_REST_WCCOM_Site_Installer_Errors::REQUEST_VERIFICATION_FAILED_MESSAGE,
@@ -142,7 +142,7 @@ class WC_WCCOM_Site {
 		if ( ! $user ) {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
-				function() {
+				static function() {
 					return new WP_Error(
 						WC_REST_WCCOM_Site_Installer_Errors::USER_NOT_FOUND_CODE,
 						WC_REST_WCCOM_Site_Installer_Errors::USER_NOT_FOUND_MESSAGE,

--- a/plugins/woocommerce/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
@@ -70,7 +70,7 @@ trait ArgumentResolverTrait
      */
     public function reflectArguments(ReflectionFunctionAbstract $method, array $args = []) : array
     {
-        $arguments = array_map(function (ReflectionParameter $param) use ($method, $args) {
+        $arguments = array_map(static function (ReflectionParameter $param) use ($method, $args) {
             $name = $param->getName();
             $type = $param->getType();
 

--- a/plugins/woocommerce/lib/packages/League/Container/Definition/DefinitionAggregate.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Definition/DefinitionAggregate.php
@@ -22,7 +22,7 @@ class DefinitionAggregate implements DefinitionAggregateInterface
      */
     public function __construct(array $definitions = [])
     {
-        $this->definitions = array_filter($definitions, function ($definition) {
+        $this->definitions = array_filter($definitions, static function ($definition) {
             return ($definition instanceof DefinitionInterface);
         });
     }

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -730,7 +730,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$params['extended_tasks'] = array(
 			'description'       => __( 'List of extended deprecated tasks from the client side filter.', 'woocommerce' ),
 			'type'              => 'array',
-			'validate_callback' => function( $param, $request, $key ) {
+			'validate_callback' => static function( $param, $request, $key ) {
 				$has_valid_keys = true;
 				foreach ( $param as $task ) {
 					if ( $has_valid_keys ) {
@@ -758,7 +758,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$lists = is_array( $task_list_ids ) && count( $task_list_ids ) > 0 ? TaskLists::get_lists_by_ids( $task_list_ids ) : TaskLists::get_lists();
 
 		$json = array_map(
-			function( $list ) {
+			static function( $list ) {
 				return $list->sort_tasks()->get_json();
 			},
 			$lists

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/DataStore.php
@@ -329,7 +329,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$where_clauses = implode(
 			' or ',
 			array_map(
-				function( $ids ) {
+				static function( $ids ) {
 					return "(
 						product_lookup.product_id = {$ids['product_id']}
 						and

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -190,7 +190,7 @@ class TaskList {
 		$viewable_tasks  = $this->get_viewable_tasks();
 		$completed_count = array_reduce(
 			$viewable_tasks,
-			function( $total, $task ) {
+			static function( $total, $task ) {
 				return $task->is_complete() ? $total + 1 : $total;
 			},
 			0
@@ -231,7 +231,7 @@ class TaskList {
 
 		return array_reduce(
 			$viewable_tasks,
-			function( $is_complete, $task ) {
+			static function( $is_complete, $task ) {
 				return ! $task->is_complete() ? false : $is_complete;
 			},
 			true
@@ -279,7 +279,7 @@ class TaskList {
 		return current(
 			array_filter(
 				$this->tasks,
-				function( $task ) use ( $task_id ) {
+				static function( $task ) use ( $task_id ) {
 					return $task->get_id() === $task_id;
 				}
 			)
@@ -295,7 +295,7 @@ class TaskList {
 		return array_values(
 			array_filter(
 				$this->tasks,
-				function( $task ) {
+				static function( $task ) {
 					return $task->can_view();
 				}
 			)
@@ -340,7 +340,7 @@ class TaskList {
 		if ( 0 !== count( $sort_by ) ) {
 			usort(
 				$this->tasks,
-				function( $a, $b ) use ( $sort_by ) {
+				static function( $a, $b ) use ( $sort_by ) {
 					return Task::sort( $a, $b, $sort_by );
 				}
 			);
@@ -410,7 +410,7 @@ class TaskList {
 			'displayProgressHeader' => $this->display_progress_header,
 			'keepCompletedTaskList' => $this->get_keep_completed_task_list(),
 			'sections'              => array_map(
-				function( $section ) {
+				static function( $section ) {
 					return $section->get_json();
 				},
 				$this->sections

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -381,7 +381,7 @@ class TaskLists {
 	public static function get_lists_by_ids( $ids ) {
 		return array_filter(
 			self::$lists,
-			function( $list ) use ( $ids ) {
+			static function( $list ) use ( $ids ) {
 				return in_array( $list->get_list_id(), $ids, true );
 			}
 		);
@@ -410,7 +410,7 @@ class TaskLists {
 	public static function get_visible() {
 		return array_filter(
 			self::get_lists(),
-			function ( $task_list ) {
+			static function ( $task_list ) {
 				return $task_list->is_visible();
 			}
 		);
@@ -449,7 +449,7 @@ class TaskLists {
 
 		$tasks_to_search = $task_list ? $task_list->tasks : array_reduce(
 			self::get_lists(),
-			function ( $all, $curr ) {
+			static function ( $all, $curr ) {
 				return array_merge( $all, $curr->tasks );
 			},
 			array()
@@ -482,7 +482,7 @@ class TaskLists {
 		$remaining_tasks = array_values(
 			array_filter(
 				$setup_list->get_viewable_tasks(),
-				function( $task ) {
+				static function( $task ) {
 					return ! $task->is_complete();
 				}
 			)

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -93,7 +93,7 @@ class AdditionalPayments extends Payments {
 		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
 		$enabled_gateways = array_filter(
 			$gateways,
-			function( $gateway ) {
+			static function( $gateway ) {
 				return 'yes' === $gateway->enabled && 'woocommerce_payments' !== $gateway->id;
 			}
 		);

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -94,7 +94,7 @@ class Marketing extends Task {
 
 		return array_reduce(
 			$bundles,
-			function( $plugins, $bundle ) {
+			static function( $plugins, $bundle ) {
 				$visible = array();
 				foreach ( $bundle['plugins'] as $plugin ) {
 					if ( $plugin->is_visible ) {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -89,7 +89,7 @@ class Payments extends Task {
 		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
 		$enabled_gateways = array_filter(
 			$gateways,
-			function( $gateway ) {
+			static function( $gateway ) {
 				return 'yes' === $gateway->enabled && 'woocommerce_payments' !== $gateway->id;
 			}
 		);

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -145,7 +145,7 @@ class WooCommercePayments extends Task {
 		$suggestion_plugins       = array_merge(
 			...array_filter(
 				array_column( $suggestions, 'plugins' ),
-				function( $plugins ) {
+				static function( $plugins ) {
 					return is_array( $plugins );
 				}
 			)

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -44,7 +44,7 @@ class Init {
 		return array_values(
 			array_filter(
 				$suggestions,
-				function( $suggestion ) {
+				static function( $suggestion ) {
 					return ! property_exists( $suggestion, 'is_visible' ) || $suggestion->is_visible;
 				}
 			)

--- a/plugins/woocommerce/src/Admin/Features/TransientNotices.php
+++ b/plugins/woocommerce/src/Admin/Features/TransientNotices.php
@@ -46,7 +46,7 @@ class TransientNotices {
 
 		return array_filter(
 			$notices,
-			function( $notice ) use ( $user_id ) {
+			static function( $notice ) use ( $user_id ) {
 				return ! isset( $notice['user_id'] ) ||
 					null === $notice['user_id'] ||
 					$user_id === $notice['user_id'];

--- a/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
+++ b/plugins/woocommerce/src/Admin/Notes/NoteTraits.php
@@ -228,7 +228,7 @@ trait NoteTraits {
 			$diff        = array_udiff(
 				$note1_field_value,
 				$note2_field_value,
-				function( $action1, $action2 ) {
+				static function( $action1, $action2 ) {
 					if ( $action1->name === $action2->name &&
 						$action1->label === $action2->label &&
 						$action1->query === $action2->query ) {

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -60,7 +60,7 @@ class PluginsHelper {
 	 */
 	public static function get_installed_plugin_slugs() {
 		return array_map(
-			function( $plugin_path ) {
+			static function( $plugin_path ) {
 				$path_parts = explode( '/', $plugin_path );
 				return $path_parts[0];
 			},
@@ -93,7 +93,7 @@ class PluginsHelper {
 	 */
 	public static function get_active_plugin_slugs() {
 		return array_map(
-			function( $plugin_path ) {
+			static function( $plugin_path ) {
 				$path_parts = explode( '/', $plugin_path );
 				return $path_parts[0];
 			},

--- a/plugins/woocommerce/src/Admin/PluginsProvider/PluginsProvider.php
+++ b/plugins/woocommerce/src/Admin/PluginsProvider/PluginsProvider.php
@@ -31,7 +31,7 @@ class PluginsProvider implements PluginsProviderInterface {
 	public function get_active_plugin_slugs() {
 		return array_filter(
 			PluginsHelper::get_active_plugin_slugs(),
-			function( $p ) {
+			static function( $p ) {
 				return $p !== self::$deactivated_plugin_slug;
 			}
 		);

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -41,7 +41,7 @@ class RemoteInboxNotificationsEngine {
 		// on_admin_init because that runs too late to hook into the action.
 		add_action(
 			'woocommerce_updated',
-			function() {
+			static function() {
 				$next_hook = WC()->queue()->get_next(
 					'woocommerce_run_on_woocommerce_admin_updated',
 					array( __CLASS__, 'run_on_woocommerce_admin_updated' ),

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -123,7 +123,7 @@ class SpecRunner {
 		$matching_wp_locales = array_values(
 			array_filter(
 				$locales,
-				function( $l ) use ( $wp_locale ) {
+				static function( $l ) use ( $wp_locale ) {
 					return $wp_locale === $l->locale;
 				}
 			)
@@ -137,7 +137,7 @@ class SpecRunner {
 		$en_us_locales = array_values(
 			array_filter(
 				$locales,
-				function( $l ) {
+				static function( $l ) {
 					return 'en_US' === $l->locale;
 				}
 			)
@@ -163,7 +163,7 @@ class SpecRunner {
 		$matching_wp_locales = array_values(
 			array_filter(
 				$action_locales,
-				function ( $l ) use ( $wp_locale ) {
+				static function ( $l ) use ( $wp_locale ) {
 					return $wp_locale === $l->locale;
 				}
 			)
@@ -177,7 +177,7 @@ class SpecRunner {
 		$en_us_locales = array_values(
 			array_filter(
 				$action_locales,
-				function( $l ) {
+				static function( $l ) {
 					return 'en_US' === $l->locale;
 				}
 			)

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/ArrayFlatten.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/ArrayFlatten.php
@@ -24,7 +24,7 @@ class ArrayFlatten implements TransformerInterface {
 		$return = array();
 		array_walk_recursive(
 			$value,
-			function( $item ) use ( &$return ) {
+			static function( $item ) use ( &$return ) {
 				$return[] = $item;
 			}
 		);

--- a/plugins/woocommerce/src/Autoloader.php
+++ b/plugins/woocommerce/src/Autoloader.php
@@ -53,7 +53,7 @@ class Autoloader {
 		}
 		add_action(
 			'admin_notices',
-			function() {
+			static function() {
 				?>
 				<div class="notice notice-error">
 					<p>

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -73,7 +73,7 @@ final class ReserveStock {
 		try {
 			$items = array_filter(
 				$order->get_items(),
-				function( $item ) {
+				static function( $item ) {
 					return $item->is_type( 'line_item' ) && $item->get_product() instanceof \WC_Product && $item->get_quantity() > 0;
 				}
 			);

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -241,7 +241,7 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 
 		$existing_records = array_filter(
 			$existing_records,
-			function( $record_data ) {
+			static function( $record_data ) {
 				return '1' === $record_data->modified;
 			}
 		);
@@ -358,7 +358,7 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 		$modified_selector   = array();
 		$core_column_mapping = array_filter(
 			$this->core_column_mapping,
-			function( $mapping ) {
+			static function( $mapping ) {
 				return ! isset( $mapping['select_clause'] );
 			}
 		);

--- a/plugins/woocommerce/src/Internal/Admin/CategoryLookup.php
+++ b/plugins/woocommerce/src/Internal/Admin/CategoryLookup.php
@@ -85,7 +85,7 @@ class CategoryLookup {
 		$insert_string = implode(
 			'),(',
 			array_map(
-				function( $item ) {
+				static function( $item ) {
 					return implode( ',', $item );
 				},
 				$inserts

--- a/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
+++ b/plugins/woocommerce/src/Internal/Admin/CustomerEffortScoreTracks.php
@@ -240,7 +240,7 @@ class CustomerEffortScoreTracks {
 
 		$has_duplicate = array_filter(
 			$queue,
-			function ( $queue_item ) use ( $item ) {
+			static function ( $queue_item ) use ( $item ) {
 				return $queue_item['action'] === $item['action'];
 			}
 		);
@@ -423,7 +423,7 @@ class CustomerEffortScoreTracks {
 		);
 		$remaining_items = array_filter(
 			$queue,
-			function ( $item ) use ( $clear_ces_tracks_queue_for_page ) {
+			static function ( $item ) use ( $clear_ces_tracks_queue_for_page ) {
 				return $clear_ces_tracks_queue_for_page['pagenow'] !== $item['pagenow']
 				|| $clear_ces_tracks_queue_for_page['adminpage'] !== $item['adminpage'];
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -104,7 +104,7 @@ class Loader {
 			$notice_action = is_network_admin() ? 'network_admin_notices' : 'admin_notices';
 			add_action(
 				$notice_action,
-				function() {
+				static function() {
 					echo '<div class="error"><p>';
 					printf(
 						/* translators: %s: is referring to the plugin's name. */

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OnboardingPayments.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OnboardingPayments.php
@@ -41,7 +41,7 @@ class OnboardingPayments {
 		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
 		$enabled_gateways = array_filter(
 			$gateways,
-			function( $gateway ) {
+			static function( $gateway ) {
 				return 'yes' === $gateway->enabled;
 			}
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
@@ -78,7 +78,7 @@ class OnboardingThemes {
 	public static function sort_woocommerce_themes( $themes ) {
 		usort(
 			$themes,
-			function ( $product_1, $product_2 ) {
+			static function ( $product_1, $product_2 ) {
 				if ( ! property_exists( $product_1, 'id' ) || ! property_exists( $product_1, 'slug' ) ) {
 					return 1;
 				}

--- a/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
+++ b/plugins/woocommerce/src/Internal/Admin/SystemStatusReport.php
@@ -77,7 +77,7 @@ class SystemStatusReport {
 		$enabled_features  = array_filter( $features );
 		$disabled_features = array_filter(
 			$features,
-			function( $feature ) {
+			static function( $feature ) {
 				return empty( $feature );
 			}
 		);

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminSharedSettings.php
@@ -57,7 +57,7 @@ class WCAdminSharedSettings {
 		if ( class_exists( '\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry' ) ) {
 			\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )->add(
 				$this->settings_prefix,
-				function() {
+				static function() {
 					return apply_filters( 'woocommerce_admin_shared_settings', array() );
 				},
 				true

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -41,7 +41,7 @@ class WCAdminUser {
 			'user',
 			'is_super_admin',
 			array(
-				'get_callback' => function() {
+				'get_callback' => static function() {
 					return is_super_admin();
 				},
 				'schema'       => null,

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -120,7 +120,7 @@ class Init {
 		$wc_pay_promotion_spec = array_values(
 			array_filter(
 				$promotions,
-				function( $promotion ) {
+				static function( $promotion ) {
 					return isset( $promotion->plugins ) && in_array( 'woocommerce-payments', $promotion->plugins, true );
 				}
 			)
@@ -144,7 +144,7 @@ class Init {
 		return array_values(
 			array_filter(
 				$suggestions,
-				function( $suggestion ) {
+				static function( $suggestion ) {
 					return ! property_exists( $suggestion, 'is_visible' ) || $suggestion->is_visible;
 				}
 			)

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -412,13 +412,13 @@ class LookupDataStore {
 		$product_attributes_data       = $this->get_attribute_taxonomies( $product );
 		$variation_attributes_data     = array_filter(
 			$product_attributes_data,
-			function( $item ) {
+			static function( $item ) {
 				return $item['used_for_variations'];
 			}
 		);
 		$non_variation_attributes_data = array_filter(
 			$product_attributes_data,
-			function( $item ) {
+			static function( $item ) {
 				return ! $item['used_for_variations'];
 			}
 		);
@@ -454,7 +454,7 @@ class LookupDataStore {
 		$product_attributes_data   = $this->get_attribute_taxonomies( $main_product );
 		$variation_attributes_data = array_filter(
 			$product_attributes_data,
-			function( $item ) {
+			static function( $item ) {
 				return $item['used_for_variations'];
 			}
 		);
@@ -547,7 +547,7 @@ class LookupDataStore {
 	private function get_variations_of( \WC_Product_Variable $product ) {
 		$variation_ids = $product->get_children();
 		return array_map(
-			function( $id ) {
+			static function( $id ) {
 				return WC()->call_function( 'wc_get_product', $id );
 			},
 			$variation_ids

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Register.php
@@ -39,7 +39,7 @@ class Register {
 	final public function init() {
 		add_action(
 			'admin_init',
-			function () {
+			static function () {
 				wc_get_container()->get( SyncUI::class )->init_hooks();
 				wc_get_container()->get( UI::class )->init_hooks();
 			}
@@ -47,7 +47,7 @@ class Register {
 
 		add_action(
 			'before_woocommerce_init',
-			function() {
+			static function() {
 				if ( get_option( Synchronize::SYNC_TASK_PAGE ) > 0 ) {
 					wc_get_container()->get( Synchronize::class )->init_hooks();
 				}

--- a/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
+++ b/plugins/woocommerce/src/Internal/ProductDownloads/ApprovedDirectories/Synchronize.php
@@ -175,7 +175,7 @@ class Synchronize {
 	 * @return array
 	 */
 	private function get_next_set_of_downloadable_products(): array {
-		$query_filter = function ( array $query ): array {
+		$query_filter = static function ( array $query ): array {
 			$query['meta_query'][] = array(
 				'key'     => '_downloadable_files',
 				'compare' => 'EXISTS',

--- a/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/BlocksUtil.php
@@ -16,7 +16,7 @@ class BlocksUtil {
 	public static function flatten_blocks( $blocks ) {
 		return array_reduce(
 			$blocks,
-			function( $carry, $block ) {
+			static function( $carry, $block ) {
 				array_push( $carry, array_diff_key( $block, array_flip( array( 'innerBlocks' ) ) ) );
 				if ( isset( $block['innerBlocks'] ) ) {
 					$inner_blocks = self::flatten_blocks( $block['innerBlocks'] );
@@ -38,7 +38,7 @@ class BlocksUtil {
 	public static function get_blocks_from_widget_area( $block_name ) {
 		return array_reduce(
 			get_option( 'widget_block' ),
-			function ( $acc, $block ) use ( $block_name ) {
+			static function ( $acc, $block ) use ( $block_name ) {
 				$parsed_blocks = ! empty( $block ) && is_array( $block ) ? parse_blocks( $block['content'] ) : array();
 				if ( ! empty( $parsed_blocks ) && $block_name === $parsed_blocks[0]['blockName'] ) {
 					array_push( $acc, $parsed_blocks[0] );
@@ -66,7 +66,7 @@ class BlocksUtil {
 		return array_values(
 			array_filter(
 				$flatten_blocks,
-				function ( $block ) use ( $block_name ) {
+				static function ( $block ) use ( $block_name ) {
 					return ( $block_name === $block['blockName'] );
 				}
 			)

--- a/plugins/woocommerce/src/Packages.php
+++ b/plugins/woocommerce/src/Packages.php
@@ -107,7 +107,7 @@ class Packages {
 		}
 		add_action(
 			'admin_notices',
-			function() use ( $package ) {
+			static function() use ( $package ) {
 				?>
 				<div class="notice notice-error">
 					<p>

--- a/plugins/woocommerce/src/Utilities/ArrayUtil.php
+++ b/plugins/woocommerce/src/Utilities/ArrayUtil.php
@@ -143,19 +143,19 @@ class ArrayUtil {
 	 */
 	public static function select( array $items, string $selector_name, int $selector_type = self::SELECT_BY_AUTO ) {
 		if ( self::SELECT_BY_OBJECT_METHOD === $selector_type ) {
-			$callback = function( $item ) use ( $selector_name ) {
+			$callback = static function( $item ) use ( $selector_name ) {
 				return $item->$selector_name();
 			};
 		} elseif ( self::SELECT_BY_OBJECT_PROPERTY === $selector_type ) {
-			$callback = function( $item ) use ( $selector_name ) {
+			$callback = static function( $item ) use ( $selector_name ) {
 				return $item->$selector_name;
 			};
 		} elseif ( self::SELECT_BY_ARRAY_KEY === $selector_type ) {
-			$callback = function( $item ) use ( $selector_name ) {
+			$callback = static function( $item ) use ( $selector_name ) {
 				return $item[ $selector_name ];
 			};
 		} else {
-			$callback = function( $item ) use ( $selector_name ) {
+			$callback = static function( $item ) use ( $selector_name ) {
 				if ( is_array( $item ) ) {
 					return $item[ $selector_name ];
 				} elseif ( method_exists( $item, $selector_name ) ) {

--- a/plugins/woocommerce/tests/Tools/CodeHacking/CodeHacker.php
+++ b/plugins/woocommerce/tests/Tools/CodeHacking/CodeHacker.php
@@ -161,7 +161,7 @@ final class CodeHacker {
 			throw new \Exception( 'CodeHacker::initialize - $paths must be a non-empty array with the directories containing the files to be hacked.' );
 		}
 		self::$paths_with_files_to_hack = array_map(
-			function( $path ) {
+			static function( $path ) {
 				return realpath( $path );
 			},
 			$paths

--- a/plugins/woocommerce/tests/cli/features/bootstrap/utils.php
+++ b/plugins/woocommerce/tests/cli/features/bootstrap/utils.php
@@ -25,7 +25,7 @@ function extract_from_phar( $path ) {
 
 	copy( $path, $tmp_path );
 
-	register_shutdown_function( function() use ( $tmp_path ) {
+	register_shutdown_function( static function() use ( $tmp_path ) {
 		@unlink( $tmp_path );
 	} );
 
@@ -454,7 +454,7 @@ function mustache_render( $template_name, $data = array() ) {
 	$template = file_get_contents( $template_name );
 
 	$m = new \Mustache_Engine( array(
-		'escape' => function ( $val ) { return $val; }
+		'escape' => static function ( $val ) { return $val; }
 	) );
 
 	return $m->render( $template, $data );
@@ -697,7 +697,7 @@ function get_flag_value( $assoc_args, $flag, $default = null ) {
 function get_temp_dir() {
 	static $temp = '';
 
-	$trailingslashit = function( $path ) {
+	$trailingslashit = static function( $path ) {
 		return rtrim( $path ) . '/';
 	};
 

--- a/plugins/woocommerce/tests/cli/features/steps/given.php
+++ b/plugins/woocommerce/tests/cli/features/steps/given.php
@@ -5,19 +5,19 @@ use Behat\Gherkin\Node\PyStringNode,
     WP_CLI\Process;
 
 $steps->Given( '/^an empty directory$/',
-	function ( $world ) {
+	static function ( $world ) {
 		$world->create_run_dir();
 	}
 );
 
 $steps->Given( '/^an empty cache/',
-	function ( $world ) {
+	static function ( $world ) {
 		$world->variables['SUITE_CACHE_DIR'] = FeatureContext::create_cache_dir();
 	}
 );
 
 $steps->Given( '/^an? ([^\s]+) file:$/',
-	function ( $world, $path, PyStringNode $content ) {
+	static function ( $world, $path, PyStringNode $content ) {
 		$content = (string) $content . "\n";
 		$full_path = $world->variables['RUN_DIR'] . "/$path";
 		Process::create( \WP_CLI\utils\esc_cmd( 'mkdir -p %s', dirname( $full_path ) ) )->run_check();
@@ -26,37 +26,37 @@ $steps->Given( '/^an? ([^\s]+) file:$/',
 );
 
 $steps->Given( '/^WP files$/',
-	function ( $world ) {
+	static function ( $world ) {
 		$world->download_wp();
 	}
 );
 
 $steps->Given( '/^wp-config\.php$/',
-	function ( $world ) {
+	static function ( $world ) {
 		$world->create_config();
 	}
 );
 
 $steps->Given( '/^a database$/',
-	function ( $world ) {
+	static function ( $world ) {
 		$world->create_db();
 	}
 );
 
 $steps->Given( '/^a WP install$/',
-	function ( $world ) {
+	static function ( $world ) {
 		$world->install_wp();
 	}
 );
 
 $steps->Given( "/^a WP install in '([^\s]+)'$/",
-	function ( $world, $subdir ) {
+	static function ( $world, $subdir ) {
 		$world->install_wp( $subdir );
 	}
 );
 
 $steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
-	function ( $world, $type = 'subdirectory' ) {
+	static function ( $world, $type = 'subdirectory' ) {
 		$world->install_wp();
 		$subdomains = ! empty( $type ) && 'subdomain' === $type ? 1 : 0;
 		$world->proc( 'wp core install-network', array( 'title' => 'WP CLI Network', 'subdomains' => $subdomains ) )->run_check();
@@ -64,14 +64,14 @@ $steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
 );
 
 $steps->Given( '/^these installed and active plugins:$/',
-	function( $world, $stream ) {
+	static function( $world, $stream ) {
 		$plugins = implode( ' ', array_map( 'trim', explode( PHP_EOL, (string)$stream ) ) );
 		$world->proc( "wp plugin install $plugins --activate" )->run_check();
 	}
 );
 
 $steps->Given( '/^a custom wp-content directory$/',
-	function ( $world ) {
+	static function ( $world ) {
 		$wp_config_path = $world->variables['RUN_DIR'] . "/wp-config.php";
 
 		$wp_config_code = file_get_contents( $wp_config_path );
@@ -89,7 +89,7 @@ $steps->Given( '/^a custom wp-content directory$/',
 );
 
 $steps->Given( '/^download:$/',
-	function ( $world, TableNode $table ) {
+	static function ( $world, TableNode $table ) {
 		foreach ( $table->getHash() as $row ) {
 			$path = $world->replace_variables( $row['path'] );
 			if ( file_exists( $path ) ) {
@@ -103,7 +103,7 @@ $steps->Given( '/^download:$/',
 );
 
 $steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?as \{(\w+)\}$/',
-	function ( $world, $stream, $output_filter, $key ) {
+	static function ( $world, $stream, $output_filter, $key ) {
 
 		$stream = strtolower( $stream );
 
@@ -121,13 +121,13 @@ $steps->Given( '/^save (STDOUT|STDERR) ([\'].+[^\'])?as \{(\w+)\}$/',
 );
 
 $steps->Given( '/^a new Phar(?: with version "([^"]+)")$/',
-	function ( $world, $version ) {
+	static function ( $world, $version ) {
 		$world->build_phar( $version );
 	}
 );
 
 $steps->Given( '/^save the (.+) file ([\'].+[^\'])?as \{(\w+)\}$/',
-	function ( $world, $filepath, $output_filter, $key ) {
+	static function ( $world, $filepath, $output_filter, $key ) {
 		$full_file = file_get_contents( $world->replace_variables( $filepath ) );
 
 		if ( $output_filter ) {
@@ -144,7 +144,7 @@ $steps->Given( '/^save the (.+) file ([\'].+[^\'])?as \{(\w+)\}$/',
 );
 
 $steps->Given('/^a misconfigured WP_CONTENT_DIR constant directory$/',
-	function($world) {
+	static function($world) {
 		$wp_config_path = $world->variables['RUN_DIR'] . "/wp-config.php";
 
 		$wp_config_code = file_get_contents( $wp_config_path );

--- a/plugins/woocommerce/tests/cli/features/steps/then.php
+++ b/plugins/woocommerce/tests/cli/features/steps/then.php
@@ -4,7 +4,7 @@ use Behat\Gherkin\Node\PyStringNode,
     Behat\Gherkin\Node\TableNode;
 
 $steps->Then( '/^the return code should be (\d+)$/',
-	function ( $world, $return_code ) {
+	static function ( $world, $return_code ) {
 		if ( $return_code != $world->result->return_code ) {
 			throw new RuntimeException( $world->result );
 		}
@@ -12,7 +12,7 @@ $steps->Then( '/^the return code should be (\d+)$/',
 );
 
 $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
-	function ( $world, $stream, $action, PyStringNode $expected ) {
+	static function ( $world, $stream, $action, PyStringNode $expected ) {
 
 		$stream = strtolower( $stream );
 
@@ -23,7 +23,7 @@ $steps->Then( '/^(STDOUT|STDERR) should (be|contain|not contain):$/',
 );
 
 $steps->Then( '/^(STDOUT|STDERR) should be a number$/',
-	function ( $world, $stream ) {
+	static function ( $world, $stream ) {
 
 		$stream = strtolower( $stream );
 
@@ -32,7 +32,7 @@ $steps->Then( '/^(STDOUT|STDERR) should be a number$/',
 );
 
 $steps->Then( '/^(STDOUT|STDERR) should not be a number$/',
-	function ( $world, $stream ) {
+	static function ( $world, $stream ) {
 
 		$stream = strtolower( $stream );
 
@@ -41,7 +41,7 @@ $steps->Then( '/^(STDOUT|STDERR) should not be a number$/',
 );
 
 $steps->Then( '/^STDOUT should be a table containing rows:$/',
-	function ( $world, TableNode $expected ) {
+	static function ( $world, TableNode $expected ) {
 		$output      = $world->result->stdout;
 		$actual_rows = explode( "\n", rtrim( $output, "\n" ) );
 
@@ -55,7 +55,7 @@ $steps->Then( '/^STDOUT should be a table containing rows:$/',
 );
 
 $steps->Then( '/^STDOUT should end with a table containing rows:$/',
-	function ( $world, TableNode $expected ) {
+	static function ( $world, TableNode $expected ) {
 		$output      = $world->result->stdout;
 		$actual_rows = explode( "\n", rtrim( $output, "\n" ) );
 
@@ -74,7 +74,7 @@ $steps->Then( '/^STDOUT should end with a table containing rows:$/',
 );
 
 $steps->Then( '/^STDOUT should be JSON containing:$/',
-	function ( $world, PyStringNode $expected ) {
+	static function ( $world, PyStringNode $expected ) {
 		$output = $world->result->stdout;
 		$expected = $world->replace_variables( (string) $expected );
 
@@ -84,7 +84,7 @@ $steps->Then( '/^STDOUT should be JSON containing:$/',
 });
 
 $steps->Then( '/^STDOUT should be a JSON array containing:$/',
-	function ( $world, PyStringNode $expected ) {
+	static function ( $world, PyStringNode $expected ) {
 		$output = $world->result->stdout;
 		$expected = $world->replace_variables( (string) $expected );
 
@@ -98,7 +98,7 @@ $steps->Then( '/^STDOUT should be a JSON array containing:$/',
 });
 
 $steps->Then( '/^STDOUT should be CSV containing:$/',
-	function ( $world, TableNode $expected ) {
+	static function ( $world, TableNode $expected ) {
 		$output = $world->result->stdout;
 
 		$expected_rows = $expected->getRows();
@@ -114,7 +114,7 @@ $steps->Then( '/^STDOUT should be CSV containing:$/',
 );
 
 $steps->Then( '/^STDOUT should be YAML containing:$/',
-	function ( $world, PyStringNode $expected ) {
+	static function ( $world, PyStringNode $expected ) {
 		$output = $world->result->stdout;
 		$expected = $world->replace_variables( (string) $expected );
 
@@ -124,7 +124,7 @@ $steps->Then( '/^STDOUT should be YAML containing:$/',
 });
 
 $steps->Then( '/^(STDOUT|STDERR) should be empty$/',
-	function ( $world, $stream ) {
+	static function ( $world, $stream ) {
 
 		$stream = strtolower( $stream );
 
@@ -135,7 +135,7 @@ $steps->Then( '/^(STDOUT|STDERR) should be empty$/',
 );
 
 $steps->Then( '/^(STDOUT|STDERR) should not be empty$/',
-	function ( $world, $stream ) {
+	static function ( $world, $stream ) {
 
 		$stream = strtolower( $stream );
 
@@ -146,7 +146,7 @@ $steps->Then( '/^(STDOUT|STDERR) should not be empty$/',
 );
 
 $steps->Then( '/^the (.+) (file|directory) should (exist|not exist|be:|contain:|not contain:)$/',
-	function ( $world, $path, $type, $action, $expected = null ) {
+	static function ( $world, $path, $type, $action, $expected = null ) {
 		$path = $world->replace_variables( $path );
 
 		// If it's a relative path, make it relative to the current test dir

--- a/plugins/woocommerce/tests/cli/features/steps/when.php
+++ b/plugins/woocommerce/tests/cli/features/steps/when.php
@@ -15,27 +15,27 @@ function invoke_proc( $proc, $mode ) {
 }
 
 $steps->When( '/^I launch in the background `([^`]+)`$/',
-	function ( $world, $cmd ) {
+	static function ( $world, $cmd ) {
 		$world->background_proc( $cmd );
 	}
 );
 
 $steps->When( '/^I (run|try) `([^`]+)`$/',
-	function ( $world, $mode, $cmd ) {
+	static function ( $world, $mode, $cmd ) {
 		$cmd = $world->replace_variables( $cmd );
 		$world->result = invoke_proc( $world->proc( $cmd ), $mode );
 	}
 );
 
 $steps->When( "/^I (run|try) `([^`]+)` from '([^\s]+)'$/",
-	function ( $world, $mode, $cmd, $subdir ) {
+	static function ( $world, $mode, $cmd, $subdir ) {
 		$cmd = $world->replace_variables( $cmd );
 		$world->result = invoke_proc( $world->proc( $cmd, array(), $subdir ), $mode );
 	}
 );
 
 $steps->When( '/^I (run|try) the previous command again$/',
-	function ( $world, $mode ) {
+	static function ( $world, $mode ) {
 		if ( !isset( $world->result ) )
 			throw new \Exception( 'No previous command.' );
 

--- a/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/plugins/woocommerce/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -232,7 +232,7 @@ class WC_Helper_Product {
 		}
 
 		$variation_ids = array_map(
-			function( $variation ) {
+			static function( $variation ) {
 				return $variation->get_id();
 			},
 			$variations

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/cart.php
@@ -2123,7 +2123,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$variation  = current(
 			array_filter(
 				$variations,
-				function( $variation ) {
+				static function( $variation ) {
 					return 'DUMMY SKU VARIABLE HUGE RED 2' === $variation['sku'];
 				}
 			)

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/class-wc-tests-product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/class-wc-tests-product.php
@@ -39,7 +39,7 @@ class WC_Tests_Product extends WC_Unit_Test_Case {
 	public function test_deferred_sync_on_save_and_delete( $operation ) {
 		$defer_sync_invoked = false;
 
-		$defer_product_callback = function () use ( &$defer_sync_invoked ) {
+		$defer_product_callback = static function () use ( &$defer_sync_invoked ) {
 			$defer_sync_invoked = true;
 		};
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
@@ -206,7 +206,7 @@ abstract class AbstractRestApiTest extends WC_REST_Unit_Test_Case {
 	 * @return array
 	 */
 	protected function get_properties( $context = 'edit' ) {
-		return array_keys( array_filter( $this->properties, function( $contexts ) use( $context ) {
+		return array_keys( array_filter( $this->properties, static function( $contexts ) use( $context ) {
 			return in_array( $context, $contexts );
 		} ) );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/templates/functions.php
@@ -157,7 +157,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		// Include a payment gateway that supports "pay button".
 		add_filter(
 			'woocommerce_payment_gateways',
-			function( $gateways ) {
+			static function( $gateways ) {
 				$gateways[] = 'WC_Mock_Payment_Gateway';
 
 				return $gateways;

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
@@ -157,7 +157,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_install_get_tables',
-			function ( $tables ) {
+			static function ( $tables ) {
 				$tables[] = 'some_table_name';
 
 				return $tables;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/leaderboards.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/leaderboards.php
@@ -168,7 +168,7 @@ class WC_Admin_Tests_API_Leaderboards extends WC_REST_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_leaderboards',
-			function( $leaderboards, $per_page, $after, $before, $persisted_query ) {
+			static function( $leaderboards, $per_page, $after, $before, $persisted_query ) {
 				$leaderboards[] = array(
 					'id'      => 'top_widgets',
 					'label'   => 'Top Widgets',

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
@@ -134,7 +134,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_rest_onboarding_profile_properties',
-			function( $properties ) {
+			static function( $properties ) {
 				$properties['test_profile_datum'] = array(
 					'type'        => 'array',
 					'description' => __( 'Test onboarding profile extensibility.', 'woocommerce-admin' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
@@ -173,7 +173,7 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_admin_onboarding_homepage_template',
-			function ( $template ) {
+			static function ( $template ) {
 				return 'Custom post content';
 			}
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-import.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-import.php
@@ -201,7 +201,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		// Verify there are actions to cancel.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
 		$pending_hooks   = array_map(
-			function ( $action ) {
+			static function ( $action ) {
 				return $action->get_hook();
 			},
 			$pending_actions
@@ -220,7 +220,7 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		// Verify there are no pending actions.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
 		$pending_hooks   = array_map(
-			function ( $action ) {
+			static function ( $action ) {
 				return $action->get_hook();
 			},
 			$pending_actions

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
@@ -453,7 +453,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		// Replace keys with "order_id".
 		$response_orders = array_reduce(
 			$response_orders,
-			function ( array $result, $item ) {
+			static function ( array $result, $item ) {
 				$result[ $item['order_id'] ] = $item;
 				return $result;
 			},

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
@@ -62,7 +62,7 @@ class WC_Admin_Tests_CES_Tracks extends WC_Unit_Test_Case {
 
 		$expected_queue_item = array_filter(
 			$queue_items,
-			function ( $item ) use ( $ces ) {
+			static function ( $item ) use ( $ces ) {
 				return $ces::SETTINGS_CHANGE_ACTION_NAME === $item['action'];
 			}
 		);
@@ -86,7 +86,7 @@ class WC_Admin_Tests_CES_Tracks extends WC_Unit_Test_Case {
 
 		$expected_queue_item = array_filter(
 			$queue_items,
-			function ( $item ) use ( $ces ) {
+			static function ( $item ) use ( $ces ) {
 				return $ces::SETTINGS_CHANGE_ACTION_NAME === $item['action'];
 			}
 		);
@@ -125,7 +125,7 @@ class WC_Admin_Tests_CES_Tracks extends WC_Unit_Test_Case {
 
 		$expected_queue_item = array_filter(
 			$queue_items,
-			function ( $item ) use ( $ces ) {
+			static function ( $item ) use ( $ces ) {
 				return $ces::SETTINGS_CHANGE_ACTION_NAME === $item['action'];
 			}
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -81,7 +81,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_display_banner_if_all_conditions_are_met() {
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
@@ -128,7 +128,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 		update_option( 'woocommerce_shipping_dismissed_timestamp', $twenty_four_hours_one_sec_ago );
 
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
@@ -151,7 +151,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	public function test_if_banner_hidden_when_store_is_not_in_us() {
 		update_option( 'woocommerce_default_country', 'ES' );
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
@@ -165,7 +165,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	public function test_if_banner_hidden_when_currency_is_not_usd() {
 		update_option( 'woocommerce_currency', 'EUR' );
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
@@ -178,7 +178,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_incompatible_plugin_installed() {
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, true );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
@@ -191,7 +191,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_jetpack_version_is_old() {
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.3', true, '1.22.5', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
@@ -204,7 +204,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_wcs_tos_accepted() {
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', true, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
@@ -217,7 +217,7 @@ class WC_Admin_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Ca
 	 */
 	public function test_if_banner_hidden_when_wcs_not_installed() {
 		$this->with_order(
-			function( $that ) {
+			static function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.4', false, false );
 
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/data-source-poller.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/data-source-poller.php
@@ -21,7 +21,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		add_filter(
 			DataSourcePoller::FILTER_NAME,
-			function() {
+			static function() {
 				return array(
 					'payment-gateway-suggestions-data-source.json',
 				);
@@ -30,7 +30,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		add_filter(
 			'pre_http_request',
-			function( $pre, $parsed_args, $url ) {
+			static function( $pre, $parsed_args, $url ) {
 				$locale = get_locale();
 
 				if ( 'payment-gateway-suggestions-data-source.json?_locale=' . $locale === $url ) {
@@ -95,7 +95,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 	public function test_read_invalid_data_source() {
 		add_filter(
 			DataSourcePoller::FILTER_NAME,
-			function() {
+			static function() {
 				return array(
 					'bad-data-source.json',
 				);
@@ -114,7 +114,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 	public function test_merge_specs() {
 		add_filter(
 			DataSourcePoller::FILTER_NAME,
-			function() {
+			static function() {
 				return array(
 					'payment-gateway-suggestions-data-source.json',
 					'payment-gateway-suggestions-data-source2.json',
@@ -149,7 +149,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 		$this->assertCount( 2, $data );
 		add_filter(
 			DataSourcePoller::FILTER_NAME,
-			function() {
+			static function() {
 				return array(
 					'bad-data-source.json',
 				);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-controller.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-controller.php
@@ -33,7 +33,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_PaymentGatewaysController extends
 
 		add_filter(
 			'woocommerce_payment_gateways',
-			function( $gateways ) {
+			static function( $gateways ) {
 				$gateways[] = 'WC_Mock_Payment_Gateway';
 				$gateways[] = 'WC_Mock_Enhanced_Payment_Gateway';
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -24,7 +24,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 		delete_option( 'woocommerce_show_marketplace_suggestions' );
 		add_filter(
 			'transient_woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
-			function( $value ) {
+			static function( $value ) {
 				if ( $value ) {
 					return $value;
 				}
@@ -70,7 +70,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 		remove_all_filters( 'transient_woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
 		add_filter(
 			DataSourcePoller::FILTER_NAME,
-			function() {
+			static function() {
 				return array();
 			}
 		);
@@ -140,7 +140,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 
 		add_filter(
 			'get_available_languages',
-			function( $languages ) {
+			static function( $languages ) {
 				$languages[] = 'zh_TW';
 				return $languages;
 			}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/includes/class-experimental-abtest-test.php
@@ -38,7 +38,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_explat_request_args',
-			function( $args ) {
+			static function( $args ) {
 				$args['test'] = 'test';
 				return $args;
 			},
@@ -68,7 +68,7 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		delete_transient( 'abtest_variation_control' );
 		add_filter(
 			'pre_http_request',
-			function( $preempt, $parsed_args, $url ) {
+			static function( $preempt, $parsed_args, $url ) {
 				return array(
 					'response'    => 200,
 					'status_code' => 200,

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-newsalesrecord-note.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-newsalesrecord-note.php
@@ -43,7 +43,7 @@ class WC_Admin_Tests_NewSalesRecord_Note extends WC_Unit_Test_Case {
 	public function test_it_uses_fjS_date_format_for_english_speaking_countries() {
 		add_filter(
 			'locale',
-			function() {
+			static function() {
 				return 'en_US';
 			}
 		);
@@ -60,7 +60,7 @@ class WC_Admin_Tests_NewSalesRecord_Note extends WC_Unit_Test_Case {
 	public function test_it_uses_system_date_format_for_non_english_speaking_countries() {
 		add_filter(
 			'locale',
-			function() {
+			static function() {
 				return 'es_MX';
 			}
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-note-traits.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-note-traits.php
@@ -86,37 +86,37 @@ class WC_Admin_Tests_NoteTraits extends WC_Unit_Test_Case {
 	public function methods_causing_exception_if_data_store_cannot_be_loaded_provider() {
 		return array(
 			array(
-				function () {
+				static function () {
 					self::note_exists();
 				},
 			),
 			array(
-				function () {
+				static function () {
 					self::can_be_added();
 				},
 			),
 			array(
-				function () {
+				static function () {
 					self::possibly_add_note();
 				},
 			),
 			array(
-				function () {
+				static function () {
 					self::add_note();
 				},
 			),
 			array(
-				function () {
+				static function () {
 					self::possibly_delete_note();
 				},
 			),
 			array(
-				function () {
+				static function () {
 					self::possibly_update_note();
 				},
 			),
 			array(
-				function () {
+				static function () {
 					self::has_note_been_actioned();
 				},
 			),
@@ -296,7 +296,7 @@ class WC_Admin_Tests_NoteTraits extends WC_Unit_Test_Case {
 	public function methods_never_causing_exception_provider() {
 		return array(
 			array(
-				function () {
+				static function () {
 					self::wc_admin_active_for( 123 );
 				},
 			),

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-notes-data-store.php
@@ -231,7 +231,7 @@ class WC_Admin_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		// Suppress deliberately caused errors.
 		$log_file = ini_set( 'error_log', '/dev/null' );  // phpcs:ignore WordPress.PHP.IniSet.Risky
 
-		$filter_datastore = function() use ( $mock_datastore ) {
+		$filter_datastore = static function() use ( $mock_datastore ) {
 			return $mock_datastore;
 		};
 
@@ -377,7 +377,7 @@ class WC_Admin_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 
 		// Add filter for 'woocommerce_note_where_clauses' that should be called only once.
 		$filter_hit_count = 0;
-		$filter_callback  = function( $arg ) use ( &$filter_hit_count ) {
+		$filter_callback  = static function( $arg ) use ( &$filter_hit_count ) {
 			$filter_hit_count++;
 			return $arg;
 		};
@@ -450,7 +450,7 @@ class WC_Admin_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 
 		// Add filter for 'woocommerce_note_where_clauses' that applies only in context.
 		$context_filter_hit_count = 0;
-		$context_filter_callback  = function( $where_clauses, $args, $context ) use ( $test_context, $global_context, $context_name, &$context_filter_hit_count ) {
+		$context_filter_callback  = static function( $where_clauses, $args, $context ) use ( $test_context, $global_context, $context_name, &$context_filter_hit_count ) {
 			if ( $context === $test_context ) {
 				$context_filter_hit_count++;
 				$where_clauses .= ' AND name = "' . $context_name . '"';
@@ -462,7 +462,7 @@ class WC_Admin_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		// Add filter for 'woocommerce_note_where_clauses' that applies in any context.
 		$no_context_filter_hit_count = 0;
 		$global_context_received     = null;
-		$no_context_filter_callback  = function( $where_clauses, $args, $context ) use ( $test_context, &$global_context_received, &$no_context_filter_hit_count ) {
+		$no_context_filter_callback  = static function( $where_clauses, $args, $context ) use ( $test_context, &$global_context_received, &$no_context_filter_hit_count ) {
 			// Record the context we get passed in.
 			if ( $test_context !== $context ) {
 				$global_context_received = $context;

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -148,7 +148,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'wc_get_price_excluding_tax' => function( $product, $args = array() ) use ( &$product_passed_to_get_price, &$args_passed_to_get_price ) {
+				'wc_get_price_excluding_tax' => static function( $product, $args = array() ) use ( &$product_passed_to_get_price, &$args_passed_to_get_price ) {
 						$product_passed_to_get_price = $product;
 						$args_passed_to_get_price    = $args;
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -72,7 +72,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// Force the "payments" task to be considered incomplete.
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function() {
+			static function() {
 				return array();
 			}
 		);
@@ -146,7 +146,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// Force the "payments" task to be considered incomplete.
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function() {
+			static function() {
 				return array();
 			}
 		);
@@ -172,7 +172,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// by faking a valid payment gateway.
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function() {
+			static function() {
 				return array(
 					new class() extends WC_Payment_Gateway {
 					},

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -28,7 +28,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 			),
 		);
 		// Call private method `maybe_add_order_item`.
-		$maybe_add_order_item_func = function () use ( $order, $data ) {
+		$maybe_add_order_item_func = static function () use ( $order, $data ) {
 			return static::maybe_add_order_item( $order->get_id(), '', $data );
 		};
 		$maybe_add_order_item_func->call( new WC_AJAX() );
@@ -66,7 +66,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 			),
 		);
 		// Call private method `maybe_add_order_item`.
-		$maybe_add_order_item_func = function () use ( $order, $data ) {
+		$maybe_add_order_item_func = static function () use ( $order, $data ) {
 			return static::maybe_add_order_item( $order->get_id(), '', $data );
 		};
 		$maybe_add_order_item_func->call( new WC_AJAX() );

--- a/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-checkout-test.php
@@ -55,7 +55,7 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_cart_needs_shipping_address',
-			function() {
+			static function() {
 				return true;
 			}
 		);
@@ -131,28 +131,28 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	public function test_validate_checkout_adds_we_dont_ship_error_only_if_country_exists( $country, $expect_we_dont_ship_error ) {
 		add_filter(
 			'woocommerce_countries_allowed_countries',
-			function() {
+			static function() {
 				return array( 'ES' );
 			}
 		);
 
 		add_filter(
 			'woocommerce_cart_needs_shipping',
-			function() {
+			static function() {
 				return true;
 			}
 		);
 
 		add_filter(
 			'wc_shipping_enabled',
-			function() {
+			static function() {
 				return true;
 			}
 		);
 
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'wc_get_shipping_method_count' => function( $include_legacy = false, $enabled_only = false ) {
+				'wc_get_shipping_method_count' => static function( $include_legacy = false, $enabled_only = false ) {
 					return 1;
 				},
 			)

--- a/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-download-handler-tests.php
@@ -59,7 +59,7 @@ class WC_Download_Handler_Tests extends \WC_Unit_Test_Case {
 		self::remove_download_handlers();
 		$downloads_served = 0;
 
-		$download_counter = function () use ( &$downloads_served ) {
+		$download_counter = static function () use ( &$downloads_served ) {
 			$downloads_served++;
 		};
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -21,7 +21,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		$rename_table_query  = 'RENAME TABLE %s to %s;';
 
 		// Workaround to call a private function.
-		$schema = function () {
+		$schema = static function () {
 			return static::get_schema();
 		};
 
@@ -62,7 +62,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		$rename_table_query  = 'RENAME TABLE %s to %s;';
 
 		// Workaround to call a private function.
-		$schema = function () {
+		$schema = static function () {
 			return static::get_schema();
 		};
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-product-downloads-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-product-downloads-test.php
@@ -98,7 +98,7 @@ class WC_Product_Download_Test extends WC_Unit_Test_Case {
 
 		add_shortcode(
 			'dynamic-download',
-			function () {
+			static function () {
 				return 'https://fast.reliable.external.fileserver.com/bucket-123/textbook.pdf';
 			}
 		);

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -77,7 +77,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	private function initialize_template_loader() {
 		// be sure shop is always returning same id doesn't matter the test setup environment
-		add_filter( 'woocommerce_get_shop_page_id', function ( $page ) {
+		add_filter( 'woocommerce_get_shop_page_id', static function ( $page ) {
 			return 5;
 		}, 10, 1 );
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -18,14 +18,14 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test the case for woocommerce_admin_disabled filter returning true.
 		add_filter(
 			'woocommerce_admin_disabled',
-			function( $default ) {
+			static function( $default ) {
 				return true;
 			}
 		);
 
 		add_filter(
 			'pre_http_request',
-			function( $pre, $args, $url ) use ( &$posted_data ) {
+			static function( $pre, $args, $url ) use ( &$posted_data ) {
 				$posted_data = $args;
 				return true;
 			},
@@ -50,7 +50,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		add_filter(
 			'pre_http_request',
-			function( $pre, $args, $url ) use ( &$posted_data ) {
+			static function( $pre, $args, $url ) use ( &$posted_data ) {
 				$posted_data = $args;
 				return true;
 			},

--- a/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
+++ b/plugins/woocommerce/tests/php/includes/cli/class-wc-cli-update-command-test.php
@@ -48,8 +48,8 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 		// Overwrite with some alternative update callbacks.
 		$this->db_updates_property->setValue(
 			array(
-				'5.0.0' => function () {},
-				'6.0.0' => function () {},
+				'5.0.0' => static function () {},
+				'6.0.0' => static function () {},
 			)
 		);
 
@@ -93,15 +93,15 @@ class WC_CLI_Update_Command_Test extends WC_Unit_Test_Case {
 		$this->register_legacy_proxy_static_mocks(
 			array(
 				WP_CLI::class => array(
-					'log'     => function () {},
-					'success' => function () {},
+					'log'     => static function () {},
+					'success' => static function () {},
 				),
 			)
 		);
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'WP_CLI\Utils\make_progress_bar' => function () {
+				'WP_CLI\Utils\make_progress_bar' => static function () {
 					return new class() {
 						/**
 						 * Stub, implemented so that calls to WP CLI methods do not break the tests.

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller-tests.php
@@ -25,7 +25,7 @@ class WC_REST_Product_Attributes_V1_Controller_Tests extends WC_Unit_Test_Case {
 	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_attribute_taxonomy_name_by_id' => function( $attribute_id ) {
+				'wc_attribute_taxonomy_name_by_id' => static function( $attribute_id ) {
 					return 'taxonomy_' . $attribute_id;
 				},
 			)

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller-tests.php
@@ -225,7 +225,7 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = array_values( $response->get_data() );
 		$ids  = array_map(
-			function( $item ) {
+			static function( $item ) {
 				return $item['id'];
 			},
 			$data
@@ -277,7 +277,7 @@ class WC_REST_Taxes_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = array_values( $response->get_data() );
 		$ids  = array_map(
-			function( $item ) {
+			static function( $item ) {
 				return $item['id'];
 			},
 			$data

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
@@ -25,7 +25,7 @@ class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
 	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_attribute_taxonomy_name_by_id' => function( $attribute_id ) {
+				'wc_attribute_taxonomy_name_by_id' => static function( $attribute_id ) {
 					return 'taxonomy_' . $attribute_id;
 				},
 			)

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-accounts-test.php
@@ -22,7 +22,7 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_account_settings',
-			function( $settings ) use ( &$actual_settings_via_filter ) {
+			static function( $settings ) use ( &$actual_settings_via_filter ) {
 				$actual_settings_via_filter = $settings;
 				return $settings;
 			},
@@ -113,12 +113,12 @@ class WC_Settings_Accounts_Test extends WC_Settings_Unit_Test_Case {
 	public function test_linked_text_for_erasure_request_settings( $current_user_can_manage_privacy_options, $blog_version, $expected_order_erasure_text, $expected_downloads_erasure_text ) {
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'current_user_can' => function( $capability, ...$args ) use ( $current_user_can_manage_privacy_options ) {
+				'current_user_can' => static function( $capability, ...$args ) use ( $current_user_can_manage_privacy_options ) {
 					return 'manage_privacy_options' === $capability ?
 						$current_user_can_manage_privacy_options :
 						current_user_can( $capability, ...$args );
 				},
-				'get_bloginfo'     => function( $show = '', $filter = 'raw' ) use ( $blog_version ) {
+				'get_bloginfo'     => static function( $show = '', $filter = 'raw' ) use ( $blog_version ) {
 					return 'version' === $show ?
 						$blog_version :
 						get_bloginfo( $show, $filter );

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-advanced-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-advanced-test.php
@@ -50,7 +50,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			$filter_name,
-			function ( $settings ) use ( &$actual_settings_via_filter ) {
+			static function ( $settings ) use ( &$actual_settings_via_filter ) {
 				$actual_settings_via_filter = $settings;
 
 				return $settings;
@@ -124,7 +124,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_cart_shortcode_tag',
-			function ( $id ) use ( &$original_id ) {
+			static function ( $id ) use ( &$original_id ) {
 				$original_id = $id;
 				return 'foobar';
 			},
@@ -137,7 +137,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 		$setting             = current(
 			array_filter(
 				$settings,
-				function( $value ) {
+				static function( $value ) {
 					return 'woocommerce_cart_page_id' === $value['id'];
 				}
 			)
@@ -202,17 +202,17 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Webhooks' => array(
-					'page_output' => function() use ( &$actual_invoked_class ) {
+					'page_output' => static function() use ( &$actual_invoked_class ) {
 						$actual_invoked_class = 'WC_Admin_Webhooks';
 					},
 				),
 				'WC_Admin_API_Keys' => array(
-					'page_output' => function() use ( &$actual_invoked_class ) {
+					'page_output' => static function() use ( &$actual_invoked_class ) {
 						$actual_invoked_class = 'WC_Admin_API_Keys';
 					},
 				),
 				'WC_Admin_Settings' => array(
-					'output_fields' => function( $settings ) use ( &$actual_invoked_class ) {
+					'output_fields' => static function( $settings ) use ( &$actual_invoked_class ) {
 						$actual_invoked_class = 'WC_Admin_Settings';
 					},
 				),
@@ -244,12 +244,12 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Webhooks' => array(
-					'notices' => function() use ( &$actual_invoked_class ) {
+					'notices' => static function() use ( &$actual_invoked_class ) {
 						$actual_invoked_class = 'WC_Admin_Webhooks';
 					},
 				),
 				'WC_Admin_API_Keys' => array(
-					'notices' => function() use ( &$actual_invoked_class ) {
+					'notices' => static function() use ( &$actual_invoked_class ) {
 						$actual_invoked_class = 'WC_Admin_API_Keys';
 					},
 				),
@@ -280,7 +280,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_rest_api_valid_to_save',
-			function ( $value ) use ( &$actual_filter_supplied_value ) {
+			static function ( $value ) use ( &$actual_filter_supplied_value ) {
 				$actual_filter_supplied_value = $value;
 
 				return false;
@@ -312,7 +312,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_rest_api_valid_to_save',
-			function ( $value ) use ( &$is_valid_to_save ) {
+			static function ( $value ) use ( &$is_valid_to_save ) {
 				return $is_valid_to_save;
 			},
 			10,
@@ -322,7 +322,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'save_fields' => function( $settings ) use ( &$settings_were_saved ) {
+					'save_fields' => static function( $settings ) use ( &$settings_were_saved ) {
 						$settings_were_saved = true;
 					},
 				),
@@ -353,7 +353,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_rest_api_valid_to_save',
-			function ( $value ) use ( &$is_valid_to_save ) {
+			static function ( $value ) use ( &$is_valid_to_save ) {
 				return $is_valid_to_save;
 			},
 			10,

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-emails-test.php
@@ -42,7 +42,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			$filter_name,
-			function ( $settings ) use ( &$actual_settings_via_filter ) {
+			static function ( $settings ) use ( &$actual_settings_via_filter ) {
 				$actual_settings_via_filter = $settings;
 
 				return $settings;
@@ -106,7 +106,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 		$sut->method( 'run_email_admin_options' )
 			->will(
 				$this->returnCallback(
-					function( $email ) use ( &$admin_options_invoked, &$actual_email ) {
+					static function( $email ) use ( &$admin_options_invoked, &$actual_email ) {
 						$admin_options_invoked = true;
 						$actual_email          = $email;
 					}
@@ -146,7 +146,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Emails' => array(
-					'instance' => function() use ( $emails ) {
+					'instance' => static function() use ( $emails ) {
 						return $emails;
 					},
 				),
@@ -160,7 +160,7 @@ class WC_Settings_Emails_Test extends WC_Settings_Unit_Test_Case {
 		$sut->method( 'save_settings_for_current_section' )
 						->will(
 							$this->returnCallback(
-								function() use ( &$save_settings_for_current_section_invoked ) {
+								static function() use ( &$save_settings_for_current_section_invoked ) {
 									$save_settings_for_current_section_invoked = true;
 								}
 							)

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-general-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-general-test.php
@@ -22,7 +22,7 @@ class WC_Settings_General_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_general_settings',
-			function( $settings ) use ( &$actual_settings_via_filter ) {
+			static function( $settings ) use ( &$actual_settings_via_filter ) {
 				$actual_settings_via_filter = $settings;
 				return $settings;
 			},
@@ -81,13 +81,13 @@ class WC_Settings_General_Test extends WC_Settings_Unit_Test_Case {
 	public function test_get_settings__currencies() {
 		FunctionsMockerHack::add_function_mocks(
 			array(
-				'get_woocommerce_currencies'      => function() {
+				'get_woocommerce_currencies'      => static function() {
 					return array(
 						'c1' => 'Currency 1',
 						'c2' => 'Currency 2',
 					);
 				},
-				'get_woocommerce_currency_symbol' => function( $currency = '' ) {
+				'get_woocommerce_currency_symbol' => static function( $currency = '' ) {
 					return "symbol for $currency";
 				},
 			)

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-page-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-page-test.php
@@ -117,7 +117,7 @@ class WC_Settings_Page_Test extends WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_get_settings_example',
-			function( $settings, $section ) use ( &$actual_settings, &$actual_section ) {
+			static function( $settings, $section ) use ( &$actual_settings, &$actual_section ) {
 				$actual_settings = $settings;
 				$actual_section  = $section;
 			},
@@ -158,7 +158,7 @@ class WC_Settings_Page_Test extends WC_Unit_Test_Case {
 
 		add_filter(
 			'woocommerce_get_sections_example',
-			function( $sections ) use ( &$actual_sections ) {
+			static function( $sections ) use ( &$actual_sections ) {
 				$actual_sections = $sections;
 			},
 			10,
@@ -206,7 +206,7 @@ HTML;
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'output_fields' => function( $settings ) use ( &$actual ) {
+					'output_fields' => static function( $settings ) use ( &$actual ) {
 						$actual = $settings;
 					},
 				),
@@ -233,7 +233,7 @@ HTML;
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'output_fields' => function( $settings ) use ( &$actual ) {
+					'output_fields' => static function( $settings ) use ( &$actual ) {
 						$actual = $settings;
 					},
 				),
@@ -260,7 +260,7 @@ HTML;
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'save_fields' => function( $settings ) use ( &$actual ) {
+					'save_fields' => static function( $settings ) use ( &$actual ) {
 						$actual = $settings;
 					},
 				),
@@ -287,7 +287,7 @@ HTML;
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'save_fields' => function( $settings ) use ( &$actual ) {
+					'save_fields' => static function( $settings ) use ( &$actual ) {
 						$actual = $settings;
 					},
 				),

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-payment-gateways-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-payment-gateways-test.php
@@ -44,7 +44,7 @@ class WC_Settings_Payment_Gateways_Test extends WC_Settings_Unit_Test_Case {
 
 		add_filter(
 			$filter_name,
-			function ( $settings ) use ( &$actual_settings_via_filter ) {
+			static function ( $settings ) use ( &$actual_settings_via_filter ) {
 				$actual_settings_via_filter = $settings;
 
 				return $settings;
@@ -100,7 +100,7 @@ class WC_Settings_Payment_Gateways_Test extends WC_Settings_Unit_Test_Case {
 		$sut->method( 'run_gateway_admin_options' )
 			->will(
 				$this->returnCallback(
-					function( $gateway ) use ( &$admin_options_invoked, &$actual_gateway ) {
+					static function( $gateway ) use ( &$admin_options_invoked, &$actual_gateway ) {
 						$admin_options_invoked = true;
 						$actual_gateway        = $gateway;
 					}
@@ -139,7 +139,7 @@ class WC_Settings_Payment_Gateways_Test extends WC_Settings_Unit_Test_Case {
 		$payment_gateways->method( 'process_admin_options' )
 						->will(
 							$this->returnCallback(
-								function() use ( &$process_admin_options_invoked ) {
+								static function() use ( &$process_admin_options_invoked ) {
 									$process_admin_options_invoked = true;
 								}
 							)
@@ -148,7 +148,7 @@ class WC_Settings_Payment_Gateways_Test extends WC_Settings_Unit_Test_Case {
 		$payment_gateways->method( 'init' )
 						->will(
 							$this->returnCallback(
-								function() use ( &$init_invoked ) {
+								static function() use ( &$init_invoked ) {
 									$init_invoked = true;
 								}
 							)
@@ -160,7 +160,7 @@ class WC_Settings_Payment_Gateways_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Payment_Gateways' => array(
-					'instance' => function() use ( $payment_gateways ) {
+					'instance' => static function() use ( $payment_gateways ) {
 						return $payment_gateways;
 					},
 				),

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -54,7 +54,7 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 		foreach ( $filter_names as $filter_name ) {
 			add_filter(
 				$filter_name,
-				function ( $settings ) use ( $filter_name, &$actual_settings_via_filter ) {
+				static function ( $settings ) use ( $filter_name, &$actual_settings_via_filter ) {
 					$actual_settings_via_filter[ $filter_name ] = $settings;
 
 					return $settings;
@@ -160,7 +160,7 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_recount_all_terms' => function() use ( &$wc_recount_all_terms_called ) {
+				'wc_recount_all_terms' => static function() use ( &$wc_recount_all_terms_called ) {
 					$wc_recount_all_terms_called = true;
 				},
 			)

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-shipping-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-shipping-test.php
@@ -128,14 +128,14 @@ class WC_Settings_Shipping_Test extends WC_Settings_Unit_Test_Case {
 		$sut->method( 'get_shipping_methods' )->willReturn( array() );
 		$sut->method( 'output_zones_screen' )->will(
 			$this->returnCallback(
-				function() use ( &$method_invoked ) {
+				static function() use ( &$method_invoked ) {
 					$method_invoked = 'output_zones_screen';
 				}
 			)
 		);
 		$sut->method( 'output_shipping_class_screen' )->will(
 			$this->returnCallback(
-				function() use ( &$method_invoked ) {
+				static function() use ( &$method_invoked ) {
 					$method_invoked = 'output_shipping_class_screen';
 				}
 			)
@@ -203,7 +203,7 @@ class WC_Settings_Shipping_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'output_fields' => function( $settings ) use ( &$output_fields_in_admin_settings_invoked ) {
+					'output_fields' => static function( $settings ) use ( &$output_fields_in_admin_settings_invoked ) {
 						$output_fields_in_admin_settings_invoked = true;
 					},
 				),
@@ -268,7 +268,7 @@ class WC_Settings_Shipping_Test extends WC_Settings_Unit_Test_Case {
 		$sut->method( 'get_shipping_methods' )->willReturn( array() );
 		$sut->method( 'save_settings_for_current_section' )->will(
 			$this->returnCallback(
-				function() use ( &$save_settings_for_current_section_invoked ) {
+				static function() use ( &$save_settings_for_current_section_invoked ) {
 					$save_settings_for_current_section_invoked = true;
 				}
 			)

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-tax-test.php
@@ -24,7 +24,7 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				WC_Tax::class => array(
-					'get_tax_classes' => function() use ( $tax_classes ) {
+					'get_tax_classes' => static function() use ( $tax_classes ) {
 						return $tax_classes;
 					},
 				),
@@ -86,7 +86,7 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Tax' => array(
-					'get_tax_class_slugs' => function() {
+					'get_tax_class_slugs' => static function() {
 						return array( 'tax_class_slug' );
 					},
 				),
@@ -99,7 +99,7 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 
 		$sut->method( 'output_tax_rates' )->will(
 			$this->returnCallback(
-				function() use ( &$output_tax_rates_invoked ) {
+				static function() use ( &$output_tax_rates_invoked ) {
 					$output_tax_rates_invoked = true;
 				}
 			)
@@ -122,12 +122,12 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Admin_Settings' => array(
-					'output_fields' => function( $settings ) use ( &$output_fields_in_admin_settings_invoked ) {
+					'output_fields' => static function( $settings ) use ( &$output_fields_in_admin_settings_invoked ) {
 						$output_fields_in_admin_settings_invoked = true;
 					},
 				),
 				'WC_Tax'            => array(
-					'get_tax_class_slugs' => function() {
+					'get_tax_class_slugs' => static function() {
 						return array( 'tax_class_slug' );
 					},
 				),
@@ -151,13 +151,13 @@ class WC_Settings_Tax_Test extends WC_Settings_Unit_Test_Case {
 		StaticMockerHack::add_method_mocks(
 			array(
 				'WC_Tax' => array(
-					'get_tax_classes'     => function() {
+					'get_tax_classes'     => static function() {
 						return array( 'tax_1', 'tax_2', 'tax_3' );
 					},
-					'delete_tax_class_by' => function( $field, $name ) use ( &$deleted ) {
+					'delete_tax_class_by' => static function( $field, $name ) use ( &$deleted ) {
 						$deleted[] = $name;
 					},
-					'create_tax_class'    => function( $name ) use ( &$created ) {
+					'create_tax_class'    => static function( $name ) use ( &$created ) {
 						$created[] = $name;
 					},
 				),

--- a/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-product-functions-test.php
@@ -46,14 +46,14 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 			array(
 				'WC_Tax' =>
 				array(
-					'get_rates'          => function( $tax_class, $customer ) use ( &$customer_passed_to_get_rates ) {
+					'get_rates'          => static function( $tax_class, $customer ) use ( &$customer_passed_to_get_rates ) {
 						$customer_passed_to_get_rates = $customer;
 					},
-					'get_base_tax_rates' => function( $tax_class ) use ( &$get_base_rates_invoked ) {
+					'get_base_tax_rates' => static function( $tax_class ) use ( &$get_base_rates_invoked ) {
 						$get_base_rates_invoked = true;
 						return 0;
 					},
-					'calc_tax'           => function( $price, $rates, $price_includes_tax = false, $deprecated = false ) {
+					'calc_tax'           => static function( $price, $rates, $price_includes_tax = false, $deprecated = false ) {
 						return array( 0 );
 					},
 				),
@@ -79,7 +79,7 @@ class WC_Product_Functions_Tests extends \WC_Unit_Test_Case {
 		$customer = new stdClass();
 		$this->register_legacy_proxy_class_mocks(
 			array(
-				'WC_Customer' => function( $customer_id ) use ( &$customer_id_passed_to_wc_customer_constructor, $customer ) {
+				'WC_Customer' => static function( $customer_id ) use ( &$customer_id_passed_to_wc_customer_constructor, $customer ) {
 					$customer_id_passed_to_wc_customer_constructor = $customer_id;
 					return $customer;
 				},

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
@@ -335,7 +335,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$unique_row = array_filter(
 			$meta_data,
-			function ( $meta_row ) {
+			static function ( $meta_row ) {
 				return 'unique_key_1' === $meta_row->meta_key;
 			}
 		);
@@ -345,7 +345,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$non_unique_rows = array_filter(
 			$meta_data,
-			function ( $meta_row ) {
+			static function ( $meta_row ) {
 				return 'non_unique_key_1' === $meta_row->meta_key;
 			}
 		);
@@ -384,7 +384,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$wpdb_mock->register_method_replacement(
 			'get_results',
-			function( ...$args ) {
+			static function( ...$args ) {
 				$wpdb_mock = $args[0];
 				$query     = $args[1];
 
@@ -396,7 +396,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$wpdb_mock->register_property_get_replacement(
 			'last_error',
-			function( $replacement_object ) {
+			static function( $replacement_object ) {
 				if ( $replacement_object->state ) {
 					return $replacement_object->state;
 				} else {
@@ -410,7 +410,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$actual_errors = $fake_logger->errors;
 		usort(
 			$actual_errors,
-			function( $a, $b ) {
+			static function( $a, $b ) {
 				return strcmp( $a['message'], $b['message'] );
 			}
 		);
@@ -435,7 +435,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$wpdb_mock->register_method_replacement(
 			'get_results',
-			function( ...$args ) use ( $exception ) {
+			static function( ...$args ) use ( $exception ) {
 				$query = $args[1];
 
 				if ( StringUtil::contains( $query, 'wc_orders' ) ) {
@@ -449,7 +449,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$actual_errors = $fake_logger->errors;
 		usort(
 			$actual_errors,
-			function( $a, $b ) {
+			static function( $a, $b ) {
 				return strcmp( $a['message'], $b['message'] );
 			}
 		);
@@ -480,7 +480,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_logger' => function() use ( $fake_logger ) {
+				'wc_get_logger' => static function() use ( $fake_logger ) {
 					return $fake_logger;
 				},
 			)
@@ -511,7 +511,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$wpdb_mock = $this->use_wpdb_mock();
 		$wpdb_mock->register_method_replacement(
 			'get_results',
-			function( ...$args ) {
+			static function( ...$args ) {
 				$wpdb_decorator                              = $args[0];
 				$wpdb_decorator->original_object->last_error = 'Something failed!';
 				return false;
@@ -532,7 +532,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$wpdb_mock = $this->use_wpdb_mock();
 		$wpdb_mock->register_method_replacement(
 			'get_results',
-			function( ...$args ) {
+			static function( ...$args ) {
 				throw new \Exception( 'Something failed!' );
 			}
 		);
@@ -588,7 +588,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$wpdb_mock = $this->use_wpdb_mock();
 		$wpdb_mock->register_method_replacement(
 			'get_results',
-			function( ...$args ) {
+			static function( ...$args ) {
 				$wpdb_decorator                              = $args[0];
 				$wpdb_decorator->original_object->last_error = 'Something failed!';
 				return false;
@@ -616,7 +616,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$wpdb_mock = $this->use_wpdb_mock();
 		$wpdb_mock->register_method_replacement(
 			'get_results',
-			function( ...$args ) {
+			static function( ...$args ) {
 				throw new \Exception( 'Something failed!' );
 			}
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -148,14 +148,14 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 	public function test_should_display_reviews_moved_notice( bool $user_has_capability, bool $user_has_dismissed_notice, bool $expected ) : void {
 		$this->register_legacy_proxy_function_mocks(
 			[
-				'current_user_can' => function( $capability, ...$args ) use ( $user_has_capability ) {
+				'current_user_can' => static function( $capability, ...$args ) use ( $user_has_capability ) {
 					if ( 'moderate_comments' === $capability ) {
 						return $user_has_capability;
 					} else {
 						return current_user_can( $capability, $args );
 					}
 				},
-				'get_user_meta' => function ( int $user_id, string $key = '', bool $single = false ) use ( $user_has_dismissed_notice ) {
+				'get_user_meta' => static function ( int $user_id, string $key = '', bool $single = false ) use ( $user_has_dismissed_notice ) {
 					if ( 'dismissed_product_reviews_moved_notice' === $key ) {
 						return $user_has_dismissed_notice;
 					} else {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsListTableTest.php
@@ -189,7 +189,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_columns_filtered() : void {
-		$filter_callback = function( $columns ) {
+		$filter_callback = static function( $columns ) {
 			return [
 				'custom_column' => 'Custom column',
 			];
@@ -1466,7 +1466,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$review = $this->factory()->comment->create_and_get();
-		$callback = function( $review ) {
+		$callback = static function( $review ) {
 			echo 'Custom content for "custom_column" for ID ' . esc_html( $review->comment_ID );
 		};
 
@@ -1495,7 +1495,7 @@ class ReviewsListTableTest extends WC_Unit_Test_Case {
 		$method->setAccessible( true );
 
 		$review = $this->factory()->comment->create_and_get();
-		$callback = function( $content, $review ) {
+		$callback = static function( $content, $review ) {
 			return 'Additional content to "' . $content . '" for test column belonging to review with ID: ' . esc_html( $review->comment_ID );
 		};
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsTest.php
@@ -53,7 +53,7 @@ class ReviewsTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 'moderate_comments', Reviews::get_capability( 'view' ) );
 		$this->assertEquals( 'edit_products', Reviews::get_capability( 'moderate' ) );
 
-		$callback = function() {
+		$callback = static function() {
 			return 'manage_woocommerce';
 		};
 
@@ -627,7 +627,7 @@ test2</p></div>',
 		);
 		$this->assertTrue( $method->invoke( $reviews, $review_reply ) );
 
-		$callback = function() {
+		$callback = static function() {
 			return true;
 		};
 

--- a/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
@@ -206,7 +206,7 @@ class AbstractServiceProviderTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_add_with_auto_arguments_works_as_expected_when_concrete_is_a_closure() {
 		$this->container->share( DependencyClass::class );
-		$callable = function( DependencyClass $dependency ) {
+		$callable = static function( DependencyClass $dependency ) {
 			return new ClassWithDependencies( $dependency );
 		};
 

--- a/plugins/woocommerce/tests/php/src/Internal/DownloadPermissionsAdjusterTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DownloadPermissionsAdjusterTest.php
@@ -31,13 +31,13 @@ class DownloadPermissionsAdjusterTest extends \WC_Unit_Test_Case {
 		// This is needed for "product->set_downloads" to work without actual files.
 		add_filter(
 			'woocommerce_downloadable_file_allowed_mime_types',
-			function() {
+			static function() {
 				return array( 'foo' => 'nonsense/foo' );
 			}
 		);
 		add_filter(
 			'woocommerce_downloadable_file_exists',
-			function( $exists, $filename ) {
+			static function( $exists, $filename ) {
 				return true;
 			},
 			10,
@@ -67,10 +67,10 @@ class DownloadPermissionsAdjusterTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'as_get_scheduled_actions'  => function( $args, $return_format ) use ( &$as_get_scheduled_actions_invoked ) {
+				'as_get_scheduled_actions'  => static function( $args, $return_format ) use ( &$as_get_scheduled_actions_invoked ) {
 					$as_get_scheduled_actions_invoked = true;
 				},
-				'as_schedule_single_action' => function( $timestamp, $hook, $args ) use ( &$as_schedule_single_action_invoked ) {
+				'as_schedule_single_action' => static function( $timestamp, $hook, $args ) use ( &$as_schedule_single_action_invoked ) {
 					$as_schedule_single_action_invoked = true;
 				},
 			)
@@ -92,11 +92,11 @@ class DownloadPermissionsAdjusterTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'as_get_scheduled_actions'  => function( $args, $return_format ) use ( &$as_get_scheduled_actions_args ) {
+				'as_get_scheduled_actions'  => static function( $args, $return_format ) use ( &$as_get_scheduled_actions_args ) {
 					$as_get_scheduled_actions_args = $args;
 					return array( 1 );
 				},
-				'as_schedule_single_action' => function( $timestamp, $hook, $args ) use ( &$as_schedule_single_action_invoked ) {
+				'as_schedule_single_action' => static function( $timestamp, $hook, $args ) use ( &$as_schedule_single_action_invoked ) {
 					$as_schedule_single_action_invoked = true;
 				},
 			)
@@ -123,14 +123,14 @@ class DownloadPermissionsAdjusterTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'as_get_scheduled_actions'  => function( $params, $return_format ) use ( &$as_get_scheduled_actions_args ) {
+				'as_get_scheduled_actions'  => static function( $params, $return_format ) use ( &$as_get_scheduled_actions_args ) {
 					$as_get_scheduled_actions_args = $params;
 					return array();
 				},
-				'as_schedule_single_action' => function( $timestamp, $hook, $args ) use ( &$as_schedule_single_action_args ) {
+				'as_schedule_single_action' => static function( $timestamp, $hook, $args ) use ( &$as_schedule_single_action_args ) {
 					$as_schedule_single_action_args = array( $timestamp, $hook, $args );
 				},
-				'time'                      => function() {
+				'time'                      => static function() {
 					return 0; },
 			)
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -109,10 +109,10 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	public function test_initiate_regeneration_initializes_temporary_options_and_enqueues_regeneration_step() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) {
+				'wc_get_products' => static function( $args ) {
 					return array( 100 );
 				},
-				'time'            => function() {
+				'time'            => static function() {
 					return 1000;
 				},
 			)
@@ -147,7 +147,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	public function test_initiate_regeneration_does_not_enqueues_regeneration_step_when_no_products( $get_products_result ) {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) use ( $get_products_result ) {
+				'wc_get_products' => static function( $args ) use ( $get_products_result ) {
 					return $get_products_result;
 				},
 			)
@@ -169,7 +169,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) use ( &$requested_products_offsets ) {
+				'wc_get_products' => static function( $args ) use ( &$requested_products_offsets ) {
 					if ( 'DESC' === current( $args['orderby'] ) ) {
 						return array( 100 );
 					} else {
@@ -177,7 +177,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 						return array( 1, 2, 3 );
 					}
 				},
-				'time'            => function() {
+				'time'            => static function() {
 					return 1000;
 				},
 			)
@@ -219,7 +219,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		if ( $set_filter ) {
 			\add_filter(
 				'woocommerce_attribute_lookup_regeneration_step_size',
-				function( $default_filter_size ) {
+				static function( $default_filter_size ) {
 					return 100;
 				}
 			);
@@ -227,7 +227,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) use ( &$requested_step_sizes ) {
+				'wc_get_products' => static function( $args ) use ( &$requested_step_sizes ) {
 					if ( 'DESC' === current( $args['orderby'] ) ) {
 						return array( 100 );
 					} else {
@@ -261,7 +261,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	public function test_initiate_regeneration_finishes_when_no_more_products_available( $product_ids ) {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_products' => function( $args ) use ( &$requested_products_offsets, $product_ids ) {
+				'wc_get_products' => static function( $args ) use ( &$requested_products_offsets, $product_ids ) {
 					if ( 'DESC' === current( $args['orderby'] ) ) {
 						return array( 100 );
 					} else {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -297,7 +297,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 			$main_product_in_stock = ! empty(
 				array_filter(
 					$data['variations'],
-					function( $variation ) {
+					static function( $variation ) {
 						return $variation['in_stock'];
 					}
 				)

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -161,7 +161,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_terms'      => function( $args ) use ( &$invokations_of_get_terms ) {
+				'get_terms'      => static function( $args ) use ( &$invokations_of_get_terms ) {
 					switch ( $args['taxonomy'] ) {
 						case 'non-variation-attribute':
 							return array(
@@ -188,7 +188,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 							throw new \Exception( "Unexpected call to 'get_terms'" );
 					}
 				},
-				'wc_get_product' => function( $id ) use ( &$products ) {
+				'wc_get_product' => static function( $id ) use ( &$products ) {
 					return $products[ $id ];
 				},
 			)
@@ -367,17 +367,17 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_post_type'    => function( $id ) use ( $product ) {
+				'get_post_type'    => static function( $id ) use ( $product ) {
 					if ( $id === $product->get_id() || $id === $product ) {
 						return 'product';
 					} else {
 						return get_post_type( $id );
 					}
 				},
-				'time'             => function() {
+				'time'             => static function() {
 					return 100;
 				},
-				'current_user_can' => function( $capability, ...$args ) {
+				'current_user_can' => static function( $capability, ...$args ) {
 					if ( 'delete_posts' === $capability ) {
 						return true;
 					} else {
@@ -461,7 +461,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_post_type'    => function( $id ) use ( $product, $variation ) {
+				'get_post_type'    => static function( $id ) use ( $product, $variation ) {
 					if ( $id === $product->get_id() || $id === $product ) {
 						return 'product';
 					} elseif ( $id === $variation->get_id() || $id === $variation ) {
@@ -470,10 +470,10 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 						return get_post_type( $id );
 					}
 				},
-				'time'             => function() {
+				'time'             => static function() {
 					return 100;
 				},
-				'current_user_can' => function( $capability, ...$args ) {
+				'current_user_can' => static function( $capability, ...$args ) {
 					if ( 'delete_posts' === $capability ) {
 						return true;
 					} else {
@@ -530,7 +530,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_post_type'    => function( $id ) use ( $product, $variation ) {
+				'get_post_type'    => static function( $id ) use ( $product, $variation ) {
 					if ( $id === $product->get_id() || $id === $product ) {
 						return 'product';
 					} elseif ( $id === $variation->get_id() || $id === $variation ) {
@@ -539,10 +539,10 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 						return get_post_type( $id );
 					}
 				},
-				'time'             => function() {
+				'time'             => static function() {
 					return 100;
 				},
-				'current_user_can' => function( $capability, ...$args ) {
+				'current_user_can' => static function( $capability, ...$args ) {
 					if ( 'delete_posts' === $capability ) {
 						return true;
 					} else {
@@ -581,7 +581,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'time' => function() {
+				'time' => static function() {
 					return 100;
 				},
 			)
@@ -690,7 +690,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'time' => function() {
+				'time' => static function() {
 					return 100;
 				},
 			)
@@ -748,7 +748,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'time' => function () {
+				'time' => static function () {
 					return 100;
 				},
 			)
@@ -858,7 +858,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 		);
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_get_product' => function( $id ) use ( $product ) {
+				'wc_get_product' => static function( $id ) use ( $product ) {
 					if ( $id === $product->get_id() || $id === $product ) {
 						return $product;
 					} else {
@@ -937,7 +937,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_terms'      => function( $args ) {
+				'get_terms'      => static function( $args ) {
 					switch ( $args['taxonomy'] ) {
 						case 'non-variation-attribute':
 							return array(
@@ -951,7 +951,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 							throw new \Exception( "Unexpected call to 'get_terms'" );
 					}
 				},
-				'wc_get_product' => function( $id ) use ( $product, $variation ) {
+				'wc_get_product' => static function( $id ) use ( $product, $variation ) {
 					if ( $id === $product->get_id() || $id === $product ) {
 						return $product;
 					} elseif ( $id === $variation->get_id() || $id === $variation ) {
@@ -1039,7 +1039,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_terms'      => function( $args ) {
+				'get_terms'      => static function( $args ) {
 					switch ( $args['taxonomy'] ) {
 						case 'non-variation-attribute':
 							return array(
@@ -1053,7 +1053,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 							throw new \Exception( "Unexpected call to 'get_terms'" );
 					}
 				},
-				'wc_get_product' => function( $id ) use ( $product, $variation ) {
+				'wc_get_product' => static function( $id ) use ( $product, $variation ) {
 					if ( $id === $product->get_id() || $id === $product ) {
 						return $product;
 					} elseif ( $id === $variation->get_id() || $id === $variation ) {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductDownloads/ApprovedDirectories/SynchronizeTest.php
@@ -60,7 +60,7 @@ class SynchronizeTest extends WC_Unit_Test_Case {
 	public function test_sync_process() {
 		$logged_messages = array();
 
-		$log_watcher = function ( string $logged_message ) use ( &$logged_messages ) {
+		$log_watcher = static function ( string $logged_message ) use ( &$logged_messages ) {
 			$logged_messages[] = $logged_message;
 		};
 

--- a/plugins/woocommerce/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
@@ -52,7 +52,7 @@ class ClassThatDependsOnLegacyCodeTest extends \WC_Unit_Test_Case {
 	public function test_function_mocks_can_be_used_via_injected_legacy_proxy_and_woocommerce_object( $method_to_use ) {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'hexdec' => function( $hex_string ) {
+				'hexdec' => static function( $hex_string ) {
 					return "Mocked hexdec for $hex_string";
 				},
 			)
@@ -85,7 +85,7 @@ class ClassThatDependsOnLegacyCodeTest extends \WC_Unit_Test_Case {
 		$this->register_legacy_proxy_static_mocks(
 			array(
 				DependencyClass::class => array(
-					'concat' => function( ...$parts ) {
+					'concat' => static function( ...$parts ) {
 						return "I'm returning concat of these parts: " . join( ' ', $parts );
 					},
 				),

--- a/plugins/woocommerce/tests/php/src/Proxies/DynamicDecoratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/DynamicDecoratorTest.php
@@ -50,7 +50,7 @@ class DynamicDecoratorTest extends \WC_Unit_Test_Case {
 	public function test_method_replacement() {
 		$this->sut->register_method_replacement(
 			'some_method',
-			function( $decorator, $a, $b ) {
+			static function( $decorator, $a, $b ) {
 				return "Replacement method invoked with \$a=$a, \$b=$b, " . $decorator->decorated_object->some_other_property;
 			}
 		);
@@ -79,7 +79,7 @@ class DynamicDecoratorTest extends \WC_Unit_Test_Case {
 	public function test_property_get_replacement_with_callback() {
 		$this->sut->register_property_get_replacement(
 			'some_property',
-			function( $decorator ) {
+			static function( $decorator ) {
 				return 'replacement value, ' . $decorator->decorated_object->some_other_property;
 			}
 		);
@@ -95,7 +95,7 @@ class DynamicDecoratorTest extends \WC_Unit_Test_Case {
 	public function test_property_set_replacement() {
 		$this->sut->register_property_set_replacement(
 			'some_property',
-			function( $decorator, $value ) {
+			static function( $decorator, $value ) {
 				$decorator->decorated_object->some_property = $decorator->decorated_object->some_other_property . ', ' . $value;
 			}
 		);
@@ -113,7 +113,7 @@ class DynamicDecoratorTest extends \WC_Unit_Test_Case {
 
 		$this->sut->register_method_replacement(
 			'some_method',
-			function( ...$args ) use ( &$replacement_invoked ) {
+			static function( ...$args ) use ( &$replacement_invoked ) {
 				$replacement_invoked = true;
 				$decorator           = $args[0];
 

--- a/plugins/woocommerce/tests/php/src/Proxies/MockableLegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/MockableLegacyProxyTest.php
@@ -78,7 +78,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	 * @testdox 'register_class_mocks' can be used to return class mocks by passing mock factory callbacks.
 	 */
 	public function test_register_class_mocks_can_be_used_so_that_get_instance_of_uses_a_factory_function_to_return_the_instance() {
-		$mock_factory = function( $code, $message, $http_status_code = 400, $data = array() ) {
+		$mock_factory = static function( $code, $message, $http_status_code = 400, $data = array() ) {
 			return "$code, $message, $http_status_code";
 		};
 		$this->sut->register_class_mocks( array( \WC_Data_Exception::class => $mock_factory ) );
@@ -100,7 +100,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	 */
 	public function data_provider_for_test_register_function_mocks_throws_if_invalid_parameters_supplied() {
 		return array(
-			array( 1234, function() {} ),
+			array( 1234, static function() {} ),
 			array( 'SomeClassName', 1234 ),
 		);
 	}
@@ -126,7 +126,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	public function test_register_function_mocks_can_be_used_so_that_call_function_calls_mock_functions() {
 		$this->sut->register_function_mocks(
 			array(
-				'substr' => function( $string, $start, $length ) {
+				'substr' => static function( $string, $start, $length ) {
 					return "I'm returning substr of '$string' from $start with length $length";
 				},
 			)
@@ -152,9 +152,9 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 	 */
 	public function data_provider_for_test_register_static_mocks_throws_if_invalid_parameters_supplied() {
 		return array(
-			array( 1234, array( 'some_method' => function(){} ) ),
+			array( 1234, array( 'some_method' => static function(){} ) ),
 			array( 'SomeClassName', 1234 ),
-			array( 'SomeClassName', array( 1234 => function(){} ) ),
+			array( 'SomeClassName', array( 1234 => static function(){} ) ),
 			array( 'SomeClassName', array( 'the_method' => 1234 ) ),
 		);
 	}
@@ -181,7 +181,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 		$this->sut->register_static_mocks(
 			array(
 				DependencyClass::class => array(
-					'concat' => function( ...$parts ) {
+					'concat' => static function( ...$parts ) {
 						return "I'm returning concat of these parts: " . join( ' ', $parts );
 					},
 				),
@@ -233,7 +233,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 
 		$this->sut->register_function_mocks(
 			array(
-				'substr' => function( $string, $start, $length ) {
+				'substr' => static function( $string, $start, $length ) {
 					return null;
 				},
 			)
@@ -242,7 +242,7 @@ class MockableLegacyProxyTest extends \WC_Unit_Test_Case {
 		$this->sut->register_static_mocks(
 			array(
 				DependencyClass::class => array(
-					'concat' => function( ...$parts ) {
+					'concat' => static function( ...$parts ) {
 						return null;
 					},
 				),

--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -112,7 +112,7 @@ class Formatter extends KeepAChangelogParser {
 		while ( strpos( $changelog, "\t" ) !== false ) {
 			$changelog = preg_replace_callback(
 				'/^([^\t\n]*)\t/m',
-				function ( $m ) {
+				static function ( $m ) {
 					return $m[1] . str_repeat( ' ', 4 - ( mb_strlen( $m[1] ) % 4 ) );
 				},
 				$changelog

--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -95,7 +95,7 @@ if ( preg_match( '/^packages:((\n\s+.+)+)/', $workspace_yaml, $matches ) ) {
         }
 }
 
-$composer_files = array_map( function( $path ) {
+$composer_files = array_map( static function( $path ) {
         return glob( $path . '/composer.json' );
 }, $workspace_paths );
 $composer_files = array_merge( ...$composer_files );


### PR DESCRIPTION
Lambdas not (indirect) referencing $this must be declared static.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
