### PR TITLE
Fix broken design of Single Product template in block themes and on-sale badge being partially hidden

### DIFF
--- a/plugins/woocommerce/changelog/fix-33304-single-product-collapsed-onsale-badge-hidden
+++ b/plugins/woocommerce/changelog/fix-33304-single-product-collapsed-onsale-badge-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix broken design of Single Product template in block themes when product had no reviews or additional info. Fix on sale badge being cut off on the Single Product template.

--- a/plugins/woocommerce/changelog/fix-33304-single-product-collapsed-onsale-badge-hidden
+++ b/plugins/woocommerce/changelog/fix-33304-single-product-collapsed-onsale-badge-hidden
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix broken design of Single Product template in block themes when product had no reviews or additional info. Fix on sale badge being cut off on the Single Product template.
+Fix broken design of Single Product template in Twenty Twenty-Two when product had no reviews or additional info. Fix on sale badge being cut off on the Single Product template.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -95,6 +95,10 @@ $tt2-gray: #f7f7f7;
 		display: none;
 	}
 
+	.woocommerce-breadcrumb {
+		margin-bottom: 1rem;
+	}
+
 	.woocommerce-message,
 	.woocommerce-error,
 	.woocommerce-info {
@@ -253,7 +257,12 @@ $tt2-gray: #f7f7f7;
 
 	div.product {
 		position: relative;
-		overflow: auto;
+
+		&::after {
+			content: "";
+			display: block;
+			clear: both;
+		}
 
 		> span.onsale {
 			position: absolute;
@@ -747,7 +756,7 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 	}
-	
+
 	table.shop_table,
 	table.shop_table_responsive {
 		tbody {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

PR https://github.com/woocommerce/woocommerce/pull/33308 added `overflow: auto` to `div.product` in Single Product template in TT2, in an attempt to fix #33304.

While testing various block themes for the WC default block styles effort, I noticed that this change introduced a regression where now the on-sale badge would be partially hidden on the Single Product template.

This PR resolves the original issue reported in #33304 in a way that doesn't hide the on-sale badge. It also introduces a margin at the bottom of the breadcrumb to ensure it doesn't overlap with the on-sale badge which is another issue present in production. 

### How to test the changes in this Pull Request:

1. Install and activate the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/).
2. Navigate to the single product page of a product that is on sale.
3. Confirm the on-sale badge is fully visible and doesn't overlap with the breadcrumb navigation.

Before | After
--- | ---
<img width="863" alt="Screenshot 2022-06-20 at 08 42 29" src="https://user-images.githubusercontent.com/1562646/174547191-322635ac-436b-4723-aa74-eae43afa5434.png">|<img width="928" alt="Screenshot 2022-06-20 at 09 24 28" src="https://user-images.githubusercontent.com/1562646/174547320-6ed35c42-4a57-4fe5-9d5c-d3e13df505c2.png">

Before | After
--- | ---
<img width="850" alt="Screenshot 2022-06-20 at 09 26 55" src="https://user-images.githubusercontent.com/1562646/174547764-8309a3ca-3c64-44ea-8883-73742c521fae.png">|<img width="880" alt="Screenshot 2022-06-20 at 09 26 25" src="https://user-images.githubusercontent.com/1562646/174547819-3698b167-2152-423f-8a68-18bcb3a251cc.png">

4. Create a new product and make sure it has no description, no reviews, and no additional information.
5. Visit that product on the Frontend.
6. Verify the footer doesn't render on top of the single product template.

Before | After
--- | ---
|<img width="1229" alt="Screenshot 2022-06-20 at 08 45 50" src="https://user-images.githubusercontent.com/1562646/174546551-246f69ee-6501-4a04-a50a-342f86b4ad2c.png">|<img width="1237" alt="Screenshot 2022-06-20 at 09 19 53" src="https://user-images.githubusercontent.com/1562646/174546458-e94bffda-f3a2-42d2-8ef7-3c40d5b51b2a.png">|

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm nx changelog <project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
