### PR TITLE
Prepare `trunk` For WooCommerce 6.8

### DIFF
--- a/plugins/woocommerce/changelog/2022-06-16-13-54-11-771754
+++ b/plugins/woocommerce/changelog/2022-06-16-13-54-11-771754
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-

--- a/plugins/woocommerce/changelog/33239-remove-contri-script
+++ b/plugins/woocommerce/changelog/33239-remove-contri-script
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Remove contributors script as it is no longer needed.

--- a/plugins/woocommerce/changelog/add-32129_remove_inbox_wp_admin_link_support
+++ b/plugins/woocommerce/changelog/add-32129_remove_inbox_wp_admin_link_support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add support to remote inbox notification actions to link to other wp-admin pages. #33237

--- a/plugins/woocommerce/changelog/add-32152-tasks-side-panel
+++ b/plugins/woocommerce/changelog/add-32152-tasks-side-panel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adding task list sidebar panel on Activity Panel.

--- a/plugins/woocommerce/changelog/add-32385-cot-admin-list-table
+++ b/plugins/woocommerce/changelog/add-32385-cot-admin-list-table
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add a new admin list table implementation that works with the Custom Order Table.

--- a/plugins/woocommerce/changelog/add-32667-cot-data-store-update
+++ b/plugins/woocommerce/changelog/add-32667-cot-data-store-update
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Implements update/saving logic for orders in the COT datastore.

--- a/plugins/woocommerce/changelog/add-32672
+++ b/plugins/woocommerce/changelog/add-32672
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add tracks to new product and edit product screens #33120

--- a/plugins/woocommerce/changelog/add-32674_new-tracks-props
+++ b/plugins/woocommerce/changelog/add-32674_new-tracks-props
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add/edit products: add new Tracks props #33177

--- a/plugins/woocommerce/changelog/add-32676_category_and_tag_tracks
+++ b/plugins/woocommerce/changelog/add-32676_category_and_tag_tracks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add wpAdmin scripts for tracking actions in the category, tags, and attribute pages. #33118

--- a/plugins/woocommerce/changelog/add-32910
+++ b/plugins/woocommerce/changelog/add-32910
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add total payments volume rule processor for inbox notifications #33192

--- a/plugins/woocommerce/changelog/add-33125
+++ b/plugins/woocommerce/changelog/add-33125
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add purchase task to experimental task lists #33178

--- a/plugins/woocommerce/changelog/add-33160-add-event-tracking-product-page-spotlight-tour
+++ b/plugins/woocommerce/changelog/add-33160-add-event-tracking-product-page-spotlight-tour
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add tracking for old product walkthrough and new product spotlight tour

--- a/plugins/woocommerce/changelog/add-33162-experiment-logic
+++ b/plugins/woocommerce/changelog/add-33162-experiment-logic
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Wrap spotlight product tour under experiment logic

--- a/plugins/woocommerce/changelog/add-33284-task-sidebar-tracks
+++ b/plugins/woocommerce/changelog/add-33284-task-sidebar-tracks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adding property to tasks tracks events to indicate context.

--- a/plugins/woocommerce/changelog/add-array_util_select_method
+++ b/plugins/woocommerce/changelog/add-array_util_select_method
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add a new ArrayUtil::select method

--- a/plugins/woocommerce/changelog/add-database-scanner-cli
+++ b/plugins/woocommerce/changelog/add-database-scanner-cli
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add script for accessing database schema via CLI

--- a/plugins/woocommerce/changelog/add-db-transaction-support-for-cot-sync
+++ b/plugins/woocommerce/changelog/add-db-transaction-support-for-cot-sync
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add optional usage of database transaction when synchronizing data between posts table and the orders table

--- a/plugins/woocommerce/changelog/add-event-track-cancel-load-sample-product
+++ b/plugins/woocommerce/changelog/add-event-track-cancel-load-sample-product
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add tasklist_cancel_load_sample_products_click event track for product task

--- a/plugins/woocommerce/changelog/add-individual-analytics-leaderboards
+++ b/plugins/woocommerce/changelog/add-individual-analytics-leaderboards
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add individual analytics leaderboard endpoints.

