### PR TITLE
Style fix for the print shipping banner close modal

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -73,10 +73,6 @@
 	max-width: 100%;
 
 	.components-modal__header {
-		border-bottom: 0;
-		margin: 4px 0;
-		padding: 0;
-		height: 50px;
 		.components-button.has-icon {
 			left: 15px;
 			svg {
@@ -96,14 +92,12 @@
 	.wc-admin-shipping-banner__dismiss-modal-help-text {
 		font-size: 16px;
 		line-height: 24px;
-		margin: 0 60px 1em 0;
 	}
 
 	.wc-admin-shipping-banner__dismiss-modal-actions {
 		text-align: right;
 
 		.components-button.is-primary {
-			height: 30px;
 			padding-left: 15px;
 			padding-right: 15px;
 			text-align: center;
@@ -120,7 +114,7 @@
 	}
 }
 
-@media (max-width: 1080px) {
+@media ( max-width: 1080px ) {
 	#woocommerce-admin-print-label {
 		text-align: center;
 

--- a/plugins/woocommerce/changelog/fix-shipping-plugin-banner
+++ b/plugins/woocommerce/changelog/fix-shipping-plugin-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix print shipping banner close modal styles


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33586  .

### How to test the changes in this Pull Request:


1. Open https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php#L38 and add `return true` at the first line of `should_show_meta_box` method.
2. Open https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php#L98 and change `$this->count_shippable_items( $order )` line to `1` so that it doesn't call the function.
3. Go to `Products -> Add New`
4. You should see a meta box (screenshot 1)
5. Make sure the image is displayed correctly.
6. Click "X" button to close.
7. The modal should have correct styles applied.

### Screenshots
![Screen Shot 2022-06-01 at 6 50 42 PM](https://user-images.githubusercontent.com/4723145/171530139-3353fd2e-f800-4ac7-bd80-0fb3ef06e28b.jpg)

![Screen Shot 2022-06-23 at 6 01 08 PM](https://user-images.githubusercontent.com/4723145/175439210-854272f9-a090-4bbd-976d-a0213b162efa.jpg)


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
