### PR TITLE
Fix wrong translation domain in marketing task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
@@ -81,7 +81,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 							onManage( slug );
 						} }
 					>
-						{ __( 'Manage', 'woocommmerce-admin' ) }
+						{ __( 'Manage', 'woocommmerce' ) }
 					</Button>
 				) }
 				{ isInstalled && ! isActive && (
@@ -91,7 +91,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>
-						{ __( 'Activate', 'woocommmerce-admin' ) }
+						{ __( 'Activate', 'woocommmerce' ) }
 					</Button>
 				) }
 				{ ! isInstalled && (
@@ -101,7 +101,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>
-						{ __( 'Get started', 'woocommmerce-admin' ) }
+						{ __( 'Get started', 'woocommmerce' ) }
 					</Button>
 				) }
 			</div>

--- a/plugins/woocommerce/changelog/fix-marketing-task-i18n
+++ b/plugins/woocommerce/changelog/fix-marketing-task-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix untranslated texts in marketing task


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the wrong translation domain `woocommerce-admin` -> `woocomemerce`

### How to test the changes in this Pull Request:

Review the changes

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