--- a/plugins/woocommerce/changelog/add-logging_for_posts_to_cot_migration
+++ b/plugins/woocommerce/changelog/add-logging_for_posts_to_cot_migration
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Log errors during the posts to orders table migrations

--- a/plugins/woocommerce/changelog/add-product-archive-description-filter
+++ b/plugins/woocommerce/changelog/add-product-archive-description-filter
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-New filter `woocommerce_taxonomy_archive_description_raw` added to provide a further way to modify product archive descriptions.

--- a/plugins/woocommerce/changelog/add-product-reviews-page
+++ b/plugins/woocommerce/changelog/add-product-reviews-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a new Product Reviews admin screen, and remove reviews from the existing Comments admin screen.

--- a/plugins/woocommerce/changelog/add-product-tour
+++ b/plugins/woocommerce/changelog/add-product-tour
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add product page spotlight tour

--- a/plugins/woocommerce/changelog/add-schema-output
+++ b/plugins/woocommerce/changelog/add-schema-output
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add script to get database schema from CLI

--- a/plugins/woocommerce/changelog/add-tour-kit-live-resize
+++ b/plugins/woocommerce/changelog/add-tour-kit-live-resize
@@ -1,4 +1,0 @@
-Significance: minor 
-Type: add
-
-Updated @automattic/tour-kit to 1.1.1 which has live resize functionality 

--- a/plugins/woocommerce/changelog/add-type-hints-to-wc_add_number_precision
+++ b/plugins/woocommerce/changelog/add-type-hints-to-wc_add_number_precision
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add type hints in the signature of wc_add_number_precision to prevent invalid inputs.

--- a/plugins/woocommerce/changelog/add-wc-admin-settings
+++ b/plugins/woocommerce/changelog/add-wc-admin-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Make it possible to specify input field names separately from the ID.

--- a/plugins/woocommerce/changelog/cookie-options
+++ b/plugins/woocommerce/changelog/cookie-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Introduce new hook `woocommerce_set_cookie_options` to exercise more control over cookie options.

--- a/plugins/woocommerce/changelog/cot-add-collation-to-schema
+++ b/plugins/woocommerce/changelog/cot-add-collation-to-schema
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add charset collation to COT tables.

--- a/plugins/woocommerce/changelog/cot-cli-migration-output
+++ b/plugins/woocommerce/changelog/cot-cli-migration-output
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Correct typos in Custom Order Tables migration runner.

--- a/plugins/woocommerce/changelog/dev-33132-migrate-woo-onboarding-to-ts
+++ b/plugins/woocommerce/changelog/dev-33132-migrate-woo-onboarding-to-ts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix onboarding task type errors after migrating woo.onboarding to TS

--- a/plugins/woocommerce/changelog/dev-33156-upgrade-react-router-v6
+++ b/plugins/woocommerce/changelog/dev-33156-upgrade-react-router-v6
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Upgraded react-router-dom to v6, it should not cause any visible changes to the end user #33156

--- a/plugins/woocommerce/changelog/dev-migrate-onboarding-store-to-ts
+++ b/plugins/woocommerce/changelog/dev-migrate-onboarding-store-to-ts
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Simply update deprecated-tasks.tsx type annotations
-
-

--- a/plugins/woocommerce/changelog/dev-migrate-woo-data-options-to-ts
+++ b/plugins/woocommerce/changelog/dev-migrate-woo-data-options-to-ts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Fix type errors in ./client after migrating options store to TS

--- a/plugins/woocommerce/changelog/dev-update-test-watch-command
+++ b/plugins/woocommerce/changelog/dev-update-test-watch-command
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update woocommerce-admin "test:watch" command

--- a/plugins/woocommerce/changelog/docs-turbo-update
+++ b/plugins/woocommerce/changelog/docs-turbo-update
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Updating documentation
-
-

--- a/plugins/woocommerce/changelog/e2e-rep-playwright-feature-flag
+++ b/plugins/woocommerce/changelog/e2e-rep-playwright-feature-flag
@@ -1,2 +1,0 @@
-Significance: patch
-Type: dev

--- a/plugins/woocommerce/changelog/fix-29529-twentytwenty-notices
+++ b/plugins/woocommerce/changelog/fix-29529-twentytwenty-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Improve styling of WooCommerce notices (frontend) for the Twenty Twenty theme.

