### PR TITLE
Add `_ui` and `_ut` to `eventProperties`

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracks-filtered-properties_follow_up
+++ b/plugins/woocommerce/changelog/fix-tracks-filtered-properties_follow_up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add _ui and _ut to eventProperties #33644

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -69,7 +69,10 @@ class WC_Site_Tracking {
 		 *
 		 * @since 6.5.0
 		 */
-		$filtered_properties = apply_filters( 'woocommerce_tracks_event_properties', array(), false );
+		$tracks_event_properties = apply_filters( 'woocommerce_tracks_event_properties', array(), false );
+		$user                    = wp_get_current_user();
+		$identity                = WC_Tracks_Client::get_identity( $user->ID );
+		$filtered_properties     = array_merge( $tracks_event_properties, $identity );
 		?>
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
@@ -83,11 +86,6 @@ class WC_Site_Tracking {
 				const eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				let eventProperties = properties || {};
 				eventProperties = { ...eventProperties, ...<?php echo json_encode( $filtered_properties ); ?> };
-				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
-					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );
-					delete( eventProperties._ui );
-					delete( eventProperties._ut );
-				}
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -147,7 +147,7 @@ class WC_Products_Tracking {
 					var properties = {
 						attributes:				$( '.woocommerce_attribute' ).length,
 						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
-						'cross-sells':			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
+						cross_sells:			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
 						description:			description_value.length ? 'Yes' : 'No',
 						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
 						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
@@ -197,7 +197,7 @@ class WC_Products_Tracking {
 		$properties = array(
 			'attributes'        => count( $product->get_attributes() ),
 			'categories'        => count( $product->get_category_ids() ),
-			'cross-sells'       => ! empty( $product->get_cross_sell_ids() ) ? 'yes' : 'no',
+			'cross_sells'       => ! empty( $product->get_cross_sell_ids() ) ? 'yes' : 'no',
 			'description'       => $product->get_description() ? 'yes' : 'no',
 			'dimensions'        => wc_format_dimensions( $product->get_dimensions( false ) ) !== 'N/A' ? 'yes' : 'no',
 			'enable_reviews'    => $product->get_reviews_allowed() ? 'yes' : 'no',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is a follow-up of [PR 33621](https://github.com/woocommerce/woocommerce/pull/33621).
We are using [this filter](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php#L72) that used to return`_ui` and `_ut` props. Those props were deleted [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php#L88-L89) so this PR adds those props again in order to fix the event tracking for the product update.

This PR also rename the prop `cross-sells` to `cross_sells` since it was breaking the regex validation.

### How to test the changes in this Pull Request:

You have 2 ways to test this PR, the easy way is to rename an event and look for that event name in _Tracks Live View_:
1. Checkout the branch `fix/tracks-filtered-properties_follow_up_test`. As you can see [in the diff](https://github.com/woocommerce/woocommerce/compare/fix/tracks-filtered-properties_follow_up...fix/tracks-filtered-properties_follow_up_test?expand=1) it renames the tracks event from `product_update` to `product_update_test`.
2. Create a .zip by using this command: `pnpm build:zip --filter=woocommerce`
3. Now create a brand new site using JN and install the `.zip`.
4. Create a new product and modify it.
5. Go to the Tracks Live View and look for the event `product_update_test`.
6. Verify that the event is being saved.


The harder but better:
1. Follow the same steps described above but from this branch (not the testing branch).
...
6. Use the _Tracks Live View_ to verify that the events are being saved.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
