### PR TITLE
Trashed coupons should not be usable (unless restored).

### DIFF
--- a/plugins/woocommerce/changelog/fix-22052-coupon-trash
+++ b/plugins/woocommerce/changelog/fix-22052-coupon-trash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When a coupon has been trashed, it should become unusable.

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -576,13 +576,16 @@ class WC_Discounts {
 	/**
 	 * Ensure coupon exists or throw exception.
 	 *
+	 * A coupon is also considered to no longer exist if it has been placed in the trash, even if the trash has not yet
+	 * been emptied.
+	 *
 	 * @since  3.2.0
 	 * @throws Exception Error message.
 	 * @param  WC_Coupon $coupon Coupon data.
 	 * @return bool
 	 */
 	protected function validate_coupon_exists( $coupon ) {
-		if ( ! $coupon->get_id() && ! $coupon->get_virtual() ) {
+		if ( ( ! $coupon->get_id() && ! $coupon->get_virtual() ) || 'trash' === $coupon->get_status() ) {
 			/* translators: %s: coupon code */
 			throw new Exception( sprintf( __( 'Coupon "%s" does not exist!', 'woocommerce' ), esc_html( $coupon->get_code() ) ), 105 );
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-discounts-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-discounts-tests.php
@@ -93,4 +93,23 @@ class WC_Discounts_Tests extends WC_Unit_Test_Case {
 		$this->assertWPError( $valid );
 		$this->assertEquals( $coupon->get_coupon_error( WC_Coupon::E_WC_COUPON_USAGE_LIMIT_COUPON_STUCK ), $valid->get_error_message() );
 	}
+
+	/**
+	 * Test if coupon is valid (it shouldn't be) if it has been placed in the trash.
+	 */
+	public function test_is_trashed_coupon_valid() {
+		$coupon = new WC_Coupon( uniqid() );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		$discounts = new WC_Discounts();
+		$this->assertTrue( $discounts->is_coupon_valid( $coupon ), 'Newly created coupon is initially valid.' );
+
+		wp_trash_post( $coupon->get_id() );
+		$coupon = new WC_Coupon( $coupon );
+		$result = $discounts->is_coupon_valid( $coupon );
+		$this->assertInstanceOf( WP_Error::class, $result, 'Once trashed, the coupon is no longer valid.' );
+		$this->assertEquals( 'invalid_coupon', $result->get_error_code(), 'We receive an appropriate WP_Error.' );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Once a coupon has been placed in the trash, it should no longer be usable.

Closes #22052.

### How to test the changes in this Pull Request:

1. Create a new coupon without any restrictions. 
2. As a customer, add a product to the cart and try applying the coupon (should work).
3. Now trash the coupon. 
4. Continuing with the same shopping session as earlier, try to checkout and buy: you should find you are directed to return to the cart and the coupon is ultimately removed.
5. Now as a **new** customer, try buying something and apply the same coupon. It should be rejected right away:

<img width="478" alt="coupon-does-not-exist" src="https://user-images.githubusercontent.com/3594411/178079347-8765550e-d0e8-4d38-9ca1-a7d3cb76915f.png">

7. As merchant, restore the coupon from the trash.
8. Continuing with the second shopping session, try applying the coupon once more. It should now work:

<img width="478" alt="coupon-applied" src="https://user-images.githubusercontent.com/3594411/178079154-af013a56-77b2-4dc9-bda1-483417d52c3d.png">

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
- [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
