### PR TITLE
Analyzer: Fix regex to handle multiple changes in a single file

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -22,7 +22,7 @@ jobs:
               id: results
               run: echo "::set-output name=results::${{ steps.run.outputs.templates }}${{ steps.run.outputs.wphooks }}${{ steps.run.outputs.schema }}${{ steps.run.outputs.database }}"
     comment:
-        name: Add comment to hightlight changes
+        name: Add comment to highlight changes
         needs: analyze
         runs-on: ubuntu-20.04
         steps:

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -19,6 +19,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Admin_Addons {
 
 	/**
+	 * A description
+	 * 
+	 * @param {string} str A string.
+	 * @since 6.8.0
+	 */
+	public static function doSomething( $str ) {
+		return 'doing' . $str;
+	}
+
+	/**
 	 * Get featured for the addons screen
 	 *
 	 * @deprecated 5.9.0 No longer used in In-App Marketplace
@@ -26,6 +36,12 @@ class WC_Admin_Addons {
 	 * @return array of objects
 	 */
 	public static function get_featured() {
+		/**
+		* Test hook that does a bunch of stuff. Here is another sentence.
+		*
+		* @since 6.8.0
+		*/
+		do_action( 'woocommerce_test_hook' );
 		$featured = get_transient( 'wc_addons_featured_2' );
 		if ( false === $featured ) {
 			$headers = array();

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -19,16 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Admin_Addons {
 
 	/**
-	 * A description
-	 * 
-	 * @param {string} str A string.
-	 * @since 6.8.0
-	 */
-	public static function doSomething( $str ) {
-		return 'doing' . $str;
-	}
-
-	/**
 	 * Get featured for the addons screen
 	 *
 	 * @deprecated 5.9.0 No longer used in In-App Marketplace
@@ -36,12 +26,6 @@ class WC_Admin_Addons {
 	 * @return array of objects
 	 */
 	public static function get_featured() {
-		/**
-		* Test hook that does a bunch of stuff. Here is another sentence.
-		*
-		* @since 6.8.0
-		*/
-		do_action( 'woocommerce_test_hook' );
 		$featured = get_transient( 'wc_addons_featured_2' );
 		if ( false === $featured ) {
 			$headers = array();

--- a/tools/code-analyzer/src/utils.ts
+++ b/tools/code-analyzer/src/utils.ts
@@ -198,13 +198,25 @@ export const isValidCommitHash = ( branch: string ): boolean => {
  * Extrace hook description from a raw diff.
  *
  * @param {string} diff raw diff.
+ * @param {string} name hook name.
  * @return {string|false} hook description or false if none exists.
  */
-export const getHookDescription = ( diff: string ): string | false => {
+export const getHookDescription = (
+	diff: string,
+	name: string
+): string | false => {
 	const diffWithoutDeletions = diff.replace( /-.*\n/g, '' );
 
+	const diffWithHook = diffWithoutDeletions
+		.split( '/**' ) // Separate by the beginning of a comment.
+		.find( ( d ) => d.includes( name ) ); // Use just the one associated with our hook.
+
+	if ( ! diffWithHook ) {
+		return false;
+	}
+
 	// Extract hook description.
-	const description = diffWithoutDeletions.match( /\/\*\*([\s\S]*) @since/ );
+	const description = diffWithHook.match( /([\s\S]*?) @since/ );
 
 	if ( ! description ) {
 		return false;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Discovered in https://github.com/woocommerce/woocommerce/pull/33341, it was found that introducing a new class function with and appropriate `@since` tag directly next to introduction of a new hook broke the pattern matching regex highlight function because both changes get included in the same diff block.

### How to test the changes in this Pull Request:

1. Create a branch, `my-test-branch`, from `trunk` to see the error.
1. Introduce a new function with a current `@since` tag and just below add a new hook with its own `@since` tag and description.

```diff
diff --git a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
index b47f5ecd3e..0ef608d898 100644
--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -18,6 +18,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Admin_Addons {
 
+       /**
+        * A description
+        * 
+        * @param {string} str A string.
+        * @since 6.8.0
+        */
+       public static function doSomething( $str ) {
+               return 'doing' . $str;
+       }
+
        /**
         * Get featured for the addons screen
         *
@@ -26,6 +36,12 @@ class WC_Admin_Addons {
         * @return array of objects
         */
        public static function get_featured() {
+               /**
+               * Test hook that does a bunch of stuff. Here is another sentence.
+               *
+               * @since 6.8.0
+               */
+               do_action( 'woocommerce_test_hook' );
                $featured = get_transient( 'wc_addons_featured_2' );
                if ( false === $featured ) {
                        $headers = array();
```
2. Commit the changes and run the analyzer. See the description displayed incorrectly. 
```
./tools/code-analyzer/bin/dev analyzer my-test-branch
```
4. Now try on this branch by cherry-picking your commit from `my-test-branch` and run the Analyzer. The tool should find the hook and correctly gather its description.
```
./tools/code-analyzer/bin/dev analyzer fix/analyzer-regex-trunk
```
### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
