### PR TITLE
Update README.md to reference the correct port no. Change from 8084 to 8086

### DIFF
--- a/packages/js/api-core-tests/README.md
+++ b/packages/js/api-core-tests/README.md
@@ -22,7 +22,7 @@ For local setup, create a `.env` file in this folder with the three required val
 Alternatively, these values can be passed in via the command line. For example:
 
 ```shell
-BASE_URL=http://localhost:8084 USER_KEY=admin USER_SECRET=password npm run e2e:api
+BASE_URL=http://localhost:8086 USER_KEY=admin USER_SECRET=password npm run e2e:api
 ```
 
 When using a username and password combination instead of a consumer secret and consumer key, make sure to have the [JSON Basic Authentication plugin](https://github.com/WP-API/Basic-Auth) installed and activated on the test site.


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
update the port number in the README.md to ensure the scripts execute correctly

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. navigate to https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/api-core-tests#:~:text=BASE_URL%3Dhttp%3A//localhost
2. validate that port 8086 is correctly being used (and not 8084)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
