### PR TITLE
Add a namespace prefix to the Psr/Container package

### DIFF
--- a/plugins/woocommerce/changelog/add-namespace-prefix-to-psr-container-package
+++ b/plugins/woocommerce/changelog/add-namespace-prefix-to-psr-container-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add a namespace to all the classes of the Psr\Container package

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -20,7 +20,6 @@
 		"composer/installers": "^1.9",
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
-		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.2",
 		"woocommerce/woocommerce-blocks": "7.8.3"
 	},

--- a/plugins/woocommerce/lib/composer.json
+++ b/plugins/woocommerce/lib/composer.json
@@ -4,15 +4,15 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
-		"php": ">=7.0",
-		"psr/container": "^1.0"
+		"php": ">=7.2"
 	},
 	"require-dev": {
-		"league/container": "3.3.5"
+		"league/container": "3.3.5",
+	    "psr/container": "^1.1"
 	},
 	"config": {
 		"platform": {
-			"php": "7.0"
+			"php": "7.2"
 		}
 	},
 	"scripts": {
@@ -28,10 +28,10 @@
 			"dep_namespace": "Automattic\\WooCommerce\\Vendor\\",
 			"dep_directory": "/packages/",
 			"packages": [
-				"league/container"
+				"league/container",
+			    "psr/container"
 			],
 			"excluded_packages": [
-				"psr/container"
 			],
 			"classmap_directory": "/classes/",
 			"classmap_prefix": "WC_Vendor_",

--- a/plugins/woocommerce/lib/composer.json
+++ b/plugins/woocommerce/lib/composer.json
@@ -8,7 +8,7 @@
 	},
 	"require-dev": {
 		"league/container": "3.3.5",
-	    "psr/container": "^1.1"
+		"psr/container": "^1.1"
 	},
 	"config": {
 		"platform": {
@@ -29,7 +29,7 @@
 			"dep_directory": "/packages/",
 			"packages": [
 				"league/container",
-			    "psr/container"
+				"psr/container"
 			],
 			"excluded_packages": [
 			],

--- a/plugins/woocommerce/lib/composer.lock
+++ b/plugins/woocommerce/lib/composer.lock
@@ -1,0 +1,151 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ee5352d3dc7eff84b896ab4900209e53",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "league/container",
+            "version": "3.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/048ab87810f508dbedbcb7ae941b606eb8ee353b",
+                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/container": "^1.0.0 || ^2.0.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0",
+                "roave/security-advisories": "dev-master",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "philipobenito@gmail.com",
+                    "homepage": "http://www.philipobenito.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/3.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-16T09:42:56+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.2"
+    },
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2"
+    },
+    "plugin-api-version": "2.0.0"
+}

--- a/plugins/woocommerce/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\Vendor\League\Container\Argument;
 use Automattic\WooCommerce\Vendor\League\Container\Container;
 use Automattic\WooCommerce\Vendor\League\Container\Exception\{ContainerException, NotFoundException};
 use Automattic\WooCommerce\Vendor\League\Container\ReflectionContainer;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
 
