### PR TITLE
Update e2e README port number, remove Nx install PreRequisite steps

### DIFF
--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -31,10 +31,6 @@ Automated end-to-end tests for WooCommerce.
 
 ## Pre-requisites
 
-### Install Nx
-
-Follow [instructions on nx.dev site](https://nx.dev/l/r/getting-started/nx-setup) to install Nx.
-
 ### Install pnpm
 
 Follow [instructions on pnpm.io site](https://pnpm.io/installation) to install pnpm.
@@ -133,7 +129,7 @@ Run the following in a terminal/command line window
 ```
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                  NAMES
 c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago       Up 5 seconds                               woocommerce_e2e_wordpress-cli
-2ab8e8439e9f        wordpress:5.5.1     "docker-entrypoint.s…"   8 seconds ago       Up 7 seconds        0.0.0.0:8084->80/tcp   woocommerce_e2e_wordpress-www
+2ab8e8439e9f        wordpress:5.5.1     "docker-entrypoint.s…"   8 seconds ago       Up 7 seconds        0.0.0.0:8086->80/tcp   woocommerce_e2e_wordpress-www
 4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_e2e_db
 ```
 
@@ -141,9 +137,9 @@ Note that by default, Docker will download the latest images available for WordP
 
 See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.  
 
-- Navigate to `http://localhost:8084/`
+- Navigate to `http://localhost:8086/`
 
-If everything went well, you should be able to access the site. If you changed the port to something other than `8084` as per [Test Variables](#test-variables) section, use the appropriate port to access your site. 
+If everything went well, you should be able to access the site. If you changed the port to something other than `8086` as per [Test Variables](#test-variables) section, use the appropriate port to access your site. 
 
 As noted in [Test Variables](#test-variables) section, use the following Admin user details to login:
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove the PreRequisite step to install Nx as it appears that we are migrating from Nx to Turborepo as can be seen in the following PR:
https://github.com/woocommerce/woocommerce/pull/33079

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When I ran the e2e tests on my local machine, I noticed that WordPress and mariadb were running but not the env_wordpress-cli
i.e. https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md stated:
![image](https://user-images.githubusercontent.com/105309450/175020161-4b351341-4489-4ee2-a403-f31b191b82fb.png)

And mine was as follows:
![image](https://user-images.githubusercontent.com/105309450/175020192-6b3bc457-e9bc-419e-92af-2af96e40e07f.png)


Then when I attempted to launch http://localhost:8084/ I saw:
![image](https://user-images.githubusercontent.com/105309450/175020230-e36d9208-f983-491d-a719-fa4f6bcc13dc.png)


I then spotted the following in the installation instructions
If you need to modify the port for your local test environment (eg. port is already in use), edit tests/e2e/config/default.json

I navigated to https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/config/default.json and spotted the url was:
http://localhost:8086/ - and thought that we may possibly need to update the instructions?

Using this url I was able to get into the "Hello world" 
[WooCommerce Core E2E Test Suite](http://localhost:8086/)
![image](https://user-images.githubusercontent.com/105309450/175020447-5e7411f2-9dce-4106-ad1a-4c52fbf4a71d.png)


### How to test the changes in this Pull Request:

n/a - this is a README.md change and if the installation instructions for Nx have been removed and the port number is updated in the 3 locations from 8084 to 8086 then the PR has been completed.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
