### PR TITLE
Shipping recommendation task set location step manual navigation

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/components/store-location.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/components/store-location.tsx
@@ -3,7 +3,7 @@
  */
 import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -15,7 +15,8 @@ import { default as StoreLocationForm } from '~/tasks/fills/steps/location';
 
 export const StoreLocation: React.FC< {
 	nextStep: () => void;
-} > = ( { nextStep } ) => {
+	onLocationComplete: () => void;
+} > = ( { nextStep, onLocationComplete } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateAndPersistSettingsForGroup } =
 		useDispatch( SETTINGS_STORE_NAME );
@@ -36,8 +37,8 @@ export const StoreLocation: React.FC< {
 		if ( isResolving || ! hasCompleteAddress( generalSettings ) ) {
 			return;
 		}
-		nextStep();
-	}, [ generalSettings, isResolving, nextStep ] );
+		onLocationComplete();
+	}, [ generalSettings, onLocationComplete, isResolving ] );
 
 	if ( isResolving ) {
 		return null;

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/shipping-recommendation.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/shipping-recommendation.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { difference } from 'lodash';
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { Stepper } from '@woocommerce/components';
 import { Card, CardBody, Button } from '@wordpress/components';
 
@@ -30,6 +30,8 @@ export const ShippingRecommendation: React.FC<
 	);
 	const [ stepIndex, setStepIndex ] = useState( 0 );
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
+	const [ locationStepRedirected, setLocationStepRedirected ] =
+		useState( false );
 
 	const nextStep = () => {
 		setStepIndex( stepIndex + 1 );
@@ -38,6 +40,19 @@ export const ShippingRecommendation: React.FC<
 	const redirect = () => {
 		setIsRedirecting( true );
 		redirectToWCSSettings();
+	};
+
+	const viewLocationStep = () => {
+		setStepIndex( 0 );
+	};
+
+	// Skips to next step only once.
+	const onLocationComplete = () => {
+		if ( locationStepRedirected ) {
+			return;
+		}
+		setLocationStepRedirected( true );
+		nextStep();
 	};
 
 	useEffect( () => {
@@ -69,7 +84,13 @@ export const ShippingRecommendation: React.FC<
 				'The address from which your business operates',
 				'woocommerce'
 			),
-			content: <StoreLocation nextStep={ nextStep } />,
+			content: (
+				<StoreLocation
+					nextStep={ nextStep }
+					onLocationComplete={ onLocationComplete }
+				/>
+			),
+			onClick: viewLocationStep,
 		},
 		{
 			key: 'plugins',

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/test/shipping-recommendation.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/test/shipping-recommendation.tsx
@@ -120,4 +120,17 @@ describe( 'ShippingRecommendation', () => {
 
 		expect( redirectToWCSSettings ).toHaveBeenCalled();
 	} );
+
+	test( 'should allow location step to be manually navigated', () => {
+		const { getByText } = render(
+			<ShippingRecommendation
+				isJetpackConnected={ true }
+				isResolving={ false }
+				activePlugins={ [] }
+			/>
+		);
+
+		getByText( 'Set store location' ).click();
+		expect( getByText( 'Address line 1' ) ).toBeInTheDocument();
+	} );
 } );

--- a/plugins/woocommerce/changelog/update-shipping-recommendation-set-location-step
+++ b/plugins/woocommerce/changelog/update-shipping-recommendation-set-location-step
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add capability for set location step to be manually navigated in shipping recommendation task


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to https://github.com/woocommerce/woocommerce/issues/33367 regarding discussion on [set location step](https://github.com/woocommerce/woocommerce/issues/33368#issuecomment-1170053408) now able to be manually navigated so that users are able to review it. I made this change to make it a consistent behaviour with shipping task.

### How to test the changes in this Pull Request:

1. Enable the `shipping-smart-defaults` feature via WCA Test helper.
2. Set up a store in US
3. Go to WooCommerce > Settings > Shipping
4. Wait for "Recommended shipping solutions" to appear and click on "Get started" or "Activate" on WooCommerce Shipping
5. When the task is loaded, click on "Set store location"
6. Observe the current step is now store location
7. Click on "Continue" button
8. Observe next step is displayed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
