### PR TITLE
Product creation experience: add more context about product data

### DIFF
--- a/plugins/woocommerce/changelog/add-33539_more_context_about_product_data
+++ b/plugins/woocommerce/changelog/add-33539_more_context_about_product_data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product creation experience: add more context about product data #33755

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4769,13 +4769,11 @@ img.help_tip {
 			display: block;
 			line-height: 24px;
 		}
-
-		.tips_product_types {
-            > .woocommerce-help-tip {
-                display: inline;
-				margin-right: 1em;
-            }
-        }
+		.product-data-wrapper {
+			label > * {
+				display: inline-block;
+			}
+		}
 
 		.type_box {
 			display: inline;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4774,7 +4774,8 @@ img.help_tip {
 				display: inline-block;
 			}
 			.woocommerce-product-type-tip {
-				margin-left: 1em;
+				font-size: 1.4em;
+				margin-left: 9px;
 			}
 		}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4770,7 +4770,7 @@ img.help_tip {
 			line-height: 24px;
 		}
 
-		.tips_prodcut_types {
+		.tips_product_types {
             > .woocommerce-help-tip {
                 display: inline;
 				margin-right: 1em;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4770,6 +4770,13 @@ img.help_tip {
 			line-height: 24px;
 		}
 
+		.tips_prodcut_types {
+            > .woocommerce-help-tip {
+                display: inline;
+				margin-right: 1em;
+            }
+        }
+
 		.type_box {
 			display: inline;
 			line-height: inherit;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1012,7 +1012,7 @@ mark.amount {
 /**
   * Help Tip
   */
-.woocommerce-help-tip {
+.woocommerce-help-tip, .woocommerce-product-type-tip {
 	color: #666;
 	display: inline-block;
 	font-size: 1.1em;
@@ -1032,13 +1032,13 @@ mark.amount {
 
 .wc-wp-version-gte-53 {
 
-	.woocommerce-help-tip {
+	.woocommerce-help-tip, .woocommerce-product-type-tip {
 		font-size: 1.2em;
 		cursor: help;
 	}
 }
 
-h2 .woocommerce-help-tip {
+h2 .woocommerce-help-tip, .woocommerce-product-type-tip {
 	margin-top: -5px;
 	margin-left: 0.25em;
 }
@@ -4772,6 +4772,9 @@ img.help_tip {
 		.product-data-wrapper {
 			label > * {
 				display: inline-block;
+			}
+			.woocommerce-product-type-tip {
+				margin-left: 1em;
 			}
 		}
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -136,7 +136,7 @@ jQuery( function( $ ) {
 			}
 
 			show_and_hide_panels();
-			change_product_type_tip_content( select_val );
+			change_product_type_tip( get_product_tip_content( select_val ) );
 
 			$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
 
@@ -152,15 +152,44 @@ jQuery( function( $ ) {
 		show_and_hide_panels();
 	} );
 
-	function change_product_type_tip_content( product_type ) {
-		$( '.woocommerce-help-tip' ).tipTip( {
+	function change_product_type_tip( content ) {
+		$( '#tiptip_holder' ).removeAttr( 'style' );
+		$( '#tiptip_arrow' ).removeAttr( 'style' );
+		$( '.woocommerce-product-type-tip' ).tipTip( {
 			attribute: 'data-tip',
-			content: `This is the ${ product_type } content`,
+			content: content,
 			fadeIn: 50,
 			fadeOut: 50,
 			delay: 200,
 			keepAlive: true,
 		} );
+	}
+
+	function get_product_tip_content( product_type ) {
+		switch ( product_type ) {
+			case 'simple':
+				return (
+					'<b>Simple –</b> covers the vast majority of any products you may sell. Simple products are ' +
+					'shipped and have no options. For example, a book.'
+				);
+			case 'grouped':
+				return (
+					'<b>Grouped –</b> a collection of related products that can be purchased individually and ' +
+					'only consist of simple products. For example, a set of six drinking glasses.'
+				);
+			case 'external':
+				return '<b>External or Affiliate –</b> one that you list and describe on your website but is sold elsewhere.';
+			case 'variable':
+				return (
+					'<b>Variable –</b> a product with variations, each of which may have a different SKU, price, ' +
+					'stock option, etc. For example, a t-shirt available in different colors and/or sizes.'
+				);
+			default:
+				return (
+					'Product types define available product details and attributes, such as downloadable ' +
+					"files and variations. They're also used for analytics and inventory management."
+				);
+		}
 	}
 
 	function show_and_hide_panels() {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -51,97 +51,134 @@ jQuery( function( $ ) {
 			} else {
 				woocommerce_product_data.addClass( 'closed' );
 			}
-		});
-	});
+		} );
+	} );
 
 	// Catalog Visibility.
-	$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).on( 'click', function() {
-		if ( $( '#catalog-visibility-select' ).is( ':hidden' ) ) {
-			$( '#catalog-visibility-select' ).slideDown( 'fast' );
-			$( this ).hide();
-		}
-		return false;
-	});
-	$( '#catalog-visibility' ).find( '.save-post-visibility' ).on( 'click', function() {
-		$( '#catalog-visibility-select' ).slideUp( 'fast' );
-		$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).show();
+	$( '#catalog-visibility' )
+		.find( '.edit-catalog-visibility' )
+		.on( 'click', function () {
+			if ( $( '#catalog-visibility-select' ).is( ':hidden' ) ) {
+				$( '#catalog-visibility-select' ).slideDown( 'fast' );
+				$( this ).hide();
+			}
+			return false;
+		} );
+	$( '#catalog-visibility' )
+		.find( '.save-post-visibility' )
+		.on( 'click', function () {
+			$( '#catalog-visibility-select' ).slideUp( 'fast' );
+			$( '#catalog-visibility' )
+				.find( '.edit-catalog-visibility' )
+				.show();
 
-		var label = $( 'input[name=_visibility]:checked' ).attr( 'data-label' );
+			var label = $( 'input[name=_visibility]:checked' ).attr(
+				'data-label'
+			);
 
-		if ( $( 'input[name=_featured]' ).is( ':checked' ) ) {
-			label = label + ', ' + woocommerce_admin_meta_boxes.featured_label;
-			$( 'input[name=_featured]' ).attr( 'checked', 'checked' );
-		}
+			if ( $( 'input[name=_featured]' ).is( ':checked' ) ) {
+				label =
+					label + ', ' + woocommerce_admin_meta_boxes.featured_label;
+				$( 'input[name=_featured]' ).attr( 'checked', 'checked' );
+			}
 
-		$( '#catalog-visibility-display' ).text( label );
-		return false;
-	});
-	$( '#catalog-visibility' ).find( '.cancel-post-visibility' ).on( 'click', function() {
-		$( '#catalog-visibility-select' ).slideUp( 'fast' );
-		$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).show();
+			$( '#catalog-visibility-display' ).text( label );
+			return false;
+		} );
+	$( '#catalog-visibility' )
+		.find( '.cancel-post-visibility' )
+		.on( 'click', function () {
+			$( '#catalog-visibility-select' ).slideUp( 'fast' );
+			$( '#catalog-visibility' )
+				.find( '.edit-catalog-visibility' )
+				.show();
 
-		var current_visibility = $( '#current_visibility' ).val();
-		var current_featured   = $( '#current_featured' ).val();
+			var current_visibility = $( '#current_visibility' ).val();
+			var current_featured = $( '#current_featured' ).val();
 
-		$( 'input[name=_visibility]' ).prop( 'checked', false );
-		$( 'input[name=_visibility][value=' + current_visibility + ']' ).attr( 'checked', 'checked' );
+			$( 'input[name=_visibility]' ).prop( 'checked', false );
+			$(
+				'input[name=_visibility][value=' + current_visibility + ']'
+			).attr( 'checked', 'checked' );
 
-		var label = $( 'input[name=_visibility]:checked' ).attr( 'data-label' );
+			var label = $( 'input[name=_visibility]:checked' ).attr(
+				'data-label'
+			);
 
-		if ( 'yes' === current_featured ) {
-			label = label + ', ' + woocommerce_admin_meta_boxes.featured_label;
-			$( 'input[name=_featured]' ).attr( 'checked', 'checked' );
-		} else {
-			$( 'input[name=_featured]' ).prop( 'checked', false );
-		}
+			if ( 'yes' === current_featured ) {
+				label =
+					label + ', ' + woocommerce_admin_meta_boxes.featured_label;
+				$( 'input[name=_featured]' ).attr( 'checked', 'checked' );
+			} else {
+				$( 'input[name=_featured]' ).prop( 'checked', false );
+			}
 
-		$( '#catalog-visibility-display' ).text( label );
-		return false;
-	});
+			$( '#catalog-visibility-display' ).text( label );
+			return false;
+		} );
 
 	// Product type specific options.
-	$( 'select#product-type' ).on( 'change', function() {
+	$( 'select#product-type' )
+		.on( 'change', function () {
+			// Get value.
+			var select_val = $( this ).val();
 
-		// Get value.
-		var select_val = $( this ).val();
+			if ( 'variable' === select_val ) {
+				$( 'input#_manage_stock' ).trigger( 'change' );
+				$( 'input#_downloadable' ).prop( 'checked', false );
+				$( 'input#_virtual' ).prop( 'checked', false );
+			} else if ( 'grouped' === select_val ) {
+				$( 'input#_downloadable' ).prop( 'checked', false );
+				$( 'input#_virtual' ).prop( 'checked', false );
+			} else if ( 'external' === select_val ) {
+				$( 'input#_downloadable' ).prop( 'checked', false );
+				$( 'input#_virtual' ).prop( 'checked', false );
+			}
 
-		if ( 'variable' === select_val ) {
-			$( 'input#_manage_stock' ).trigger( 'change' );
-			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' ).prop( 'checked', false );
-		} else if ( 'grouped' === select_val ) {
-			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' ).prop( 'checked', false );
-		} else if ( 'external' === select_val ) {
-			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' ).prop( 'checked', false );
-		}
+			show_and_hide_panels();
+			change_product_type_tip_content( select_val );
 
+			$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
+
+			$( document.body ).trigger(
+				'woocommerce-product-type-change',
+				select_val,
+				$( this )
+			);
+		} )
+		.trigger( 'change' );
+
+	$( 'input#_downloadable, input#_virtual' ).on( 'change', function () {
 		show_and_hide_panels();
+	} );
 
-		$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
-
-		$( document.body ).trigger( 'woocommerce-product-type-change', select_val, $( this ) );
-
-	}).trigger( 'change' );
-
-	$( 'input#_downloadable, input#_virtual' ).on( 'change', function() {
-		show_and_hide_panels();
-	});
+	function change_product_type_tip_content( product_type ) {
+		$( '.woocommerce-help-tip' ).tipTip( {
+			attribute: 'data-tip',
+			content: `This is the ${ product_type } content`,
+			fadeIn: 50,
+			fadeOut: 50,
+			delay: 200,
+			keepAlive: true,
+		} );
+	}
 
 	function show_and_hide_panels() {
-		var product_type    = $( 'select#product-type' ).val();
-		var is_virtual      = $( 'input#_virtual:checked' ).length;
+		var product_type = $( 'select#product-type' ).val();
+		var is_virtual = $( 'input#_virtual:checked' ).length;
 		var is_downloadable = $( 'input#_downloadable:checked' ).length;
 
 		// Hide/Show all with rules.
 		var hide_classes = '.hide_if_downloadable, .hide_if_virtual';
 		var show_classes = '.show_if_downloadable, .show_if_virtual';
 
-		$.each( woocommerce_admin_meta_boxes.product_types, function( index, value ) {
+		$.each( woocommerce_admin_meta_boxes.product_types, function (
+			index,
+			value
+		) {
 			hide_classes = hide_classes + ', .hide_if_' + value;
 			show_classes = show_classes + ', .show_if_' + value;
-		});
+		} );
 
 		$( hide_classes ).show();
 		$( show_classes ).hide();

--- a/plugins/woocommerce/client/legacy/js/admin/system-status.js
+++ b/plugins/woocommerce/client/legacy/js/admin/system-status.js
@@ -1,13 +1,16 @@
 /* global jQuery, woocommerce_admin_system_status, wcSetClipboard, wcClearClipboard */
 jQuery( function ( $ ) {
-
 	/**
 	 * Users country and state fields
 	 */
 	var wcSystemStatus = {
-		init: function() {
+		init: function () {
 			$( document.body )
-				.on( 'click', 'a.help_tip, a.woocommerce-help-tip', this.preventTipTipClick )
+				.on(
+					'click',
+					'a.help_tip, a.woocommerce-help-tip, woocommerce-product-type-tip',
+					this.preventTipTipClick
+				)
 				.on( 'click', 'a.debug-report', this.generateReport )
 				.on( 'click', '#copy-for-support', this.copyReport )
 				.on( 'aftercopy', '#copy-for-support', this.copySuccess )

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <div class="panel-wrap product_data">
 
-	<span class="type_box hidden"> &mdash;
+	<span class="product-data-wrapper type_box hidden"> &mdash;
 		<label for="product-type">
 			<select id="product-type" name="product-type">
 				<optgroup label="<?php esc_attr_e( 'Product Type', 'woocommerce' ); ?>">
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php endforeach; ?>
 				</optgroup>
 			</select>
-			<a href="https://woocommerce.com/document/managing-products/#product-types" class="tips_product_types" target="_blank"><?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?></a>
+			<?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?>
 		</label>
 
 		<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php endforeach; ?>
 				</optgroup>
 			</select>
-			<?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?>
+			<span class="woocommerce-product-type-tip"></span>
 		</label>
 
 		<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php endforeach; ?>
 				</optgroup>
 			</select>
-			<a href="https://woocommerce.com/document/managing-products/#product-types" class="tips_prodcut_types"><?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?></a>
+			<a href="https://woocommerce.com/document/managing-products/#product-types" class="tips_prodcut_types" target="_blank"><?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?></a>
 		</label>
 
 		<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php endforeach; ?>
 				</optgroup>
 			</select>
-			<a href="https://woocommerce.com/document/managing-products/#product-types" class="tips_prodcut_types" target="_blank"><?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?></a>
+			<a href="https://woocommerce.com/document/managing-products/#product-types" class="tips_product_types" target="_blank"><?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?></a>
 		</label>
 
 		<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php endforeach; ?>
 				</optgroup>
 			</select>
+			<a href="https://woocommerce.com/document/managing-products/#product-types" class="tips_prodcut_types"><?php echo wc_help_tip( __( 'Click in the icon to learn more about each product type', 'woocommerce' ) ); ?></a>
 		</label>
 
 		<?php


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a tooltip to provide more context to the `Product data` area, during product creation.

![Screen Capture on 2022-07-15 at 13-04-52](https://user-images.githubusercontent.com/1314156/179262851-f1da34c7-653a-48ee-8cc4-27ebad1cc46d.gif)

Closes #33539.

// cc @jarekmorawski @pmcpinto 

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. Go to `Products` > `Add New`.
3. Verify an interrogation sign (`?`) icon is visible next to the product type selector, in the `Product data` area.
4. Verify that the text in the tooltip looks correct.

| Product tye | Text |
| --------- | -------- |
| `simple` | Simple – covers the vast majority of any products you may sell. Simple products are shipped and have no options. For example, a book. |
| `grouped` | Grouped – a collection of related products that can be purchased individually and only consist of simple products. For example, a set of six drinking glasses. |
| `external` | External or Affiliate – one that you list and describe on your website but is sold elsewhere. |
| `variable` | Variable – a product with variations, each of which may have a different SKU, price, stock option, etc. For example, a t-shirt available in different colors and/or sizes. |

5. Install [this plugin](https://gist.github.com/octaedro/4230eac7e4395a52767392cc21778bef) (it will include a product type to the selector).
6. Verify that the product type `My product` has been added.
7. Select it and verify the tooltip shows the text `Product types define available product details and attributes, such as downloadable files and variations. They're also used for analytics and inventory management.`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
