### PR TITLE
Dev: allow unused destructured variables in lint rules

### DIFF
--- a/packages/js/data/src/items/utils.ts
+++ b/packages/js/data/src/items/utils.ts
@@ -129,10 +129,6 @@ export function searchItemsByString< T extends ItemType >(
  * @return {string} Resource name for item totals.
  */
 export function getTotalCountResourceName( itemType: string, query: Query ) {
-	// Disable eslint rule because we're using this spread to omit properties
-	// that don't affect item totals count results.
-	// eslint-disable-next-line no-unused-vars, camelcase
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { _fields, page, per_page, ...totalsQuery } = query;
 
 	return getResourceName( 'total-' + itemType, { ...totalsQuery } );

--- a/packages/js/data/src/orders/test/reducer.ts
+++ b/packages/js/data/src/orders/test/reducer.ts
@@ -100,8 +100,6 @@ describe( 'orders reducer', () => {
 			totalCount,
 		} );
 
-		const resourceName = getOrderResourceName( query );
-
 		expect( state.data[ 1 ].total ).toEqual( initialState.data[ 1 ].total );
 		expect( state.data[ 2 ] ).toEqual( orders[ 1 ] );
 	} );

--- a/packages/js/data/src/orders/utils.ts
+++ b/packages/js/data/src/orders/utils.ts
@@ -28,9 +28,6 @@ export function getOrderResourceName( query: Partial< OrdersQuery > ) {
 export function getTotalOrderCountResourceName(
 	query: Partial< OrdersQuery >
 ) {
-	// Disable eslint rule because we're using this spread to omit properties
-	// that don't affect item totals count results.
-	// eslint-disable-next-line no-unused-vars, camelcase
 	const { _fields, page, per_page, ...totalsQuery } = query;
 
 	return getOrderResourceName( totalsQuery );

--- a/packages/js/data/src/products/utils.ts
+++ b/packages/js/data/src/products/utils.ts
@@ -28,10 +28,6 @@ export function getProductResourceName( query: Partial< ProductQuery > ) {
 export function getTotalProductCountResourceName(
 	query: Partial< ProductQuery >
 ) {
-	// Disable eslint rule because we're using this spread to omit properties
-	// that don't affect item totals count results.
-	// eslint-disable-next-line no-unused-vars, camelcase
 	const { _fields, page, per_page, ...totalsQuery } = query;
-
 	return getProductResourceName( totalsQuery );
 }

--- a/packages/js/eslint-plugin/changelog/dev-allow-unused-destructured-vars
+++ b/packages/js/eslint-plugin/changelog/dev-allow-unused-destructured-vars
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Allow unused destructured variables in lint rules #35548

--- a/packages/js/eslint-plugin/configs/recommended.js
+++ b/packages/js/eslint-plugin/configs/recommended.js
@@ -35,10 +35,11 @@ module.exports = {
 				],
 			},
 		],
-		'no-unused-vars': [
+		'@typescript-eslint/no-unused-vars': [
 			'error',
 			{
 				varsIgnorePattern: 'createElement',
+				ignoreRestSiblings: true,
 			},
 		],
 		'react/react-in-jsx-scope': 'error',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added exception to eslint rule for no-unused-vars to allow destructured variables to have unused siblings to rest variables.

There were exceptions to the rule being added everywhere and it seems to be a legitimate use case

### How to test the changes in this Pull Request:

1. Repo should build fine without any issue as there were no changes


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
