### PR TITLE
Update shipping task display logic

### DIFF
--- a/plugins/woocommerce/changelog/update-shipping-task-display-logic
+++ b/plugins/woocommerce/changelog/update-shipping-task-display-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update display shipping task logic and add ReviewShippingOptions task

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -8,8 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedExtendedTask;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use Automattic\WooCommerce\Internal\Admin\Loader;
-
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\ReviewShippingOptions;
 /**
  * Task Lists class.
  */
@@ -51,6 +50,7 @@ class TaskLists {
 		'Marketing',
 		'Appearance',
 		'AdditionalPayments',
+		'ReviewShippingOptions',
 	);
 
 	/**
@@ -153,10 +153,10 @@ class TaskLists {
 
 		self::add_list(
 			array(
-				'id'           => 'setup_experiment_2',
-				'hidden_id'    => 'setup',
-				'title'        => __( 'Get ready to start selling', 'woocommerce' ),
-				'tasks'        => array(
+				'id'                      => 'setup_experiment_2',
+				'hidden_id'               => 'setup',
+				'title'                   => __( 'Get ready to start selling', 'woocommerce' ),
+				'tasks'                   => array(
 					'StoreCreation',
 					'StoreDetails',
 					'Purchase',
@@ -168,14 +168,14 @@ class TaskLists {
 					'Marketing',
 					'Appearance',
 				),
-				'event_prefix' => 'tasklist_',
-				'visible'      => self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' )
+				'event_prefix'            => 'tasklist_',
+				'visible'                 => self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' )
 					&& ! self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ),
-				'options'      => array(
+				'options'                 => array(
 					'use_completed_title' => true,
 				),
 				'display_progress_header' => true,
-				'sections'     => array(
+				'sections'                => array(
 					array(
 						'id'          => 'basics',
 						'title'       => __( 'Cover the basics', 'woocommerce' ),
@@ -268,6 +268,21 @@ class TaskLists {
 			)
 		);
 
+		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
+			self::add_task(
+				'extended',
+				new ReviewShippingOptions(
+					self::get_list( 'extended' )
+				)
+			);
+
+			self::add_task(
+				'extended_two_column',
+				new ReviewShippingOptions(
+					self::get_list( 'extended_two_column' )
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -64,7 +64,7 @@ class ReviewShippingOptions extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		// TODO: Just check automated shipping options have been set up when #33366 is completed.
+		// TODO: Update when #33366 is completed.
 		if ( Shipping::sell_only_digital_type() || Shipping::sell_unknown_product_type() ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -69,7 +69,7 @@ class ReviewShippingOptions extends Task {
 			return false;
 		}
 
-		if ( ! self::has_shipping_zones() ) {
+		if ( ! Shipping::has_shipping_zones() ) {
 			return false;
 		}
 
@@ -82,9 +82,8 @@ class ReviewShippingOptions extends Task {
 		$is_jetpack_installed = PluginsHelper::is_plugin_installed( 'jetpack' );
 		$is_jetpack_connected = class_exists( 'Jetpack_Connection_Manager' ) && ( new Jetpack_Connection_Manager() )->is_connected();
 
-		$is_wcs_installed = $is_jetpack_connected && PluginsHelper::is_plugin_installed( 'woocommerce-services' );
-		// Is it installed and WooCommerce Shipping & Tax Terms of Service accepted?
-		$is_wcs_connected = $is_wcs_installed && class_exists( '\WC_Connect_Options' ) && \WC_Connect_Options::get_option( 'tos_accepted' );
+		$is_wcs_installed = PluginsHelper::is_plugin_installed( 'woocommerce-services' );
+		$is_wcs_connected = class_exists( '\WC_Connect_Options' ) && \WC_Connect_Options::get_option( 'tos_accepted' );
 
 		return 'US' === $store_country && (
 			$is_jetpack_connected && $is_wcs_connected || $is_jetpack_installed && ! $is_wcs_installed ) ||
@@ -97,17 +96,6 @@ class ReviewShippingOptions extends Task {
 	 * @return string
 	 */
 	public function get_action_url() {
-		return self::has_shipping_zones()
-			? admin_url( 'admin.php?page=wc-settings&tab=shipping' )
-			: null;
-	}
-
-	/**
-	 * Check if the store has any shipping zones.
-	 *
-	 * @return bool
-	 */
-	public static function has_shipping_zones() {
-		return count( WC_Data_Store::load( 'shipping-zone' )->get_zones() ) > 0;
+		return admin_url( 'admin.php?page=wc-settings&tab=shipping' );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -3,10 +3,6 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use \Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
-use \Automattic\WooCommerce\Admin\PluginsHelper;
-use WC_Data_Store;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping;
 
 /**
  * Review Shipping Options Task
@@ -54,8 +50,7 @@ class ReviewShippingOptions extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		// TODO: Implement is_complete() method.
-		return false;
+		return 'yes' === get_option( 'woocommerce_admin_reviewed_default_shipping_zones' );
 	}
 
 	/**
@@ -64,22 +59,7 @@ class ReviewShippingOptions extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		// TODO: Update when #33366 is completed.
-		if ( Shipping::sell_only_digital_type() || Shipping::sell_unknown_product_type() ) {
-			return false;
-		}
-
-		if ( ! Shipping::has_shipping_zones() ) {
-			return false;
-		}
-
-		$store_country = wc_format_country_state_string( get_option( 'woocommerce_default_country', '' ) )['country'];
-
-		if ( ! $store_country ) {
-			return false;
-		}
-
-		return 'US' === $store_country || ! in_array( $store_country, array( 'US', 'CA', 'AU', 'UK' ), true );
+		return 'yes' === get_option( 'woocommerce_admin_created_default_shipping_zones' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -79,15 +79,7 @@ class ReviewShippingOptions extends Task {
 			return false;
 		}
 
-		$is_jetpack_installed = PluginsHelper::is_plugin_installed( 'jetpack' );
-		$is_jetpack_connected = class_exists( 'Jetpack_Connection_Manager' ) && ( new Jetpack_Connection_Manager() )->is_connected();
-
-		$is_wcs_installed = PluginsHelper::is_plugin_installed( 'woocommerce-services' );
-		$is_wcs_connected = class_exists( '\WC_Connect_Options' ) && \WC_Connect_Options::get_option( 'tos_accepted' );
-
-		return 'US' === $store_country && (
-			$is_jetpack_connected && $is_wcs_connected || $is_jetpack_installed && ! $is_wcs_installed ) ||
-			! in_array( $store_country, array( 'US', 'CA', 'AU', 'UK' ), true );
+		return 'US' === $store_country || ! in_array( $store_country, array( 'US', 'CA', 'AU', 'UK' ), true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use \Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use \Automattic\WooCommerce\Admin\PluginsHelper;
+use WC_Data_Store;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping;
+
+/**
+ * Review Shipping Options Task
+ */
+class ReviewShippingOptions extends Task {
+	/**
+	 * ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'shipping';
+	}
+
+	/**
+	 * Title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return __( 'Review Shipping Options', 'woocommerce' );
+	}
+
+	/**
+	 * Content.
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+		return '';
+	}
+
+	/**
+	 * Time.
+	 *
+	 * @return string
+	 */
+	public function get_time() {
+		return '';
+	}
+
+	/**
+	 * Task completion.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		// TODO: Implement is_complete() method.
+		return false;
+	}
+
+	/**
+	 * Task visibility.
+	 *
+	 * @return bool
+	 */
+	public function can_view() {
+		// TODO: Just check automated shipping options have been set up when #33366 is completed.
+		if ( Shipping::sell_only_digital_type() || Shipping::sell_unknown_product_type() ) {
+			return false;
+		}
+
+		if ( ! self::has_shipping_zones() ) {
+			return false;
+		}
+
+		$store_country = wc_format_country_state_string( get_option( 'woocommerce_default_country', '' ) )['country'];
+
+		if ( ! $store_country ) {
+			return false;
+		}
+
+		$is_jetpack_installed = PluginsHelper::is_plugin_installed( 'jetpack' );
+		$is_jetpack_connected = class_exists( 'Jetpack_Connection_Manager' ) && ( new Jetpack_Connection_Manager() )->is_connected();
+
+		$is_wcs_installed = $is_jetpack_connected && PluginsHelper::is_plugin_installed( 'woocommerce-services' );
+		// Is it installed and WooCommerce Shipping & Tax Terms of Service accepted?
+		$is_wcs_connected = $is_wcs_installed && class_exists( '\WC_Connect_Options' ) && \WC_Connect_Options::get_option( 'tos_accepted' );
+
+		return 'US' === $store_country && (
+			$is_jetpack_connected && $is_wcs_connected || $is_jetpack_installed && ! $is_wcs_installed ) ||
+			! in_array( $store_country, array( 'US', 'CA', 'AU', 'UK' ), true );
+	}
+
+	/**
+	 * Action URL.
+	 *
+	 * @return string
+	 */
+	public function get_action_url() {
+		return self::has_shipping_zones()
+			? admin_url( 'admin.php?page=wc-settings&tab=shipping' )
+			: null;
+	}
+
+	/**
+	 * Check if the store has any shipping zones.
+	 *
+	 * @return bool
+	 */
+	public static function has_shipping_zones() {
+		return count( WC_Data_Store::load( 'shipping-zone' )->get_zones() ) > 0;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -132,11 +132,11 @@ class Shipping extends Task {
 			) > 0;
 	}
 
-		/**
-		 * Check if the store sells digital products only.
-		 *
-		 * @return bool
-		 */
+	/**
+	 * Check if the store sells digital products only.
+	 *
+	 * @return bool
+	 */
 	public static function sell_unknown_product_type() {
 		$profiler_data = get_option( OnboardingProfile::DATA_OPTION, array() );
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -79,6 +79,11 @@ class Shipping extends Task {
 	 */
 	public function can_view() {
 		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
+			if ( 'yes' === get_option( 'woocommerce_admin_created_default_shipping_zones' ) ) {
+				// If the user has already created a default shipping zone, we don't need to show the task.
+				return false;
+			}
+
 			/**
 			 * Do not display the task when:
 			 * - The store sells digital products only

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -94,6 +94,7 @@ class Shipping extends Task {
 			$default_store_country = wc_format_country_state_string( get_option( 'woocommerce_default_country', '' ) )['country'];
 
 			// Check if a store address is set so that we don't default to WooCommerce's default country US.
+			// Similar logic: https://github.com/woocommerce/woocommerce/blob/059d542394b48468587f252dcb6941c6425cd8d3/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js#L511-L516.
 			$store_country = '';
 			if ( ! empty( get_option( 'woocommerce_store_address', '' ) ) || 'US' !== $default_store_country ) {
 				$store_country = $default_store_country;

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -79,7 +79,15 @@ class Shipping extends Task {
 	 */
 	public function can_view() {
 		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
-			if ( self::sell_only_digital_type() ) {
+			/**
+			 * Do not display the task when:
+			 * - The store sells digital products only
+			 * Display the task when:
+			 * - We don't know where the store's located
+			 * - The store is located in the UK, Australia or Canada
+			*/
+
+			if ( self::is_selling_digital_type_only() ) {
 				return false;
 			}
 
@@ -91,6 +99,7 @@ class Shipping extends Task {
 				$store_country = $default_store_country;
 			}
 
+			// Unknown country.
 			if ( empty( $store_country ) ) {
 				return true;
 			}
@@ -146,7 +155,7 @@ class Shipping extends Task {
 	 *
 	 * @return bool
 	 */
-	private static function sell_only_digital_type() {
+	private static function is_selling_digital_type_only() {
 		$profiler_data = get_option( OnboardingProfile::DATA_OPTION, array() );
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Test the Tasks/Shipping class.
+ *
+ * @package WooCommerce\Admin\Tests\OnboardingTasks/Tasks/Shipping
+ */
+
+use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping;
+
+/**
+ * class WC_Admin_Tests_OnboardingTasks_Task_Shipping
+ */
+class WC_Admin_Tests_OnboardingTasks_Task_Shipping extends WC_Unit_Test_Case {
+
+	/**
+	 * Task list.
+	 *
+	 * @var Task|null
+	 */
+	protected $task = null;
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->task = new Shipping( new TaskList() );
+		add_filter( 'woocommerce_admin_features', array( $this, 'turn_on_smart_shipping_defaults_feature' ), 20, 1 );
+
+		update_option(
+			OnboardingProfile::DATA_OPTION,
+			array(
+				'product_types' => array(
+					'physical',
+				),
+			)
+		);
+	}
+
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_filter( 'woocommerce_admin_features', array( $this, 'turn_on_smart_shipping_defaults_feature' ), 1 );
+
+		delete_option( OnboardingProfile::DATA_OPTION );
+	}
+
+
+	/**
+	 * Filter to enable shipping-smart-defaults feature.
+	 *
+	 * @param  array $features Array of active features.
+	 */
+	public static function turn_on_smart_shipping_defaults_feature( $features ) {
+		return array_merge( $features, array( 'shipping-smart-defaults' ) );
+	}
+
+	/**
+	 * Test can_view function of task when store only sells digital products.
+	 */
+	public function test_can_view_return_false_when_sell_only_digital_type() {
+		update_option(
+			OnboardingProfile::DATA_OPTION,
+			array(
+				'product_types' => array(
+					'downloads',
+				),
+			)
+		);
+		$this->assertEquals( $this->task->can_view(), false );
+	}
+
+	/**
+	 * Test can_view function of task when store location is an eligible country.
+	 *
+	 * @dataProvider data_provider_can_view_eligible_countries
+	 * @param string $country Country to test.
+	 */
+	public function test_can_view_return_true_for_eligible_countries( $country ) {
+		update_option(
+			'woocommerce_default_country',
+			$country
+		);
+		$this->assertEquals( $this->task->can_view(), true );
+	}
+
+	/**
+	 * Test can_view function of task when store location is unknown.
+	 *
+	 */
+	public function test_can_view_return_true_when_store_location_is_unknown() {
+		delete_option( 'woocommerce_default_country' );
+
+		$this->assertEquals( $this->task->can_view(), true );
+
+		update_option(
+			'woocommerce_default_country',
+			'US:CA'
+		);
+
+		delete_option(
+			'woocommerce_store_address',
+			''
+		);
+
+		$this->assertEquals( $this->task->can_view(), true );
+	}
+
+
+	/**
+	 * Data provider for test_can_view_return_true_for_eligible_countries.
+	 *
+	 */
+	public function data_provider_can_view_eligible_countries() {
+		return array(
+			array( 'AU' ),
+			array( 'CA' ),
+			array( 'UK' ),
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33363.

This PR updates the shipping task display logic

I'll have another PR to update `woocommerce_admin_reviewed_default_shipping_zones` option when we have a conclusion on how to determine whether a user completes the task or not (#33363).

**Acceptance Criteria:**

Do not display the shipping task on the home page when:
- The store sells digital products only

When automated shipping options have been set in https://github.com/woocommerce/woocommerce/issues/33366:
- Change the name of the shipping task to Review shipping options and move it the Things to do next section.

Otherwise, display the "Set up shipping" task in the "Get ready to start selling" section when either of the following is true:
- We don't know if ~the store sells physical products~ (If a user skips OBW, we assume they sell physical products) and where it's located
- The store is located in the UK, Australia or Canada


### How to test the changes in this Pull Request:

**Prerequisites**

1. Use a fresh site
2. Enable the shipping-smart-defaults feature via WCA Test helper.


**When a user skips OBW**

1. Skip OBW
2. Go to Woocommerce > Home
4. Observe that the "Shipping" task is displayed. (Shipping task name may be different if you're assigned to a tasklist experiment treatment group. It should be `Select how to ship your products`, `Set up shipping`, or `Add shipping costs`. )

**When store location is AU, CA or UK**

1. Change store location to Australia.
2. Go to Woocommerce > Home
4. Observe that the "Shipping" task is displayed.


**When store only sells digital products**

1. Go to OBW > product types
2. Select "Downloads", and uncheck "Physical products"
3. Go to Woocommerce > Home
5. Observe that the "Shipping" task is not displayed.

**Review shipping options Task**

1. Update `woocommerce_admin_created_default_shipping_zones` option to `yes`.
2. Go to Woocommerce > Home
3. Observe that `Review Shipping Options` task is displayed.
5. Click the `Review Shipping Options` task
6. Observe that the page is redirected to `Setting > Shipping`
7. Update `woocommerce_admin_reviewed_default_shipping_zones ` option to `yes`.
8. Go to Woocommerce > Home
9. Observe that `Review Shipping Options` task is completed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
