### PR TITLE
Fix/33253 fix order number in notice

### DIFF
--- a/plugins/woocommerce/changelog/fix-33253-fix-order-count-in-order-notice
+++ b/plugins/woocommerce/changelog/fix-33253-fix-order-count-in-order-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the order count displayed in the 'Order status changed' and 'Removed personal data' notices

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -591,7 +591,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		foreach ( $order_statuses as $slug => $name ) {
 			if ( 'marked_' . str_replace( 'wc-', '', $slug ) === $bulk_action ) { // WPCS: input var ok, CSRF ok.
 				/* translators: %d: orders count */
-				$message = sprintf( _n( '%d order status changed.', '%d order statuses changed.', $number, 'woocommerce' ), number_format_i18n( $number ) );
+				$message = sprintf( _n( '%s order status changed.', '%s order statuses changed.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 				echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';
 				break;
 			}
@@ -599,7 +599,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 		if ( 'removed_personal_data' === $bulk_action ) { // WPCS: input var ok, CSRF ok.
 			/* translators: %d: orders count */
-			$message = sprintf( _n( 'Removed personal data from %d order.', 'Removed personal data from %d orders.', $number, 'woocommerce' ), number_format_i18n( $number ) );
+			$message = sprintf( _n( 'Removed personal data from %s order.', 'Removed personal data from %s orders.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 			echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';
 		}
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes the incorrect count of order numbers displayed in the 'Order status changed' and 'Removed personal data' notices after bulk editing a large number of orders (  > 999 ).

The problem lies in [this line of code](https://github.com/woocommerce/woocommerce/blob/6.6.1/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php#L725) : 

`sprintf( _n( '%s order status changed.', '%d order statuses changed.', $number, 'woocommerce' ), number_format_i18n( $number ) )`

So, if $number is 1000, `number_format_i18n()` converts it into string '1,000' which `sprintf()` renders as '1' due to the specifier `%d`, which treats the resultant string ('1,000') as an integer and renders it as a (signed) decimal number.
I have replaced the `%d` with `%s` for both 'Order status changed' and 'Removed personal data' notices.

With this fix, the order count will reflect correctly in the notice :

<img width="1675" alt="33253-order-count-fix" src="https://user-images.githubusercontent.com/64858136/178210432-86fb296c-b44a-4db0-86e7-a44a50e7cd4e.png">


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33253 

### How to test the changes in this Pull Request:

1. Setup a WooCommerce store with one product
2. Go to the Orders page with this link:
/wp-admin/edit.php?post_type=shop_order&paged=1&bulk_action=marked_completed&changed=9999
3. Check the notice message

OR

1. Setup a WooCommerce store with one product
2. Make a large number of orders (at least 9999)
3. Mark all orders as "completed"
4. Check the notice message

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
