### PR TITLE
Fix Protected Directory Detection and Admin Notice

### DIFF
--- a/plugins/woocommerce/changelog/unprotected-dir-warning
+++ b/plugins/woocommerce/changelog/unprotected-dir-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make the 'unprotected upload directory' notice dismissable.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -646,16 +646,9 @@ class WC_Admin_Notices {
 		$response_code    = intval( wp_remote_retrieve_response_code( $response ) );
 		$response_content = wp_remote_retrieve_body( $response );
 
-		// Check that the request either...
-		// 1. Returns a non-200 status code
-		// 2. Has empty or null contents (protected by empty index files; avoids regex test when possible)
-		// 3. Does not look like an Index page (i.e., it has "Index of <...>" in title and contains a <table> element)
-		$is_protected = (
-			200 !== $response_code
-			|| empty( $response_content )
-			|| 1 !== preg_match( '/<title[^>]*>\\s*index\\s+of\\s+[\\s\\S]*<table/i', $response_content )
-		);
-
+		// Check if returns 200 with empty content in case can open an index.html file,
+		// and check for non-200 codes in case the directory is protected.
+		$is_protected = ( 200 === $response_code && empty( $response_content ) ) || ( 200 !== $response_code );
 		set_transient( $cache_key, $is_protected ? 'protected' : 'unprotected', 1 * DAY_IN_SECONDS );
 
 		return $is_protected;

--- a/plugins/woocommerce/includes/admin/views/html-notice-uploads-directory-is-unprotected.php
+++ b/plugins/woocommerce/includes/admin/views/html-notice-uploads-directory-is-unprotected.php
@@ -12,7 +12,7 @@ $uploads = wp_get_upload_dir();
 
 ?>
 <div id="message" class="error woocommerce-message">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'uploads_directory_is_public' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'uploads_directory_is_unprotected' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
 	<p>
 	<?php


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. make unprotected directory detection smarter: not every /woocommerce_uploads/ page with content is a directory listing
2. make notice actually close when clicking "Dismiss"

Closes #33436.

### How to test the changes in this Pull Request:

1. Modify `wp-content/uploads/woocommerce-uploads/index.html` (create it if it does not exist) and add some text  to this file (anything at all will do).
2. Reset your admin notices by clearing transients and calling `WC_Admin_Notices::reset_admin_notices()`. Additionally, a user meta field (`dismissed_uploads_directory_is_unprotected_notice`) may need to be deleted. To do this via WP CLI:
     - `wp transient delete _woocommerce_upload_directory_status`
     - `wp eval "WC_Admin_Notices::reset_admin_notices();"`
     - `wp user meta delete $(wp user get admin --field=ID) dismissed_uploads_directory_is_unprotected_notice` ← *change `admin` to the username of your test user.*
3. Now visit an admin screen such as **WooCommerce ▸ Settings ▸ General** and you should see an admin notice warning that your uploads directory is not protected:

![unprotected-downloads-dir](https://user-images.githubusercontent.com/3594411/204891850-2e8c698f-fe7f-4f2d-8faa-e22d3d282ecd.png)

4. Dismiss the notice ... give it a few seconds so that the page reloads and the notice should no longer be present.
5. Navigate to another admin screen such as **WooCommerce ▸ Settings ▸ Products**, then back to **WooCommerce ▸ Settings ▸ General**. The unprotected directory notice should remain hidden.
6. Once you complete your testing, you should restore `wp-content/uploads/woocommerce-uploads/index.html` to its earlier state (normally, this file is present but is completely empty).

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
