### PR TITLE
Get class to class keyword

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -77,7 +77,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 
 		if ( $current_section ) {
 			foreach ( $payment_gateways as $gateway ) {
-				if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
+				if ( in_array( $current_section, array( $gateway->id, sanitize_title( $gateway::class   ) ), true ) ) {
 					if ( isset( $_GET['toggle_enabled'] ) ) {
 						$enabled = $gateway->get_option( 'enabled' );
 
@@ -265,7 +265,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 		} else {
 			// There is a section - this may be a gateway or custom section.
 			foreach ( $wc_payment_gateways->payment_gateways() as $gateway ) {
-				if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
+				if ( in_array( $current_section, array( $gateway->id, sanitize_title( $gateway::class   ) ), true ) ) {
 					do_action( 'woocommerce_update_options_payment_gateways_' . $gateway->id );
 					$wc_payment_gateways->init();
 				}

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -182,7 +182,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		} else {
 			$is_shipping_method = false;
 			foreach ( $shipping_methods as $method ) {
-				if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ), true ) && $method->has_settings() ) {
+				if ( in_array( $current_section, array( $method->id, sanitize_title( $method::class   ) ), true ) && $method->has_settings() ) {
 					$is_shipping_method = true;
 					$method->admin_options();
 				}
@@ -213,7 +213,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				$is_shipping_method = false;
 
 				foreach ( $this->get_shipping_methods() as $method_id => $method ) {
-					if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ), true ) ) {
+					if ( in_array( $current_section, array( $method->id, sanitize_title( $method::class   ) ), true ) ) {
 						$is_shipping_method = true;
 						$this->do_update_options_action( $method->id );
 					}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3090,7 +3090,7 @@ class WC_AJAX {
 			$gateway_id = wc_clean( wp_unslash( $_POST['gateway_id'] ) );
 
 			foreach ( $payment_gateways as $gateway ) {
-				if ( ! in_array( $gateway_id, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
+				if ( ! in_array( $gateway_id, array( $gateway->id, sanitize_title( $gateway::class   ) ), true ) ) {
 					continue;
 				}
 				$enabled = $gateway->get_option( 'enabled', 'no' );

--- a/plugins/woocommerce/includes/class-wc-data-store.php
+++ b/plugins/woocommerce/includes/class-wc-data-store.php
@@ -94,7 +94,7 @@ class WC_Data_Store {
 				if ( ! $store instanceof WC_Object_Data_Store_Interface ) {
 					throw new Exception( __( 'Invalid data store.', 'woocommerce' ) );
 				}
-				$this->current_class_name = get_class( $store );
+				$this->current_class_name = $store::class  ;
 				$this->instance           = $store;
 			} else {
 				if ( ! class_exists( $store ) ) {

--- a/plugins/woocommerce/includes/class-wc-logger.php
+++ b/plugins/woocommerce/includes/class-wc-logger.php
@@ -54,7 +54,7 @@ class WC_Logger implements WC_Logger_Interface {
 						sprintf(
 							/* translators: 1: class name 2: WC_Log_Handler_Interface */
 							__( 'The provided handler %1$s does not implement %2$s.', 'woocommerce' ),
-							'<code>' . esc_html( is_object( $handler ) ? get_class( $handler ) : $handler ) . '</code>',
+							'<code>' . esc_html( is_object( $handler ) ? $handler::class   : $handler ) . '</code>',
 							'<code>WC_Log_Handler_Interface</code>'
 						),
 						'3.0'

--- a/plugins/woocommerce/includes/class-wc-shipping-zone.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zone.php
@@ -175,7 +175,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 				// as classes. If the "class" is an instance, just use it. If not,
 				// create an instance.
 				if ( is_object( $class_name ) ) {
-					$class_name_of_instance  = get_class( $class_name );
+					$class_name_of_instance  = $class_name::class  ;
 					$methods[ $instance_id ] = new $class_name_of_instance( $instance_id );
 				} else {
 					// If the class is not an object, it should be a string. It's better

--- a/plugins/woocommerce/includes/class-wc-shipping-zones.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-zones.php
@@ -98,7 +98,7 @@ class WC_Shipping_Zones {
 		if ( ! empty( $raw_shipping_method ) && in_array( $raw_shipping_method->method_id, array_keys( $allowed_classes ), true ) ) {
 			$class_name = $allowed_classes[ $raw_shipping_method->method_id ];
 			if ( is_object( $class_name ) ) {
-				$class_name = get_class( $class_name );
+				$class_name = $class_name::class  ;
 			}
 			return new $class_name( $raw_shipping_method->instance_id );
 		}

--- a/plugins/woocommerce/includes/data-stores/class-wc-customer-download-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-customer-download-data-store.php
@@ -127,7 +127,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 	 * @throws Exception The passed value can't be converted to a date.
 	 */
 	private function adjust_date_for_db( $date ) {
-		if ( 'WC_DateTime' === get_class( $date ) ) {
+		if ( 'WC_DateTime' === $date::class   ) {
 			$date = $date->getTimestamp();
 		}
 
@@ -137,7 +137,7 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 			return $adjusted_date;
 		}
 
-		$msg = sprintf( __( "I don't know how to get a date from a %s", 'woocommerce' ), is_object( $date ) ? get_class( $date ) : gettype( $date ) );
+		$msg = sprintf( __( "I don't know how to get a date from a %s", 'woocommerce' ), is_object( $date ) ? $date::class   : gettype( $date ) );
 		throw new Exception( $msg );
 	}
 

--- a/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-resource.php
+++ b/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-resource.php
@@ -191,7 +191,7 @@ class WC_API_Resource {
 			}
 
 			// define the top-level property name for the meta
-			switch ( get_class( $resource ) ) {
+			switch ( $resource::class   ) {
 
 				case 'WC_Order':
 					$meta_name = 'order_meta';

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-resource.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-resource.php
@@ -250,7 +250,7 @@ class WC_API_Resource {
 			}
 
 			// define the top-level property name for the meta
-			switch ( get_class( $resource ) ) {
+			switch ( $resource::class   ) {
 
 				case 'WC_Order':
 					$meta_name = 'order_meta';

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-resource.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-resource.php
@@ -258,7 +258,7 @@ class WC_API_Resource {
 			}
 
 			// define the top-level property name for the meta
-			switch ( get_class( $resource ) ) {
+			switch ( $resource::class   ) {
 
 				case 'WC_Order':
 					$meta_name = 'order_meta';

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2012,7 +2012,7 @@ function wc_get_logger() {
 			sprintf(
 				/* translators: 1: class name 2: woocommerce_logging_class 3: WC_Logger_Interface */
 				__( 'The class %1$s provided by %2$s filter must implement %3$s.', 'woocommerce' ),
-				'<code>' . esc_html( is_object( $class ) ? get_class( $class ) : $class ) . '</code>',
+				'<code>' . esc_html( is_object( $class ) ? $class::class   : $class ) . '</code>',
 				'<code>woocommerce_logging_class</code>',
 				'<code>WC_Logger_Interface</code>'
 			),

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -550,7 +550,7 @@ function wc_create_refund( $args = array() ) {
 					continue;
 				}
 
-				$class         = get_class( $item );
+				$class         = $item::class  ;
 				$refunded_item = new $class( $item );
 				$refunded_item->set_id( 0 );
 				$refunded_item->add_meta_data( '_refunded_item_id', $item_id, true );

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -264,7 +264,7 @@ class TaskList {
 			return;
 		}
 
-		$task_class_name                             = substr( get_class( $task ), strrpos( get_class( $task ), '\\' ) + 1 );
+		$task_class_name                             = substr( $task::class  , strrpos( $task::class  , '\\' ) + 1 );
 		$this->task_class_id_map[ $task_class_name ] = $task->get_id();
 		$this->tasks[]                               = $task;
 	}

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -157,7 +157,7 @@ class PostsToOrdersMigrationController {
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( $query );
 		} catch ( \Exception $exception ) {
-			$exception_class = get_class( $exception );
+			$exception_class = $exception::class  ;
 			$this->error_logger->error(
 				"PostsToOrdersMigrationController: when executing $query: ($exception_class) {$exception->getMessage()}, {$exception->getTraceAsString()}",
 				array(
@@ -204,7 +204,7 @@ class PostsToOrdersMigrationController {
 		$batch                = ArrayUtil::to_ranges_string( $order_post_ids );
 
 		if ( null !== $exception ) {
-			$exception_class = get_class( $exception );
+			$exception_class = $exception::class  ;
 			$this->error_logger->error(
 				"$migration_class_name: when processing ids $batch: ($exception_class) {$exception->getMessage()}, {$exception->getTraceAsString()}",
 				array(

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -129,7 +129,7 @@ class ExtendedContainer extends BaseContainer {
 				return $this->get_class_from_concrete( $concrete->getConcrete() );
 			}
 
-			return get_class( $concrete );
+			return $concrete::class  ;
 		}
 
 		if ( is_string( $concrete ) && class_exists( $concrete ) ) {

--- a/plugins/woocommerce/tests/Tools/CodeHacking/CodeHacker.php
+++ b/plugins/woocommerce/tests/Tools/CodeHacking/CodeHacker.php
@@ -117,7 +117,7 @@ final class CodeHacker {
 	 */
 	public static function add_hack( $hack ) {
 		if ( ! self::is_valid_hack_object( $hack ) ) {
-			$class = get_class( $hack );
+			$class = $hack::class  ;
 			throw new \Exception( "CodeHacker::add_hack for instance of $class: Hacks must be objects having a 'process(\$text, \$path)' method and a 'reset()' method." );
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/get-rule-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/get-rule-processor.php
@@ -21,6 +21,6 @@ class WC_Admin_Tests_RemoteInboxNotifications_GetRuleProcessor extends WC_Unit_T
 
 		$result = $get_rule_processor->get_processor( 'unknown rule type' );
 
-		$this->assertEquals( 'Automattic\\WooCommerce\\Admin\\RemoteInboxNotifications\\FailRuleProcessor', get_class( $result ) );
+		$this->assertEquals( 'Automattic\\WooCommerce\\Admin\\RemoteInboxNotifications\\FailRuleProcessor', $result::class   );
 	}
 }


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
