### PR TITLE
Prepare for WooCommerce 6.6.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 == Changelog ==
 
+= 6.6.1 2022-06-21 =
+
+**WooCommerce**
+
+* Fix - Make sure payment gateway title is a string before sanitizing.  [#33434](https://github.com/woocommerce/woocommerce/pull/33434)
+
+**WooCommerce Blocks 7.6.1**
+
+* Fix - Fix error Uncaught Error: Call to undefined function Automattic\WooCommerce\Blocks\Templates\wp_is_block_theme() in WP 5.8.  [#6590](https://github.com/woocommerce/woocommerce-blocks/pull/6590)
+* Fix - Fix PHP notice in Mini Cart when prices included taxes.  [#6537](https://github.com/woocommerce/woocommerce-blocks/pull/6537)
+
 = 6.6.0 2022-06-14 =
 
 **WooCommerce**

--- a/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
+++ b/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Make sure payment gateway title is a string before sanitizing

--- a/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
+++ b/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure payment gateway title is a string before sanitizing

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.6.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-7.6.1
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update WooCommerce Blocks to 7.6.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/woocommerce",
 	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
 	"homepage": "https://woocommerce.com/",
-	"version": "6.6.0",
+	"version": "6.6.1",
 	"type": "wordpress-plugin",
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -305,7 +305,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_title() {
-		$title = wc_get_container()->get( HtmlSanitizer::class )->sanitize( $this->title, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
+		$title = wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $this->title, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 		return apply_filters( 'woocommerce_gateway_title', $title, $this->id );
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -868,8 +868,8 @@ abstract class WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function validate_safe_text_field( string $key, string $value ): string {
-		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
+	public function validate_safe_text_field( string $key, $value ): string {
+		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -868,7 +868,7 @@ abstract class WC_Settings_API {
 	 *
 	 * @return string
 	 */
-	public function validate_safe_text_field( string $key, $value ): string {
+	public function validate_safe_text_field( string $key, ?string $value ): string {
 		return wc_get_container()->get( HtmlSanitizer::class )->sanitize( (string) $value, HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS );
 	}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -30,7 +30,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '6.6.0';
+	public $version = '6.6.1';
 
 	/**
 	 * WooCommerce Schema version.

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce",
 	"title": "WooCommerce",
-	"version": "6.6.0",
+	"version": "6.6.1",
 	"homepage": "https://woocommerce.com/",
 	"repository": {
 		"type": "git",

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.8
 Tested up to: 6.0
 Requires PHP: 7.2
-Stable tag: 6.6.0
+Stable tag: 6.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -159,6 +159,17 @@ If you encounter issues with the shop/category pages after an update, flush the 
 WooCommerce comes with some sample data you can use to see how products look; import sample_products.xml via the [WordPress importer](https://wordpress.org/plugins/wordpress-importer/). You can also use the core [CSV importer](https://docs.woocommerce.com/document/product-csv-importer-exporter/?utm_source=wp%20org%20repo%20listing&utm_content=3.6) or our [CSV Import Suite extension](https://woocommerce.com/products/product-csv-import-suite/?utm_source=wp%20org%20repo%20listing&utm_content=3.6) to import sample_products.csv
 
 == Changelog ==
+
+= 6.6.1 2022-06-21 =
+
+**WooCommerce**
+
+* Fix - Make sure payment gateway title is a string before sanitizing.  [#33434](https://github.com/woocommerce/woocommerce/pull/33434)
+
+**WooCommerce Blocks 7.6.1**
+
+* Fix - Fix error Uncaught Error: Call to undefined function Automattic\WooCommerce\Blocks\Templates\wp_is_block_theme() in WP 5.8.  [#6590](https://github.com/woocommerce/woocommerce-blocks/pull/6590)
+* Fix - Fix PHP notice in Mini Cart when prices included taxes.  [#6537](https://github.com/woocommerce/woocommerce-blocks/pull/6537)
 
 = 6.6.0 2022-06-14 =
 

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 6.6.0
+ * Version: 6.6.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This PR prepares for the 6.6.1 release of WooCommerce.

It cherry-picks the following PR:
* #33434

It updates the changelogs for the aforementioned PR in addition to #33499 (which was previously merged directly into the release branch), and removes their associated change files.

It updates the versions to 6.6.1 in the readme's stable tag, composer and package files, and in `woocommerce.php` as well as `class-woocommerce.php`