### PR TITLE
[DO NOT MERGE] WooCommerce Twenty Twenty-Two Stylesheet audit comments

### DIFF
--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -1,7 +1,7 @@
 /**
 * Fonts
 */
-@font-face {
+@font-face { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 	font-family: star;
 	src: url(../fonts/star.eot);
 	src:
@@ -13,7 +13,7 @@
 	font-style: normal;
 }
 
-@font-face {
+@font-face { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 	font-family: WooCommerce;
 	src: url(../fonts/WooCommerce.eot);
 	src:
@@ -34,13 +34,13 @@ $tt2-gray: #f7f7f7;
  * Main layout.
  */
 
-.woocommerce-page {
+.woocommerce-page { // TODO remove comment - Note: remaining styles WC 2022 styles specific
 
-	h1.wp-block-post-title {
+	h1.wp-block-post-title { // TODO remove comment - Note: WC 2022 styles specific
 		font-size: var(--wp--preset--font-size--huge);
 	}
 
-	h2 {
+	h2 { // TODO remove comment - Note: WC 2022 styles specific
 		font-size: var(--wp--preset--font-size--large);
 	}
 
@@ -55,7 +55,7 @@ $tt2-gray: #f7f7f7;
 .woocommerce {
 
 	// Common
-	.woocommerce-products-header {
+	.woocommerce-products-header { // TODO remove comment - Note: /shop header, style not needed for all block themes
 		h1.page-title {
 			font-family: var(--wp--preset--font-family--source-serif-pro);
 			font-size: var(--wp--custom--typography--font-size--gigantic);
@@ -65,54 +65,50 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	span.onsale {
+	span.onsale { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		top: -1rem;
 		right: -1rem;
 		position: absolute;
-		background: var( --wp--preset--color--secondary );
+		background: var(--wp--preset--color--secondary);
 		border-radius: 2rem;
 		line-height: 2.6rem;
 		font-size: 0.8rem;
-		padding: 0rem 0.5rem 0rem 0.5rem;
+		padding: 0 0.5rem 0 0.5rem;
 	}
 
-	.price ins, bdi {
-		text-decoration: none;
-	}
-
-	.quantity {
-		input[type='number'] {
+	.quantity { // TODO remove comment - Note: remaining WC 2022 styles specific
+		input[type="number"] { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			width: 3em;
 		}
 
-		input[type='number']::-webkit-inner-spin-button,
-		input[type='number']::-webkit-outer-spin-button{
+		input[type="number"]::-webkit-inner-spin-button,
+		input[type="number"]::-webkit-outer-spin-button { // TODO remove comment - Note: WC 2022 styles specific
 			opacity: 1;
 		}
 	}
 
-	&.woocommerce-shop .woocommerce-breadcrumb {
+	&.woocommerce-shop .woocommerce-breadcrumb { // TODO remove comment - Note: WC 2022 styles specific
 		display: none;
 	}
 
-	.woocommerce-breadcrumb {
+	.woocommerce-breadcrumb { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		margin-bottom: 1rem;
 	}
 
 	.woocommerce-message,
 	.woocommerce-error,
-	.woocommerce-info {
+	.woocommerce-info { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		background: $tt2-gray;
-		border-top-color: var( --wp--preset--color--primary );
+		border-top-color: var(--wp--preset--color--primary);
 		border-top-style: solid;
 		padding: 1rem 1.5rem;
 		margin-bottom: 2rem;
 		list-style: none;
 		font-size: var(--wp--preset--font-size--small);
 
-		&[role='alert']::before {
-			color: var( --wp--preset--color--background );
-			background: var( --wp--preset--color--primary );
+		&[role="alert"]::before {
+			color: var(--wp--preset--color--background);
+			background: var(--wp--preset--color--primary);
 			border-radius: 5rem;
 			font-size: 1rem;
 			padding-left: 3px;
@@ -134,11 +130,11 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	.woocommerce-error[role='alert'] {
+	.woocommerce-error[role="alert"] { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		margin: 0;
 
 		&::before {
-			content: 'X';
+			content: "X";
 			padding-right: 4px;
 			padding-left: 4px;
 		}
@@ -148,14 +144,14 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	.woocommerce-message {
-		&[role='alert']::before {
-			content: '\2713';
+	.woocommerce-message { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
+		&[role="alert"]::before {
+			content: "\2713";
 		}
 	}
 
 	.woocommerce-NoticeGroup-checkout {
-		ul.woocommerce-error[role='alert'] {
+		ul.woocommerce-error[role="alert"] { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			&::before {
 				display: none;
 			}
@@ -167,14 +163,14 @@ $tt2-gray: #f7f7f7;
 	}
 
 	a.button,
-	button[name='add-to-cart'],
-	input[name='submit'],
+	button[name="add-to-cart"],
+	input[name="submit"],
 	button.single_add_to_cart_button,
-	button[type='submit']:not(.wp-block-search__button) {
+	button[type="submit"]:not(.wp-block-search__button) { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		display: inline-block;
 		text-align: center;
 		word-break: break-word;
-		background-color: var( --wp--preset--color--primary );
+		background-color: var(--wp--preset--color--primary);
 		color: #fff;
 		border: 1px solid var(--wp--preset--color--black);
 		padding: 1rem 2rem;
@@ -185,26 +181,52 @@ $tt2-gray: #f7f7f7;
 
 		&:hover,
 		&:visited {
-			color: var( --wp--preset--color--white );
+			color: var(--wp--preset--color--white);
 			text-decoration: underline;
+		}
+	}
+
+	#respond input#submit.alt,
+	a.button.alt,
+	button.button.alt,
+	input.button.alt { // TODO remove comment - Note: Added for WC 2022 specific overrides
+		background-color: var(--wp--preset--color--primary);
+		color: #fff;
+
+		&:hover {
+			background-color: var(--wp--preset--color--primary);
+			color: #fff;
+			opacity: 1;
+		}
+
+		&.disabled,
+		&:disabled,
+		&:disabled[disabled],
+		&.disabled:hover,
+		&:disabled:hover,
+		&:disabled[disabled]:hover {
+			background-color: var(--wp--preset--color--primary);
+			color: #fff;
+			opacity: 0.5;
+			cursor: not-allowed;
 		}
 	}
 
 	button.woocommerce-form-login__submit,
 	button.single_add_to_cart_button,
-	a.checkout-button {
+	a.checkout-button {  // TODO remove comment - Note: WC 2022 specific overrides
 		font-size: 18px;
 		padding: 1.5rem 3.5rem;
 	}
 
 	// Shop page
 
-	.woocommerce-result-count {
+	.woocommerce-result-count { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		margin-top: 0;
 		font-size: 0.9rem;
 	}
 
-	.woocommerce-ordering {
+	.woocommerce-ordering { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		margin-top: -0.2rem;
 		margin-bottom: 3rem;
 
@@ -214,7 +236,7 @@ $tt2-gray: #f7f7f7;
 	}
 
 	// Products.
-	ul.products {
+	ul.products { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 
 		padding-inline-start: 0;
 
@@ -223,15 +245,14 @@ $tt2-gray: #f7f7f7;
 			margin-top: var(--wp--style--block-gap);
 			text-align: center;
 
-			a.woocommerce-loop-product__link {
+			a.woocommerce-loop-product__link {  // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 				text-decoration: none;
 				display: block;
 			}
 
 			h2.woocommerce-loop-product__title {
-				color: var( --wp--preset--color--primary );
-				font-family: var( --wp--preset--font-family--system-font );
-				font-size: 1.2rem;
+				color: var(--wp--preset--color--primary);
+				font-family: var(--wp--preset--font-family--system-font);
 				text-decoration: none;
 				margin-bottom: 0;
 			}
@@ -244,27 +265,17 @@ $tt2-gray: #f7f7f7;
 				}
 			}
 
-			a.added_to_cart {
-				display: block;
-				margin-top: 1rem;
-			}
 		}
 	}
 
-	ul.page-numbers {
+	ul.page-numbers { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		text-align: center;
 	}
 
-	div.product {
+	div.product { // TODO remove comment - Note: remaining styles WC 2022 specific
 		position: relative;
 
-		&::after {
-			content: "";
-			display: block;
-			clear: both;
-		}
-
-		> span.onsale {
+		> span.onsale { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			position: absolute;
 			left: -1rem;
 			top: -1rem;
@@ -272,10 +283,10 @@ $tt2-gray: #f7f7f7;
 			z-index: 1;
 		}
 
-		div.woocommerce-product-gallery {
+		div.woocommerce-product-gallery { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			position: relative;
 
-			a.woocommerce-product-gallery__trigger {
+			a.woocommerce-product-gallery__trigger { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 				position: absolute;
 				top: 1rem;
 				right: 1rem;
@@ -286,8 +297,8 @@ $tt2-gray: #f7f7f7;
 				line-height: 1.5rem;
 				padding: 0;
 				font-size: 0.6rem;
-				background: var( --wp--preset--color--white );
-				border-color: var( --wp--preset--color--white );
+				background: var(--wp--preset--color--white);
+				border-color: var(--wp--preset--color--white);
 				height: 1.5rem;
 				width: 1.5rem;
 				overflow: hidden;
@@ -306,27 +317,23 @@ $tt2-gray: #f7f7f7;
 
 		}
 
-		div.summary {
+		div.summary { // TODO remove comment - Note: remaining styles WC 2022 specific
 			font-size: 1rem;
-
-			> *{
-				margin-bottom: var( --wp--style--block-gap );
-			}
 
 			h1.product_title {
 				font-size: 2.5rem;
 				margin: 0;
 			}
 
-			figure.woocommerce-product-gallery__wrapper {
+			figure.woocommerce-product-gallery__wrapper { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 				margin: 0;
 			}
 
-			.woocommerce-product-rating {
+			.woocommerce-product-rating { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 				.star-rating {
 					display: inline-block;
 				}
-				.woocommerce-review-link {
+				.woocommerce-review-link { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 					display: inline-block;
 					overflow: hidden;
 					position: relative;
@@ -336,27 +343,13 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
-		button[name='add-to-cart'], button.single_add_to_cart_button {
+		button[name="add-to-cart"],
+		button.single_add_to_cart_button {
 			margin-top: 0.5rem;
-			margin-bottom: var( --wp--style--block-gap );
+			margin-bottom: var(--wp--style--block-gap);
 		}
 
-		table.variations {
-			tr {
-				display: block;
-				margin-bottom: var( --wp--style--block-gap );
-
-				th {
-					padding-right: 1rem;
-				}
-
-				td select {
-					padding: 2px;
-				}
-			}
-		}
-
-		ol.flex-control-thumbs {
+		ol.flex-control-thumbs { // TODO remove comment - Note: styles WC 2022 specific
 			padding-left: 0;
 			float: left;
 
@@ -370,7 +363,7 @@ $tt2-gray: #f7f7f7;
 
 		}
 
-		a.reset_variations {
+		a.reset_variations { // TODO remove comment - Note: remaining styles needed as WC 2022 styles remove WC woocommerce-general
 			margin-left: 0.5em;
 		}
 
@@ -380,46 +373,44 @@ $tt2-gray: #f7f7f7;
 				padding-bottom: 1rem;
 			}
 
-			margin-bottom: var( --wp--style--block-gap );
+			margin-bottom: var(--wp--style--block-gap);
 		}
 
-		.related.products {
+		.related.products { // TODO remove comment - Note: remaining styles WC 2022 specific
 			margin-top: 7rem;
 		}
 	}
 
-	.woocommerce-tabs {
-		padding-top: var( --wp--style--block-gap );
+	.woocommerce-tabs { // TODO remove comment - Note: remaining styles needed as WC 2022 styles remove WC woocommerce-general
+		padding-top: var(--wp--style--block-gap);
 
 		ul.wc-tabs {
 			padding: 0;
 			border-bottom-style: solid;
 			border-bottom-width: 1px;
-			border-bottom-color: #EAE9EB;
+			border-bottom-color: #eae9eb;
 
 			li {
-				background: #EAE9EB;
+				background: #eae9eb;
 				margin: 0;
 				padding: 0.5em 1em 0.5em 1em;
-				border-color: #EAE9EB;
+				border-color: #eae9eb;
 				border-top-left-radius: 5px;
 				border-top-right-radius: 5px;
 				float: left;
 				border-style: solid;
 				border-width: 1px;
-				border-left-color: var( --wp--preset--color--background );
+				border-left-color: var(--wp--preset--color--background);
 				font-weight: 600;
 				font-size: var(--wp--preset--font-size--medium);
 
 				&:first-child {
-					border-left-color: #EAE9EB;
+					border-left-color: #eae9eb;
 					margin-left: 1em;
 				}
 
 				&.active {
-					background: var( --wp--preset--color--background );
-					border-bottom-color: var( --wp--preset--color--background );
-					box-shadow: 0 1px var( --wp--preset--color--background );
+					box-shadow: 0 1px var(--wp--preset--color--background);
 				}
 
 				a {
@@ -428,8 +419,8 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
-		.woocommerce-Tabs-panel {
-			padding-top: var( --wp--style--block-gap );
+		.woocommerce-Tabs-panel { // TODO remove comment - Note: WC 2022 styles specific
+			padding-top: var(--wp--style--block-gap);
 			font-size: var(--wp--preset--font-size--small);
 			margin-left: 1em;
 
@@ -439,7 +430,7 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	.woocommerce-Reviews {
+	.woocommerce-Reviews { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		ol.commentlist {
 			list-style: none;
 			padding-left: 0;
@@ -454,7 +445,7 @@ $tt2-gray: #f7f7f7;
 
 			.comment-text {
 				display: inline-block;
-				padding-left: var( --wp--style--block-gap );
+				padding-left: var(--wp--style--block-gap);
 
 				.star-rating {
 					margin-top: 0;
@@ -467,14 +458,14 @@ $tt2-gray: #f7f7f7;
 		.comment-form-rating {
 			label {
 				display: inline-block;
-				padding-right: var( --wp--style--block-gap );
-				padding-top: var( --wp--style--block-gap );
+				padding-right: var(--wp--style--block-gap);
+				padding-top: var(--wp--style--block-gap);
 			}
 
 			p.stars {
 				display: inline;
 				a::before {
-					color: var( --wp--preset--color--secondary );
+					color: var(--wp--preset--color--secondary);
 				}
 			}
 		}
@@ -482,30 +473,25 @@ $tt2-gray: #f7f7f7;
 		.comment-form-comment {
 			label {
 				float: left;
-				padding-right: var( --wp--style--block-gap );
+				padding-right: var(--wp--style--block-gap);
 			}
 		}
 
 		#review_form_wrapper {
 			margin-top: 5rem;
 		}
-
-		.comment-reply-title {
-			font-size: var(--wp--preset--font-size--medium);
-			font-weight: 700;
-		}
 	}
 
 
-	.star-rating {
+	.star-rating {  // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		overflow: hidden;
 		position: relative;
 		height: 1em;
 		line-height: 1;
 		width: 5.4rem;
 		font-family: star;
-		color: var( --wp--preset--color--secondary );
-		margin: 1rem auto .7rem auto;
+		color: var(--wp--preset--color--secondary);
+		margin: 1rem auto 0.7rem auto;
 
 		&::before {
 			content: "\73\73\73\73\73";
@@ -534,7 +520,7 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	p.stars {
+	p.stars {  // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		margin-top: 0;
 
 		a {
@@ -599,50 +585,45 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	.woocommerce-product-gallery__trigger {
+	.woocommerce-product-gallery__trigger { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		position: absolute;
 		top: 1rem;
 		right: 1rem;
 		z-index: 99;
 	}
 
-	.return-to-shop {
+	.return-to-shop { // TODO remove comment - Note: styles WC 2022 specific
 		a.button {
 			background-color: #fff;
-			color: var( --wp--preset--color--primary );
-			border: 2px solid var( --wp--preset--color--primary );
+			color: var(--wp--preset--color--primary);
+			border: 2px solid var(--wp--preset--color--primary);
 			padding: 0.7rem 2rem;
 		}
 	}
 
-	mark {
-		background: var( --wp--preset--color--secondary );
+	mark { // TODO remove comment - Note: WC 2022 styles specific
+		background: var(--wp--preset--color--secondary);
+		color: initial;
 	}
 }
 
 /**
  * Form fields
  */
-.woocommerce-page {
+.woocommerce-page { // TODO remove comment - Note: remaining styles WC 2022 specific
 
-	form {
+	form { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 
-		.input-text {
+		.input-text { // TODO remove comment - Note: WC 2022 styles specific
 			border: 1px solid var(--wp--preset--color--black);
 			border-radius: 0;
-			font-size: var(--wp--preset--font-size--small);
-			padding: .9rem 1.1rem;
-		}
-
-		label {
-			margin-bottom: .7rem;
 		}
 
 		abbr.required {
 			text-decoration: none;
 		}
 
-		ul {
+		ul { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			margin-top: 0;
 			margin-bottom: 0;
 			list-style-type: none;
@@ -650,8 +631,8 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	input[type="radio"][name='payment_method'],
-	input[type="radio"].shipping_method {
+	input[type="radio"][name="payment_method"],
+	input[type="radio"].shipping_method { // TODO remove comment - Note: WC 2022 styles specific
 		display: none;
 
 		& + label {
@@ -666,7 +647,7 @@ $tt2-gray: #f7f7f7;
 				margin-left: 4px;
 				margin-right: 1.2rem;
 				border-radius: 100%;
-				transform: translateY(.2rem);
+				transform: translateY(0.2rem);
 			}
 		}
 
@@ -683,7 +664,7 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	label.woocommerce-form__label-for-checkbox {
+	label.woocommerce-form__label-for-checkbox { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		font-weight: normal;
 		cursor: pointer;
 
@@ -696,8 +677,8 @@ $tt2-gray: #f7f7f7;
 				width: 1rem;
 				border: 2px solid var(--wp--preset--color--black);
 				background: var(--wp--preset--color--white);
-				margin-right: .5rem;
-				transform: translateY(.2rem);
+				margin-right: 0.5rem;
+				transform: translateY(0.2rem);
 			}
 		}
 
@@ -707,15 +688,12 @@ $tt2-gray: #f7f7f7;
 
 		input[type="checkbox"]:checked + span::before {
 			background: var(--wp--preset--color--black);
-			box-shadow: inset .2rem .2rem var(--wp--preset--color--white), inset -.2rem -.2rem var(--wp--preset--color--white);
+			box-shadow: inset 0.2rem 0.2rem var(--wp--preset--color--white), inset -0.2rem -0.2rem var(--wp--preset--color--white);
 		}
 	}
 
-	table.shop_table_responsive {
-
-		width: 100%;
+	table.shop_table_responsive { // TODO remove comment - Note: remaining styles WC 2022 specific
 		text-align: left;
-		border-collapse: collapse;
 
 		th,
 		td {
@@ -730,7 +708,7 @@ $tt2-gray: #f7f7f7;
 		tbody {
 
 			tr {
-				border-top: 1px solid var( --wp--preset--color--black );
+				border-top: 1px solid var(--wp--preset--color--black);
 			}
 
 			td {
@@ -758,7 +736,7 @@ $tt2-gray: #f7f7f7;
 	}
 
 	table.shop_table,
-	table.shop_table_responsive {
+	table.shop_table_responsive { // TODO remove comment - Note: WC 2022 styles specific
 		tbody {
 			.product-name {
 				a:not(:hover) {
@@ -792,15 +770,18 @@ $tt2-gray: #f7f7f7;
 	/*
 	 * Cart / Checkout
 	 */
-	.woocommerce-cart-form {
+	.woocommerce-cart-form { // TODO remove comment - Note: remaining styles WC 2022 specific
 
-		#coupon_code {
-			width: auto;
+		#coupon_code,
+		.actions .button {
+			height: auto;
+			margin-right: 0;
 		}
 
 		table.shop_table_responsive {
 
-			td, th {
+			td,
+			th {
 				padding: 1rem 0 0.5rem 1rem;
 			}
 
@@ -816,53 +797,39 @@ $tt2-gray: #f7f7f7;
 					}
 
 					.product-remove {
-						width: auto;
 						text-align: left !important;
 					}
 
 					#coupon_code {
-						width: 50%;
 						float: left;
 						margin-bottom: 1rem;
 					}
 				}
 			}
 
-			button[name='apply_coupon'],
-			button[name='update_cart'] {
+			button[name="apply_coupon"],
+			button[name="update_cart"] {
 				padding: 1rem 2rem;
 				border: 2px solid #ebe9eb;
 				margin: 0;
 			}
 
 			.product-remove {
-				width: 1rem;
 				font-size: var(--wp--preset--font-size--large);
 
 				a {
 					text-decoration: none;
 				}
 			}
-
-			.product-thumbnail {
-				width: 7.5rem;
-
-				a {
-					img {
-						width: 117px;
-					}
-				}
-			}
 		}
 	}
 
-	.cart-collaterals {
+	.cart-collaterals { // TODO remove comment - Note: WC 2022 styles specific
 		margin-top: 1.5rem;
 
 		h2 {
 			text-transform: uppercase;
 			font-family: inherit;
-			font-size: var(--wp--preset--font-size--medium);
 		}
 
 		table.shop_table_responsive {
@@ -875,13 +842,14 @@ $tt2-gray: #f7f7f7;
 				width: 11rem;
 			}
 
-			td, th {
+			td,
+			th {
 				padding: 1rem 0;
 				vertical-align: text-top;
 			}
 		}
 
-		button[name='calc_shipping'] {
+		button[name="calc_shipping"] {
 			padding: 1rem 2rem;
 		}
 
@@ -891,7 +859,7 @@ $tt2-gray: #f7f7f7;
 	}
 
 	.woocommerce-checkout,
-	&.woocommerce-order-pay {
+	&.woocommerce-order-pay { // TODO remove comment - Note: WC 2022 styles specific
 		display: table;
 
 		h3 {
@@ -905,22 +873,23 @@ $tt2-gray: #f7f7f7;
 			float: right;
 		}
 
-		.blockUI.blockOverlay {
+		.blockUI.blockOverlay { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			position: relative;
 			@include loader();
 		}
 
-		#customer_details {
+		#customer_details { // TODO remove comment - Note: WC 2022 styles specific
 			width: 53%;
 			float: left;
 
-			.col-1, .col-2 {
+			.col-1,
+			.col-2 {
 				width: 100%;
 				float: none;
 			}
 		}
 
-		@media only screen and (max-width: 768px) {
+		@media only screen and (max-width: 768px) { // TODO remove comment - Note: WC 2022 styles specific
 			.col2-set,
 			#customer_details {
 				width: 100%;
@@ -931,12 +900,12 @@ $tt2-gray: #f7f7f7;
 		.woocommerce-billing-fields__field-wrapper,
 		.woocommerce-checkout-review-order-table,
 		.woocommerce-checkout-payment,
-		#payment {
+		#payment { // TODO remove comment - Note: WC 2022 styles specific
 			margin-top: 4rem;
 		}
 
 		.woocommerce-checkout-review-order-table,
-		#order_review .shop_table {
+		#order_review .shop_table { // TODO remove comment - Note: WC 2022 styles specific
 			border-collapse: collapse;
 			width: 100%;
 
@@ -949,7 +918,8 @@ $tt2-gray: #f7f7f7;
 				font-weight: normal;
 			}
 
-			th, td {
+			th,
+			td {
 				padding: 1rem 1rem 1rem 0;
 				vertical-align: text-top;
 			}
@@ -978,13 +948,13 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
-		button#place_order {
+		button#place_order { // TODO remove comment - Note: WC 2022 styles specific
 			width: 100%;
 			text-transform: uppercase;
 		}
 	}
 
-	form.checkout_coupon {
+	form.checkout_coupon { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		background: $tt2-gray;
 		padding-left: 1.5rem;
 		float: left;
@@ -992,21 +962,21 @@ $tt2-gray: #f7f7f7;
 		width: calc(100% - 1.5rem);
 
 		.form-row {
-			button[name='apply_coupon'] {
+			button[name="apply_coupon"] {
 				margin-top: 0;
 			}
 		}
 	}
 
 	ul.wc_payment_methods,
-	ul.woocommerce-shipping-methods {
+	ul.woocommerce-shipping-methods { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 		margin-top: 0;
 		margin-bottom: 0;
 		list-style-type: none;
 		padding-left: 0;
 
-		input[type='radio'] {
-			margin-right: .6rem;
+		input[type="radio"] {
+			margin-right: 0.6rem;
 		}
 
 		li.wc_payment_method {
@@ -1014,51 +984,38 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
-	.woocommerce-thankyou-order-received {
+	.woocommerce-thankyou-order-received { // TODO remove comment - WC 2022 specific
 		margin-top: 0;
 	}
 
 	.woocommerce-thankyou-order-received,
-	h2.woocommerce-column__title {
+	h2.woocommerce-column__title { // TODO remove comment - WC 2022 specific
 		font-family: var(--wp--preset--font-family--source-serif-pro);
-		font-size: var(--wp--preset--font-size--large);
-		font-weight: 300;
 	}
 
-	.woocommerce-order > * {
-		margin-bottom: var( --wp--style--block-gap );
+	.woocommerce-order > * {  // TODO remove comment - WC 2022 specific
+		margin-bottom: var(--wp--style--block-gap);
 	}
 
-	ul.woocommerce-order-overview {
-		font-size: var(--wp--preset--font-size--small);
-		display: flex;
-		padding-left: 0;
-		width: 100%;
+	ul.woocommerce-order-overview { // TODO remove comment - WC 2022 specific
 
-		li {
+		li { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 			display: inline;
-			flex-grow: 1;
-			margin-bottom: 1rem;
 			text-transform: uppercase;
 
-			strong {
+			strong { // TODO remove comment - Note: needed as WC 2022 styles remove WC woocommerce-general
 				text-transform: none;
 				display: block;
 			}
 		}
-
-		@media only screen and (max-width: 768px) {
-			flex-direction: column;
-		}
 	}
 
-	.woocommerce-customer-details {
+	.woocommerce-customer-details { // TODO remove comment - WC 2022 specific
 		address {
-			padding: 2rem;
 			border: 1px solid var(--wp--preset--color--black);
 			font-style: inherit;
 
-			p[class^='woocommerce-customer-details--'] {
+			p[class^="woocommerce-customer-details--"] {
 				&:first-of-type {
 					margin-top: 2rem;
 				}
@@ -1068,26 +1025,24 @@ $tt2-gray: #f7f7f7;
 			}
 
 			.woocommerce-customer-details--phone::before {
-				content: '\01F4DE';
+				content: "\01F4DE";
 				margin-right: 1rem;
 			}
 
 			.woocommerce-customer-details--email::before {
-				content: '\2709';
+				content: "\2709";
 				margin-right: 1rem;
 				font-size: 1.8rem;
 			}
 		}
 	}
 
-	.woocommerce-table--order-details {
+	.woocommerce-table--order-details { // TODO remove comment - remaining styles are WC 2022 specific
 		border: 1px solid var(--wp--preset--color--black);
-		border-collapse: collapse;
-		width: 70%;
 
-		th, td {
+		th,
+		td {
 			text-align: left;
-			padding: 1rem;
 			border-top: 1px solid var(--wp--preset--color--black);
 			border-bottom: 1px solid var(--wp--preset--color--black);
 			font-weight: normal;
@@ -1096,21 +1051,10 @@ $tt2-gray: #f7f7f7;
 		thead th {
 			text-transform: uppercase;
 		}
-
-		@media only screen and (max-width: 768px) {
-			width: 100%;
-		}
 	}
 }
 
-.select2-container {
-
-	.select2-selection,
-	.select2-search__field {
-		height: 3.5rem;
-		font-size: var(--wp--preset--font-size--small);
-		padding: .9rem 1.1rem;
-	}
+.select2-container { // TODO remove comment - remaining styles are WC 2022 specific
 
 	.select2-selection,
 	.select2-dropdown {
@@ -1120,98 +1064,52 @@ $tt2-gray: #f7f7f7;
 
 	.select2-dropdown {
 		border-top: 0;
-		padding: .9rem 1.1rem;
 
 		.select2-search__field {
 			border: 1px solid var(--wp--preset--color--black);
 			border-radius: 0;
-			margin-bottom: 1rem;
 		}
-	}
-
-	.select2-selection .select2-selection__arrow {
-		height: 3.5rem;
-		position: absolute;
-		top: 0;
-		right: 0;
-		width: 3rem;
 	}
 }
 
 /**
  * Account section
  */
-.woocommerce-account {
+.woocommerce-account { // TODO remove comment - Note: remaining styles are WC 2022 styles specific
 
 	.woocommerce-MyAccount-navigation {
 
-		ul {
-			margin: 0;
-			padding: 0;
-		}
-
 		li {
-			list-style: none;
-			padding: 1rem 0;
-
-			&:first-child {
-				padding-top: 0;
-			}
 
 			a {
 				box-shadow: none;
-				text-decoration: none;
-
-				&:hover {
-					text-decoration: underline;
-				}
 			}
 
 			&.is-active {
 
 				a {
-					color: var( --wp--preset--color--primary );
-					text-decoration: underline;
+					color: var(--wp--preset--color--primary);
 				}
 			}
 		}
 	}
 
-	.woocommerce-MyAccount-content {
-
-		> p:first-of-type,
-		p.form-row-first,
-		p.form-row-last {
-			margin-block-start: 0px;
-		}
+	table.shop_table_responsive.my_account_orders th {
+		padding-top: 0;
 	}
 
-	&.woocommerce-edit-address {
-
-		.woocommerce-MyAccount-content {
-			form > h3 {
-				margin-block-start: 0px;
-			}
-		}
-	}
-
-	.woocommerce-form-login {
+	.woocommerce-form-login { // TODO remove comment - Note: WC 2022 styles specific
 		max-width: 516px;
 		margin: 0 auto;
-
-		.show-password-input {
-			top: .8rem;
-			right: 1.2rem;
-		}
 	}
 }
 
-.wp-block-search {
+.wp-block-search { // TODO remove comment - Note: WC 2022 styles specific
 	.wp-block-search__label {
 		font-weight: normal;
 	}
 	.wp-block-search__input {
-		padding: .9rem 1.1rem;
+		padding: 0.9rem 1.1rem;
 		border: 1px solid var(--wp--preset--color--black);
 	}
 	.wp-block-search__button {
@@ -1219,7 +1117,7 @@ $tt2-gray: #f7f7f7;
 	}
 }
 
-.wc-block-product-search {
+.wc-block-product-search { // TODO remove comment - Note: update Product Search in WC Blocks
 	form {
 		.wc-block-product-search__fields {
 			display: flex;
@@ -1228,7 +1126,7 @@ $tt2-gray: #f7f7f7;
 			max-width: 100%;
 
 			.wc-block-product-search__field {
-				padding: .9rem 1.1rem;
+				padding: 0.9rem 1.1rem;
 				flex-grow: 1;
 				border: 1px solid var(--wp--preset--color--black);
 				font-size: inherit;
@@ -1237,19 +1135,19 @@ $tt2-gray: #f7f7f7;
 
 			.wc-block-product-search__button {
 				display: flex;
-				background-color: var( --wp--preset--color--primary );
+				background-color: var(--wp--preset--color--primary);
 				color: #fff;
 				border: 1px solid var(--wp--preset--color--black);
 				padding: 1rem 1.2rem;
-				margin: 0 0 0 .7rem;
+				margin: 0 0 0 0.7rem;
 			}
 		}
 	}
 }
 
-.woocommerce-store-notice {
+.theme-twentytwentytwo .woocommerce-store-notice { // TODO remove comment - Note: WC 2022 styles specific
 	color: var(--wp--preset--color--black);
-	border-top: 2px solid var( --wp--preset--color--primary );
+	border-top: 2px solid var(--wp--preset--color--primary);
 	background: $tt2-gray;
 	padding: 2rem;
 	position: fixed;
@@ -1262,6 +1160,6 @@ $tt2-gray: #f7f7f7;
 	.woocommerce-store-notice__dismiss-link {
 		float: right;
 		margin-right: 4rem;
+		color: inherit;
 	}
 }
-


### PR DESCRIPTION
### [DO NOT MERGE] WooCommerce Twenty Twenty-Two Stylesheet audit comments

This Draft PR exists purely as a reference for the changes in https://github.com/woocommerce/woocommerce/pull/33518. This Draft PR is not meant to ever be merged!

This Draft PR only shows which parts of the WooCommerce Twenty Twenty-Two Stylesheet:
- are Twenty Twenty-Two specific styles not broadly applicable to other block themes
- are needed because the WC 2022 specific code unsets the WC `woocommerce-general` stylesheet
- are removed in favor of the new block theme default styles
- were added to account for the new block theme default styles and prevent regressions in WC 2022
