### PR TITLE
Remove deprecated warnings in unit tests in PHP 8.1

### DIFF
--- a/plugins/woocommerce/changelog/fix-php81-test-update-wc-admin
+++ b/plugins/woocommerce/changelog/fix-php81-test-update-wc-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Added checks to correct types passed to functions to remove PHP 8.1 notices.

--- a/plugins/woocommerce/src/Admin/API/Leaderboards.php
+++ b/plugins/woocommerce/src/Admin/API/Leaderboards.php
@@ -388,7 +388,7 @@ class Leaderboards extends \WC_REST_Data_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$persisted_query = json_decode( $request['persisted_query'], true );
+		$persisted_query = json_decode( $request['persisted_query'] ?? '', true );
 
 		switch ( $request['leaderboard'] ) {
 			case 'customers':

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -69,7 +69,7 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		$params = explode( ',', $request['options'] );
+		$params = explode( ',', $request['options'] ?? '' );
 
 		if ( ! isset( $request['options'] ) || ! is_array( $params ) ) {
 			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of options.', 'woocommerce' ), 500 );
@@ -201,7 +201,7 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return array Options object with option values.
 	 */
 	public function get_options( $request ) {
-		$params  = explode( ',', $request['options'] );
+		$params  = explode( ',', $request['options'] ?? '' );
 		$options = array();
 
 		if ( ! is_array( $params ) ) {

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -242,7 +242,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * @return WP_Error|array Plugin Status
 	 */
 	public function install_plugins( $request ) {
-		$plugins = explode( ',', $request['plugins'] );
+		$plugins = explode( ',', $request['plugins'] ?? '' );
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );
@@ -337,7 +337,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * @return WP_Error|array Plugin Status
 	 */
 	public function activate_plugins( $request ) {
-		$plugins = explode( ',', $request['plugins'] );
+		$plugins = explode( ',', $request['plugins'] ?? '' );
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce' ), 404 );

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -125,7 +125,7 @@ class PageController {
 		}
 
 		$current_query = wp_parse_url( $current_url, PHP_URL_QUERY );
-		parse_str( $current_query, $current_pieces );
+		parse_str( $current_query ?? '', $current_pieces );
 		$current_path  = empty( $current_pieces['page'] ) ? '' : $current_pieces['page'];
 		$current_path .= empty( $current_pieces['path'] ) ? '' : '&path=' . $current_pieces['path'];
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Contributes towards #31270.

Just adds a couple of checks to not pass null where functions expect string.

### How to test the changes in this Pull Request:

1. Run unit tests in PHP 8.1
2. Observe a bunch of PHP notices from WC Admin code
3. Apply patch
4. Run unit tests again
5. Observe no more PHP notices from WC Admin related code.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

I'm not sure how to add changelog, tried project `woocommerce/client/admin`, `woocommerce/admin` and `woocommerce-admin`, but none of these worked.

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
