### PR TITLE
Fix untranslated texts on payment setting page

### DIFF
--- a/plugins/woocommerce-admin/client/payments/payment-settings-banner.tsx
+++ b/plugins/woocommerce-admin/client/payments/payment-settings-banner.tsx
@@ -137,11 +137,13 @@ const WcPayBanner = () => {
 
 const DefaultPaymentMethodsHeaderText = () => (
 	<>
-		<h2>Payment Methods</h2>
+		<h2>{ __( 'Payment Methods', 'woocommerce' ) }</h2>
 		<div id="payment_gateways_options-description">
 			<p>
-				Installed payment methods are listed below and can be sorted to
-				control their display order on the frontend.
+				{ __(
+					'Installed payment methods are listed below and can be sorted to control their display order on the frontend.',
+					'woocommerce'
+				) }
 			</p>
 		</div>
 	</>

--- a/plugins/woocommerce/changelog/fix-untranslated-strings-in-payment-setting-page
+++ b/plugins/woocommerce/changelog/fix-untranslated-strings-in-payment-setting-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix untranslated texts on payment setting page


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/33666#issuecomment-1172045936

This PR fixes untranslated texts on the payment setting page.

![Screen Shot 2022-07-05 at 10 23 37](https://user-images.githubusercontent.com/4344253/177237145-e7c79c10-13a6-45fe-b704-4266a7ae3361.png)


### How to test the changes in this Pull Request:

Review the changes

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
