### PR TITLE
Payment task: fix wrong copy in the accordion link

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -248,7 +248,10 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 				<>
 					<WCPaySuggestion paymentGateway={ wcPayGateway[ 0 ] } />
 					<Toggle
-						heading={ __( 'Other payment methods', 'woocommerce' ) }
+						heading={ __(
+							'Other payment providers',
+							'woocommerce'
+						) }
 						onToggle={ trackToggle }
 					>
 						{ additionalSection }

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
@@ -287,7 +287,7 @@ describe( 'PaymentGatewaySuggestions', () => {
 		} );
 	} );
 
-	test( 'should record event correctly when other payment methods is clicked', () => {
+	test( 'should record event correctly when Other payment providers is clicked', () => {
 		const onComplete = jest.fn();
 		const query = {};
 		useSelect.mockImplementation( () => ( {
@@ -305,7 +305,7 @@ describe( 'PaymentGatewaySuggestions', () => {
 			/>
 		);
 
-		fireEvent.click( screen.getByText( 'Other payment methods' ) );
+		fireEvent.click( screen.getByText( 'Other payment providers' ) );
 
 		// By default it's hidden, so when toggle it shows.
 		// Second call after "tasklist_payments_options".
@@ -315,7 +315,7 @@ describe( 'PaymentGatewaySuggestions', () => {
 			'tasklist_payment_show_toggle',
 			{
 				toggle: 'show',
-				payment_method_count: paymentGatewaySuggestions.length - 1, // Minus one for WCPay since it's not counted in "other payment methods".
+				payment_method_count: paymentGatewaySuggestions.length - 1, // Minus one for WCPay since it's not counted in "Other payment providers".
 			},
 		] );
 	} );
@@ -338,7 +338,7 @@ describe( 'PaymentGatewaySuggestions', () => {
 			/>
 		);
 
-		fireEvent.click( screen.getByText( 'Other payment methods' ) );
+		fireEvent.click( screen.getByText( 'Other payment providers' ) );
 		fireEvent.click( screen.getByText( 'See more' ) );
 		expect(
 			recordEvent.mock.calls[ recordEvent.mock.calls.length - 1 ]

--- a/plugins/woocommerce/changelog/fix-33597-wrong-copy-in-payment-accordion-link
+++ b/plugins/woocommerce/changelog/fix-33597-wrong-copy-in-payment-accordion-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong copy in the accordion link for payment task


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33597.

This PR updates the title of the accordion link from `Other payment methods` -> `Other payment providers`

before:

![Screen Shot 2022-06-30 at 10 22 13](https://user-images.githubusercontent.com/4344253/176579106-55270541-d972-4256-bb31-099cefd10694.png)

after:

![Screen Shot 2022-06-30 at 10 21 43](https://user-images.githubusercontent.com/4344253/176579150-29b39297-a6c2-47c1-b62a-1cd481a2247c.png)


### How to test the changes in this Pull Request:

1. Onboard to WooCommerce from a WCPay eligible country **BUT** during onboarding opt-out from installing WCPay
2. Go to WooCommerce Home
3. Click on the payments-related task on the task list
4. Observe that the accordion link should say `Other payment providers`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
