### PR TITLE
Fix: improve woocommerce-admin plugin deactivation notice message

### DIFF
--- a/plugins/woocommerce/changelog/fix-improved-wca-plugin-deactivation-message
+++ b/plugins/woocommerce/changelog/fix-improved-wca-plugin-deactivation-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WooCommerce Admin plugin deactivation message was causing much unnecessary alarm and has been improved #33592

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -108,7 +108,7 @@ class Loader {
 					echo '<div class="error"><p>';
 					printf(
 						/* translators: %s: is referring to the plugin's name. */
-						esc_html__( '%1$s plugin has been deactivated as %1$s plugin is now included with %2$s plugin.', 'woocommerce' ),
+						esc_html__( 'The %1$s plugin has been deactivated as the latest improvements are now included with the %2$s plugin.', 'woocommerce' ),
 						'<code>WooCommerce Admin</code>',
 						'<code>WooCommerce</code>'
 					);

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -108,7 +108,7 @@ class Loader {
 					echo '<div class="error"><p>';
 					printf(
 						/* translators: %s: is referring to the plugin's name. */
-						esc_html__( '%1$s plugin has been deactivated to avoid conflicts with %2$s plugin.', 'woocommerce' ),
+						esc_html__( '%1$s plugin has been deactivated as %1$s plugin is now included with %2$s plugin.', 'woocommerce' ),
 						'<code>WooCommerce Admin</code>',
 						'<code>WooCommerce</code>'
 					);


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WooCommerce Admin plugin deactivation message was causing much unnecessary alarm and has been improved

### How to test the changes in this Pull Request:

1. Install WooCommerce < 6.4 , and WooCommerce Admin 3.3.2
2. Update WooCommerce to this version
3. Should see updated notice message

![image](https://user-images.githubusercontent.com/27843274/175489095-ccd947af-842e-43e1-91b1-80f9b992b370.png)

https://user-images.githubusercontent.com/27843274/175489129-426a056c-31f7-403d-9389-fde16cfff0e7.mp4

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
