### PR TITLE
Remove deprecated warnings in unit tests in PHP 8.1 for core

### DIFF
--- a/plugins/woocommerce/changelog/fix-php81-unit-tests-wc-core
+++ b/plugins/woocommerce/changelog/fix-php81-unit-tests-wc-core
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Added checks to correct types passed to functions to remove PHP 8.1 notices in core.

--- a/plugins/woocommerce/src/Internal/Utilities/URL.php
+++ b/plugins/woocommerce/src/Internal/Utilities/URL.php
@@ -139,9 +139,9 @@ class URL {
 	 * without touching the filesystem.
 	 */
 	private function process_path() {
-		$segments                    = explode( '/', $this->components['path'] );
-		$this->is_absolute           = substr( $this->components['path'], 0, 1 ) === '/' || ! empty( $this->components['host'] );
-		$this->is_non_root_directory = substr( $this->components['path'], -1, 1 ) === '/' && strlen( $this->components['path'] ) > 1;
+		$segments                    = explode( '/', $this->components['path'] ?? '' );
+		$this->is_absolute           = substr( $this->components['path'] ?? '', 0, 1 ) === '/' || ! empty( $this->components['host'] );
+		$this->is_non_root_directory = substr( $this->components['path'] ?? '', -1, 1 ) === '/' && strlen( $this->components['path'] ) > 1;
 		$resolve_traversals          = 'file' !== $this->components['scheme'] || $this->is_absolute;
 		$retain_traversals           = false;
 

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
@@ -136,7 +136,7 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	 * @param int    $code    Optional. The exception code. Default is empty.
 	 * @throws Exception Containing the given message and code.
 	 */
-	public function throwAnException( $message = null, $code = null ) {
+	public function throwAnException( $message = '', $code = 0 ) {
 		$message = $message ? $message : "We're all doomed!";
 		throw new Exception( $message, $code );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Contributes towards https://github.com/woocommerce/woocommerce/issues/31270.

Just adds a couple of checks to not pass null where functions expect string.

### How to test the changes in this Pull Request:

1. Run unit tests in PHP 8.1
2. Observe a bunch of notices
3. Apply patch
4. Run unit tests again
5. Observe no more notices from WC core related code.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
