### PR TITLE
Filter reload_checkout when processing customer on submit order

### DIFF
--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1052,7 +1052,7 @@ class WC_Checkout {
 			wc_set_customer_auth_cookie( $customer_id );
 
 			// As we are now logged in, checkout will need to refresh to show logged in data.
-			WC()->session->set( 'reload_checkout', true );
+			WC()->session->set( 'reload_checkout', apply_filters( 'woocommerce_checkout_reload_checkout', true ) );
 
 			// Also, recalculate cart totals to reveal any role-based discounts that were unavailable before registering.
 			WC()->cart->calculate_totals();


### PR DESCRIPTION
-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:
When a user who does not have an account submits an order, the session variable, `reload_checkout`, is set to true. This sometimes causes the checkout page to reload when it should not. Add a filter to change the value of `reload_checkout`.

Example: we have a page that accepts donations. 
1. The user selects or types in the amount they want to donate
2. User clicks `Continue as a guest`
3. Checkout form loads(AJAX)
4. User fills outs their checkout info
5. User clicks `Submit`. They realize they want to donate more.
6. User goes back to the page
7. User selects or types in the amount
8. User clicks `Continue as a guest` and almost immediately the page refreshes. They have to select/type their amount and click the button again.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
