### PR TITLE
Update `jest-puppeteer@5.0.4` (from `4.4.0`)

### DIFF
--- a/packages/js/e2e-environment/changelog/update-jest-puppeteer
+++ b/packages/js/e2e-environment/changelog/update-jest-puppeteer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Updated `jest-puppeteer@^5.0.4`.

--- a/packages/js/e2e-environment/package.json
+++ b/packages/js/e2e-environment/package.json
@@ -33,7 +33,7 @@
 		"jest": "^25.1.0",
 		"jest-circus": "25.1.0",
 		"jest-each": "25.5.0",
-		"jest-puppeteer": "^4.4.0",
+		"jest-puppeteer": "^5.0.4",
 		"node-stream-zip": "^1.13.6",
 		"puppeteer": "2.1.1",
 		"readline-sync": "^1.4.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,7 +705,7 @@ importers:
       jest: ^25.1.0
       jest-circus: 25.1.0
       jest-each: 25.5.0
-      jest-puppeteer: ^4.4.0
+      jest-puppeteer: ^5.0.4
       ndb: ^1.1.5
       node-stream-zip: ^1.13.6
       puppeteer: 2.1.1
@@ -726,7 +726,7 @@ importers:
       jest: 25.5.4
       jest-circus: 25.1.0
       jest-each: 25.5.0
-      jest-puppeteer: 4.4.0_puppeteer@2.1.1
+      jest-puppeteer: 5.0.4_puppeteer@2.1.1
       node-stream-zip: 1.15.0
       puppeteer: 2.1.1
       readline-sync: 1.4.10
@@ -7973,18 +7973,20 @@ packages:
   /@hapi/address/2.1.4:
     resolution: {integrity: sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==}
     deprecated: Moved to 'npm install @sideway/address'
+    dev: true
 
   /@hapi/bourne/1.3.2:
     resolution: {integrity: sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==}
     deprecated: This version has been deprecated and is no longer supported or maintained
+    dev: true
 
   /@hapi/hoek/8.5.1:
     resolution: {integrity: sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==}
     deprecated: This version has been deprecated and is no longer supported or maintained
+    dev: true
 
   /@hapi/hoek/9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
-    dev: true
 
   /@hapi/joi/15.1.1:
     resolution: {integrity: sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==}
@@ -7994,18 +7996,19 @@ packages:
       '@hapi/bourne': 1.3.2
       '@hapi/hoek': 8.5.1
       '@hapi/topo': 3.1.6
+    dev: true
 
   /@hapi/topo/3.1.6:
     resolution: {integrity: sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==}
     deprecated: This version has been deprecated and is no longer supported or maintained
     dependencies:
       '@hapi/hoek': 8.5.1
+    dev: true
 
   /@hapi/topo/5.1.0:
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
     dependencies:
       '@hapi/hoek': 9.3.0
-    dev: true
 
   /@humanwhocodes/config-array/0.5.0:
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
@@ -9542,15 +9545,12 @@ packages:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
     dependencies:
       '@hapi/hoek': 9.3.0
-    dev: true
 
   /@sideway/formula/3.0.0:
     resolution: {integrity: sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==}
-    dev: true
 
   /@sideway/pinpoint/2.0.0:
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
-    dev: true
 
   /@sindresorhus/is/2.1.1:
     resolution: {integrity: sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==}
@@ -20591,6 +20591,7 @@ packages:
     resolution: {integrity: sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==}
     deprecated: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
     requiresBuild: true
+    dev: true
 
   /core-js/3.21.1:
     resolution: {integrity: sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==}
@@ -23674,6 +23675,11 @@ packages:
 
   /expect-puppeteer/4.4.0:
     resolution: {integrity: sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==}
+    dev: true
+
+  /expect-puppeteer/5.0.4:
+    resolution: {integrity: sha512-NV7jSiKhK+byocxg9A+0av+Q2RSCP9bcLVRz7zhHaESeCOkuomMvl9oD+uo1K+NdqRCXhNkQlUGWlmtbrpR1qw==}
+    dev: false
 
   /expect/24.9.0:
     resolution: {integrity: sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==}
@@ -27691,6 +27697,7 @@ packages:
       wait-on: 3.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-dev-server/5.0.3:
     resolution: {integrity: sha512-aJR3a5KdY18Lsz+VbREKwx2HM3iukiui+J9rlv9o6iYTwZCSsJazSTStcD9K1q0AIF3oA+FqLOKDyo/sc7+fJw==}
@@ -27705,7 +27712,6 @@ packages:
     transitivePeerDependencies:
       - debug
       - supports-color
-    dev: true
 
   /jest-diff/24.9.0:
     resolution: {integrity: sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==}
@@ -27990,6 +27996,20 @@ packages:
       merge-deep: 3.0.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /jest-environment-puppeteer/5.0.4:
