### PR TITLE
Fixed WooCommerce Beta Tester Zip Build

### DIFF
--- a/plugins/woocommerce-beta-tester/bin/build-zip.sh
+++ b/plugins/woocommerce-beta-tester/bin/build-zip.sh
@@ -12,7 +12,7 @@ mkdir -p "$DEST_PATH"
 echo "Installing PHP and JS dependencies..."
 pnpm install
 echo "Running JS Build..."
-pnpm run build
+pnpm -w exec turbo run build --filter=woocommerce-beta-tester || exit "$?"
 
 echo "Syncing files..."
 rsync -rc --exclude-from="$PROJECT_PATH/.distignore" "$PROJECT_PATH/" "$DEST_PATH/" --delete --delete-excluded

--- a/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-release
+++ b/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-release
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This only changes a build step.
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After it was merged, the `build:zip` script for the WooCommerce Beta Tester plugin did not work. It's currently only building the beta tester package, when instead, it needs to build using `turbo`. This pull request updates the zip building to run this command instead.

### How to test the changes in this Pull Request:

1. Run `pnpm run build:zip --filter=woocommerce-beta-tester`
2. Check the output in `plugins/woocommerce-beta-tester/woocommerce-beta-tester.zip`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
