### PR TITLE
Set up i18n-text-domain rule and fix missing text domain

### DIFF
--- a/packages/js/components/changelog/dev-update-eslint-config
+++ b/packages/js/components/changelog/dev-update-eslint-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing text domain

--- a/packages/js/components/src/image-upload/index.js
+++ b/packages/js/components/src/image-upload/index.js
@@ -25,9 +25,9 @@ class ImageUpload extends Component {
 		}
 
 		const frame = wp.media( {
-			title: __( 'Select or upload image' ),
+			title: __( 'Select or upload image', 'woocommerce' ),
 			button: {
-				text: __( 'Select' ),
+				text: __( 'Select', 'woocommerce' ),
 			},
 			library: {
 				type: 'image',

--- a/packages/js/components/src/order-status/stories/index.js
+++ b/packages/js/components/src/order-status/stories/index.js
@@ -5,9 +5,9 @@ import { __ } from '@wordpress/i18n';
 import { OrderStatus } from '@woocommerce/components';
 
 const orderStatusMap = {
-	processing: __( 'Processing Order' ),
-	pending: __( 'Pending Order' ),
-	completed: __( 'Completed Order' ),
+	processing: __( 'Processing Order', 'woocommerce' ),
+	pending: __( 'Pending Order', 'woocommerce' ),
+	completed: __( 'Completed Order', 'woocommerce' ),
 };
 
 export const Basic = () => (

--- a/packages/js/eslint-plugin/changelog/dev-update-eslint-config
+++ b/packages/js/eslint-plugin/changelog/dev-update-eslint-config
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update i18n-text-domain rule to only allow woocommerce text domain

--- a/packages/js/eslint-plugin/configs/recommended.js
+++ b/packages/js/eslint-plugin/configs/recommended.js
@@ -19,7 +19,7 @@ module.exports = {
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{
-				allowedTextDomain: 'woocommmerce',
+				allowedTextDomain: 'woocommerce',
 			},
 		],
 		'@wordpress/valid-sprintf': 'warn',

--- a/packages/js/eslint-plugin/configs/recommended.js
+++ b/packages/js/eslint-plugin/configs/recommended.js
@@ -16,6 +16,12 @@ module.exports = {
 		yoda: [ 'error', 'never' ],
 		// temporary conversion to warnings until the below are all handled.
 		'@wordpress/i18n-translator-comments': 'warn',
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				allowedTextDomain: 'woocommmerce',
+			},
+		],
 		'@wordpress/valid-sprintf': 'warn',
 		'@wordpress/no-unsafe-wp-apis': 'warn',
 		'@wordpress/no-global-active-element': 'warn',

--- a/plugins/woocommerce-admin/client/analytics/components/report-table/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-table/index.js
@@ -317,7 +317,7 @@ const ReportTable = ( props ) => {
 			label: (
 				<CheckboxControl
 					onChange={ selectAllRows }
-					aria-label={ __( 'Select All' ) }
+					aria-label={ __( 'Select All', 'woocommerce' ) }
 					checked={ isAllChecked }
 					disabled={ ! hasData }
 				/>

--- a/plugins/woocommerce-admin/client/analytics/report/variations/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/variations/table.js
@@ -132,7 +132,7 @@ class VariationsReportTable extends Component {
 			return [
 				{
 					display: deleted ? (
-						name + ' ' + __( '(Deleted)', ' woocommerce-admin' )
+						name + ' ' + __( '(Deleted)', 'woocommerce' )
 					) : (
 						<Link href={ editPostLink } type="wp-admin">
 							{ name }

--- a/plugins/woocommerce-admin/client/dashboard/section-controls.js
+++ b/plugins/woocommerce-admin/client/dashboard/section-controls.js
@@ -56,7 +56,7 @@ class SectionControls extends Component {
 						<MenuItem isClickable onInvoke={ this.onMoveUp }>
 							<Icon
 								icon={ <ChevronUpIcon /> }
-								label={ __( 'Move up' ) }
+								label={ __( 'Move up', 'woocommerce' ) }
 								size={ 20 }
 								className="icon-control"
 							/>
@@ -68,7 +68,7 @@ class SectionControls extends Component {
 							<Icon
 								icon={ <ChevronDownIcon /> }
 								size={ 20 }
-								label={ __( 'Move down' ) }
+								label={ __( 'Move down', 'woocommerce' ) }
 								className="icon-control"
 							/>
 							{ __( 'Move down', 'woocommerce' ) }
@@ -78,7 +78,7 @@ class SectionControls extends Component {
 						<Icon
 							icon={ trash }
 							size={ 20 }
-							label={ __( 'Remove block' ) }
+							label={ __( 'Remove block', 'woocommerce' ) }
 							className="icon-control"
 						/>
 						{ __( 'Remove section', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/layout/transient-notices/snackbar/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/snackbar/index.js
@@ -120,7 +120,11 @@ function Snackbar(
 			tabIndex="0"
 			role={ ! explicitDismiss ? 'button' : '' }
 			onKeyPress={ ! explicitDismiss ? dismissMe : noop }
-			aria-label={ ! explicitDismiss ? __( 'Dismiss this notice' ) : '' }
+			aria-label={
+				! explicitDismiss
+					? __( 'Dismiss this notice', 'woocommerce' )
+					: ''
+			}
 		>
 			<div className={ snackbarContentClassnames }>
 				{ icon && (

--- a/plugins/woocommerce-admin/client/navigation/components/header/index.js
+++ b/plugins/woocommerce-admin/client/navigation/components/header/index.js
@@ -96,7 +96,9 @@ const Header = () => {
 	} );
 
 	if ( siteIconUrl ) {
-		buttonIcon = <img alt={ __( 'Site Icon' ) } src={ siteIconUrl } />;
+		buttonIcon = (
+			<img alt={ __( 'Site Icon', 'woocommerce' ) } src={ siteIconUrl } />
+		);
 	} else if ( isRequestingSiteIcon ) {
 		buttonIcon = null;
 	}

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/Plugin.tsx
@@ -81,7 +81,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 							onManage( slug );
 						} }
 					>
-						{ __( 'Manage', 'woocommmerce-admin' ) }
+						{ __( 'Manage', 'woocommerce' ) }
 					</Button>
 				) }
 				{ isInstalled && ! isActive && (
@@ -91,7 +91,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>
-						{ __( 'Activate', 'woocommmerce-admin' ) }
+						{ __( 'Activate', 'woocommerce' ) }
 					</Button>
 				) }
 				{ ! isInstalled && (
@@ -101,7 +101,7 @@ export const Plugin: React.FC< PluginProps > = ( {
 						isSecondary
 						onClick={ () => installAndActivate( slug ) }
 					>
-						{ __( 'Get started', 'woocommmerce-admin' ) }
+						{ __( 'Get started', 'woocommerce' ) }
 					</Button>
 				) }
 			</div>

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-modal.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-modal.tsx
@@ -21,10 +21,13 @@ const LoadSampleProductModal: React.FC = () => {
 		>
 			<Spinner color="#007cba" size={ 48 } />
 			<Text className="woocommerce-load-sample-product-modal__title">
-				{ __( 'Loading sample products' ) }
+				{ __( 'Loading sample products', 'woocommerce' ) }
 			</Text>
 			<Text className="woocommerce-load-sample-product-modal__description">
-				{ __( 'We are loading 9 sample products into your store' ) }
+				{ __(
+					'We are loading 9 sample products into your store',
+					'woocommerce'
+				) }
 			</Text>
 		</Modal>
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/card-layout.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/card-layout.tsx
@@ -30,7 +30,8 @@ const CardLayout: React.FC< CardProps > = ( { items } ) => {
 			<Text className="woocommerce-products-card-layout__description">
 				{ interpolateComponents( {
 					mixedString: __(
-						'{{sbLink}}Start blank{{/sbLink}} or select a product type:'
+						'{{sbLink}}Start blank{{/sbLink}} or select a product type:',
+						'woocommerce'
 					),
 					components: {
 						sbLink: (

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/constants.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/constants.tsx
@@ -76,7 +76,8 @@ export const LoadSampleProductType = {
 	key: 'load-sample-product' as const,
 	title: __( 'can’t decide?', 'woocommerce' ),
 	content: __(
-		'Load sample products and see what they look like in your store.'
+		'Load sample products and see what they look like in your store.',
+		'woocommerce'
 	),
 	before: <LightBulb />,
 	after: <Icon icon={ chevronRight } />,

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/footer.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/footer.tsx
@@ -25,7 +25,8 @@ const Footer: React.FC = () => {
 			<Text className="woocommerce-products-footer__import-options">
 				{ interpolateComponents( {
 					mixedString: __(
-						'{{importCSVLink}}Import your products from a CSV file{{/importCSVLink}} or {{_3rdLink}}use a 3rd party migration plugin{{/_3rdLink}}.'
+						'{{importCSVLink}}Import your products from a CSV file{{/importCSVLink}} or {{_3rdLink}}use a 3rd party migration plugin{{/_3rdLink}}.',
+						'woocommerce'
 					),
 					components: {
 						importCSVLink: (

--- a/plugins/woocommerce-admin/client/tasks/fills/products/product-template-modal.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/product-template-modal.js
@@ -159,7 +159,7 @@ export default function ProductTemplateModal( { onClose } ) {
 
 	return (
 		<Modal
-			title={ __( 'Start with a template' ) }
+			title={ __( 'Start with a template', 'woocommerce' ) }
 			isDismissible={ true }
 			onRequestClose={ () => onClose() }
 			className="woocommerce-product-template-modal"
@@ -193,7 +193,7 @@ export default function ProductTemplateModal( { onClose } ) {
 						disabled={ ! selectedTemplate || isRedirecting }
 						onClick={ createTemplate }
 					>
-						{ __( 'Go' ) }
+						{ __( 'Go', 'woocommerce' ) }
 					</Button>
 				</div>
 			</div>

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -66,7 +66,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 
 	const onDismiss = useCallback( () => {
 		dismissTask( id );
-		createNotice( 'success', __( 'Task dismissed' ), {
+		createNotice( 'success', __( 'Task dismissed', 'woocommerce' ), {
 			actions: [
 				{
 					label: __( 'Undo', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/two-column-tasks/headers/woocommerce-payments.js
+++ b/plugins/woocommerce-admin/client/two-column-tasks/headers/woocommerce-payments.js
@@ -89,7 +89,7 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 				</Button>
 				<p className="woocommerce-task-header__timer">
 					<img src={ TimerImage } alt="Timer" />{ ' ' }
-					<span>{ __( '2 minutes' ) }</span>
+					<span>{ __( '2 minutes', 'woocommerce' ) }</span>
 				</p>
 			</div>
 		</div>

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item-two-column.tsx
@@ -46,7 +46,7 @@ export const TaskListItemTwoColumn: React.FC< TaskListItemProps > = ( {
 
 	const onDismissTask = ( onDismiss?: () => void ) => {
 		dismissTask( taskId );
-		createNotice( 'success', __( 'Task dismissed' ), {
+		createNotice( 'success', __( 'Task dismissed', 'woocommerce' ), {
 			actions: [
 				{
 					label: __( 'Undo', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-item.tsx
@@ -97,7 +97,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 
 	const onDismiss = useCallback( () => {
 		dismissTask( task.id );
-		createNotice( 'success', __( 'Task dismissed' ), {
+		createNotice( 'success', __( 'Task dismissed', 'woocommerce' ), {
 			actions: [
 				{
 					label: __( 'Undo', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/utils/admin-settings.js
+++ b/plugins/woocommerce-admin/client/utils/admin-settings.js
@@ -40,7 +40,10 @@ export function getAdminSetting(
 ) {
 	if ( mutableSources.includes( name ) ) {
 		throw new Error(
-			__( 'Mutable settings should be accessed via data store.' )
+			__(
+				'Mutable settings should be accessed via data store.',
+				'woocommerce'
+			)
 		);
 	}
 	const value = ADMIN_SETTINGS_SOURCE.hasOwnProperty( name )
@@ -75,7 +78,10 @@ export const ORDER_STATUSES = getAdminSetting( 'orderStatuses' );
 export function setAdminSetting( name, value, filter = ( val ) => val ) {
 	if ( mutableSources.includes( name ) ) {
 		throw new Error(
-			__( 'Mutable settings should be mutated via data store.' )
+			__(
+				'Mutable settings should be mutated via data store.',
+				'woocommerce'
+			)
 		);
 	}
 	ADMIN_SETTINGS_SOURCE[ name ] = filter( value );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-load-sample-products-notice/index.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/onboarding-load-sample-products-notice/index.ts
@@ -8,7 +8,7 @@ import { getAdminLink } from '@woocommerce/settings';
 
 domReady( () => {
 	dispatch( 'core/notices' ).createSuccessNotice(
-		__( 'Sample products added' ),
+		__( 'Sample products added', 'woocommerce' ),
 		{
 			id: 'WOOCOMMERCE_ONBOARDING_LOAD_SAMPLE_PRODUCTS_NOTICE',
 			actions: [

--- a/plugins/woocommerce/changelog/dev-update-eslint-config
+++ b/plugins/woocommerce/changelog/dev-update-eslint-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing text domain strings


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Update the `i18n-text-domain` eslint rule to only allow `woocommerce` text domain to prevent missing or wrong text domain issues.
- Fix missing/wrong text domain in `__()`

### How to test the changes in this Pull Request:

Review the changes

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
