### PR TITLE
Move all beta tester release config into woorelease

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/consolidate-beta-tester-config
+++ b/plugins/woocommerce-beta-tester/changelog/consolidate-beta-tester-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Move release config in package json into woorelease object.

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -9,9 +9,6 @@
 	"title": "WooCommerce Beta Tester",
 	"version": "2.1.0",
 	"homepage": "http://github.com/woocommerce/woocommerce-beta-tester",
-	"config": {
-		"build_step": "pnpm run build:zip"
-	},
 	"devDependencies": {
 		"@woocommerce/dependency-extraction-webpack-plugin": "workspace:*",
 		"@woocommerce/eslint-plugin": "workspace:*",
@@ -67,7 +64,8 @@
 	},
 	"woorelease": {
 		"svn_reauth": "true",
-		"wp_org_slug": "woocommerce-beta-tester"
+		"wp_org_slug": "woocommerce-beta-tester",
+		"build_step": "pnpm run build:zip"
 	},
 	"lint-staged": {
 		"*.php": [


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
As discussed with @psealock in https://github.com/woocommerce/woorelease/pull/381 this consolidates all the release config for `woocommerce-beta-tester` into `woorelease`. `config` was supported in `woorelease` for backward compatibility but `woorelease` does not support having both in place. Once https://github.com/woocommerce/woorelease/pull/381 is merged, releases for `woocommerce-beta-tester` should work properly again.

### How to test the changes in this Pull Request:

There is not a direct way to test this until https://github.com/woocommerce/woorelease/pull/381 is merged. 
### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
