### PR TITLE
Fix additional payment task name

### DIFF
--- a/plugins/woocommerce/changelog/fix-33624-setup-payment-option
+++ b/plugins/woocommerce/changelog/fix-33624-setup-payment-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix AdditionalPayments task name

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -27,7 +27,10 @@ class AdditionalPayments extends Payments {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Set up additional payment providers', 'woocommerce' );
+		return __(
+			'Set up additional payment options',
+			'woocommerce'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33624.

Rename the task from `Set up additional payment providers` to `Set up additional payment options`

### How to test the changes in this Pull Request:

1. Onboard to WooCommerce from a WCPay eligible country
2. Install WCPay
3. Set up WCPay
4. Go to WooCommerce Home
5. Observe that `Set up additional payment options` task is displayed.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
