### PR TITLE
Add tracks for shipping smart defaults

### DIFF
--- a/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
@@ -5,17 +5,29 @@ import { __ } from '@wordpress/i18n';
 import { Button, ExternalLink } from '@wordpress/components';
 import { Pill } from '@woocommerce/components';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
+import { useContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './woocommerce-services-item.scss';
 import WooIcon from './woo-icon.svg';
+import { LayoutContext } from '~/layout';
 
 const WooCommerceServicesItem: React.FC< {
 	isWCSInstalled: boolean | undefined;
 } > = ( { isWCSInstalled } ) => {
+	const layoutContext = useContext( LayoutContext );
+	const updatedLayoutContext = useMemo(
+		() => layoutContext.getExtendedContext( 'wc-settings' ),
+		[ layoutContext ]
+	);
 	const handleSetupClick = () => {
+		recordEvent( 'tasklist_click', {
+			task_name: 'shipping-recommendation',
+			context: updatedLayoutContext.toString(),
+		} );
 		navigateTo( {
 			url: getNewPath( { task: 'shipping-recommendation' }, '/', {} ),
 		} );

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -42,6 +42,9 @@ describe( 'WooCommerceServicesItem', () => {
 		render( <WooCommerceServicesItem isWCSInstalled={ false } /> );
 
 		screen.queryByRole( 'button', { name: 'Get started' } )?.click();
-		expect( recordEvent ).toBeCalled();
+		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_click', {
+			context: 'root/wc-settings',
+			task_name: 'shipping-recommendation',
+		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -2,11 +2,16 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
 import WooCommerceServicesItem from '../experimental-woocommerce-services-item';
+jest.mock( '@woocommerce/tracks', () => ( {
+	...jest.requireActual( '@woocommerce/tracks' ),
+	recordEvent: jest.fn(),
+} ) );
 
 describe( 'WooCommerceServicesItem', () => {
 	it( 'should render WCS item with CTA = "Get started" when WCS is not installed', () => {
@@ -31,5 +36,12 @@ describe( 'WooCommerceServicesItem', () => {
 		expect(
 			screen.queryByRole( 'button', { name: 'Activate' } )
 		).toBeInTheDocument();
+	} );
+
+	it( 'should record track when clicking setup button', () => {
+		render( <WooCommerceServicesItem isWCSInstalled={ false } /> );
+
+		screen.queryByRole( 'button', { name: 'Get started' } )?.click();
+		expect( recordEvent ).toBeCalled();
 	} );
 } );

--- a/plugins/woocommerce/changelog/add-33369-tracks-for-shipping-smart-defaults
+++ b/plugins/woocommerce/changelog/add-33369-tracks-for-shipping-smart-defaults
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Tracks for shipping smart defaults

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -14,7 +14,7 @@ class ReviewShippingOptions extends Task {
 	 * @return string
 	 */
 	public function get_id() {
-		return 'shipping';
+		return 'review-shipping';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33369.

This PR 

1. Click track for `shipping-recommendation` task from the settings page
2. Renames ReviewShippingOptions task id to `review-shipping` to make sure it tracks the correct task on completion

### How to test the changes in this Pull Request:

**Prerequisite**

1. Enable the `shipping-smart-defaults` and `shipping-setting-tour` feature via WCA Test helper.
2. Set up a store in US, select physical products, install all extensions and connect your site

**Testing review-shipping track**
1. Go to WooCommerce > Home
2. Click on "Review shipping options" task in the "Things to do next"
4. After redirected to settings page, complete the spotlight tour and go back to WooCommerce > Home
5. Observe the task is marked as completed
6. With a database viewer, look for `woocommerce_task_list_tracked_completed_tasks` option in `wp_options` table
7. Observe `review-shipping` is in the serialized PHP data

**Testing click track**
1. Deactivate WooCommerce Shipping or Jetpack plugin
1. Go to WooCommerce > Settings > Shipping
1. Open browser developer console and ensure debug is enabled `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Wait for "Recommended shipping solutions" to appear and click on "Get started" or "Activate" on WooCommerce Shipping
1. Observe track `wcadmin_tasklist_click` with props `{task_name: 'shipping-recommendation', context: 'root/wc-settings'}`


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
