### PR TITLE
add CLI `wc com extension install` command

### DIFF
--- a/plugins/woocommerce/changelog/add-cli-com-extension-install-command
+++ b/plugins/woocommerce/changelog/add-cli-com-extension-install-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add `wc com extension install` CLI command

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -125,6 +125,37 @@ class WC_Helper_Updater {
 	}
 
 	/**
+	 * Get update data for all plugins.
+	 *
+	 * @return array Update data {product_id => data}
+	 * @see get_update_data
+	 */
+	public static function get_available_extensions_downloads_data() {
+		$payload = array();
+
+		// Scan subscriptions.
+		foreach ( WC_Helper::get_subscriptions() as $subscription ) {
+			$payload[ $subscription['product_id'] ] = array(
+				'product_id' => $subscription['product_id'],
+				'file_id'    => '',
+			);
+		}
+
+		// Scan local plugins which may or may not have a subscription.
+		foreach ( WC_Helper::get_local_woo_plugins() as $data ) {
+			if ( ! isset( $payload[ $data['_product_id'] ] ) ) {
+				$payload[ $data['_product_id'] ] = array(
+					'product_id' => $data['_product_id'],
+				);
+			}
+
+			$payload[ $data['_product_id'] ]['file_id'] = $data['_file_id'];
+		}
+
+		return self::_update_check( $payload );
+	}
+
+	/**
 	 * Get update data for all extensions.
 	 *
 	 * Scans through all subscriptions for the connected user, as well

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -31,6 +31,7 @@ class WC_CLI {
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tool-command.php';
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-update-command.php';
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tracker-command.php';
+		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-com-command.php';
 	}
 
 	/**
@@ -41,6 +42,7 @@ class WC_CLI {
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tool_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Update_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tracker_Command::register_commands' );
+		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_COM_Command::register_commands' );
 		$cli_runner = wc_get_container()->get( CLIRunner::class );
 		WP_CLI::add_hook( 'after_wp_load', array( $cli_runner, 'register_commands' ) );
 	}

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -42,6 +42,7 @@ class WC_CLI {
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tool_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Update_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tracker_Command::register_commands' );
+		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_COM_Extension_Command::register_commands' );
 		$cli_runner = wc_get_container()->get( CLIRunner::class );
 		WP_CLI::add_hook( 'after_wp_load', array( $cli_runner, 'register_commands' ) );
 	}

--- a/plugins/woocommerce/includes/class-wc-cli.php
+++ b/plugins/woocommerce/includes/class-wc-cli.php
@@ -31,7 +31,7 @@ class WC_CLI {
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tool-command.php';
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-update-command.php';
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tracker-command.php';
-		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-com-command.php';
+		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-com-extension-command.php';
 	}
 
 	/**
@@ -42,7 +42,6 @@ class WC_CLI {
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tool_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Update_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tracker_Command::register_commands' );
-		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_COM_Command::register_commands' );
 		$cli_runner = wc_get_container()->get( CLIRunner::class );
 		WP_CLI::add_hook( 'after_wp_load', array( $cli_runner, 'register_commands' ) );
 	}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
@@ -33,7 +33,6 @@ class WC_CLI_COM_Command {
 	 *
 	 * @param  array $args WP-CLI positional arguments.
 	 * @param  array $assoc_args WP-CLI associative arguments.
-	 *
 	 */
 	public static function list_extensions( array $args, array $assoc_args ) {
 	}
