### PR TITLE
Wrap the container interface to avoid conflict

### DIFF
--- a/plugins/woocommerce/changelog/fix-33611-container-interface
+++ b/plugins/woocommerce/changelog/fix-33611-container-interface
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+
+Modified a dependency (Psr\Container) by wrapping it inside our own namespace, to reduce risk of conflict with other plugins.
+

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -20,7 +20,6 @@
 		"composer/installers": "^1.9",
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
-		"psr/container": "1.0.0",
 		"woocommerce/action-scheduler": "3.4.2",
 		"woocommerce/woocommerce-blocks": "7.8.3"
 	},

--- a/plugins/woocommerce/lib/composer.json
+++ b/plugins/woocommerce/lib/composer.json
@@ -5,9 +5,7 @@
 	"minimum-stability": "dev",
 	"require": {
 		"php": ">=7.0",
-		"psr/container": "^1.0"
-	},
-	"require-dev": {
+		"psr/container": "^1.0", 
 		"league/container": "3.3.5"
 	},
 	"config": {
@@ -28,9 +26,7 @@
 			"dep_namespace": "Automattic\\WooCommerce\\Vendor\\",
 			"dep_directory": "/packages/",
 			"packages": [
-				"league/container"
-			],
-			"excluded_packages": [
+				"league/container",
 				"psr/container"
 			],
 			"classmap_directory": "/classes/",

--- a/plugins/woocommerce/lib/composer.lock
+++ b/plugins/woocommerce/lib/composer.lock
@@ -1,0 +1,156 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2434f4259fddabd5b2a6516c86cad85a",
+    "packages": [
+        {
+            "name": "league/container",
+            "version": "3.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/048ab87810f508dbedbcb7ae941b606eb8ee353b",
+                "reference": "048ab87810f508dbedbcb7ae941b606eb8ee353b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/container": "^1.0.0 || ^2.0.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0",
+                "roave/security-advisories": "dev-master",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "philipobenito@gmail.com",
+                    "homepage": "http://www.philipobenito.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/3.3.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-16T09:42:56+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
+            "time": "2017-02-14T16:28:37+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0"
+    },
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.0"
+    },
+    "plugin-api-version": "2.2.0"
+}

--- a/plugins/woocommerce/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Argument/ArgumentResolverTrait.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\Vendor\League\Container\Argument;
 use Automattic\WooCommerce\Vendor\League\Container\Container;
 use Automattic\WooCommerce\Vendor\League\Container\Exception\{ContainerException, NotFoundException};
 use Automattic\WooCommerce\Vendor\League\Container\ReflectionContainer;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 use ReflectionFunctionAbstract;
 use ReflectionParameter;
 
