### PR TITLE
Fixing activity panel does not appear after navigating to OBW and back

### DIFF
--- a/packages/js/navigation/src/index.js
+++ b/packages/js/navigation/src/index.js
@@ -235,7 +235,7 @@ export function updateQueryString(
 export const addHistoryListener = ( listener ) => {
 	// Monkey patch pushState to allow trigger the pushstate event listener.
 
-	window.wcNavigation = window.wcNavigation ? window.wcNavigation : {};
+	window.wcNavigation = window.wcNavigation ?? {};
 
 	if ( ! window.wcNavigation.historyPatched ) {
 		( ( history ) => {

--- a/packages/js/navigation/src/index.js
+++ b/packages/js/navigation/src/index.js
@@ -234,7 +234,10 @@ export function updateQueryString(
  */
 export const addHistoryListener = ( listener ) => {
 	// Monkey patch pushState to allow trigger the pushstate event listener.
-	if ( window.wcNavigation && ! window.wcNavigation.historyPatched ) {
+
+	window.wcNavigation = window.wcNavigation ? window.wcNavigation : {};
+
+	if ( ! window.wcNavigation.historyPatched ) {
 		( ( history ) => {
 			/* global CustomEvent */
 			const pushState = history.pushState;

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lazy, useState, useContext, useMemo } from '@wordpress/element';
+import {
+	lazy,
+	useState,
+	useContext,
+	useMemo,
+	useEffect,
+} from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
@@ -14,7 +20,7 @@ import {
 	useUserPreferences,
 	getVisibleTasks,
 } from '@woocommerce/data';
-import { getHistory } from '@woocommerce/navigation';
+import { getHistory, addHistoryListener } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useSlot } from '@woocommerce/experimental';
 
@@ -70,6 +76,13 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		() => layoutContext.getExtendedContext( 'activity-panel' ),
 		[ layoutContext ]
 	);
+
+	useEffect( () => {
+		return addHistoryListener( () => {
+			closePanel();
+			clearPanel();
+		} );
+	}, [] );
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
 		let trackData = {};

--- a/plugins/woocommerce/changelog/fix-33705
+++ b/plugins/woocommerce/changelog/fix-33705
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixing bug where the activity panel stopped functioning after route changes.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Addressing an issue that stems from the Activity Panel logic failing to account for route changes. This was resulting in the Activity Panel buttons (such as "Finish Setup") not responding after having clicked through to the OBW and navigating back.

Closes #33705  .

### How to test the changes in this Pull Request:

1. Checkout branch on fresh site.
2. Skip onboarding wizard.
3. Go to customers page, and click "Finish Setup" button in the Activity Panel.
4. Skip the OBW again. This will put you on the Homescreen.
5. Navigate to the customers page again, and click "Finish Setup" again. 
6. The setup panel should appear as it did the first time.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
