### PR TITLE
Update daily smoke test to add k6 smoke tests

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -121,7 +121,6 @@ jobs:
                   C_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
                   C_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
                   P_ID: 274
-
               run: |
                   ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
 

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -85,6 +85,46 @@ jobs:
                       ${{ env.API_TEST_REPORT_DIR }}/allure-report
                   retention-days: 5
 
+            - name: Update performance test site with E2E test
+              if: always()
+              working-directory: plugins/woocommerce
+              env:
+                SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_PERF_URL }}/
+                SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                SMOKE_TEST_ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                SMOKE_TEST_ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
+                SMOKE_TEST_CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+                SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+                WC_E2E_SCREENSHOTS: 1
+                E2E_RETEST: 1
+                E2E_RETRY_TIMES: 0
+                E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
+                E2E_SLACK_CHANNEL: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
+                UPDATE_WC: 1
+                DEFAULT_TIMEOUT_OVERRIDE: 120000
+              run: |
+                pnpx wc-e2e test:e2e tests/e2e/specs/smoke-tests/update-woocommerce.js
+              continue-on-error: true
+
+            - name: Install k6
+              if: always()
+              run: |
+                  curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
+
+            - name: Run k6 smoke tests
+              if: always()
+              env:
+                  URL: ${{ secrets.SMOKE_TEST_PERF_URL }}
+                  HOST: ${{ secrets.SMOKE_TEST_PERF_HOST }}
+                  A_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                  A_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                  C_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                  C_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                  P_ID: 274
+
+              run: |
+                  ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
+
     build:
         name: Build zip for PR
         runs-on: ubuntu-20.04

--- a/plugins/woocommerce/changelog/daily smoke add k6
+++ b/plugins/woocommerce/changelog/daily smoke add k6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: test related, not included in release
+
+

--- a/plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
@@ -1,0 +1,135 @@
+/**
+ * Internal dependencies
+ */
+import { homePage } from '../requests/shopper/home.js';
+import { shopPage } from '../requests/shopper/shop-page.js';
+import { searchProduct } from '../requests/shopper/search-product.js';
+import { singleProduct } from '../requests/shopper/single-product.js';
+import { cart } from '../requests/shopper/cart.js';
+import { cartRemoveItem } from '../requests/shopper/cart-remove-item.js';
+import { checkoutGuest } from '../requests/shopper/checkout-guest.js';
+import { checkoutCustomerLogin } from '../requests/shopper/checkout-customer-login.js';
+import { coupons } from '../requests/merchant/coupons.js';
+import { myAccount } from '../requests/shopper/my-account.js';
+import { categoryPage } from '../requests/shopper/category-page.js';
+import { myAccountMerchantLogin } from '../requests/merchant/my-account-merchant.js';
+import { products } from '../requests/merchant/products.js';
+import { addProduct } from '../requests/merchant/add-product.js';
+import { orders } from '../requests/merchant/orders.js';
+import { ordersSearch } from '../requests/merchant/orders-search.js';
+import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
+
+export const options = {
+	scenarios: {
+		homePageSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '60s',
+			exec: 'homePageFlow',
+		},
+		shopPageSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '60s',
+			startTime: '5s',
+			exec: 'shopPageFlow',
+		},
+		searchProductSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '60s',
+			startTime: '10s',
+			exec: 'searchProductFlow',
+		},
+		singleProductSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '60s',
+			startTime: '15s',
+			exec: 'singleProductFlow',
+		},
+		myAccountSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '60s',
+			startTime: '20s',
+			exec: 'myAccountFlow',
+		},
+		cartSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '60s',
+			startTime: '25s',
+			exec: 'cartFlow',
+		},
+		checkoutGuestSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '120s',
+			startTime: '30s',
+			exec: 'checkoutGuestFlow',
+		},
+		checkoutCustomerLoginSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '120s',
+			startTime: '40s',
+			exec: 'checkoutCustomerLoginFlow',
+		},
+		allMerchantSmoke: {
+			executor: 'per-vu-iterations',
+			vus: 1,
+			iterations: 3,
+			maxDuration: '360s',
+			exec: 'allMerchantFlow',
+		},
+	},
+	thresholds: {
+		checks: [ 'rate==1' ],
+	},
+};
+
+export function homePageFlow() {
+	homePage();
+}
+export function shopPageFlow() {
+	shopPage();
+}
+export function searchProductFlow() {
+	searchProduct();
+}
+export function singleProductFlow() {
+	singleProduct();
+	categoryPage();
+}
+export function checkoutGuestFlow() {
+	cart();
+	checkoutGuest();
+}
+export function checkoutCustomerLoginFlow() {
+	cart();
+	checkoutCustomerLogin();
+}
+export function myAccountFlow() {
+	myAccount();
+}
+export function cartFlow() {
+	cartRemoveItem();
+}
+export function allMerchantFlow() {
+	myAccountMerchantLogin();
+	homeWCAdmin();
+	orders();
+	ordersSearch();
+	products();
+	addProduct();
+	coupons();
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the execution of k6 smoke tests to the daily smoke test action.

This entails
- Updating the external test site the tests are ran against to use the same daily build of trunk as the other tests. An e2e test is ran to perform this update.
- Installing k6
- Running a k6 smoke test scenario created for this action (this scenario is also being added as part of this PR)

Closes 132-gh-woocommerce/woocommerce-quality Running K6 test daily against external site

### How to test the changes in this Pull Request:

It isn't possible to test this action from the PR as it uses `cron` and the code checkout uses `ref: trunk` so it won't find the test scenario included in this PR.

Instead to test it I used a different branch and in that branch I changed to the trigger to `on:push`, removed the `ref: trunk` for the `actions/checkout@v3` step  and ran the workflow there.

The modified version used in that branch can be viewed here https://github.com/woocommerce/woocommerce/compare/update/daily-smoke-add-k6-ext...try/k6-daily-smoke-ext#diff-3b2ff7d93606602bcae1ce86708096f7755e592f68aff14ade8d6656027b81fc

The results of that workflow run can be found here 
https://github.com/woocommerce/woocommerce/runs/7116507223?check_suite_focus=true

In that run all the k6 tests added passed successfully

There are some failures in both the e2e tests and the API tests for that run however this appears to be consistent with [recent runs in this workflow for trunk](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml?query=branch%3Atrunk) and is likely unrelated to the changes proposed in this PR.

To test the changes
1. Verify the syntax looks okay
2. [Review the workflow run results](https://github.com/woocommerce/woocommerce/runs/7116507223?check_suite_focus=true
) (as noted above this was with modified triggers to generate this run) 


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
