### PR TITLE
Update method for getting Reports API cache version number... again

### DIFF
--- a/plugins/woocommerce/changelog/fix-33315-stats-cache-ttl-part-deux
+++ b/plugins/woocommerce/changelog/fix-33315-stats-cache-ttl-part-deux
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change invalidation and TTL of the analytics cache for better cache resilience

--- a/plugins/woocommerce/src/Admin/API/Reports/Cache.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Cache.php
@@ -41,7 +41,7 @@ class Cache {
 
 		if ( false === $transient_value || true === $refresh ) {
 			// Round to the nearest $minutes increment.
-			$minutes = 10;
+			$minutes         = 10;
 			$transient_value = (string) round( time() / ( MINUTE_IN_SECONDS * $minutes ) ) * ( MINUTE_IN_SECONDS * $minutes );
 
 			set_transient( $transient_name, $transient_value );

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -221,6 +221,7 @@ class DataStore extends SqlQuery {
 		if ( true === $this->debug_cache ) {
 			$this->debug_cache_data['should_use_cache']    = $this->should_use_cache();
 			$this->debug_cache_data['force_cache_refresh'] = $this->force_cache_refresh;
+			$this->debug_cache_data['cache_version']       = Cache::get_version();
 			$this->debug_cache_data['cache_hit']           = false;
 		}
 

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -139,7 +139,7 @@ class DataStore extends SqlQuery {
 		}
 
 		// Utilize enveloped responses to include debugging info.
-		// See https://querymonitor.com/blog/2021/05/debugging-wordpress-rest-api-requests/
+		// See https://querymonitor.com/blog/2021/05/debugging-wordpress-rest-api-requests/ .
 		if ( isset( $_GET['_envelope'] ) ) {
 			$this->debug_cache = true;
 			add_filter( 'rest_envelope_response', array( $this, 'add_debug_cache_to_envelope' ), 999, 2 );
@@ -260,8 +260,8 @@ class DataStore extends SqlQuery {
 	/**
 	 * Add cache debugging information to an enveloped API response.
 	 *
-	 * @param array             $envelope
-	 * @param \WP_REST_Response $response
+	 * @param array             $envelope Envelope containing the API response.
+	 * @param \WP_REST_Response $response The original API response object.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This reintroduces the changes from #33353 that ended up having to be reverted in #33706. See the [revert PR](https://github.com/woocommerce/woocommerce/pull/33706) for details.

Note that this shouldn't be merged until the related mobile app issues have been resolved:

* https://github.com/woocommerce/woocommerce-ios/issues/7055
* https://github.com/woocommerce/woocommerce-android/issues/6719

Closes #33315

### How to test the changes in this Pull Request:

1. See #33353 for testing information.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
