### PR TITLE
Add logic to set the default shipping options on homescreen

### DIFF
--- a/plugins/woocommerce/changelog/feature-33366-automatically-set-default-shipping-options
+++ b/plugins/woocommerce/changelog/feature-33366-automatically-set-default-shipping-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Set default shipping methods based on the OBW selections

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -83,7 +83,7 @@ class Homescreen {
 			return $settings;
 		}
 
-		$country_code = explode( ':', $settings['preloadSettings']['general']['woocommerce_default_country'] ?? '' )[0];
+		$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
 		$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
 
 		if ( '' === $country_code || null === $country_name ) {

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -87,7 +87,7 @@ class Homescreen {
 		}
 
 		$user_skipped_obw = $settings['onboarding']['profile']['skipped'] ?? false;
-		$store_address = $settings['preloadSettings']['general']['store_address'] ?? '';
+		$store_address = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
 		$product_types = $settings['onboarding']['profile']['product_types'] ?? array();
 
 		// If user skipped the obw or has not completed the store_details
@@ -117,7 +117,7 @@ class Homescreen {
 		if (
 			( 'US' === $country_code && $is_jetpack_installed && $is_wcs_installed && $is_jetpack_connected )
 			||
-			( ! in_array( $country_code, array( 'US', 'CA', 'AU', 'UK' ), true ) )
+			( ! in_array( $country_code, array( 'US', 'CA', 'AU', 'GB' ), true ) )
 			||
 			( 'US' === $country_code && false === $is_jetpack_installed && false === $is_wcs_installed )
 		) {

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -125,24 +125,6 @@ class Homescreen {
 			$zone->set_zone_name( $country_name );
 			$zone->add_location( $country_code, 'country' );
 			$zone->add_shipping_method( 'free_shipping' );
-
-			$other_countries_zone = new \WC_Shipping_Zone( 0 );
-			if ( ! $other_countries_zone->meta_exists( 'flat_rate' ) ) {
-				$instance_id = $other_countries_zone->add_shipping_method( 'flat_rate' );
-				$other_countries_zone->save();
-
-				$shipping_methods = $other_countries_zone->get_shipping_methods( true );
-				foreach ( $shipping_methods as $shipping_method ) {
-					if ( $shipping_method->get_instance_id() === $instance_id ) {
-						$option_id        = 'woocommerce_flat_rate_' . $instance_id . '_settings';
-						$settings         = get_option( $option_id );
-						$settings['cost'] = 15;
-						update_option( $option_id, $settings );
-						break;
-					}
-				}
-			}
-
 			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -86,7 +86,17 @@ class Homescreen {
 			return $settings;
 		}
 
-		if ( false === in_array( 'physical', $settings['onboarding']['profile']['product_types'] ?? array(), true ) ) {
+		$user_skipped_obw = $settings['onboarding']['profile']['skipped'] ?? false;
+		$store_address = $settings['preloadSettings']['general']['store_address'] ?? '';
+		$product_types = $settings['onboarding']['profile']['product_types'] ?? array();
+
+		// If user skipped the obw or has not completed the store_details
+		// then we assume the user is going to sell physical products.
+		if ( $user_skipped_obw || '' === $store_address ) {
+			$product_types[] = 'physical';
+		}
+
+		if ( false === in_array( 'physical', $product_types, true ) ) {
 			return $settings;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -103,7 +103,10 @@ class Homescreen {
 		$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
 		$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
 
-		if ( '' === $country_code || null === $country_name ) {
+		// we also need to make sure woocommerce_store_address is not empty
+		// to make sure store country is set by an actual user
+		// since woocommerce_store_address is set to US:CA by default.
+		if ( '' === $country_code || null === $country_name || '' === $store_address ) {
 			return $settings;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -6,8 +6,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
-use Automattic\WooCommerce\Internal\Admin\Settings;
-use WC_Shipping_Flat_Rate;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 /**
  * Contains backend logic for the homescreen feature.
@@ -50,8 +49,16 @@ class Homescreen {
 			// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 			add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );
 		}
+
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
-		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'maybe_set_default_shipping_options_on_home' ), 9999 );
+
+		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
+			add_filter(
+				'woocommerce_admin_shared_settings',
+				array( $this, 'maybe_set_default_shipping_options_on_home' ),
+				9999
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33366  .

- Adds a shipping zone for the store country based on OBW selections
- Adds Flat rate for any other countries.

### How to test the changes in this Pull Request:

For each test case, please delete all the shipping zones and `woocommerce_admin_created_default_shipping_zones` option, or start with a fresh install.

You can also run the following queries to clear shipping settings

```
delete from wp_woocommerce_shipping_zones
delete from wp_woocommerce_shipping_zone_methods
delete from wp_woocommerce_shipping_zone_locations
```

**Case 1: The store sells physical products and is located in the US, but JP and WCS are not installed.**

1. Start with a fresh install
2. Sart OBW and choose `United States` as store country
3. Choose "Physical products" 
4. Complete the OBW without installing anything from the `Business Details` tab.
5. Navigate to WooCommerce -> Settings -> Shipping
6. "United States (US)" zone should be created with `Free shipping` method

**Case 2: The store sells physical products, has JP and WCS installed and connected, and is located in the US.**

1. Start with a fresh install
2. Sart OBW and choose `United States` as store country
3. Choose "Physical products" 
4. Install Jetpack and WooCommerce Shipping from the `Business Details` tab.
5. Complete the OBW 
6. Connect and approve Jetpack when prompted.
7. Navigate to WooCommerce -> Settings -> Shipping
8. "United States (US)" zone should be created with `Free shipping` method

**Case 3: The store sells physical products, and is not located in US/Canada/Australia/UK (irrelevant if JP is installed or not).**

1. Start with a fresh install
2. Sart OBW and choose a country that is not one of the US, Canada, Australia, and UK
3. Choose "Physical products" 
4. Complete the OBW without installing anything from the `Business Details` tab.
5. Navigate to WooCommerce -> Settings -> Shipping
6. "Country-you-chose" zone should be created with `Free shipping` method


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
