### PR TITLE
Changelogger: Fix JS package epilogues

### DIFF
--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -63,6 +63,9 @@ class Formatter extends KeepAChangelogParser {
 	 */
 	public $subentry_pattern = '/^###(.+)\n/m';
 
+	/**
+	 * Return the epiologue.
+	 */
 	public function getEpilogue() {
 		return $this->epilogue;
 	}

--- a/tools/changelogger/Formatter.php
+++ b/tools/changelogger/Formatter.php
@@ -63,6 +63,10 @@ class Formatter extends KeepAChangelogParser {
 	 */
 	public $subentry_pattern = '/^###(.+)\n/m';
 
+	public function getEpilogue() {
+		return $this->epilogue;
+	}
+
 	/**
 	 * Get Release link given a version number.
 	 *
@@ -220,7 +224,7 @@ class Formatter extends KeepAChangelogParser {
 
 		$ret->setEntries( $entries );
 		$ret->setPrologue( $this->prologue );
-		$ret->setEpilogue( $this->epilogue );
+		$ret->setEpilogue( $this->getEpilogue() );
 		return $ret;
 	}
 

--- a/tools/changelogger/PackageFormatter.php
+++ b/tools/changelogger/PackageFormatter.php
@@ -23,10 +23,11 @@ class PackageFormatter extends Formatter implements FormatterPlugin {
 	 */
 	public $prologue = "# Changelog \n\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).";
 
-	/**
-	 * Epilogue text.
-	 *
-	 * @var string
-	 */
-	public $epilogue = "---\n\n[See legacy changelogs for previous versions](https://github.com/woocommerce/woocommerce-admin/blob/main/packages/components/CHANGELOG.md).";
+	public function getEpilogue() {
+		$cwd = getcwd();
+		$pos = stripos( $cwd, 'packages/js/' );
+		$package = substr( $cwd, $pos + 12 );
+
+		return '[See legacy changelogs for previous versions](https://github.com/woocommerce/woocommerce/blob/68581955106947918d2b17607a01bdfdf22288a9/packages/js/' . $package . '/CHANGELOG.md).';
+	}
 }

--- a/tools/changelogger/PackageFormatter.php
+++ b/tools/changelogger/PackageFormatter.php
@@ -23,6 +23,9 @@ class PackageFormatter extends Formatter implements FormatterPlugin {
 	 */
 	public $prologue = "# Changelog \n\nThis project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).";
 
+	/**
+	 * Return the epilogue string based on the package being released.
+	 */
 	public function getEpilogue() {
 		$cwd = getcwd();
 		$pos = stripos( $cwd, 'packages/js/' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Epilogues (the text at the very bottom of the changelog) was incorrectly referencing `@woocommerce/components` for each package. This PR changes this to reflect the correct package.

### How to test the changes in this Pull Request:

1. Run the prepare script to generate changelogs for all packages that have changes
```
./tools/package-release/bin/dev prepare -a
```
2. Check the diffs and make sure epilogues were correctly written.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
