### PR TITLE
Expanded Turbo Task Inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -12,12 +12,18 @@
         "build": {
             "dependsOn":  [ "^build" ],
             "inputs": [
-                "src/**.js",
-                "src/**.jsx",
-                "src/**.ts",
-                "src/**.tsx",
-                "src/**.php",
-                "includes/**.php"
+                "src/*.js",
+                "src/**/*.js",
+                "src/*.jsx",
+                "src/**/*.jsx",
+                "src/*.ts",
+                "src/**/*.ts",
+                "src/*.tsx",
+                "src/**/*.tsx",
+                "src/*.php",
+                "src/**/*.php",
+                "includes/*.php",
+                "includes/**/*.php"
             ],
             "outputs": [
                 "dist/**",
@@ -35,21 +41,28 @@
             ],
             "outputs": [],
             "inputs": [
-                "src/**.php",
-                "includes/**.php",
-                "!legacy/**"
+                "src/*.php",
+                "src/**/*.php",
+                "includes/*.php",
+                "includes/**/*.php"
             ]
         },
 
         "test": {
             "dependsOn":  [ "build" ],
             "inputs": [
-                "src/**.js",
-                "src/**.jsx",
-                "src/**.ts",
-                "src/**.tsx",
-                "src/**.php",
-                "includes/**.php"
+                "src/*.js",
+                "src/**/*.js",
+                "src/*.jsx",
+                "src/**/*.jsx",
+                "src/*.ts",
+                "src/**/*.ts",
+                "src/*.tsx",
+                "src/**/*.tsx",
+                "src/*.php",
+                "src/**/*.php",
+                "includes/*.php",
+                "includes/**/*.php"
             ],
             "outputs": []
         },


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

According to https://github.com/vercel/turborepo/issues/1241, Turbo uses an inconsistent globbing syntax right now. This pull request changes the `"inputs"` for our pipelines to accommodate that.

### How to test the changes in this Pull Request:

1. Run `pnpm -- turbo run build`
2. Make a change to `plugins/woocommerce/src/Autoloader.php`
3. Without this PR, it will not rebuild the WooCommerce package. With this PR, it will rebuild the package.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
