### PR TITLE
Add/33331 wcadmin install timestamp explat default

### DIFF
--- a/packages/js/explat/changelog/add-33331-wcadmin-install-timestamp-explat-default
+++ b/packages/js/explat/changelog/add-33331-wcadmin-install-timestamp-explat-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Include the woocommerce_admin_install_timestamp option value in the explat assignment query string as woo_wcadmin_install_timestamp. #33574

--- a/packages/js/explat/src/assignment.ts
+++ b/packages/js/explat/src/assignment.ts
@@ -13,6 +13,7 @@ type QueryParams = {
 	experiment_name: string;
 	anon_id: string | null;
 	woo_country_code: string;
+	woo_wcadmin_install_timestamp: string;
 };
 
 const isValidQueryParams = (
@@ -20,7 +21,10 @@ const isValidQueryParams = (
 ): queryParams is QueryParams => {
 	return (
 		( queryParams as QueryParams ).hasOwnProperty( 'experiment_name' ) &&
-		( queryParams as QueryParams ).hasOwnProperty( 'woo_country_code' )
+		( queryParams as QueryParams ).hasOwnProperty( 'woo_country_code' ) &&
+		( queryParams as QueryParams ).hasOwnProperty(
+			'woo_wcadmin_install_timestamp'
+		)
 	);
 };
 
@@ -52,6 +56,9 @@ const getRequestQueryParams = ( {
 				?.woocommerce_default_country ||
 			window.wcSettings?.admin?.preloadSettings?.general
 				?.woocommerce_default_country,
+		woo_wcadmin_install_timestamp:
+			window.wcSettings?.admin?.preloadOptions
+				?.woocommerce_admin_install_timestamp,
 	} );
 
 	if ( ! isValidQueryParams( queryParams ) ) {

--- a/packages/js/explat/src/test/assignment-test.js
+++ b/packages/js/explat/src/test/assignment-test.js
@@ -85,6 +85,28 @@ describe( 'fetchExperimentAssignment', () => {
 		} );
 		await expect( assignment ).toEqual( data );
 	} );
+
+	it( 'adds woo_wcadmin_install_timestamp to request args', () => {
+		const filterArgs = { args: {} };
+		addFilter(
+			'woocommerce_explat_request_args',
+			'woo_wcadmin_install_timestamp_test',
+			function ( args ) {
+				filterArgs.args = args;
+				return args;
+			}
+		);
+
+		const fetchPromise = fetchExperimentAssignmentWithAuth( {
+			experimentName: '123',
+			anonId: 'abc',
+		} );
+		Promise.resolve( fetchPromise );
+
+		expect( filterArgs.args ).toHaveProperty(
+			'woo_wcadmin_install_timestamp'
+		);
+	} );
 } );
 
 describe( 'fetchExperimentAssignmentWithAuth', () => {
@@ -112,6 +134,28 @@ describe( 'fetchExperimentAssignmentWithAuth', () => {
 				credentials: 'include',
 				headers: { Accept: 'application/json, */*;q=0.1' },
 			}
+		);
+	} );
+
+	it( 'adds woo_wcadmin_install_timestamp to request args', () => {
+		const filterArgs = { args: {} };
+		addFilter(
+			'woocommerce_explat_request_args',
+			'woo_wcadmin_install_timestamp_test',
+			function ( args ) {
+				filterArgs.args = args;
+				return args;
+			}
+		);
+
+		const fetchPromise = fetchExperimentAssignmentWithAuth( {
+			experimentName: '123',
+			anonId: 'abc',
+		} );
+		Promise.resolve( fetchPromise );
+
+		expect( filterArgs.args ).toHaveProperty(
+			'woo_wcadmin_install_timestamp'
 		);
 	} );
 } );

--- a/packages/js/explat/src/utils.ts
+++ b/packages/js/explat/src/utils.ts
@@ -10,8 +10,14 @@ interface generalSettings {
 interface preloadSettings {
 	general: generalSettings;
 }
+
+interface preloadOptions {
+	woocommerce_admin_install_timestamp: string;
+}
+
 interface admin {
 	preloadSettings: preloadSettings;
+	preloadOptions: preloadOptions;
 }
 
 interface wcSettings {


### PR DESCRIPTION
Add `wcSettings.admin.preloadOptions.woocommerce_admin_install_timestamp` to default Explat `queryArgs`.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add preloaded option `woo_wcadmin_install_timestamp` to default query string arguments for explat fetches from the client.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33331 .

### How to test the changes in this Pull Request:

1. Open the Network tab of Developer Tools (or the equivalent in your browser) and filter by 'experiment_name'.
2. Go through the onboarding wizard. (If you're not starting from a fresh site you may also need to use WCA Test Helper to clear existing experiment assignment options.)
3. Verify that all requests for explat assignments have a query string parameter called 'woo_wcadmin_install_timestamp' that contains number (for bonus points check it against the install timestamp in your database).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
