### PR TITLE
Proper commenting of a function

### DIFF
--- a/plugins/woocommerce/changelog/update-proper-commenting-of-a-function
+++ b/plugins/woocommerce/changelog/update-proper-commenting-of-a-function
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Fixed 33822 - I have written the commenting proper of this get_formatted_shipping_address function.

--- a/plugins/woocommerce/changelog/update-proper-commenting-of-a-function
+++ b/plugins/woocommerce/changelog/update-proper-commenting-of-a-function
@@ -1,4 +1,4 @@
 Significance: minor
-Type: update
+Type: dev
 
-Fixed 33822 - I have written the commenting proper of this get_formatted_shipping_address function.
+Proper comment of get_formatted_shipping_address function.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -948,8 +948,8 @@ class WC_Order extends WC_Abstract_Order {
 		 * Filter orders formatted shipping address.
 		 *
 		 * @since 3.8.0
-		 * @param string   $address     Formatted billing address string.
-		 * @param array    $raw_address Raw billing address.
+		 * @param string   $address     Formatted shipping address string.
+		 * @param array    $raw_address Raw shipping address.
 		 * @param WC_Order $order       Order data. @since 3.9.0
 		 */
 		return apply_filters( 'woocommerce_order_get_formatted_shipping_address', $address ? $address : $empty_content, $raw_address, $this );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
I have written the commenting proper of this `get_formatted_shipping_address` function.

Closes #33822 

### How to test the changes in this Pull Request:

1. Search this '**get_formatted_shipping_address( $empty_content = '' )**' function in the WooCommerce plugin's files.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
