### PR TITLE
Add CRUD data store typing

### DIFF
--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -16,90 +16,93 @@ type SelectorOptions = {
 	pluralResourceName: string;
 };
 
+export const getItemCreateError = (
+	state: ResourceState,
+	query: ItemQuery
+) => {
+	const itemQuery = getResourceName( CRUD_ACTIONS.CREATE_ITEM, query );
+	return state.errors[ itemQuery ];
+};
+
+export const getItemDeleteError = ( state: ResourceState, id: IdType ) => {
+	const itemQuery = getResourceName( CRUD_ACTIONS.DELETE_ITEM, { id } );
+	return state.errors[ itemQuery ];
+};
+
+export const getItem = ( state: ResourceState, id: IdType ) => {
+	return state.data[ id ];
+};
+
+export const getItemError = ( state: ResourceState, id: IdType ) => {
+	const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEM, { id } );
+	return state.errors[ itemQuery ];
+};
+
+export const getItems = createSelector(
+	( state: ResourceState, query: ItemQuery ) => {
+		const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
+
+		const ids = state.items[ itemQuery ]
+			? state.items[ itemQuery ].data
+			: undefined;
+
+		if ( ! ids ) {
+			return null;
+		}
+
+		if ( query._fields ) {
+			return ids.map( ( id: IdType ) => {
+				return query._fields.reduce(
+					( item: Partial< Item >, field: string ) => {
+						return {
+							...item,
+							[ field ]: state.data[ id ][ field ],
+						};
+					},
+					{} as Partial< Item >
+				);
+			} );
+		}
+
+		return ids.map( ( id: IdType ) => {
+			return state.data[ id ];
+		} );
+	},
+	( state, query ) => {
+		const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
+		const ids = state.items[ itemQuery ]
+			? state.items[ itemQuery ].data
+			: undefined;
+		return [
+			state.items[ itemQuery ],
+			...( ids || [] ).map( ( id: string ) => {
+				return state.data[ id ];
+			} ),
+		];
+	}
+);
+
+export const getItemsError = ( state: ResourceState, query: ItemQuery ) => {
+	const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
+	return state.errors[ itemQuery ];
+};
+
+export const getItemUpdateError = ( state: ResourceState, id: IdType ) => {
+	const itemQuery = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, { id } );
+	return state.errors[ itemQuery ];
+};
+
 export const createSelectors = ( {
 	resourceName,
 	pluralResourceName,
 }: SelectorOptions ) => {
-	const getCreateItemError = ( state: ResourceState, query: ItemQuery ) => {
-		const itemQuery = getResourceName( CRUD_ACTIONS.CREATE_ITEM, query );
-		return state.errors[ itemQuery ];
-	};
-
-	const getDeleteItemError = ( state: ResourceState, id: IdType ) => {
-		const itemQuery = getResourceName( CRUD_ACTIONS.DELETE_ITEM, { id } );
-		return state.errors[ itemQuery ];
-	};
-
-	const getItem = ( state: ResourceState, id: IdType ) => {
-		return state.data[ id ];
-	};
-
-	const getItemError = ( state: ResourceState, id: IdType ) => {
-		const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEM, { id } );
-		return state.errors[ itemQuery ];
-	};
-
-	const getItems = createSelector(
-		( state: ResourceState, query: ItemQuery ) => {
-			const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
-
-			const ids = state.items[ itemQuery ]
-				? state.items[ itemQuery ].data
-				: undefined;
-
-			if ( ! ids ) {
-				return null;
-			}
-
-			if ( query._fields ) {
-				return ids.map( ( id: IdType ) => {
-					return query._fields.reduce(
-						( item: Partial< Item >, field: string ) => {
-							return {
-								...item,
-								[ field ]: state.data[ id ][ field ],
-							};
-						},
-						{} as Partial< Item >
-					);
-				} );
-			}
-
-			return ids.map( ( id: IdType ) => {
-				return state.data[ id ];
-			} );
-		},
-		( state, query ) => {
-			const itemQuery = getResourceName( resourceName, query );
-			const ids = state.items[ itemQuery ]
-				? state.items[ itemQuery ].data
-				: undefined;
-			return [
-				state.items[ itemQuery ],
-				...( ids || [] ).map( ( id: string ) => {
-					return state.data[ id ];
-				} ),
-			];
-		}
-	);
-
-	const getItemsError = ( state: ResourceState, query: ItemQuery ) => {
-		const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
-		return state.errors[ itemQuery ];
-	};
-
-	const getUpdateItemError = ( state: ResourceState, id: IdType ) => {
-		const itemQuery = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, { id } );
-		return state.errors[ itemQuery ];
-	};
-
 	return {
 		[ `get${ resourceName }` ]: getItem,
 		[ `get${ resourceName }Error` ]: getItemError,
 		[ `get${ pluralResourceName }` ]: getItems,
 		[ `get${ pluralResourceName }Error` ]: getItemsError,
-		[ `getCreate${ resourceName }Error` ]: getCreateItemError,
-		[ `getDelete${ resourceName }Error` ]: getDeleteItemError,
-		[ `getUpdate${ resourceName }Error` ]: getUpdateItemError,
+		[ `get${ resourceName }CreateError` ]: getItemCreateError,
+		[ `get${ resourceName }DeleteError` ]: getItemDeleteError,
+		[ `get${ resourceName }UpdateError` ]: getItemUpdateError,
 	};
 };

