### PR TITLE
Fixed missing wcpay setup task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/woocommerce-payments.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/woocommerce-payments.js
@@ -1,11 +1,15 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { registerPlugin } from '@wordpress/plugins';
-import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
+import {
+	WooOnboardingTaskListItem,
+	WooOnboardingTask,
+} from '@woocommerce/onboarding';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
+import { Spinner } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -20,6 +24,7 @@ const WoocommercePaymentsTaskItem = () => {
 		<WooOnboardingTaskListItem id="woocommerce-payments">
 			{ ( { defaultTaskItem: DefaultTaskItem } ) => (
 				<DefaultTaskItem
+					// intercept the click on the task list item so that we don't have to see a intermediate page before installing woocommerce payments
 					onClick={ () => {
 						return new Promise( ( resolve, reject ) => {
 							return installActivateAndConnectWcpay(
@@ -38,4 +43,48 @@ const WoocommercePaymentsTaskItem = () => {
 registerPlugin( 'woocommerce-admin-task-wcpay', {
 	scope: 'woocommerce-tasks',
 	render: WoocommercePaymentsTaskItem,
+} );
+
+const ReadyWcPay = () => {
+	const { installAndActivatePlugins } = useDispatch( PLUGINS_STORE_NAME );
+	const { createNotice } = useDispatch( 'core/notices' );
+
+	useEffect( () => {
+		new Promise( ( resolve, reject ) => {
+			return installActivateAndConnectWcpay(
+				reject,
+				createNotice,
+				installAndActivatePlugins
+			);
+		} );
+	}, [ createNotice, installAndActivatePlugins ] );
+
+	return (
+		<div
+			style={ {
+				height: '70vh',
+				display: 'flex',
+				flexDirection: 'column',
+				justifyContent: 'center',
+				alignItems: 'center',
+			} }
+		>
+			<Spinner />
+			<div style={ { marginTop: '1rem' } }>
+				Preparing payment settings...
+			</div>
+		</div>
+	);
+};
+
+// shows up at http://host/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments which is the default url for woocommerce-payments task
+const WoocommercePaymentsTaskPage = () => (
+	<WooOnboardingTask id="woocommerce-payments">
+		<ReadyWcPay />
+	</WooOnboardingTask>
+);
+
+registerPlugin( 'woocommerce-admin-task-wcpay-page', {
+	scope: 'woocommerce-tasks',
+	render: WoocommercePaymentsTaskPage,
 } );

--- a/plugins/woocommerce/changelog/fix-missing-wcpay-setup-task-page
+++ b/plugins/woocommerce/changelog/fix-missing-wcpay-setup-task-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed missing wcpay setup task, task fill page was missing for the woocommerce-payments task


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Background

The WooCommerce setup widget was linking directly to the URL of the woocommerce-payments task page, which was not expected to be rendered as the task item on the task list intercepts the onClick and begins the setup immediately without going to the woocommerce-payments task page.

This meant that when the task page was reached from the setup widget, there was no fill to render and showed a blank page.

### Changes proposed in this Pull Request:

This PR adds a loading screen for that page which also initiates the same setup procedure as you would see by clicking on the task list item.

Closes #33564 .

### How to test the changes in this Pull Request:

Setup store with wcpay installed, then finish steps 1 (onboarding wizard) and 2 (add a product) of task list.

Go to Wordpress home and click on Woocommerce setup widget which should be at step 3

Expect to proceed with woocommerce payments setup instead of blank screen

If woocommerce-payments plugin is not installed:

https://user-images.githubusercontent.com/27843274/175479408-0ca2b21a-cecd-480b-bcfd-5038a9834be4.mp4


If woocommerce-payments plugin is installed and activated but not setup:

https://user-images.githubusercontent.com/27843274/175479413-08699be7-4d80-4d30-971c-ce87d55acd2b.mp4


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
