### PR TITLE
Fix wrong link and copy in payment setting page

### DIFF
--- a/plugins/woocommerce/changelog/fix-33622-wrong-link-and-some-copy-in-payment-settings
+++ b/plugins/woocommerce/changelog/fix-33622-wrong-link-and-some-copy-in-payment-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong link and copy in payment setting page

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -198,7 +198,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 												$setup_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . strtolower( $gateway->id ) );
 											}
 											/* Translators: %s Payment gateway name. */
-											echo '<a class="button alignright" aria-label="' . esc_attr( sprintf( __( 'Set up the "%s" payment method', 'woocommerce' ), $method_title ) ) . '" href="' . esc_url( $setup_url ) . '">' . esc_html__( 'Set up', 'woocommerce' ) . '</a>';
+											echo '<a class="button alignright" aria-label="' . esc_attr( sprintf( __( 'Set up the "%s" payment method', 'woocommerce' ), $method_title ) ) . '" href="' . esc_url( $setup_url ) . '">' . esc_html__( 'Finish set up', 'woocommerce' ) . '</a>';
 										}
 										break;
 									case 'status':
@@ -226,12 +226,12 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 						 */
 						if ( WooCommercePayments::is_supported() ) {
 							$columns_count      = count( $columns );
-							$link_text          = __( 'Other payment methods', 'woocommerce' );
+							$link_text          = __( 'Discover other payment providers', 'woocommerce' );
 							$external_link_icon = '<svg style="margin-left: 4px" class="gridicon gridicons-external needs-offset" height="18" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M19 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h6v2H5v12h12v-6h2zM13 3v2h4.586l-7.793 7.793 1.414 1.414L19 6.414V11h2V3h-8z"></path></g></svg>';
 							echo '<tr>';
 							// phpcs:ignore -- ignoring the error since the value is harded.
 							echo "<td style='border-top: 1px solid #c3c4c7; background-color: #fff' colspan='{$columns_count}'>";
-							echo "<a id='settings-other-payment-methods' href='" . esc_url( admin_url( 'admin.php?page=wc-addons&section=payment-gateways' ) ) . "' target='_blank' class='components-button is-tertiary'>";
+							echo "<a id='settings-other-payment-methods' href='https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations' target='_blank' class='components-button is-tertiary'>";
 							// phpcs:ignore
 							echo $link_text;
 							// phpcs:ignore


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33622.

This PR fixes the wrong link and copy in payment setting page, as in this Figma design e428PXC0QyEwYqtX48lLq0-fi-12830%3A96868

Before:
![Screen Shot 2022-07-04 at 12 04 02](https://user-images.githubusercontent.com/4344253/177079625-2013c5bd-96cb-4f27-8779-ecebeba5c523.png)

After:
![Screen Shot 2022-07-04 at 12 03 39](https://user-images.githubusercontent.com/4344253/177079658-b61856c7-928f-4789-b1b9-5f0f7f34eeed.png)



### How to test the changes in this Pull Request:

1. Onboard to WooCommerce from a WCPay eligible country (opt in to install WCPay during the initial onboarding)
2. Go to Payments Settings
3. The CTA for WCPay inside the table should say `Finish set up`
4. The link at the bottom of the Payment Methods table should say `Discover other payment providers`
5. The Discover other payment providers link should direct the user to the external marketplace (https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.