### PR TITLE
Add data store attribute terms

### DIFF
--- a/packages/js/data/changelog/add-data-store-attribute-terms
+++ b/packages/js/data/changelog/add-data-store-attribute-terms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product attribute terms data store

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { addQueryArgs } from '@wordpress/url';
 import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
  */
 import CRUD_ACTIONS from './crud-actions';
+import { getRestPath } from './utils';
 import TYPES from './action-types';
 import { IdType, Item, ItemQuery } from './types';
 
@@ -106,10 +106,13 @@ export const createDispatchActions = ( {
 	namespace,
 	resourceName,
 }: ResolverOptions ) => {
-	const createItem = function* ( query: Partial< ItemQuery > ) {
+	const createItem = function* (
+		query: Partial< ItemQuery >,
+		...urlParameters: string[]
+	) {
 		try {
 			const item: Item = yield apiFetch( {
-				path: addQueryArgs( namespace, query ),
+				path: getRestPath( namespace, query, urlParameters ),
 				method: 'POST',
 			} );
 
@@ -121,10 +124,18 @@ export const createDispatchActions = ( {
 		}
 	};
 
-	const deleteItem = function* ( id: IdType, force = true ) {
+	const deleteItem = function* (
+		id: IdType,
+		force = true,
+		...urlParameters: string[]
+	) {
 		try {
 			const item: Item = yield apiFetch( {
-				path: addQueryArgs( `${ namespace }/${ id }`, { force } ),
+				path: getRestPath(
+					`${ namespace }/${ id }`,
+					{ force },
+					urlParameters
+				),
 				method: 'DELETE',
 			} );
 
@@ -136,10 +147,18 @@ export const createDispatchActions = ( {
 		}
 	};
 
-	const updateItem = function* ( id: IdType, query: Partial< ItemQuery > ) {
+	const updateItem = function* (
+		id: IdType,
+		query: Partial< ItemQuery >,
+		...urlParameters: string[]
+	) {
 		try {
 			const item: Item = yield apiFetch( {
-				path: addQueryArgs( `${ namespace }/${ id }`, query ),
+				path: getRestPath(
+					`${ namespace }/${ id }`,
+					query,
+					urlParameters
+				),
 				method: 'PUT',
 			} );
 

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -6,7 +6,7 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { getUrlParameters, getRestPath, parseId } from './utils';
+import { cleanQuery, getUrlParameters, getRestPath, parseId } from './utils';
 import CRUD_ACTIONS from './crud-actions';
 import TYPES from './action-types';
 import { IdType, IdQuery, Item, ItemQuery } from './types';
@@ -68,7 +68,10 @@ export function getItemSuccess( key: IdType, item: Item ) {
 	};
 }
 
-export function getItemsError( query: Partial< ItemQuery >, error: unknown ) {
+export function getItemsError(
+	query: Partial< ItemQuery > | undefined,
+	error: unknown
+) {
 	return {
 		type: TYPES.GET_ITEMS_ERROR as const,
 		query,
@@ -78,7 +81,7 @@ export function getItemsError( query: Partial< ItemQuery >, error: unknown ) {
 }
 
 export function getItemsSuccess(
-	query: Partial< ItemQuery >,
+	query: Partial< ItemQuery > | undefined,
 	items: Item[],
 	urlParameters: IdType[]
 ) {
@@ -116,7 +119,11 @@ export const createDispatchActions = ( {
 
 		try {
 			const item: Item = yield apiFetch( {
-				path: getRestPath( namespace, query, urlParameters ),
+				path: getRestPath(
+					namespace,
+					cleanQuery( query, namespace ),
+					urlParameters
+				),
 				method: 'POST',
 			} );
 			const { key } = parseId( item.id, urlParameters );
@@ -162,7 +169,7 @@ export const createDispatchActions = ( {
 			const item: Item = yield apiFetch( {
 				path: getRestPath(
 					`${ namespace }/${ id }`,
-					query,
+					cleanQuery( query, namespace ),
 					urlParameters
 				),
 				method: 'PUT',

--- a/packages/js/data/src/crud/index.ts
+++ b/packages/js/data/src/crud/index.ts
@@ -36,7 +36,10 @@ export const createCrudDataStore = ( {
 		pluralResourceName,
 		namespace,
 	} );
-	const selectors = createSelectors( { resourceName, pluralResourceName } );
+	const selectors = createSelectors( {
+		resourceName,
+		pluralResourceName,
+	} );
 
 	registerStore( storeName, {
 		reducer: reducer as Reducer< ResourceState >,

--- a/packages/js/data/src/crud/index.ts
+++ b/packages/js/data/src/crud/index.ts
@@ -18,6 +18,7 @@ type CrudDataStore = {
 	resourceName: string;
 	pluralResourceName: string;
 	namespace: string;
+	urlParameters?: string[];
 };
 
 export const createCrudDataStore = ( {
@@ -25,20 +26,24 @@ export const createCrudDataStore = ( {
 	resourceName,
 	namespace,
 	pluralResourceName,
+	urlParameters = [],
 }: CrudDataStore ) => {
 	const reducer = createReducer();
 	const actions = createDispatchActions( {
 		resourceName,
 		namespace,
+		urlParameters,
 	} );
 	const resolvers = createResolvers( {
 		resourceName,
 		pluralResourceName,
 		namespace,
+		urlParameters,
 	} );
 	const selectors = createSelectors( {
 		resourceName,
 		pluralResourceName,
+		urlParameters,
 	} );
 
 	registerStore( storeName, {

--- a/packages/js/data/src/crud/index.ts
+++ b/packages/js/data/src/crud/index.ts
@@ -18,7 +18,6 @@ type CrudDataStore = {
 	resourceName: string;
 	pluralResourceName: string;
 	namespace: string;
-	urlParameters?: string[];
 };
 
 export const createCrudDataStore = ( {

--- a/packages/js/data/src/crud/index.ts
+++ b/packages/js/data/src/crud/index.ts
@@ -26,24 +26,21 @@ export const createCrudDataStore = ( {
 	resourceName,
 	namespace,
 	pluralResourceName,
-	urlParameters = [],
 }: CrudDataStore ) => {
 	const reducer = createReducer();
 	const actions = createDispatchActions( {
 		resourceName,
 		namespace,
-		urlParameters,
 	} );
 	const resolvers = createResolvers( {
 		resourceName,
 		pluralResourceName,
 		namespace,
-		urlParameters,
 	} );
 	const selectors = createSelectors( {
 		resourceName,
 		pluralResourceName,
-		urlParameters,
+		namespace,
 	} );
 
 	registerStore( storeName, {

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -8,6 +8,7 @@ import { Reducer } from 'redux';
  */
 import { Actions } from './actions';
 import CRUD_ACTIONS from './crud-actions';
+import { getKey } from './utils';
 import { getResourceName } from '../utils';
 import { IdType, Item, ItemQuery } from './types';
 import { TYPES } from './action-types';
@@ -56,25 +57,25 @@ export const createReducer = () => {
 						...state,
 						data: {
 							...itemData,
-							[ payload.id ]: {
-								...( itemData[ payload.id ] || {} ),
+							[ payload.key ]: {
+								...( itemData[ payload.key ] || {} ),
 								...payload.item,
 							},
 						},
 					};
 
 				case TYPES.DELETE_ITEM_SUCCESS:
-					const itemIds = Object.keys( state.data );
-					const nextData = itemIds.reduce< Data >(
-						( items: Data, id: string ) => {
-							if ( id !== payload.id.toString() ) {
-								items[ id ] = state.data[ id ];
+					const itemKeys = Object.keys( state.data );
+					const nextData = itemKeys.reduce< Data >(
+						( items: Data, key: string ) => {
+							if ( key !== payload.key.toString() ) {
+								items[ key ] = state.data[ key ];
 								return items;
 							}
 							if ( payload.force ) {
 								return items;
 							}
-							items[ id ] = payload.item;
+							items[ key ] = payload.item;
 							return items;
 						},
 						{} as Data
@@ -93,7 +94,7 @@ export const createReducer = () => {
 						errors: {
 							...state.errors,
 							[ getResourceName( payload.errorType, {
-								id: payload.id,
+								key: payload.key,
 							} ) ]: payload.error,
 						},
 					};
@@ -104,9 +105,10 @@ export const createReducer = () => {
 					const nextResources = payload.items.reduce<
 						Record< string, Item >
 					>( ( result, item ) => {
-						ids.push( item.id );
-						result[ item.id ] = {
-							...( state.data[ item.id ] || {} ),
+						const key = getKey( item.id, payload.parent_id );
+						ids.push( key );
+						result[ key ] = {
+							...( state.data[ key ] || {} ),
 							...item,
 						};
 						return result;

--- a/packages/js/data/src/crud/reducer.ts
+++ b/packages/js/data/src/crud/reducer.ts
@@ -105,7 +105,7 @@ export const createReducer = () => {
 					const nextResources = payload.items.reduce<
 						Record< string, Item >
 					>( ( result, item ) => {
-						const key = getKey( item.id, payload.parent_id );
+						const key = getKey( item.id, payload.urlParameters );
 						ids.push( key );
 						result[ key ] = {
 							...( state.data[ key ] || {} ),

--- a/packages/js/data/src/crud/resolvers.ts
+++ b/packages/js/data/src/crud/resolvers.ts
@@ -6,53 +6,50 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { getRestPath, parseId } from './utils';
+import { getParamsFromQuery, getRestPath, parseId } from './utils';
 import {
 	getItemError,
 	getItemSuccess,
 	getItemsError,
 	getItemsSuccess,
 } from './actions';
+import { IdQuery, Item, ItemQuery } from './types';
 import { request } from '../utils';
-import { IdType, IdQuery, Item, ItemQuery } from './types';
 
 type ResolverOptions = {
 	resourceName: string;
 	pluralResourceName: string;
 	namespace: string;
+	urlParameters: string[];
 };
 
 export const createResolvers = ( {
 	resourceName,
 	pluralResourceName,
 	namespace,
+	urlParameters,
 }: ResolverOptions ) => {
 	const getItem = function* ( idQuery: IdQuery ) {
-		const { id, parent_id } = parseId( idQuery );
+		const params = parseId( idQuery, urlParameters );
+		const { id } = params;
 		try {
 			const item: Item = yield apiFetch( {
-				path: getRestPath(
-					`${ namespace }/${ id }`,
-					{},
-					parent_id ? [ parent_id ] : []
-				),
+				path: getRestPath( `${ namespace }/${ id }`, {}, params ),
 				method: 'GET',
 			} );
 
-			yield getItemSuccess( item.id, item );
+			yield getItemSuccess( item.id, item, urlParameters );
 			return item;
 		} catch ( error ) {
-			yield getItemError( id, error );
+			yield getItemError( id, error, urlParameters );
 			throw error;
 		}
 	};
 
-	const getItems = function* (
-		query?: Partial< ItemQuery >,
-		...urlParameters: string[]
-	) {
+	const getItems = function* ( query?: Partial< ItemQuery > ) {
 		// Require ID when requesting specific fields to later update the resource data.
 		const resourceQuery = query ? { ...query } : {};
+		const params = getParamsFromQuery( resourceQuery, urlParameters );
 
 		if (
 			resourceQuery &&
@@ -63,21 +60,16 @@ export const createResolvers = ( {
 		}
 
 		try {
-			const parent_id = query.parent_id as IdType;
-			const path = getRestPath(
-				namespace,
-				{},
-				parent_id ? [ parent_id ] : []
-			);
+			const path = getRestPath( namespace, {}, params );
 			const { items }: { items: Item[] } = yield request<
 				ItemQuery,
 				Item
 			>( path, resourceQuery );
 
-			yield getItemsSuccess( query, items );
+			yield getItemsSuccess( query, items, urlParameters );
 			return items;
 		} catch ( error ) {
-			yield getItemsError( query, error );
+			yield getItemsError( query, error, urlParameters );
 			throw error;
 		}
 	};

--- a/packages/js/data/src/crud/resolvers.ts
+++ b/packages/js/data/src/crud/resolvers.ts
@@ -6,7 +6,7 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { getUrlParameters, getRestPath, parseId } from './utils';
+import { cleanQuery, getUrlParameters, getRestPath, parseId } from './utils';
 import {
 	getItemError,
 	getItemSuccess,
@@ -49,10 +49,10 @@ export const createResolvers = ( {
 	};
 
 	const getItems = function* ( query?: Partial< ItemQuery > ) {
-		// Require ID when requesting specific fields to later update the resource data.
-		const resourceQuery = query ? { ...query } : {};
-		const urlParameters = getUrlParameters( namespace, query );
+		const urlParameters = getUrlParameters( namespace, query || {} );
+		const resourceQuery = cleanQuery( query || {}, namespace );
 
+		// Require ID when requesting specific fields to later update the resource data.
 		if (
 			resourceQuery &&
 			resourceQuery._fields &&

--- a/packages/js/data/src/crud/resolvers.ts
+++ b/packages/js/data/src/crud/resolvers.ts
@@ -12,6 +12,7 @@ import {
 	getItemsError,
 	getItemsSuccess,
 } from './actions';
+import { getRestPath } from './utils';
 import { request } from '../utils';
 import { Item, ItemQuery } from './types';
 
@@ -26,10 +27,14 @@ export const createResolvers = ( {
 	pluralResourceName,
 	namespace,
 }: ResolverOptions ) => {
-	const getItem = function* ( id: number ) {
+	const getItem = function* ( id: number, ...urlParameters: string[] ) {
 		try {
 			const item: Item = yield apiFetch( {
-				path: `${ namespace }/${ id }`,
+				path: getRestPath(
+					`${ namespace }/${ id }`,
+					{},
+					urlParameters
+				),
 				method: 'GET',
 			} );
 
@@ -41,7 +46,10 @@ export const createResolvers = ( {
 		}
 	};
 
-	const getItems = function* ( query?: Partial< ItemQuery > ) {
+	const getItems = function* (
+		query?: Partial< ItemQuery >,
+		...urlParameters: string[]
+	) {
 		// Require ID when requesting specific fields to later update the resource data.
 		const resourceQuery = query ? { ...query } : {};
 
@@ -54,10 +62,11 @@ export const createResolvers = ( {
 		}
 
 		try {
+			const path = getRestPath( namespace, {}, urlParameters );
 			const { items }: { items: Item[] } = yield request<
 				ItemQuery,
 				Item
-			>( namespace, resourceQuery );
+			>( path, resourceQuery );
 
 			yield getItemsSuccess( query, items );
 			return items;

--- a/packages/js/data/src/crud/resolvers.ts
+++ b/packages/js/data/src/crud/resolvers.ts
@@ -6,15 +6,15 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
+import { getRestPath, parseId } from './utils';
 import {
 	getItemError,
 	getItemSuccess,
 	getItemsError,
 	getItemsSuccess,
 } from './actions';
-import { getRestPath } from './utils';
 import { request } from '../utils';
-import { Item, ItemQuery } from './types';
+import { IdType, IdQuery, Item, ItemQuery } from './types';
 
 type ResolverOptions = {
 	resourceName: string;
@@ -27,13 +27,14 @@ export const createResolvers = ( {
 	pluralResourceName,
 	namespace,
 }: ResolverOptions ) => {
-	const getItem = function* ( id: number, ...urlParameters: string[] ) {
+	const getItem = function* ( idQuery: IdQuery ) {
+		const { id, parent_id } = parseId( idQuery );
 		try {
 			const item: Item = yield apiFetch( {
 				path: getRestPath(
 					`${ namespace }/${ id }`,
 					{},
-					urlParameters
+					parent_id ? [ parent_id ] : []
 				),
 				method: 'GET',
 			} );
@@ -62,7 +63,12 @@ export const createResolvers = ( {
 		}
 
 		try {
-			const path = getRestPath( namespace, {}, urlParameters );
+			const parent_id = query.parent_id as IdType;
+			const path = getRestPath(
+				namespace,
+				{},
+				parent_id ? [ parent_id ] : []
+			);
 			const { items }: { items: Item[] } = yield request<
 				ItemQuery,
 				Item

--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -6,7 +6,7 @@ import createSelector from 'rememo';
 /**
  * Internal dependencies
  */
-import { applyNamespace, parseId } from './utils';
+import { applyNamespace, getUrlParameters, parseId } from './utils';
 import { getResourceName } from '../utils';
 import { IdQuery, IdType, Item, ItemQuery } from './types';
 import { ResourceState } from './reducer';
@@ -28,20 +28,32 @@ export const getItemCreateError = (
 
 export const getItemDeleteError = (
 	state: ResourceState,
-	idQuery: IdQuery
+	idQuery: IdQuery,
+	namespace: string
 ) => {
-	const { key } = parseId( idQuery );
+	const urlParameters = getUrlParameters( namespace, idQuery );
+	const { key } = parseId( idQuery, urlParameters );
 	const itemQuery = getResourceName( CRUD_ACTIONS.DELETE_ITEM, { key } );
 	return state.errors[ itemQuery ];
 };
 
-export const getItem = ( state: ResourceState, idQuery: IdQuery ) => {
-	const { key } = parseId( idQuery );
+export const getItem = (
+	state: ResourceState,
+	idQuery: IdQuery,
+	namespace: string
+) => {
+	const urlParameters = getUrlParameters( namespace, idQuery );
+	const { key } = parseId( idQuery, urlParameters );
 	return state.data[ key ];
 };
 
-export const getItemError = ( state: ResourceState, idQuery: IdQuery ) => {
-	const { key } = parseId( idQuery );
+export const getItemError = (
+	state: ResourceState,
+	idQuery: IdQuery,
+	namespace: string
+) => {
+	const urlParameters = getUrlParameters( namespace, idQuery );
+	const { key } = parseId( idQuery, urlParameters );
 	const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEM, { key } );
 	return state.errors[ itemQuery ];
 };
@@ -75,11 +87,13 @@ export const getItems = createSelector(
 			} );
 		}
 
-		return ids
+		const data = ids
 			.map( ( id: IdType ) => {
 				return state.data[ id ];
 			} )
 			.filter( ( item ) => item !== undefined );
+
+		return data;
 	},
 	( state, query ) => {
 		const itemQuery = getResourceName(
@@ -89,6 +103,7 @@ export const getItems = createSelector(
 		const ids = state.items[ itemQuery ]
 			? state.items[ itemQuery ].data
 			: undefined;
+
 		return [
 			state.items[ itemQuery ],
 			...( ids || [] ).map( ( id: string ) => {

--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -7,9 +7,10 @@ import createSelector from 'rememo';
  * Internal dependencies
  */
 import { getResourceName } from '../utils';
-import { IdType, Item, ItemQuery } from './types';
+import { IdQuery, IdType, Item, ItemQuery } from './types';
 import { ResourceState } from './reducer';
 import CRUD_ACTIONS from './crud-actions';
+import { parseId } from './utils';
 
 type SelectorOptions = {
 	resourceName: string;
@@ -24,17 +25,23 @@ export const getItemCreateError = (
 	return state.errors[ itemQuery ];
 };
 
-export const getItemDeleteError = ( state: ResourceState, id: IdType ) => {
-	const itemQuery = getResourceName( CRUD_ACTIONS.DELETE_ITEM, { id } );
+export const getItemDeleteError = (
+	state: ResourceState,
+	idQuery: IdQuery
+) => {
+	const { key } = parseId( idQuery );
+	const itemQuery = getResourceName( CRUD_ACTIONS.DELETE_ITEM, { key } );
 	return state.errors[ itemQuery ];
 };
 
-export const getItem = ( state: ResourceState, id: IdType ) => {
-	return state.data[ id ];
+export const getItem = ( state: ResourceState, idQuery: IdQuery ) => {
+	const { key } = parseId( idQuery );
+	return state.data[ key ];
 };
 
-export const getItemError = ( state: ResourceState, id: IdType ) => {
-	const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEM, { id } );
+export const getItemError = ( state: ResourceState, idQuery: IdQuery ) => {
+	const { key } = parseId( idQuery );
+	const itemQuery = getResourceName( CRUD_ACTIONS.GET_ITEM, { key } );
 	return state.errors[ itemQuery ];
 };
 
@@ -95,8 +102,12 @@ export const getItemsError = ( state: ResourceState, query?: ItemQuery ) => {
 	return state.errors[ itemQuery ];
 };
 
-export const getItemUpdateError = ( state: ResourceState, id: IdType ) => {
-	const itemQuery = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, { id } );
+export const getItemUpdateError = (
+	state: ResourceState,
+	idQuery: IdQuery
+) => {
+	const { key } = parseId( idQuery );
+	const itemQuery = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, { key } );
 	return state.errors[ itemQuery ];
 };
 

--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -6,7 +6,7 @@ import createSelector from 'rememo';
 /**
  * Internal dependencies
  */
-import { applyUrlParameters, parseId } from './utils';
+import { applyNamespace, parseId } from './utils';
 import { getResourceName } from '../utils';
 import { IdQuery, IdType, Item, ItemQuery } from './types';
 import { ResourceState } from './reducer';
@@ -15,7 +15,7 @@ import CRUD_ACTIONS from './crud-actions';
 type SelectorOptions = {
 	resourceName: string;
 	pluralResourceName: string;
-	urlParameters: IdType[];
+	namespace: string;
 };
 
 export const getItemCreateError = (
@@ -120,36 +120,30 @@ export const getItemUpdateError = (
 export const createSelectors = ( {
 	resourceName,
 	pluralResourceName,
-	urlParameters = [],
+	namespace,
 }: SelectorOptions ) => {
 	return {
-		[ `get${ resourceName }` ]: applyUrlParameters(
-			getItem,
-			urlParameters
-		),
-		[ `get${ resourceName }Error` ]: applyUrlParameters(
+		[ `get${ resourceName }` ]: applyNamespace( getItem, namespace ),
+		[ `get${ resourceName }Error` ]: applyNamespace(
 			getItemError,
-			urlParameters
+			namespace
 		),
-		[ `get${ pluralResourceName }` ]: applyUrlParameters(
-			getItems,
-			urlParameters
-		),
-		[ `get${ pluralResourceName }Error` ]: applyUrlParameters(
+		[ `get${ pluralResourceName }` ]: applyNamespace( getItems, namespace ),
+		[ `get${ pluralResourceName }Error` ]: applyNamespace(
 			getItemsError,
-			urlParameters
+			namespace
 		),
-		[ `get${ resourceName }CreateError` ]: applyUrlParameters(
+		[ `get${ resourceName }CreateError` ]: applyNamespace(
 			getItemCreateError,
-			urlParameters
+			namespace
 		),
-		[ `get${ resourceName }DeleteError` ]: applyUrlParameters(
+		[ `get${ resourceName }DeleteError` ]: applyNamespace(
 			getItemDeleteError,
-			urlParameters
+			namespace
 		),
-		[ `get${ resourceName }UpdateError` ]: applyUrlParameters(
+		[ `get${ resourceName }UpdateError` ]: applyNamespace(
 			getItemUpdateError,
-			urlParameters
+			namespace
 		),
 	};
 };

--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -6,7 +6,7 @@ import createSelector from 'rememo';
 /**
  * Internal dependencies
  */
-import { applyNamespace, cleanQuery, getUrlParameters, parseId } from './utils';
+import { applyNamespace, getUrlParameters, parseId } from './utils';
 import { getResourceName } from '../utils';
 import { IdQuery, IdType, Item, ItemQuery } from './types';
 import { ResourceState } from './reducer';

--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -6,7 +6,7 @@ import createSelector from 'rememo';
 /**
  * Internal dependencies
  */
-import { applyNamespace, getUrlParameters, parseId } from './utils';
+import { applyNamespace, cleanQuery, getUrlParameters, parseId } from './utils';
 import { getResourceName } from '../utils';
 import { IdQuery, IdType, Item, ItemQuery } from './types';
 import { ResourceState } from './reducer';

--- a/packages/js/data/src/crud/selectors.ts
+++ b/packages/js/data/src/crud/selectors.ts
@@ -6,15 +6,16 @@ import createSelector from 'rememo';
 /**
  * Internal dependencies
  */
+import { applyUrlParameters, parseId } from './utils';
 import { getResourceName } from '../utils';
 import { IdQuery, IdType, Item, ItemQuery } from './types';
 import { ResourceState } from './reducer';
 import CRUD_ACTIONS from './crud-actions';
-import { parseId } from './utils';
 
 type SelectorOptions = {
 	resourceName: string;
 	pluralResourceName: string;
+	urlParameters: IdType[];
 };
 
 export const getItemCreateError = (
@@ -104,24 +105,51 @@ export const getItemsError = ( state: ResourceState, query?: ItemQuery ) => {
 
 export const getItemUpdateError = (
 	state: ResourceState,
-	idQuery: IdQuery
+	idQuery: IdQuery,
+	urlParameters: IdType[]
 ) => {
-	const { key } = parseId( idQuery );
-	const itemQuery = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, { key } );
+	const params = parseId( idQuery, urlParameters );
+	const { key } = params;
+	const itemQuery = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, {
+		key,
+		params,
+	} );
 	return state.errors[ itemQuery ];
 };
 
 export const createSelectors = ( {
 	resourceName,
 	pluralResourceName,
+	urlParameters = [],
 }: SelectorOptions ) => {
 	return {
-		[ `get${ resourceName }` ]: getItem,
-		[ `get${ resourceName }Error` ]: getItemError,
-		[ `get${ pluralResourceName }` ]: getItems,
-		[ `get${ pluralResourceName }Error` ]: getItemsError,
-		[ `get${ resourceName }CreateError` ]: getItemCreateError,
-		[ `get${ resourceName }DeleteError` ]: getItemDeleteError,
-		[ `get${ resourceName }UpdateError` ]: getItemUpdateError,
+		[ `get${ resourceName }` ]: applyUrlParameters(
+			getItem,
+			urlParameters
+		),
+		[ `get${ resourceName }Error` ]: applyUrlParameters(
+			getItemError,
+			urlParameters
+		),
+		[ `get${ pluralResourceName }` ]: applyUrlParameters(
+			getItems,
+			urlParameters
+		),
+		[ `get${ pluralResourceName }Error` ]: applyUrlParameters(
+			getItemsError,
+			urlParameters
+		),
+		[ `get${ resourceName }CreateError` ]: applyUrlParameters(
+			getItemCreateError,
+			urlParameters
+		),
+		[ `get${ resourceName }DeleteError` ]: applyUrlParameters(
+			getItemDeleteError,
+			urlParameters
+		),
+		[ `get${ resourceName }UpdateError` ]: applyUrlParameters(
+			getItemUpdateError,
+			urlParameters
+		),
 	};
 };

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -80,6 +80,26 @@ describe( 'crud reducer', () => {
 		expect( state.data[ 2 ] ).toEqual( items[ 1 ] );
 	} );
 
+	it( 'should handle GET_ITEMS_SUCCESS with parent_id', () => {
+		const items: Item[] = [
+			{ id: 1, name: 'Yum!' },
+			{ id: 2, name: 'Dynamite!' },
+		];
+		const query: Partial< ItemQuery > = { status: 'draft' };
+		const state = reducer( defaultState, {
+			type: TYPES.GET_ITEMS_SUCCESS,
+			items,
+			query,
+			parent_id: 5,
+		} );
+
+		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
+
+		expect( state.items[ resourceName ].data ).toHaveLength( 2 );
+		expect( state.data[ '5/1' ] ).toEqual( items[ 0 ] );
+		expect( state.data[ '5/2' ] ).toEqual( items[ 1 ] );
+	} );
+
 	it( 'GET_ITEMS_SUCCESS should not remove previously added fields, only update new ones', () => {
 		const initialState: ResourceState = {
 			...defaultState,

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -44,7 +44,7 @@ describe( 'crud reducer', () => {
 
 		const state = reducer( initialState, {
 			type: TYPES.GET_ITEM_SUCCESS,
-			id: update.id,
+			key: update.id,
 			item: update,
 		} );
 
@@ -67,6 +67,7 @@ describe( 'crud reducer', () => {
 			type: TYPES.GET_ITEMS_SUCCESS,
 			items,
 			query,
+			parent_id: null,
 		} );
 
 		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
@@ -102,6 +103,7 @@ describe( 'crud reducer', () => {
 			type: TYPES.GET_ITEMS_SUCCESS,
 			items,
 			query,
+			parent_id: null,
 		} );
 
 		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
@@ -133,12 +135,12 @@ describe( 'crud reducer', () => {
 	} );
 
 	it( 'should handle GET_ITEM_ERROR', () => {
-		const id = 3;
-		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEM, { id } );
+		const key = 3;
+		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEM, { key } );
 		const error = 'Baaam!';
 		const state = reducer( defaultState, {
 			type: TYPES.GET_ITEM_ERROR,
-			id,
+			key,
 			error,
 			errorType: CRUD_ACTIONS.GET_ITEM,
 		} );
@@ -147,12 +149,12 @@ describe( 'crud reducer', () => {
 	} );
 
 	it( 'should handle GET_ITEM_ERROR', () => {
-		const id = 3;
-		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEM, { id } );
+		const key = 3;
+		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEM, { key } );
 		const error = 'Baaam!';
 		const state = reducer( defaultState, {
 			type: TYPES.GET_ITEM_ERROR,
-			id,
+			key,
 			error,
 			errorType: CRUD_ACTIONS.GET_ITEM,
 		} );
@@ -175,14 +177,14 @@ describe( 'crud reducer', () => {
 	} );
 
 	it( 'should handle UPDATE_ITEM_ERROR', () => {
-		const id = 2;
+		const key = 2;
 		const resourceName = getResourceName( CRUD_ACTIONS.UPDATE_ITEM, {
-			id,
+			key,
 		} );
 		const error = 'Baaam!';
 		const state = reducer( defaultState, {
 			type: TYPES.UPDATE_ITEM_ERROR,
-			id,
+			key,
 			error,
 			errorType: CRUD_ACTIONS.UPDATE_ITEM,
 		} );
@@ -212,7 +214,7 @@ describe( 'crud reducer', () => {
 
 		const state = reducer( initialState, {
 			type: TYPES.UPDATE_ITEM_SUCCESS,
-			id: item.id,
+			key: item.id,
 			item,
 		} );
 
@@ -234,7 +236,7 @@ describe( 'crud reducer', () => {
 
 		const state = reducer( defaultState, {
 			type: TYPES.CREATE_ITEM_SUCCESS,
-			id: item.id,
+			key: item.id,
 			item,
 		} );
 
@@ -267,13 +269,13 @@ describe( 'crud reducer', () => {
 
 		let state = reducer( initialState, {
 			type: TYPES.DELETE_ITEM_SUCCESS,
-			id: item1Updated.id,
+			key: item1Updated.id,
 			item: item1Updated,
 			force: true,
 		} );
 		state = reducer( state, {
 			type: TYPES.DELETE_ITEM_SUCCESS,
-			id: item2Updated.id,
+			key: item2Updated.id,
 			item: item2Updated,
 			force: false,
 		} );
@@ -284,14 +286,14 @@ describe( 'crud reducer', () => {
 	} );
 
 	it( 'should handle DELETE_ITEM_ERROR', () => {
-		const id = 2;
+		const key = 2;
 		const resourceName = getResourceName( CRUD_ACTIONS.DELETE_ITEM, {
-			id,
+			key,
 		} );
 		const error = 'Baaam!';
 		const state = reducer( defaultState, {
 			type: TYPES.DELETE_ITEM_ERROR,
-			id,
+			key,
 			error,
 			errorType: CRUD_ACTIONS.DELETE_ITEM,
 		} );

--- a/packages/js/data/src/crud/test/reducer.ts
+++ b/packages/js/data/src/crud/test/reducer.ts
@@ -67,7 +67,7 @@ describe( 'crud reducer', () => {
 			type: TYPES.GET_ITEMS_SUCCESS,
 			items,
 			query,
-			parent_id: null,
+			urlParameters: [],
 		} );
 
 		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
@@ -80,7 +80,7 @@ describe( 'crud reducer', () => {
 		expect( state.data[ 2 ] ).toEqual( items[ 1 ] );
 	} );
 
-	it( 'should handle GET_ITEMS_SUCCESS with parent_id', () => {
+	it( 'should handle GET_ITEMS_SUCCESS with urlParameters', () => {
 		const items: Item[] = [
 			{ id: 1, name: 'Yum!' },
 			{ id: 2, name: 'Dynamite!' },
@@ -90,7 +90,7 @@ describe( 'crud reducer', () => {
 			type: TYPES.GET_ITEMS_SUCCESS,
 			items,
 			query,
-			parent_id: 5,
+			urlParameters: [ 5 ],
 		} );
 
 		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );
@@ -123,7 +123,7 @@ describe( 'crud reducer', () => {
 			type: TYPES.GET_ITEMS_SUCCESS,
 			items,
 			query,
-			parent_id: null,
+			urlParameters: [],
 		} );
 
 		const resourceName = getResourceName( CRUD_ACTIONS.GET_ITEMS, query );

--- a/packages/js/data/src/crud/test/selectors.ts
+++ b/packages/js/data/src/crud/test/selectors.ts
@@ -6,6 +6,7 @@ import { createSelectors } from '../selectors';
 const selectors = createSelectors( {
 	resourceName: 'Product',
 	pluralResourceName: 'Products',
+	namespace: '',
 } );
 
 describe( 'crud selectors', () => {

--- a/packages/js/data/src/crud/test/utils.ts
+++ b/packages/js/data/src/crud/test/utils.ts
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import { getKey, getRestPath, parseId } from '../utils';
+
+describe( 'utils', () => {
+	it( 'should get the rest path when no parameters are given', () => {
+		const path = getRestPath( 'test/path', {} );
+		expect( path ).toEqual( 'test/path' );
+	} );
+
+	it( 'should replace the rest path parameters when provided', () => {
+		const path = getRestPath( 'test/{parent}/path', {}, [ 'insert' ] );
+		expect( path ).toEqual( 'test/insert/path' );
+	} );
+
+	it( 'should replace the rest path parameters when multiple are provided', () => {
+		const path = getRestPath( 'test/{parent}/{other}/path', {}, [
+			'insert',
+			'next',
+		] );
+		expect( path ).toEqual( 'test/insert/next/path' );
+	} );
+
+	it( 'should get the key when no parent is provided', () => {
+		const key = getKey( 3, null );
+		expect( key ).toEqual( 3 );
+	} );
+
+	it( 'should get the key when a parent is provided', () => {
+		const key = getKey( 3, 5 );
+		expect( key ).toEqual( '5/3' );
+	} );
+
+	it( 'should get the correct ID information when only an ID is given', () => {
+		const parsed = parseId( 3 );
+		expect( parsed.key ).toEqual( 3 );
+		expect( parsed.id ).toEqual( 3 );
+		expect( parsed.parent_id ).toEqual( null );
+	} );
+
+	it( 'should get the correct ID information when an object is given', () => {
+		const parsed = parseId( { id: 3, parent_id: 5 } );
+		expect( parsed.key ).toEqual( '5/3' );
+		expect( parsed.id ).toEqual( 3 );
+		expect( parsed.parent_id ).toEqual( 5 );
+	} );
+} );

--- a/packages/js/data/src/crud/test/utils.ts
+++ b/packages/js/data/src/crud/test/utils.ts
@@ -22,6 +22,12 @@ describe( 'utils', () => {
 		expect( path ).toEqual( 'test/insert/next/path' );
 	} );
 
+	it( 'should throw an error when not all parameters are replaced', () => {
+		expect( () =>
+			getRestPath( 'test/{parent}/{other}/path', {}, [ 'insert' ] )
+		).toThrow( Error );
+	} );
+
 	it( 'should get the key when no parent is provided', () => {
 		const key = getKey( 3, null );
 		expect( key ).toEqual( 3 );

--- a/packages/js/data/src/crud/test/utils.ts
+++ b/packages/js/data/src/crud/test/utils.ts
@@ -5,7 +5,7 @@ import { getKey, getRestPath, parseId } from '../utils';
 
 describe( 'utils', () => {
 	it( 'should get the rest path when no parameters are given', () => {
-		const path = getRestPath( 'test/path', {} );
+		const path = getRestPath( 'test/path', {}, [] );
 		expect( path ).toEqual( 'test/path' );
 	} );
 
@@ -29,12 +29,12 @@ describe( 'utils', () => {
 	} );
 
 	it( 'should get the key when no parent is provided', () => {
-		const key = getKey( 3, null );
+		const key = getKey( 3, [] );
 		expect( key ).toEqual( 3 );
 	} );
 
 	it( 'should get the key when a parent is provided', () => {
-		const key = getKey( 3, 5 );
+		const key = getKey( 3, [ 5 ] );
 		expect( key ).toEqual( '5/3' );
 	} );
 
@@ -42,13 +42,11 @@ describe( 'utils', () => {
 		const parsed = parseId( 3 );
 		expect( parsed.key ).toEqual( 3 );
 		expect( parsed.id ).toEqual( 3 );
-		expect( parsed.parent_id ).toEqual( null );
 	} );
 
 	it( 'should get the correct ID information when an object is given', () => {
-		const parsed = parseId( { id: 3, parent_id: 5 } );
+		const parsed = parseId( { id: 3, parent_id: 5 }, [ 5 ] );
 		expect( parsed.key ).toEqual( '5/3' );
 		expect( parsed.id ).toEqual( 3 );
-		expect( parsed.parent_id ).toEqual( 5 );
 	} );
 } );

--- a/packages/js/data/src/crud/test/utils.ts
+++ b/packages/js/data/src/crud/test/utils.ts
@@ -1,7 +1,15 @@
 /**
  * Internal dependencies
  */
-import { getKey, getRestPath, parseId } from '../utils';
+import {
+	applyNamespace,
+	cleanQuery,
+	getKey,
+	getNamespaceKeys,
+	getRestPath,
+	getUrlParameters,
+	parseId,
+} from '../utils';
 
 describe( 'utils', () => {
 	it( 'should get the rest path when no parameters are given', () => {
@@ -48,5 +56,61 @@ describe( 'utils', () => {
 		const parsed = parseId( { id: 3, parent_id: 5 }, [ 5 ] );
 		expect( parsed.key ).toEqual( '5/3' );
 		expect( parsed.id ).toEqual( 3 );
+	} );
+
+	it( 'should apply the namespace as an argument to a given function', () => {
+		const namespace = 'test/namespace';
+		const mockedCallback = jest.fn();
+		const wrappedFunction = applyNamespace( mockedCallback, namespace );
+		wrappedFunction( 'a' );
+
+		expect( mockedCallback ).toBeCalledTimes( 1 );
+		expect( mockedCallback ).toBeCalledWith( 'a', 'test/namespace' );
+	} );
+
+	it( 'should get the keys from a namespace', () => {
+		const namespace = 'test/{first}/namespace/{second}';
+		const keys = getNamespaceKeys( namespace );
+		expect( keys.length ).toBe( 2 );
+		expect( keys[ 0 ] ).toBe( 'first' );
+		expect( keys[ 1 ] ).toBe( 'second' );
+	} );
+
+	it( 'should return an empty array from a namespace without params', () => {
+		const namespace = 'test/namespace';
+		const keys = getNamespaceKeys( namespace );
+		expect( keys.length ).toBe( 0 );
+	} );
+
+	it( 'should get the URL parameters given a namespace and query', () => {
+		const namespace = 'test/{my_attribute}/namespace/{other_attribute}';
+		const params = getUrlParameters( namespace, {
+			id: 5,
+			my_attribute: 'flavortown',
+			other_attribute: 'donkeysauce',
+		} );
+		expect( params.length ).toBe( 2 );
+		expect( params[ 0 ] ).toBe( 'flavortown' );
+		expect( params[ 1 ] ).toBe( 'donkeysauce' );
+	} );
+
+	it( 'should return an empty array when no namespace variables are matched', () => {
+		const namespace = 'test/{my_attribute}/namespace';
+		const params = getUrlParameters( namespace, {
+			id: 5,
+			different_attribute: 'flavortown',
+		} );
+		expect( params.length ).toBe( 0 );
+	} );
+
+	it( 'should remove namespace params from a given query', () => {
+		const namespace = 'test/{my_attribute}/namespace';
+		const query = {
+			other_attribute: 'a',
+			my_attribute: 'b',
+		};
+		const params = cleanQuery( query, namespace );
+		expect( params.other_attribute ).toBe( 'a' );
+		expect( params.my_attribute ).toBeUndefined();
 	} );
 } );

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -28,6 +28,7 @@ export type Item = {
 
 export type ItemQuery = BaseQueryParams & {
 	[ key: string ]: unknown;
+	parent_id?: IdType;
 };
 
 type WithRequiredProperty< Type, Key extends keyof Type > = Type & {

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -14,6 +14,13 @@ import {
 
 export type IdType = number | string;
 
+export type IdQuery =
+	| IdType
+	| {
+			id: IdType;
+			parent_id: IdType;
+	  };
+
 export type Item = {
 	id: IdType;
 	[ key: string ]: unknown;

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -18,7 +18,7 @@ export type IdQuery =
 	| IdType
 	| {
 			id: IdType;
-			parent_id: IdType;
+			[ key: string ]: IdType;
 	  };
 
 export type Item = {
@@ -29,6 +29,10 @@ export type Item = {
 export type ItemQuery = BaseQueryParams & {
 	[ key: string ]: unknown;
 	parent_id?: IdType;
+};
+
+export type Params = {
+	[ key: string ]: IdType;
 };
 
 type WithRequiredProperty< Type, Key extends keyof Type > = Type & {

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -21,9 +21,16 @@ export const getRestPath = (
 	query: Partial< ItemQuery >,
 	urlParameters: IdType[] = []
 ) => {
+	const pattern = /\{(.*?)}/;
 	const path = urlParameters.reduce( ( str, param ) => {
-		return str.toString().replace( /\{(.*?)}/, param.toString() );
+		return str.toString().replace( pattern, param.toString() );
 	}, templatePath );
+
+	const regex = new RegExp( pattern );
+	if ( regex.test( path.toString() ) ) {
+		throw new Error( 'Not all URL parameters were replaced' );
+	}
+
 	return addQueryArgs( path.toString(), query );
 };
 

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -6,15 +6,57 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { ItemQuery } from './types';
+import { IdQuery, IdType, ItemQuery } from './types';
 
+/**
+ * Get a REST path given a template path and URL params.
+ *
+ * @param  templatePath  Path with variable names.
+ * @param  query         Item query.
+ * @param  urlParameters Array of items to replace in the templatePath.
+ * @return string REST path.
+ */
 export const getRestPath = (
 	templatePath: string,
 	query: Partial< ItemQuery >,
-	urlParameters: string[] = []
+	urlParameters: IdType[] = []
 ) => {
 	const path = urlParameters.reduce( ( str, param ) => {
-		return str.replace( /\{(.*?)}/, param );
+		return str.toString().replace( /\{(.*?)}/, param.toString() );
 	}, templatePath );
-	return addQueryArgs( path, query );
+	return addQueryArgs( path.toString(), query );
+};
+
+/**
+ * Get a key from an item ID and optional parent.
+ *
+ * @param  id        Item ID.
+ * @param  parent_id Optional parent ID.
+ * @return string
+ */
+export const getKey = ( id: IdType, parent_id: IdType | null | undefined ) => {
+	if ( ! parent_id ) {
+		return id;
+	}
+
+	return `${ parent_id }/${ id }`;
+};
+
+/**
+ * Parse an ID query into a ID string.
+ *
+ * @param  query Id Query
+ * @return string ID.
+ */
+export const parseId = ( query: IdQuery ) => {
+	if ( typeof query === 'string' || typeof query === 'number' ) {
+		return {
+			id: query,
+			parent_id: null,
+			key: query,
+		};
+	}
+
+	const key = getKey( query.id, query.parent_id );
+	return { ...query, key };
 };

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { ItemQuery } from './types';
+
+export const getRestPath = (
+	templatePath: string,
+	query: Partial< ItemQuery >,
+	urlParameters: string[] = []
+) => {
+	const path = urlParameters.reduce( ( str, param ) => {
+		return str.replace( /\{(.*?)}/, param );
+	}, templatePath );
+	return addQueryArgs( path, query );
+};

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -81,21 +81,6 @@ export const parseId = ( query: IdQuery, urlParameters: IdType[] = [] ) => {
 };
 
 /**
- * Delete params from a query.
- *
- * @param  query         Query to delete from.
- * @param  parameterKeys Keys to delete.
- */
-export const deleteParamsFromQuery = (
-	query: Partial< ItemQuery >,
-	parameterKeys: string[]
-) => {
-	parameterKeys.forEach( ( key ) => {
-		delete query[ key ];
-	} );
-};
-
-/**
  * Create a new function that adds in the namespace.
  *
  * @param  fn        Function to wrap.
@@ -112,6 +97,12 @@ export const applyNamespace = < T extends ( ...args: any[] ) => unknown >(
 	};
 };
 
+/**
+ * Get the key names from a namespace string.
+ *
+ * @param  namespace Namespace to get keys from.
+ * @return Array of keys.
+ */
 export const getNamespaceKeys = ( namespace: string ) => {
 	const keys: string[] = [];
 

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -61,24 +61,6 @@ export const getKey = ( query: IdQuery, urlParameters: IdType[] = [] ) => {
 };
 
 /**
- * Get parameters from query.
- *
- * @param  query         Query object to look for params.
- * @param  parameterKeys Keys to look for.
- * @return object        Object of found parameters in query.
- */
-export const getParamsFromQuery = (
-	query: Partial< ItemQuery >,
-	parameterKeys: IdType[]
-) => {
-	const params = {} as { [ key: string ]: IdType };
-	parameterKeys.forEach( ( key ) => {
-		params[ key ] = query[ key ] as IdType;
-	} );
-	return params;
-};
-
-/**
  * Parse an ID query into a ID string.
  *
  * @param  query Id Query
@@ -126,7 +108,7 @@ export const applyNamespace = < T extends ( ...args: any[] ) => unknown >(
 	namespace: string
 ) => {
 	return ( ...args: Parameters< T > ) => {
-		fn( ...args, namespace );
+		return fn( ...args, namespace );
 	};
 };
 
@@ -139,14 +121,20 @@ export const applyNamespace = < T extends ( ...args: any[] ) => unknown >(
  */
 export const getUrlParameters = (
 	namespace: string,
-	query: Partial< ItemQuery > | IdQuery
+	query: IdQuery | Partial< ItemQuery >
 ) => {
+	if ( typeof query !== 'object' ) {
+		return [];
+	}
+
 	const params: IdType[] = [];
+	const keys: string[] = [];
 
 	namespace.match( /{(.*?)}/g )?.forEach( ( match ) => {
 		const key = match.substr( 1, match.length - 2 );
+		keys.push( key );
 		if ( query.hasOwnProperty( key ) ) {
-			params.push( key );
+			params.push( query[ key ] as IdType );
 		}
 	} );
 

--- a/packages/js/data/src/crud/utils.ts
+++ b/packages/js/data/src/crud/utils.ts
@@ -112,6 +112,17 @@ export const applyNamespace = < T extends ( ...args: any[] ) => unknown >(
 	};
 };
 
+export const getNamespaceKeys = ( namespace: string ) => {
+	const keys: string[] = [];
+
+	namespace.match( /{(.*?)}/g )?.forEach( ( match ) => {
+		const key = match.substr( 1, match.length - 2 );
+		keys.push( key );
+	} );
+
+	return keys;
+};
+
 /**
  * Get URL parameters from namespace and provided query.
  *
@@ -128,15 +139,33 @@ export const getUrlParameters = (
 	}
 
 	const params: IdType[] = [];
-	const keys: string[] = [];
-
-	namespace.match( /{(.*?)}/g )?.forEach( ( match ) => {
-		const key = match.substr( 1, match.length - 2 );
-		keys.push( key );
+	const keys = getNamespaceKeys( namespace );
+	keys.forEach( ( key ) => {
 		if ( query.hasOwnProperty( key ) ) {
 			params.push( query[ key ] as IdType );
 		}
 	} );
 
 	return params;
+};
+
+/**
+ * Clean a query of all namespaced params.
+ *
+ * @param  query     Query to clean.
+ * @param  namespace
+ * @return Cleaned query object.
+ */
+export const cleanQuery = (
+	query: Partial< ItemQuery >,
+	namespace: string
+) => {
+	const cleaned = { ...query };
+
+	const keys = getNamespaceKeys( namespace );
+	keys.forEach( ( key ) => {
+		delete cleaned[ key ];
+	} );
+
+	return cleaned;
 };

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -22,6 +22,7 @@ export { EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME } from './product-attributes
 export { EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME } from './product-shipping-classes';
 export { EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME } from './shipping-zones';
 export { EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME } from './product-tags';
+export { EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME } from './product-attribute-terms';
 export { PaymentGateway } from './payment-gateways/types';
 
 // Export hooks
@@ -97,6 +98,7 @@ import type { EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME } from './product-attri
 import type { EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME } from './product-shipping-classes';
 import type { EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME } from './shipping-zones';
 import type { EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME } from './product-tags';
+import type { EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME } from './product-attribute-terms';
 
 export type WCDataStoreName =
 	| typeof REVIEWS_STORE_NAME
@@ -114,6 +116,7 @@ export type WCDataStoreName =
 	| typeof PRODUCTS_STORE_NAME
 	| typeof ORDERS_STORE_NAME
 	| typeof EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME
+	| typeof EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME
 	| typeof EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
 	| typeof EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME
 	| typeof EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME;
@@ -132,6 +135,7 @@ import { ProductAttributeSelectors } from './product-attributes/types';
 import { ProductShippingClassSelectors } from './product-shipping-classes/types';
 import { ShippingZonesSelectors } from './shipping-zones/types';
 import { ProductTagSelectors } from './product-tags/types';
+import { ProductAttributeTermsSelectors } from './product-attribute-terms/types';
 
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
@@ -167,6 +171,8 @@ export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME
 	? ProductShippingClassSelectors
 	: T extends typeof EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME
 	? ProductTagSelectors
+	: T extends typeof EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME
+	? ProductAttributeTermsSelectors
 	: T extends typeof ORDERS_STORE_NAME
 	? OrdersSelectors
 	: T extends typeof EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME
@@ -181,6 +187,7 @@ export interface WCDataSelector {
 export { ActionDispatchers as PluginsStoreActions } from './plugins/actions';
 export { ActionDispatchers as ProductAttributesActions } from './product-attributes/types';
 export { ActionDispatchers as ProductTagsActions } from './product-tags/types';
+export { ActionDispatchers as ProductAttributeTermsActions } from './product-attribute-terms/types';
 export { ActionDispatchers as ProductsStoreActions } from './products/actions';
 export { ActionDispatchers as ProductShippingClassesActions } from './product-shipping-classes/types';
 export { ActionDispatchers as ShippingZonesActions } from './shipping-zones/types';

--- a/packages/js/data/src/product-attribute-terms/constants.ts
+++ b/packages/js/data/src/product-attribute-terms/constants.ts
@@ -1,0 +1,4 @@
+export const STORE_NAME = 'wc/admin/products/attributes/terms';
+
+export const WC_PRODUCT_ATTRIBUTE_TERMS_NAMESPACE =
+	'/wc/v3/products/attributes/{attribute_id}/terms';

--- a/packages/js/data/src/product-attribute-terms/index.ts
+++ b/packages/js/data/src/product-attribute-terms/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME, WC_PRODUCT_ATTRIBUTE_TERMS_NAMESPACE } from './constants';
+import { createCrudDataStore } from '../crud';
+
+createCrudDataStore( {
+	storeName: STORE_NAME,
+	resourceName: 'ProductAttributeTerm',
+	pluralResourceName: 'ProductAttributeTerms',
+	namespace: WC_PRODUCT_ATTRIBUTE_TERMS_NAMESPACE,
+} );
+
+export const EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME = STORE_NAME;

--- a/packages/js/data/src/product-attribute-terms/index.ts
+++ b/packages/js/data/src/product-attribute-terms/index.ts
@@ -9,7 +9,6 @@ createCrudDataStore( {
 	resourceName: 'ProductAttributeTerm',
 	pluralResourceName: 'ProductAttributeTerms',
 	namespace: WC_PRODUCT_ATTRIBUTE_TERMS_NAMESPACE,
-	urlParameters: [ 'attribute_id' ],
 } );
 
 export const EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME = STORE_NAME;

--- a/packages/js/data/src/product-attribute-terms/index.ts
+++ b/packages/js/data/src/product-attribute-terms/index.ts
@@ -9,6 +9,7 @@ createCrudDataStore( {
 	resourceName: 'ProductAttributeTerm',
 	pluralResourceName: 'ProductAttributeTerms',
 	namespace: WC_PRODUCT_ATTRIBUTE_TERMS_NAMESPACE,
+	urlParameters: [ 'attribute_id' ],
 } );
 
 export const EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME = STORE_NAME;

--- a/packages/js/data/src/product-attribute-terms/types.ts
+++ b/packages/js/data/src/product-attribute-terms/types.ts
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { DispatchFromMap } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import { CrudActions, CrudSelectors } from '../crud/types';
+
+type ProductAttributeTerm = {
+	id: number;
+	slug: string;
+	name: string;
+	description: string;
+	menu_order: number;
+	count: number;
+};
+
+type Query = {
+	context: string;
+	page: number;
+	per_page: number;
+	search: string;
+	exclude: number[];
+	include: number[];
+	offset: number;
+	order: string;
+	orderby: string;
+	hide_empty: boolean;
+	product: number;
+	slug: string;
+};
+
+type ReadOnlyProperties = 'id' | 'count';
+
+type MutableProperties = Partial<
+	Omit< ProductAttributeTerm, ReadOnlyProperties >
+>;
+
+type ProductAttributeTermActions = CrudActions<
+	'ProductAttributeTerm',
+	ProductAttributeTerm,
+	MutableProperties
+>;
+
+export type ProductAttributeTermsSelectors = CrudSelectors<
+	'ProductAttributeTerm',
+	'ProductAttributeTerms',
+	ProductAttributeTerm,
+	Query,
+	MutableProperties
+>;
+
+export type ActionDispatchers = DispatchFromMap< ProductAttributeTermActions >;

--- a/packages/js/data/src/product-attribute-terms/types.ts
+++ b/packages/js/data/src/product-attribute-terms/types.ts
@@ -41,7 +41,8 @@ type MutableProperties = Partial<
 type ProductAttributeTermActions = CrudActions<
 	'ProductAttributeTerm',
 	ProductAttributeTerm,
-	MutableProperties
+	MutableProperties,
+	'name'
 >;
 
 export type ProductAttributeTermsSelectors = CrudSelectors<


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows nested resources in our CRUD data stores.  Also adds the product attribute terms data store.

`some/path/{parent_id}/morepath/{id}`

Closes #33439, closes #33440, #33441 .

### How to test the changes in this Pull Request:

1. In your console run `wp.data.select('wc/admin/products/attributes/terms').getProductAttributeTerms({parent_id: 3});` - replacing `3` with an actual product attribute ID in your store.
2. Run `wp.data.select('wc/admin/products/attributes/terms').getProductAttributeTerms({id: 5, parent_id: 3});` Replacing `3` and `5` with actual attribute IDs and term IDs respectively in your store. 
3. Attempt to update a term using an attribute and term ID- `wp.data.dispatch('wc/admin/products/attributes/terms').updateProductAttributeTerm({id: 5, parent_id: 3 }, {name: 'Hooray!'});`
4. Attempt to delete a term - `wp.data.dispatch('wc/admin/products/attributes/terms').deleteProductAttributeTerm({id: 5, parent_id: 3 });`
5. Note that skipping the `parent_id` on any of these actions/resolvers stores an error in Redux - `wp.data.dispatch('wc/admin/products/attributes/terms').deleteProductAttributeTerm({id: 161 });

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
