### PR TITLE
Packages: Fix postinstall errors on install

### DIFF
--- a/packages/js/admin-e2e-tests/changelog/fix-packages-postinall
+++ b/packages/js/admin-e2e-tests/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/admin-e2e-tests/package.json
+++ b/packages/js/admin-e2e-tests/package.json
@@ -51,7 +51,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"build": "node ./node_modules/require-turbo && tsc --build",
 		"start": "tsc --build --watch",

--- a/packages/js/api/changelog/fix-packages-postinall
+++ b/packages/js/api/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/api/package.json
+++ b/packages/js/api/package.json
@@ -26,7 +26,7 @@
 	],
 	"sideEffects": false,
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "rm -rf ./dist ./tsconfig.tsbuildinfo",
 		"compile": "tsc -b",

--- a/packages/js/components/changelog/fix-packages-postinall
+++ b/packages/js/components/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -115,7 +115,7 @@
 		"webpack-cli": "^3.3.12"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"build": "node ./node_modules/require-turbo && pnpm run build:js && pnpm run build:css",
 		"build:js": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/csv-export/changelog/fix-packages-postinall
+++ b/packages/js/csv-export/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/csv-export/package.json
+++ b/packages/js/csv-export/package.json
@@ -29,7 +29,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/currency/changelog/fix-packages-postinall
+++ b/packages/js/currency/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/currency/package.json
+++ b/packages/js/currency/package.json
@@ -32,7 +32,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/customer-effort-score/changelog/fix-packages-postinall
+++ b/packages/js/customer-effort-score/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/customer-effort-score/package.json
+++ b/packages/js/customer-effort-score/package.json
@@ -62,7 +62,7 @@
 		"react-dom": "^17.0.0"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && pnpm run build:js && pnpm run build:css",

--- a/packages/js/data/changelog/fix-export-button-error
+++ b/packages/js/data/changelog/fix-export-button-error
@@ -1,4 +1,4 @@
-Significance: patch
-Type: minor
+Significance: minor
+Type: fix
 
 Fix 'Cannot read properties of undefined' error when clicking Export button on Analytic pages.

--- a/packages/js/data/changelog/fix-export-button-error
+++ b/packages/js/data/changelog/fix-export-button-error
@@ -1,4 +1,4 @@
-Significance: fix
+Significance: patch
 Type: minor
 
 Fix 'Cannot read properties of undefined' error when clicking Export button on Analytic pages.

--- a/packages/js/data/changelog/fix-packages-postinall
+++ b/packages/js/data/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -70,7 +70,7 @@
 		"react-dom": "^17.0.0"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/date/changelog/fix-packages-postinall
+++ b/packages/js/date/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/date/package.json
+++ b/packages/js/date/package.json
@@ -48,7 +48,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/dependency-extraction-webpack-plugin/changelog/fix-packages-postinall
+++ b/packages/js/dependency-extraction-webpack-plugin/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/dependency-extraction-webpack-plugin/package.json
+++ b/packages/js/dependency-extraction-webpack-plugin/package.json
@@ -37,7 +37,7 @@
 		"webpack-cli": "^3.3.12"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"lint": "node ./node_modules/require-turbo && eslint src",
 		"lint:fix": "eslint src --fix"

--- a/packages/js/eslint-plugin/changelog/fix-packages-postinall
+++ b/packages/js/eslint-plugin/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/eslint-plugin/package.json
+++ b/packages/js/eslint-plugin/package.json
@@ -36,7 +36,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"lint": "node ./node_modules/require-turbo && eslint ./rules ./configs",
 		"lint:fix": "eslint ./rules ./configs --fix"

--- a/packages/js/experimental/changelog/fix-packages-postinall
+++ b/packages/js/experimental/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/experimental/package.json
+++ b/packages/js/experimental/package.json
@@ -75,7 +75,7 @@
 		"react-dom": "^17.0.0"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && pnpm run build:js && pnpm run build:css",

