### PR TITLE
Fix product variation tooltip

### DIFF
--- a/plugins/woocommerce/changelog/fix-33552_product_variation_tooltip
+++ b/plugins/woocommerce/changelog/fix-33552_product_variation_tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix tooltip not showing in variations meta box, and update tooltip copy. #33741

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5857,6 +5857,7 @@ img.tips {
 	z-index: 8675309;
 	position: absolute;
 	top: 0;
+	pointer-events: none;
 
 	/*rtl:ignore*/
 	left: 0;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1,27 +1,46 @@
 /* global wp, woocommerce_admin_meta_boxes_variations, woocommerce_admin, accounting */
-jQuery( function( $ ) {
-    'use strict';
+jQuery( function ( $ ) {
+	'use strict';
 
 	/**
 	 * Variations actions
 	 */
 	var wc_meta_boxes_product_variations_actions = {
-
 		/**
 		 * Initialize variations actions
 		 */
-		init: function() {
+		init: function () {
 			$( '#variable_product_options' )
-				.on( 'change', 'input.variable_is_downloadable', this.variable_is_downloadable )
-				.on( 'change', 'input.variable_is_virtual', this.variable_is_virtual )
-				.on( 'change', 'input.variable_manage_stock', this.variable_manage_stock )
+				.on(
+					'change',
+					'input.variable_is_downloadable',
+					this.variable_is_downloadable
+				)
+				.on(
+					'change',
+					'input.variable_is_virtual',
+					this.variable_is_virtual
+				)
+				.on(
+					'change',
+					'input.variable_manage_stock',
+					this.variable_manage_stock
+				)
 				.on( 'click', 'button.notice-dismiss', this.notice_dismiss )
 				.on( 'click', 'h3 .sort', this.set_menu_order )
 				.on( 'reload', this.reload );
 
-			$( 'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock' ).trigger( 'change' );
-			$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded', this.variations_loaded );
-			$( document.body ).on( 'woocommerce_variations_added', this.variation_added );
+			$(
+				'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock'
+			).trigger( 'change' );
+			$( '#woocommerce-product-data' ).on(
+				'woocommerce_variations_loaded',
+				this.variations_loaded
+			);
+			$( document.body ).on(
+				'woocommerce_variations_added',
+				this.variation_added
+			);
 		},
 
 		/**
@@ -30,7 +49,7 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		reload: function() {
+		reload: function () {
 			wc_meta_boxes_product_variations_ajax.load_variations( 1 );
 			wc_meta_boxes_product_variations_pagenav.set_paginav( 0 );
 		},
@@ -38,47 +57,74 @@ jQuery( function( $ ) {
 		/**
 		 * Check if variation is downloadable and show/hide elements
 		 */
-		variable_is_downloadable: function() {
-			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_downloadable' ).hide();
+		variable_is_downloadable: function () {
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.show_if_variation_downloadable' )
+				.hide();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_downloadable' ).show();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.show_if_variation_downloadable' )
+					.show();
 			}
 		},
 
 		/**
 		 * Check if variation is virtual and show/hide elements
 		 */
-		variable_is_virtual: function() {
-			$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_virtual' ).show();
+		variable_is_virtual: function () {
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.hide_if_variation_virtual' )
+				.show();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_virtual' ).hide();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.hide_if_variation_virtual' )
+					.hide();
 			}
 		},
 
 		/**
 		 * Check if variation manage stock and show/hide elements
 		 */
-		variable_manage_stock: function() {
-			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).hide();
-			$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).show();
+		variable_manage_stock: function () {
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.show_if_variation_manage_stock' )
+				.hide();
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.variable_stock_status' )
+				.show();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).show();
-				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.show_if_variation_manage_stock' )
+					.show();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.variable_stock_status' )
+					.hide();
 			}
 
 			// Parent level.
 			if ( $( 'input#_manage_stock:checked' ).length ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.variable_stock_status' )
+					.hide();
 			}
 		},
 
 		/**
 		 * Notice dismiss
 		 */
-		notice_dismiss: function() {
+		notice_dismiss: function () {
 			$( this ).closest( 'div.notice' ).remove();
 		},
 
@@ -88,74 +134,97 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} needsUpdate
 		 */
-		variations_loaded: function( event, needsUpdate ) {
+		variations_loaded: function ( event, needsUpdate ) {
 			needsUpdate = needsUpdate || false;
 
 			var wrapper = $( '#woocommerce-product-data' );
 
 			if ( ! needsUpdate ) {
 				// Show/hide downloadable, virtual and stock fields
-				$( 'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock', wrapper ).trigger( 'change' );
+				$(
+					'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock',
+					wrapper
+				).trigger( 'change' );
 
 				// Open sale schedule fields when have some sale price date
-				$( '.woocommerce_variation', wrapper ).each( function( index, el ) {
-					var $el       = $( el ),
+				$( '.woocommerce_variation', wrapper ).each( function (
+					index,
+					el
+				) {
+					var $el = $( el ),
 						date_from = $( '.sale_price_dates_from', $el ).val(),
-						date_to   = $( '.sale_price_dates_to', $el ).val();
+						date_to = $( '.sale_price_dates_to', $el ).val();
 
 					if ( '' !== date_from || '' !== date_to ) {
 						$( 'a.sale_schedule', $el ).trigger( 'click' );
 					}
-				});
+				} );
 
 				// Remove variation-needs-update classes
-				$( '.woocommerce_variations .variation-needs-update', wrapper ).removeClass( 'variation-needs-update' );
+				$(
+					'.woocommerce_variations .variation-needs-update',
+					wrapper
+				).removeClass( 'variation-needs-update' );
 
 				// Disable cancel and save buttons
-				$( 'button.cancel-variation-changes, button.save-variation-changes', wrapper ).attr( 'disabled', 'disabled' );
+				$(
+					'button.cancel-variation-changes, button.save-variation-changes',
+					wrapper
+				).attr( 'disabled', 'disabled' );
 			}
 
 			// Init TipTip
 			$( '#tiptip_holder' ).removeAttr( 'style' );
 			$( '#tiptip_arrow' ).removeAttr( 'style' );
-			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper )
-				.tipTip({
-					'attribute': 'data-tip',
-					'fadeIn':    50,
-					'fadeOut':   50,
-					'delay':     200
-			});
+			$(
+				'.woocommerce_variations .tips, ' +
+				'.woocommerce_variations .help_tip, ' +
+				'.woocommerce_variations .woocommerce-help-tip, ' +
+				'.toolbar-variations-defaults .woocommerce-help-tip',
+				wrapper
+			).tipTip( {
+				attribute: 'data-tip',
+				fadeIn: 50,
+				fadeOut: 50,
+				delay: 200,
+			} );
 
 			// Datepicker fields
-			$( '.sale_price_dates_fields', wrapper ).find( 'input' ).datepicker({
-				defaultDate:     '',
-				dateFormat:      'yy-mm-dd',
-				numberOfMonths:  1,
-				showButtonPanel: true,
-				onSelect:        function() {
-					var option = $( this ).is( '.sale_price_dates_from' ) ? 'minDate' : 'maxDate',
-						dates  = $( this ).closest( '.sale_price_dates_fields' ).find( 'input' ),
-						date   = $( this ).datepicker( 'getDate' );
+			$( '.sale_price_dates_fields', wrapper )
+				.find( 'input' )
+				.datepicker( {
+					defaultDate: '',
+					dateFormat: 'yy-mm-dd',
+					numberOfMonths: 1,
+					showButtonPanel: true,
+					onSelect: function () {
+						var option = $( this ).is( '.sale_price_dates_from' )
+								? 'minDate'
+								: 'maxDate',
+							dates = $( this )
+								.closest( '.sale_price_dates_fields' )
+								.find( 'input' ),
+							date = $( this ).datepicker( 'getDate' );
 
-					dates.not( this ).datepicker( 'option', option, date );
-					$( this ).trigger( 'change' );
-				}
-			});
+						dates.not( this ).datepicker( 'option', option, date );
+						$( this ).trigger( 'change' );
+					},
+				} );
 
 			// Allow sorting
-			$( '.woocommerce_variations', wrapper ).sortable({
-				items:                '.woocommerce_variation',
-				cursor:               'move',
-				axis:                 'y',
-				handle:               '.sort',
-				scrollSensitivity:    40,
+			$( '.woocommerce_variations', wrapper ).sortable( {
+				items: '.woocommerce_variation',
+				cursor: 'move',
+				axis: 'y',
+				handle: '.sort',
+				scrollSensitivity: 40,
 				forcePlaceholderSize: true,
-				helper:               'clone',
-				opacity:              0.65,
-				stop:                 function() {
-				    wc_meta_boxes_product_variations_actions.variation_row_indexes();
-				}
-			});
+				helper: 'clone',
+				opacity: 0.65,
+				stop: function () {
+					wc_meta_boxes_product_variations_actions.variation_row_indexes();
+				},
+			} );
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 		},
@@ -166,32 +235,51 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		variation_added: function( event, qty ) {
+		variation_added: function ( event, qty ) {
 			if ( 1 === qty ) {
-				wc_meta_boxes_product_variations_actions.variations_loaded( null, true );
+				wc_meta_boxes_product_variations_actions.variations_loaded(
+					null,
+					true
+				);
 			}
 		},
 
 		/**
 		 * Lets the user manually input menu order to move items around pages
 		 */
-		set_menu_order: function( event ) {
+		set_menu_order: function ( event ) {
 			event.preventDefault();
-			var $menu_order  = $( this ).closest( '.woocommerce_variation' ).find( '.variation_menu_order' );
-			var variation_id = $( this ).closest( '.woocommerce_variation' ).find( '.variable_post_id' ).val();
-			var value        = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order, $menu_order.val() );
+			var $menu_order = $( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.variation_menu_order' );
+			var variation_id = $( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.variable_post_id' )
+				.val();
+			var value = window.prompt(
+				woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order,
+				$menu_order.val()
+			);
 
 			if ( value != null ) {
 				// Set value, save changes and reload view
 				$menu_order.val( parseInt( value, 10 ) ).trigger( 'change' );
 
-				$( this ).closest( '.woocommerce_variation' )
-					.append( '<input type="hidden" name="new_variation_menu_order_id" value="'
-						+ encodeURIComponent( variation_id ) + '" />' );
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.append(
+						'<input type="hidden" name="new_variation_menu_order_id" value="' +
+							encodeURIComponent( variation_id ) +
+							'" />'
+					);
 
-				$( this ).closest( '.woocommerce_variation' )
-					.append( '<input type="hidden" name="new_variation_menu_order_value" value="'
-						+ encodeURIComponent( parseInt( value, 10 ) ) + '" />' );
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.append(
+						'<input type="hidden" name="new_variation_menu_order_value" value="' +
+							encodeURIComponent( parseInt( value, 10 ) ) +
+							'" />'
+					);
 
 				wc_meta_boxes_product_variations_ajax.save_variations();
 			}
@@ -200,25 +288,40 @@ jQuery( function( $ ) {
 		/**
 		 * Set menu order
 		 */
-		variation_row_indexes: function() {
-			var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+		variation_row_indexes: function () {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
 				current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
-				offset       = parseInt( ( current_page - 1 ) * woocommerce_admin_meta_boxes_variations.variations_per_page, 10 );
+				offset = parseInt(
+					( current_page - 1 ) *
+						woocommerce_admin_meta_boxes_variations.variations_per_page,
+					10
+				);
 
-			$( '.woocommerce_variations .woocommerce_variation' ).each( function ( index, el ) {
-				$( '.variation_menu_order', el )
-					.val( parseInt( $( el )
-					.index( '.woocommerce_variations .woocommerce_variation' ), 10 ) + 1 + offset )
-					.trigger( 'change' );
-			});
-		}
+			$( '.woocommerce_variations .woocommerce_variation' ).each(
+				function ( index, el ) {
+					$( '.variation_menu_order', el )
+						.val(
+							parseInt(
+								$( el ).index(
+									'.woocommerce_variations .woocommerce_variation'
+								),
+								10
+							) +
+								1 +
+								offset
+						)
+						.trigger( 'change' );
+				}
+			);
+		},
 	};
 
 	/**
 	 * Variations media actions
 	 */
 	var wc_meta_boxes_product_variations_media = {
-
 		/**
 		 * wp.media frame object
 		 *
@@ -250,8 +353,12 @@ jQuery( function( $ ) {
 		/**
 		 * Initialize media actions
 		 */
-		init: function() {
-			$( '#variable_product_options' ).on( 'click', '.upload_image_button', this.add_image );
+		init: function () {
+			$( '#variable_product_options' ).on(
+				'click',
+				'.upload_image_button',
+				this.add_image
+			);
 			$( 'a.add_media' ).on( 'click', this.restore_wp_media_post_id );
 		},
 
@@ -260,64 +367,101 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} event
 		 */
-		add_image: function( event ) {
+		add_image: function ( event ) {
 			var $button = $( this ),
 				post_id = $button.attr( 'rel' ),
 				$parent = $button.closest( '.upload_image' );
 
-			wc_meta_boxes_product_variations_media.setting_variation_image    = $parent;
+			wc_meta_boxes_product_variations_media.setting_variation_image = $parent;
 			wc_meta_boxes_product_variations_media.setting_variation_image_id = post_id;
 
 			event.preventDefault();
 
 			if ( $button.is( '.remove' ) ) {
-
-				$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( '' ).trigger( 'change' );
-				wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 )
-					.attr( 'src', woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src );
-				wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).removeClass( 'remove' );
-
+				$(
+					'.upload_image_id',
+					wc_meta_boxes_product_variations_media.setting_variation_image
+				)
+					.val( '' )
+					.trigger( 'change' );
+				wc_meta_boxes_product_variations_media.setting_variation_image
+					.find( 'img' )
+					.eq( 0 )
+					.attr(
+						'src',
+						woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src
+					);
+				wc_meta_boxes_product_variations_media.setting_variation_image
+					.find( '.upload_image_button' )
+					.removeClass( 'remove' );
 			} else {
-
 				// If the media frame already exists, reopen it.
-				if ( wc_meta_boxes_product_variations_media.variable_image_frame ) {
-					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader
-						.param( 'post_id', wc_meta_boxes_product_variations_media.setting_variation_image_id );
+				if (
+					wc_meta_boxes_product_variations_media.variable_image_frame
+				) {
+					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader.param(
+						'post_id',
+						wc_meta_boxes_product_variations_media.setting_variation_image_id
+					);
 					wc_meta_boxes_product_variations_media.variable_image_frame.open();
 					return;
 				} else {
-					wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.setting_variation_image_id;
+					wp.media.model.settings.post.id =
+						wc_meta_boxes_product_variations_media.setting_variation_image_id;
 				}
 
 				// Create the media frame.
-				wc_meta_boxes_product_variations_media.variable_image_frame = wp.media.frames.variable_image = wp.media({
-					// Set the title of the modal.
-					title: woocommerce_admin_meta_boxes_variations.i18n_choose_image,
-					button: {
-						text: woocommerce_admin_meta_boxes_variations.i18n_set_image
-					},
-					states: [
-						new wp.media.controller.Library({
-							title: woocommerce_admin_meta_boxes_variations.i18n_choose_image,
-							filterable: 'all'
-						})
-					]
-				});
+				wc_meta_boxes_product_variations_media.variable_image_frame = wp.media.frames.variable_image = wp.media(
+					{
+						// Set the title of the modal.
+						title:
+							woocommerce_admin_meta_boxes_variations.i18n_choose_image,
+						button: {
+							text:
+								woocommerce_admin_meta_boxes_variations.i18n_set_image,
+						},
+						states: [
+							new wp.media.controller.Library( {
+								title:
+									woocommerce_admin_meta_boxes_variations.i18n_choose_image,
+								filterable: 'all',
+							} ),
+						],
+					}
+				);
 
 				// When an image is selected, run a callback.
-				wc_meta_boxes_product_variations_media.variable_image_frame.on( 'select', function () {
+				wc_meta_boxes_product_variations_media.variable_image_frame.on(
+					'select',
+					function () {
+						var attachment = wc_meta_boxes_product_variations_media.variable_image_frame
+								.state()
+								.get( 'selection' )
+								.first()
+								.toJSON(),
+							url =
+								attachment.sizes && attachment.sizes.thumbnail
+									? attachment.sizes.thumbnail.url
+									: attachment.url;
 
-					var attachment = wc_meta_boxes_product_variations_media.variable_image_frame.state()
-						.get( 'selection' ).first().toJSON(),
-						url = attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url;
+						$(
+							'.upload_image_id',
+							wc_meta_boxes_product_variations_media.setting_variation_image
+						)
+							.val( attachment.id )
+							.trigger( 'change' );
+						wc_meta_boxes_product_variations_media.setting_variation_image
+							.find( '.upload_image_button' )
+							.addClass( 'remove' );
+						wc_meta_boxes_product_variations_media.setting_variation_image
+							.find( 'img' )
+							.eq( 0 )
+							.attr( 'src', url );
 
-					$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( attachment.id )
-						.trigger( 'change' );
-					wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).addClass( 'remove' );
-					wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 ).attr( 'src', url );
-
-					wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.wp_media_post_id;
-				});
+						wp.media.model.settings.post.id =
+							wc_meta_boxes_product_variations_media.wp_media_post_id;
+					}
+				);
 
 				// Finally, open the modal.
 				wc_meta_boxes_product_variations_media.variable_image_frame.open();
@@ -327,41 +471,65 @@ jQuery( function( $ ) {
 		/**
 		 * Restore wp.media post ID.
 		 */
-		restore_wp_media_post_id: function() {
-			wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.wp_media_post_id;
-		}
+		restore_wp_media_post_id: function () {
+			wp.media.model.settings.post.id =
+				wc_meta_boxes_product_variations_media.wp_media_post_id;
+		},
 	};
 
 	/**
 	 * Product variations metabox ajax methods
 	 */
 	var wc_meta_boxes_product_variations_ajax = {
-
 		/**
 		 * Initialize variations ajax methods
 		 */
-		init: function() {
+		init: function () {
 			$( 'li.variations_tab a' ).on( 'click', this.initial_load );
 
 			$( '#variable_product_options' )
-				.on( 'click', 'button.save-variation-changes', this.save_variations )
-				.on( 'click', 'button.cancel-variation-changes', this.cancel_variations )
+				.on(
+					'click',
+					'button.save-variation-changes',
+					this.save_variations
+				)
+				.on(
+					'click',
+					'button.cancel-variation-changes',
+					this.cancel_variations
+				)
 				.on( 'click', '.remove_variation', this.remove_variation )
-				.on( 'click','.downloadable_files a.delete', this.input_changed );
+				.on(
+					'click',
+					'.downloadable_files a.delete',
+					this.input_changed
+				);
 
 			$( document.body )
-				.on( 'change input', '#variable_product_options .woocommerce_variations :input', this.input_changed )
-				.on( 'change', '.variations-defaults select', this.defaults_changed );
+				.on(
+					'change input',
+					'#variable_product_options .woocommerce_variations :input',
+					this.input_changed
+				)
+				.on(
+					'change',
+					'.variations-defaults select',
+					this.defaults_changed
+				);
 
 			var postForm = $( 'form#post' );
 
 			postForm.on( 'submit', this.save_on_submit );
 
-			$( 'input:submit', postForm ).on( 'click keypress', function() {
+			$( 'input:submit', postForm ).on( 'click keypress', function () {
 				postForm.data( 'callerid', this.id );
-			});
+			} );
 
-			$( '.wc-metaboxes-wrapper' ).on( 'click', 'a.do_variation_action', this.do_variation_action );
+			$( '.wc-metaboxes-wrapper' ).on(
+				'click',
+				'a.do_variation_action',
+				this.do_variation_action
+			);
 		},
 
 		/**
@@ -369,11 +537,17 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		check_for_changes: function() {
-			var need_update = $( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' );
+		check_for_changes: function () {
+			var need_update = $( '#variable_product_options' ).find(
+				'.woocommerce_variations .variation-needs-update'
+			);
 
 			if ( 0 < need_update.length ) {
-				if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_edited_variations ) ) {
+				if (
+					window.confirm(
+						woocommerce_admin_meta_boxes_variations.i18n_edited_variations
+					)
+				) {
 					wc_meta_boxes_product_variations_ajax.save_changes();
 				} else {
 					need_update.removeClass( 'variation-needs-update' );
@@ -387,20 +561,20 @@ jQuery( function( $ ) {
 		/**
 		 * Block edit screen
 		 */
-		block: function() {
-			$( '#woocommerce-product-data' ).block({
+		block: function () {
+			$( '#woocommerce-product-data' ).block( {
 				message: null,
 				overlayCSS: {
 					background: '#fff',
-					opacity: 0.6
-				}
-			});
+					opacity: 0.6,
+				},
+			} );
 		},
 
 		/**
 		 * Unblock edit screen
 		 */
-		unblock: function() {
+		unblock: function () {
 			$( '#woocommerce-product-data' ).unblock();
 		},
 
@@ -409,8 +583,13 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		initial_load: function() {
-			if ( 0 === $( '#variable_product_options' ).find( '.woocommerce_variations .woocommerce_variation' ).length ) {
+		initial_load: function () {
+			if (
+				0 ===
+				$( '#variable_product_options' ).find(
+					'.woocommerce_variations .woocommerce_variation'
+				).length
+			) {
 				wc_meta_boxes_product_variations_pagenav.go_to_page();
 			}
 		},
@@ -421,33 +600,43 @@ jQuery( function( $ ) {
 		 * @param {Int} page (default: 1)
 		 * @param {Int} per_page (default: 10)
 		 */
-		load_variations: function( page, per_page ) {
-			page     = page || 1;
-			per_page = per_page || woocommerce_admin_meta_boxes_variations.variations_per_page;
+		load_variations: function ( page, per_page ) {
+			page = page || 1;
+			per_page =
+				per_page ||
+				woocommerce_admin_meta_boxes_variations.variations_per_page;
 
-			var wrapper = $( '#variable_product_options' ).find( '.woocommerce_variations' );
+			var wrapper = $( '#variable_product_options' ).find(
+				'.woocommerce_variations'
+			);
 
 			wc_meta_boxes_product_variations_ajax.block();
 
-			$.ajax({
+			$.ajax( {
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,
 				data: {
-					action:     'woocommerce_load_variations',
-					security:   woocommerce_admin_meta_boxes_variations.load_variations_nonce,
+					action: 'woocommerce_load_variations',
+					security:
+						woocommerce_admin_meta_boxes_variations.load_variations_nonce,
 					product_id: woocommerce_admin_meta_boxes_variations.post_id,
 					attributes: wrapper.data( 'attributes' ),
-					page:       page,
-					per_page:   per_page
+					page: page,
+					per_page: per_page,
 				},
 				type: 'POST',
-				success: function( response ) {
-					wrapper.empty().append( response ).attr( 'data-page', page );
+				success: function ( response ) {
+					wrapper
+						.empty()
+						.append( response )
+						.attr( 'data-page', page );
 
-					$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_loaded' );
+					$( '#woocommerce-product-data' ).trigger(
+						'woocommerce_variations_loaded'
+					);
 
 					wc_meta_boxes_product_variations_ajax.unblock();
-				}
-			});
+				},
+			} );
 		},
 
 		/**
@@ -457,13 +646,16 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Object}
 		 */
-		get_variations_fields: function( fields ) {
+		get_variations_fields: function ( fields ) {
 			var data = $( ':input', fields ).serializeJSON();
 
-			$( '.variations-defaults select' ).each( function( index, element ) {
+			$( '.variations-defaults select' ).each( function (
+				index,
+				element
+			) {
 				var select = $( element );
 				data[ select.attr( 'name' ) ] = select.val();
-			});
+			} );
 
 			return data;
 		},
@@ -473,39 +665,49 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Function} callback Called once saving is complete
 		 */
-		save_changes: function( callback ) {
-			var wrapper     = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+		save_changes: function ( callback ) {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
 				need_update = $( '.variation-needs-update', wrapper ),
-				data        = {};
+				data = {};
 
 			// Save only with products need update.
 			if ( 0 < need_update.length ) {
 				wc_meta_boxes_product_variations_ajax.block();
 
-				data                 = wc_meta_boxes_product_variations_ajax.get_variations_fields( need_update );
-				data.action          = 'woocommerce_save_variations';
-				data.security        = woocommerce_admin_meta_boxes_variations.save_variations_nonce;
-				data.product_id      = woocommerce_admin_meta_boxes_variations.post_id;
-				data['product-type'] = $( '#product-type' ).val();
+				data = wc_meta_boxes_product_variations_ajax.get_variations_fields(
+					need_update
+				);
+				data.action = 'woocommerce_save_variations';
+				data.security =
+					woocommerce_admin_meta_boxes_variations.save_variations_nonce;
+				data.product_id =
+					woocommerce_admin_meta_boxes_variations.post_id;
+				data[ 'product-type' ] = $( '#product-type' ).val();
 
-				$.ajax({
+				$.ajax( {
 					url: woocommerce_admin_meta_boxes_variations.ajax_url,
 					data: data,
 					type: 'POST',
-					success: function( response ) {
+					success: function ( response ) {
 						// Allow change page, delete and add new variations
 						need_update.removeClass( 'variation-needs-update' );
-						$( 'button.cancel-variation-changes, button.save-variation-changes' ).attr( 'disabled', 'disabled' );
+						$(
+							'button.cancel-variation-changes, button.save-variation-changes'
+						).attr( 'disabled', 'disabled' );
 
-						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_saved' );
+						$( '#woocommerce-product-data' ).trigger(
+							'woocommerce_variations_saved'
+						);
 
 						if ( typeof callback === 'function' ) {
 							callback( response );
 						}
 
 						wc_meta_boxes_product_variations_ajax.unblock();
-					}
-				});
+					},
+				} );
 			}
 		},
 
@@ -514,25 +716,33 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		save_variations: function() {
-			$( '#variable_product_options' ).trigger( 'woocommerce_variations_save_variations_button' );
+		save_variations: function () {
+			$( '#variable_product_options' ).trigger(
+				'woocommerce_variations_save_variations_button'
+			);
 
-			wc_meta_boxes_product_variations_ajax.save_changes( function( error ) {
-				var wrapper = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+			wc_meta_boxes_product_variations_ajax.save_changes( function (
+				error
+			) {
+				var wrapper = $( '#variable_product_options' ).find(
+						'.woocommerce_variations'
+					),
 					current = wrapper.attr( 'data-page' );
 
-				$( '#variable_product_options' ).find( '#woocommerce_errors' ).remove();
+				$( '#variable_product_options' )
+					.find( '#woocommerce_errors' )
+					.remove();
 
 				if ( error ) {
 					wrapper.before( error );
 				}
 
-				$( '.variations-defaults select' ).each( function() {
+				$( '.variations-defaults select' ).each( function () {
 					$( this ).attr( 'data-current', $( this ).val() );
-				});
+				} );
 
 				wc_meta_boxes_product_variations_pagenav.go_to_page( current );
-			});
+			} );
 
 			return false;
 		},
@@ -540,27 +750,41 @@ jQuery( function( $ ) {
 		/**
 		 * Save on post form submit
 		 */
-		save_on_submit: function( e ) {
-			var need_update = $( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' );
+		save_on_submit: function ( e ) {
+			var need_update = $( '#variable_product_options' ).find(
+				'.woocommerce_variations .variation-needs-update'
+			);
 
 			if ( 0 < need_update.length ) {
 				e.preventDefault();
-				$( '#variable_product_options' ).trigger( 'woocommerce_variations_save_variations_on_submit' );
-				wc_meta_boxes_product_variations_ajax.save_changes( wc_meta_boxes_product_variations_ajax.save_on_submit_done );
+				$( '#variable_product_options' ).trigger(
+					'woocommerce_variations_save_variations_on_submit'
+				);
+				wc_meta_boxes_product_variations_ajax.save_changes(
+					wc_meta_boxes_product_variations_ajax.save_on_submit_done
+				);
 			}
 		},
 
 		/**
 		 * After saved, continue with form submission
 		 */
-		save_on_submit_done: function() {
+		save_on_submit_done: function () {
 			var postForm = $( 'form#post' ),
 				callerid = postForm.data( 'callerid' );
 
 			if ( 'publish' === callerid ) {
-				postForm.append('<input type="hidden" name="publish" value="1" />').trigger( 'submit' );
+				postForm
+					.append(
+						'<input type="hidden" name="publish" value="1" />'
+					)
+					.trigger( 'submit' );
 			} else {
-				postForm.append('<input type="hidden" name="save-post" value="1" />').trigger( 'submit' );
+				postForm
+					.append(
+						'<input type="hidden" name="save-post" value="1" />'
+					)
+					.trigger( 'submit' );
 			}
 		},
 
@@ -569,14 +793,20 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		cancel_variations: function() {
-			var current = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-page' ), 10 );
+		cancel_variations: function () {
+			var current = parseInt(
+				$( '#variable_product_options' )
+					.find( '.woocommerce_variations' )
+					.attr( 'data-page' ),
+				10
+			);
 
-			$( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' )
+			$( '#variable_product_options' )
+				.find( '.woocommerce_variations .variation-needs-update' )
 				.removeClass( 'variation-needs-update' );
-			$( '.variations-defaults select' ).each( function() {
+			$( '.variations-defaults select' ).each( function () {
 				$( this ).val( $( this ).attr( 'data-current' ) );
-			});
+			} );
 
 			wc_meta_boxes_product_variations_pagenav.go_to_page( current );
 
@@ -588,26 +818,38 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		add_variation: function() {
+		add_variation: function () {
 			wc_meta_boxes_product_variations_ajax.block();
 
 			var data = {
 				action: 'woocommerce_add_variation',
 				post_id: woocommerce_admin_meta_boxes_variations.post_id,
 				loop: $( '.woocommerce_variation' ).length,
-				security: woocommerce_admin_meta_boxes_variations.add_variation_nonce
+				security:
+					woocommerce_admin_meta_boxes_variations.add_variation_nonce,
 			};
 
-			$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function( response ) {
-				var variation = $( response );
-				variation.addClass( 'variation-needs-update' );
+			$.post(
+				woocommerce_admin_meta_boxes_variations.ajax_url,
+				data,
+				function ( response ) {
+					var variation = $( response );
+					variation.addClass( 'variation-needs-update' );
 
-				$( '.woocommerce-notice-invalid-variation' ).remove();
-				$( '#variable_product_options' ).find( '.woocommerce_variations' ).prepend( variation );
-				$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
-				$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', 1 );
-				wc_meta_boxes_product_variations_ajax.unblock();
-			});
+					$( '.woocommerce-notice-invalid-variation' ).remove();
+					$( '#variable_product_options' )
+						.find( '.woocommerce_variations' )
+						.prepend( variation );
+					$(
+						'button.cancel-variation-changes, button.save-variation-changes'
+					).prop( 'disabled', false );
+					$( '#variable_product_options' ).trigger(
+						'woocommerce_variations_added',
+						1
+					);
+					wc_meta_boxes_product_variations_ajax.unblock();
+				}
+			);
 
 			return false;
 		},
@@ -617,14 +859,18 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		remove_variation: function() {
+		remove_variation: function () {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_remove_variation ) ) {
-				var variation     = $( this ).attr( 'rel' ),
+			if (
+				window.confirm(
+					woocommerce_admin_meta_boxes_variations.i18n_remove_variation
+				)
+			) {
+				var variation = $( this ).attr( 'rel' ),
 					variation_ids = [],
-					data          = {
-						action: 'woocommerce_remove_variations'
+					data = {
+						action: 'woocommerce_remove_variations',
 					};
 
 				wc_meta_boxes_product_variations_ajax.block();
@@ -633,27 +879,52 @@ jQuery( function( $ ) {
 					variation_ids.push( variation );
 
 					data.variation_ids = variation_ids;
-					data.security      = woocommerce_admin_meta_boxes_variations.delete_variations_nonce;
+					data.security =
+						woocommerce_admin_meta_boxes_variations.delete_variations_nonce;
 
-					$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function() {
-						var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-							current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
-							total_pages  = Math.ceil( (
-								parseInt( wrapper.attr( 'data-total' ), 10 ) - 1
-							) / woocommerce_admin_meta_boxes_variations.variations_per_page ),
-							page         = 1;
+					$.post(
+						woocommerce_admin_meta_boxes_variations.ajax_url,
+						data,
+						function () {
+							var wrapper = $( '#variable_product_options' ).find(
+									'.woocommerce_variations'
+								),
+								current_page = parseInt(
+									wrapper.attr( 'data-page' ),
+									10
+								),
+								total_pages = Math.ceil(
+									( parseInt(
+										wrapper.attr( 'data-total' ),
+										10
+									) -
+										1 ) /
+										woocommerce_admin_meta_boxes_variations.variations_per_page
+								),
+								page = 1;
 
-						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_removed' );
+							$( '#woocommerce-product-data' ).trigger(
+								'woocommerce_variations_removed'
+							);
 
-						if ( current_page === total_pages || current_page <= total_pages ) {
-							page = current_page;
-						} else if ( current_page > total_pages && 0 !== total_pages ) {
-							page = total_pages;
+							if (
+								current_page === total_pages ||
+								current_page <= total_pages
+							) {
+								page = current_page;
+							} else if (
+								current_page > total_pages &&
+								0 !== total_pages
+							) {
+								page = total_pages;
+							}
+
+							wc_meta_boxes_product_variations_pagenav.go_to_page(
+								page,
+								-1
+							);
 						}
-
-						wc_meta_boxes_product_variations_pagenav.go_to_page( page, -1 );
-					});
-
+					);
 				} else {
 					wc_meta_boxes_product_variations_ajax.unblock();
 				}
@@ -667,36 +938,61 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		link_all_variations: function() {
+		link_all_variations: function () {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_link_all_variations ) ) {
+			if (
+				window.confirm(
+					woocommerce_admin_meta_boxes_variations.i18n_link_all_variations
+				)
+			) {
 				wc_meta_boxes_product_variations_ajax.block();
 
 				var data = {
 					action: 'woocommerce_link_all_variations',
 					post_id: woocommerce_admin_meta_boxes_variations.post_id,
-					security: woocommerce_admin_meta_boxes_variations.link_variation_nonce
+					security:
+						woocommerce_admin_meta_boxes_variations.link_variation_nonce,
 				};
 
-				$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function( response ) {
-					var count = parseInt( response, 10 );
+				$.post(
+					woocommerce_admin_meta_boxes_variations.ajax_url,
+					data,
+					function ( response ) {
+						var count = parseInt( response, 10 );
 
-					if ( 1 === count ) {
-						window.alert( count + ' ' + woocommerce_admin_meta_boxes_variations.i18n_variation_added );
-					} else if ( 0 === count || count > 1 ) {
-						window.alert( count + ' ' + woocommerce_admin_meta_boxes_variations.i18n_variations_added );
-					} else {
-						window.alert( woocommerce_admin_meta_boxes_variations.i18n_no_variations_added );
-					}
+						if ( 1 === count ) {
+							window.alert(
+								count +
+									' ' +
+									woocommerce_admin_meta_boxes_variations.i18n_variation_added
+							);
+						} else if ( 0 === count || count > 1 ) {
+							window.alert(
+								count +
+									' ' +
+									woocommerce_admin_meta_boxes_variations.i18n_variations_added
+							);
+						} else {
+							window.alert(
+								woocommerce_admin_meta_boxes_variations.i18n_no_variations_added
+							);
+						}
 
-					if ( count > 0 ) {
-						wc_meta_boxes_product_variations_pagenav.go_to_page( 1, count );
-						$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', count );
-					} else {
-						wc_meta_boxes_product_variations_ajax.unblock();
+						if ( count > 0 ) {
+							wc_meta_boxes_product_variations_pagenav.go_to_page(
+								1,
+								count
+							);
+							$( '#variable_product_options' ).trigger(
+								'woocommerce_variations_added',
+								count
+							);
+						} else {
+							wc_meta_boxes_product_variations_ajax.unblock();
+						}
 					}
-				});
+				);
 			}
 
 			return false;
@@ -705,87 +1001,119 @@ jQuery( function( $ ) {
 		/**
 		 * Add new class when have changes in some input
 		 */
-		input_changed: function( event ) {
+		input_changed: function ( event ) {
 			$( this )
 				.closest( '.woocommerce_variation' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
+			$(
+				'button.cancel-variation-changes, button.save-variation-changes'
+			).prop( 'disabled', false );
 
 			// Do not trigger 'woocommerce_variations_input_changed' for 'input' events for backwards compat.
 			if ( 'input' === event.type && $( this ).is( ':text' ) ) {
 				return;
 			}
 
-			$( '#variable_product_options' ).trigger( 'woocommerce_variations_input_changed' );
+			$( '#variable_product_options' ).trigger(
+				'woocommerce_variations_input_changed'
+			);
 		},
 
 		/**
 		 * Added new .variation-needs-update class when defaults is changed
 		 */
-		defaults_changed: function() {
+		defaults_changed: function () {
 			$( this )
 				.closest( '#variable_product_options' )
 				.find( '.woocommerce_variation:first' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
+			$(
+				'button.cancel-variation-changes, button.save-variation-changes'
+			).prop( 'disabled', false );
 
-			$( '#variable_product_options' ).trigger( 'woocommerce_variations_defaults_changed' );
+			$( '#variable_product_options' ).trigger(
+				'woocommerce_variations_defaults_changed'
+			);
 		},
 
 		/**
 		 * Actions
 		 */
-		do_variation_action: function() {
+		do_variation_action: function () {
 			var do_variation_action = $( 'select.variation_actions' ).val(),
-				data       = {},
-				changes    = 0,
+				data = {},
+				changes = 0,
 				value;
 
 			switch ( do_variation_action ) {
-				case 'add_variation' :
+				case 'add_variation':
 					wc_meta_boxes_product_variations_ajax.add_variation();
 					return;
-				case 'link_all_variations' :
+				case 'link_all_variations':
 					wc_meta_boxes_product_variations_ajax.link_all_variations();
 					return;
-				case 'delete_all' :
-					if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations ) ) {
-						if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_last_warning ) ) {
+				case 'delete_all':
+					if (
+						window.confirm(
+							woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations
+						)
+					) {
+						if (
+							window.confirm(
+								woocommerce_admin_meta_boxes_variations.i18n_last_warning
+							)
+						) {
 							data.allowed = true;
-							changes      = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' )
-								.attr( 'data-total' ), 10 ) * -1;
+							changes =
+								parseInt(
+									$( '#variable_product_options' )
+										.find( '.woocommerce_variations' )
+										.attr( 'data-total' ),
+									10
+								) * -1;
 						}
 					}
 					break;
-				case 'variable_regular_price_increase' :
-				case 'variable_regular_price_decrease' :
-				case 'variable_sale_price_increase' :
-				case 'variable_sale_price_decrease' :
-					value = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent );
+				case 'variable_regular_price_increase':
+				case 'variable_regular_price_decrease':
+				case 'variable_sale_price_increase':
+				case 'variable_sale_price_decrease':
+					value = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent
+					);
 
 					if ( value != null ) {
 						if ( value.indexOf( '%' ) >= 0 ) {
-							data.value = accounting.unformat( value.replace( /\%/, '' ), woocommerce_admin.mon_decimal_point ) + '%';
+							data.value =
+								accounting.unformat(
+									value.replace( /\%/, '' ),
+									woocommerce_admin.mon_decimal_point
+								) + '%';
 						} else {
-							data.value = accounting.unformat( value, woocommerce_admin.mon_decimal_point );
+							data.value = accounting.unformat(
+								value,
+								woocommerce_admin.mon_decimal_point
+							);
 						}
 					} else {
 						return;
 					}
 					break;
-				case 'variable_regular_price' :
-				case 'variable_sale_price' :
-				case 'variable_stock' :
-				case 'variable_low_stock_amount' :
-				case 'variable_weight' :
-				case 'variable_length' :
-				case 'variable_width' :
-				case 'variable_height' :
-				case 'variable_download_limit' :
-				case 'variable_download_expiry' :
-					value = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_a_value );
+				case 'variable_regular_price':
+				case 'variable_sale_price':
+				case 'variable_stock':
+				case 'variable_low_stock_amount':
+				case 'variable_weight':
+				case 'variable_length':
+				case 'variable_width':
+				case 'variable_height':
+				case 'variable_download_limit':
+				case 'variable_download_expiry':
+					value = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value
+					);
 
 					if ( value != null ) {
 						data.value = value;
@@ -793,9 +1121,13 @@ jQuery( function( $ ) {
 						return;
 					}
 					break;
-				case 'variable_sale_schedule' :
-					data.date_from = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_start );
-					data.date_to   = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_end );
+				case 'variable_sale_schedule':
+					data.date_from = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_start
+					);
+					data.date_to = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_end
+					);
 
 					if ( null === data.date_from ) {
 						data.date_from = false;
@@ -809,10 +1141,15 @@ jQuery( function( $ ) {
 						return;
 					}
 					break;
-				default :
-					$( 'select.variation_actions' ).trigger( do_variation_action );
-					data = $( 'select.variation_actions' ).triggerHandler( do_variation_action + '_ajax_data', data );
-					
+				default:
+					$( 'select.variation_actions' ).trigger(
+						do_variation_action
+					);
+					data = $( 'select.variation_actions' ).triggerHandler(
+						do_variation_action + '_ajax_data',
+						data
+					);
+
 					if ( null === data ) {
 						return;
 					}
@@ -820,47 +1157,67 @@ jQuery( function( $ ) {
 			}
 
 			if ( 'delete_all' === do_variation_action && data.allowed ) {
-				$( '#variable_product_options' ).find( '.variation-needs-update' ).removeClass( 'variation-needs-update' );
+				$( '#variable_product_options' )
+					.find( '.variation-needs-update' )
+					.removeClass( 'variation-needs-update' );
 			} else {
 				wc_meta_boxes_product_variations_ajax.check_for_changes();
 			}
 
 			wc_meta_boxes_product_variations_ajax.block();
 
-			$.ajax({
+			$.ajax( {
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,
 				data: {
-					action:       'woocommerce_bulk_edit_variations',
-					security:     woocommerce_admin_meta_boxes_variations.bulk_edit_variations_nonce,
-					product_id:   woocommerce_admin_meta_boxes_variations.post_id,
+					action: 'woocommerce_bulk_edit_variations',
+					security:
+						woocommerce_admin_meta_boxes_variations.bulk_edit_variations_nonce,
+					product_id: woocommerce_admin_meta_boxes_variations.post_id,
 					product_type: $( '#product-type' ).val(),
-					bulk_action:  do_variation_action,
-					data:         data
+					bulk_action: do_variation_action,
+					data: data,
 				},
 				type: 'POST',
-				success: function() {
-					wc_meta_boxes_product_variations_pagenav.go_to_page( 1, changes );
-				}
-			});
-		}
+				success: function () {
+					wc_meta_boxes_product_variations_pagenav.go_to_page(
+						1,
+						changes
+					);
+				},
+			} );
+		},
 	};
 
 	/**
 	 * Product variations pagenav
 	 */
 	var wc_meta_boxes_product_variations_pagenav = {
-
 		/**
 		 * Initialize products variations meta box
 		 */
-		init: function() {
+		init: function () {
 			$( document.body )
-				.on( 'woocommerce_variations_added', this.update_single_quantity )
-				.on( 'change', '.variations-pagenav .page-selector', this.page_selector )
-				.on( 'click', '.variations-pagenav .first-page', this.first_page )
+				.on(
+					'woocommerce_variations_added',
+					this.update_single_quantity
+				)
+				.on(
+					'change',
+					'.variations-pagenav .page-selector',
+					this.page_selector
+				)
+				.on(
+					'click',
+					'.variations-pagenav .first-page',
+					this.first_page
+				)
 				.on( 'click', '.variations-pagenav .prev-page', this.prev_page )
 				.on( 'click', '.variations-pagenav .next-page', this.next_page )
-				.on( 'click', '.variations-pagenav .last-page', this.last_page );
+				.on(
+					'click',
+					'.variations-pagenav .last-page',
+					this.last_page
+				);
 		},
 
 		/**
@@ -870,18 +1227,30 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Int}
 		 */
-		update_variations_count: function( qty ) {
-			var wrapper        = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-				total          = parseInt( wrapper.attr( 'data-total' ), 10 ) + qty,
+		update_variations_count: function ( qty ) {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
+				total = parseInt( wrapper.attr( 'data-total' ), 10 ) + qty,
 				displaying_num = $( '.variations-pagenav .displaying-num' );
 
 			// Set the new total of variations
 			wrapper.attr( 'data-total', total );
 
 			if ( 1 === total ) {
-				displaying_num.text( woocommerce_admin_meta_boxes_variations.i18n_variation_count_single.replace( '%qty%', total ) );
+				displaying_num.text(
+					woocommerce_admin_meta_boxes_variations.i18n_variation_count_single.replace(
+						'%qty%',
+						total
+					)
+				);
 			} else {
-				displaying_num.text( woocommerce_admin_meta_boxes_variations.i18n_variation_count_plural.replace( '%qty%', total ) );
+				displaying_num.text(
+					woocommerce_admin_meta_boxes_variations.i18n_variation_count_plural.replace(
+						'%qty%',
+						total
+					)
+				);
 			}
 
 			return total;
@@ -893,11 +1262,13 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		update_single_quantity: function( event, qty ) {
+		update_single_quantity: function ( event, qty ) {
 			if ( 1 === qty ) {
 				var page_nav = $( '.variations-pagenav' );
 
-				wc_meta_boxes_product_variations_pagenav.update_variations_count( qty );
+				wc_meta_boxes_product_variations_pagenav.update_variations_count(
+					qty
+				);
 
 				if ( page_nav.is( ':hidden' ) ) {
 					$( 'option, optgroup', '.variation_actions' ).show();
@@ -914,15 +1285,22 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Int} qty
 		 */
-		set_paginav: function( qty ) {
-			var wrapper          = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-				new_qty          = wc_meta_boxes_product_variations_pagenav.update_variations_count( qty ),
-				toolbar          = $( '#variable_product_options' ).find( '.toolbar' ),
+		set_paginav: function ( qty ) {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
+				new_qty = wc_meta_boxes_product_variations_pagenav.update_variations_count(
+					qty
+				),
+				toolbar = $( '#variable_product_options' ).find( '.toolbar' ),
 				variation_action = $( '.variation_actions' ),
-				page_nav         = $( '.variations-pagenav' ),
+				page_nav = $( '.variations-pagenav' ),
 				displaying_links = $( '.pagination-links', page_nav ),
-				total_pages      = Math.ceil( new_qty / woocommerce_admin_meta_boxes_variations.variations_per_page ),
-				options          = '';
+				total_pages = Math.ceil(
+					new_qty /
+						woocommerce_admin_meta_boxes_variations.variations_per_page
+				),
+				options = '';
 
 			// Set the new total of pages
 			wrapper.attr( 'data-total_pages', total_pages );
@@ -943,7 +1321,6 @@ jQuery( function( $ ) {
 				$( 'option, optgroup', variation_action ).hide();
 				$( '.variation_actions' ).val( 'add_variation' );
 				$( 'option[data-global="true"]', variation_action ).show();
-
 			} else {
 				toolbar.show();
 				page_nav.show();
@@ -964,18 +1341,18 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		check_is_enabled: function( current ) {
+		check_is_enabled: function ( current ) {
 			return ! $( current ).hasClass( 'disabled' );
 		},
 
 		/**
 		 * Change "disabled" class on pagenav
 		 */
-		change_classes: function( selected, total ) {
+		change_classes: function ( selected, total ) {
 			var first_page = $( '.variations-pagenav .first-page' ),
-				prev_page  = $( '.variations-pagenav .prev-page' ),
-				next_page  = $( '.variations-pagenav .next-page' ),
-				last_page  = $( '.variations-pagenav .last-page' );
+				prev_page = $( '.variations-pagenav .prev-page' ),
+				next_page = $( '.variations-pagenav .next-page' ),
+				last_page = $( '.variations-pagenav .last-page' );
 
 			if ( 1 === selected ) {
 				first_page.addClass( 'disabled' );
@@ -997,8 +1374,11 @@ jQuery( function( $ ) {
 		/**
 		 * Set page
 		 */
-		set_page: function( page ) {
-			$( '.variations-pagenav .page-selector' ).val( page ).first().trigger( 'change' );
+		set_page: function ( page ) {
+			$( '.variations-pagenav .page-selector' )
+				.val( page )
+				.first()
+				.trigger( 'change' );
 		},
 
 		/**
@@ -1007,9 +1387,9 @@ jQuery( function( $ ) {
 		 * @param {Int} page
 		 * @param {Int} qty
 		 */
-		go_to_page: function( page, qty ) {
+		go_to_page: function ( page, qty ) {
 			page = page || 1;
-			qty  = qty || 0;
+			qty = qty || 0;
 
 			wc_meta_boxes_product_variations_pagenav.set_paginav( qty );
 			wc_meta_boxes_product_variations_pagenav.set_page( page );
@@ -1018,14 +1398,19 @@ jQuery( function( $ ) {
 		/**
 		 * Paginav pagination selector
 		 */
-		page_selector: function() {
+		page_selector: function () {
 			var selected = parseInt( $( this ).val(), 10 ),
-				wrapper  = $( '#variable_product_options' ).find( '.woocommerce_variations' );
+				wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				);
 
 			$( '.variations-pagenav .page-selector' ).val( selected );
 
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
-			wc_meta_boxes_product_variations_pagenav.change_classes( selected, parseInt( wrapper.attr( 'data-total_pages' ), 10 ) );
+			wc_meta_boxes_product_variations_pagenav.change_classes(
+				selected,
+				parseInt( wrapper.attr( 'data-total_pages' ), 10 )
+			);
 			wc_meta_boxes_product_variations_ajax.load_variations( selected );
 		},
 
@@ -1034,8 +1419,12 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		first_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
+		first_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
 				wc_meta_boxes_product_variations_pagenav.set_page( 1 );
 			}
 
@@ -1047,11 +1436,17 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		prev_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
-				var wrapper   = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+		prev_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
+				var wrapper = $( '#variable_product_options' ).find(
+						'.woocommerce_variations'
+					),
 					prev_page = parseInt( wrapper.attr( 'data-page' ), 10 ) - 1,
-					new_page  = ( 0 < prev_page ) ? prev_page : 1;
+					new_page = 0 < prev_page ? prev_page : 1;
 
 				wc_meta_boxes_product_variations_pagenav.set_page( new_page );
 			}
@@ -1064,12 +1459,22 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		next_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
-				var wrapper     = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-					total_pages = parseInt( wrapper.attr( 'data-total_pages' ), 10 ),
-					next_page   = parseInt( wrapper.attr( 'data-page' ), 10 ) + 1,
-					new_page    = ( total_pages >= next_page ) ? next_page : total_pages;
+		next_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
+				var wrapper = $( '#variable_product_options' ).find(
+						'.woocommerce_variations'
+					),
+					total_pages = parseInt(
+						wrapper.attr( 'data-total_pages' ),
+						10
+					),
+					next_page = parseInt( wrapper.attr( 'data-page' ), 10 ) + 1,
+					new_page =
+						total_pages >= next_page ? next_page : total_pages;
 
 				wc_meta_boxes_product_variations_pagenav.set_page( new_page );
 			}
@@ -1082,20 +1487,25 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		last_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
-				var last_page = $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-total_pages' );
+		last_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
+				var last_page = $( '#variable_product_options' )
+					.find( '.woocommerce_variations' )
+					.attr( 'data-total_pages' );
 
 				wc_meta_boxes_product_variations_pagenav.set_page( last_page );
 			}
 
 			return false;
-		}
+		},
 	};
 
 	wc_meta_boxes_product_variations_actions.init();
 	wc_meta_boxes_product_variations_media.init();
 	wc_meta_boxes_product_variations_ajax.init();
 	wc_meta_boxes_product_variations_pagenav.init();
-
-});
+} );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1,46 +1,27 @@
 /* global wp, woocommerce_admin_meta_boxes_variations, woocommerce_admin, accounting */
-jQuery( function ( $ ) {
-	'use strict';
+jQuery( function( $ ) {
+    'use strict';
 
 	/**
 	 * Variations actions
 	 */
 	var wc_meta_boxes_product_variations_actions = {
+
 		/**
 		 * Initialize variations actions
 		 */
-		init: function () {
+		init: function() {
 			$( '#variable_product_options' )
-				.on(
-					'change',
-					'input.variable_is_downloadable',
-					this.variable_is_downloadable
-				)
-				.on(
-					'change',
-					'input.variable_is_virtual',
-					this.variable_is_virtual
-				)
-				.on(
-					'change',
-					'input.variable_manage_stock',
-					this.variable_manage_stock
-				)
+				.on( 'change', 'input.variable_is_downloadable', this.variable_is_downloadable )
+				.on( 'change', 'input.variable_is_virtual', this.variable_is_virtual )
+				.on( 'change', 'input.variable_manage_stock', this.variable_manage_stock )
 				.on( 'click', 'button.notice-dismiss', this.notice_dismiss )
 				.on( 'click', 'h3 .sort', this.set_menu_order )
 				.on( 'reload', this.reload );
 
-			$(
-				'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock'
-			).trigger( 'change' );
-			$( '#woocommerce-product-data' ).on(
-				'woocommerce_variations_loaded',
-				this.variations_loaded
-			);
-			$( document.body ).on(
-				'woocommerce_variations_added',
-				this.variation_added
-			);
+			$( 'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock' ).trigger( 'change' );
+			$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded', this.variations_loaded );
+			$( document.body ).on( 'woocommerce_variations_added', this.variation_added );
 		},
 
 		/**
@@ -49,7 +30,7 @@ jQuery( function ( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		reload: function () {
+		reload: function() {
 			wc_meta_boxes_product_variations_ajax.load_variations( 1 );
 			wc_meta_boxes_product_variations_pagenav.set_paginav( 0 );
 		},
@@ -57,74 +38,47 @@ jQuery( function ( $ ) {
 		/**
 		 * Check if variation is downloadable and show/hide elements
 		 */
-		variable_is_downloadable: function () {
-			$( this )
-				.closest( '.woocommerce_variation' )
-				.find( '.show_if_variation_downloadable' )
-				.hide();
+		variable_is_downloadable: function() {
+			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_downloadable' ).hide();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.find( '.show_if_variation_downloadable' )
-					.show();
+				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_downloadable' ).show();
 			}
 		},
 
 		/**
 		 * Check if variation is virtual and show/hide elements
 		 */
-		variable_is_virtual: function () {
-			$( this )
-				.closest( '.woocommerce_variation' )
-				.find( '.hide_if_variation_virtual' )
-				.show();
+		variable_is_virtual: function() {
+			$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_virtual' ).show();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.find( '.hide_if_variation_virtual' )
-					.hide();
+				$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_virtual' ).hide();
 			}
 		},
 
 		/**
 		 * Check if variation manage stock and show/hide elements
 		 */
-		variable_manage_stock: function () {
-			$( this )
-				.closest( '.woocommerce_variation' )
-				.find( '.show_if_variation_manage_stock' )
-				.hide();
-			$( this )
-				.closest( '.woocommerce_variation' )
-				.find( '.variable_stock_status' )
-				.show();
+		variable_manage_stock: function() {
+			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).hide();
+			$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).show();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.find( '.show_if_variation_manage_stock' )
-					.show();
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.find( '.variable_stock_status' )
-					.hide();
+				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).show();
+				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
 			}
 
 			// Parent level.
 			if ( $( 'input#_manage_stock:checked' ).length ) {
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.find( '.variable_stock_status' )
-					.hide();
+				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
 			}
 		},
 
 		/**
 		 * Notice dismiss
 		 */
-		notice_dismiss: function () {
+		notice_dismiss: function() {
 			$( this ).closest( 'div.notice' ).remove();
 		},
 
@@ -134,43 +88,31 @@ jQuery( function ( $ ) {
 		 * @param {Object} event
 		 * @param {Int} needsUpdate
 		 */
-		variations_loaded: function ( event, needsUpdate ) {
+		variations_loaded: function( event, needsUpdate ) {
 			needsUpdate = needsUpdate || false;
 
 			var wrapper = $( '#woocommerce-product-data' );
 
 			if ( ! needsUpdate ) {
 				// Show/hide downloadable, virtual and stock fields
-				$(
-					'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock',
-					wrapper
-				).trigger( 'change' );
+				$( 'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock', wrapper ).trigger( 'change' );
 
 				// Open sale schedule fields when have some sale price date
-				$( '.woocommerce_variation', wrapper ).each( function (
-					index,
-					el
-				) {
-					var $el = $( el ),
+				$( '.woocommerce_variation', wrapper ).each( function( index, el ) {
+					var $el       = $( el ),
 						date_from = $( '.sale_price_dates_from', $el ).val(),
-						date_to = $( '.sale_price_dates_to', $el ).val();
+						date_to   = $( '.sale_price_dates_to', $el ).val();
 
 					if ( '' !== date_from || '' !== date_to ) {
 						$( 'a.sale_schedule', $el ).trigger( 'click' );
 					}
-				} );
+				});
 
 				// Remove variation-needs-update classes
-				$(
-					'.woocommerce_variations .variation-needs-update',
-					wrapper
-				).removeClass( 'variation-needs-update' );
+				$( '.woocommerce_variations .variation-needs-update', wrapper ).removeClass( 'variation-needs-update' );
 
 				// Disable cancel and save buttons
-				$(
-					'button.cancel-variation-changes, button.save-variation-changes',
-					wrapper
-				).attr( 'disabled', 'disabled' );
+				$( 'button.cancel-variation-changes, button.save-variation-changes', wrapper ).attr( 'disabled', 'disabled' );
 			}
 
 			// Init TipTip
@@ -182,49 +124,44 @@ jQuery( function ( $ ) {
 				'.woocommerce_variations .woocommerce-help-tip, ' +
 				'.toolbar-variations-defaults .woocommerce-help-tip',
 				wrapper
-			).tipTip( {
-				attribute: 'data-tip',
-				fadeIn: 50,
-				fadeOut: 50,
-				delay: 200,
-			} );
+			)
+				.tipTip({
+					'attribute': 'data-tip',
+					'fadeIn':    50,
+					'fadeOut':   50,
+					'delay':     200
+			});
 
 			// Datepicker fields
-			$( '.sale_price_dates_fields', wrapper )
-				.find( 'input' )
-				.datepicker( {
-					defaultDate: '',
-					dateFormat: 'yy-mm-dd',
-					numberOfMonths: 1,
-					showButtonPanel: true,
-					onSelect: function () {
-						var option = $( this ).is( '.sale_price_dates_from' )
-								? 'minDate'
-								: 'maxDate',
-							dates = $( this )
-								.closest( '.sale_price_dates_fields' )
-								.find( 'input' ),
-							date = $( this ).datepicker( 'getDate' );
+			$( '.sale_price_dates_fields', wrapper ).find( 'input' ).datepicker({
+				defaultDate:     '',
+				dateFormat:      'yy-mm-dd',
+				numberOfMonths:  1,
+				showButtonPanel: true,
+				onSelect:        function() {
+					var option = $( this ).is( '.sale_price_dates_from' ) ? 'minDate' : 'maxDate',
+						dates  = $( this ).closest( '.sale_price_dates_fields' ).find( 'input' ),
+						date   = $( this ).datepicker( 'getDate' );
 
-						dates.not( this ).datepicker( 'option', option, date );
-						$( this ).trigger( 'change' );
-					},
-				} );
+					dates.not( this ).datepicker( 'option', option, date );
+					$( this ).trigger( 'change' );
+				}
+			});
 
 			// Allow sorting
-			$( '.woocommerce_variations', wrapper ).sortable( {
-				items: '.woocommerce_variation',
-				cursor: 'move',
-				axis: 'y',
-				handle: '.sort',
-				scrollSensitivity: 40,
+			$( '.woocommerce_variations', wrapper ).sortable({
+				items:                '.woocommerce_variation',
+				cursor:               'move',
+				axis:                 'y',
+				handle:               '.sort',
+				scrollSensitivity:    40,
 				forcePlaceholderSize: true,
-				helper: 'clone',
-				opacity: 0.65,
-				stop: function () {
-					wc_meta_boxes_product_variations_actions.variation_row_indexes();
-				},
-			} );
+				helper:               'clone',
+				opacity:              0.65,
+				stop:                 function() {
+				    wc_meta_boxes_product_variations_actions.variation_row_indexes();
+				}
+			});
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 		},
@@ -235,51 +172,32 @@ jQuery( function ( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		variation_added: function ( event, qty ) {
+		variation_added: function( event, qty ) {
 			if ( 1 === qty ) {
-				wc_meta_boxes_product_variations_actions.variations_loaded(
-					null,
-					true
-				);
+				wc_meta_boxes_product_variations_actions.variations_loaded( null, true );
 			}
 		},
 
 		/**
 		 * Lets the user manually input menu order to move items around pages
 		 */
-		set_menu_order: function ( event ) {
+		set_menu_order: function( event ) {
 			event.preventDefault();
-			var $menu_order = $( this )
-				.closest( '.woocommerce_variation' )
-				.find( '.variation_menu_order' );
-			var variation_id = $( this )
-				.closest( '.woocommerce_variation' )
-				.find( '.variable_post_id' )
-				.val();
-			var value = window.prompt(
-				woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order,
-				$menu_order.val()
-			);
+			var $menu_order  = $( this ).closest( '.woocommerce_variation' ).find( '.variation_menu_order' );
+			var variation_id = $( this ).closest( '.woocommerce_variation' ).find( '.variable_post_id' ).val();
+			var value        = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order, $menu_order.val() );
 
 			if ( value != null ) {
 				// Set value, save changes and reload view
 				$menu_order.val( parseInt( value, 10 ) ).trigger( 'change' );
 
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.append(
-						'<input type="hidden" name="new_variation_menu_order_id" value="' +
-							encodeURIComponent( variation_id ) +
-							'" />'
-					);
+				$( this ).closest( '.woocommerce_variation' )
+					.append( '<input type="hidden" name="new_variation_menu_order_id" value="'
+						+ encodeURIComponent( variation_id ) + '" />' );
 
-				$( this )
-					.closest( '.woocommerce_variation' )
-					.append(
-						'<input type="hidden" name="new_variation_menu_order_value" value="' +
-							encodeURIComponent( parseInt( value, 10 ) ) +
-							'" />'
-					);
+				$( this ).closest( '.woocommerce_variation' )
+					.append( '<input type="hidden" name="new_variation_menu_order_value" value="'
+						+ encodeURIComponent( parseInt( value, 10 ) ) + '" />' );
 
 				wc_meta_boxes_product_variations_ajax.save_variations();
 			}
@@ -288,40 +206,25 @@ jQuery( function ( $ ) {
 		/**
 		 * Set menu order
 		 */
-		variation_row_indexes: function () {
-			var wrapper = $( '#variable_product_options' ).find(
-					'.woocommerce_variations'
-				),
+		variation_row_indexes: function() {
+			var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
 				current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
-				offset = parseInt(
-					( current_page - 1 ) *
-						woocommerce_admin_meta_boxes_variations.variations_per_page,
-					10
-				);
+				offset       = parseInt( ( current_page - 1 ) * woocommerce_admin_meta_boxes_variations.variations_per_page, 10 );
 
-			$( '.woocommerce_variations .woocommerce_variation' ).each(
-				function ( index, el ) {
-					$( '.variation_menu_order', el )
-						.val(
-							parseInt(
-								$( el ).index(
-									'.woocommerce_variations .woocommerce_variation'
-								),
-								10
-							) +
-								1 +
-								offset
-						)
-						.trigger( 'change' );
-				}
-			);
-		},
+			$( '.woocommerce_variations .woocommerce_variation' ).each( function ( index, el ) {
+				$( '.variation_menu_order', el )
+					.val( parseInt( $( el )
+					.index( '.woocommerce_variations .woocommerce_variation' ), 10 ) + 1 + offset )
+					.trigger( 'change' );
+			});
+		}
 	};
 
 	/**
 	 * Variations media actions
 	 */
 	var wc_meta_boxes_product_variations_media = {
+
 		/**
 		 * wp.media frame object
 		 *
@@ -353,12 +256,8 @@ jQuery( function ( $ ) {
 		/**
 		 * Initialize media actions
 		 */
-		init: function () {
-			$( '#variable_product_options' ).on(
-				'click',
-				'.upload_image_button',
-				this.add_image
-			);
+		init: function() {
+			$( '#variable_product_options' ).on( 'click', '.upload_image_button', this.add_image );
 			$( 'a.add_media' ).on( 'click', this.restore_wp_media_post_id );
 		},
 
@@ -367,101 +266,64 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} event
 		 */
-		add_image: function ( event ) {
+		add_image: function( event ) {
 			var $button = $( this ),
 				post_id = $button.attr( 'rel' ),
 				$parent = $button.closest( '.upload_image' );
 
-			wc_meta_boxes_product_variations_media.setting_variation_image = $parent;
+			wc_meta_boxes_product_variations_media.setting_variation_image    = $parent;
 			wc_meta_boxes_product_variations_media.setting_variation_image_id = post_id;
 
 			event.preventDefault();
 
 			if ( $button.is( '.remove' ) ) {
-				$(
-					'.upload_image_id',
-					wc_meta_boxes_product_variations_media.setting_variation_image
-				)
-					.val( '' )
-					.trigger( 'change' );
-				wc_meta_boxes_product_variations_media.setting_variation_image
-					.find( 'img' )
-					.eq( 0 )
-					.attr(
-						'src',
-						woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src
-					);
-				wc_meta_boxes_product_variations_media.setting_variation_image
-					.find( '.upload_image_button' )
-					.removeClass( 'remove' );
+
+				$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( '' ).trigger( 'change' );
+				wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 )
+					.attr( 'src', woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src );
+				wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).removeClass( 'remove' );
+
 			} else {
+
 				// If the media frame already exists, reopen it.
-				if (
-					wc_meta_boxes_product_variations_media.variable_image_frame
-				) {
-					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader.param(
-						'post_id',
-						wc_meta_boxes_product_variations_media.setting_variation_image_id
-					);
+				if ( wc_meta_boxes_product_variations_media.variable_image_frame ) {
+					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader
+						.param( 'post_id', wc_meta_boxes_product_variations_media.setting_variation_image_id );
 					wc_meta_boxes_product_variations_media.variable_image_frame.open();
 					return;
 				} else {
-					wp.media.model.settings.post.id =
-						wc_meta_boxes_product_variations_media.setting_variation_image_id;
+					wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.setting_variation_image_id;
 				}
 
 				// Create the media frame.
-				wc_meta_boxes_product_variations_media.variable_image_frame = wp.media.frames.variable_image = wp.media(
-					{
-						// Set the title of the modal.
-						title:
-							woocommerce_admin_meta_boxes_variations.i18n_choose_image,
-						button: {
-							text:
-								woocommerce_admin_meta_boxes_variations.i18n_set_image,
-						},
-						states: [
-							new wp.media.controller.Library( {
-								title:
-									woocommerce_admin_meta_boxes_variations.i18n_choose_image,
-								filterable: 'all',
-							} ),
-						],
-					}
-				);
+				wc_meta_boxes_product_variations_media.variable_image_frame = wp.media.frames.variable_image = wp.media({
+					// Set the title of the modal.
+					title: woocommerce_admin_meta_boxes_variations.i18n_choose_image,
+					button: {
+						text: woocommerce_admin_meta_boxes_variations.i18n_set_image
+					},
+					states: [
+						new wp.media.controller.Library({
+							title: woocommerce_admin_meta_boxes_variations.i18n_choose_image,
+							filterable: 'all'
+						})
+					]
+				});
 
 				// When an image is selected, run a callback.
-				wc_meta_boxes_product_variations_media.variable_image_frame.on(
-					'select',
-					function () {
-						var attachment = wc_meta_boxes_product_variations_media.variable_image_frame
-								.state()
-								.get( 'selection' )
-								.first()
-								.toJSON(),
-							url =
-								attachment.sizes && attachment.sizes.thumbnail
-									? attachment.sizes.thumbnail.url
-									: attachment.url;
+				wc_meta_boxes_product_variations_media.variable_image_frame.on( 'select', function () {
 
-						$(
-							'.upload_image_id',
-							wc_meta_boxes_product_variations_media.setting_variation_image
-						)
-							.val( attachment.id )
-							.trigger( 'change' );
-						wc_meta_boxes_product_variations_media.setting_variation_image
-							.find( '.upload_image_button' )
-							.addClass( 'remove' );
-						wc_meta_boxes_product_variations_media.setting_variation_image
-							.find( 'img' )
-							.eq( 0 )
-							.attr( 'src', url );
+					var attachment = wc_meta_boxes_product_variations_media.variable_image_frame.state()
+						.get( 'selection' ).first().toJSON(),
+						url = attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url;
 
-						wp.media.model.settings.post.id =
-							wc_meta_boxes_product_variations_media.wp_media_post_id;
-					}
-				);
+					$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( attachment.id )
+						.trigger( 'change' );
+					wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).addClass( 'remove' );
+					wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 ).attr( 'src', url );
+
+					wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.wp_media_post_id;
+				});
 
 				// Finally, open the modal.
 				wc_meta_boxes_product_variations_media.variable_image_frame.open();
@@ -471,65 +333,41 @@ jQuery( function ( $ ) {
 		/**
 		 * Restore wp.media post ID.
 		 */
-		restore_wp_media_post_id: function () {
-			wp.media.model.settings.post.id =
-				wc_meta_boxes_product_variations_media.wp_media_post_id;
-		},
+		restore_wp_media_post_id: function() {
+			wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.wp_media_post_id;
+		}
 	};
 
 	/**
 	 * Product variations metabox ajax methods
 	 */
 	var wc_meta_boxes_product_variations_ajax = {
+
 		/**
 		 * Initialize variations ajax methods
 		 */
-		init: function () {
+		init: function() {
 			$( 'li.variations_tab a' ).on( 'click', this.initial_load );
 
 			$( '#variable_product_options' )
-				.on(
-					'click',
-					'button.save-variation-changes',
-					this.save_variations
-				)
-				.on(
-					'click',
-					'button.cancel-variation-changes',
-					this.cancel_variations
-				)
+				.on( 'click', 'button.save-variation-changes', this.save_variations )
+				.on( 'click', 'button.cancel-variation-changes', this.cancel_variations )
 				.on( 'click', '.remove_variation', this.remove_variation )
-				.on(
-					'click',
-					'.downloadable_files a.delete',
-					this.input_changed
-				);
+				.on( 'click','.downloadable_files a.delete', this.input_changed );
 
 			$( document.body )
-				.on(
-					'change input',
-					'#variable_product_options .woocommerce_variations :input',
-					this.input_changed
-				)
-				.on(
-					'change',
-					'.variations-defaults select',
-					this.defaults_changed
-				);
+				.on( 'change input', '#variable_product_options .woocommerce_variations :input', this.input_changed )
+				.on( 'change', '.variations-defaults select', this.defaults_changed );
 
 			var postForm = $( 'form#post' );
 
 			postForm.on( 'submit', this.save_on_submit );
 
-			$( 'input:submit', postForm ).on( 'click keypress', function () {
+			$( 'input:submit', postForm ).on( 'click keypress', function() {
 				postForm.data( 'callerid', this.id );
-			} );
+			});
 
-			$( '.wc-metaboxes-wrapper' ).on(
-				'click',
-				'a.do_variation_action',
-				this.do_variation_action
-			);
+			$( '.wc-metaboxes-wrapper' ).on( 'click', 'a.do_variation_action', this.do_variation_action );
 		},
 
 		/**
@@ -537,17 +375,11 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		check_for_changes: function () {
-			var need_update = $( '#variable_product_options' ).find(
-				'.woocommerce_variations .variation-needs-update'
-			);
+		check_for_changes: function() {
+			var need_update = $( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' );
 
 			if ( 0 < need_update.length ) {
-				if (
-					window.confirm(
-						woocommerce_admin_meta_boxes_variations.i18n_edited_variations
-					)
-				) {
+				if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_edited_variations ) ) {
 					wc_meta_boxes_product_variations_ajax.save_changes();
 				} else {
 					need_update.removeClass( 'variation-needs-update' );
@@ -561,20 +393,20 @@ jQuery( function ( $ ) {
 		/**
 		 * Block edit screen
 		 */
-		block: function () {
-			$( '#woocommerce-product-data' ).block( {
+		block: function() {
+			$( '#woocommerce-product-data' ).block({
 				message: null,
 				overlayCSS: {
 					background: '#fff',
-					opacity: 0.6,
-				},
-			} );
+					opacity: 0.6
+				}
+			});
 		},
 
 		/**
 		 * Unblock edit screen
 		 */
-		unblock: function () {
+		unblock: function() {
 			$( '#woocommerce-product-data' ).unblock();
 		},
 
@@ -583,13 +415,8 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		initial_load: function () {
-			if (
-				0 ===
-				$( '#variable_product_options' ).find(
-					'.woocommerce_variations .woocommerce_variation'
-				).length
-			) {
+		initial_load: function() {
+			if ( 0 === $( '#variable_product_options' ).find( '.woocommerce_variations .woocommerce_variation' ).length ) {
 				wc_meta_boxes_product_variations_pagenav.go_to_page();
 			}
 		},
@@ -600,43 +427,33 @@ jQuery( function ( $ ) {
 		 * @param {Int} page (default: 1)
 		 * @param {Int} per_page (default: 10)
 		 */
-		load_variations: function ( page, per_page ) {
-			page = page || 1;
-			per_page =
-				per_page ||
-				woocommerce_admin_meta_boxes_variations.variations_per_page;
+		load_variations: function( page, per_page ) {
+			page     = page || 1;
+			per_page = per_page || woocommerce_admin_meta_boxes_variations.variations_per_page;
 
-			var wrapper = $( '#variable_product_options' ).find(
-				'.woocommerce_variations'
-			);
+			var wrapper = $( '#variable_product_options' ).find( '.woocommerce_variations' );
 
 			wc_meta_boxes_product_variations_ajax.block();
 
-			$.ajax( {
+			$.ajax({
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,
 				data: {
-					action: 'woocommerce_load_variations',
-					security:
-						woocommerce_admin_meta_boxes_variations.load_variations_nonce,
+					action:     'woocommerce_load_variations',
+					security:   woocommerce_admin_meta_boxes_variations.load_variations_nonce,
 					product_id: woocommerce_admin_meta_boxes_variations.post_id,
 					attributes: wrapper.data( 'attributes' ),
-					page: page,
-					per_page: per_page,
+					page:       page,
+					per_page:   per_page
 				},
 				type: 'POST',
-				success: function ( response ) {
-					wrapper
-						.empty()
-						.append( response )
-						.attr( 'data-page', page );
+				success: function( response ) {
+					wrapper.empty().append( response ).attr( 'data-page', page );
 
-					$( '#woocommerce-product-data' ).trigger(
-						'woocommerce_variations_loaded'
-					);
+					$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_loaded' );
 
 					wc_meta_boxes_product_variations_ajax.unblock();
-				},
-			} );
+				}
+			});
 		},
 
 		/**
@@ -646,16 +463,13 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Object}
 		 */
-		get_variations_fields: function ( fields ) {
+		get_variations_fields: function( fields ) {
 			var data = $( ':input', fields ).serializeJSON();
 
-			$( '.variations-defaults select' ).each( function (
-				index,
-				element
-			) {
+			$( '.variations-defaults select' ).each( function( index, element ) {
 				var select = $( element );
 				data[ select.attr( 'name' ) ] = select.val();
-			} );
+			});
 
 			return data;
 		},
@@ -665,49 +479,39 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Function} callback Called once saving is complete
 		 */
-		save_changes: function ( callback ) {
-			var wrapper = $( '#variable_product_options' ).find(
-					'.woocommerce_variations'
-				),
+		save_changes: function( callback ) {
+			var wrapper     = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
 				need_update = $( '.variation-needs-update', wrapper ),
-				data = {};
+				data        = {};
 
 			// Save only with products need update.
 			if ( 0 < need_update.length ) {
 				wc_meta_boxes_product_variations_ajax.block();
 
-				data = wc_meta_boxes_product_variations_ajax.get_variations_fields(
-					need_update
-				);
-				data.action = 'woocommerce_save_variations';
-				data.security =
-					woocommerce_admin_meta_boxes_variations.save_variations_nonce;
-				data.product_id =
-					woocommerce_admin_meta_boxes_variations.post_id;
-				data[ 'product-type' ] = $( '#product-type' ).val();
+				data                 = wc_meta_boxes_product_variations_ajax.get_variations_fields( need_update );
+				data.action          = 'woocommerce_save_variations';
+				data.security        = woocommerce_admin_meta_boxes_variations.save_variations_nonce;
+				data.product_id      = woocommerce_admin_meta_boxes_variations.post_id;
+				data['product-type'] = $( '#product-type' ).val();
 
-				$.ajax( {
+				$.ajax({
 					url: woocommerce_admin_meta_boxes_variations.ajax_url,
 					data: data,
 					type: 'POST',
-					success: function ( response ) {
+					success: function( response ) {
 						// Allow change page, delete and add new variations
 						need_update.removeClass( 'variation-needs-update' );
-						$(
-							'button.cancel-variation-changes, button.save-variation-changes'
-						).attr( 'disabled', 'disabled' );
+						$( 'button.cancel-variation-changes, button.save-variation-changes' ).attr( 'disabled', 'disabled' );
 
-						$( '#woocommerce-product-data' ).trigger(
-							'woocommerce_variations_saved'
-						);
+						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_saved' );
 
 						if ( typeof callback === 'function' ) {
 							callback( response );
 						}
 
 						wc_meta_boxes_product_variations_ajax.unblock();
-					},
-				} );
+					}
+				});
 			}
 		},
 
@@ -716,33 +520,25 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		save_variations: function () {
-			$( '#variable_product_options' ).trigger(
-				'woocommerce_variations_save_variations_button'
-			);
+		save_variations: function() {
+			$( '#variable_product_options' ).trigger( 'woocommerce_variations_save_variations_button' );
 
-			wc_meta_boxes_product_variations_ajax.save_changes( function (
-				error
-			) {
-				var wrapper = $( '#variable_product_options' ).find(
-						'.woocommerce_variations'
-					),
+			wc_meta_boxes_product_variations_ajax.save_changes( function( error ) {
+				var wrapper = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
 					current = wrapper.attr( 'data-page' );
 
-				$( '#variable_product_options' )
-					.find( '#woocommerce_errors' )
-					.remove();
+				$( '#variable_product_options' ).find( '#woocommerce_errors' ).remove();
 
 				if ( error ) {
 					wrapper.before( error );
 				}
 
-				$( '.variations-defaults select' ).each( function () {
+				$( '.variations-defaults select' ).each( function() {
 					$( this ).attr( 'data-current', $( this ).val() );
-				} );
+				});
 
 				wc_meta_boxes_product_variations_pagenav.go_to_page( current );
-			} );
+			});
 
 			return false;
 		},
@@ -750,41 +546,27 @@ jQuery( function ( $ ) {
 		/**
 		 * Save on post form submit
 		 */
-		save_on_submit: function ( e ) {
-			var need_update = $( '#variable_product_options' ).find(
-				'.woocommerce_variations .variation-needs-update'
-			);
+		save_on_submit: function( e ) {
+			var need_update = $( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' );
 
 			if ( 0 < need_update.length ) {
 				e.preventDefault();
-				$( '#variable_product_options' ).trigger(
-					'woocommerce_variations_save_variations_on_submit'
-				);
-				wc_meta_boxes_product_variations_ajax.save_changes(
-					wc_meta_boxes_product_variations_ajax.save_on_submit_done
-				);
+				$( '#variable_product_options' ).trigger( 'woocommerce_variations_save_variations_on_submit' );
+				wc_meta_boxes_product_variations_ajax.save_changes( wc_meta_boxes_product_variations_ajax.save_on_submit_done );
 			}
 		},
 
 		/**
 		 * After saved, continue with form submission
 		 */
-		save_on_submit_done: function () {
+		save_on_submit_done: function() {
 			var postForm = $( 'form#post' ),
 				callerid = postForm.data( 'callerid' );
 
 			if ( 'publish' === callerid ) {
-				postForm
-					.append(
-						'<input type="hidden" name="publish" value="1" />'
-					)
-					.trigger( 'submit' );
+				postForm.append('<input type="hidden" name="publish" value="1" />').trigger( 'submit' );
 			} else {
-				postForm
-					.append(
-						'<input type="hidden" name="save-post" value="1" />'
-					)
-					.trigger( 'submit' );
+				postForm.append('<input type="hidden" name="save-post" value="1" />').trigger( 'submit' );
 			}
 		},
 
@@ -793,20 +575,14 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		cancel_variations: function () {
-			var current = parseInt(
-				$( '#variable_product_options' )
-					.find( '.woocommerce_variations' )
-					.attr( 'data-page' ),
-				10
-			);
+		cancel_variations: function() {
+			var current = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-page' ), 10 );
 
-			$( '#variable_product_options' )
-				.find( '.woocommerce_variations .variation-needs-update' )
+			$( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' )
 				.removeClass( 'variation-needs-update' );
-			$( '.variations-defaults select' ).each( function () {
+			$( '.variations-defaults select' ).each( function() {
 				$( this ).val( $( this ).attr( 'data-current' ) );
-			} );
+			});
 
 			wc_meta_boxes_product_variations_pagenav.go_to_page( current );
 
@@ -818,38 +594,26 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		add_variation: function () {
+		add_variation: function() {
 			wc_meta_boxes_product_variations_ajax.block();
 
 			var data = {
 				action: 'woocommerce_add_variation',
 				post_id: woocommerce_admin_meta_boxes_variations.post_id,
 				loop: $( '.woocommerce_variation' ).length,
-				security:
-					woocommerce_admin_meta_boxes_variations.add_variation_nonce,
+				security: woocommerce_admin_meta_boxes_variations.add_variation_nonce
 			};
 
-			$.post(
-				woocommerce_admin_meta_boxes_variations.ajax_url,
-				data,
-				function ( response ) {
-					var variation = $( response );
-					variation.addClass( 'variation-needs-update' );
+			$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function( response ) {
+				var variation = $( response );
+				variation.addClass( 'variation-needs-update' );
 
-					$( '.woocommerce-notice-invalid-variation' ).remove();
-					$( '#variable_product_options' )
-						.find( '.woocommerce_variations' )
-						.prepend( variation );
-					$(
-						'button.cancel-variation-changes, button.save-variation-changes'
-					).prop( 'disabled', false );
-					$( '#variable_product_options' ).trigger(
-						'woocommerce_variations_added',
-						1
-					);
-					wc_meta_boxes_product_variations_ajax.unblock();
-				}
-			);
+				$( '.woocommerce-notice-invalid-variation' ).remove();
+				$( '#variable_product_options' ).find( '.woocommerce_variations' ).prepend( variation );
+				$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
+				$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', 1 );
+				wc_meta_boxes_product_variations_ajax.unblock();
+			});
 
 			return false;
 		},
@@ -859,18 +623,14 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		remove_variation: function () {
+		remove_variation: function() {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if (
-				window.confirm(
-					woocommerce_admin_meta_boxes_variations.i18n_remove_variation
-				)
-			) {
-				var variation = $( this ).attr( 'rel' ),
+			if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_remove_variation ) ) {
+				var variation     = $( this ).attr( 'rel' ),
 					variation_ids = [],
-					data = {
-						action: 'woocommerce_remove_variations',
+					data          = {
+						action: 'woocommerce_remove_variations'
 					};
 
 				wc_meta_boxes_product_variations_ajax.block();
@@ -879,52 +639,27 @@ jQuery( function ( $ ) {
 					variation_ids.push( variation );
 
 					data.variation_ids = variation_ids;
-					data.security =
-						woocommerce_admin_meta_boxes_variations.delete_variations_nonce;
+					data.security      = woocommerce_admin_meta_boxes_variations.delete_variations_nonce;
 
-					$.post(
-						woocommerce_admin_meta_boxes_variations.ajax_url,
-						data,
-						function () {
-							var wrapper = $( '#variable_product_options' ).find(
-									'.woocommerce_variations'
-								),
-								current_page = parseInt(
-									wrapper.attr( 'data-page' ),
-									10
-								),
-								total_pages = Math.ceil(
-									( parseInt(
-										wrapper.attr( 'data-total' ),
-										10
-									) -
-										1 ) /
-										woocommerce_admin_meta_boxes_variations.variations_per_page
-								),
-								page = 1;
+					$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function() {
+						var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+							current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
+							total_pages  = Math.ceil( (
+								parseInt( wrapper.attr( 'data-total' ), 10 ) - 1
+							) / woocommerce_admin_meta_boxes_variations.variations_per_page ),
+							page         = 1;
 
-							$( '#woocommerce-product-data' ).trigger(
-								'woocommerce_variations_removed'
-							);
+						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_removed' );
 
-							if (
-								current_page === total_pages ||
-								current_page <= total_pages
-							) {
-								page = current_page;
-							} else if (
-								current_page > total_pages &&
-								0 !== total_pages
-							) {
-								page = total_pages;
-							}
-
-							wc_meta_boxes_product_variations_pagenav.go_to_page(
-								page,
-								-1
-							);
+						if ( current_page === total_pages || current_page <= total_pages ) {
+							page = current_page;
+						} else if ( current_page > total_pages && 0 !== total_pages ) {
+							page = total_pages;
 						}
-					);
+
+						wc_meta_boxes_product_variations_pagenav.go_to_page( page, -1 );
+					});
+
 				} else {
 					wc_meta_boxes_product_variations_ajax.unblock();
 				}
@@ -938,61 +673,36 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		link_all_variations: function () {
+		link_all_variations: function() {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if (
-				window.confirm(
-					woocommerce_admin_meta_boxes_variations.i18n_link_all_variations
-				)
-			) {
+			if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_link_all_variations ) ) {
 				wc_meta_boxes_product_variations_ajax.block();
 
 				var data = {
 					action: 'woocommerce_link_all_variations',
 					post_id: woocommerce_admin_meta_boxes_variations.post_id,
-					security:
-						woocommerce_admin_meta_boxes_variations.link_variation_nonce,
+					security: woocommerce_admin_meta_boxes_variations.link_variation_nonce
 				};
 
-				$.post(
-					woocommerce_admin_meta_boxes_variations.ajax_url,
-					data,
-					function ( response ) {
-						var count = parseInt( response, 10 );
+				$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function( response ) {
+					var count = parseInt( response, 10 );
 
-						if ( 1 === count ) {
-							window.alert(
-								count +
-									' ' +
-									woocommerce_admin_meta_boxes_variations.i18n_variation_added
-							);
-						} else if ( 0 === count || count > 1 ) {
-							window.alert(
-								count +
-									' ' +
-									woocommerce_admin_meta_boxes_variations.i18n_variations_added
-							);
-						} else {
-							window.alert(
-								woocommerce_admin_meta_boxes_variations.i18n_no_variations_added
-							);
-						}
-
-						if ( count > 0 ) {
-							wc_meta_boxes_product_variations_pagenav.go_to_page(
-								1,
-								count
-							);
-							$( '#variable_product_options' ).trigger(
-								'woocommerce_variations_added',
-								count
-							);
-						} else {
-							wc_meta_boxes_product_variations_ajax.unblock();
-						}
+					if ( 1 === count ) {
+						window.alert( count + ' ' + woocommerce_admin_meta_boxes_variations.i18n_variation_added );
+					} else if ( 0 === count || count > 1 ) {
+						window.alert( count + ' ' + woocommerce_admin_meta_boxes_variations.i18n_variations_added );
+					} else {
+						window.alert( woocommerce_admin_meta_boxes_variations.i18n_no_variations_added );
 					}
-				);
+
+					if ( count > 0 ) {
+						wc_meta_boxes_product_variations_pagenav.go_to_page( 1, count );
+						$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', count );
+					} else {
+						wc_meta_boxes_product_variations_ajax.unblock();
+					}
+				});
 			}
 
 			return false;
@@ -1001,119 +711,87 @@ jQuery( function ( $ ) {
 		/**
 		 * Add new class when have changes in some input
 		 */
-		input_changed: function ( event ) {
+		input_changed: function( event ) {
 			$( this )
 				.closest( '.woocommerce_variation' )
 				.addClass( 'variation-needs-update' );
 
-			$(
-				'button.cancel-variation-changes, button.save-variation-changes'
-			).prop( 'disabled', false );
+			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
 
 			// Do not trigger 'woocommerce_variations_input_changed' for 'input' events for backwards compat.
 			if ( 'input' === event.type && $( this ).is( ':text' ) ) {
 				return;
 			}
 
-			$( '#variable_product_options' ).trigger(
-				'woocommerce_variations_input_changed'
-			);
+			$( '#variable_product_options' ).trigger( 'woocommerce_variations_input_changed' );
 		},
 
 		/**
 		 * Added new .variation-needs-update class when defaults is changed
 		 */
-		defaults_changed: function () {
+		defaults_changed: function() {
 			$( this )
 				.closest( '#variable_product_options' )
 				.find( '.woocommerce_variation:first' )
 				.addClass( 'variation-needs-update' );
 
-			$(
-				'button.cancel-variation-changes, button.save-variation-changes'
-			).prop( 'disabled', false );
+			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
 
-			$( '#variable_product_options' ).trigger(
-				'woocommerce_variations_defaults_changed'
-			);
+			$( '#variable_product_options' ).trigger( 'woocommerce_variations_defaults_changed' );
 		},
 
 		/**
 		 * Actions
 		 */
-		do_variation_action: function () {
+		do_variation_action: function() {
 			var do_variation_action = $( 'select.variation_actions' ).val(),
-				data = {},
-				changes = 0,
+				data       = {},
+				changes    = 0,
 				value;
 
 			switch ( do_variation_action ) {
-				case 'add_variation':
+				case 'add_variation' :
 					wc_meta_boxes_product_variations_ajax.add_variation();
 					return;
-				case 'link_all_variations':
+				case 'link_all_variations' :
 					wc_meta_boxes_product_variations_ajax.link_all_variations();
 					return;
-				case 'delete_all':
-					if (
-						window.confirm(
-							woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations
-						)
-					) {
-						if (
-							window.confirm(
-								woocommerce_admin_meta_boxes_variations.i18n_last_warning
-							)
-						) {
+				case 'delete_all' :
+					if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations ) ) {
+						if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_last_warning ) ) {
 							data.allowed = true;
-							changes =
-								parseInt(
-									$( '#variable_product_options' )
-										.find( '.woocommerce_variations' )
-										.attr( 'data-total' ),
-									10
-								) * -1;
+							changes      = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' )
+								.attr( 'data-total' ), 10 ) * -1;
 						}
 					}
 					break;
-				case 'variable_regular_price_increase':
-				case 'variable_regular_price_decrease':
-				case 'variable_sale_price_increase':
-				case 'variable_sale_price_decrease':
-					value = window.prompt(
-						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent
-					);
+				case 'variable_regular_price_increase' :
+				case 'variable_regular_price_decrease' :
+				case 'variable_sale_price_increase' :
+				case 'variable_sale_price_decrease' :
+					value = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent );
 
 					if ( value != null ) {
 						if ( value.indexOf( '%' ) >= 0 ) {
-							data.value =
-								accounting.unformat(
-									value.replace( /\%/, '' ),
-									woocommerce_admin.mon_decimal_point
-								) + '%';
+							data.value = accounting.unformat( value.replace( /\%/, '' ), woocommerce_admin.mon_decimal_point ) + '%';
 						} else {
-							data.value = accounting.unformat(
-								value,
-								woocommerce_admin.mon_decimal_point
-							);
+							data.value = accounting.unformat( value, woocommerce_admin.mon_decimal_point );
 						}
 					} else {
 						return;
 					}
 					break;
-				case 'variable_regular_price':
-				case 'variable_sale_price':
-				case 'variable_stock':
-				case 'variable_low_stock_amount':
-				case 'variable_weight':
-				case 'variable_length':
-				case 'variable_width':
-				case 'variable_height':
-				case 'variable_download_limit':
-				case 'variable_download_expiry':
-					value = window.prompt(
-						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value
-					);
+				case 'variable_regular_price' :
+				case 'variable_sale_price' :
+				case 'variable_stock' :
+				case 'variable_low_stock_amount' :
+				case 'variable_weight' :
+				case 'variable_length' :
+				case 'variable_width' :
+				case 'variable_height' :
+				case 'variable_download_limit' :
+				case 'variable_download_expiry' :
+					value = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_a_value );
 
 					if ( value != null ) {
 						data.value = value;
@@ -1121,13 +799,9 @@ jQuery( function ( $ ) {
 						return;
 					}
 					break;
-				case 'variable_sale_schedule':
-					data.date_from = window.prompt(
-						woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_start
-					);
-					data.date_to = window.prompt(
-						woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_end
-					);
+				case 'variable_sale_schedule' :
+					data.date_from = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_start );
+					data.date_to   = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_end );
 
 					if ( null === data.date_from ) {
 						data.date_from = false;
@@ -1141,14 +815,9 @@ jQuery( function ( $ ) {
 						return;
 					}
 					break;
-				default:
-					$( 'select.variation_actions' ).trigger(
-						do_variation_action
-					);
-					data = $( 'select.variation_actions' ).triggerHandler(
-						do_variation_action + '_ajax_data',
-						data
-					);
+				default :
+					$( 'select.variation_actions' ).trigger( do_variation_action );
+					data = $( 'select.variation_actions' ).triggerHandler( do_variation_action + '_ajax_data', data );
 
 					if ( null === data ) {
 						return;
@@ -1157,67 +826,47 @@ jQuery( function ( $ ) {
 			}
 
 			if ( 'delete_all' === do_variation_action && data.allowed ) {
-				$( '#variable_product_options' )
-					.find( '.variation-needs-update' )
-					.removeClass( 'variation-needs-update' );
+				$( '#variable_product_options' ).find( '.variation-needs-update' ).removeClass( 'variation-needs-update' );
 			} else {
 				wc_meta_boxes_product_variations_ajax.check_for_changes();
 			}
 
 			wc_meta_boxes_product_variations_ajax.block();
 
-			$.ajax( {
+			$.ajax({
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,
 				data: {
-					action: 'woocommerce_bulk_edit_variations',
-					security:
-						woocommerce_admin_meta_boxes_variations.bulk_edit_variations_nonce,
-					product_id: woocommerce_admin_meta_boxes_variations.post_id,
+					action:       'woocommerce_bulk_edit_variations',
+					security:     woocommerce_admin_meta_boxes_variations.bulk_edit_variations_nonce,
+					product_id:   woocommerce_admin_meta_boxes_variations.post_id,
 					product_type: $( '#product-type' ).val(),
-					bulk_action: do_variation_action,
-					data: data,
+					bulk_action:  do_variation_action,
+					data:         data
 				},
 				type: 'POST',
-				success: function () {
-					wc_meta_boxes_product_variations_pagenav.go_to_page(
-						1,
-						changes
-					);
-				},
-			} );
-		},
+				success: function() {
+					wc_meta_boxes_product_variations_pagenav.go_to_page( 1, changes );
+				}
+			});
+		}
 	};
 
 	/**
 	 * Product variations pagenav
 	 */
 	var wc_meta_boxes_product_variations_pagenav = {
+
 		/**
 		 * Initialize products variations meta box
 		 */
-		init: function () {
+		init: function() {
 			$( document.body )
-				.on(
-					'woocommerce_variations_added',
-					this.update_single_quantity
-				)
-				.on(
-					'change',
-					'.variations-pagenav .page-selector',
-					this.page_selector
-				)
-				.on(
-					'click',
-					'.variations-pagenav .first-page',
-					this.first_page
-				)
+				.on( 'woocommerce_variations_added', this.update_single_quantity )
+				.on( 'change', '.variations-pagenav .page-selector', this.page_selector )
+				.on( 'click', '.variations-pagenav .first-page', this.first_page )
 				.on( 'click', '.variations-pagenav .prev-page', this.prev_page )
 				.on( 'click', '.variations-pagenav .next-page', this.next_page )
-				.on(
-					'click',
-					'.variations-pagenav .last-page',
-					this.last_page
-				);
+				.on( 'click', '.variations-pagenav .last-page', this.last_page );
 		},
 
 		/**
@@ -1227,30 +876,18 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Int}
 		 */
-		update_variations_count: function ( qty ) {
-			var wrapper = $( '#variable_product_options' ).find(
-					'.woocommerce_variations'
-				),
-				total = parseInt( wrapper.attr( 'data-total' ), 10 ) + qty,
+		update_variations_count: function( qty ) {
+			var wrapper        = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+				total          = parseInt( wrapper.attr( 'data-total' ), 10 ) + qty,
 				displaying_num = $( '.variations-pagenav .displaying-num' );
 
 			// Set the new total of variations
 			wrapper.attr( 'data-total', total );
 
 			if ( 1 === total ) {
-				displaying_num.text(
-					woocommerce_admin_meta_boxes_variations.i18n_variation_count_single.replace(
-						'%qty%',
-						total
-					)
-				);
+				displaying_num.text( woocommerce_admin_meta_boxes_variations.i18n_variation_count_single.replace( '%qty%', total ) );
 			} else {
-				displaying_num.text(
-					woocommerce_admin_meta_boxes_variations.i18n_variation_count_plural.replace(
-						'%qty%',
-						total
-					)
-				);
+				displaying_num.text( woocommerce_admin_meta_boxes_variations.i18n_variation_count_plural.replace( '%qty%', total ) );
 			}
 
 			return total;
@@ -1262,13 +899,11 @@ jQuery( function ( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		update_single_quantity: function ( event, qty ) {
+		update_single_quantity: function( event, qty ) {
 			if ( 1 === qty ) {
 				var page_nav = $( '.variations-pagenav' );
 
-				wc_meta_boxes_product_variations_pagenav.update_variations_count(
-					qty
-				);
+				wc_meta_boxes_product_variations_pagenav.update_variations_count( qty );
 
 				if ( page_nav.is( ':hidden' ) ) {
 					$( 'option, optgroup', '.variation_actions' ).show();
@@ -1285,22 +920,15 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Int} qty
 		 */
-		set_paginav: function ( qty ) {
-			var wrapper = $( '#variable_product_options' ).find(
-					'.woocommerce_variations'
-				),
-				new_qty = wc_meta_boxes_product_variations_pagenav.update_variations_count(
-					qty
-				),
-				toolbar = $( '#variable_product_options' ).find( '.toolbar' ),
+		set_paginav: function( qty ) {
+			var wrapper          = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+				new_qty          = wc_meta_boxes_product_variations_pagenav.update_variations_count( qty ),
+				toolbar          = $( '#variable_product_options' ).find( '.toolbar' ),
 				variation_action = $( '.variation_actions' ),
-				page_nav = $( '.variations-pagenav' ),
+				page_nav         = $( '.variations-pagenav' ),
 				displaying_links = $( '.pagination-links', page_nav ),
-				total_pages = Math.ceil(
-					new_qty /
-						woocommerce_admin_meta_boxes_variations.variations_per_page
-				),
-				options = '';
+				total_pages      = Math.ceil( new_qty / woocommerce_admin_meta_boxes_variations.variations_per_page ),
+				options          = '';
 
 			// Set the new total of pages
 			wrapper.attr( 'data-total_pages', total_pages );
@@ -1321,6 +949,7 @@ jQuery( function ( $ ) {
 				$( 'option, optgroup', variation_action ).hide();
 				$( '.variation_actions' ).val( 'add_variation' );
 				$( 'option[data-global="true"]', variation_action ).show();
+
 			} else {
 				toolbar.show();
 				page_nav.show();
@@ -1341,18 +970,18 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		check_is_enabled: function ( current ) {
+		check_is_enabled: function( current ) {
 			return ! $( current ).hasClass( 'disabled' );
 		},
 
 		/**
 		 * Change "disabled" class on pagenav
 		 */
-		change_classes: function ( selected, total ) {
+		change_classes: function( selected, total ) {
 			var first_page = $( '.variations-pagenav .first-page' ),
-				prev_page = $( '.variations-pagenav .prev-page' ),
-				next_page = $( '.variations-pagenav .next-page' ),
-				last_page = $( '.variations-pagenav .last-page' );
+				prev_page  = $( '.variations-pagenav .prev-page' ),
+				next_page  = $( '.variations-pagenav .next-page' ),
+				last_page  = $( '.variations-pagenav .last-page' );
 
 			if ( 1 === selected ) {
 				first_page.addClass( 'disabled' );
@@ -1374,11 +1003,8 @@ jQuery( function ( $ ) {
 		/**
 		 * Set page
 		 */
-		set_page: function ( page ) {
-			$( '.variations-pagenav .page-selector' )
-				.val( page )
-				.first()
-				.trigger( 'change' );
+		set_page: function( page ) {
+			$( '.variations-pagenav .page-selector' ).val( page ).first().trigger( 'change' );
 		},
 
 		/**
@@ -1387,9 +1013,9 @@ jQuery( function ( $ ) {
 		 * @param {Int} page
 		 * @param {Int} qty
 		 */
-		go_to_page: function ( page, qty ) {
+		go_to_page: function( page, qty ) {
 			page = page || 1;
-			qty = qty || 0;
+			qty  = qty || 0;
 
 			wc_meta_boxes_product_variations_pagenav.set_paginav( qty );
 			wc_meta_boxes_product_variations_pagenav.set_page( page );
@@ -1398,19 +1024,14 @@ jQuery( function ( $ ) {
 		/**
 		 * Paginav pagination selector
 		 */
-		page_selector: function () {
+		page_selector: function() {
 			var selected = parseInt( $( this ).val(), 10 ),
-				wrapper = $( '#variable_product_options' ).find(
-					'.woocommerce_variations'
-				);
+				wrapper  = $( '#variable_product_options' ).find( '.woocommerce_variations' );
 
 			$( '.variations-pagenav .page-selector' ).val( selected );
 
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
-			wc_meta_boxes_product_variations_pagenav.change_classes(
-				selected,
-				parseInt( wrapper.attr( 'data-total_pages' ), 10 )
-			);
+			wc_meta_boxes_product_variations_pagenav.change_classes( selected, parseInt( wrapper.attr( 'data-total_pages' ), 10 ) );
 			wc_meta_boxes_product_variations_ajax.load_variations( selected );
 		},
 
@@ -1419,12 +1040,8 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		first_page: function () {
-			if (
-				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
-					this
-				)
-			) {
+		first_page: function() {
+			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
 				wc_meta_boxes_product_variations_pagenav.set_page( 1 );
 			}
 
@@ -1436,17 +1053,11 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		prev_page: function () {
-			if (
-				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
-					this
-				)
-			) {
-				var wrapper = $( '#variable_product_options' ).find(
-						'.woocommerce_variations'
-					),
+		prev_page: function() {
+			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
+				var wrapper   = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
 					prev_page = parseInt( wrapper.attr( 'data-page' ), 10 ) - 1,
-					new_page = 0 < prev_page ? prev_page : 1;
+					new_page  = ( 0 < prev_page ) ? prev_page : 1;
 
 				wc_meta_boxes_product_variations_pagenav.set_page( new_page );
 			}
@@ -1459,22 +1070,12 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		next_page: function () {
-			if (
-				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
-					this
-				)
-			) {
-				var wrapper = $( '#variable_product_options' ).find(
-						'.woocommerce_variations'
-					),
-					total_pages = parseInt(
-						wrapper.attr( 'data-total_pages' ),
-						10
-					),
-					next_page = parseInt( wrapper.attr( 'data-page' ), 10 ) + 1,
-					new_page =
-						total_pages >= next_page ? next_page : total_pages;
+		next_page: function() {
+			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
+				var wrapper     = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+					total_pages = parseInt( wrapper.attr( 'data-total_pages' ), 10 ),
+					next_page   = parseInt( wrapper.attr( 'data-page' ), 10 ) + 1,
+					new_page    = ( total_pages >= next_page ) ? next_page : total_pages;
 
 				wc_meta_boxes_product_variations_pagenav.set_page( new_page );
 			}
@@ -1487,25 +1088,20 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		last_page: function () {
-			if (
-				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
-					this
-				)
-			) {
-				var last_page = $( '#variable_product_options' )
-					.find( '.woocommerce_variations' )
-					.attr( 'data-total_pages' );
+		last_page: function() {
+			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
+				var last_page = $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-total_pages' );
 
 				wc_meta_boxes_product_variations_pagenav.set_page( last_page );
 			}
 
 			return false;
-		},
+		}
 	};
 
 	wc_meta_boxes_product_variations_actions.init();
 	wc_meta_boxes_product_variations_media.init();
 	wc_meta_boxes_product_variations_ajax.init();
 	wc_meta_boxes_product_variations_pagenav.init();
-} );
+
+});

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="toolbar toolbar-variations-defaults">
 				<div class="variations-defaults">
-					<strong><?php esc_html_e( 'Default Form Values', 'woocommerce' ); ?>: <?php echo wc_help_tip( __( 'These are the attributes that will be pre-selected on the frontend.', 'woocommerce' ) ); ?></strong>
+					<strong><?php esc_html_e( 'Default Form Values', 'woocommerce' ); ?>: <?php echo wc_help_tip( __( 'Choose a default form value if you want a certain variation already selected when a user visits the product page.', 'woocommerce' ) ); ?></strong>
 					<?php
 					foreach ( $variation_attributes as $attribute ) {
 						$selected_value = isset( $default_attributes[ sanitize_title( $attribute->get_name() ) ] ) ? $default_attributes[ sanitize_title( $attribute->get_name() ) ] : '';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the copy of the default form values tooltip shown in the variable product meta box and also fixes the tooltip initialization when no variations exist yet.

Closes #33552 .

### How to test the changes in this Pull Request:

1. Load this PR and do a build, make sure the `woocommerce/client/legacy` is freshly build, I had to run `pnpm -- turbo run build --filter=woocommerce/client/legacy --force` to make sure the changes propagated instead of it using the cached version.
2. Go to **Products > Attributes** and add some attributes with terms
3. Go to **Products > Add New** and change the product to **Variable product**
4. Go to the **Attributes** tab and add the attribute you created in step 2, make sure to select **Used for variations** and click **Save attributes** after (you have to add values here)
5. Go to the **Variations** tab and click **Go** for the **Add variation** selection.
6. It should now show a **Default Form Values** with a tooltip after (as shown in the screenshot), the tooltip should work as expected
7. The tooltip should say: `Choose a default form value if you want a certain variation already selected when a user visits the product page`

<img width="1615" alt="Screen Shot 2022-07-05 at 4 31 11 PM" src="https://user-images.githubusercontent.com/2240960/177401848-ff7f9c3b-efc1-494e-a9aa-d247e726cab9.png">


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
