### PR TITLE
Fix shipping display logic United Kingdom country code

### DIFF
--- a/plugins/woocommerce/changelog/fix-uk-country-code
+++ b/plugins/woocommerce/changelog/fix-uk-country-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping display logic country code

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -110,7 +110,7 @@ class Shipping extends Task {
 				return true;
 			}
 
-			return in_array( $store_country, array( 'AU', 'CA', 'UK' ), true );
+			return in_array( $store_country, array( 'AU', 'CA', 'GB' ), true );
 		}
 
 		return self::has_physical_products();

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
@@ -121,7 +121,7 @@ class WC_Admin_Tests_OnboardingTasks_Task_Shipping extends WC_Unit_Test_Case {
 		return array(
 			array( 'AU' ),
 			array( 'CA' ),
-			array( 'UK' ),
+			array( 'GB' ),
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a bug in #33533 that United Kingdom's country code should be `GB`.

https://github.com/woocommerce/woocommerce/blob/14066bdeae9abdec059b2a647489a07d7e7b3d9f/plugins/woocommerce/i18n/countries.php#L249

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Enable the `shipping-smart-defaults` feature via WCA Test helper.
3. Go to OBW
4. Set store location to the UK.
5. Go to `Woocommerce > Home`
6. Observe that the "Shipping" task is displayed.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
