### PR TITLE
Consider WC Admin is disabled when analytics feature is disabled in WC Status widget

### DIFF
--- a/plugins/woocommerce/changelog/feature-33814-wc-status-errors-when-analytics-feature-is-disabled
+++ b/plugins/woocommerce/changelog/feature-33814-wc-status-errors-when-analytics-feature-is-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WC Status widget errors when analytics feature is disabled

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -127,7 +128,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
 
-			$is_wc_admin_disabled = apply_filters( 'woocommerce_admin_disabled', false );
+			//phpcs:ignore
+			$is_wc_admin_disabled = apply_filters( 'woocommerce_admin_disabled', false ) || ! Features::is_enabled( 'analytics' );
 
 			$reports = new WC_Admin_Report();
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33814  .

This PR fixes WC Status widget error when the analytics feature is disabled by not querying Analytics endpoints when the feature is disabled.

### How to test the changes in this Pull Request:

Confirm the errors by following steps from the original issue #33814 

1. Enable `WP_DEBUG` and `WP_DEBUG_LOG` constants.
2. Check out this branch and repeat the steps from the original issue #33814 
3. Confirm no errors/notices are shown in `wp-contents/debug.log` file.


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
