### PR TITLE
Prepare Script: Fix failure on only comment changelog entries

### DIFF
--- a/tools/package-release/src/changelogger.ts
+++ b/tools/package-release/src/changelogger.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { execSync } from 'child_process';
-import { readdirSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -78,7 +78,7 @@ export const writeChangelog = ( name: string ) => {
  * @param {string} name Package name.
  * @return {boolean} If there are changelogs.
  */
-export const hasChangelogs = ( name: string ): boolean | void => {
+export const hasValidChangelogs = ( name: string ): boolean | void => {
 	try {
 		const changelogDir = join(
 			getFilepathFromPackageName( name ),
@@ -88,10 +88,36 @@ export const hasChangelogs = ( name: string ): boolean | void => {
 			encoding: 'utf-8',
 		} );
 
-		return (
-			changelogDirContents.filter( ( entry ) => entry !== '.gitkeep' )
-				.length > 0
+		const changelogs = changelogDirContents.filter(
+			( entry ) => entry !== '.gitkeep'
 		);
+
+		if ( changelogs.length === 0 ) {
+			return false;
+		}
+
+		return changelogs.some( ( changelog ) => {
+			const contents = readFileSync(
+				join( changelogDir, changelog ),
+				'utf8'
+			);
+
+			const commentRegex = /Comment:.*\n([\s\S]*)?/;
+			const hasComment = commentRegex.test( contents );
+
+			if ( ! hasComment ) {
+				// Has no comment, must be a real changelog.
+				return true;
+			}
+
+			const textAfterComment = /Comment:.*\n([\s\S]*)?/.exec( contents );
+
+			if ( textAfterComment ) {
+				return textAfterComment[ 1 ].trim().length > 0;
+			}
+
+			return false;
+		} );
 	} catch ( e ) {
 		if ( e instanceof Error ) {
 			console.log( e );

--- a/tools/package-release/src/changelogger.ts
+++ b/tools/package-release/src/changelogger.ts
@@ -96,6 +96,7 @@ export const hasValidChangelogs = ( name: string ): boolean | void => {
 			return false;
 		}
 
+		// If there is at least one changelog that is not just a comment, there are valid changelogs.
 		return changelogs.some( ( changelog ) => {
 			const contents = readFileSync(
 				join( changelogDir, changelog ),
@@ -113,6 +114,7 @@ export const hasValidChangelogs = ( name: string ): boolean | void => {
 			const textAfterComment = /Comment:.*\n([\s\S]*)?/.exec( contents );
 
 			if ( textAfterComment ) {
+				// Return true if there is more than just whitespace.
 				return textAfterComment[ 1 ].trim().length > 0;
 			}
 

--- a/tools/package-release/src/commands/prepare/index.ts
+++ b/tools/package-release/src/commands/prepare/index.ts
@@ -16,7 +16,7 @@ import {
 	getNextVersion,
 	validateChangelogEntries,
 	writeChangelog,
-	hasChangelogs,
+	hasValidChangelogs,
 } from '../../changelogger';
 
 /**
@@ -85,7 +85,7 @@ export default class PackageRelease extends Command {
 			CliUx.ux.action.start( `Preparing ${ name }` );
 
 			try {
-				if ( hasChangelogs( name ) ) {
+				if ( hasValidChangelogs( name ) ) {
 					validateChangelogEntries( name );
 					const nextVersion = getNextVersion( name );
 					writeChangelog( name );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The package release prepare script only proceeds if there are changelogs available. This didn't account for comment changelog entries which denote changes that don't warrant representation in the changelog. This causes errors in the write process because there is nothing to write. This PR reads the contents of entries to make sure at least one is a changelog entry describing a bump-worthy change.

### How to test the changes in this Pull Request:

1. Currently `@woocommerce/csv-export` has just one changelog that only has a comment, no actual entry. Confirm this is the case and run the tool. There should be a message saying the package is being skipped due to no changelogs.
```
./tools/package-release/bin/dev prepare @woocommerce/csv-export
```
2. Open `packages/js/components/changelog/add-require-turbo` and add a changelog entry below the comment. Re-run the tool and see it prepare for a release. Stash changes.
2. Repeat the process with `@woocommerce/components` which has valid entries. It should write a new changelog.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
