### PR TITLE
Changelogger Formatter: Parse previous significance

### DIFF
--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -195,7 +195,7 @@ class Formatter extends KeepAChangelogParser {
 						$changes,
 						array(
 							'subheading' => $is_subentry ? '' : trim( $row_segments[0] ),
-							'content'    => $is_subentry ? trim( $row ) : trim( $row_segments[1] ),
+							'content'    => $is_subentry ? trim( $row ) : trim( isset($row_segments[1]) ? $row_segments[1] : '' ),
 						)
 					);
 				}
@@ -262,7 +262,14 @@ class Formatter extends KeepAChangelogParser {
 					$breaking_change = 'major' === $significance ? ' [ **BREAKING CHANGE** ]' : '';
 					$text            = trim( $change->getContent() );
 					if ( '' !== $text ) {
-						$preamble = $is_subentry ? '' : $bullet . ucfirst( $significance ) . $breaking_change . ' - ';
+						$preamble;
+						if ( $is_subentry ) {
+							$preamble = '';
+						} else if ( ! $significance ) {
+							$preamble = $bullet;
+						} else {
+							$preamble = $bullet . ucfirst( $significance ) . $breaking_change . ' - ';
+						}
 						$ret     .= $preamble . str_replace( "\n", "\n$indent", $text ) . "\n";
 					}
 				}

--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -190,12 +190,14 @@ class Formatter extends KeepAChangelogParser {
 					$row          = trim( $row );
 					$row          = preg_replace( '/' . $this->bullet . '/', '', $row, 1 );
 					$row_segments = explode( ' - ', $row );
-
+					$significance = trim( strtolower( $row_segments[0] ) );
+					
 					array_push(
 						$changes,
 						array(
-							'subheading' => $is_subentry ? '' : trim( $row_segments[0] ),
-							'content'    => $is_subentry ? trim( $row ) : trim( isset($row_segments[1]) ? $row_segments[1] : '' ),
+							'subheading'   => $is_subentry ? '' : trim( $row_segments[0] ),
+							'content'      => $is_subentry ? trim( $row ) : trim( isset($row_segments[1]) ? $row_segments[1] : '' ),
+							'significance' => in_array( $significance, array( 'patch', 'minor', 'major' ) ) ? $significance : null,
 						)
 					);
 				}
@@ -204,9 +206,10 @@ class Formatter extends KeepAChangelogParser {
 					$entry->appendChange(
 						$this->newChangeEntry(
 							array(
-								'subheading' => $change['subheading'],
-								'content'    => $change['content'],
-								'timestamp'  => $entry_timestamp,
+								'subheading'   => $change['subheading'],
+								'content'      => $change['content'],
+								'significance' => $change['significance'],
+								'timestamp'    => $entry_timestamp,
 							)
 						)
 					);
@@ -262,14 +265,7 @@ class Formatter extends KeepAChangelogParser {
 					$breaking_change = 'major' === $significance ? ' [ **BREAKING CHANGE** ]' : '';
 					$text            = trim( $change->getContent() );
 					if ( '' !== $text ) {
-						$preamble;
-						if ( $is_subentry ) {
-							$preamble = '';
-						} else if ( ! $significance ) {
-							$preamble = $bullet;
-						} else {
-							$preamble = $bullet . ucfirst( $significance ) . $breaking_change . ' - ';
-						}
+						$preamble = $is_subentry ? '' : $bullet . ucfirst( $significance ) . $breaking_change . ' - ';
 						$ret     .= $preamble . str_replace( "\n", "\n$indent", $text ) . "\n";
 					}
 				}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changelogger `Formatter.php` wasn't gathering previous `patch`, `minor`, `major` significances. This made the formatting look wrong. This PR makes sure to parse and format correctly.

### How to test the changes in this Pull Request:

1. Navigate to a package with changelog entries, `cd packages/js/components`.
2. Write a changelog `./vendor/bin/changelogger write`
3. Note the previous changelog entry has correctly formatted significances

```md
## [10.1.0](https://www.npmjs.com/package/@woocommerce/components/v/10.1.0) - 2022-06-09 

-   Minor - Add tour kit component
-   Minor - Update dependency `memoize-one` to ^6.0.0. #32936
-   Minor - Update dependency `react-dates` to ^21.8.0. #32883
-   Minor - Add Jetpack Changelogger
-   Minor - Update dependency `@wordpress/hooks` to ^3.5.0
-   Minor - Update dependency `@wordpress/icons` to ^8.1.0
-   Minor - Add `className` prop for Pill component. #32605
-   Patch - Removed unused react-router-dom dependency #33156
-   Patch - Standardize lint scripts: add lint:fix
-   Patch - Fix documentation for `TableCard` component
-   Patch - Update `StepperProps` prop types. #32712
```

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
