### PR TITLE
Added the border bottom of the modal's header

### DIFF
--- a/plugins/woocommerce-admin/client/layout/style.scss
+++ b/plugins/woocommerce-admin/client/layout/style.scss
@@ -136,7 +136,6 @@
 	max-width: 100%;
 
 	.components-modal__header {
-		border-bottom: 0;
 		margin-bottom: 0;
 	}
 

--- a/plugins/woocommerce-admin/client/tasks/tasks.scss
+++ b/plugins/woocommerce-admin/client/tasks/tasks.scss
@@ -54,7 +54,6 @@
 
 .components-modal__frame {
 	.components-modal__header {
-		border-bottom: 0;
 		margin-bottom: 0;
 	}
 

--- a/plugins/woocommerce/changelog/added-modal-border-bottom
+++ b/plugins/woocommerce/changelog/added-modal-border-bottom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Fixed 33720 - I have fixed the border-bottom not coming in the header of the component modal.

--- a/plugins/woocommerce/changelog/added-modal-border-bottom
+++ b/plugins/woocommerce/changelog/added-modal-border-bottom
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Fixed 33720 - I have fixed the border-bottom not coming in the header of the component modal.
+Add the border bottom of the modal's header


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
I have fixed the border-bottom not coming in the header of the component modal.

Closes #33720

### Steps to reproduce:

1. Use a fresh site
2. Go to OBW
3. Fill out store details
4. Click "Continue"
5. Observer that the `Build a better WooCommerce` modal's header contains a bottom border 

![Screen Shot 2022-07-15 at 14 34 22](https://user-images.githubusercontent.com/4344253/179165436-9214d70c-d31c-4359-a712-e4afd14be318.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
