### PR TITLE
[COT] Implement `delete()` in the COT datastore

### DIFF
--- a/plugins/woocommerce/changelog/add-32668-cot-datastore-delete
+++ b/plugins/woocommerce/changelog/add-32668-cot-datastore-delete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Implement `delete()` in the COT datastore

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -8,6 +8,7 @@
  * @version 2.2.0
  */
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore as ProductAttributesLookupDataStore;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 
@@ -326,6 +327,7 @@ class WC_Post_Data {
 
 				break;
 			case 'shop_order':
+			case DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE:
 				global $wpdb;
 
 				$refunds = $wpdb->get_results( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = 'shop_order_refund' AND post_parent = %d", $id ) );

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -102,10 +102,6 @@ abstract class CustomMetaDataStore {
 	public function add_meta( &$object, $meta ) {
 		global $wpdb;
 
-		if ( ! is_a( $meta, 'WC_Meta_Data' ) ) {
-			return false;
-		}
-
 		$db_info = $this->get_db_info();
 
 		$object_id  = $object->get_id();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -74,6 +74,18 @@ class DataSynchronizer {
 				$this->maybe_start_synchronizing_pending_orders();
 			}
 		);
+
+		// When posts is authoritative and sync is enabled, deleting a post also deletes COT data.
+		add_action(
+			'deleted_post',
+			function( $postid, $post ) {
+				if ( 'shop_order' === $post->post_type && ! $this->custom_orders_table_is_authoritative() && $this->data_sync_is_enabled() ) {
+					$this->data_store->delete_order_data_from_custom_order_tables( $postid );
+				}
+			},
+			10,
+			2
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1008,6 +1008,43 @@ LEFT JOIN {$operational_data_clauses['join']}
 	//phpcs:disable Squiz.Commenting, Generic.Commenting
 
 	/**
+	 * Trashes an order.
+	 *
+	 * @param \WC_Order $order The order object
+	 * @return void
+	 */
+	private function trash_order( $order ) {
+		global $wpdb;
+
+		if ( 'trash' === $order->get_status() ) {
+			return;
+		}
+
+		$trash_metadata = array(
+			'_wp_trash_meta_status' => $order->get_status( 'edit' ),
+			'_wp_trash_meta_time'   => time(),
+		);
+
+		foreach ( $trash_metadata as $meta_key => $meta_value ) {
+			$this->add_meta(
+				$order,
+				(object) array(
+					'key'   => $meta_key,
+					'value' => $meta_value,
+				)
+			);
+		}
+
+		$wpdb->update(
+			self::get_orders_table_name(),
+			array( 'status' => 'trash' ),
+			array( 'id' => $order->get_id() ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
 	 * Deletes order data from custom order tables.
 	 *
 	 * @param int $order_id The order ID.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1016,7 +1016,6 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 * @return void
 	 */
 	public function delete( &$order, $args = array() ) {
-		$data_sync = wc_get_container()->get( DataSynchronizer::class );
 		$order_id  = $order->get_id();
 
 		if ( ! $order_id ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1028,7 +1028,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 			$order->set_id( 0 );
 
 			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
-			if ( ! $data_sync->custom_orders_table_is_authoritative() ) {
+			if ( ! is_a( $order->get_data_store(), self::class ) ) {
 				return;
 			}
 
@@ -1053,7 +1053,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 	public function trash_order( &$order ) {
 		global $wpdb;
 
-		if ( 'trash' === $order->get_status() ) {
+		if ( 'trash' === $order->get_status( 'edit' ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1008,6 +1008,27 @@ LEFT JOIN {$operational_data_clauses['join']}
 	//phpcs:disable Squiz.Commenting, Generic.Commenting
 
 	/**
+	 * Deletes order data from custom order tables.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return void
+	 */
+	public function delete_order_data_from_custom_order_tables( $order_id ): void {
+		global $wpdb;
+
+		// Delete COT-specific data.
+		foreach ( $this->get_all_table_names() as $table ) {
+			$wpdb->delete(
+				$table,
+				( self::get_orders_table_name() === $table )
+					? array( 'id' => $order_id )
+					: array( 'order_id' => $order_id ),
+				array( '%d' )
+			);
+		}
+	}
+
+	/**
 	 * Method to create an order in the database.
 	 *
 	 * @param \WC_Order $order

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -199,6 +199,91 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * Tests create() on the COT datastore.
 	 */
 	public function test_cot_datastore_create() {
+		$order    = $this->create_complex_cot_order();
+		$order_id = $order->get_id();
+
+		$this->assertIsInteger( $order_id );
+		$this->assertLessThan( $order_id, 0 );
+
+		wp_cache_flush();
+
+		// Read the order again (fresh).
+		$r_order = new WC_Order();
+		$r_order->set_id( $order_id );
+		$this->switch_data_store( $r_order, $this->sut );
+		$this->sut->read( $r_order );
+
+		// Compare some of the prop/meta values to those that should've been persisted.
+		$props_to_compare = array(
+			'status',
+			'created_via',
+			'currency',
+			'customer_ip_address',
+			'billing_first_name',
+			'billing_last_name',
+			'billing_company',
+			'billing_address_1',
+			'billing_city',
+			'billing_state',
+			'billing_postcode',
+			'billing_country',
+			'billing_email',
+			'billing_phone',
+			'shipping_total',
+			'total',
+		);
+
+		foreach ( $props_to_compare as $prop ) {
+			$this->assertEquals( $order->{"get_$prop"}( 'edit' ), $r_order->{"get_$prop"}( 'edit' ) );
+		}
+
+		$this->assertEquals( $order->get_meta( 'my_meta', true, 'edit' ), $r_order->get_meta( 'my_meta', true, 'edit' ) );
+		$this->assertEquals( $this->sut->get_stock_reduced( $order ), $this->sut->get_stock_reduced( $r_order ) );
+	}
+
+	/**
+	 * Tests creation of full vs placeholder records in the posts table when creating orders in the COT datastore.
+	 *
+	 * @return void
+	 */
+	public function test_cot_datastore_create_sync() {
+		global $wpdb;
+
+		// Sync enabled implies a full post should be created.
+		add_filter( 'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, function() { return 'yes'; } );
+		$order = $this->create_complex_cot_order();
+		$this->assertEquals( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE ID = %d AND post_type = %s", $order->get_id(), 'shop_order' ) ) );
+
+		// Sync disabled implies a placeholder post should be created.
+		add_filter( 'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, function() { return 'no'; } );
+		$order = $this->create_complex_cot_order();
+		$this->assertEquals( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE ID = %d AND post_type = %s", $order->get_id(), DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE ) ) );
+	}
+
+	/**
+	 * Helper function to delete all meta for post.
+	 *
+	 * @param int $post_id Post ID to delete data for.
+	 */
+	private function delete_all_meta_for_post( $post_id ) {
+		global $wpdb;
+		$wpdb->delete( $wpdb->postmeta, array( 'post_id' => $post_id ) );
+	}
+
+	/**
+	 * Helper method to allow switching data stores.
+	 *
+	 * @param WC_Order      $order Order object.
+	 * @param WC_Data_Store $data_store Data store object to switch order to.
+	 */
+	private function switch_data_store( $order, $data_store ) {
+		$update_data_store_func = function ( $data_store ) {
+			$this->data_store = $data_store;
+		};
+		$update_data_store_func->call( $order, $data_store );
+	}
+
+	private function create_complex_cot_order() {
 		$order = new WC_Order();
 		$this->switch_data_store( $order, $this->sut );
 
@@ -248,67 +333,9 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		$order->update_meta_data( 'my_meta', rand( 0, 255 ) );
 
-		$order_id = $order->save();
+		$order->save();
 
-		$this->assertIsInteger( $order_id );
-		$this->assertLessThan( $order_id, 0 );
-
-		wp_cache_flush();
-
-		// Read the order again (fresh).
-		$r_order = new WC_Order();
-		$r_order->set_id( $order_id );
-		$this->switch_data_store( $r_order, $this->sut );
-		$this->sut->read( $r_order );
-
-		// Compare some of the prop/meta values to those that should've been persisted.
-		$props_to_compare = array(
-			'status',
-			'created_via',
-			'currency',
-			'customer_ip_address',
-			'billing_first_name',
-			'billing_last_name',
-			'billing_company',
-			'billing_address_1',
-			'billing_city',
-			'billing_state',
-			'billing_postcode',
-			'billing_country',
-			'billing_email',
-			'billing_phone',
-			'shipping_total',
-			'total',
-		);
-
-		foreach ( $props_to_compare as $prop ) {
-			$this->assertEquals( $order->{"get_$prop"}( 'edit' ), $r_order->{"get_$prop"}( 'edit' ) );
-		}
-
-		$this->assertEquals( $order->get_meta( 'my_meta', true, 'edit' ), $r_order->get_meta( 'my_meta', true, 'edit' ) );
-		$this->assertEquals( $this->sut->get_stock_reduced( $order ), $this->sut->get_stock_reduced( $r_order ) );
+		return $order;
 	}
 
-	/**
-	 * Helper function to delete all meta for post.
-	 *
-	 * @param int $post_id Post ID to delete data for.
-	 */
-	private function delete_all_meta_for_post( $post_id ) {
-		global $wpdb;
-		$wpdb->delete( $wpdb->postmeta, array( 'post_id' => $post_id ) );
-	}
-
-	/**
-	 * Helper method to allow switching data stores.
-	 *
-	 * @param WC_Order      $order Order object.
-	 * @param WC_Data_Store $data_store Data store object to switch order to.
-	 */
-	private function switch_data_store( $order, $data_store ) {
-		$update_data_store_func = function ( $data_store ) {
-			$this->data_store = $data_store;
-		};
-		$update_data_store_func->call( $order, $data_store );
-	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR implements the `delete()` method in the COT datastore. A few remarks:

- The PR reworks some tests for the `create()` method to make sure we test the creation of full/placeholder orders in the posts table. This to ensure that deleting accounts for those records.
- The posts > orders migrator doesn't handle deleting of records right now, so I've added a "quick & dirty" solution for [removing data from COT tables when an order is removed](https://github.com/woocommerce/woocommerce/blob/6b5708e46e56071d3fb055b64d740d44963de1d6/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php#L78-L88) (while posts is authoritative). This is probably territory of [#32842](https://github.com/woocommerce/woocommerce/issues/32842) so I'd be more than happy to remove it if it's not necessary at this stage. I just wanted to make sure things were consistent during my testing.
- The "implementation" of `delete()` is a bit lazy as it basically deletes the associated post using `wp_delete_post()` and relies on [`WC_Post_Data`](https://github.com/woocommerce/woocommerce/blob/6b5708e46e56071d3fb055b64d740d44963de1d6/plugins/woocommerce/includes/class-wc-post-data.php) to remove other data (order items, etc.).
   This is not necessarily want we want to do, but after trying various approaches, I felt this was an ok solution until the time comes when we stop creating placeholder posts for orders. It also helps with not requiring special handling for things like reducing the count order in a customer.

   The scenarios (and what we do in each case) are as follows:

   - **Posts is authoritative:** `delete()` only removes COT specific data for the given order. This is mostly a safeguard, if (for instance) the method is manually called by code, but shouldn't happen under normal circumstances.
   - **COT authoritative / sync enabled:**  `delete()` removes COT specific data and the full order post, which triggers removal actions in `WC_Post_Data`.
   - **COT authoritative / sync disabled:** `delete()` removes COT specific data and the placeholder post, which is an order type itself, and thus triggers other removal actions in `WC_Post_Data`.

Closes #32668.

### How to test the changes in this Pull Request:

1. Enable the COT feature and make COT authoritative.
2. Migrate some orders over to COT to make sure we have data to work with.
3. Test the delete functionality by using custom code such as:
   ```php
   $order = wc_get_order( ORDER_ID );
   $order->delete();
   // ... or for full deletes:
   // $order->delete( true );
   ```
4. Make sure order statuses change to "trash" (if not using `$force_delete = true`) in the orders table or that all data for the order is removed from the database (if `$force_delete = true`).
5. Switch back to posts being authoritative.
6. Confirm that deleting a post removes order data from the COT tables.