### PR TITLE
Fix marketing task completion logic

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
@@ -21,6 +21,7 @@ export type PluginProps = {
 	isInstalled: boolean;
 	description?: string;
 	installAndActivate?: ( slug: string ) => void;
+	onManage?: ( slug: string ) => void;
 	imageUrl?: string;
 	manageUrl?: string;
 	name: string;
@@ -31,6 +32,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 	description,
 	imageUrl,
 	installAndActivate = () => {},
+	onManage = () => {},
 	isActive,
 	isBusy,
 	isBuiltByWC,
@@ -72,11 +74,12 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isBusy={ isBusy }
 						isSecondary
 						href={ getAdminLink( manageUrl ) }
-						onClick={ () =>
+						onClick={ () => {
 							recordEvent( 'marketing_manage', {
 								extension_name: slug,
-							} )
-						}
+							} );
+							onManage( slug );
+						} }
 					>
 						{ __( 'Manage', 'woocommmerce-admin' ) }
 					</Button>

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/PluginList.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/PluginList.tsx
@@ -13,6 +13,7 @@ export type PluginListProps = {
 	currentPlugin?: string | null;
 	key?: string;
 	installAndActivate?: ( slug: string ) => void;
+	onManage?: ( slug: string ) => void;
 	plugins?: PluginProps[];
 	title?: string;
 };
@@ -20,6 +21,7 @@ export type PluginListProps = {
 export const PluginList: React.FC< PluginListProps > = ( {
 	currentPlugin,
 	installAndActivate = () => {},
+	onManage = () => {},
 	plugins = [],
 	title,
 } ) => {
@@ -51,6 +53,7 @@ export const PluginList: React.FC< PluginListProps > = ( {
 						name={ name }
 						imageUrl={ imageUrl }
 						installAndActivate={ installAndActivate }
+						onManage={ onManage }
 						isActive={ isActive }
 						isBuiltByWC={ isBuiltByWC }
 						isBusy={ currentPlugin === slug }

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
@@ -145,6 +145,10 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 			} );
 	};
 
+	const onManage = () => {
+		actionTask( 'marketing' );
+	};
+
 	if ( isResolving ) {
 		return <Spinner />;
 	}
@@ -168,6 +172,7 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 					<PluginList
 						currentPlugin={ currentPlugin }
 						installAndActivate={ installAndActivate }
+						onManage={ onManage }
 						plugins={ installedExtensions }
 					/>
 				</Card>
@@ -198,6 +203,7 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 							<PluginList
 								currentPlugin={ currentPlugin }
 								installAndActivate={ installAndActivate }
+								onManage={ onManage }
 								key={ key }
 								plugins={ plugins }
 								title={ title }

--- a/plugins/woocommerce/changelog/fix-marketing-task-complete-only-after-action
+++ b/plugins/woocommerce/changelog/fix-marketing-task-complete-only-after-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert marketing task completion logic to only complete after actioned by user

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Marketing.php
@@ -125,8 +125,8 @@ class Marketing extends Task {
 			}
 		}
 
-		// Make sure the task has been actioned or a marketing extension has been installed.
-		if ( count( $installed ) > 0 || Task::is_task_actioned( 'marketing' ) ) {
+		// Make sure the task has been actioned and a marketing extension has been installed.
+		if ( count( $installed ) > 0 && Task::is_task_actioned( 'marketing' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

This PR:

1. Reverts the changes in https://github.com/woocommerce/woocommerce/pull/32630 so that marketing task isn't automatically complete on installing any marketing plugin
2. Update marketing task to also be marked as completed once actioning on either "Get started", "Activate", or "Manage"

### How to test the changes in this Pull Request:

1. On a fresh site, go through onboarding and install extensions
3. Go to WooCommerce > Home and observe that marketing task isn't marked as completed
4. Click on marketing task
5. Click on "Manage" on Mailpoet
6. Go to WooCommerce > Home and observe that marketing task is marked as completed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