--- a/plugins/woocommerce/changelog/fix-29560-twentytwentyone-notices
+++ b/plugins/woocommerce/changelog/fix-29560-twentytwentyone-notices
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Improve Twenty Twenty One notice styles

--- a/plugins/woocommerce/changelog/fix-32137
+++ b/plugins/woocommerce/changelog/fix-32137
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Suppressing warnings for malformed metadata in product template downloads.

--- a/plugins/woocommerce/changelog/fix-32588-continue-button-is-enabled-when-email-is-null
+++ b/plugins/woocommerce/changelog/fix-32588-continue-button-is-enabled-when-email-is-null
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix continue button is enabled even when email is null in setup wizard

--- a/plugins/woocommerce/changelog/fix-33036-failing-timeinterval-test
+++ b/plugins/woocommerce/changelog/fix-33036-failing-timeinterval-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix failing TimeInterval test

--- a/plugins/woocommerce/changelog/fix-33086-admin-disable-filter-notice
+++ b/plugins/woocommerce/changelog/fix-33086-admin-disable-filter-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix notice on woocommerce_admin_disabled filter enabled

--- a/plugins/woocommerce/changelog/fix-33141
+++ b/plugins/woocommerce/changelog/fix-33141
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Use term ID to query category IDs in analytics #33164

--- a/plugins/woocommerce/changelog/fix-33172-setup-wizard-click-button-loading-state
+++ b/plugins/woocommerce/changelog/fix-33172-setup-wizard-click-button-loading-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix setup wizard usage button loading state

--- a/plugins/woocommerce/changelog/fix-33182-twenty-twenty
+++ b/plugins/woocommerce/changelog/fix-33182-twenty-twenty
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Swap info and message notice colors in Twenty-Twenty

--- a/plugins/woocommerce/changelog/fix-33221-force-cache-refresh
+++ b/plugins/woocommerce/changelog/fix-33221-force-cache-refresh
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a new collection parameter, force_cache_refresh, to Reports API endpoints which will cause the current request to bypass the cache, re-run the queries for the requested data, and overwrite the previous cache entry with the new results.

--- a/plugins/woocommerce/changelog/fix-33262-wp-cli-updates
+++ b/plugins/woocommerce/changelog/fix-33262-wp-cli-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes for the WP CLI updates

--- a/plugins/woocommerce/changelog/fix-33298
+++ b/plugins/woocommerce/changelog/fix-33298
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix a warning caused by an attempt to iterate over a submenu that may not exist on WC Pay subscriptions page.

--- a/plugins/woocommerce/changelog/fix-33304-single-product-no-reviews-block-themes
+++ b/plugins/woocommerce/changelog/fix-33304-single-product-no-reviews-block-themes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix broken design of Single Product template in block themes when product had no reviews or additional info

--- a/plugins/woocommerce/changelog/fix-33314
+++ b/plugins/woocommerce/changelog/fix-33314
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Clean up unused remote inbox notifications option #33373

--- a/plugins/woocommerce/changelog/fix-33315-stats-cache-ttl
+++ b/plugins/woocommerce/changelog/fix-33315-stats-cache-ttl
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Change invalidation and TTL of the analytics cache for better cache resilience

--- a/plugins/woocommerce/changelog/fix-advanced-feature-tracks
+++ b/plugins/woocommerce/changelog/fix-advanced-feature-tracks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Settings: fix Tracks event when enabling/disabling advanced features settings. #33305

--- a/plugins/woocommerce/changelog/fix-cot-merge
+++ b/plugins/woocommerce/changelog/fix-cot-merge
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix accidently deleted method during merge for 33034.

--- a/plugins/woocommerce/changelog/fix-e2e-test
+++ b/plugins/woocommerce/changelog/fix-e2e-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update webpack.config.js to ensure we use styles from build-style

--- a/plugins/woocommerce/changelog/fix-error-when-creating-products-via-rest-api-v1
+++ b/plugins/woocommerce/changelog/fix-error-when-creating-products-via-rest-api-v1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: update
-Comment: Changelog already added (see fix-product_attributes_lookup_table_update), the intention is for this to ship in the same release.
-
-

