### PR TITLE
Fix wrong copy in the payment task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/List/List.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/List/List.js
@@ -12,6 +12,7 @@ import './List.scss';
 
 export const List = ( {
 	heading,
+	headingDescription,
 	markConfigured,
 	recommendation,
 	paymentGateways,
@@ -19,7 +20,16 @@ export const List = ( {
 } ) => {
 	return (
 		<Card>
-			{ heading && <CardHeader as="h2">{ heading }</CardHeader> }
+			{ heading && (
+				<CardHeader as="h2">
+					{ heading }
+					{ headingDescription && (
+						<p className="woocommerce-task-payment-header__description">
+							{ headingDescription }
+						</p>
+					) }
+				</CardHeader>
+			) }
 			{ paymentGateways.map( ( paymentGateway ) => {
 				const { id } = paymentGateway;
 				return (

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -203,27 +203,53 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		);
 	}
 
+	let additionalSectionHeading = __(
+		'Choose a payment provider',
+		'woocommerce'
+	);
+	let additionalSectionHeadingDescription = __(
+		'To start accepting online payments',
+		'woocommerce'
+	);
+	if ( isWCPaySupported ) {
+		if ( isWCPayOrOtherCategoryDoneSetup ) {
+			additionalSectionHeading = __(
+				'Additional payment options',
+				'woocommerce'
+			);
+			additionalSectionHeadingDescription = __(
+				'Give your customers additional choices in ways to pay.',
+				'woocommerce'
+			);
+		} else {
+			additionalSectionHeading = __(
+				'Other payment providers',
+				'woocommerce'
+			);
+			additionalSectionHeadingDescription = __(
+				'Try one of the alternative payment providers.',
+				'woocommerce'
+			);
+		}
+	}
+
 	const additionalSection = !! additionalGateways.length && (
 		<List
-			heading={
-				! wcPayGateway.length &&
-				__( 'Choose a payment provider', 'woocommerce' )
-			}
+			heading={ additionalSectionHeading }
+			headingDescription={ additionalSectionHeadingDescription }
 			recommendation={ recommendation }
 			paymentGateways={ additionalGateways }
 			markConfigured={ markConfigured }
 			footerLink={
-				! isWCPayOrOtherCategoryDoneSetup && (
-					<Button
-						href="https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations"
-						target="_blank"
-						onClick={ trackSeeMore }
-						isTertiary
-					>
-						{ __( 'See more', 'woocommerce' ) }
-						<ExternalIcon size={ 18 } />
-					</Button>
-				)
+				<Button
+					href="https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?utm_source=payments_recommendations"
+					target="_blank"
+					onClick={ trackSeeMore }
+					isTertiary
+				>
+					{ __( 'See more', 'woocommerce' ) }
+					<ExternalIcon size={ 18 } />
+				</Button>
 			}
 		></List>
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/payment-gateway-suggestions.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/payment-gateway-suggestions.scss
@@ -20,6 +20,16 @@
 		font-weight: 400;
 		line-height: 28px;
 		margin: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.woocommerce-task-payment-header__description {
+		margin: 0;
+		color: $gray-700;
+		font-weight: 400;
+		font-size: 14px;
 	}
 
 	.components-card__footer {

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
@@ -139,6 +139,10 @@ describe( 'PaymentGatewaySuggestions', () => {
 			/>
 		);
 
+		expect(
+			screen.getByText( 'Choose a payment provider' )
+		).toBeInTheDocument();
+
 		const paymentTitleElements = container.querySelectorAll(
 			'.woocommerce-task-payment__title > span:first-child'
 		);
@@ -237,6 +241,10 @@ describe( 'PaymentGatewaySuggestions', () => {
 				query={ query }
 			/>
 		);
+
+		expect(
+			screen.getByText( 'Additional payment options' )
+		).toBeInTheDocument();
 
 		const paymentTitleElements = container.querySelectorAll(
 			'.woocommerce-task-payment__title'

--- a/plugins/woocommerce/changelog/fix-33747-wrong-copy-in-payment-task
+++ b/plugins/woocommerce/changelog/fix-33747-wrong-copy-in-payment-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong copy in the payment task


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/33747

As shown in this Figma: e428PXC0QyEwYqtX48lLq0-fi-12830%3A95364

- Add heading description to payment gateway card
- Display "see more" link for all cases
- Display different heading and descriptions for different cases.

### How to test the changes in this Pull Request:

❌ WCPay Eligible country

1. Choose a country that WCPay is not supported
2. Go to Woocommerce > Home
3. Go to the payment task
4. Observe that the section is displayed with the title `Choose a payment provider` and the description `To start accepting online payments`.
5. Observe that  "see more" link is displayed

![https://user-images.githubusercontent.com/4344253/177476305-e413ee4c-361c-49c5-a207-3fa3e875f16d.png](https://user-images.githubusercontent.com/4344253/177476305-e413ee4c-361c-49c5-a207-3fa3e875f16d.png)

✅ WCPay Eligible country
❌ WCPay NOT Set up

1. Choose a country that WCPay is supported
2. Go to Woocommerce > Home
3. Go to the payment task
4. Click "Other payment providers"
5. Observe that the section is displayed with the title `Other payment providers` and the description `Try one of the alternative payment providers.`.
7. Observe that  "see more" link is displayed

![https://user-images.githubusercontent.com/4344253/177476307-e5eb2e77-c17e-4a25-9c00-ddd54c0ebbd5.png](https://user-images.githubusercontent.com/4344253/177476307-e5eb2e77-c17e-4a25-9c00-ddd54c0ebbd5.png)

✅ WCPay Eligible country
✅ WCPay Set up

1. Choose a country that WCPay is supported
2. Install and set up WCPay
3. Go to Woocommerce > Home
4. Go to the payment task
6. Observe that the section is displayed with the title `Additional payment options` and the description `Give your customers additional choices in ways to pay.`.
8. Observe that  "see more" link is displayed

![Payments _ WooCommerce Payments (1)](https://user-images.githubusercontent.com/4344253/177482520-cf86d0fa-cd3b-4783-8fd5-5a213f0c1208.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