@@ -56,7 +55,6 @@ class WC_CLI_COM_Command {
 	 *
 	 * @param  array $args WP-CLI positional arguments.
 	 * @param  array $assoc_args WP-CLI associative arguments.
-	 *
 	 */
 	public static function install_extension( array $args, array $assoc_args ) {
 	}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
@@ -17,29 +17,29 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_CLI_COM_Command {
 	/**
-	 * Registers a command for showing WooCommerce Tracker snapshot data.
+	 * Registers a commands for managing WooCommerce.com extensions.
 	 */
 	public static function register_commands() {
-		WP_CLI::add_command( 'wc com install', array( 'WC_CLI_COM_Command', 'install_extension' ) );
-		WP_CLI::add_command( 'wc com list', array( 'WC_CLI_COM_Command', 'list_extensions' ) );
+		WP_CLI::add_command( 'wc com extension install', array( 'WC_CLI_COM_Command', 'install_extension' ) );
+		WP_CLI::add_command( 'wc com extension list', array( 'WC_CLI_COM_Command', 'list_extensions' ) );
 	}
 
 	/**
-	 *
+	 * List extensions available for the connected site.
 	 *
 	 * ## EXAMPLES
 	 *
 	 * wp wc com extension list
 	 *
-	 * @param  array  $args  WP-CLI positional arguments.
-	 * @param  array  $assoc_args  WP-CLI associative arguments.
+	 * @param  array $args WP-CLI positional arguments.
+	 * @param  array $assoc_args WP-CLI associative arguments.
 	 *
 	 */
 	public static function list_extensions( array $args, array $assoc_args ) {
 	}
 
 	/**
-	 * Dump tracker snapshot data to screen.
+	 * Download and install an extension.
 	 *
 	 * ## OPTIONS
 	 *
@@ -54,8 +54,8 @@ class WC_CLI_COM_Command {
 	 * wp wc com extension install automatewoo
 	 * wp wc com extension install woocommerce-subscriptions --activate
 	 *
-	 * @param  array  $args  WP-CLI positional arguments.
-	 * @param  array  $assoc_args  WP-CLI associative arguments.
+	 * @param  array $args WP-CLI positional arguments.
+	 * @param  array $assoc_args WP-CLI associative arguments.
 	 *
 	 */
 	public static function install_extension( array $args, array $assoc_args ) {

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WC_CLI_COM_Command class file.
+ *
+ * @package WooCommerce\CLI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Allows to interact with extensions from WCCOM marketplace via CLI.
+ *
+ * @version 6.8
+ * @package WooCommerce
+ */
+class WC_CLI_COM_Command {
+	/**
+	 * Registers a command for showing WooCommerce Tracker snapshot data.
+	 */
+	public static function register_commands() {
+		WP_CLI::add_command( 'wc com install', array( 'WC_CLI_COM_Command', 'install_extension' ) );
+		WP_CLI::add_command( 'wc com list', array( 'WC_CLI_COM_Command', 'list_extensions' ) );
+	}
+
+	/**
+	 *
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp wc com extension list
+	 *
+	 * @param  array  $args  WP-CLI positional arguments.
+	 * @param  array  $assoc_args  WP-CLI associative arguments.
+	 *
+	 */
+	public static function list_extensions( array $args, array $assoc_args ) {
+	}
+
+	/**
+	 * Dump tracker snapshot data to screen.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <extension>
+	 * : One or more plugins to install. Accepts a plugin slug
+	 *
+	 * [--activate]
+	 * : If set, the plugin will be activated immediately after install.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp wc com extension install automatewoo
+	 * wp wc com extension install woocommerce-subscriptions --activate
+	 *
+	 * @param  array  $args  WP-CLI positional arguments.
+	 * @param  array  $assoc_args  WP-CLI associative arguments.
+	 *
+	 */
+	public static function install_extension( array $args, array $assoc_args ) {
+	}
+}

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -81,7 +81,7 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 		// Remove `--version` as we don't support it.
 		unset( $assoc_args['version'] );
 
-		// Filter by slug
+		// Filter by slug.
 		foreach ( $subscriptions as $subscription ) {
 			if ( $subscription['slug'] === $extension && ! is_null( $subscription['package'] ) ) {
 
@@ -98,6 +98,6 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 			return;
 		}
 
-		parent::install( [ $extension_package_url ], $assoc_args );
+		parent::install( array( $extension_package_url ), $assoc_args );
 	}
 }

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -32,8 +32,8 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <extension|zip|url>...
-	 * : One or more plugins to install. Accepts a plugin slug, the path to a local zip file, or a URL to a remote zip file.
+	 * <extension>...
+	 * : One or more plugins to install. Accepts a plugin slug.
 	 *
 	 * [--force]
 	 * : If set, the command will overwrite any installed version of the plugin, without prompting
@@ -59,21 +59,6 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	 *     Plugin installed successfully.
 	 *     Activating 'automatewoo'...
 	 *     Plugin 'automatewoo' activated.
-	 *     Success: Installed 1 of 1 plugins.
-	 *
-	 *     # Install from a local zip file
-	 *     $ wp wc com extension install ../my-plugin.zip
-	 *     Unpacking the package...
-	 *     Installing the plugin...
-	 *     Plugin installed successfully.
-	 *     Success: Installed 1 of 1 plugins.
-	 *
-	 *     # Install from a remote zip file
-	 *     $ wp wc com extension install http://s3.amazonaws.com/bucketname/my-plugin.zip?AWSAccessKeyId=123&Expires=456&Signature=abcdef
-	 *     Downloading install package from http://s3.amazonaws.com/bucketname/my-plugin.zip?AWSAccessKeyId=123&Expires=456&Signature=abcdef
-	 *     Unpacking the package...
-	 *     Installing the plugin...
-	 *     Plugin installed successfully.
 	 *     Success: Installed 1 of 1 plugins.
 	 *
 	 *     # Forcefully re-install an installed plugin
@@ -102,9 +87,12 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 			}
 		}
 