--- a/plugins/woocommerce/changelog/fix-leaderboard-menu-styling
+++ b/plugins/woocommerce/changelog/fix-leaderboard-menu-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the styling of the frame in the Leaderboard section of Analytics. #33163

--- a/plugins/woocommerce/changelog/fix-obw-free-extensions-for-php8
+++ b/plugins/woocommerce/changelog/fix-obw-free-extensions-for-php8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix obw free extension rules for the marketing task with php 8

--- a/plugins/woocommerce/changelog/fix-onboarding-email-optin
+++ b/plugins/woocommerce/changelog/fix-onboarding-email-optin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update email marketing checkbox to be unticked by default.

--- a/plugins/woocommerce/changelog/fix-product-tour-spotlight-location
+++ b/plugins/woocommerce/changelog/fix-product-tour-spotlight-location
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix product tour splotlight location

--- a/plugins/woocommerce/changelog/fix-tour-kit-undefined-error
+++ b/plugins/woocommerce/changelog/fix-tour-kit-undefined-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix product tour TypeError when reading innerHTML

--- a/plugins/woocommerce/changelog/fix-twenty-twenty-two-integration
+++ b/plugins/woocommerce/changelog/fix-twenty-twenty-two-integration
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix: Content width issue and Classic Template blocks alignment issue for Twenty Twenty-Two.

--- a/plugins/woocommerce/changelog/fix-typos
+++ b/plugins/woocommerce/changelog/fix-typos
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix typos in various cot migration messages.

--- a/plugins/woocommerce/changelog/fix-variation-table-role
+++ b/plugins/woocommerce/changelog/fix-variation-table-role
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add role="presentation" to table on the add-to-cart form as an accessibility enhancement.

--- a/plugins/woocommerce/changelog/fix-wc-attribute-slug-len
+++ b/plugins/woocommerce/changelog/fix-wc-attribute-slug-len
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Change attribute slug length requirement and add wc_create_attribute tests

--- a/plugins/woocommerce/changelog/fix-webpack-async-chunk-ver
+++ b/plugins/woocommerce/changelog/fix-webpack-async-chunk-ver
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix the script version parameter for chunk URLs

--- a/plugins/woocommerce/changelog/hahn208-master
+++ b/plugins/woocommerce/changelog/hahn208-master
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Allow strings to be passed as 'class' arg to '`woocommerce_form_field()`

--- a/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
+++ b/plugins/woocommerce/changelog/html-sanitizer-on-null-gateway-title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Make sure payment gateway title is a string before sanitizing

--- a/plugins/woocommerce/changelog/improve-unit-testing-infrastructure
+++ b/plugins/woocommerce/changelog/improve-unit-testing-infrastructure
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Add a mechanism to mock globals and a DynamicDecorator class.

--- a/plugins/woocommerce/changelog/photoswipe-event-target
+++ b/plugins/woocommerce/changelog/photoswipe-event-target
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Trigger Photoswipe modal when clicking child elements of the trigger element

--- a/plugins/woocommerce/changelog/prep-post-6.6.0
+++ b/plugins/woocommerce/changelog/prep-post-6.6.0
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
- Updates the stable tag and changelog from 6.6.0 release.

--- a/plugins/woocommerce/changelog/remove-33129
+++ b/plugins/woocommerce/changelog/remove-33129
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Remove the navigation nudge note #33241

--- a/plugins/woocommerce/changelog/tweak-update-product-task-experiment-names
+++ b/plugins/woocommerce/changelog/tweak-update-product-task-experiment-names
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Update product task experiment names

--- a/plugins/woocommerce/changelog/ui-transparent-product-thumbnails
+++ b/plugins/woocommerce/changelog/ui-transparent-product-thumbnails
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove placeholder product icon if a featured product image is available (avoids issues with transparent images).

--- a/plugins/woocommerce/changelog/update-31881-lazyload-ua-option
+++ b/plugins/woocommerce/changelog/update-31881-lazyload-ua-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Make the option 'woocommerce_tracker_ua' load on demand.

