### PR TITLE
Apply shipping smart defaults when country is US and Jetpack is installed

### DIFF
--- a/plugins/woocommerce/changelog/update-33751-shipping-smart-defaults-edge-cases
+++ b/plugins/woocommerce/changelog/update-33751-shipping-smart-defaults-edge-cases
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Set ddefault shipping methods when store country is the US and Jetpack is intalled

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -111,12 +111,9 @@ class Homescreen {
 		}
 
 		$is_jetpack_installed = in_array( 'jetpack', $settings['plugins']['installedPlugins'] ?? array(), true );
-		$is_jetpack_connected = $settings['dataEndpoints']['jetpackStatus']['isUserConnected'] ?? false;
 		$is_wcs_installed     = in_array( 'woocommerce-services', $settings['plugins']['installedPlugins'] ?? array(), true );
 
 		if (
-			( 'US' === $country_code && $is_jetpack_installed && $is_wcs_installed && $is_jetpack_connected )
-			||
 			( 'US' === $country_code && $is_jetpack_installed )
 			||
 			( ! in_array( $country_code, array( 'US', 'CA', 'AU', 'GB' ), true ) )

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -87,8 +87,8 @@ class Homescreen {
 		}
 
 		$user_skipped_obw = $settings['onboarding']['profile']['skipped'] ?? false;
-		$store_address = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
-		$product_types = $settings['onboarding']['profile']['product_types'] ?? array();
+		$store_address    = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
+		$product_types    = $settings['onboarding']['profile']['product_types'] ?? array();
 
 		// If user skipped the obw or has not completed the store_details
 		// then we assume the user is going to sell physical products.
@@ -116,6 +116,8 @@ class Homescreen {
 
 		if (
 			( 'US' === $country_code && $is_jetpack_installed && $is_wcs_installed && $is_jetpack_connected )
+			||
+			( 'US' === $country_code && $is_jetpack_installed )
 			||
 			( ! in_array( $country_code, array( 'US', 'CA', 'AU', 'GB' ), true ) )
 			||


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33751

### How to test the changes in this Pull Request:

1. Start with a fresh install
2. Enable `shipping-smart-defaults` feature
3. Sart OBW and choose the United States as store country
4. Choose "Physical products"
5. Install Jetpack from the `Business Details` step
6. Complete the OBW
7. Navigate to `WooCommerce -> Home`
8. Confirm the shipping task is not on the task list.
9. Navigate to `WooCommerce -> Settings -> Shipping`
10. "United States (US)" zone should be created with Free shipping method

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