-		// No package found, pass <extension> to Plugin_Command::install to search in wp.org
+		// No package found.
 		if ( is_null( $extension_package_url ) ) {
-			$extension_package_url = $extension;
+			WP_CLI::warning( sprintf( 'We couldn\'t find a Subscription for \'%s\'', $extension ) );
+			WP_CLI\Utils\report_batch_operation_results( $this->item_type, 'install', count( $args ), 0, 1 );
+
+			return;
 		}
 
 		parent::install( [ $extension_package_url ], $assoc_args );

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -9,13 +9,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Plugin_Command' ) ) {
+	exit;
+}
+
 /**
  * Allows to interact with extensions from WCCOM marketplace via CLI.
  *
  * @version 6.8
  * @package WooCommerce
  */
-class WC_CLI_COM_Command {
+class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	/**
 	 * Registers a commands for managing WooCommerce.com extensions.
 	 */

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -24,8 +24,7 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	 * Registers a commands for managing WooCommerce.com extensions.
 	 */
 	public static function register_commands() {
-		WP_CLI::add_command( 'wc com extension install', array( 'WC_CLI_COM_Command', 'install_extension' ) );
-		WP_CLI::add_command( 'wc com extension list', array( 'WC_CLI_COM_Command', 'list_extensions' ) );
+		WP_CLI::add_command( 'wc com extension', 'WC_CLI_COM_Extension_Command' );
 	}
 
 	/**
@@ -35,10 +34,10 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	 *
 	 * wp wc com extension list
 	 *
-	 * @param  array $args WP-CLI positional arguments.
-	 * @param  array $assoc_args WP-CLI associative arguments.
+	 * @param array $args WP-CLI positional arguments.
+	 * @param array $assoc_args WP-CLI associative arguments.
 	 */
-	public static function list_extensions( array $args, array $assoc_args ) {
+	public function list_( $args, $assoc_args ) {
 	}
 
 	/**

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -74,7 +74,7 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	 * @param array $assoc_args WP-CLI associative arguments.
 	 */
 	public function install( $args, $assoc_args ) {
-		$subscriptions         = WC_Helper_Updater::get_update_data();
+		$subscriptions         = WC_Helper_Updater::get_available_extensions_downloads_data();
 		$extension             = reset( $args );
 		$extension_package_url = null;
 

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -69,6 +69,9 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	 *     Removing the old version of the plugin...
 	 *     Plugin updated successfully
 	 *     Success: Installed 1 of 1 plugins.
+	 *
+	 * @param array $args WP-CLI positional arguments.
+	 * @param array $assoc_args WP-CLI associative arguments.
 	 */
 	public function install( $args, $assoc_args ) {
 		$subscriptions         = WC_Helper_Updater::get_update_data();

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-extension-command.php
@@ -28,19 +28,6 @@ class WC_CLI_COM_Extension_Command extends Plugin_Command {
 	}
 
 	/**
-	 * List extensions available for the connected site.
-	 *
-	 * ## EXAMPLES
-	 *
-	 * wp wc com extension list
-	 *
-	 * @param array $args WP-CLI positional arguments.
-	 * @param array $assoc_args WP-CLI associative arguments.
-	 */
-	public function list_( $args, $assoc_args ) {
-	}
-
-	/**
 	 * Installs one or more plugins from wccom marketplace.
 	 *
 	 * ## OPTIONS


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

PR adds `wc com extension install` command, this command is extended off `wp plugin install` but search for extension using `WC_Helper` and fallback to WPORG repository.

In order to use this command you need a connected site to your WCCOM

Closes https://github.com/Automattic/woocommerce.com/issues/13764.

### How to test the changes in this Pull Request:

1. Make sure the site is connected to WCCOM via <your test site root>wp-admin/admin.php?page=wc-addons&section=helper
1. Checkout this branch
4. Run `wp wc com extension install <extension>` where `<extension>` is the slug for one of the purchased extension
5. Extension should be downloaded and saved in `wp-content/plugins` folder
6. Now run `wp wc com extension install <extension> --activate`
7. Extension should be activated after download

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
