### PR TITLE
Fix payments settings banner experiment logic

### DIFF
--- a/plugins/woocommerce-admin/client/payments/use-payments-experiment.ts
+++ b/plugins/woocommerce-admin/client/payments/use-payments-experiment.ts
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { loadExperimentAssignment } from '@woocommerce/explat';
+import { ExperimentAssignment } from '@automattic/explat-client';
+import { useSelect } from '@wordpress/data';
+import {
+	ONBOARDING_STORE_NAME,
+	PAYMENT_GATEWAYS_STORE_NAME,
+	PaymentGateway,
+	WCDataSelector,
+} from '@woocommerce/data';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { isWcPaySupported } from './utils';
+
+export const usePaymentExperiment = () => {
+	const [ isLoadingExperiment, setIsLoadingExperiment ] =
+		useState< boolean >( true );
+	const [ experimentAssignment, setExperimentAssignment ] =
+		useState< null | ExperimentAssignment >( null );
+
+	const {
+		installedPaymentGateways,
+		paymentGatewaySuggestions,
+		hasFinishedResolution,
+	} = useSelect( ( select: WCDataSelector ) => {
+		return {
+			installedPaymentGateways: select(
+				PAYMENT_GATEWAYS_STORE_NAME
+			).getPaymentGateways(),
+			paymentGatewaySuggestions: select(
+				ONBOARDING_STORE_NAME
+			).getPaymentGatewaySuggestions(),
+			hasFinishedResolution:
+				select( ONBOARDING_STORE_NAME ).hasFinishedResolution(
+					'getPaymentGatewaySuggestions'
+				) &&
+				select( PAYMENT_GATEWAYS_STORE_NAME ).hasFinishedResolution(
+					'getPaymentGateways'
+				),
+		};
+	} );
+
+	const isWcPayInstalled = installedPaymentGateways.some(
+		( gateway: PaymentGateway ) => {
+			return gateway.id === 'woocommerce_payments';
+		}
+	);
+
+	const isWcPayDisabled = installedPaymentGateways.find(
+		( gateway: PaymentGateway ) => {
+			return (
+				gateway.id === 'woocommerce_payments' &&
+				gateway.enabled === false
+			);
+		}
+	);
+
+	useEffect( () => {
+		if (
+			experimentAssignment === null &&
+			hasFinishedResolution &&
+			isWcPaySupported( paymentGatewaySuggestions ) &&
+			isWcPayInstalled &&
+			isWcPayDisabled
+		) {
+			const momentDate = moment().utc();
+			const year = momentDate.format( 'YYYY' );
+			const month = momentDate.format( 'MM' );
+			setIsLoadingExperiment( true );
+			loadExperimentAssignment(
+				`woocommerce_payments_settings_banner_${ year }_${ month }`
+			)
+				.then( ( assignment ) => {
+					setExperimentAssignment( assignment );
+					setIsLoadingExperiment( false );
+				} )
+				.catch( () => {
+					setIsLoadingExperiment( false );
+				} );
+		} else if ( hasFinishedResolution ) {
+			setIsLoadingExperiment( false );
+		}
+	}, [
+		experimentAssignment,
+		hasFinishedResolution,
+		isWcPayDisabled,
+		isWcPayInstalled,
+		paymentGatewaySuggestions,
+	] );
+
+	return {
+		isLoadingExperiment,
+		experimentAssignment,
+	};
+};

--- a/plugins/woocommerce/changelog/fix-payments-settings-banner-experiment-logic
+++ b/plugins/woocommerce/changelog/fix-payments-settings-banner-experiment-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix payments experiment banner logic to be executed before experiment is called


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Previously, the payments settings banner experiment was called before the logic for eligibility is executed. This means that all users who visited the payments settings screen were participants of the experiment, which will skew the experiment results since most of them would be in `treatment` but they don't experience the banner.

This fix ensures only eligible users can participate the experiment.

### How to test the changes in this Pull Request:

2. Create a site where WooCommerce Payments isn't installed but is in a supported country (such as US)
3. Use the `treatment` bookmarklet obtained from Abacus for `woocommerce_payments_settings_banner_2022_06` experiment
4. Open browser's console and go to application cache
5. Delete `woocommerce_payments_settings_banner_2022_06 ` experiment from the cache
6. Open the Networks tab and filter for the keyword `woocommerce_payments_settings_banner_2022_06`
7. Navigate to WooCommerce > Settings > Payment
8. Make sure no experiment is requested in the networks tab
9. Install & enable WooCommerce Payments plugin
6. Navigate to WooCommerce > Settings > Payment
7. Observe the experiment is requested and the banner is shown

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
