### PR TITLE
Update WooCommerce Blocks package to 8.0.0

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.8.0
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-7.8.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 8.0.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -22,7 +22,7 @@
 		"pelago/emogrifier": "^6.0",
 		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "7.8.3"
+		"woocommerce/woocommerce-blocks": "8.0.0"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.0.0, and is intended to target WooCommerce 6.8 for release. 

## WooCommerce Blocks 7.9.0

- [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/6604)
- [Testing notes](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/790.md)

## WooCommerce Blocks 8.0.0

- [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/6652)
- [Testing notes](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/800.md)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

- Disable page scroll when Mini Cart drawer is open. ([6532](https://github.com/woocommerce/woocommerce-blocks/pull/6532))
- Register filter blocks using block metadata. ([6505](https://github.com/woocommerce/woocommerce-blocks/pull/6505))
- Enhancement: Make form components require onChange and have a default value. ([6636](https://github.com/woocommerce/woocommerce-blocks/pull/6636))
- Enhancement: Footer Template Parts use now `<footer>` instead of `<div>` and Header uses `<header>` instead of `<div>`. ([6596](https://github.com/woocommerce/woocommerce-blocks/pull/6596))
- Enhancement: Replace the ProductTag tax_query field to be the term_id instead of the id. ([6585](https://github.com/woocommerce/woocommerce-blocks/pull/6585))

#### Bug Fixes

- Fix: Ensure WooCommerce templates show correct titles. ([6452](https://github.com/woocommerce/woocommerce-blocks/pull/6452))
- Fix images hidden by default in Product grid blocks after WC 6.6 update. ([6599](https://github.com/woocommerce/woocommerce-blocks/pull/6599))
- Fix: Scrolling issue of the Filled Mini Cart Contents block. ([6565](https://github.com/woocommerce/woocommerce-blocks/pull/6565))
- Fix an endless loop when using product grid blocks inside product descriptions. ([6471](https://github.com/woocommerce/woocommerce-blocks/pull/6471))

#### Various

- Add template descriptions. ([6345](https://github.com/woocommerce/woocommerce-blocks/pull/6345))

### Changelog entry

> Dev - Update WooCommerce Blocks version to 8.0.0