### PR TITLE
Update shipping recommendations display logic

### DIFF
--- a/packages/js/data/changelog/update-display-shipping-recommendations
+++ b/packages/js/data/changelog/update-display-shipping-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix product type

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -100,7 +100,7 @@ export type ProductCount = '0' | '1-10' | '11-100' | '101 - 1000' | '1000+';
 export type ProductTypeSlug =
 	| 'physical'
 	| 'bookings'
-	| 'download'
+	| 'downloads'
 	| 'memberships'
 	| 'product-add-ons'
 	| 'product-bundles'

--- a/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -1,10 +1,13 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
-import { PLUGINS_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
+import {
+	PLUGINS_STORE_NAME,
+	SETTINGS_STORE_NAME,
+	ONBOARDING_STORE_NAME,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -15,29 +18,39 @@ import { ShippingRecommendationsList } from './shipping-recommendations';
 import './shipping-recommendations.scss';
 
 const ShippingRecommendations: React.FC = () => {
-	const { activePlugins, installedPlugins, countryCode, isJetpackConnected } =
-		useSelect( ( select ) => {
-			const settings = select( SETTINGS_STORE_NAME ).getSettings< {
-				general?: {
-					woocommerce_default_country: string;
-				};
-			} >( 'general' );
-
-			const {
-				getActivePlugins,
-				getInstalledPlugins,
-				isJetpackConnected: _isJetpackConnected,
-			} = select( PLUGINS_STORE_NAME );
-
-			return {
-				activePlugins: getActivePlugins(),
-				installedPlugins: getInstalledPlugins(),
-				countryCode: getCountryCode(
-					settings.general?.woocommerce_default_country
-				),
-				isJetpackConnected: _isJetpackConnected(),
+	const {
+		activePlugins,
+		installedPlugins,
+		countryCode,
+		isJetpackConnected,
+		isSellingDigitalProductsOnly,
+	} = useSelect( ( select ) => {
+		const settings = select( SETTINGS_STORE_NAME ).getSettings< {
+			general?: {
+				woocommerce_default_country: string;
 			};
-		} );
+		} >( 'general' );
+
+		const {
+			getActivePlugins,
+			getInstalledPlugins,
+			isJetpackConnected: _isJetpackConnected,
+		} = select( PLUGINS_STORE_NAME );
+
+		const profileItems = select( ONBOARDING_STORE_NAME ).getProfileItems()
+			.product_types;
+
+		return {
+			activePlugins: getActivePlugins(),
+			installedPlugins: getInstalledPlugins(),
+			countryCode: getCountryCode(
+				settings.general?.woocommerce_default_country
+			),
+			isJetpackConnected: _isJetpackConnected(),
+			isSellingDigitalProductsOnly:
+				profileItems?.length === 1 && profileItems[ 0 ] === 'downloads',
+		};
+	} );
 
 	if (
 		activePlugins.includes( 'woocommerce-services' ) &&
@@ -46,7 +59,7 @@ const ShippingRecommendations: React.FC = () => {
 		return null;
 	}
 
-	if ( countryCode !== 'US' ) {
+	if ( countryCode !== 'US' || isSellingDigitalProductsOnly ) {
 		return null;
 	}
 

--- a/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+import { PLUGINS_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { getCountryCode } from '~/dashboard/utils';
+import WooCommerceServicesItem from './experimental-woocommerce-services-item';
+import { ShippingRecommendationsList } from './shipping-recommendations';
+import './shipping-recommendations.scss';
+
+const ShippingRecommendations: React.FC = () => {
+	const { activePlugins, installedPlugins, countryCode, isJetpackConnected } =
+		useSelect( ( select ) => {
+			const settings = select( SETTINGS_STORE_NAME ).getSettings< {
+				general?: {
+					woocommerce_default_country: string;
+				};
+			} >( 'general' );
+
+			const {
+				getActivePlugins,
+				getInstalledPlugins,
+				isJetpackConnected: _isJetpackConnected,
+			} = select( PLUGINS_STORE_NAME );
+
+			return {
+				activePlugins: getActivePlugins(),
+				installedPlugins: getInstalledPlugins(),
+				countryCode: getCountryCode(
+					settings.general?.woocommerce_default_country
+				),
+				isJetpackConnected: _isJetpackConnected(),
+			};
+		} );
+
+	if (
+		activePlugins.includes( 'woocommerce-services' ) &&
+		isJetpackConnected
+	) {
+		return null;
+	}
+
+	if ( countryCode !== 'US' ) {
+		return null;
+	}
+
+	return (
+		<ShippingRecommendationsList>
+			<WooCommerceServicesItem
+				isWCSInstalled={ installedPlugins.includes(
+					'woocommerce-services'
+				) }
+			/>
+		</ShippingRecommendationsList>
+	);
+};
+
+export default ShippingRecommendations;

--- a/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
@@ -14,7 +14,9 @@ import WooIcon from './woo-icon.svg';
 const WooCommerceServicesItem: React.FC< {
 	isWCSInstalled: boolean | undefined;
 } > = ( { isWCSInstalled } ) => {
-	const handleSetupClick = async () => {};
+	const handleSetupClick = () => {
+		// TODO: Go to new WCS flow #33367
+	};
 
 	return (
 		<div className="woocommerce-list__item-inner woocommerce-services-item">

--- a/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, ExternalLink } from '@wordpress/components';
+import { Pill } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import './woocommerce-services-item.scss';
+import WooIcon from './woo-icon.svg';
+
+const WooCommerceServicesItem: React.FC< {
+	isWCSInstalled: boolean | undefined;
+} > = ( { isWCSInstalled } ) => {
+	const handleSetupClick = async () => {};
+
+	return (
+		<div className="woocommerce-list__item-inner woocommerce-services-item">
+			<div className="woocommerce-list__item-before">
+				<img
+					className="woocommerce-services-item__logo"
+					src={ WooIcon }
+					alt="Woocommerce Service Logo"
+				/>
+			</div>
+			<div className="woocommerce-list__item-text">
+				<span className="woocommerce-list__item-title">
+					{ __( 'Woocommerce Shipping', 'woocommerce' ) }
+					<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
+				</span>
+				<span className="woocommerce-list__item-content">
+					{ __(
+						'Print USPS and DHL Express labels straight from your WooCommerce dashboard and save on shipping.',
+						'woocommerce'
+					) }
+					<br />
+					<ExternalLink href="https://woocommerce.com/woocommerce-shipping/">
+						{ __( 'Learn more', 'woocommerce' ) }
+					</ExternalLink>
+				</span>
+			</div>
+			<div className="woocommerce-list__item-after">
+				<Button isSecondary onClick={ handleSetupClick }>
+					{ isWCSInstalled
+						? __( 'Activate', 'woocommerce' )
+						: __( 'Get started', 'woocommerce' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default WooCommerceServicesItem;

--- a/plugins/woocommerce-admin/client/shipping/shipping-recommendations-wrapper.tsx
+++ b/plugins/woocommerce-admin/client/shipping/shipping-recommendations-wrapper.tsx
@@ -9,12 +9,17 @@ import { lazy, Suspense } from '@wordpress/element';
 import { EmbeddedBodyProps } from '../embedded-body-layout/embedded-body-props';
 import RecommendationsEligibilityWrapper from '../settings-recommendations/recommendations-eligibility-wrapper';
 
-const ShippingRecommendationsLoader = lazy(
-	() =>
-		import(
-			/* webpackChunkName: "shipping-recommendations" */ './shipping-recommendations'
-		)
-);
+const ShippingRecommendationsLoader = lazy( () => {
+	if ( window.wcAdminFeatures[ 'shipping-smart-defaults' ] ) {
+		return import(
+			/* webpackChunkName: "shipping-recommendations" */ './experimental-shipping-recommendations'
+		);
+	}
+
+	return import(
+		/* webpackChunkName: "shipping-recommendations" */ './shipping-recommendations'
+	);
+} );
 
 export const ShippingRecommendations: React.FC< EmbeddedBodyProps > = ( {
 	page,

--- a/plugins/woocommerce-admin/client/shipping/shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/shipping-recommendations.tsx
@@ -52,7 +52,7 @@ const useInstallPlugin = () => {
 	return [ pluginsBeingSetup, handleSetup ] as const;
 };
 
-const ShippingRecommendationsList: React.FC = ( { children } ) => (
+export const ShippingRecommendationsList: React.FC = ( { children } ) => (
 	<DismissableList
 		className="woocommerce-recommended-shipping-extensions"
 		dismissOptionName="woocommerce_settings_shipping_recommendations_hidden"

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import ShippingRecommendations from '../experimental-shipping-recommendations';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
+	DismissableList: ( ( { children } ) => children ) as React.FC,
+	DismissableListHeading: ( ( { children } ) => children ) as React.FC,
+} ) );
+
+const defaultSelectReturn = {
+	getActivePlugins: () => [],
+	getInstalledPlugins: () => [],
+	isJetpackConnected: () => false,
+	getSettings: () => ( {
+		general: {
+			woocommerce_default_country: 'US',
+		},
+	} ),
+};
+
+describe( 'ShippingRecommendations', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( { ...defaultSelectReturn } ) )
+		);
+	} );
+
+	it( 'should not render when WCS is already installed and Jetpack is conneclted', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				...defaultSelectReturn,
+				getActivePlugins: () => [ 'woocommerce-services' ],
+				isJetpackConnected: () => true,
+			} ) )
+		);
+		render( <ShippingRecommendations /> );
+
+		expect(
+			screen.queryByText( 'Woocommerce Shipping' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when store location is not US', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				...defaultSelectReturn,
+				getSettings: () => ( {
+					general: {
+						woocommerce_default_country: 'JP',
+					},
+				} ),
+			} ) )
+		);
+		render( <ShippingRecommendations /> );
+
+		expect(
+			screen.queryByText( 'Woocommerce Shipping' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render WCS when not installed', () => {
+		render( <ShippingRecommendations /> );
+
+		expect(
+			screen.queryByText( 'Woocommerce Shipping' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -27,6 +27,7 @@ const defaultSelectReturn = {
 			woocommerce_default_country: 'US',
 		},
 	} ),
+	getProfileItems: () => ( {} ),
 };
 
 describe( 'ShippingRecommendations', () => {
@@ -59,6 +60,22 @@ describe( 'ShippingRecommendations', () => {
 					general: {
 						woocommerce_default_country: 'JP',
 					},
+				} ),
+			} ) )
+		);
+		render( <ShippingRecommendations /> );
+
+		expect(
+			screen.queryByText( 'Woocommerce Shipping' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when store sells digital products only', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				...defaultSelectReturn,
+				getProfileItems: () => ( {
+					product_types: [ 'downloads' ],
 				} ),
 			} ) )
 		);

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -37,7 +37,7 @@ describe( 'ShippingRecommendations', () => {
 		);
 	} );
 
-	it( 'should not render when WCS is already installed and Jetpack is conneclted', () => {
+	it( 'should not render when WCS is already installed and Jetpack is connected', () => {
 		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
 			fn( () => ( {
 				...defaultSelectReturn,

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import WooCommerceServicesItem from '../experimental-woocommerce-services-item';
+
+describe( 'WooCommerceServicesItem', () => {
+	it( 'should render WCS item with CTA = "Get started" when WCS is not installed', () => {
+		render( <WooCommerceServicesItem isWCSInstalled={ false } /> );
+
+		expect(
+			screen.queryByText( 'Woocommerce Shipping' )
+		).toBeInTheDocument();
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Get started' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render WCS item with CTA = "Activate" when WCS is installed', () => {
+		render( <WooCommerceServicesItem isWCSInstalled={ true } /> );
+
+		expect(
+			screen.queryByText( 'Woocommerce Shipping' )
+		).toBeInTheDocument();
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Activate' } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce-admin/client/shipping/test/shipping-recommendations-wrapper.test.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/shipping-recommendations-wrapper.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ShippingRecommendations } from '../shipping-recommendations-wrapper';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	Suspense: () => <div>Woocommerce Shipping</div>,
+} ) );
+
+const eligibleSelectReturn = {
+	getOption: () => 'yes',
+	getCurrentUser: () => ( {
+		is_super_admin: true,
+	} ),
+	hasStartedResolution: () => true,
+	hasFinishedResolution: () => true,
+};
+
+describe( 'ShippingRecommendations', () => {
+	beforeEach( () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => eligibleSelectReturn )
+		);
+	} );
+
+	it( 'should not render when section is not empty', () => {
+		const { queryByText } = render(
+			<ShippingRecommendations
+				page="wc-settings"
+				tab="shipping"
+				section={ 'section' }
+				zone_id={ undefined }
+			/>
+		);
+
+		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when zone_id is not empty', () => {
+		const { queryByText } = render(
+			<ShippingRecommendations
+				page="wc-settings"
+				tab="shipping"
+				section={ undefined }
+				zone_id={ 'zone_id' }
+			/>
+		);
+
+		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when woocommerce_show_marketplace_suggestions is "no"', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				...eligibleSelectReturn,
+				getOption: () => 'no',
+			} ) )
+		);
+		const { queryByText } = render(
+			<ShippingRecommendations
+				page="wc-settings"
+				tab="shipping"
+				section={ undefined }
+				zone_id={ undefined }
+			/>
+		);
+		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render when user is not allowed', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				...eligibleSelectReturn,
+				getCurrentUser: () => ( {
+					is_super_admin: false,
+					capabilities: {},
+				} ),
+			} ) )
+		);
+		const { queryByText } = render(
+			<ShippingRecommendations
+				page="wc-settings"
+				tab="shipping"
+				section={ undefined }
+				zone_id={ undefined }
+			/>
+		);
+		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render WCS', async () => {
+		const { getByText } = render(
+			<ShippingRecommendations
+				page="wc-settings"
+				tab="shipping"
+				section={ undefined }
+				zone_id={ undefined }
+			/>
+		);
+
+		expect( getByText( 'Woocommerce Shipping' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -28,6 +28,7 @@ declare global {
 			'wc-pay-promotion': boolean;
 			'wc-pay-welcome-page': boolean;
 			'wc-pay-subscriptions-page': boolean;
+			'shipping-smart-defaults': boolean;
 		};
 	}
 }

--- a/plugins/woocommerce/changelog/update-display-shipping-recommendations
+++ b/plugins/woocommerce/changelog/update-display-shipping-recommendations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update shipping recommendations display logic


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33370.

This PR updates shipping recommendations display logic:

- Display WCS as recommended extension to be installed in Shipping Settings If the store sells physical products and is located in US, but JP and WCS are not installed and connected:
- If the user doesn't complete all the steps (eg. they leave the stepper before activating WCS), we can still display the banner (img attached below) changing the CTA from `Get started` to `Activate`.



![Screen Shot 2022-06-22 at 13 03 12](https://user-images.githubusercontent.com/4344253/174947810-2d499013-3f7b-41ef-a6ed-93be01689770.png)

note: CTA button should be handled in #33367 or a follow-up issue.

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Enable the `shipping-smart-defaults` feature via WCA Test helper.
3. Go to OBW and set store country to a non-US country.
4. Go to `Woocommerce > Settings > Shipping` tab
5. Observe that "Woocommerce Shipping" is NOT displayed as a recommended extension
6. Change store country to the US.
7. Go back to `Woocommerce > Settings > Shipping` tab
8. Observe that "Woocommerce Shipping" is displayed as a recommended extension
9. Install and activate `Woocommerce Shipping`
10. Go back to `Woocommerce > Settings > Shipping` tab
11. Observe that "Woocommerce Shipping" is displayed and the CTA button is `Activate`.
12. Install and connect Jetpack.
13. Go back to `Woocommerce > Settings > Shipping` tab
14. Observe that "Woocommerce Shipping" is NOT displayed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
