### PR TITLE
Fix wrong link in setup payments screen

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -14,7 +14,6 @@ import { useMemo, useCallback, useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
 import { getNewPath } from '@woocommerce/navigation';
-import { getAdminLink } from '@woocommerce/settings';
 import { Button } from '@wordpress/components';
 import ExternalIcon from 'gridicons/dist/external';
 
@@ -216,9 +215,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			footerLink={
 				! isWCPayOrOtherCategoryDoneSetup && (
 					<Button
-						href={ getAdminLink(
-							'admin.php?page=wc-addons&section=payment-gateways'
-						) }
+						href="https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations"
 						target="_blank"
 						onClick={ trackSeeMore }
 						isTertiary

--- a/plugins/woocommerce/changelog/fix-33617-wrong-link-in-setup-payments-screen
+++ b/plugins/woocommerce/changelog/fix-33617-wrong-link-in-setup-payments-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong link in Set up payments screen


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33617.

This PR changes the "See more" link in the payment task to direct the user to the external marketplace instead.

![Screen Shot 2022-07-04 at 12 02 15](https://user-images.githubusercontent.com/4344253/177079478-f0b7f5b0-c6b6-4da1-b9c6-66c326147c6b.png)

### How to test the changes in this Pull Request:

1. Onboard to WooCommerce from a country that WCPayments doesn't support
2. Go to WooCommerce Home
3. Click on the `Set up payments` task
4. Click "See more"
5. Should redirect to https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
