### PR TITLE
Removed WooCommerce 6.7 Changelog Files

### DIFF
--- a/plugins/woocommerce/changelog/fix-33583-cannot-read-property-on-clicking-download-btn
+++ b/plugins/woocommerce/changelog/fix-33583-cannot-read-property-on-clicking-download-btn
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Import correct controls for export function

--- a/plugins/woocommerce/changelog/fix-33673-uncaught-domexception-on-extensions-page
+++ b/plugins/woocommerce/changelog/fix-33673-uncaught-domexception-on-extensions-page
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix Uncaught DOMException on WooCommerce -> Extensions page

--- a/plugins/woocommerce/changelog/fix-marketing-task-complete-only-after-action
+++ b/plugins/woocommerce/changelog/fix-marketing-task-complete-only-after-action
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Revert marketing task completion logic to only complete after actioned by user


### PR DESCRIPTION
This pull request is the `trunk` sibling of https://github.com/woocommerce/woocommerce/pull/33725. This removes the changelog files that are removed in that pull request, since, they're a part of WooCommerce 6.7 now.