### PR TITLE
Move tracks _ui and _ut properties out of filtered tracks properties

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracks-filtered-properties
+++ b/plugins/woocommerce/changelog/fix-tracks-filtered-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move tracks _ui and _ut properties out of filtered tracks properties #33621

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -262,9 +262,8 @@ class WC_Site_Tracking {
 			: array();
 
 		$server_details = self::get_server_details();
-		$identity       = WC_Tracks_Client::get_identity( $user->ID );
 		$blog_details   = self::get_blog_details( $user->ID );
 
-		return array_merge( $data, $properties, $server_details, $identity, $blog_details );
+		return array_merge( $data, $properties, $server_details, $blog_details );
 	}
 }

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -39,14 +39,19 @@ class WC_Tracks {
 		}
 		$prefixed_event_name = self::PREFIX . $event_name;
 
-		// Allow event props to be filtered to enable adding site-wide props.
+		/**
+		 * Allow event props to be filtered to enable adding site-wide props.
+		 *
+		 * @since 4.1.0
+		 */
 		$filtered_properties = apply_filters( 'woocommerce_tracks_event_properties', $properties, $prefixed_event_name );
+		$identity            = WC_Tracks_Client::get_identity( $user->ID );
 
 		// Delete _ui and _ut protected properties.
 		unset( $filtered_properties['_ui'] );
 		unset( $filtered_properties['_ut'] );
 
-		$event_obj = new WC_Tracks_Event( $filtered_properties );
+		$event_obj = new WC_Tracks_Event( array_merge( $filtered_properties, $identity ) );
 
 		if ( is_wp_error( $event_obj->error ) ) {
 			return $event_obj->error;

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -38,8 +38,8 @@ class WC_Tracks {
 			return false;
 		}
 		$prefixed_event_name = self::PREFIX . $event_name;
-		$event_properties    = self::get_properties( $event_name, $properties );
-		$event_obj           = new WC_Tracks_Event( $event_properties );
+		$properties          = self::get_properties( $prefixed_event_name, $event_properties );
+		$event_obj           = new WC_Tracks_Event( $properties );
 
 		if ( is_wp_error( $event_obj->error ) ) {
 			return $event_obj->error;

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -20,10 +20,10 @@ class WC_Tracks {
 	 * Note: the event request won't be made if $properties has a member called `error`.
 	 *
 	 * @param string $event_name The name of the event.
-	 * @param array  $properties Custom properties to send with the event.
+	 * @param array  $event_properties Custom properties to send with the event.
 	 * @return bool|WP_Error True for success or WP_Error if the event pixel could not be fired.
 	 */
-	public static function record_event( $event_name, $properties = array() ) {
+	public static function record_event( $event_name, $event_properties = array() ) {
 		/**
 		 * Don't track users who don't have tracking enabled.
 		 */
@@ -38,25 +38,37 @@ class WC_Tracks {
 			return false;
 		}
 		$prefixed_event_name = self::PREFIX . $event_name;
-
-		/**
-		 * Allow event props to be filtered to enable adding site-wide props.
-		 *
-		 * @since 4.1.0
-		 */
-		$filtered_properties = apply_filters( 'woocommerce_tracks_event_properties', $properties, $prefixed_event_name );
-		$identity            = WC_Tracks_Client::get_identity( $user->ID );
-
-		// Delete _ui and _ut protected properties.
-		unset( $filtered_properties['_ui'] );
-		unset( $filtered_properties['_ut'] );
-
-		$event_obj = new WC_Tracks_Event( array_merge( $filtered_properties, $identity ) );
+		$event_properties    = self::get_properties( $event_name, $properties );
+		$event_obj           = new WC_Tracks_Event( $event_properties );
 
 		if ( is_wp_error( $event_obj->error ) ) {
 			return $event_obj->error;
 		}
 
 		return $event_obj->record();
+	}
+
+	/**
+	 * Get all properties for the event including filtered and identity properties.
+	 *
+	 * @param string $event_name Event name.
+	 * @param array  $event_properties Event specific properties.
+	 * @return array
+	 */
+	public static function get_properties( $event_name, $event_properties ) {
+		/**
+		 * Allow event props to be filtered to enable adding site-wide props.
+		 *
+		 * @since 4.1.0
+		 */
+		$properties = apply_filters( 'woocommerce_tracks_event_properties', $event_properties, $event_name );
+		$user       = wp_get_current_user();
+		$identity   = WC_Tracks_Client::get_identity( $user->ID );
+
+		// Delete _ui and _ut protected properties.
+		unset( $properties['_ui'] );
+		unset( $properties['_ut'] );
+
+		return array_merge( $properties, $identity );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Class WC_Tracks_Test.
+ */
+class WC_Tracks_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Set up test
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+	}
+
+	/**
+	 * Test that custom event properties are returned when passed.
+	 */
+	public function test_get_properties() {
+		$properties = \WC_Tracks::get_properties(
+			'test_event',
+			array(
+				'test_property' => 5,
+			)
+		);
+		$this->assertContains( 'test_property', array_keys( $properties ) );
+		$this->assertEquals( 5, $properties['test_property'] );
+	}
+
+
+	/**
+	 * Test that identity properties are added to the properties.
+	 */
+	public function test_addition_of_identity() {
+		$properties = \WC_Tracks::get_properties(
+			'test_event',
+			array(
+				'test_property' => 5,
+			)
+		);
+		$this->assertContains( '_ui', array_keys( $properties ) );
+		$this->assertContains( '_ut', array_keys( $properties ) );
+	}
+
+	/**
+	 * Test that custom identity properties cannot be added.
+	 */
+	public function test_invalid_identity() {
+		$properties = \WC_Tracks::get_properties(
+			'test_event',
+			array(
+				'_ui' => 'bad',
+				'_ut' => 'bad',
+			)
+		);
+		$this->assertNotEquals( 'bad', $properties['_ui'] );
+		$this->assertNotEquals( 'bad', $properties['_ut'] );
+	}
+
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33594 .

### How to test the changes in this Pull Request:

1. Open live tracks in MC (filter by your username if logged in).
2. Navigate to various WC pages to trigger some events
3. Note that expected events come through without being rejected

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
