### PR TITLE
Use transient to cache Shipping::has_shipping_zones() result

### DIFF
--- a/plugins/woocommerce/changelog/update-33782-add-caching-for-loading-shipping-zones
+++ b/plugins/woocommerce/changelog/update-33782-add-caching-for-loading-shipping-zones
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Use transient to cache Shipping:has_shipping_zones() method

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -5,13 +5,34 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use Automattic\WooCommerce\Admin\PluginsHelper;
 use WC_Data_Store;
 
 /**
  * Shipping Task
  */
 class Shipping extends Task {
+
+	const ZONE_COUNT_TRANSIENT_NAME = 'woocommerce_shipping_task_zone_count_transient';
+
+	/**
+	 * Constructor
+	 *
+	 * @param TaskList $task_list Parent task list.
+	 */
+	public function __construct( $task_list = null ) {
+		parent::__construct( $task_list );
+		// wp_ajax_woocommerce_shipping_zone_methods_save_changes
+		// and wp_ajax_woocommerce_shipping_zones_save_changes get fired
+		// when a new zone is added or an existing one has been changed.
+		// Delete the zone count transient used in has_shipping_zones() method
+		// to refresh the cache.
+		$delete_transient = function() {
+			delete_transient( self::ZONE_COUNT_TRANSIENT_NAME );
+		};
+		add_action( 'wp_ajax_woocommerce_shipping_zones_save_changes', $delete_transient, 9 );
+		add_action( 'wp_ajax_woocommerce_shipping_zone_methods_save_changes', $delete_transient, 9 );
+	}
+
 	/**
 	 * ID.
 	 *
@@ -133,7 +154,15 @@ class Shipping extends Task {
 	 * @return bool
 	 */
 	public static function has_shipping_zones() {
-		return count( WC_Data_Store::load( 'shipping-zone' )->get_zones() ) > 0;
+		$zone_count = get_transient( self::ZONE_COUNT_TRANSIENT_NAME );
+		if ( false !== $zone_count ) {
+			return (int) $zone_count > 0;
+		}
+
+		$zone_count = count( WC_Data_Store::load( 'shipping-zone' )->get_zones() );
+		set_transient( self::ZONE_COUNT_TRANSIENT_NAME, $zone_count );
+
+		return $zone_count > 0;
 	}
 
 	/**
@@ -165,6 +194,6 @@ class Shipping extends Task {
 		$profiler_data = get_option( OnboardingProfile::DATA_OPTION, array() );
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 
-		return [ 'downloads' ] === $product_types;
+		return array( 'downloads' ) === $product_types;
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33782 

This PR uses a transient to cache has_shipping_zones call result to save unnecessary D.B calls.

### How to test the changes in this Pull Request:

It's hard to test visually. Let's use `error_log` to log to test.

1. Start with a fresh install and complete OBW.
2. Open `plugins/woocommerce/src/Features/OnboardingTasks/Tasks/Shipping.php` and make changes to `has_shipping_zones()

**Before**

```
	public static function has_shipping_zones() {
		$zone_count = get_transient( self::ZONE_COUNT_TRANSIENT_NAME );
		if ( false !== $zone_count ) {
			return (int) $zone_count > 0;
		}

		$zone_count = count( WC_Data_Store::load( 'shipping-zone' )->get_zones() );
		set_transient( self::ZONE_COUNT_TRANSIENT_NAME, $zone_count );

		return $zone_count > 0;
	}
```

**After**: Added error_log() 
```
	public static function has_shipping_zones() {
		$zone_count = get_transient( self::ZONE_COUNT_TRANSIENT_NAME );
		if ( false !== $zone_count ) {
                         error_log('from cache '.$zone_count);
			return (int) $zone_count > 0;
		}

		$zone_count = count( WC_Data_Store::load( 'shipping-zone' )->get_zones() );
		set_transient( self::ZONE_COUNT_TRANSIENT_NAME, $zone_count );
                error_log('from db '.$zone_count);
		return $zone_count > 0;
	}
```

3. Open a terminal session and start tailing `wp-content/debug.log`. Make sure `WP_DEBUG` and `WP_DEBUG_LOG` constants are set in your WordPress `config.php`
4. Go to `WooCommerce -> Settings -> Shipping`
5. You should see a single `from db 0` log and multiple `from cache 0` logs
6. Add a shipping zone.
7. You should see a single `from db 1` log and multiple `from cache 1` logs.
8. Refresh the page. You should only see multiple `from cache 1` logs



### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
