### PR TITLE
List syntax

### DIFF
--- a/plugins/woocommerce/includes/admin/class-wc-admin-webhooks.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-webhooks.php
@@ -105,7 +105,7 @@ class WC_Admin_Webhooks {
 					break;
 
 				default:
-					list( $resource, $event ) = explode( '.', sanitize_text_field( wp_unslash( $_POST['webhook_topic'] ) ) ); // WPCS: input var okay, CSRF ok.
+					[ $resource, $event ] = explode( '.', sanitize_text_field( wp_unslash( $_POST['webhook_topic'] ) ) ); // WPCS: input var okay, CSRF ok.
 					break;
 			}
 
@@ -318,7 +318,7 @@ class WC_Admin_Webhooks {
 		$resource = '';
 
 		if ( $topic ) {
-			list( $resource, $event ) = explode( '.', $topic );
+			[ $resource, $event ] = explode( '.', $topic );
 
 			if ( 'action' === $resource ) {
 				$topic = 'action';

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1223,7 +1223,7 @@ class WC_Helper {
 				continue;
 			}
 
-			list( $product_id, $file_id ) = explode( ':', $data['Woo'] );
+			[ $product_id, $file_id ] = explode( ':', $data['Woo'] );
 			if ( empty( $product_id ) || empty( $file_id ) ) {
 				continue;
 			}
@@ -1265,7 +1265,7 @@ class WC_Helper {
 				continue;
 			}
 
-			list( $product_id, $file_id ) = explode( ':', $header );
+			[ $product_id, $file_id ] = explode( ':', $header );
 			if ( empty( $product_id ) || empty( $file_id ) ) {
 				continue;
 			}

--- a/plugins/woocommerce/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -154,7 +154,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 
 				while ( false !== $row ) {
 
-					list( $country, $state, $postcode, $city, $rate, $name, $priority, $compound, $shipping, $class ) = $row;
+					[ $country, $state, $postcode, $city, $rate, $name, $priority, $compound, $shipping, $class ] = $row;
 
 					$tax_rate = array(
 						'tax_rate_country'  => $country,

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -154,7 +154,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return bool
 	 */
 	public function is_customer_outside_base() {
-		list( $country, $state ) = $this->get_taxable_address();
+		[ $country, $state ] = $this->get_taxable_address();
 		if ( $country ) {
 			$default = wc_get_base_location();
 			if ( $default['country'] !== $country ) {

--- a/plugins/woocommerce/includes/class-wc-download-handler.php
+++ b/plugins/woocommerce/includes/class-wc-download-handler.php
@@ -414,7 +414,7 @@ class WC_Download_Handler {
 			$c_start = $start;
 			$c_end   = $end;
 			// Extract the range string.
-			list( , $range ) = explode( '=', $http_range, 2 );
+			[ , $range ] = explode( '=', $http_range, 2 );
 			// Make sure the client hasn't sent us a multibyte range.
 			if ( strpos( $range, ',' ) !== false ) {
 				return $download_range;

--- a/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images-request.php
@@ -210,7 +210,7 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 			if ( false === $image_sizes ) {
 				continue;
 			}
-			list( $orig_w, $orig_h ) = $image_sizes;
+			[ $orig_w, $orig_h ] = $image_sizes;
 
 			$dimensions = image_resize_dimensions( $orig_w, $orig_h, $size_data['width'], $size_data['height'], $size_data['crop'] );
 

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -316,7 +316,7 @@ class WC_Regenerate_Images {
 	 * @return array|false An array of the filename, thumbnail width, and thumbnail height, or false on failure to resize such as the thumbnail being larger than the fullsize image.
 	 */
 	private static function get_image( $fullsizepath, $thumbnail_width, $thumbnail_height, $crop ) {
-		list( $fullsize_width, $fullsize_height ) = getimagesize( $fullsizepath );
+		[ $fullsize_width, $fullsize_height ] = getimagesize( $fullsizepath );
 
 		$dimensions = image_resize_dimensions( $fullsize_width, $fullsize_height, $thumbnail_width, $thumbnail_height, $crop );
 		$editor     = wp_get_image_editor( $fullsizepath );
@@ -329,7 +329,7 @@ class WC_Regenerate_Images {
 			return false;
 		}
 
-		list( , , , , $dst_w, $dst_h ) = $dimensions;
+		[ , , , , $dst_w, $dst_h ] = $dimensions;
 		$suffix                        = "{$dst_w}x{$dst_h}";
 		$file_ext                      = strtolower( pathinfo( $fullsizepath, PATHINFO_EXTENSION ) );
 

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -292,7 +292,7 @@ class WC_Session_Handler extends WC_Session {
 			return false;
 		}
 
-		list( $customer_id, $session_expiration, $session_expiring, $cookie_hash ) = explode( '||', $cookie_value );
+		[ $customer_id, $session_expiration, $session_expiring, $cookie_hash ] = explode( '||', $cookie_value );
 
 		if ( empty( $customer_id ) ) {
 			return false;

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -498,7 +498,7 @@ class WC_Tax {
 		$matched_tax_rates = array();
 
 		if ( count( $location ) === 4 ) {
-			list( $country, $state, $postcode, $city ) = $location;
+			[ $country, $state, $postcode, $city ] = $location;
 
 			$matched_tax_rates = self::find_rates(
 				array(
@@ -566,7 +566,7 @@ class WC_Tax {
 		$matched_tax_rates = array();
 
 		if ( 4 === count( $location ) ) {
-			list( $country, $state, $postcode, $city ) = $location;
+			[ $country, $state, $postcode, $city ] = $location;
 
 			if ( ! is_null( $tax_class ) ) {
 				// This will be per item shipping.

--- a/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-rest-command.php
@@ -127,7 +127,7 @@ class WC_CLI_REST_Command {
 	 */
 	public function create_item( $args, $assoc_args ) {
 		$assoc_args            = self::decode_json( $assoc_args );
-		list( $status, $body ) = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
+		[ $status, $body ] = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $body['id'] );
 		} else {
@@ -144,7 +144,7 @@ class WC_CLI_REST_Command {
 	 * @param array $assoc_args WP-CLI associative arguments.
 	 */
 	public function delete_item( $args, $assoc_args ) {
-		list( $status, $body ) = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );
+		[ $status, $body ] = $this->do_request( 'DELETE', $this->get_filled_route( $args ), $assoc_args );
 		$object_id = isset( $body['id'] ) ? $body['id'] : '';
 		if ( ! $object_id && isset( $body['slug'] ) ) {
 			$object_id = $body['slug'];
@@ -171,7 +171,7 @@ class WC_CLI_REST_Command {
 	 */
 	public function get_item( $args, $assoc_args ) {
 		$route                           = $this->get_filled_route( $args );
-		list( $status, $body, $headers ) = $this->do_request( 'GET', $route, $assoc_args );
+		[ $status, $body, $headers ] = $this->do_request( 'GET', $route, $assoc_args );
 
 		if ( ! empty( $assoc_args['fields'] ) ) {
 			$body = self::limit_item_to_fields( $body, $assoc_args['fields'] );
@@ -218,7 +218,7 @@ class WC_CLI_REST_Command {
 			$assoc_args['per_page'] = '100';
 		}
 
-		list( $status, $body, $headers ) = $this->do_request( $method, $this->get_filled_route( $args ), $assoc_args );
+		[ $status, $body, $headers ] = $this->do_request( $method, $this->get_filled_route( $args ), $assoc_args );
 		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
 			$items = array_column( $body, 'id' );
 		} else {
@@ -266,7 +266,7 @@ class WC_CLI_REST_Command {
 	 */
 	public function update_item( $args, $assoc_args ) {
 		$assoc_args            = self::decode_json( $assoc_args );
-		list( $status, $body ) = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
+		[ $status, $body ] = $this->do_request( 'POST', $this->get_filled_route( $args ), $assoc_args );
 		if ( \WP_CLI\Utils\get_flag_value( $assoc_args, 'porcelain' ) ) {
 			WP_CLI::line( $body['id'] );
 		} else {

--- a/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-resource.php
+++ b/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-resource.php
@@ -256,7 +256,7 @@ class WC_API_Resource {
 
 			if ( false !== strpos( $field, '.' ) ) {
 
-				list( $name, $value ) = explode( '.', $field );
+				[ $name, $value ] = explode( '.', $field );
 
 				$sub_fields[ $name ] = $value;
 			}

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-resource.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-resource.php
@@ -315,7 +315,7 @@ class WC_API_Resource {
 
 			if ( false !== strpos( $field, '.' ) ) {
 
-				list( $name, $value ) = explode( '.', $field );
+				[ $name, $value ] = explode( '.', $field );
 
 				$sub_fields[ $name ] = $value;
 			}

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-resource.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-resource.php
@@ -323,7 +323,7 @@ class WC_API_Resource {
 
 			if ( false !== strpos( $field, '.' ) ) {
 
-				list( $name, $value ) = explode( '.', $field );
+				[ $name, $value ] = explode( '.', $field );
 
 				$sub_fields[ $name ] = $value;
 			}

--- a/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
+++ b/plugins/woocommerce/includes/react-admin/wc-admin-update-functions.php
@@ -122,7 +122,7 @@ function wc_admin_update_270_delete_report_downloads() {
 
 	// Delete all export files based on the status option values.
 	foreach ( $exports_status as $key => $progress ) {
-		list( $report_type, $export_id ) = explode( ':', $key );
+		[ $report_type, $export_id ] = explode( ':', $key );
 
 		if ( ! $export_id ) {
 			continue;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -623,7 +623,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		foreach ( $fields as $field ) {
 			// If we're looking for a sub-property, like environment.version we need
 			// to extract the first-level property here so we know which function to run.
-			list( $prop ) = explode( '.', $field, 2 );
+			[ $prop ] = explode( '.', $field, 2 );
 			switch ( $prop ) {
 				case 'environment':
 					$items['environment'] = $this->get_environment_info_per_fields( $fields );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
@@ -759,13 +759,13 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 			$date_data = rest_get_date_with_gmt( $request['date_created'] );
 
 			if ( ! empty( $date_data ) ) {
-				list( $prepared_review['comment_date'], $prepared_review['comment_date_gmt'] ) = $date_data;
+				[ $prepared_review['comment_date'], $prepared_review['comment_date_gmt'] ] = $date_data;
 			}
 		} elseif ( ! empty( $request['date_created_gmt'] ) ) {
 			$date_data = rest_get_date_with_gmt( $request['date_created_gmt'], true );
 
 			if ( ! empty( $date_data ) ) {
-				list( $prepared_review['comment_date'], $prepared_review['comment_date_gmt'] ) = $date_data;
+				[ $prepared_review['comment_date'], $prepared_review['comment_date_gmt'] ] = $date_data;
 			}
 		}
 

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -237,7 +237,7 @@ class WC_Shortcode_My_Account {
 			 */
 		} elseif ( ! empty( $_GET['show-reset-form'] ) ) { // WPCS: input var ok, CSRF ok.
 			if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {  // @codingStandardsIgnoreLine
-				list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) ); // @codingStandardsIgnoreLine
+				[ $rp_id, $rp_key ] = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) ); // @codingStandardsIgnoreLine
 				$userdata               = get_userdata( absint( $rp_id ) );
 				$rp_login               = $userdata ? $userdata->user_login : '';
 				$user                   = self::check_password_reset_key( $rp_key, $rp_login );

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1307,7 +1307,7 @@ add_filter( 'mod_rewrite_rules', 'wc_ms_protect_download_rewite_rules' );
  */
 function wc_format_country_state_string( $country_string ) {
 	if ( strstr( $country_string, ':' ) ) {
-		list( $country, $state ) = explode( ':', $country_string );
+		[ $country, $state ] = explode( ':', $country_string );
 	} else {
 		$country = $country_string;
 		$state   = '';
@@ -1663,7 +1663,7 @@ function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $obj
 				continue;
 			}
 
-			list( $min, $max ) = $range;
+			[ $min, $max ] = $range;
 
 			// If the postcode is non-numeric, make it numeric.
 			if ( ! is_numeric( $min ) || ! is_numeric( $max ) ) {

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -137,7 +137,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		list($data, $format) = self::get_customer_order_data_and_format( $order );
+		[$data, $format] = self::get_customer_order_data_and_format( $order );
 
 		$result = $wpdb->update( self::get_db_table_name(), $data, array( 'customer_id' => $customer_id ), $format );
 
@@ -516,7 +516,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return $returning_customer_id;
 		}
 
-		list($data, $format) = self::get_customer_order_data_and_format( $order );
+		[$data, $format] = self::get_customer_order_data_and_format( $order );
 
 		$result      = $wpdb->insert( self::get_db_table_name(), $data, $format );
 		$customer_id = $wpdb->insert_id;

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -119,7 +119,7 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 	private function generate_insert_sql_for_batch( array $batch ): string {
 		$table = $this->schema_config['destination']['table_name'];
 
-		list( $value_sql, $column_sql ) = $this->generate_column_clauses( array_merge( $this->core_column_mapping, $this->meta_column_mapping ), $batch );
+		[ $value_sql, $column_sql ] = $this->generate_column_clauses( array_merge( $this->core_column_mapping, $this->meta_column_mapping ), $batch );
 
 		return "INSERT IGNORE INTO $table (`$column_sql`) VALUES $value_sql;"; // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, -- $insert_query is hardcoded, $value_sql is already escaped.
 	}
@@ -149,7 +149,7 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 			$batch[ $entity_id ][ $destination_primary_id_schema['destination_primary_key']['destination'] ] = $entity_row_mapping[ $entity_id ]->destination_id;
 		}
 
-		list( $value_sql, $column_sql, $columns ) = $this->generate_column_clauses(
+		[ $value_sql, $column_sql, $columns ] = $this->generate_column_clauses(
 			array_merge( $destination_primary_id_schema, $this->core_column_mapping, $this->meta_column_mapping ),
 			$batch
 		);

--- a/plugins/woocommerce/tests/cli/features/bootstrap/utils.php
+++ b/plugins/woocommerce/tests/cli/features/bootstrap/utils.php
@@ -400,7 +400,7 @@ function mysql_host_to_cli_args( $raw_host ) {
 
 	$host_parts = explode( ':',  $raw_host );
 	if ( count( $host_parts ) == 2 ) {
-		list( $assoc_args['host'], $extra ) = $host_parts;
+		[ $assoc_args['host'], $extra ] = $host_parts;
 		$extra = trim( $extra );
 		if ( is_numeric( $extra ) ) {
 			$assoc_args['port'] = intval( $extra );
@@ -656,7 +656,7 @@ function get_named_sem_ver( $new_version, $original_version ) {
 	}
 
 	$parts = explode( '-', $original_version );
-	list( $major, $minor, $patch ) = explode( '.', $parts[0] );
+	[ $major, $minor, $patch ] = explode( '.', $parts[0] );
 
 	if ( Semver::satisfies( $new_version, "{$major}.{$minor}.x" ) ) {
 		return 'patch';

--- a/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/checkout/checkout.php
@@ -215,7 +215,7 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	 * @throws Exception When unable to create order.
 	 */
 	public function test_create_order_when_out_of_stock() {
-		list( $product, $order ) = $this->create_order_for_managed_inventory_product();
+		[ $product, $order ] = $this->create_order_for_managed_inventory_product();
 
 		$this->assertEquals( 9, $order->get_item_count() );
 		$this->assertEquals( 'pending', $order->get_status() );
@@ -233,7 +233,7 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	 * @throws Exception When unable to create order.
 	 */
 	public function test_pending_is_cleared_when_order_is_cancelled() {
-		list( $product, $order ) = $this->create_order_for_managed_inventory_product();
+		[ $product, $order ] = $this->create_order_for_managed_inventory_product();
 
 		$this->assertEquals( 9, wc_get_held_stock_quantity( $product ) );
 		$order->set_status( 'cancelled' );
@@ -250,7 +250,7 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	 * @throws Exception When unable to create order.
 	 */
 	public function test_pending_is_cleared_when_order_processed() {
-		list( $product, $order ) = $this->create_order_for_managed_inventory_product();
+		[ $product, $order ] = $this->create_order_for_managed_inventory_product();
 
 		$this->assertEquals( 9, wc_get_held_stock_quantity( $product ) );
 		$order->set_status( 'processing' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
@@ -103,7 +103,7 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_variable_product_stock_status_sync() {
-		list($product, $child1, $child2) = $this->get_variable_product_with_children();
+		[$product, $child1, $child2] = $this->get_variable_product_with_children();
 
 		// Product should be in stock if a child is in stock.
 		$child1->set_stock_status( 'instock' );
@@ -159,7 +159,7 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 	 * @param string $expected_stock_status The expected stock status of the product after being saved.
 	 */
 	public function test_stock_status_on_save_when_managing_stock( $stock_quantity, $notify_no_stock_amount, $accepts_backorders, $expected_stock_status ) {
-		list( $product, $child1, $child2 ) = $this->get_variable_product_with_children();
+		[ $product, $child1, $child2 ] = $this->get_variable_product_with_children();
 
 		update_option( 'woocommerce_notify_no_stock_amount', $notify_no_stock_amount );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -900,7 +900,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		);
 
 		foreach ( $test_cases as $test_case ) {
-			list( $value, $options, $result ) = $test_case;
+			[ $value, $options, $result ] = $test_case;
 			$actual_result                    = $result ? " selected='selected'" : '';
 			$this->assertEquals( wc_selected( $value, $options ), $actual_result );
 		}


### PR DESCRIPTION
List (array destructuring) assignment should be declared using the configured syntax.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