--- a/packages/js/explat/changelog/fix-packages-postinall
+++ b/packages/js/explat/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/explat/package.json
+++ b/packages/js/explat/package.json
@@ -48,7 +48,7 @@
 		"typescript": "^4.6.2"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/navigation/changelog/fix-packages-postinall
+++ b/packages/js/navigation/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -39,7 +39,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/number/changelog/fix-packages-postinall
+++ b/packages/js/number/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/number/package.json
+++ b/packages/js/number/package.json
@@ -27,7 +27,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/packages/js/onboarding/changelog/fix-packages-postinall
+++ b/packages/js/onboarding/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/onboarding/package.json
+++ b/packages/js/onboarding/package.json
@@ -56,7 +56,7 @@
 		"webpack-cli": "^3.3.12"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && pnpm run build:js && pnpm run build:css",

--- a/packages/js/tracks/changelog/fix-packages-postinall
+++ b/packages/js/tracks/changelog/fix-packages-postinall
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove PHP and Composer dependencies for packaged JS packages

--- a/packages/js/tracks/package.json
+++ b/packages/js/tracks/package.json
@@ -28,7 +28,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
 		"build": "node ./node_modules/require-turbo && tsc --build ./tsconfig.json ./tsconfig-cjs.json",

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -39,7 +39,7 @@
 		}
 	},
 	"scripts": {
-		"prepare": "composer install",
+		"postinstall": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"build": "node ./node_modules/require-turbo && pnpm run build:admin && pnpm run uglify",
 		"build:admin": "wp-scripts build",

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -39,7 +39,7 @@
 		}
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"build": "node ./node_modules/require-turbo && pnpm run build:admin && pnpm run uglify",
 		"build:admin": "wp-scripts build",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
-		"postinstall": "composer install",
+		"prepare": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"build": "node ./node_modules/require-turbo && WC_ADMIN_PHASE=core pnpm run build:feature-config",
 		"build:feature-config": "php bin/generate-feature-config.php",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
-		"prepare": "composer install",
+		"postinstall": "composer install",
 		"changelog": "composer exec -- changelogger",
 		"build": "node ./node_modules/require-turbo && WC_ADMIN_PHASE=core pnpm run build:feature-config",
 		"build:feature-config": "php bin/generate-feature-config.php",


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Post install scripts are being executed in our JS packages in the context of consuming apps. This causes an issue because the scripts being executed depend on PHP and composer. This PR changes the scripts to execute on [`prepare`](https://pnpm.io/cli/install) instead.

### How to test the changes in this Pull Request:

1. Prepare all packages for release and commit changes locally. This will bump versions so our testing package will be an update.
```
./tools/package-release/bin/dev prepare -a
```
2. Disable the Require Turbo tool. In order to run pnpm commands directly, the tools needs to be changed. I created an issue to track this https://github.com/woocommerce/platform-private/issues/63. Until thats fixed, just comment out this entire file https://github.com/woocommerce/woocommerce/blob/trunk/tools/require-turbo/index.js
3. Use `pnpm pack` to create a package to test locally. I've chosen `@woocommerce/eslint-plugin` because it has no dependencies on other packages in the repo, making testing easier. A tarball will result, `woocommerce-eslint-plugin-2.1.0.tgz`
```
cd packages/js/eslint-plugin
pnpm pack
```
4. Disable `composer`. In order to test this, you'll need to make sure Composer doesn't work to confirm an error. One easy way to do this is to change the file name found in the output of `which composer`. Run `composer -h` to confirm an error occurs.
5. Create a test repo and `npm init` to initialize it.
6. Run `npm install --save @woocommerce/eslint-plugin` to pull from the registry and confirm a failure occurs on install.
7. Now install your newly created package, `npm install --save ../<path-to-monorepo/package/js/eslint-plugin/woocommerce-eslint-plugin-2.1.0.tgz`.
8. See no resulting errors.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
