### PR TITLE
Fix Uncaught DOMException on WooCommerce -> Extensions page.

### DIFF
--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -96,6 +96,7 @@ if ( appRoot ) {
 
 	const wrap =
 		wpBody.querySelector( '.wrap.woocommerce' ) ||
+		wpBody.querySelector( '.woocommerce' ) ||
 		wpBody.querySelector( '.wrap' );
 	const noticeContainer = document.createElement( 'div' );
 

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -96,7 +96,7 @@ if ( appRoot ) {
 
 	const wrap =
 		wpBody.querySelector( '.wrap.woocommerce' ) ||
-		wpBody.querySelector( '.woocommerce' ) ||
+		document.querySelector( '#wpbody-content > .woocommerce' ) ||
 		wpBody.querySelector( '.wrap' );
 	const noticeContainer = document.createElement( 'div' );
 

--- a/plugins/woocommerce/changelog/fix-33673-uncaught-domexception-on-extensions-page
+++ b/plugins/woocommerce/changelog/fix-33673-uncaught-domexception-on-extensions-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Uncaught DOMException on WooCommerce -> Extensions page


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33673  .

This PR fixes `Uncaught DOMException` error on `WooCommerce -> Extensions` page.

The extensions page's `.wrap' div doesn't have `.woocommerce`. It is actually a parent of `.wrap`

This PR adds `.woocommerce` selector after `wpBody.querySelector( '.wrap.woocommerce' )` selector and preserve `.wrap` as well to keep any backward compatibility.

### How to test the changes in this Pull Request:

Follow test steps from https://github.com/woocommerce/woocommerce/issues/33673

### Screenshots
![Screen Shot 2022-07-01 at 7 36 24 PM](https://user-images.githubusercontent.com/4723145/176983616-05e0534b-fa0a-4b4a-9cdb-b7a1602ac19d.jpg)


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