@@ -79,7 +79,7 @@ trait ArgumentResolverTrait
             }
 
             if ($type) {
-                if (PHP_VERSION_ID >= 70200) {
+                if (PHP_VERSION_ID >= 70100) {
                     $typeName = $type->getName();
                 } else {
                     $typeName = (string) $type;

--- a/plugins/woocommerce/lib/packages/League/Container/Container.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Container.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\Vendor\League\Container\ServiceProvider\{
     ServiceProviderAggregateInterface,
     ServiceProviderInterface
 };
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 class Container implements ContainerInterface
 {

--- a/plugins/woocommerce/lib/packages/League/Container/ContainerAwareInterface.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ContainerAwareInterface.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Vendor\League\Container;
 
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 interface ContainerAwareInterface
 {
@@ -13,7 +13,7 @@ interface ContainerAwareInterface
      *
      * @return self
      */
-    public function setContainer(ContainerInterface $container) : self;
+    public function setContainer(ContainerInterface $container) : ContainerAwareInterface;
 
     /**
      * Get the container

--- a/plugins/woocommerce/lib/packages/League/Container/ContainerAwareTrait.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ContainerAwareTrait.php
@@ -3,7 +3,7 @@
 namespace Automattic\WooCommerce\Vendor\League\Container;
 
 use Automattic\WooCommerce\Vendor\League\Container\Exception\ContainerException;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 trait ContainerAwareTrait
 {
@@ -22,7 +22,7 @@ trait ContainerAwareTrait
      *
      * @param ContainerInterface $container
      *
-     * @return self
+     * @return ContainerAwareInterface
      */
     public function setContainer(ContainerInterface $container) : ContainerAwareInterface
     {

--- a/plugins/woocommerce/lib/packages/League/Container/Definition/Definition.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Definition/Definition.php
@@ -216,6 +216,10 @@ class Definition implements ArgumentResolverInterface, DefinitionInterface
             $concrete = $this->invokeMethods($concrete);
         }
 
+        if (is_string($concrete) && $this->getContainer()->has($concrete)) {
+            $concrete = $this->getContainer()->get($concrete);
+        }
+
         $this->resolved = $concrete;
 
         return $concrete;

--- a/plugins/woocommerce/lib/packages/League/Container/Exception/ContainerException.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Exception/ContainerException.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Vendor\League\Container\Exception;
 
-use Psr\Container\ContainerExceptionInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
 use RuntimeException;
 
 class ContainerException extends RuntimeException implements ContainerExceptionInterface

--- a/plugins/woocommerce/lib/packages/League/Container/Exception/NotFoundException.php
+++ b/plugins/woocommerce/lib/packages/League/Container/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Automattic\WooCommerce\Vendor\League\Container\Exception;
 
-use Psr\Container\NotFoundExceptionInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
 use InvalidArgumentException;
 
 class NotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface

--- a/plugins/woocommerce/lib/packages/League/Container/ReflectionContainer.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ReflectionContainer.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Vendor\League\Container;
 
 use Automattic\WooCommerce\Vendor\League\Container\Argument\{ArgumentResolverInterface, ArgumentResolverTrait};
 use Automattic\WooCommerce\Vendor\League\Container\Exception\NotFoundException;
-use Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;

--- a/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -98,8 +98,8 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
             }
 
             if ($provider->provides($service)) {
-                $provider->register();
                 $this->registered[] = $provider->getIdentifier();
+                $provider->register();
             }
         }
     }

--- a/plugins/woocommerce/lib/packages/Psr/Container/ContainerExceptionInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/ContainerExceptionInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace Automattic\WooCommerce\Vendor\Psr\Container;
+
+/**
+ * Base interface representing a generic exception in a container.
+ */
+interface ContainerExceptionInterface
+{
+}

--- a/plugins/woocommerce/lib/packages/Psr/Container/ContainerInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/ContainerInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace Automattic\WooCommerce\Vendor\Psr\Container;
+
+/**
+ * Describes the interface of a container that exposes methods to read its entries.
+ */
+interface ContainerInterface
+{
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id);
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has($id);
+}

--- a/plugins/woocommerce/lib/packages/Psr/Container/NotFoundExceptionInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/NotFoundExceptionInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
+
+namespace Automattic\WooCommerce\Vendor\Psr\Container;
+
+/**
+ * No entry was found in the container.
+ */
+interface NotFoundExceptionInterface extends ContainerExceptionInterface
+{
+}

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -17,12 +17,15 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\Produc
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ProxiesServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\RestockRefundedItemsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\UtilsClassesServiceProvider;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
 
 /**
  * PSR11 compliant dependency injection container for WooCommerce.
  *
  * Classes in the `src` directory should specify dependencies from that directory via an 'init' method having arguments
- * with type hints. If an instance of the container itself is needed, the type hint to use is \Psr\Container\ContainerInterface.
+ * with type hints. If an instance of the container itself is needed, the type hint to use is
+ * Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface.
  *
  * Classes in the `src` directory should interact with anything outside (especially code in the `includes` directory
  * and WordPress functions) by using the classes in the `Proxies` directory. The exception is idempotent
@@ -35,7 +38,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\UtilsC
  * and those should go in the `src\Internal\DependencyManagement\ServiceProviders` folder unless there's a good reason
  * to put them elsewhere. All the service provider class names must be in the `SERVICE_PROVIDERS` constant.
  */
-final class Container implements \Psr\Container\ContainerInterface {
+final class Container implements ContainerInterface {
 	/**
 	 * The list of service provider classes to register.
 	 *
@@ -71,7 +74,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 		// Add ourselves as the shared instance of ContainerInterface,
 		// register everything else using service providers.
 
-		$this->container->share( \Psr\Container\ContainerInterface::class, $this );
+		$this->container->share( ContainerInterface::class, $this );
 
 		foreach ( $this->service_providers as $service_provider_class ) {
 			$this->container->addServiceProvider( $service_provider_class );
@@ -84,7 +87,7 @@ final class Container implements \Psr\Container\ContainerInterface {
 	 * @param string $id Identifier of the entry to look for.
 	 *
 	 * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
-	 * @throws Psr\Container\ContainerExceptionInterface Error while retrieving the entry.
+	 * @throws ContainerExceptionInterface Error while retrieving the entry.
 	 *
 	 * @return mixed Entry.
 	 */

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -34,9 +34,7 @@ class ExtendedContainer extends BaseContainer {
 	 *
 	 * @var string[]
 	 */
-	private $registration_whitelist = array(
-		\Psr\Container\ContainerInterface::class,
-	);
+	private $registration_whitelist = array();
 
 	/**
 	 * Register a class in the container.

--- a/plugins/woocommerce/src/Proxies/LegacyProxy.php
+++ b/plugins/woocommerce/src/Proxies/LegacyProxy.php
@@ -6,7 +6,7 @@
 namespace Automattic\WooCommerce\Proxies;
 
 use Automattic\WooCommerce\Internal\DependencyManagement\Definition;
-use \Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Proxy class to access legacy WooCommerce functionality.

--- a/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
@@ -32,7 +32,7 @@ class LegacyProxyTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_get_instance_of_throws_when_trying_to_get_a_namespaced_class() {
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'The LegacyProxy class is not intended for getting instances of classes in the src directory, please use ' . Definition::INJECTION_METHOD . ' method injection or the instance of Automattic\Vendor\Psr\Container\ContainerInterface for that.' );
+		$this->expectExceptionMessage( 'The LegacyProxy class is not intended for getting instances of classes in the src directory, please use ' . Definition::INJECTION_METHOD . ' method injection or the instance of Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface for that.' );
 
 		$this->sut->get_instance_of( DependencyClass::class );
 	}

--- a/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/plugins/woocommerce/tests/php/src/Proxies/LegacyProxyTest.php
@@ -32,7 +32,7 @@ class LegacyProxyTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_get_instance_of_throws_when_trying_to_get_a_namespaced_class() {
 		$this->expectException( \Exception::class );
-		$this->expectExceptionMessage( 'The LegacyProxy class is not intended for getting instances of classes in the src directory, please use ' . Definition::INJECTION_METHOD . ' method injection or the instance of Psr\Container\ContainerInterface for that.' );
+		$this->expectExceptionMessage( 'The LegacyProxy class is not intended for getting instances of classes in the src directory, please use ' . Definition::INJECTION_METHOD . ' method injection or the instance of Automattic\Vendor\Psr\Container\ContainerInterface for that.' );
 
 		$this->sut->get_instance_of( DependencyClass::class );
 	}

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -52,9 +52,9 @@ function WC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.Fu
  * Code in the `includes` directory should use the container to get instances of classes in the `src` directory.
  *
  * @since  4.4.0
- * @return \Psr\Container\ContainerInterface The WooCommerce PSR11 container.
+ * @return Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface The WooCommerce PSR11 container.
  */
-function wc_get_container() : \Psr\Container\ContainerInterface {
+function wc_get_container() : Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface {
 	return $GLOBALS['wc_container'];
 }
 


### PR DESCRIPTION
If another plugin includes [`psr\container:^2.0.0`](https://github.com/php-fig/container/releases/tag/2.0.0), then their version of `Psr\Container\ContainerInterface` may "collide" with our own—resulting in fatal errors.

Closes #33611.

### How to test the changes in this Pull Request:

To simulate the problem, add a single-file plugin as follows:

```php
<?php
/**
 * Plugin name: Test #33611
 */

namespace Psr\Container {
	/**
	 * This is a condensed version of the same interface found in php-fig/container 2.0.0.
	 * 
	 * @see https://github.com/php-fig/container/blob/2.0.0/src/ContainerInterface.php
	 */
	interface ContainerInterface {
		public function get(string $id);
		public function has(string $id): bool;
	}
}
```

Then:

1. Deactivate all plugins.
2. Activate the test plugin.
3. Try to activate WooCommerce.

Without this change, you should encounter a fatal error looking something like the following:

<img width="924" alt="psr-container-fatal" src="https://user-images.githubusercontent.com/3594411/177767436-a724ad35-50f3-4f3b-b29d-5d3704251b9f.png">

With this change, it should activate cleanly and all functionality should work as normal.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
