### PR TITLE
Add required fields to CrudActions type

### DIFF
--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -23,24 +23,34 @@ export type ItemQuery = BaseQueryParams & {
 	[ key: string ]: unknown;
 };
 
-export type CrudActions< ResourceName, ItemType, MutableProperties > =
+type WithRequiredProperty< Type, Key extends keyof Type > = Type & {
+	[ Property in Key ]-?: Type[ Property ];
+};
+
+export type CrudActions<
+	ResourceName,
+	ItemType,
+	MutableProperties,
+	RequiredFields extends keyof MutableProperties | undefined = undefined
+> = MapActions<
+	{
+		create: ( query: Partial< ItemType > ) => Item;
+		update: ( query: Partial< ItemType > ) => Item;
+	},
+	ResourceName,
+	RequiredFields extends keyof MutableProperties
+		? WithRequiredProperty< Partial< MutableProperties >, RequiredFields >
+		: Partial< MutableProperties >,
+	Generator< unknown, ItemType >
+> &
 	MapActions<
 		{
-			create: ( query: ItemQuery ) => Item;
-			update: ( query: ItemQuery ) => Item;
+			delete: ( id: IdType ) => Item;
 		},
 		ResourceName,
-		MutableProperties,
+		IdType,
 		Generator< unknown, ItemType >
-	> &
-		MapActions<
-			{
-				delete: ( id: IdType ) => Item;
-			},
-			ResourceName,
-			IdType,
-			Generator< unknown, ItemType >
-		>;
+	>;
 
 export type CrudSelectors<
 	ResourceName,

--- a/packages/js/data/src/product-shipping-classes/types.ts
+++ b/packages/js/data/src/product-shipping-classes/types.ts
@@ -26,14 +26,13 @@ type Query = BaseQueryParams< keyof ProductShippingClass > & {
 
 type ReadOnlyProperties = 'id';
 
-type MutableProperties = Partial<
-	Omit< ProductShippingClass, ReadOnlyProperties >
->;
+type MutableProperties = Omit< ProductShippingClass, ReadOnlyProperties >;
 
 type ProductShippingClassActions = CrudActions<
 	'ProductShippingClass',
 	ProductShippingClass,
-	MutableProperties
+	MutableProperties,
+	'name'
 >;
 
 export type ProductShippingClassSelectors = CrudSelectors<


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Modify the `CrudActions` type to allow the passing in of required fields that are required when creating a specific crud type.
This was suggested as part of #33765

### How to test the changes in this Pull Request:

1. Load this branch and run a build
2. Open a Typescript component file in WooCommerce Client Admin, I have been using `progress-header.tsx` (you could also create a new TS file)
3. Paste in:
```
const test = useDispatch(
		EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
) as ProductShippingClassesActions;
test.createProductShippingClass( { name: 'test', slug: 'test' } );
const test2 = useDispatch(
		PRODUCT_ATTRIBUTES_STORE_NAME
) as ProductAttributesActions;
test2.createProductAttribute( { name: 'test' } );
```
4. You will likely have to import some of the above types and constants from `@woocommerce/data`
5. Now remove `name: 'test'` from `createProductShippingClass`, it should show a Typescript error that `name` is required.
6. You can remove `name: 'test'` from `createProductAttribute` without a Typescript error as it isn't required.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
