### PR TITLE
Remove FB extension from Installed marketing extensions list.

### DIFF
--- a/plugins/woocommerce/changelog/tweak-remove-fb-from-marketing-extensions-list
+++ b/plugins/woocommerce/changelog/tweak-remove-fb-from-marketing-extensions-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Removed Facebook for WooCommerce extension from the Installed marketing extensions list.

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -23,7 +23,6 @@ class InstalledExtensions {
 
 		$automatewoo = self::get_automatewoo_extension_data();
 		$mailchimp   = self::get_mailchimp_extension_data();
-		$facebook    = self::get_facebook_extension_data();
 		$pinterest   = self::get_pinterest_extension_data();
 		$google      = self::get_google_extension_data();
 		$hubspot     = self::get_hubspot_extension_data();
@@ -36,10 +35,6 @@ class InstalledExtensions {
 
 		if ( $mailchimp ) {
 			$data[] = $mailchimp;
-		}
-
-		if ( $facebook ) {
-			$data[] = $facebook;
 		}
 
 		if ( $pinterest ) {
@@ -75,7 +70,6 @@ class InstalledExtensions {
 			'automatewoo',
 			'mailchimp-for-woocommerce',
 			'creative-mail-by-constant-contact',
-			'facebook-for-woocommerce',
 			'pinterest-for-woocommerce',
 			'google-listings-and-ads',
 			'hubspot-for-woocommerce',
@@ -130,35 +124,6 @@ class InstalledExtensions {
 			if ( mailchimp_is_configured() ) {
 				$data['status'] = 'configured';
 			}
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Get Facebook extension data.
-	 *
-	 * @return array|bool
-	 */
-	protected static function get_facebook_extension_data() {
-		$slug = 'facebook-for-woocommerce';
-
-		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
-			return false;
-		}
-
-		$data         = self::get_extension_base_data( $slug );
-		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/facebook.svg';
-
-		if ( 'activated' === $data['status'] && function_exists( 'facebook_for_woocommerce' ) ) {
-			$integration = facebook_for_woocommerce()->get_integration();
-
-			if ( $integration->is_configured() ) {
-				$data['status'] = 'configured';
-			}
-
-			$data['settingsUrl'] = facebook_for_woocommerce()->get_settings_url();
-			$data['docsUrl']     = facebook_for_woocommerce()->get_documentation_url();
 		}
 
 		return $data;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

We receive a request to remove Facebook for Woocommerce from the  Installed marketing extensions list.

Slack:
p1657265537452759-slack-CK365S85V

### How to test the changes in this Pull Request:

1. Check out this branch. 
2. then navigate the Marketing in your WooCommerce site - https://example.site/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing
3. Confirm that FB isn't listed in the "Installed marketing extensions" section of the marketing page.

After this change:

![Screenshot 2022-07-08 at 09 48 27](https://user-images.githubusercontent.com/4209011/177947543-b5e222f8-b607-4e8d-8770-742095b44d30.jpg)

Before this change:

![Screenshot 2022-07-08 at 09 48 18](https://user-images.githubusercontent.com/4209011/177947557-1e3a2db2-49c8-4e71-90e2-ec38004639db.jpg)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable? - N/A
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.