--- a/packages/js/data/src/crud/test/selectors.ts
+++ b/packages/js/data/src/crud/test/selectors.ts
@@ -15,8 +15,8 @@ describe( 'crud selectors', () => {
 		expect( selectors ).toHaveProperty( 'getProducts' );
 		expect( selectors ).toHaveProperty( 'getProductError' );
 		expect( selectors ).toHaveProperty( 'getProductsError' );
-		expect( selectors ).toHaveProperty( 'getCreateProductError' );
-		expect( selectors ).toHaveProperty( 'getDeleteProductError' );
-		expect( selectors ).toHaveProperty( 'getUpdateProductError' );
+		expect( selectors ).toHaveProperty( 'getProductCreateError' );
+		expect( selectors ).toHaveProperty( 'getProductDeleteError' );
+		expect( selectors ).toHaveProperty( 'getProductUpdateError' );
 	} );
 } );

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -1,7 +1,16 @@
 /**
  * Internal dependencies
  */
-import { BaseQueryParams } from '../types';
+import { BaseQueryParams, WPDataSelector, WPDataSelectors } from '../types';
+import {
+	getItem,
+	getItemError,
+	getItems,
+	getItemsError,
+	getItemCreateError,
+	getItemDeleteError,
+	getItemUpdateError,
+} from './selectors';
 
 export type IdType = number | string;
 
@@ -12,4 +21,80 @@ export type Item = {
 
 export type ItemQuery = BaseQueryParams & {
 	[ key: string ]: unknown;
+};
+
+export type CrudActions< ResourceName, ItemConfig, MutableProperties > =
+	MapActions<
+		{
+			create: ( query: ItemQuery ) => Item;
+			update: ( query: ItemQuery ) => Item;
+		},
+		ResourceName,
+		MutableProperties,
+		ItemConfig
+	> &
+		MapActions<
+			{
+				delete: ( id: IdType ) => Item;
+			},
+			ResourceName,
+			IdType,
+			ItemConfig
+		>;
+
+export type CrudSelectors<
+	ResourceName,
+	PluralResourceName,
+	ItemConfig,
+	ItemQueryConfig,
+	MutableProperties
+> = MapSelectors<
+	{
+		'': WPDataSelector< typeof getItem >;
+		Error: WPDataSelector< typeof getItemError >;
+		DeleteError: WPDataSelector< typeof getItemDeleteError >;
+		UpdateError: WPDataSelector< typeof getItemUpdateError >;
+	},
+	ResourceName,
+	IdType,
+	unknown
+> &
+	MapSelectors<
+		{
+			'': WPDataSelector< typeof getItems >;
+		},
+		PluralResourceName,
+		ItemQueryConfig,
+		ItemConfig[]
+	> &
+	MapSelectors<
+		{
+			Error: WPDataSelector< typeof getItemsError >;
+		},
+		PluralResourceName,
+		ItemQueryConfig,
+		unknown
+	> &
+	MapSelectors<
+		{
+			CreateError: WPDataSelector< typeof getItemCreateError >;
+		},
+		PluralResourceName,
+		MutableProperties,
+		unknown
+	> &
+	WPDataSelectors;
+
+export type MapSelectors< Type, ResourceName, ParamType, ReturnType > = {
+	[ Property in keyof Type as `get${ Capitalize<
+		string & ResourceName
+	> }${ Capitalize< string & Property > }` ]: ( x: ParamType ) => ReturnType;
+};
+
+export type MapActions< Type, ResourceName, ParamType, ReturnType > = {
+	[ Property in keyof Type as `${ Lowercase<
+		string & Property
+	> }${ Capitalize< string & ResourceName > }` ]: (
+		x: ParamType
+	) => ReturnType;
 };

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -31,7 +31,7 @@ export type CrudActions< ResourceName, ItemType, MutableProperties > =
 		},
 		ResourceName,
 		MutableProperties,
-		ItemType
+		Generator< unknown, ItemType >
 	> &
 		MapActions<
 			{
@@ -39,7 +39,7 @@ export type CrudActions< ResourceName, ItemType, MutableProperties > =
 			},
 			ResourceName,
 			IdType,
-			ItemType
+			Generator< unknown, ItemType >
 		>;
 
 export type CrudSelectors<

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -23,7 +23,7 @@ export type ItemQuery = BaseQueryParams & {
 	[ key: string ]: unknown;
 };
 
-export type CrudActions< ResourceName, ItemConfig, MutableProperties > =
+export type CrudActions< ResourceName, ItemType, MutableProperties > =
 	MapActions<
 		{
 			create: ( query: ItemQuery ) => Item;
@@ -31,7 +31,7 @@ export type CrudActions< ResourceName, ItemConfig, MutableProperties > =
 		},
 		ResourceName,
 		MutableProperties,
