### PR TITLE
Adding additional instructions around product image upload modal

### DIFF
--- a/plugins/woocommerce/changelog/update-33559-product-image-guidance
+++ b/plugins/woocommerce/changelog/update-33559-product-image-guidance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding additional suggestions for product image when adding.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4646,9 +4646,41 @@ img.help_tip {
 	width: 100%;
 }
 
-#postimagediv img {
-	border: 1px solid #d5d5d5;
-	max-width: 100%;
+#postimagediv {
+
+	.inside {
+		padding: 0;
+		margin: 0;
+	}
+
+	p {
+		margin: 0;
+		padding: 10px;
+	}
+
+	.image-added-detail {
+		border-top: 1px solid #dcdcde;
+		background-color: #f6f7f7;
+		color: #7f8388;
+		font-size: 12px;
+		margin-top: 4px;
+
+		.dashicons {
+			font-size: 13px;
+			width: 13px;
+			height: 13px;
+			margin: 3px 3px 0 0;
+		}
+
+		a {
+			text-decoration: none;
+		}
+	}
+
+	img {
+		border: 1px solid #d5d5d5;
+		max-width: 100%;
+	}
 }
 
 #woocommerce-product-images .inside {

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -15,6 +15,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Product_Simple extends WC_Product {
 
 	/**
+	 * Track wehther post_upload_ui hook was run.
+	 *
+	 * @var boolean
+	 */
+	public static $post_upload_hook_done = false;
+
+	/**
 	 * Initialize simple product.
 	 *
 	 * @param WC_Product|int $product Product instance or ID.
@@ -22,6 +29,24 @@ class WC_Product_Simple extends WC_Product {
 	public function __construct( $product = 0 ) {
 		$this->supports[] = 'ajax_add_to_cart';
 		parent::__construct( $product );
+		add_action( 'post-upload-ui', array( $this, 'add_product_photo_suggestions' ) );
+	}
+
+	/**
+	 * Adding product photo suggestions in upload modal.
+	 */
+	public function add_product_photo_suggestions() {
+
+		if ( self::$post_upload_hook_done ) {
+			return;
+		}
+
+		echo '<p>';
+		echo 'For best results, upload JPEG files that are 1000 by 1000 pixels or larger.';
+		echo '</p>';
+		echo '<a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">Learn more about product photos</a>';
+
+		self::$post_upload_hook_done = true;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -42,9 +42,9 @@ class WC_Product_Simple extends WC_Product {
 		}
 
 		echo '<p>';
-		echo 'For best results, upload JPEG files that are 1000 by 1000 pixels or larger.';
+		echo esc_html__( 'For best results, upload JPEG files that are 1000 by 1000 pixels or larger.', 'woocommerce' );
 		echo '</p>';
-		echo '<a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">Learn more about product photos</a>';
+		echo '<a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '</a>';
 
 		self::$post_upload_hook_done = true;
 	}

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -29,24 +29,21 @@ class WC_Product_Simple extends WC_Product {
 	public function __construct( $product = 0 ) {
 		$this->supports[] = 'ajax_add_to_cart';
 		parent::__construct( $product );
-		add_action( 'post-upload-ui', array( $this, 'add_product_photo_suggestions' ) );
+		add_filter('admin_post_thumbnail_html', array( $this, 'add_product_photo_suggestions' ) );
 	}
 
 	/**
 	 * Adding product photo suggestions in upload modal.
 	 */
-	public function add_product_photo_suggestions() {
+	public function add_product_photo_suggestions ( $content ) {
+		error_log(print_r($content, true));
 
-		if ( self::$post_upload_hook_done ) {
-			return;
-		}
+		$meta_content = '<p>';
+		$meta_content .= esc_html__( 'For best results, upload JPEG files that are 1000 by 1000 pixels or larger. Maximum upload size: 2 GB', 'woocommerce' );
+		$meta_content .= ' <a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '</a>';
+		$meta_content .= '</p>';
 
-		echo '<p>';
-		echo esc_html__( 'For best results, upload JPEG files that are 1000 by 1000 pixels or larger.', 'woocommerce' );
-		echo '</p>';
-		echo '<a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '</a>';
-
-		self::$post_upload_hook_done = true;
+		return "$content $meta_content";
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -36,14 +36,16 @@ class WC_Product_Simple extends WC_Product {
 	 * Adding product photo suggestions in upload modal.
 	 */
 	public function add_product_photo_suggestions ( $content ) {
-		error_log(print_r($content, true));
 
-		$meta_content = '<p>';
-		$meta_content .= esc_html__( 'For best results, upload JPEG files that are 1000 by 1000 pixels or larger. Maximum upload size: 2 GB', 'woocommerce' );
-		$meta_content .= ' <a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '</a>';
-		$meta_content .= '</p>';
+		$suggestion  = '<div class="image-added-detail">';
+		$suggestion .= '<p>';
+		$suggestion .= '<span class="dashicons-info-outline dashicons"></span>';
+		$suggestion .= esc_html__( 'Upload JPEG files that are 1000 x 1000 pixels or larger (max. 2 GB).', 'woocommerce' );
+		$suggestion .= ' <a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '<span class="dashicons-external dashicons"></span></a>';
+		$suggestion .= '</p>';
+		$suggestion .= '</div>';
 
-		return "$content $meta_content";
+		return $content . $suggestion;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding more detail around product photos appearing in the upload modal on the product page. This includes suggestion dimensions, format, and a link to a relevant blog post.

Closes #33559  .

# Screenshots

![image](https://user-images.githubusercontent.com/444632/179618381-fa3eb2a7-f9d9-40fc-99bb-6d177dc3e85d.png)


### How to test the changes in this Pull Request:

1. Checkout branch on fresh site
2. Go to WooCommerce -> Products and  Create Product
3. Observe the extra content in the bottom of the product image metabox.
4. Click the new link and ensure it works as expected.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
