### PR TITLE
Update store details task action url

### DIFF
--- a/plugins/woocommerce/changelog/update-store-details-task
+++ b/plugins/woocommerce/changelog/update-store-details-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update StoreDetails task action url to navigate to the setting page

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -60,7 +60,7 @@ class StoreDetails extends Task {
 	 * @return string
 	 */
 	public function get_action_url() {
-		return '/setup-wizard';
+		return admin_url( 'admin.php?page=wc-settings' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -69,7 +69,7 @@ class StoreDetails extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		$profiler_data = get_option( OnboardingProfile::DATA_OPTION, array() );
-		return isset( $profiler_data['completed'] ) && true === $profiler_data['completed'];
+		// Mark as completed if the store address and city are set. We don't need to check the country because it's set by default.
+		return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '';
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/store-details.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/store-details.php
@@ -51,7 +51,8 @@ class WC_Admin_Tests_OnboardingTasks_Task_StoreDetails extends WC_Unit_Test_Case
 	 * Test get_title function of StoreDetails task.
 	 */
 	public function test_completed_task_get_title_with_use_completed_title_option() {
-		update_option( OnboardingProfile::DATA_OPTION, array( 'completed' => true ) );
+		update_option( 'woocommerce_store_address', 'Market Street' );
+		update_option( 'woocommerce_store_city', 'San Francisco' );
 		$this->task_list->options['use_completed_title'] = true;
 		$this->assertEquals( 'You added store details', $this->task->get_title() );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #32587 and close #33267 

This PR updates "store details" task action URL to navigate users to the setting page instead.

p1656570355390069/1656563847.142019-slack-C01SFMVEYAK

### How to test the changes in this Pull Request:

1. Go to `Woomcmerce > Home`
2. Click "store details"
3. Observe that you're redirected to the setting page.
4. Fill out "Address line 1" and "city"
5. Go to `Woomcmerce > Home`
6. Observe that "store details" is mark as completed.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.