### PR TITLE
Deploy header task variant from task list experiment

### DIFF
--- a/plugins/woocommerce/changelog/update-deploy-task-list-experiment-1
+++ b/plugins/woocommerce/changelog/update-deploy-task-list-experiment-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Deploy header task variant from task list experiment

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -121,8 +121,7 @@ class TaskLists {
 					'Appearance',
 				),
 				'event_prefix' => 'tasklist_',
-				'visible'      => ! self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' )
-					&& ! self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' ),
+				'visible'      => false,
 			)
 		);
 
@@ -147,7 +146,7 @@ class TaskLists {
 				'options'                 => array(
 					'use_completed_title' => true,
 				),
-				'visible'                 => self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ),
+				'visible'                 => true,
 			)
 		);
 
@@ -169,8 +168,7 @@ class TaskLists {
 					'Appearance',
 				),
 				'event_prefix'            => 'tasklist_',
-				'visible'                 => self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' )
-					&& ! self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ),
+				'visible'                 => false,
 				'options'                 => array(
 					'use_completed_title' => true,
 				),
@@ -293,7 +291,7 @@ class TaskLists {
 						'ExperimentalShippingRecommendation',
 					),
 					'event_prefix' => 'secret_tasklist_',
-					'visible' => false,
+					'visible'      => false,
 				)
 			);
 		}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33745.

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Skip OBW and not allow to be tracked
3. Go to `woocommerce > Home`
4. Observe that the header task variant (a header progress area and ordered list) is displayed. 

![Screen Shot 2022-07-06 at 16 43 36](https://user-images.githubusercontent.com/4344253/177509160-08122f0d-a790-4cd4-865d-a5e5246f64a0.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
