### PR TITLE
Added mechanism to customize data before AJAX requests in `meta-boxes-order.js`

### DIFF
--- a/plugins/woocommerce/changelog/add-order-metabox-data-filter
+++ b/plugins/woocommerce/changelog/add-order-metabox-data-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added a mechanism to customize the data being sent via AJAX by the order meta box

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -334,7 +334,11 @@ jQuery( function ( $ ) {
 		},
 
 		filter_data: function( handle, data ) {
-			const filteredData = $( '#woocommerce-order-items' ).triggerHandler( `woocommerce_order_meta_box_${handle}_ajax_data`, [ data ] );
+			const filteredData = $( '#woocommerce-order-items' )
+				.triggerHandler( 
+					`woocommerce_order_meta_box_${handle}_ajax_data`, 
+					[ data ] 
+				);
 
 			if ( filteredData ) {
 				return filteredData;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -334,7 +334,7 @@ jQuery( function ( $ ) {
 		},
 
 		filter_data: function( handle, data ) {
-			const filteredData = $( '#woocommerce-order-items' ).triggerHandler( `${handle}_ajax_data`, [ data ] );
+			const filteredData = $( '#woocommerce-order-items' ).triggerHandler( `woocommerce_order_meta_box_${handle}_ajax_data`, [ data ] );
 
 			if ( filteredData ) {
 				return filteredData;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -333,12 +333,24 @@ jQuery( function ( $ ) {
 			$( '#woocommerce-order-items' ).unblock();
 		},
 
+		filter_data: function( handle, data ) {
+			const filteredData = $( '#woocommerce-order-items' ).triggerHandler( `${handle}_ajax_data`, [ data ] );
+
+			if ( filteredData ) {
+				return filteredData;
+			}
+
+			return data;
+		},
+
 		reload_items: function() {
 			var data = {
 				order_id: woocommerce_admin_meta_boxes.post_id,
 				action:   'woocommerce_load_order_items',
 				security: woocommerce_admin_meta_boxes.order_item_nonce
 			};
+
+			data = wc_meta_boxes_order_items.filter_data( 'reload_items', data );
 
 			wc_meta_boxes_order_items.block();
 
@@ -462,6 +474,8 @@ jQuery( function ( $ ) {
 					user_email : user_email
 				} );
 
+				data = wc_meta_boxes_order_items.filter_data( 'add_coupon', data );
+
 				$.ajax( {
 					url:     woocommerce_admin_meta_boxes.ajax_url,
 					data:    data,
@@ -499,6 +513,8 @@ jQuery( function ( $ ) {
 				security : woocommerce_admin_meta_boxes.order_item_nonce,
 				coupon : $this.data( 'code' )
 			} );
+
+			data = wc_meta_boxes_order_items.filter_data( 'remove_coupon', data );
 
 			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 				if ( response.success ) {
@@ -587,6 +603,8 @@ jQuery( function ( $ ) {
 					amount  : value
 				} );
 
+				data = wc_meta_boxes_order_items.filter_data( 'add_fee', data );
+
 				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 					if ( response.success ) {
 						$( '#woocommerce-order-items' ).find( '.inside' ).empty();
@@ -594,7 +612,7 @@ jQuery( function ( $ ) {
 							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
 							window.wcTracks.recordEvent( 'order_edit_added_fee', {
-								order_id: data.post_id,
+								order_id: woocommerce_admin_meta_boxes.post_id,
 								status: $( '#order_status' ).val()
 							} );
 					} else {
@@ -616,11 +634,13 @@ jQuery( function ( $ ) {
 				dataType : 'json'
 			};
 
+			data = wc_meta_boxes_order_items.filter_data( 'add_shipping', data );
+
 			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 				if ( response.success ) {
 					$( 'table.woocommerce_order_items tbody#order_shipping_line_items' ).append( response.data.html );
 					window.wcTracks.recordEvent( 'order_edit_add_shipping', {
-						order_id: data.post_id,
+						order_id: woocommerce_admin_meta_boxes.post_id,
 						status: $( '#order_status' ).val()
 					} );
 				} else {
@@ -683,6 +703,8 @@ jQuery( function ( $ ) {
 					data.items = $( 'table.woocommerce_order_items :input[name], .wc-order-totals-items :input[name]' ).serialize();
 				}
 
+				data = wc_meta_boxes_order_items.filter_data( 'delete_item', data );
+
 				$.ajax({
 					url:     woocommerce_admin_meta_boxes.ajax_url,
 					data:    data,
@@ -707,7 +729,7 @@ jQuery( function ( $ ) {
 					},
 					complete: function() {
 						window.wcTracks.recordEvent( 'order_edit_remove_item', {
-							order_id: data.post_id,
+							order_id: woocommerce_admin_meta_boxes.post_id,
 							status: $( '#order_status' ).val()
 						} );
 					}
@@ -726,6 +748,8 @@ jQuery( function ( $ ) {
 					order_id: woocommerce_admin_meta_boxes.post_id,
 					security: woocommerce_admin_meta_boxes.order_item_nonce
 				};
+
+				data = wc_meta_boxes_order_items.filter_data( 'delete_tax', data );
 
 				$.ajax({
 					url:  woocommerce_admin_meta_boxes.ajax_url,
@@ -797,6 +821,8 @@ jQuery( function ( $ ) {
 					security: woocommerce_admin_meta_boxes.calc_totals_nonce
 				} );
 
+				data = wc_meta_boxes_order_items.filter_data( 'recalculate', data );
+
 				$( document.body ).trigger( 'order-totals-recalculate-before', data );
 
 				$.ajax({
@@ -815,7 +841,7 @@ jQuery( function ( $ ) {
 						$( document.body ).trigger( 'order-totals-recalculate-complete', response );
 
 						window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
-							order_id: data.post_id,
+							order_id: woocommerce_admin_meta_boxes.post_id,
 							ok_cancel: 'OK',
 							status: $( '#order_status' ).val()
 						} );
@@ -839,6 +865,8 @@ jQuery( function ( $ ) {
 				action:   'woocommerce_save_order_items',
 				security: woocommerce_admin_meta_boxes.order_item_nonce
 			};
+
+			data = wc_meta_boxes_order_items.filter_data( 'save_line_items', data );
 
 			wc_meta_boxes_order_items.block();
 
@@ -866,7 +894,7 @@ jQuery( function ( $ ) {
 				},
 				complete: function() {
 					window.wcTracks.recordEvent( 'order_edit_save_line_items', {
-						order_id: data.post_id,
+						order_id: woocommerce_admin_meta_boxes.post_id,
 						status: $( '#order_status' ).val()
 					} );
 				}
@@ -938,6 +966,8 @@ jQuery( function ( $ ) {
 						security              : woocommerce_admin_meta_boxes.order_item_nonce
 					};
 
+					data = wc_meta_boxes_order_items.filter_data( 'do_refund', data );
+
 					$.ajax( {
 						url:     woocommerce_admin_meta_boxes.ajax_url,
 						data:    data,
@@ -979,6 +1009,8 @@ jQuery( function ( $ ) {
 						refund_id: refund_id,
 						security:  woocommerce_admin_meta_boxes.order_item_nonce
 					};
+
+					data = wc_meta_boxes_order_items.filter_data( 'delete_refund', data );
 
 					$.ajax({
 						url:     woocommerce_admin_meta_boxes.ajax_url,
@@ -1192,6 +1224,8 @@ jQuery( function ( $ ) {
 					data.items = $( 'table.woocommerce_order_items :input[name], .wc-order-totals-items :input[name]' ).serialize();
 				}
 
+				data = wc_meta_boxes_order_items.filter_data( 'add_items', data );
+
 				$.ajax({
 					type: 'POST',
 					url: woocommerce_admin_meta_boxes.ajax_url,
@@ -1216,7 +1250,7 @@ jQuery( function ( $ ) {
 					},
 					complete: function() {
 						window.wcTracks.recordEvent( 'order_edit_add_products', {
-							order_id: data.post_id,
+							order_id: woocommerce_admin_meta_boxes.post_id,
 							status: $( '#order_status' ).val()
 						} );
 					},
@@ -1248,6 +1282,8 @@ jQuery( function ( $ ) {
 						security: woocommerce_admin_meta_boxes.order_item_nonce
 					};
 
+					data = wc_meta_boxes_order_items.filter_data( 'add_tax', data );
+
 					$.ajax({
 						url      : woocommerce_admin_meta_boxes.ajax_url,
 						data     : data,
@@ -1265,7 +1301,7 @@ jQuery( function ( $ ) {
 						},
 						complete: function() {
 							window.wcTracks.recordEvent( 'order_edit_add_tax', {
-								order_id: data.post_id,
+								order_id: woocommerce_admin_meta_boxes.post_id,
 								status: $( '#order_status' ).val()
 							} );
 						}
@@ -1330,7 +1366,7 @@ jQuery( function ( $ ) {
 				$( '#woocommerce-order-notes' ).unblock();
 				$( '#add_order_note' ).val( '' );
 				window.wcTracks.recordEvent( 'order_edit_add_order_note', {
-					order_id: data.post_id,
+					order_id: woocommerce_admin_meta_boxes.post_id,
 					note_type: data.note_type || 'private',
 					status: $( '#order_status' ).val()
 				} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

#### Context
This PR adds a mechanism to customize the data sent by each AJAX-related method of the `wc_meta_boxes_order_items` object. This mechanism is similar to [what is already in place](https://github.com/woocommerce/woocommerce/blob/3669426bd6af4a6816184f843ffdaf9790af8d84/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js#L814) in the `meta-boxes-product-variation.js` script. Thanks to this change, third-party plugins can customize the data before it is processed by the server-side functions.

#### Use case
A plugin allows using custom product prices based on the customer (e.g. role, country, previous purchases, etc.). The current script doesn't send any information related to the selected customer. For this reason, there is no way to determine the correct product price to be used in the order. With this change, the plugin in this example can alter the data being sent via AJAX by adding the following script:

```js
$( '#woocommerce-order-items' ).on( 'add_items_ajax_data recalculate_ajax_data', (event, data) => {
	const customer = $( '#customer_user' ).val();

	if (  customer ) {
		data.customer = customer
	}

	return data;
} )

```
It then can use the additional data to process the price calculation on the server-side.

#### Technical details
A call to `triggerHandler` has been added to each method of the `wc_meta_boxes_order_items` that sends an AJAX request. This way, a third-party plugin can alter the data before it is sent via AJAX. Consistently with the above-mentioned `meta-boxes-product-variation.js` script, the call to `triggerHandler` uses an event name in the form of `${methodName}_ajax_data`. For example, the `add_items` method will call it as follows:

```js
data = $( '#woocommerce-order-items' ).triggerHandler( 'add_items_ajax_data', [ data ] );
```

Since `triggerHandler` always returns `undefined` if no callback is attached to the event, a `filter_data` wrapper method has been added to the `wc_meta_boxes_order_items` object so that the method returns the filtered data only if it is not falsey. The method receives two parameters: (1) a prefix for the handle/event name that depends on the method calling `filter_data`; (2) the data object.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
