### PR TITLE
Fix export functionality on Analytic pages

### DIFF
--- a/packages/js/data/changelog/fix-export-button-error
+++ b/packages/js/data/changelog/fix-export-button-error
@@ -1,0 +1,4 @@
+Significance: fix
+Type: minor
+
+Fix 'Cannot read properties of undefined' error when clicking Export button on Analytic pages.

--- a/packages/js/data/src/export/index.ts
+++ b/packages/js/data/src/export/index.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerStore } from '@wordpress/data';
-import { controls } from '@wordpress/data-controls';
 import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 import { Reducer, AnyAction } from 'redux';
 /**
@@ -13,6 +12,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import reducer, { State } from './reducer';
 import { WPDataSelectors } from '../types';
+import controls from '../controls';
 export * from './types';
 export type { State };
 

--- a/plugins/woocommerce/changelog/fix-33583-cannot-read-property-on-clicking-download-btn
+++ b/plugins/woocommerce/changelog/fix-33583-cannot-read-property-on-clicking-download-btn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Import correct controls for export function


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33583  .

This PR fixes`Cannot read properties of undefined` error when clicking `Export` button on Analytic pages.

The Ajax call did not start due to incorrect controls imported. This PR imports the correct controls.

### How to test the changes in this Pull Request:

Follow `Steps to reproduce` from https://github.com/woocommerce/woocommerce/issues/33583

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