+    resolution: {integrity: sha512-wd4EDOD4QRi11QZ1IV8WsL1wlnnMUtcqtU0BNm+REzRtg78K2XHn3jS6YxGeXIOnsgrJeHxsD7DlRZ/GkFteLg==}
+    dependencies:
+      chalk: 4.1.2
+      cwd: 0.10.0
+      jest-dev-server: 5.0.3
+      jest-environment-node: 27.5.1
+      merge-deep: 3.0.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+    dev: false
 
   /jest-get-type/24.9.0:
     resolution: {integrity: sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==}
@@ -28512,15 +28532,16 @@ packages:
       - supports-color
     dev: true
 
-  /jest-puppeteer/4.4.0_puppeteer@2.1.1:
-    resolution: {integrity: sha512-ZaiCTlPZ07B9HW0erAWNX6cyzBqbXMM7d2ugai4epBDKpKvRDpItlRQC6XjERoJELKZsPziFGS0OhhUvTvQAXA==}
+  /jest-puppeteer/5.0.4_puppeteer@2.1.1:
+    resolution: {integrity: sha512-IUOVKgHEaKsLqahZy/J/DvXB59SQx4AVpZKTRDvJzCdkvdGc3NVsNwUhovr6SK+HOK1TOiqAiXPTAPiIq3mkrg==}
     peerDependencies:
-      puppeteer: '>= 1.5.0 < 3'
+      puppeteer: '>= 1.5.0 < 10'
     dependencies:
-      expect-puppeteer: 4.4.0
-      jest-environment-puppeteer: 4.4.0
+      expect-puppeteer: 5.0.4
+      jest-environment-puppeteer: 5.0.4
       puppeteer: 2.1.1
     transitivePeerDependencies:
+      - debug
       - supports-color
     dev: false
 
@@ -29467,7 +29488,6 @@ packages:
       '@sideway/address': 4.1.4
       '@sideway/formula': 3.0.0
       '@sideway/pinpoint': 2.0.0
-    dev: true
 
   /js-base64/2.6.4:
     resolution: {integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==}
@@ -36100,6 +36120,7 @@ packages:
 
   /rx/4.1.0:
     resolution: {integrity: sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=}
+    dev: true
 
   /rxjs/6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -36800,6 +36821,7 @@ packages:
       wait-port: 0.2.9
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /spawnd/5.0.0:
     resolution: {integrity: sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==}
@@ -36810,7 +36832,6 @@ packages:
       wait-port: 0.2.9
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /spdx-correct/3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
@@ -39671,6 +39692,7 @@ packages:
       minimist: 1.2.5
       request: 2.88.2
       rx: 4.1.0
+    dev: true
 
   /wait-on/5.3.0:
     resolution: {integrity: sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==}
@@ -39684,7 +39706,6 @@ packages:
       rxjs: 6.6.7
     transitivePeerDependencies:
       - debug
-    dev: true
 
   /wait-port/0.2.9:
     resolution: {integrity: sha512-hQ/cVKsNqGZ/UbZB/oakOGFqic00YAMM5/PEj3Bt4vKarv2jWIWzDbqlwT94qMs/exAQAsvMOq99sZblV92zxQ==}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update `jest-puppeteer@5.0.4` (from `4.4.0`) to be able to run with jest 28.

As a plugin developer, I'd like to use Jest 28 (to be able to run `admin-e2e-tests` directly from `node_modules`).

Before this PR `npx wc-e2e test:e2e` was throwing with an error with `jest-environment-puppeteer` missing some jest 27 exports


### How to test the changes in this Pull Request:

#### Bug repro
1. Clone an extension that uses Jest 28, like https://github.com/woocommerce/google-listings-and-ads/tree/940d9c2686b6c768d974080ca57fb0d263821029
2. run `npx wc-e2e docker:up && npx wc-e2e test:e2e`

#### jest 25 compact

1. Clone an extension that uses Jest 25, like https://github.com/woocommerce/google-listings-and-ads/tree/53372cc4fd10120a1d6c1dca1db9066a294486a9
2. ~Install this version of e2e-environment~
   ```
   cd node_modules/@woocommerce/e2e-environment/
   npm i --save jest-puppeteer@^5.0.4
   cd -
   ```
4. run `npx wc-e2e docker:up && npx wc-e2e test:e2e`

#### jest 28 compact

1. Clone an extension that uses Jest 25, like https://github.com/woocommerce/google-listings-and-ads/tree/940d9c2686b6c768d974080ca57fb0d263821029
2. ~Install this version of e2e-environment~
   ```
   cd node_modules/@woocommerce/e2e-environment/
   npm i --save jest-puppeteer@^5.0.4
   cd -
   ```
3. run `npx wc-e2e docker:up && npx wc-e2e test:e2e`

### Other information:

I was not able to run build and fully test  locally due to https://github.com/woocommerce/woocommerce/issues/33684
That's also why I bump only to `5.0.4` not `6.x` to limit the potential breaking changes.

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?
   ```
   None of the selected packages has a "changelog" script
   ```
   So I added the changelog entry manually to `CHANGELOG.md`

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
