### PR TITLE
Analyzer: Remove check for hook without description

### DIFF
--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -274,7 +274,8 @@ export default class Analyzer extends Command {
 			return null;
 		}
 
-		const updateFunctionRegex = /\+{1,2}\s*'(\d.\d.\d)' => array\(\n\+{1,2}\s*'(.*)',\n\+{1,2}\s*\),/m;
+		const updateFunctionRegex =
+			/\+{1,2}\s*'(\d.\d.\d)' => array\(\n\+{1,2}\s*'(.*)',\n\+{1,2}\s*\),/m;
 		const match = databaseUpdatePatch.match( updateFunctionRegex );
 
 		if ( ! match ) {
@@ -376,19 +377,12 @@ export default class Analyzer extends Command {
 		for ( const p in patches ) {
 			const patch = patches[ p ];
 			const results = patch.match( newRegEx );
-			const hasHookRegex = /apply_filters|do_action/g;
-			const hasHook = patch.match( hasHookRegex );
 			const hooksList: Map< string, string[] > = new Map<
 				string,
 				string[]
 			>();
 
 			if ( ! results ) {
-				if ( hasHook ) {
-					this.error(
-						'A hook has been introduced or updated without a docBlock. Please add a docBlock.'
-					);
-				}
 				continue;
 			}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes a problematic check for changes that add a hook but not a description. This check was erroneously picking up additional uses of hooks that were introduced in previous versions.

Since we will have a Code Sniffer violation against adding a hook with no description, the original intention of the hook no is longer needed.

Closes https://github.com/woocommerce/woocommerce/issues/33525

### How to test the changes in this Pull Request:

1. Add a hook that already exists. Note the `@since` tag signifies an introduction in a previous version, so nothing new has been added.
```php
/**
 * Fires when a new order is created.
 * @param int       Order ID.
 * @param \WC_Order Order object.
 * @since 2.7.0
 */
do_action( 'woocommerce_new_order', $order->get_id(), $order );
```
3. Commit the change locally
4. Run the Analyzer `./tools/code-analyzer/bin/dev analyzer fix/analyzer-hasHook-fail`
5. See the output not pick up any new hooks

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
