### PR TITLE
Revert "Update method for getting Reports API cache version number"

### DIFF
--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -22,32 +22,18 @@ class Cache {
 	 * Invalidate cache.
 	 */
 	public static function invalidate() {
-		self::get_version( true );
+		\WC_Cache_Helper::get_transient_version( self::VERSION_OPTION, true );
 	}
 
 	/**
 	 * Get cache version number.
 	 *
-	 * This is based on WC_Cache_Helper::get_transient_version, but rounds the Unix timestamp to the nearest
-	 * increment to rate-limit cache invalidations.
-	 *
-	 * @param bool $refresh True to generate a new value.
-	 *
 	 * @return string
 	 */
-	public static function get_version( $refresh = false ) {
-		$transient_name  = self::VERSION_OPTION . '-transient-version';
-		$transient_value = get_transient( $transient_name );
+	public static function get_version() {
+		$version = \WC_Cache_Helper::get_transient_version( self::VERSION_OPTION );
 
-		if ( false === $transient_value || true === $refresh ) {
-			// Round to the nearest $minutes increment.
-			$minutes = 10;
-			$transient_value = (string) round( time() / ( MINUTE_IN_SECONDS * $minutes ) ) * ( MINUTE_IN_SECONDS * $minutes );
-
-			set_transient( $transient_name, $transient_value );
-		}
-
-		return $transient_value;
+		return $version;
 	}
 
 	/**
@@ -84,7 +70,7 @@ class Cache {
 			'value'   => $value,
 		);
 
-		$result = set_transient( $key, $transient_value, HOUR_IN_SECONDS );
+		$result = set_transient( $key, $transient_value, WEEK_IN_SECONDS );
 
 		return $result;
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -221,7 +221,6 @@ class DataStore extends SqlQuery {
 		if ( true === $this->debug_cache ) {
 			$this->debug_cache_data['should_use_cache']    = $this->should_use_cache();
 			$this->debug_cache_data['force_cache_refresh'] = $this->force_cache_refresh;
-			$this->debug_cache_data['cache_version']       = Cache::get_version();
 			$this->debug_cache_data['cache_hit']           = false;
 		}
 


### PR DESCRIPTION
Reverts woocommerce/woocommerce#33353

### Why?

When we merged this PR, we thought the Woo mobile apps would have enough time to implement some corresponding changes on their side ([iOS](https://github.com/woocommerce/woocommerce-ios/issues/7055), [Android](https://github.com/woocommerce/woocommerce-android/issues/6719)). That turned out not to be the case. Without the ability to force a refresh of the analytics cache, this PR causes the apps to have a greater risk of showing users stale analytics data that they can’t immediately update. So it could negatively impact app performance, which is the opposite of what we’re hoping to achieve 😬