### PR TITLE
Product creation experience: improve inventory copy

### DIFF
--- a/plugins/woocommerce/changelog/add-33557_improve_inventory_copy
+++ b/plugins/woocommerce/changelog/add-33557_improve_inventory_copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product creation experience: improve inventory copy #33754

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5242,6 +5242,9 @@ img.help_tip {
 	p.form-field,
 	fieldset.form-field {
 		padding: 5px 20px 5px 162px !important; /** Padding for aligning labels left - 12px + 150 label width **/
+		&._sold_individually_field {
+			padding-right: 0px !important;
+		}
 	}
 
 	.sale_price_dates_fields {
@@ -5391,6 +5394,13 @@ img.help_tip {
 
 	.select2-container {
 		float: left;
+	}
+
+	.inventory_sold_individually {
+		display: flex;
+		.woocommerce-help-tip {
+			align-self: center;
+		}
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -111,7 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 	</div>
 
-	<div class="options_group show_if_simple show_if_variable">
+	<div class="inventory_sold_individually options_group show_if_simple show_if_variable">
 		<?php
 		woocommerce_wp_checkbox(
 			array(
@@ -122,6 +122,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				'description'   => __( 'Limit purchases to 1 item per order', 'woocommerce' ),
 			)
 		);
+
+		echo wc_help_tip( __( 'Check to let customers to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, for example art or handmade goods.', 'woocommerce' ) );
 
 		do_action( 'woocommerce_product_options_sold_individually' );
 		?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					'value'         => $product_object->get_manage_stock( 'edit' ) ? 'yes' : 'no',
 					'wrapper_class' => 'show_if_simple show_if_variable',
 					'label'         => __( 'Manage stock?', 'woocommerce' ),
-					'description'   => __( 'Enable stock management at product level', 'woocommerce' ),
+					'description'   => __( 'Manage stock level (quantity)', 'woocommerce' ),
 				)
 			);
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -119,7 +119,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				'value'         => $product_object->get_sold_individually( 'edit' ) ? 'yes' : 'no',
 				'wrapper_class' => 'show_if_simple show_if_variable',
 				'label'         => __( 'Sold individually', 'woocommerce' ),
-				'description'   => __( 'Enable this to only allow one of this item to be bought in a single order', 'woocommerce' ),
+				'description'   => __( 'Limit purchases to 1 item per order', 'woocommerce' ),
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a few changes in the `Inventory` section during the product creation.

![Screen Shot 2022-07-06 at 13 18 59](https://user-images.githubusercontent.com/1314156/177597309-97b26eb5-5340-40d2-ad52-602df0f7066b.png)

In summary this PR:
- Changes the copy “Enable stock management at product level” for “Manage stock level (quantity)”.
- Changes the text “Enable this to only allow one of this item to be bought in a single order” for “Limit purchases to 1 item per order”.
- Adds a tooltip after the "Limit purchases to 1 item..." with the text: "Check to let customers to purchase only 1 item in a single order. This is particularly useful for items that have limited quantity, for example art or handmade goods."

Closes #33557.

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. Go to `Products` > `Add New`.
3. Go to `Product data`, and press `Inventory`.
4. Verify the copies and tooltip look correct.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