@@ -79,7 +79,7 @@ trait ArgumentResolverTrait
             }
 
             if ($type) {
-                if (PHP_VERSION_ID >= 70200) {
+                if (PHP_VERSION_ID >= 70100) {
                     $typeName = $type->getName();
                 } else {
                     $typeName = (string) $type;

--- a/plugins/woocommerce/lib/packages/League/Container/Container.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Container.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\Vendor\League\Container\ServiceProvider\{
     ServiceProviderAggregateInterface,
     ServiceProviderInterface
 };
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 class Container implements ContainerInterface
 {

--- a/plugins/woocommerce/lib/packages/League/Container/ContainerAwareInterface.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ContainerAwareInterface.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Vendor\League\Container;
 
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 interface ContainerAwareInterface
 {
@@ -13,7 +13,7 @@ interface ContainerAwareInterface
      *
      * @return self
      */
-    public function setContainer(ContainerInterface $container) : self;
+    public function setContainer(ContainerInterface $container) : ContainerAwareInterface;
 
     /**
      * Get the container

--- a/plugins/woocommerce/lib/packages/League/Container/ContainerAwareTrait.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ContainerAwareTrait.php
@@ -3,7 +3,7 @@
 namespace Automattic\WooCommerce\Vendor\League\Container;
 
 use Automattic\WooCommerce\Vendor\League\Container\Exception\ContainerException;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 trait ContainerAwareTrait
 {
@@ -22,7 +22,7 @@ trait ContainerAwareTrait
      *
      * @param ContainerInterface $container
      *
-     * @return self
+     * @return ContainerAwareInterface
      */
     public function setContainer(ContainerInterface $container) : ContainerAwareInterface
     {

--- a/plugins/woocommerce/lib/packages/League/Container/Definition/Definition.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Definition/Definition.php
@@ -216,6 +216,10 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
             $concrete = $this->invokeMethods($concrete);
         }
 
+        if (is_string($concrete) && $this->getContainer()->has($concrete)) {
+            $concrete = $this->getContainer()->get($concrete);
+        }
+
         $this->resolved = $concrete;
 
         return $concrete;

--- a/plugins/woocommerce/lib/packages/League/Container/Exception/ContainerException.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Exception/ContainerException.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Vendor\League\Container\Exception;
 
-use Psr\Container\ContainerExceptionInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
 use RuntimeException;
 
 class ContainerException extends RuntimeException implements ContainerExceptionInterface

--- a/plugins/woocommerce/lib/packages/League/Container/Exception/NotFoundException.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Vendor\League\Container\Exception;
 
-use Psr\Container\NotFoundExceptionInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
 use InvalidArgumentException;
 
 class NotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface

--- a/plugins/woocommerce/lib/packages/League/Container/ReflectionContainer.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ReflectionContainer.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Vendor\League\Container;
 
 use Automattic\WooCommerce\Vendor\League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait};
 use Automattic\WooCommerce\Vendor\League\Container\Exception\NotFoundException;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;

--- a/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -98,8 +98,8 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
             }
 
             if ($provider->provides($service)) {
-                $provider->register();
                 $this->registered[] = $provider->getIdentifier();
+                $provider->register();
             }
         }
     }

--- a/plugins/woocommerce/lib/packages/Psr/Container/ContainerExceptionInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/ContainerExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Vendor\Psr\Container;
+
+/**
+ * Base interface representing a generic exception in a container.
+ */
+interface ContainerExceptionInterface
+{
+}

--- a/plugins/woocommerce/lib/packages/Psr/Container/ContainerInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/ContainerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Vendor\Psr\Container;
+
+/**
+ * Describes the interface of a container that exposes methods to read its entries.
+ */
+interface ContainerInterface
+{
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get(string $id);
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has(string $id);
+}

--- a/plugins/woocommerce/lib/packages/Psr/Container/NotFoundExceptionInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/NotFoundExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Automattic\WooCommerce\Vendor\Psr\Container;
+
+/**
+ * No entry was found in the container.
+ */
+interface NotFoundExceptionInterface extends ContainerExceptionInterface
+{
+}

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -35,7 +35,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\UtilsC
  * and those should go in the `src\Internal\DependencyManagement\ServiceProviders` folder unless there's a good reason
  * to put them elsewhere. All the service provider class names must be in the `SERVICE_PROVIDERS` constant.
  */
-final class Container implements \Psr\Container\ContainerInterface {
+final class Container {
 	/**
 	 * The list of service provider classes to register.
 	 *
@@ -71,7 +71,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 		// Add ourselves as the shared instance of ContainerInterface,
 		// register everything else using service providers.
 
-		$this->container->share( \Psr\Container\ContainerInterface::class, $this );
+		$this->container->share( __CLASS__, $this );
 
 		foreach ( $this->service_providers as $service_provider_class ) {
 			$this->container->addServiceProvider( $service_provider_class );
@@ -88,7 +88,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 	 *
 	 * @return mixed Entry.
 	 */
-	public function get( $id ) {
+	public function get( string $id ): object {
 		return $this->container->get( $id );
 	}
 
@@ -103,7 +103,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 	 *
 	 * @return bool
 	 */
-	public function has( $id ) {
+	public function has( string $id ): bool {
 		return $this->container->has( $id );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\Container;
 use Automattic\WooCommerce\Utilities\StringUtil;
 use Automattic\WooCommerce\Vendor\League\Container\Container as BaseContainer;
 use Automattic\WooCommerce\Vendor\League\Container\Definition\DefinitionInterface;
@@ -35,7 +36,7 @@ class ExtendedContainer extends BaseContainer {
 	 * @var string[]
 	 */
 	private $registration_whitelist = array(
-		\Psr\Container\ContainerInterface::class,
+		Container::class,
 	);
 
 	/**

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -48,11 +48,11 @@ function WC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.Fu
 }
 
 /**
- * Returns the WooCommerce PSR11-compatible object container.
+ * Returns the WooCommerce object container.
  * Code in the `includes` directory should use the container to get instances of classes in the `src` directory.
  *
  * @since  4.4.0
- * @return \Psr\Container\ContainerInterface The WooCommerce PSR11 container.
+ * @return \Automattic\WooCommerce\Container The WooCommerce object container.
  */
 function wc_get_container() {
 	return $GLOBALS['wc_container'];

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -54,7 +54,7 @@ function WC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.Fu
  * @since  4.4.0
  * @return \Psr\Container\ContainerInterface The WooCommerce PSR11 container.
  */
-function wc_get_container() : \Psr\Container\ContainerInterface {
+function wc_get_container() {
 	return $GLOBALS['wc_container'];
 }
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a `Automattic\WooCommerce\Vendor` namespace prefix to all the classes of the `Psr\Container` package (a dependency of `League\Container`, the dependency injection engine used by WooCommerce) [using Mozart](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/lib#readme). This is done to prevent conflicts with other plugins/packages that might use a different version of the package.

As a side effect, the package ceases to be a regular dependency of WooCommerce code and gets confined into the `lib` directory in the namespaced form; this implies that the `Automattic\WooCommerce\Container` class is no longer declared as `implements \Psr\Container\ContainerInterface`. That declaration didn't have any practical usage anyway since the container is always used as-is everywhere in the WooCommerce codebase and never assumed to implement any given interface.

It's recommended to review the individual commits separately, as the second one is mostly autogenerated code.

Closes (maybe) #33611.

### How to test the changes in this Pull Request:

Try to reproduce the original issue and verify that it disappears with this patch. Otherwise, you can run the unit tests and smoketest WooCommerce to check that nothing is broken.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
