### PR TITLE
Normalize collection param handling in Reports API controllers

### DIFF
--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -35,28 +35,13 @@ class Controller extends ReportsController implements ExportableInterface {
 	protected $rest_base = 'reports/categories';
 
 	/**
-	 * Maps query arguments from the REST request.
+	 * Mapping between external parameter name and name used in query class.
 	 *
-	 * @param array $request Request array.
-	 * @return array
+	 * @var array
 	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['interval']            = $request['interval'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['extended_info']       = $request['extended_info'];
-		$args['category_includes']   = (array) $request['categories'];
-		$args['status_is']           = (array) $request['status_is'];
-		$args['status_is_not']       = (array) $request['status_is_not'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
+	protected $param_mapping = array(
+		'categories' => 'category_includes',
+	);
 
 	/**
 	 * Get all reports.
@@ -65,7 +50,18 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args       = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$categories_query = new Query( $query_args );
 		$report_data      = $categories_query->get_data();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -32,6 +32,13 @@ class Controller extends \WC_REST_Reports_Controller {
 	protected $rest_base = 'reports';
 
 	/**
+	 * Mapping between external parameter name and name used in query class.
+	 *
+	 * @var array
+	 */
+	protected $param_mapping = array();
+
+	/**
 	 * Register the routes for reports.
 	 */
 	public function register_routes() {

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 
 /**
@@ -17,7 +18,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends ReportsController implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -34,33 +35,24 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	protected $rest_base = 'reports/coupons';
 
 	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['coupons']             = (array) $request['coupons'];
-		$args['extended_info']       = $request['extended_info'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-		return $args;
-	}
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args    = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$coupons_query = new Query( $query_args );
 		$report_data   = $coupons_query->get_data();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 
 /**
@@ -17,7 +18,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.
@@ -33,30 +34,6 @@ class Controller extends \WC_REST_Reports_Controller {
 	 */
 	protected $rest_base = 'reports/coupons/stats';
 
-
-	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['interval']            = $request['interval'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['coupons']             = (array) $request['coupons'];
-		$args['segmentby']           = $request['segmentby'];
-		$args['fields']              = $request['fields'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
-
 	/**
 	 * Get all reports.
 	 *
@@ -64,7 +41,18 @@ class Controller extends \WC_REST_Reports_Controller {
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args    = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$coupons_query = new Query( $query_args );
 		try {
 			$report_data = $coupons_query->get_data();

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Customers;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
@@ -19,7 +20,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends ReportsController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
@@ -40,45 +41,34 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	protected $rest_base = 'reports/customers';
 
 	/**
+	 * Mapping between external parameter name and name used in query class.
+	 *
+	 * @var array
+	 */
+	protected $param_mapping = array(
+		'before' => 'order_before',
+		'after' => 'order_after',
+	);
+
+	/**
 	 * Maps query arguments from the REST request.
 	 *
 	 * @param array $request Request array.
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['registered_before']   = $request['registered_before'];
-		$args['registered_after']    = $request['registered_after'];
-		$args['order_before']        = $request['before'];
-		$args['order_after']         = $request['after'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['order']               = $request['order'];
-		$args['orderby']             = $request['orderby'];
-		$args['match']               = $request['match'];
-		$args['search']              = $request['search'];
-		$args['searchby']            = $request['searchby'];
-		$args['name_includes']       = $request['name_includes'];
-		$args['name_excludes']       = $request['name_excludes'];
-		$args['username_includes']   = $request['username_includes'];
-		$args['username_excludes']   = $request['username_excludes'];
-		$args['email_includes']      = $request['email_includes'];
-		$args['email_excludes']      = $request['email_excludes'];
-		$args['country_includes']    = $request['country_includes'];
-		$args['country_excludes']    = $request['country_excludes'];
-		$args['last_active_before']  = $request['last_active_before'];
-		$args['last_active_after']   = $request['last_active_after'];
-		$args['orders_count_min']    = $request['orders_count_min'];
-		$args['orders_count_max']    = $request['orders_count_max'];
-		$args['total_spend_min']     = $request['total_spend_min'];
-		$args['total_spend_max']     = $request['total_spend_max'];
-		$args['avg_order_value_min'] = $request['avg_order_value_min'];
-		$args['avg_order_value_max'] = $request['avg_order_value_max'];
-		$args['last_order_before']   = $request['last_order_before'];
-		$args['last_order_after']    = $request['last_order_after'];
-		$args['customers']           = $request['customers'];
-		$args['users']               = $request['users'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
+		$args = array();
+
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
 
 		$between_params_numeric    = array( 'orders_count', 'total_spend', 'avg_order_value' );
 		$normalized_params_numeric = TimeInterval::normalize_between_params( $request, $between_params_numeric, false );

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -9,13 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Downloads\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+
 /**
  * REST API Reports downloads stats controller class.
  *
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.
@@ -32,43 +34,24 @@ class Controller extends \WC_REST_Reports_Controller {
 	protected $rest_base = 'reports/downloads/stats';
 
 	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['interval']            = $request['interval'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['match']               = $request['match'];
-		$args['product_includes']    = (array) $request['product_includes'];
-		$args['product_excludes']    = (array) $request['product_excludes'];
-		$args['customer_includes']   = (array) $request['customer_includes'];
-		$args['customer_excludes']   = (array) $request['customer_excludes'];
-		$args['order_includes']      = (array) $request['order_includes'];
-		$args['order_excludes']      = (array) $request['order_excludes'];
-		$args['ip_address_includes'] = (array) $request['ip_address_includes'];
-		$args['ip_address_excludes'] = (array) $request['ip_address_excludes'];
-		$args['fields']              = $request['fields'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args      = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$downloads_query = new Query( $query_args );
 		$report_data     = $downloads_query->get_data();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -35,50 +35,24 @@ class Controller extends ReportsController implements ExportableInterface {
 	protected $rest_base = 'reports/orders';
 
 	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['product_includes']    = (array) $request['product_includes'];
-		$args['product_excludes']    = (array) $request['product_excludes'];
-		$args['variation_includes']  = (array) $request['variation_includes'];
-		$args['variation_excludes']  = (array) $request['variation_excludes'];
-		$args['coupon_includes']     = (array) $request['coupon_includes'];
-		$args['coupon_excludes']     = (array) $request['coupon_excludes'];
-		$args['tax_rate_includes']   = (array) $request['tax_rate_includes'];
-		$args['tax_rate_excludes']   = (array) $request['tax_rate_excludes'];
-		$args['status_is']           = (array) $request['status_is'];
-		$args['status_is_not']       = (array) $request['status_is_not'];
-		$args['customer_type']       = $request['customer_type'];
-		$args['extended_info']       = $request['extended_info'];
-		$args['refunds']             = $request['refunds'];
-		$args['match']               = $request['match'];
-		$args['order_includes']      = $request['order_includes'];
-		$args['order_excludes']      = $request['order_excludes'];
-		$args['attribute_is']        = (array) $request['attribute_is'];
-		$args['attribute_is_not']    = (array) $request['attribute_is_not'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args   = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$orders_query = new Query( $query_args );
 		$report_data  = $orders_query->get_data();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -34,47 +34,13 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	protected $rest_base = 'reports/orders/stats';
 
 	/**
-	 * Maps query arguments from the REST request.
+	 * Mapping between external parameter name and name used in query class.
 	 *
-	 * @param array $request Request array.
-	 * @return array
+	 * @var array
 	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['interval']            = $request['interval'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['fields']              = $request['fields'];
-		$args['match']               = $request['match'];
-		$args['status_is']           = (array) $request['status_is'];
-		$args['status_is_not']       = (array) $request['status_is_not'];
-		$args['product_includes']    = (array) $request['product_includes'];
-		$args['product_excludes']    = (array) $request['product_excludes'];
-		$args['variation_includes']  = (array) $request['variation_includes'];
-		$args['variation_excludes']  = (array) $request['variation_excludes'];
-		$args['coupon_includes']     = (array) $request['coupon_includes'];
-		$args['coupon_excludes']     = (array) $request['coupon_excludes'];
-		$args['tax_rate_includes']   = (array) $request['tax_rate_includes'];
-		$args['tax_rate_excludes']   = (array) $request['tax_rate_excludes'];
-		$args['customer_type']       = $request['customer_type'];
-		$args['refunds']             = $request['refunds'];
-		$args['attribute_is']        = (array) $request['attribute_is'];
-		$args['attribute_is_not']    = (array) $request['attribute_is_not'];
-		$args['category_includes']   = (array) $request['categories'];
-		$args['segmentby']           = $request['segmentby'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		// For backwards compatibility, `customer` is aliased to `customer_type`.
-		if ( empty( $request['customer_type'] ) && ! empty( $request['customer'] ) ) {
-			$args['customer_type'] = $request['customer'];
-		}
-
-		return $args;
-	}
+	protected $param_mapping = array(
+		'categories' => 'category_includes',
+	);
 
 	/**
 	 * Get all reports.
@@ -83,7 +49,23 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args   = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
+		// For backwards compatibility, `customer` is aliased to `customer_type`.
+		if ( empty( $request['customer_type'] ) && ! empty( $request['customer'] ) ) {
+			$query_args['customer_type'] = $request['customer'];
+		}
+
 		$orders_query = new Query( $query_args );
 		try {
 			$report_data = $orders_query->get_data();

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 
 defined( 'ABSPATH' ) || exit;
@@ -17,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.
@@ -113,20 +114,6 @@ class Controller extends \WC_REST_Reports_Controller {
 				'schema' => array( $this, 'get_public_allowed_item_schema' ),
 			)
 		);
-	}
-
-	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args           = array();
-		$args['before'] = $request['before'];
-		$args['after']  = $request['after'];
-		$args['stats']  = $request['stats'];
-		return $args;
 	}
 
 	/**
@@ -403,7 +390,17 @@ class Controller extends \WC_REST_Reports_Controller {
 			return $indicator_data;
 		}
 
-		$query_args = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
 		if ( empty( $query_args['stats'] ) ) {
 			return new \WP_Error( 'woocommerce_analytics_performance_indicators_empty_query', __( 'A list of stats to query must be provided.', 'woocommerce' ), 400 );
 		}

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 
 /**
@@ -17,7 +18,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends ReportsController implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 
 /**
@@ -17,7 +18,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Revenue\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\Revenue\Query as RevenueQuery;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
@@ -20,7 +21,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends ReportsController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
@@ -41,35 +42,24 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	protected $rest_base = 'reports/revenue/stats';
 
 	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['interval']            = $request['interval'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['segmentby']           = $request['segmentby'];
-		$args['fields']              = $request['fields'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args      = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$reports_revenue = new RevenueQuery( $query_args );
 		try {
 			$report_data = $reports_revenue->get_data();

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
@@ -9,13 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Stock\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+
 /**
  * REST API Reports stock stats controller class.
  *
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 
@@ -18,7 +19,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends ReportsController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
@@ -39,33 +40,24 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	protected $rest_base = 'reports/taxes';
 
 	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['taxes']               = $request['taxes'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args  = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$taxes_query = new Query( $query_args );
 		$report_data = $taxes_query->get_data();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -9,13 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+
 /**
  * REST API Reports taxes stats controller class.
  *
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.
@@ -63,36 +65,24 @@ class Controller extends \WC_REST_Reports_Controller {
 	}
 
 	/**
-	 * Maps query arguments from the REST request.
-	 *
-	 * @param array $request Request array.
-	 * @return array
-	 */
-	protected function prepare_reports_query( $request ) {
-		$args                        = array();
-		$args['before']              = $request['before'];
-		$args['after']               = $request['after'];
-		$args['interval']            = $request['interval'];
-		$args['page']                = $request['page'];
-		$args['per_page']            = $request['per_page'];
-		$args['orderby']             = $request['orderby'];
-		$args['order']               = $request['order'];
-		$args['taxes']               = (array) $request['taxes'];
-		$args['segmentby']           = $request['segmentby'];
-		$args['fields']              = $request['fields'];
-		$args['force_cache_refresh'] = $request['force_cache_refresh'];
-
-		return $args;
-	}
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args  = $this->prepare_reports_query( $request );
+		$query_args = array();
+		$registered = array_keys( $this->get_collection_params() );
+		foreach ( $registered as $param_name ) {
+			if ( isset( $request[ $param_name ] ) ) {
+				if ( isset( $this->param_mapping[ $param_name ] ) ) {
+					$query_args[ $this->param_mapping[ $param_name ] ] = $request[ $param_name ];
+				} else {
+					$query_args[ $param_name ] = $request[ $param_name ];
+				}
+			}
+		}
+
 		$taxes_query = new Query( $query_args );
 		$report_data = $taxes_query->get_data();
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Variations\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
 use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 
 /**
@@ -17,7 +18,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\ParameterException;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends ReportsController {
 
 	/**
 	 * Endpoint namespace.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

_Work in progress._

Aims to implement the changes discussed [here](https://github.com/woocommerce/woocommerce/pull/33325#discussion_r894811161):

> 1. Most of the controllers use a prepare_reports_query method ([example](https://github.com/woocommerce/woocommerce/blob/9d98f1b1dac56cee53106dd3f6749fe960f99f47/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php#L36-L76)), which, as you can see, mostly just copies parameters from the request into a query args array. Occasionally it needs to map a param from the request to a different name for the query args. A few of the controllers have a more efficient way of doing this ([example](https://github.com/woocommerce/woocommerce/blob/9d98f1b1dac56cee53106dd3f6749fe960f99f47/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php#L71-L80)) which I think we should standardize on, because it makes it easier to manage collection params and it more closely matches how things are done in WP Core.
> 2. There is a subset of collection params that almost all of the Reports controllers use (before, after, per_page, fields, etc.). The new force_cache_refresh param would fall into this category as well. Right now, each controller is defining them separately. Instead, the common params could be defined in the parent class and then added using parent::get_collection_params() and merged with params that are unique to the report.

### How to test the changes in this Pull Request:

1. TBD

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