-		ItemConfig
+		ItemType
 	> &
 		MapActions<
 			{
@@ -39,14 +39,14 @@ export type CrudActions< ResourceName, ItemConfig, MutableProperties > =
 			},
 			ResourceName,
 			IdType,
-			ItemConfig
+			ItemType
 		>;
 
 export type CrudSelectors<
 	ResourceName,
 	PluralResourceName,
-	ItemConfig,
-	ItemQueryConfig,
+	ItemType,
+	ItemQueryType,
 	MutableProperties
 > = MapSelectors<
 	{
@@ -54,7 +54,7 @@ export type CrudSelectors<
 	},
 	ResourceName,
 	IdType,
-	ItemConfig
+	ItemType
 > &
 	MapSelectors<
 		{
@@ -71,15 +71,15 @@ export type CrudSelectors<
 			'': WPDataSelector< typeof getItems >;
 		},
 		PluralResourceName,
-		ItemQueryConfig,
-		ItemConfig[]
+		ItemQueryType,
+		ItemType[]
 	> &
 	MapSelectors<
 		{
 			Error: WPDataSelector< typeof getItemsError >;
 		},
 		PluralResourceName,
-		ItemQueryConfig,
+		ItemQueryType,
 		unknown
 	> &
 	MapSelectors<

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -51,14 +51,21 @@ export type CrudSelectors<
 > = MapSelectors<
 	{
 		'': WPDataSelector< typeof getItem >;
-		Error: WPDataSelector< typeof getItemError >;
-		DeleteError: WPDataSelector< typeof getItemDeleteError >;
-		UpdateError: WPDataSelector< typeof getItemUpdateError >;
 	},
 	ResourceName,
 	IdType,
-	unknown
+	ItemConfig
 > &
+	MapSelectors<
+		{
+			Error: WPDataSelector< typeof getItemError >;
+			DeleteError: WPDataSelector< typeof getItemDeleteError >;
+			UpdateError: WPDataSelector< typeof getItemUpdateError >;
+		},
+		ResourceName,
+		IdType,
+		unknown
+	> &
 	MapSelectors<
 		{
 			'': WPDataSelector< typeof getItems >;

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -119,6 +119,7 @@ import { OnboardingSelectors } from './onboarding/selectors';
 import { OptionsSelectors } from './options/types';
 import { ProductsSelectors } from './products/selectors';
 import { OrdersSelectors } from './orders/selectors';
+import { ProductAttributeSelectors } from './product-attributes/types';
 
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
@@ -148,6 +149,8 @@ export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME
 	? WPDataSelectors
 	: T extends typeof PRODUCTS_STORE_NAME
 	? ProductsSelectors
+	: T extends typeof PRODUCT_ATTRIBUTES_STORE_NAME
+	? ProductAttributeSelectors
 	: T extends typeof ORDERS_STORE_NAME
 	? OrdersSelectors
 	: never;
@@ -158,4 +161,5 @@ export interface WCDataSelector {
 
 // Other exports
 export { ActionDispatchers as PluginsStoreActions } from './plugins/actions';
+export { ActionDispatchers as ProductAttributesActions } from './product-attributes/types';
 export { ActionDispatchers as ProductsStoreActions } from './products/actions';

--- a/packages/js/data/src/product-attributes/types.ts
+++ b/packages/js/data/src/product-attributes/types.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { DispatchFromMap } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import { CrudActions, CrudSelectors } from '../crud/types';
+
+type ProductAttribute = {
+	id: number;
+	slug: string;
+	name: string;
+	type: string;
+	order_by: string;
+	has_archives: boolean;
+};
+
+type Query = {
+	context?: string;
+};
+
+type ReadOnlyProperties = 'id';
+
+type MutableProperties = Partial<
+	Omit< ProductAttribute, ReadOnlyProperties >
+>;
+
+type ProductAttributeActions = CrudActions<
+	'ProductAttribute',
+	ProductAttribute,
+	MutableProperties
+>;
+
+export type ProductAttributeSelectors = CrudSelectors<
+	'ProductAttribute',
+	'ProductAttributes',
+	ProductAttribute,
+	Query,
+	MutableProperties
+>;
+
+export type ActionDispatchers = DispatchFromMap< ProductAttributeActions >;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds typing for the default selectors and actions provided by the CRUD data stores.  It adds these to Product Attributes so you can see it implemented.

In order to automate this, it requires renaming some of the selectors in a hacky way via TS.  While this is super convenient, I am open to discussion on whether or not we should just manually type out each data store method.

Closes # .

### How to test the changes in this Pull Request:

1. In your code editor, use the product attributes selector as a type:
```
const storeSelect: ProductAttributeSelectors = {};
storeSelect.getProductAttribute();
```
2. Note that `getProductAttribute` does not throw an error and other available selectors work as well.
3. Repeat this for `ProductAttributeActions`

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
