### PR TITLE
Switch to ESLint to fix admin lint command 

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -26,10 +26,10 @@
 		"lint:fix": "pnpm lint:js-fix && pnpm lint:css-fix",
 		"lint:css": "stylelint '**/*.scss'",
 		"lint:css-fix": "stylelint '**/*.scss' --fix --ip 'storybook/wordpress'",
-		"lint:js": "wp-scripts lint-js ./client --ext=js,ts,tsx",
+		"lint:js": "eslint ./client --ext=js,ts,tsx",
 		"lint:js-fix": "pnpm run lint:js -- --fix --ext=js,ts,tsx",
-		"lint:js-packages": "wp-scripts lint-js ../../packages/js --ext=js,ts,tsx",
-		"lint:js-pre-commit": "wp-scripts lint-js --ext=js,ts,tsx",
+		"lint:js-packages": "eslint ../../packages/js --ext=js,ts,tsx",
+		"lint:js-pre-commit": "eslint --ext=js,ts,tsx",
 		"prepack": "pnpm install && pnpm run lint && pnpm run test && cross-env WC_ADMIN_PHASE=core pnpm run build",
 		"packages:fix:textdomain": "node ./bin/package-update-textdomain.js",
 		"packages:watch": "cross-env WC_ADMIN_PHASE=development pnpm run:packages -- start --parallel",
@@ -228,8 +228,7 @@
 			"pnpm lint:css-fix"
 		],
 		"client/**/*.(t|j)s?(x)": [
-			"pnpm reformat-files",
-			"pnpm wp-scripts lint-js",
+			"pnpm lint:js-pre-commit",
 			"pnpm test-staged"
 		]
 	},

--- a/plugins/woocommerce/changelog/dev-fix-admin-lint
+++ b/plugins/woocommerce/changelog/dev-fix-admin-lint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Switch woo admin lint command from wp-script to eslint
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the broken WCA lint command with a temporary fix.

### How to test the changes in this Pull Request:

1. Review the change
2. Test the following commands:

- `pnpm -- turbo run lint '--filter=woocommerce/client/admin'`
- `pnpm -- turbo run lint:fix '--filter=woocommerce/client/admin'`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
