### PR TITLE
Fixed checking post object and field ID

### DIFF
--- a/plugins/woocommerce/changelog/wc-meta-box-functions
+++ b/plugins/woocommerce/changelog/wc-meta-box-functions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed issue to check post object and field ID when text input create

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -19,6 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 function woocommerce_wp_text_input( $field ) {
 	global $thepostid, $post;
 
+	if( empty( $thepostid ) && ( ! isset( $post->ID ) || empty( $post->ID ) ) ) {
+		return;
+	}
+
+	if( ! isset( $field['id'] ) || empty( $field['id'] ) ) {
+		return;
+	}
+
 	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
 	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
 	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33372.

### How to test the changes in this Pull Request:

1. If the post ID or post object does not have data then it would be returned so it would not cause any warning/errors.
2. It returns when text field ID is not provided as it is required.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
