### PR TITLE
Product: check for empty object before deleting subscription notes.

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
@@ -301,9 +301,10 @@ class WooSubscriptionsNotes {
 
 				foreach ( (array) $bump_thresholds as $bump_threshold ) {
 					if ( ( $note_days_until_expiration > $bump_threshold ) && ( $days_until_expiration <= $bump_threshold ) ) {
-						$note->delete();
-						$note = false;
-						continue;
+						if ( $note ) {
+							$note->delete();
+							$note = false;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/mothra-private/issues/23.

It seems to be coming from an edge case when the condition `($note_days_until_expiration > $bump_threshold ) && ( $days_until_expiration <= $bump_threshold ) )` is met for > 1 combination of thresholds as we iterate over them. 

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.


### References:

- p1655797891082209-slack-C7U3Y3VMY
- p1655887957113069-slack-C01CMSA1VHS