### PR TITLE
Stock checks not required if stock levels have already been reduced.

### DIFF
--- a/plugins/woocommerce/changelog/fix-33307-my-account-order-pay
+++ b/plugins/woocommerce/changelog/fix-33307-my-account-order-pay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Customers should be able to pay for orders so long as any required stock reductions have already taken place.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -138,31 +138,34 @@ class WC_Shortcode_Checkout {
 						}
 					}
 
-					foreach ( $order->get_items() as $item_key => $item ) {
-						if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
-							$product = $item->get_product();
+					// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
+					if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
+						foreach ( $order->get_items() as $item_key => $item ) {
+							if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+								$product = $item->get_product();
 
-							if ( ! $product ) {
-								continue;
-							}
+								if ( ! $product ) {
+									continue;
+								}
 
-							if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
-								/* translators: %s: product name */
-								throw new Exception( sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name() ) );
-							}
+								if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
+									/* translators: %s: product name */
+									throw new Exception( sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name() ) );
+								}
 
-							// We only need to check products managing stock, with a limited stock qty.
-							if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
-								continue;
-							}
+								// We only need to check products managing stock, with a limited stock qty.
+								if ( ! $product->managing_stock() || $product->backorders_allowed()  ) {
+									continue;
+								}
 
-							// Check stock based on all items in the cart and consider any held stock within pending orders.
-							$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
-							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
+								// Check stock based on all items in the cart and consider any held stock within pending orders.
+								$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
+								$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
-							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
-								/* translators: 1: product name 2: quantity in stock */
-								throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
+								if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
+									/* translators: 1: product name 2: quantity in stock */
+									throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Let's suppose we have an order that:

- Still requires payment to be taken
- But where stock levels have already been reduced
- Consequently, one or more line items are now low on stock (or have no stock remaining)

In these conditions, customers should still be able to locate and pay for the order via **My Account ‣ Orders ‣ Pay**. Currently, though, they potentially will see one of the following error messages and will be blocked from making payment:

- *Sorry, \<PRODUCT\> is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.*
- *Sorry, we do not have enough \<PRODUCT\> in stock to fulfill your order (\<QTY\> available). We apologize for any inconvenience caused.*

These might make sense for a new order, and where stock levels have not been reduced, but neither error makes sense in our case because stock levels have already been successfully reduced when the order was placed: the merchant should still be able to accept payment in these cases/the customer should still be able to pay.

Closes #33307

### How to test the changes in this Pull Request:

**Setup**

You will need:

- A customer-role user account.
- A test product, with inventory management enabled and an initial stock of 4 units.
- A suitable payment gateway (Stripe, PayPal classic) that can be used to take actual payment must be enabled (gateways like BACS or cheque payments are not suitable).
- Additionally, add the following snippet to a location such as `wp-content/mu-plugins/test-33575.php` to facilitate testing:

```php
<?php
/**
 * Register a custom order status (known simply as 'Custom'). When an order moves to this status it will:
 * 
 * A) Trigger a stock reduction.
 * B) Payment will still be required.
 */

add_action( 'init', function() {
	register_post_status( 'wc-custom', [ 'label' => 'Custom' ] );
} );

add_filter( 'wc_order_statuses', function ( $statuses ) {
	$statuses['wc-custom'] = 'Custom';
	return $statuses;
} );

add_filter( 'woocommerce_valid_order_statuses_for_payment', function ( $statuses, $order ) {
	$statuses[] = 'custom';
	return $statuses;
}, 10, 2 );

add_action( 'woocommerce_order_status_custom', 'wc_maybe_reduce_stock_levels' );
```

**Part One (Admin-user)**

1. As an admin user, create a new order manually.
2. Add the test user and add 3 units of the test product.
3. Set the status to `Custom` and create the order. It should save successfully.
4. Navigate to/refresh the product editor (for the test product), the inventory should have been reduced from 4 units to 1 unit.

**Part Two (Customer-user)**

1. As the customer, navigate to **My Account ▸ Orders**.
2. Locate the newly created order: you should be able to click on a `Pay` link.
3. You should be able to pay (by contrast, without this change you would see one of the error messages noted earlier).

*(Above steps are a slight modification from those in the parent ticket.)*

### Other information:

The new code is [simply an `if` statement wrapper](https://github.com/woocommerce/woocommerce/pull/33575/files#diff-ecb655f2768e2d34cc11c4348a36ecf560bc33a55745204e7ba542eb93643dbdR141-R142) ... the [remaining code](https://github.com/woocommerce/woocommerce/pull/33575/files#diff-ecb655f2768e2d34cc11c4348a36ecf560bc33a55745204e7ba542eb93643dbdR143-R167) is pre-existing and has not been changed. 

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
