### PR TITLE
Enhancement - Add new customer address functions

### DIFF
--- a/plugins/woocommerce/changelog/class-wc-customer
+++ b/plugins/woocommerce/changelog/class-wc-customer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Fixed 33702 - Added functions to get formatted billing and shipping addresses

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -1146,4 +1146,51 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function set_is_paying_customer( $is_paying_customer ) {
 		$this->set_prop( 'is_paying_customer', (bool) $is_paying_customer );
 	}
+
+	/**
+	 * Get a formatted billing address for the customer.
+	 *
+	 * @param string $empty_content Content to show if no address is present.
+	 * @return string
+	 */
+	public function get_formatted_billing_address( $empty_content = '' ) {
+		$address     = '';
+		$raw_address = apply_filters( 'woocommerce_get_customer_address', array_merge( $this->data[ 'billing' ], $this->get_prop( 'billing', 'view' ) ), 'billing', $this );
+		
+		$raw_address = apply_filters( 'woocommerce_customer_formatted_billing_address', $raw_address, $this );
+		$address     = WC()->countries->get_formatted_address( $raw_address );
+
+		/**
+		 * Filter customer formatted billing address.
+		 *
+		 * @param string      $address     Formatted billing address string.
+		 * @param array       $raw_address Raw billing address.
+		 * @param WC_Customer $customer    Customer data.
+		 */
+		return apply_filters( 'woocommerce_customer_get_formatted_billing_address', $address ? $address : $empty_content, $raw_address, $this );
+	}
+
+	/**
+	 * Get a formatted shipping address for the order.
+	 *
+	 * @param string $empty_content Content to show if no address is present.
+	 * @return string
+	 */
+	public function get_formatted_shipping_address( $empty_content = '' ) {
+		$address     = '';
+		$raw_address = apply_filters( 'woocommerce_get_customer_address', array_merge( $this->data[ 'shipping' ], $this->get_prop( 'shipping', 'view' ) ), 'shipping', $this );
+		
+		$raw_address = apply_filters( 'woocommerce_customer_formatted_shipping_address', $raw_address, $this );
+		$address     = WC()->countries->get_formatted_address( $raw_address );
+
+		/**
+		 * Filter orders formatted shipping address.
+		 *
+		 * @since 3.8.0
+		 * @param string      $address     Formatted shipping address string.
+		 * @param array       $raw_address Raw shipping address.
+		 * @param WC_Customer $customer    Customer data.
+		 */
+		return apply_filters( 'woocommerce_order_get_formatted_shipping_address', $address ? $address : $empty_content, $raw_address, $this );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

Closes #33702

Added functions to get formatted billing and shipping address for customers to display on custom pages, emails, or any other places.

Simply you can use these function like below code:

`$customer_id = 2;
 $customer = new WC_Customer( $customer_id );
 echo $customer->get_formatted_shipping_address();`

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
