### PR TITLE
Fix wrong copy in the payments task on the Home Task list

### DIFF
--- a/plugins/woocommerce/changelog/fix-33619-wrong-copy-in-payments-task
+++ b/plugins/woocommerce/changelog/fix-33619-wrong-copy-in-payments-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong copy in the payments task on the Home Task list

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -27,7 +27,7 @@ class WooCommercePayments extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Get paid with WooCommerce Payments', 'woocommerce' );
+		return __( 'Set up WooCommerce Payments', 'woocommerce' );
 	}
 
 	/**
@@ -67,7 +67,7 @@ class WooCommercePayments extends Task {
 	 */
 	public function get_additional_info() {
 		return __(
-			'By setting up, you are agreeing to the <a href="https://wordpress.com/tos/" target="_blank">Terms of Service</a>',
+			'By using WooCommerce Payments you agree to be bound by our <a href="https://wordpress.com/tos/" target="_blank">Terms of Service</a> and acknowledge that you have read our <a href="https://automattic.com/privacy/" target="_blank">Privacy Policy</a>',
 			'woocommerce'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33619.

This PR updates the title and description of the WCPay task.

[As in this Figma design](e428PXC0QyEwYqtX48lLq0-fi-12835%3A105679), the copy should say:

```
**Set up WooCommerce Payments**
By using WooCommerce Payments you agree to be bound by our Terms of Service and acknowledge that you have read our Privacy Policy
```

before:
<img src="https://user-images.githubusercontent.com/4344253/176580817-a21f3acb-5efe-48aa-ac7b-925e87b6961b.png" width="500px" />

after:

<img src="https://user-images.githubusercontent.com/4344253/176580827-fadd884f-2af9-433d-b48b-1f63fb232c12.png" width="500px" />

### How to test the changes in this Pull Request:

1. Go to OBW and choose a WCPay eligible country
2. Opt-in to install WCPay during the initial onboarding
3. Go to WooCommerce Home
4. Observe that the payment task displays:

```
**Set up WooCommerce Payments**
By using WooCommerce Payments you agree to be bound by our Terms of Service and acknowledge that you have read our Privacy Policy
```



### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.