### PR TITLE
Column sorting for the COT admin list table.

### DIFF
--- a/plugins/woocommerce/changelog/add-33199-cot-list-sortability
+++ b/plugins/woocommerce/changelog/add-33199-cot-list-sortability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add support for sorting columns in the COT admin list UI.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -430,7 +430,7 @@ class ListTable extends WP_List_Table {
 		return array(
 			'order_number' => 'ID',
 			'order_date'   => 'date',
-			'order_total'  => 'total',
+			'order_total'  => 'order_total',
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -195,36 +195,14 @@ class ListTable extends WP_List_Table {
 	private function set_order_args() {
 		$sortable  = $this->get_sortable_columns();
 		$field     = sanitize_text_field( wp_unslash( $_GET['orderby'] ?? '' ) );
-		$direction = sanitize_text_field( wp_unslash( $_GET['order'] ?? '' ) );
-
-		switch ( $direction ) {
-			case 'asc':
-			case 'desc':
-				$direction = strtoupper( $direction );
-				break;
-
-			default:
-				return;
-		}
+		$direction = strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ?? '' ) ) );
 
 		if ( ! in_array( $field, $sortable, true ) ) {
 			return;
 		}
 
-		switch ( $field ) {
-			// @todo Revise and replace once work on https://github.com/woocommerce/woocommerce/issues/33613 completes.
-			//       This approach to sorting by order total works with the legacy data store, but will not work well
-			//       with COT (however, we can do something clean and efficient once query support is added by #33613).
-			case 'total':
-				$this->order_query_args['meta_key'] = '_order_total';
-				$this->order_query_args['orderby']  = 'meta_value_num';
-				break;
-
-			default:
-				$this->order_query_args['orderby'] = $field;
-		}
-
-		$this->order_query_args['order']   = $direction;
+		$this->order_query_args['orderby'] = $field;
+		$this->order_query_args['order']   = in_array( $direction, array( 'ASC', 'DESC' ), true ) ? $direction : 'ASC';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -235,6 +235,7 @@ class ListTable extends WP_List_Table {
 		return $view_links;
 	}
 
+	// phpcs:disable Generic.Commenting.Todo.CommentFound
 	/**
 	 * Count orders by status.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -174,7 +174,7 @@ class ListTable extends WP_List_Table {
 		 * Provides an opportunity to modify the query arguments used in the (Custom Order Table-powered) order list
 		 * table.
 		 *
-		 * @since 6.8.0
+		 * @since 6.9.0
 		 *
 		 * @param array $query_args Arguments to be passed to `wc_get_orders()`.
 		 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -164,7 +164,7 @@ class ListTable extends WP_List_Table {
 			'limit'    => $limit,
 			'page'     => $this->get_pagenum(),
 			'paginate' => true,
-			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? 'all' ) ),
+			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? 'any' ) ),
 			'type'     => 'shop_order',
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -171,7 +171,15 @@ class ListTable extends WP_List_Table {
 
 		$this->set_order_args();
 
-		$orders      = wc_get_orders( $this->order_query_args );
+		/**
+		 * Provides an opportunity to modify the query arguments used in the (Custom Order Table-powered) order list
+		 * table.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array $query_args Arguments to be passed to `wc_get_orders()`.
+		 */
+		$orders      = wc_get_orders( (array) apply_filters( 'woocommerce_order_list_table_prepare_items_query_args', $this->order_query_args ) );
 		$this->items = $orders->orders;
 
 		$this->set_pagination_args(

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -3,7 +3,6 @@
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
-use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use WC_Order;
 use WP_List_Table;
 use WP_Screen;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -261,12 +261,16 @@ class OrdersTableQuery {
 
 		// Translate $orderby to a valid field.
 		$mapping = array(
-			'ID'       => "{$this->tables['orders']}.id",
-			'id'       => "{$this->tables['orders']}.id",
-			'type'     => "{$this->tables['orders']}.type",
-			'date'     => "{$this->tables['orders']}.date_created_gmt",
-			'modified' => "{$this->tables['orders']}.date_updated_gmt",
-			'parent'   => "{$this->tables['orders']}.parent_order_id",
+			'ID'            => "{$this->tables['orders']}.id",
+			'id'            => "{$this->tables['orders']}.id",
+			'type'          => "{$this->tables['orders']}.type",
+			'date'          => "{$this->tables['orders']}.date_created_gmt",
+			'date_created'  => "{$this->tables['orders']}.date_created_gmt",
+			'modified'      => "{$this->tables['orders']}.date_updated_gmt",
+			'date_modified' => "{$this->tables['orders']}.date_updated_gmt",
+			'parent'        => "{$this->tables['orders']}.parent_order_id",
+			'total'         => "{$this->tables['orders']}.total_amount",
+			'order_total'   => "{$this->tables['orders']}.total_amount",
 		);
 
 		$order   = $this->args['order'] ?? '';


### PR DESCRIPTION
Implements sortable columns for the COT admin list table.

![cot-order-table-sortability](https://user-images.githubusercontent.com/3594411/178050315-0bc89bc5-e9ce-4496-b301-7de4e9fe69ab.gif)

Closes #33199.

### How to test the changes in this Pull Request:

Provisionally (until COT querying is supported), we can test this using a 'shim'. Temporarily modify the first line in `WC_Admin_Menus::orders_menu()`, changing it to:

```php
if ( $_GET['page'] === 'wc-orders' || wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
```

This lets us test the new COT admin list table screen (access it at `/wp-admin/admin.php?page=wc-orders`) but also leaves the CPT admin list table (access it at `/wp-admin/edit.php?post_type=shop_order`) available for easy comparison between the two. 

Alternatively, follow the slightly simpler but similar instructions in https://github.com/woocommerce/woocommerce/pull/32864. From there, simply test that you can sort the following columns (in ascending as well as descending order):

1. Order ID
2. Order Date
3. Order Total

### Other information:

- The code for sorting by order total mimics how we do things for CPT orders (and probably won't work with COT orders). Once initial work on $33613 is ready, however, we can revise this and improve it. We should keep this as a draft until then.
- I've added one additional hook to allow customizations to do their own filtering and sorting magic as needed. For various other things, they can continue to use standard WP hooks such as `manage_woocommerce_page_<SCREEN-ID>_sortable_columns` to customize the table.

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
