### PR TITLE
Fix missing manage button for TikTok

### DIFF
--- a/plugins/woocommerce/changelog/fix-33656-tiktok-manage-button
+++ b/plugins/woocommerce/changelog/fix-33656-tiktok-manage-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing manage button for TikTok

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -443,6 +443,7 @@ class DefaultFreeExtensions {
 				'image_url'      => plugins_url( '/assets/images/onboarding/tiktok.svg', WC_PLUGIN_FILE ),
 				'description'    =>
 					__( 'Grow your online sales by promoting your products on TikTok to over one billion monthly active users around the world.', 'woocommerce' ),
+				'manage_url'     => 'admin.php?page=tiktok',
 				'is_visible'     => [
 					[
 						'type'     => 'or',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33656.

This PR adds a `manage_url` to TikTok to fix the missing manage button issue.

### How to test the changes in this Pull Request:

1. Set `woocommerce_show_marketplace_suggestions` option to `false`
2. Go to the home screen and select the "Set up Marketing tools" task
3. Install TikTok
4. Visit the task again and confirm that the "Manage" button exists
5. Click the "Manage" button
6. Should be redirected to the TikTok manage page

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
