### PR TITLE
Update review shipping options task complete logic

### DIFF
--- a/plugins/woocommerce/changelog/update-review-shipping-task-complete-logic
+++ b/plugins/woocommerce/changelog/update-review-shipping-task-complete-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update review shipping options task complete logic

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -9,6 +9,16 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
  */
 class ReviewShippingOptions extends Task {
 	/**
+	 * Constructor
+	 *
+	 * @param TaskList $task_list Parent task list.
+	 */
+	public function __construct( $task_list ) {
+		parent::__construct( $task_list );
+		add_action( 'current_screen', array( $this, 'possibly_mark_task_as_completed' ) );
+	}
+
+	/**
 	 * ID.
 	 *
 	 * @return string
@@ -69,5 +79,27 @@ class ReviewShippingOptions extends Task {
 	 */
 	public function get_action_url() {
 		return admin_url( 'admin.php?page=wc-settings&tab=shipping' );
+	}
+
+	/**
+	 * Mark task as completed when the user visits the shipping setting page.
+	 */
+	public function possibly_mark_task_as_completed() {
+		$screen = get_current_screen();
+
+		if (
+			! $screen ||
+			'woocommerce_page_wc-settings' !== $screen->id ||
+			! isset( $_GET['tab'] ) || 'shipping' !== $_GET['tab'] // phpcs:ignore CSRF okok.
+		) {
+			// It's not the shipping settings page.
+			return;
+		}
+
+		if ( self::is_complete() || ! self::can_view() ) {
+			return;
+		}
+
+		update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33580.

This PR implements the review shipping options task complete logic



### How to test the changes in this Pull Request:

1.  Set `woocommerce_admin_created_default_shipping_zones` option to `yes`
2. Enable the `shipping-smart-defaults` feature via WCA Test helper. 
3. Go to `Woocommerce > Home`
4. Observe that `Review Shipping Options` task is displayed
5. Click on `Review Shipping Options` task
6. Should be redirected to shipping settings page
7. Go to `Woocommerce > Home`
8. Observe that `Review Shipping Options` task is marked as completed.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
