### PR TITLE
[COT] Implement order bulk actions

### DIFF
--- a/plugins/woocommerce/changelog/add-33198-cot-admin-list-table-actions
+++ b/plugins/woocommerce/changelog/add-33198-cot-admin-list-table-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Implement bulk actions in the new orders admin list table.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable as Custom_Orders_List_Table;
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController as Custom_Orders_PageController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
 defined( 'ABSPATH' ) || exit;
@@ -316,38 +317,9 @@ class WC_Admin_Menus {
 	 */
 	public function orders_menu(): void {
 		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
-			add_submenu_page( 'woocommerce', __( 'Orders', 'woocommerce' ), __( 'Orders', 'woocommerce' ), 'edit_others_shop_orders', 'wc-orders', array( $this, 'orders_page' ) );
-			add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'orders_table' ) );
-
-			// In some cases (such as if the authoritative order store was changed earlier in the current request) we
-			// need an extra step to remove the menu entry for the menu post type.
-			add_action(
-				'admin_init',
-				function () {
-					remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
-				}
-			);
+			$this->orders_page_controller = new Custom_Orders_PageController();
+			$this->orders_page_controller->setup();
 		}
-	}
-
-	/**
-	 * Set-up the orders admin list table.
-	 *
-	 * @return void
-	 */
-	public function orders_table(): void {
-		$this->orders_list_table = new Custom_Orders_List_Table();
-		$this->orders_list_table->setup();
-	}
-
-	/**
-	 * Render the orders admin list table.
-	 *
-	 * @return void
-	 */
-	public function orders_page(): void {
-		$this->orders_list_table->prepare_items();
-		$this->orders_list_table->display();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -730,10 +730,12 @@ class ListTable extends WP_List_Table {
 		foreach ( $order_ids as $id ) {
 			$order = wc_get_order( $id );
 
-			if ( $order ) {
-				do_action( 'woocommerce_remove_order_personal_data', $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-				$changed++;
+			if ( ! $order ) {
+				continue;
 			}
+
+			do_action( 'woocommerce_remove_order_personal_data', $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			$changed++;
 		}
 
 		return $changed;
@@ -754,7 +756,12 @@ class ListTable extends WP_List_Table {
 
 		foreach ( $order_ids as $id ) {
 			$order = wc_get_order( $id );
-			$order->update_status( $new_status, __( 'Order status changed by bulk edit:', 'woocommerce' ), true );
+
+			if ( ! $order ) {
+				continue;
+			}
+
+			$order->update_status( $new_status, __( 'Order status changed by bulk edit.', 'woocommerce' ), true );
 			do_action( 'woocommerce_order_edit_status', $id, $new_status ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			$changed++;
 		}
@@ -771,22 +778,22 @@ class ListTable extends WP_List_Table {
 		}
 
 		$order_statuses = wc_get_order_statuses();
-		$number         = isset( $_REQUEST['changed'] ) ? absint( $_REQUEST['changed'] ) : 0;
+		$number         = absint( $_REQUEST['changed'] ?? 0 );
 		$bulk_action    = wc_clean( wp_unslash( $_REQUEST['bulk_action'] ) );
 
 		// Check if any status changes happened.
 		foreach ( $order_statuses as $slug => $name ) {
 			if ( 'marked_' . str_replace( 'wc-', '', $slug ) === $bulk_action ) { // WPCS: input var ok, CSRF ok.
-				/* translators: %d: orders count */
-				$message = sprintf( _n( '%d order status changed.', '%d order statuses changed.', $number, 'woocommerce' ), number_format_i18n( $number ) );
+				/* translators: %s: orders count */
+				$message = sprintf( _n( '%s order status changed.', '%s order statuses changed.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 				echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';
 				break;
 			}
 		}
 
 		if ( 'removed_personal_data' === $bulk_action ) { // WPCS: input var ok, CSRF ok.
-			/* translators: %d: orders count */
-			$message = sprintf( _n( 'Removed personal data from %d order.', 'Removed personal data from %d orders.', $number, 'woocommerce' ), number_format_i18n( $number ) );
+			/* translators: %s: orders count */
+			$message = sprintf( _n( 'Removed personal data from %s order.', 'Removed personal data from %s orders.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 			echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -120,7 +120,7 @@ class ListTable extends WP_List_Table {
 			/**
 			 * Renders after the 'blank state' message for the order list table has rendered.
 			 */
-			do_action( 'wc_marketplace_suggestions_orders_empty_state' );
+			do_action( 'wc_marketplace_suggestions_orders_empty_state' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
 			?>
 
 			</div>
@@ -460,7 +460,7 @@ class ListTable extends WP_List_Table {
 				human_time_diff( $order->get_date_created()->getTimestamp(), time() )
 			);
 		} else {
-			$show_date = $order->get_date_created()->date_i18n( apply_filters( 'woocommerce_admin_order_date_format', __( 'M j, Y', 'woocommerce' ) ) );
+			$show_date = $order->get_date_created()->date_i18n( apply_filters( 'woocommerce_admin_order_date_format', __( 'M j, Y', 'woocommerce' ) ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		}
 		printf(
 			'<time datetime="%1$s" title="%2$s">%3$s</time>',
@@ -585,6 +585,7 @@ class ListTable extends WP_List_Table {
 		 * are registered.
 		 *
 		 * @param WC_Order $order Current order object.
+		 * @since 6.7.0
 		 */
 		do_action( 'woocommerce_admin_order_actions_start', $order );
 
@@ -611,6 +612,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @param array    $action Order actions.
 		 * @param WC_Order $order  Current order object.
+		 * @since 6.7.0
 		 */
 		$actions = apply_filters( 'woocommerce_admin_order_actions', $actions, $order );
 
@@ -622,6 +624,7 @@ class ListTable extends WP_List_Table {
 		 * are rendered.
 		 *
 		 * @param WC_Order $order Current order object.
+		 * @since 6.7.0
 		 */
 		do_action( 'woocommerce_admin_order_actions_end', $order );
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use WC_Order;
-use WC_Order_Data_Store_Interface;
 use WP_List_Table;
 use WP_Screen;
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -1,0 +1,116 @@
+<?php
+namespace Automattic\WooCommerce\Internal\Admin\Orders;
+
+/**
+ * Controls the different pages/screens associated to the "Orders" menu page.
+ */
+class PageController {
+
+	/**
+	 * Instance of the orders list table.
+	 *
+	 * @var Automattic\WooCommerce\Internal\Admin\Orders\ListTable
+	 */
+	private $orders_table;
+
+	/**
+	 * Current action.
+	 *
+	 * @var string
+	 */
+	private $current_action = '';
+
+	/**
+	 * Sets up the page controller, including registering the menu item.
+	 *
+	 * @return void
+	 */
+	public function setup(): void {
+		// Register menu.
+		if ( 'admin_menu' === current_action() ) {
+			$this->register_menu();
+		} else {
+			add_action( 'admin_menu', 'register_menu', 9 );
+		}
+
+		$this->set_action();
+
+		// Perform initialization for the current action.
+		add_action(
+			'load-woocommerce_page_wc-orders',
+			function() {
+				if ( method_exists( $this, 'setup_action_' . $this->current_action ) ) {
+					$this->{"setup_action_{$this->current_action}"}();
+				}
+			}
+		);
+	}
+
+	/**
+	 * Sets the current action based on querystring arguments. Defaults to 'list_orders'.
+	 *
+	 * @return void
+	 */
+	private function set_action(): void {
+		$this->current_action = 'list_orders';
+
+		if ( ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
+			$this->current_action = 'edit_order';
+		}
+	}
+
+	/**
+	 * Registers the "Orders" menu.
+	 *
+	 * @return void
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'woocommerce',
+			__( 'Orders', 'woocommerce' ),
+			__( 'Orders', 'woocommerce' ),
+			'edit_others_shop_orders',
+			'wc-orders',
+			array( $this, 'output' )
+		);
+
+		// In some cases (such as if the authoritative order store was changed earlier in the current request) we
+		// need an extra step to remove the menu entry for the menu post type.
+		add_action(
+			'admin_init',
+			function() {
+				remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
+			}
+		);
+	}
+
+	/**
+	 * Outputs content for the current orders screen.
+	 *
+	 * @return void
+	 */
+	public function output(): void {
+		switch ( $this->current_action ) {
+			case 'list_orders':
+			default:
+				$this->orders_table->prepare_items();
+				$this->orders_table->display();
+				break;
+		}
+	}
+
+	/**
+	 * Handles initialization of the orders list table.
+	 *
+	 * @return void
+	 */
+	private function setup_action_list_orders(): void {
+		$this->orders_table = new ListTable();
+		$this->orders_table->setup();
+
+		if ( $this->orders_table->current_action() ) {
+			$this->orders_table->handle_bulk_actions();
+		}
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR implements order [bulk actions](https://user-images.githubusercontent.com/3594411/170389458-2c2f11ef-3953-454f-aac1-7bc937852b24.png) for the new implementation of the orders list table for COT (#32864).

- The PR introduces class `Internal\Admin\Orders\PageController` to handle registration of the "Orders" menu item and initialization of all things associated to it. For example, it takes care of figuring out which order screen to display, which might be useful for #33638 (which implements the "edit order" screen and logic).
- Bulk actions are implemented inside the list table directly, in line with the current CPT implementation, but similar to other TODO's in this file, we might want to move it outside of the table implementation (maybe an "OrderPage" class that the "PageController" manages?).
- Row-level actions (i.e. not bulk actions) do not require changes to the codebase, as those are handled [by an AJAX handler](https://github.com/woocommerce/woocommerce/blob/a2b6b9bd2d46e8021230809dee227ed5f72f1368/plugins/woocommerce/includes/class-wc-ajax.php#L517-L533) that is datastore & list table implementation agnostic.


Closes #33198.

### How to test the changes in this Pull Request:

As there's nothing COT datastore specific in this PR, it should be possible to test by "tricking" the code as described in #

1. Get the new list table showing.
   - As there's nothing COT datastore specific in this PR, it should be possible to do this by tricking WC into displaying the new table as described in #32864:
   
      > I temporarily tweaked [this line of code](https://github.com/woocommerce/woocommerce/pull/32864/files#diff-1c0f35a6fb307b4248784e1f47ff1e71754b02fd1315315e44b5b5eb725f30b4R319) by adding `true ||` to the start of the condition, to make the new admin list table render anyway.
   - For the full COT-datastore experience, make sure to enable the feature and migrate some orders over to the new tables. Set COT as authoritative and use a snippet like [this one](https://gist.github.com/jorgeatorres/e0e12088756425d3d15762864f18bea1) to "mock" a `query()` method implementation.
2. Use either the top or bottom bulk actions drop-down to apply different statuses to your orders.
3. Make sure the actions work correctly, including the redirect and admin notices:
   <img width="650" alt="Screen Shot 2022-06-30 at 17 08 00" src="https://user-images.githubusercontent.com/184724/176768573-1f469ada-8d5a-4542-a1a6-d15169fabddc.png">

