### PR TITLE
Add product archive header template and re-hook

### DIFF
--- a/plugins/woocommerce/changelog/2023-10-24-08-52-26-105513
+++ b/plugins/woocommerce/changelog/2023-10-24-08-52-26-105513
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new product archive header template and hook into woocommerce_before_main_content

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1245,6 +1245,17 @@ if ( ! function_exists( 'woocommerce_template_loop_category_link_close' ) ) {
 	}
 }
 
+if ( ! function_exists( 'woocommerce_product_taxonomy_archive_header' ) ) {
+	/**
+	 * Output the products header on taxonomy archives.
+	 */
+	function woocommerce_product_taxonomy_archive_header() {
+		if ( is_product_taxonomy() ) {
+			wc_get_template( 'loop/header.php' );
+		}
+	}
+}
+
 if ( ! function_exists( 'woocommerce_taxonomy_archive_description' ) ) {
 	/**
 	 * Show an archive description on taxonomy archives.

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1250,9 +1250,7 @@ if ( ! function_exists( 'woocommerce_product_taxonomy_archive_header' ) ) {
 	 * Output the products header on taxonomy archives.
 	 */
 	function woocommerce_product_taxonomy_archive_header() {
-		if ( is_product_taxonomy() ) {
-			wc_get_template( 'loop/header.php' );
-		}
+		wc_get_template( 'loop/header.php' );
 	}
 }
 

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -58,7 +58,7 @@ add_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
  *
  * @see woocommerce_product_taxonomy_archive_header()
  */
-add_action( 'woocommerce_before_main_content', 'woocommerce_product_taxonomy_archive_header', 40 );
+add_action( 'woocommerce_shop_loop_header', 'woocommerce_product_taxonomy_archive_header' );
 
 /**
  * Archive descriptions.

--- a/plugins/woocommerce/includes/wc-template-hooks.php
+++ b/plugins/woocommerce/includes/wc-template-hooks.php
@@ -54,6 +54,13 @@ add_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb', 20, 0 )
 add_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
 
 /**
+ * Archive header.
+ *
+ * @see woocommerce_product_taxonomy_archive_header()
+ */
+add_action( 'woocommerce_before_main_content', 'woocommerce_product_taxonomy_archive_header', 40 );
+
+/**
  * Archive descriptions.
  *
  * @see woocommerce_taxonomy_archive_description()

--- a/plugins/woocommerce/templates/archive-product.php
+++ b/plugins/woocommerce/templates/archive-product.php
@@ -12,7 +12,7 @@
  *
  * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.0
+ * @version 8.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/archive-product.php
+++ b/plugins/woocommerce/templates/archive-product.php
@@ -25,9 +25,17 @@ get_header( 'shop' );
  * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
  * @hooked woocommerce_breadcrumb - 20
  * @hooked WC_Structured_Data::generate_website_data() - 30
- * @hooked woocommerce_product_taxonomy_archive_header - 40
  */
 do_action( 'woocommerce_before_main_content' );
+
+/**
+ * Hook: woocommerce_shop_loop_header.
+ *
+ * @since 8.6.0
+ *
+ * @hooked woocommerce_product_taxonomy_archive_header - 10
+ */
+do_action( 'woocommerce_shop_loop_header' );
 
 if ( woocommerce_product_loop() ) {
 

--- a/plugins/woocommerce/templates/archive-product.php
+++ b/plugins/woocommerce/templates/archive-product.php
@@ -12,7 +12,7 @@
  *
  * @see https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.0
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/archive-product.php
+++ b/plugins/woocommerce/templates/archive-product.php
@@ -25,26 +25,10 @@ get_header( 'shop' );
  * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
  * @hooked woocommerce_breadcrumb - 20
  * @hooked WC_Structured_Data::generate_website_data() - 30
+ * @hooked woocommerce_product_taxonomy_archive_header - 40
  */
 do_action( 'woocommerce_before_main_content' );
 
-?>
-<header class="woocommerce-products-header">
-	<?php if ( apply_filters( 'woocommerce_show_page_title', true ) ) : ?>
-		<h1 class="woocommerce-products-header__title page-title"><?php woocommerce_page_title(); ?></h1>
-	<?php endif; ?>
-
-	<?php
-	/**
-	 * Hook: woocommerce_archive_description.
-	 *
-	 * @hooked woocommerce_taxonomy_archive_description - 10
-	 * @hooked woocommerce_product_archive_description - 10
-	 */
-	do_action( 'woocommerce_archive_description' );
-	?>
-</header>
-<?php
 if ( woocommerce_product_loop() ) {
 
 	/**

--- a/plugins/woocommerce/templates/loop/header.php
+++ b/plugins/woocommerce/templates/loop/header.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version     1.0.0
+ * @version 8.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/loop/header.php
+++ b/plugins/woocommerce/templates/loop/header.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Product taxonomy archive header
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/loop/header.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<header class="woocommerce-products-header">
+	<?php
+	/**
+	 * Hook: woocommerce_show_page_title.
+	 *
+	 * Allow developers to remove the product taxonomy archive page title.
+	 *
+	 * @since 2.0.6.
+	 */
+	if ( apply_filters( 'woocommerce_show_page_title', true ) ) :
+		?>
+		<h1 class="woocommerce-products-header__title page-title"><?php woocommerce_page_title(); ?></h1>
+	<?php endif; ?>
+
+	<?php
+	/**
+	 * Hook: woocommerce_archive_description.
+	 *
+	 * @since 1.6.2.
+	 * @hooked woocommerce_taxonomy_archive_description - 10
+	 * @hooked woocommerce_product_archive_description - 10
+	 */
+	do_action( 'woocommerce_archive_description' );
+	?>
+</header>

--- a/plugins/woocommerce/templates/loop/header.php
+++ b/plugins/woocommerce/templates/loop/header.php
@@ -12,6 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
+ * @version     1.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Moves the product taxonomy archive header into its own template file, creates a related output function, and then re-hooks the new template back into the archive-product.php file in the same place, via the new `woocommerce_shop_loop_header` hook.

This is so that this template part can be removed/unhooked via the `remove_action` function, which is a cleaner approach than template overrides or additional style changes. Moreover, this is consistent with the rest of the `archive-product.php` template, which is already being rendered via actions.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33672 

### How to test the changes in this Pull Request:

1. View the shop archive or a product category archive with this patch applied.
    **Result:** Archive header should appear as normal.
2. Add the following to the test theme functions.php file (or via another route):
  `remove_action( 'woocommerce_shop_loop_header', 'woocommerce_product_taxonomy_archive_header', 40 );`
  **Result:** Archive header should be removed from the markup.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
