### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -166,6 +166,8 @@ jobs:
                   ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
 
     publish-test-reports:
+        permissions:
+          contents: none
         name: Publish test reports
         if: |
             always() && 

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -6,6 +6,9 @@ on:
 concurrency:
   group: changelogger-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   changelogger_used:
     name: Changelogger use

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -8,8 +8,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   label_project:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/labeler@v3

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -232,6 +232,8 @@ jobs:
                   pnpm exec wc-e2e test:e2e
 
     publish-test-reports:
+        permissions:
+          contents: none
         name: Publish test reports
         if: always()
         runs-on: ubuntu-20.04

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: '21 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     if: |
       ! contains(github.event.issue.labels.*.name, 'type: enhancement')
     runs-on: ubuntu-20.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
