### PR TITLE
Making product image meta box more prominent as a default

### DIFF
--- a/plugins/woocommerce/changelog/update-33560-gallery-visibility
+++ b/plugins/woocommerce/changelog/update-33560-gallery-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Making default state of product image meta boxes more prominent.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -43,6 +43,7 @@ class WC_Admin_Meta_Boxes {
 		add_action( 'add_meta_boxes', array( $this, 'remove_meta_boxes' ), 10 );
 		add_action( 'add_meta_boxes', array( $this, 'rename_meta_boxes' ), 20 );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 30 );
+		add_action( 'add_meta_boxes', array( $this, 'add_product_boxes_sort_order' ), 40 );
 		add_action( 'save_post', array( $this, 'save_meta_boxes' ), 1, 2 );
 
 		/**
@@ -164,6 +165,28 @@ class WC_Admin_Meta_Boxes {
 		if ( 'comment' === $screen_id && isset( $_GET['c'] ) && metadata_exists( 'comment', wc_clean( wp_unslash( $_GET['c'] ) ), 'rating' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_meta_box( 'woocommerce-rating', __( 'Rating', 'woocommerce' ), 'WC_Meta_Box_Product_Reviews::output', 'comment', 'normal', 'high' );
 		}
+	}
+
+	/**
+	 * Add default sort order for meta boxes on product page.
+	 */
+	public function add_product_boxes_sort_order() {
+		$current_value = get_user_meta( get_current_user_id(), 'meta-box-order_product', true );
+
+		if ( $current_value ) {
+			return;
+		}
+
+		update_user_meta(
+			get_current_user_id(),
+			'meta-box-order_product',
+			array(
+				'side'     => 'submitdiv,postimagediv,woocommerce-product-images,product_catdiv,tagsdiv-product_tag',
+				'normal'   => 'woocommerce-product-data,postcustom,slugdiv,postexcerpt',
+				'advanced' => '',
+			)
+		);
+
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Making the product image and gallery meta boxes more prominent on product management by default. 

Closes #33560 .

### How to test the changes in this Pull Request:

1. Check out on fresh site (no preexisting DB entries).
2. Skip OBW.
3. Go to Product management page and add new product. 
4. Confirm that the Product Image and Product gallery meta boxes are 2nd and 3rd in line on the right side.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
