### PR TITLE
Use the different file structure of legacy projects to inform the cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,11 @@
 				"src/*.php",
 				"src/**/*.php",
 				"includes/*.php",
-				"includes/**/*.php"
+				"includes/**/*.php",
+				"js/*.js",
+				"js/**/*.js",
+				"css/*.scss",
+				"css/**/*.scss"
 			],
 			"outputs": [
 				"dist/**",
@@ -32,12 +36,6 @@
 				"build-style/**",
 				"build-types/**"
 			]
-		},
-		"woocommerce/client/admin#build": {
-			"inputs": [ "js/**/*.js", "js/**/*.scss" ]
-		},
-		"woocommerce/client/legacy#build": {
-			"inputs": [ "js/**/*.js", "js/**/*.scss" ]
 		},
 		"woocommerce#build": {
 			"dependsOn": [

--- a/turbo.json
+++ b/turbo.json
@@ -1,84 +1,89 @@
 {
-    "$schema": "https://turborepo.org/schema.json",
-    "baseBranch": "origin/trunk",
-    "pipeline": {
-        "lint": {
-            "cache": false
-        },
-        "lint:fix": {
-            "cache": false
-        },
+	"$schema": "https://turborepo.org/schema.json",
+	"baseBranch": "origin/trunk",
+	"pipeline": {
+		"lint": {
+			"cache": false
+		},
+		"lint:fix": {
+			"cache": false
+		},
 
-        "build": {
-            "dependsOn":  [ "^build" ],
-            "inputs": [
-                "src/*.js",
-                "src/**/*.js",
-                "src/*.jsx",
-                "src/**/*.jsx",
-                "src/*.ts",
-                "src/**/*.ts",
-                "src/*.tsx",
-                "src/**/*.tsx",
-                "src/*.php",
-                "src/**/*.php",
-                "includes/*.php",
-                "includes/**/*.php"
-            ],
-            "outputs": [
-                "dist/**",
-                "build/**",
-                "build-module/**",
-                "build-style/**",
-                "build-types/**"
-            ]
-        },
-        "woocommerce#build": {
-            "dependsOn":  [ 
-                "^build",
-                "woocommerce/client/admin#build",
-                "woocommerce/client/legacy#build"
-            ],
-            "outputs": [],
-            "inputs": [
-                "src/*.php",
-                "src/**/*.php",
-                "includes/*.php",
-                "includes/**/*.php"
-            ]
-        },
+		"build": {
+			"dependsOn": [ "^build" ],
+			"inputs": [
+				"src/*.js",
+				"src/**/*.js",
+				"src/*.jsx",
+				"src/**/*.jsx",
+				"src/*.ts",
+				"src/**/*.ts",
+				"src/*.tsx",
+				"src/**/*.tsx",
+				"src/*.php",
+				"src/**/*.php",
+				"includes/*.php",
+				"includes/**/*.php"
+			],
+			"outputs": [
+				"dist/**",
+				"build/**",
+				"build-module/**",
+				"build-style/**",
+				"build-types/**"
+			]
+		},
+		"woocommerce/client/admin#build": {
+			"inputs": [ "js/**/*.js", "js/**/*.scss" ]
+		},
+		"woocommerce/client/legacy#build": {
+			"inputs": [ "js/**/*.js", "js/**/*.scss" ]
+		},
+		"woocommerce#build": {
+			"dependsOn": [
+				"^build",
+				"woocommerce/client/admin#build",
+				"woocommerce/client/legacy#build"
+			],
+			"outputs": [],
+			"inputs": [
+				"src/*.php",
+				"src/**/*.php",
+				"includes/*.php",
+				"includes/**/*.php"
+			]
+		},
 
-        "test": {
-            "dependsOn":  [ "build" ],
-            "inputs": [
-                "src/*.js",
-                "src/**/*.js",
-                "src/*.jsx",
-                "src/**/*.jsx",
-                "src/*.ts",
-                "src/**/*.ts",
-                "src/*.tsx",
-                "src/**/*.tsx",
-                "src/*.php",
-                "src/**/*.php",
-                "includes/*.php",
-                "includes/**/*.php"
-            ],
-            "outputs": []
-        },
+		"test": {
+			"dependsOn": [ "build" ],
+			"inputs": [
+				"src/*.js",
+				"src/**/*.js",
+				"src/*.jsx",
+				"src/**/*.jsx",
+				"src/*.ts",
+				"src/**/*.ts",
+				"src/*.tsx",
+				"src/**/*.tsx",
+				"src/*.php",
+				"src/**/*.php",
+				"includes/*.php",
+				"includes/**/*.php"
+			],
+			"outputs": []
+		},
 
-        "e2e": {
-            "dependsOn":  [ "build" ],
-            "cache": false
-        },
-        "e2e:debug": {
-            "dependsOn":  [ "build" ],
-            "cache": false
-        },
-        "e2e:dev": {
-            "dependsOn":  [ "build" ],
-            "cache": false
-        }
-    }
+		"e2e": {
+			"dependsOn": [ "build" ],
+			"cache": false
+		},
+		"e2e:debug": {
+			"dependsOn": [ "build" ],
+			"cache": false
+		},
+		"e2e:dev": {
+			"dependsOn": [ "build" ],
+			"cache": false
+		}
+	}
 }
-  


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/pull/33741#pullrequestreview-1030425057 it was noted that `--force` was required to rebuild the legacy JS code and the cache could not be trusted. This is because the legacy scripts built by gulp are in a different folder structure from the `src/...` structure we have everywhere else. For admin and legacy I've added inputs that check the files as they structured in those projects.

This ensures that a regular build will be a cache hit and any changes made to any files under these `js` or `css` directories will be a cache miss.

### How to test the changes in this Pull Request:

1. First checkout this branch
2. Then run a build for these legacy scripts, e.g. `pnpm -- turbo run build --filter=woocommerce/client/legacy`
3. Now make a single file change in one of the CSS or JS files under `css` or `js` in `client/legacy`
4. Now rerun the build (no force) with: `pnpm -- turbo run build --filter=woocommerce/client/legacy`
5. Turbo should inform you of a cache miss with output like: `cache miss, executing 7630b260fe36b9df`, and a full build should be performed.
6. Now run the build again `pnpm -- turbo run build --filter=woocommerce/client/legacy`, this time it should be very fast with cache hit and a build is not run.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
