### PR TITLE
Make store location and rates steps clickable

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
@@ -32,7 +32,6 @@ import StoreLocation from '../steps/location';
 import ShippingRates from './rates';
 import { WCSBanner } from '../experimental-shipping-recommendation/components/wcs-banner';
 import { ShipStationBanner } from '../experimental-shipping-recommendation/components/shipstation-banner';
-
 import { createNoticesFromResponse } from '../../../lib/notices';
 import './shipping.scss';
 
@@ -54,6 +53,8 @@ export class Shipping extends Component {
 		this.shippingSmartDefaultsEnabled =
 			window.wcAdminFeatures &&
 			window.wcAdminFeatures[ 'shipping-smart-defaults' ];
+
+		this.store_location_completed = false;
 	}
 
 	componentDidMount() {
@@ -148,7 +149,15 @@ export class Shipping extends Component {
 			storeAddress && defaultCountry && storePostCode
 		);
 
-		if ( step === 'store_location' && isCompleteAddress ) {
+		if (
+			this.shippingSmartDefaultsEnabled &&
+			step === 'store_location' &&
+			isCompleteAddress &&
+			! this.store_location_completed
+		) {
+			this.completeStep();
+			this.store_location_completed = true;
+		} else if ( step === 'store_location' && isCompleteAddress ) {
 			this.completeStep();
 		}
 	}
@@ -225,7 +234,11 @@ export class Shipping extends Component {
 							recordEvent( 'tasklist_shipping_set_location', {
 								country,
 							} );
+
 							// Don't need to trigger completeStep here as it's triggered by the address updates in the componentDidUpdate function.
+							if ( this.shippingSmartDefaultsEnabled ) {
+								this.completeStep();
+							}
 						} }
 					/>
 				),
@@ -356,6 +369,12 @@ export class Shipping extends Component {
 						'We recommend the following shipping options based on your location. You can manage your shipping options again at any time in WooCommerce Shipping settings.',
 						'woocommerce'
 					),
+					onClick:
+						this.state.step !== 'rates'
+							? () => {
+									this.setState( { step: 'rates' } );
+							  }
+							: undefined,
 					content: (
 						<ShippingRates
 							buttonText={ __(
@@ -481,6 +500,12 @@ export class Shipping extends Component {
 						'Add your store location to help us calculate shipping rates and the best shipping options for you. You can manage your store location again at any time in WooCommerce Settings General.',
 						'woocommerce'
 					),
+					onClick:
+						this.state.step !== 'store_location'
+							? () => {
+									this.setState( { step: 'store_location' } );
+							  }
+							: undefined,
 					buttonText: __( 'Save store location', 'woocommerce' ),
 				},
 			};

--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
@@ -54,7 +54,7 @@ export class Shipping extends Component {
 			window.wcAdminFeatures &&
 			window.wcAdminFeatures[ 'shipping-smart-defaults' ];
 
-		this.store_location_completed = false;
+		this.storeLocationCompleted = false;
 	}
 
 	componentDidMount() {

--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
@@ -54,7 +54,7 @@ export class Shipping extends Component {
 			window.wcAdminFeatures &&
 			window.wcAdminFeatures[ 'shipping-smart-defaults' ];
 
-		this.storeLocationCompleted = false;
+		this.store_location_completed = false;
 	}
 
 	componentDidMount() {
@@ -149,16 +149,16 @@ export class Shipping extends Component {
 			storeAddress && defaultCountry && storePostCode
 		);
 
-		if (
-			this.shippingSmartDefaultsEnabled &&
-			step === 'store_location' &&
-			isCompleteAddress &&
-			! this.storeLocationCompleted
-		) {
-			this.completeStep();
-			this.storeLocationCompleted = true;
-		} else if ( step === 'store_location' && isCompleteAddress ) {
-			this.completeStep();
+		if ( step === 'store_location' && isCompleteAddress ) {
+			if (
+				this.shippingSmartDefaultsEnabled &&
+				! this.storeLocationCompleted
+			) {
+				this.completeStep();
+				this.storeLocationCompleted = true;
+			} else if ( ! this.shippingSmartDefaultsEnabled ) {
+				this.completeStep();
+			}
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/index.js
@@ -54,7 +54,7 @@ export class Shipping extends Component {
 			window.wcAdminFeatures &&
 			window.wcAdminFeatures[ 'shipping-smart-defaults' ];
 
-		this.store_location_completed = false;
+		this.storeLocationCompleted = false;
 	}
 
 	componentDidMount() {
@@ -153,10 +153,10 @@ export class Shipping extends Component {
 			this.shippingSmartDefaultsEnabled &&
 			step === 'store_location' &&
 			isCompleteAddress &&
-			! this.store_location_completed
+			! this.storeLocationCompleted
 		) {
 			this.completeStep();
-			this.store_location_completed = true;
+			this.storeLocationCompleted = true;
 		} else if ( step === 'store_location' && isCompleteAddress ) {
 			this.completeStep();
 		}

--- a/plugins/woocommerce/changelog/update-33368-make-completed-shipping-task-steps-clickable
+++ b/plugins/woocommerce/changelog/update-33368-make-completed-shipping-task-steps-clickable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+MakeThis PR makes Set your store location and Review your shipping options steps clickable on the shipping task when shipping-smart-defaults feature is enabled.


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33368 

This PR makes `Set your store location` and `Review your shipping options` steps clickable on the shipping task when `shipping-smart-defaults` feature is enabled.

One minor problem I noticed is that we ask users to set the cost for the free shipping, which doesn't have a cost (it's free). We should work on this in a separate issue.

![Screen Shot 2022-06-29 at 5 34 11 PM](https://user-images.githubusercontent.com/4723145/176568550-63ce5e10-4cfd-4433-a205-44f2aa50b851.jpg)

 
### How to test the changes in this Pull Request:

1. Start with a fresh install.
2. Skip OBW
3. Install WCA Test Helper and enable `shipping-smart-defaults` feature
4. Navigate to `WooCommerce -> Home` and click the shipping task.
5. Complete the store details and click continue
6. Complete the shipping rates and click continue
7. Try to revisit the store details and shipping rates by clicking them.



### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
