### PR TITLE
Fix wrong copy in the payments settings for a country that WCPay is not supported

### DIFF
--- a/plugins/woocommerce-admin/client/payments/payment-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/payments/payment-recommendations.tsx
@@ -208,7 +208,7 @@ const PaymentRecommendations: React.FC = () => {
 						size="20"
 						lineHeight="28px"
 					>
-						{ __( 'Additional ways to get paid', 'woocommerce' ) }
+						{ __( 'Recommended payment providers', 'woocommerce' ) }
 					</Text>
 					<Text
 						className={
@@ -243,7 +243,7 @@ const PaymentRecommendations: React.FC = () => {
 			<List items={ pluginsList } />
 			<CardFooter>
 				<Button href={ SEE_MORE_LINK } target="_blank" isTertiary>
-					{ __( 'See more options', 'woocommerce' ) }
+					{ __( 'Discover other payment providers', 'woocommerce' ) }
 					<ExternalIcon size={ 18 } />
 				</Button>
 			</CardFooter>

--- a/plugins/woocommerce/changelog/fix-33618-wrong-link-in-the-payment-settings-for-non-eligible-wcpay-store
+++ b/plugins/woocommerce/changelog/fix-33618-wrong-link-in-the-payment-settings-for-non-eligible-wcpay-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong copy in payment recommendations


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33618.

This PR updates the table and link's title for a user onboarding from a country that's not supported by WCPay.

As in this [Figma design](e428PXC0QyEwYqtX48lLq0-fi-12830%3A97134)

Before:

![Screen Shot 2022-06-30 at 11 10 32](https://user-images.githubusercontent.com/4344253/176584977-e4d86b29-2764-4fe5-b39f-6323b0271572.png)

After:

![Screen Shot 2022-06-30 at 11 10 12](https://user-images.githubusercontent.com/4344253/176584989-21e2031a-8fb5-43cb-8379-a808168feb94.png)

### How to test the changes in this Pull Request:

1. Onboard to WooCommerce from a country that WCPayments doesn't support
2. Go to `WooCommerce Settings > Payments`
3. Scroll down to see the link at the bottom of the page
4. The table title should be: `Recommended payment providers`
5. The link copy should say: `Discover other payment providers`
6. The link should direct the user to the external marketplace: https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.