--- a/plugins/woocommerce/changelog/update-32491-deprecate-wcadminasseturl
+++ b/plugins/woocommerce/changelog/update-32491-deprecate-wcadminasseturl
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Deprecate wcAdminAssetUrl and WC_ADMIN_IMAGES_FOLDER_URL

--- a/plugins/woocommerce/changelog/update-32524_order_product_count_api_requests_use_data_store
+++ b/plugins/woocommerce/changelog/update-32524_order_product_count_api_requests_use_data_store
@@ -1,4 +1,0 @@
-Significance: minor
-Type: performance
-
-Remove orderCount and publishedProductCount from preloaded settings and moved to using orders/products data stores. #33064

--- a/plugins/woocommerce/changelog/update-32881-history-to-530
+++ b/plugins/woocommerce/changelog/update-32881-history-to-530
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Update dependency history to ^5.3.0

--- a/plugins/woocommerce/changelog/update-33302-remove-wca-installation-merge-test
+++ b/plugins/woocommerce/changelog/update-33302-remove-wca-installation-merge-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Remove WCA installation merge test -- no longer needed

--- a/plugins/woocommerce/changelog/update-actionscheduler-3.4.1
+++ b/plugins/woocommerce/changelog/update-actionscheduler-3.4.1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update the version of Action Scheduler to 3.4.1

--- a/plugins/woocommerce/changelog/update-analyzer-command-refactor
+++ b/plugins/woocommerce/changelog/update-analyzer-command-refactor
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Whitespace change, no changelog required
-
-

--- a/plugins/woocommerce/changelog/update-as-3.4.2
+++ b/plugins/woocommerce/changelog/update-as-3.4.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update ActionScheduler to 3.4.2

--- a/plugins/woocommerce/changelog/update-fix-CLIRunner-translations
+++ b/plugins/woocommerce/changelog/update-fix-CLIRunner-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Update CLI messages in COT migration to be more clear.

--- a/plugins/woocommerce/changelog/update-pinterest-built-by-woo
+++ b/plugins/woocommerce/changelog/update-pinterest-built-by-woo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Add "built by Woo" label to Pinterest

--- a/plugins/woocommerce/changelog/update-prepare-trunk-for-6.7
+++ b/plugins/woocommerce/changelog/update-prepare-trunk-for-6.7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: update
-Comment: Bumping versions for 6.7
-
-

--- a/plugins/woocommerce/changelog/update-product-template-descriptions
+++ b/plugins/woocommerce/changelog/update-product-template-descriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Update product template descriptions

--- a/plugins/woocommerce/changelog/update-reports-datastore-date-column
+++ b/plugins/woocommerce/changelog/update-reports-datastore-date-column
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Replace the date_created column name with a class property in the analytics datastore

--- a/plugins/woocommerce/changelog/update-tax-task-title
+++ b/plugins/woocommerce/changelog/update-tax-task-title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update the tax task title to "Set up tax rates"

--- a/plugins/woocommerce/changelog/update-turn-on-product-tour-feature-flag
+++ b/plugins/woocommerce/changelog/update-turn-on-product-tour-feature-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Turn on experimental-product-tour feature flag

--- a/plugins/woocommerce/changelog/update-webpack-5
+++ b/plugins/woocommerce/changelog/update-webpack-5
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Update Webpack to 5.x

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.8.0
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-7.8.0
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Woo Blocks 7.7.0, 7.8.0 and 7.8.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/woocommerce",
 	"description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
 	"homepage": "https://woocommerce.com/",
-	"version": "6.7.0",
+	"version": "6.8.0",
 	"type": "wordpress-plugin",
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -30,7 +30,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '6.7.0';
+	public $version = '6.8.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.8
 Tested up to: 6.0
 Requires PHP: 7.2
-Stable tag: 6.6.0
+Stable tag: 6.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -160,6 +160,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
-= 6.7.0 2022-XX-XX =
+= 6.8.0 2022-XX-XX =
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/changelog.txt).

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 6.7.0-dev
+ * Version: 6.8.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request prepares `trunk` for the WooCommerce 6.8 release cycle. All of the changelogs removed in #33505 have also been removed in this pull request, making sure there are no floating changelog entries from the previous release.

### How to test the changes in this Pull Request:

N/A

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
