### PR TITLE
Update `@woocommerce/extend-checkout-block` to include an example of a forced inner block

### DIFF
--- a/packages/js/extend-cart-checkout-block/$slug-blocks-integration.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug-blocks-integration.php.mustache
@@ -22,6 +22,10 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 	 *
 	 */
 	public function initialize() {
+		$this->register_frontend_scripts();
+		$this->register_editor_scripts();
+		$this->register_editor_blocks();
+        $this->register_editor_styles();
 		$script_path = '/build/index.js';
 		$style_path  = '/build/style-index.css';
 
@@ -53,7 +57,6 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 		wp_set_script_translations(
 			'{{slug}}-blocks-integration',
 			'{{slug}}',
-			'{{slug}}',
 			dirname( __FILE__ ) . '/languages'
 		);
 	}
@@ -64,7 +67,7 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 	 * @return string[]
 	 */
 	public function get_script_handles() {
-		return array( '{{slug}}-blocks-integration' );
+		return array( '{{slug}}-blocks-integration', '{{slug}}-checkout-newsletter-subscription-block-frontend' );
 	}
 
 	/**
@@ -73,7 +76,7 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 	 * @return string[]
 	 */
 	public function get_editor_script_handles() {
-		return array( '{{slug}}-blocks-integration' );
+		return array( '{{slug}}-blocks-integration', '{{slug}}-checkout-newsletter-subscription-block-editor' );
 	}
 
 	/**
@@ -84,12 +87,85 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 	public function get_script_data() {
 		$data = array(
 			'{{slug}}-active' => true,
-			'example-data' => 'This is some example data from the server',
+			'example-data' => __( 'This is some example data from the server', '{{slug}}' ),
+            'optInDefaultText' => __( 'I want to receive updates about products and promotions.', '{{ slug }}' ),
 		);
 
 		return $data;
 
 	}
+
+    public function register_editor_styles() {
+        $style_path  = '/build/style-{{slug}}-checkout-newsletter-subscription-block.css';
+
+        $style_url  = plugins_url( $style_path, __FILE__ );
+        wp_enqueue_style(
+            '{{slug}}-blocks-integration',
+            $style_url,
+            [],
+            $this->get_file_version( $style_path )
+        );
+    }
+
+    public function register_editor_scripts() {
+        $script_path       = '/build/{{slug}}-checkout-newsletter-subscription-block.js';
+        $script_url        = plugins_url( $script_path, __FILE__ );
+        $script_asset_path = dirname( __FILE__ ) . '/build/{{slug}}-checkout-newsletter-subscription-block.asset.php';
+        $script_asset      = file_exists( $script_asset_path )
+            ? require $script_asset_path
+            : array(
+                'dependencies' => array(),
+                'version'      => $this->get_file_version( $script_asset_path ),
+            );
+
+        wp_register_script(
+            '{{slug}}-checkout-newsletter-subscription-block-editor',
+            $script_url,
+            $script_asset['dependencies'],
+            $script_asset['version'],
+            true
+        );
+
+        wp_set_script_translations(
+            '{{slug}}-newsletter-block-editor', // script handle
+            '{{slug}}', // text domain
+            dirname( __FILE__ ) . '/languages'
+        );
+    }
+
+    public function register_frontend_scripts() {
+        $script_path       = '/build/{{slug}}-checkout-newsletter-subscription-block-frontend.js';
+        $script_url        = plugins_url( $script_path, __FILE__ );
+        $script_asset_path = dirname( __FILE__ ) . '/build/newsletter-block-frontend.asset.php';
+        $script_asset      = file_exists( $script_asset_path )
+            ? require $script_asset_path
+            : array(
+                'dependencies' => array(),
+                'version'      => $this->get_file_version( $script_asset_path ),
+            );
+
+        wp_register_script(
+            '{{slug}}-checkout-newsletter-subscription-block-frontend',
+            $script_url,
+            $script_asset['dependencies'],
+            $script_asset['version'],
+            true
+        );
+        wp_set_script_translations(
+            '{{slug}}-checkout-newsletter-subscription-block-frontend', // script handle
+            '{{slug}}', // text domain
+            dirname( __FILE__ ) . '/languages'
+        );
+    }
+
+    /**
+     * Register blocks.
+     */
+    public function register_editor_blocks() {
+        register_block_type( dirname( __FILE__ ) . '/assets/js/checkout-newsletter-subscription-block', array(
+            'editor_script' => '{{slug}}-checkout-newsletter-subscription-block-editor',
+        ) );
+    }
 
 	/**
 	 * Get the file modified time as a cache buster if we're in dev mode.

--- a/packages/js/extend-cart-checkout-block/$slug-blocks-integration.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug-blocks-integration.php.mustache
@@ -19,13 +19,19 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 
 	/**
 	 * When called invokes any initialization/setup for the integration.
-	 *
 	 */
 	public function initialize() {
-		$this->register_frontend_scripts();
-		$this->register_editor_scripts();
-		$this->register_editor_blocks();
-        $this->register_editor_styles();
+		$this->register_newsletter_block_frontend_scripts();
+		$this->register_newsletter_block_editor_scripts();
+		$this->register_newsletter_block_editor_blocks();
+        $this->register_newsletter_block_editor_styles();
+        $this->register_main_integration();
+	}
+
+	/**
+	 * Registers the main JS file required to add filters and Slot/Fills.
+	 */
+	public function register_main_integration() {
 		$script_path = '/build/index.js';
 		$style_path  = '/build/style-index.css';
 
@@ -95,7 +101,7 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 
 	}
 
-    public function register_editor_styles() {
+    public function register_newsletter_block_editor_styles() {
         $style_path  = '/build/style-{{slug}}-checkout-newsletter-subscription-block.css';
 
         $style_url  = plugins_url( $style_path, __FILE__ );
@@ -107,7 +113,7 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
         );
     }
 
-    public function register_editor_scripts() {
+    public function register_newsletter_block_editor_scripts() {
         $script_path       = '/build/{{slug}}-checkout-newsletter-subscription-block.js';
         $script_url        = plugins_url( $script_path, __FILE__ );
         $script_asset_path = dirname( __FILE__ ) . '/build/{{slug}}-checkout-newsletter-subscription-block.asset.php';
@@ -133,7 +139,7 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
         );
     }
 
-    public function register_frontend_scripts() {
+    public function register_newsletter_block_frontend_scripts() {
         $script_path       = '/build/{{slug}}-checkout-newsletter-subscription-block-frontend.js';
         $script_url        = plugins_url( $script_path, __FILE__ );
         $script_asset_path = dirname( __FILE__ ) . '/build/newsletter-block-frontend.asset.php';
@@ -161,7 +167,7 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
     /**
      * Register blocks.
      */
-    public function register_editor_blocks() {
+    public function register_newsletter_block_editor_blocks() {
         register_block_type( dirname( __FILE__ ) . '/assets/js/checkout-newsletter-subscription-block', array(
             'editor_script' => '{{slug}}-checkout-newsletter-subscription-block-editor',
         ) );

--- a/packages/js/extend-cart-checkout-block/$slug-blocks-integration.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug-blocks-integration.php.mustache
@@ -23,7 +23,6 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
 	public function initialize() {
 		$this->register_newsletter_block_frontend_scripts();
 		$this->register_newsletter_block_editor_scripts();
-		$this->register_newsletter_block_editor_blocks();
         $this->register_newsletter_block_editor_styles();
         $this->register_main_integration();
 	}
@@ -162,15 +161,6 @@ class {{slugPascalCase}}_Blocks_Integration implements IntegrationInterface {
             '{{slug}}', // text domain
             dirname( __FILE__ ) . '/languages'
         );
-    }
-
-    /**
-     * Register blocks.
-     */
-    public function register_newsletter_block_editor_blocks() {
-        register_block_type( dirname( __FILE__ ) . '/assets/js/checkout-newsletter-subscription-block', array(
-            'editor_script' => '{{slug}}-checkout-newsletter-subscription-block-editor',
-        ) );
     }
 
 	/**

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -34,6 +34,9 @@ add_action('woocommerce_blocks_loaded', function() {
 	);
 });
 
+/**
+ * Registers the slug as a block category with WordPress.
+ */
 function register_{{slugPascalCase}}_block_category( $categories ) {
     return array_merge(
         $categories,

--- a/packages/js/extend-cart-checkout-block/$slug.php.mustache
+++ b/packages/js/extend-cart-checkout-block/$slug.php.mustache
@@ -33,3 +33,16 @@ add_action('woocommerce_blocks_loaded', function() {
 		}
 	);
 });
+
+function register_{{slugPascalCase}}_block_category( $categories ) {
+    return array_merge(
+        $categories,
+        [
+            [
+                'slug'  => '{{slug}}',
+                'title' => __( '{{slugPascalCase}} Blocks', '{{slug}}' ),
+            ],
+        ]
+    );
+}
+add_action( 'block_categories_all', 'register_{{slugPascalCase}}_block_category', 10, 2 );

--- a/packages/js/extend-cart-checkout-block/changelog/add-inner-block-example
+++ b/packages/js/extend-cart-checkout-block/changelog/add-inner-block-example
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Include an example of adding an inner block to the WooCommerce Blocks Checkout Block

--- a/packages/js/extend-cart-checkout-block/src/index.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/index.js.mustache
@@ -1,1 +1,2 @@
 import './js/index';
+import './js/checkout-newsletter-subscription-block';

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.js.mustache
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { CheckboxControl } from '@woocommerce/blocks-checkout';
+import { getSetting } from '@woocommerce/settings';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+const { optInDefaultText } = getSetting( '{{slug}}_data', '' );
+
+const Block = ( { children, checkoutExtensionData } ) => {
+	const [ checked, setChecked ] = useState( false );
+	const { setExtensionData } = checkoutExtensionData;
+
+	const { setValidationErrors, clearValidationError } = useDispatch(
+		'wc/store/validation'
+	);
+
+	useEffect( () => {
+		setExtensionData( '{{slug}}', 'optin', checked );
+		if ( ! checked ) {
+			setValidationErrors( {
+				'{{slug}}': {
+					message: 'Please tick the box',
+					hidden: false,
+				},
+			} );
+			return;
+		}
+		clearValidationError( '{{slug}}' );
+	}, [
+		clearValidationError,
+		setValidationErrors,
+		checked,
+		setExtensionData,
+	] );
+
+	const { getValidationError } = useSelect( ( select ) => {
+		const store = select( 'wc/store/validation' );
+		return {
+			getValidationError: store.getValidationError(),
+		};
+	} );
+
+	const errorMessage = getValidationError( '{{slug}}' )?.message;
+
+	return (
+		<>
+			<CheckboxControl
+				id="subscribe-to-newsletter"
+				checked={ checked }
+				onChange={ setChecked }
+			>
+				{ children || optInDefaultText }
+			</CheckboxControl>
+
+			{ errorMessage && (
+				<div>
+					<span role="img" aria-label="Warning emoji">
+						⚠️
+					</span>
+					{ errorMessage }
+				</div>
+			) }
+		</>
+	);
+};
+
+export default Block;

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.js.mustache
@@ -38,11 +38,9 @@ const Block = ( { children, checkoutExtensionData } ) => {
 	const { validationError } = useSelect( ( select ) => {
 		const store = select( 'wc/store/validation' );
 		return {
-			getValidationError: store.getValidationError( '{{slug}}' ),
+			validationError: store.getValidationError( '{{slug}}' ),
 		};
 	} );
-
-	const errorMessage = validationError?.message;
 
 	return (
 		<>
@@ -54,12 +52,12 @@ const Block = ( { children, checkoutExtensionData } ) => {
 				{ children || optInDefaultText }
 			</CheckboxControl>
 
-			{ ! errorMessage?.hidden && (
+			{ validationError?.hidden === false && (
 				<div>
 					<span role="img" aria-label="Warning emoji">
 						⚠️
 					</span>
-					{ errorMessage?.message }
+					{ validationError?.message }
 				</div>
 			) }
 		</>

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.js.mustache
@@ -35,14 +35,14 @@ const Block = ( { children, checkoutExtensionData } ) => {
 		setExtensionData,
 	] );
 
-	const { getValidationError } = useSelect( ( select ) => {
+	const { validationError } = useSelect( ( select ) => {
 		const store = select( 'wc/store/validation' );
 		return {
-			getValidationError: store.getValidationError(),
+			getValidationError: store.getValidationError( '{{slug}}' ),
 		};
 	} );
 
-	const errorMessage = getValidationError( '{{slug}}' )?.message;
+	const errorMessage = validationError?.message;
 
 	return (
 		<>
@@ -54,12 +54,12 @@ const Block = ( { children, checkoutExtensionData } ) => {
 				{ children || optInDefaultText }
 			</CheckboxControl>
 
-			{ errorMessage && (
+			{ ! errorMessage?.hidden && (
 				<div>
 					<span role="img" aria-label="Warning emoji">
 						⚠️
 					</span>
-					{ errorMessage }
+					{ errorMessage?.message }
 				</div>
 			) }
 		</>

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.json.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/block.json.mustache
@@ -1,0 +1,34 @@
+{
+	"apiVersion": 2,
+	"name": "{{slug}}/checkout-newsletter-subscription",
+	"version": "2.0.0",
+	"title": "Newsletter Subscription!",
+	"category": "{{slug}}",
+	"description": "Adds a newsletter subscription checkbox to the checkout.",
+	"supports": {
+		"html": false,
+		"align": false,
+		"multiple": false,
+		"reusable": false
+	},
+	"parent": [
+		"woocommerce/checkout-contact-information-block"
+	],
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		},
+		"text": {
+			"type": "string",
+			"source": "html",
+			"selector": ".wp-block-{{slug}}-checkout-newsletter-subscription",
+			"default": ""
+		}
+	},
+	"textdomain": "{{slug}}",
+	"editorStyle": "file:../../../build/style-{{slug}}-checkout-newsletter-subscription-block.css"
+}

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/edit.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/edit.js.mustache
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	useBlockProps,
+	RichText,
+	InspectorControls,
+} from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
+import { CheckboxControl } from '@woocommerce/blocks-checkout';
+import { getSetting } from '@woocommerce/settings';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+const { optInDefaultText } = getSetting( '{{slug}}_data', '' );
+
+export const Edit = ( { attributes, setAttributes } ) => {
+	const { text } = attributes;
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Block options', '{{slug}}' ) }>
+					Options for the block go here.
+				</PanelBody>
+			</InspectorControls>
+			<CheckboxControl
+				id="newsletter-text"
+				checked={ false }
+				disabled={ true }
+			/>
+			<RichText
+				value={ text || optInDefaultText }
+				onChange={ ( value ) => setAttributes( { text: value } ) }
+			/>
+		</div>
+	);
+};
+
+export const Save = ( { attributes } ) => {
+	const { text } = attributes;
+	return (
+		<div { ...useBlockProps.save() }>
+			<RichText.Content value={ text } />
+		</div>
+	);
+};

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/frontend.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/frontend.js.mustache
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { registerCheckoutBlock } from '@woocommerce/blocks-checkout';
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import metadata from './block.json';
+
+registerCheckoutBlock( {
+	metadata,
+	component: Block,
+} );

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/index.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/index.js.mustache
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { SVG } from '@wordpress/components';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { Edit, Save } from './edit';
+import metadata from './block.json';
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 16">
+				<g fill="none" fillRule="evenodd">
+					<path
+						stroke="currentColor"
+						strokeWidth="1.5"
+						d="M2 .75h16c.69 0 1.25.56 1.25 1.25v12c0 .69-.56 1.25-1.25 1.25H2c-.69 0-1.25-.56-1.25-1.25V2C.75 1.31 1.31.75 2 .75z"
+					/>
+					<path
+						fill="currentColor"
+						d="M7.667 7.667A2.34 2.34 0 0010 5.333 2.34 2.34 0 007.667 3a2.34 2.34 0 00-2.334 2.333 2.34 2.34 0 002.334 2.334zM11.556 3H17v3.889h-5.444V3zm2.722 2.916l1.944-1.36v-.779L14.278 5.14l-1.945-1.362v.778l1.945 1.361zm-5.834-.583a.78.78 0 00-.777-.777.78.78 0 00-.778.777c0 .428.35.778.778.778a.78.78 0 00.777-.778zm3.89 5.904c0-1.945-3.088-2.785-4.667-2.785-1.58 0-4.667.84-4.667 2.785v1.097h9.333v-1.097zM7.666 10c-1.012 0-2.163.389-2.738.778h5.475C9.821 10.38 8.678 10 7.667 10z"
+					/>
+				</g>
+			</SVG>
+		),
+		foreground: '#874FB9',
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/style.scss.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/style.scss.mustache
@@ -1,0 +1,17 @@
+.wp-block-{{slug}}-checkout-newsletter-subscription {
+	margin: 20px 0;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	display: flex;
+	align-items: flex-start;
+
+	.block-editor-rich-text__editable {
+		vertical-align: middle;
+		line-height: 24px;
+	}
+
+	.wc-block-components-checkbox {
+		margin-right: 16px;
+		margin-top: 0;
+	}
+}

--- a/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/style.scss.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/checkout-newsletter-subscription-block/style.scss.mustache
@@ -15,3 +15,13 @@
 		margin-top: 0;
 	}
 }
+
+.editor-styles-wrapper {
+
+	.wp-block-{{slug}}-checkout-newsletter-subscription {
+		.wc-block-components-checkbox {
+			margin-right: 0;
+			margin-top: 0;
+		}
+	}
+}

--- a/packages/js/extend-cart-checkout-block/src/js/index.js.mustache
+++ b/packages/js/extend-cart-checkout-block/src/js/index.js.mustache
@@ -9,13 +9,10 @@ import { getSetting } from '@woocommerce/settings';
  */
 import './style.scss';
 
-const exampleDataFromSettings = getSetting( '{{slug}}_data' );
-
-/**
- * Internal dependencies
- */
 import { registerFilters } from './filters';
 import { ExampleComponent } from './ExampleComponent';
+
+const exampleDataFromSettings = getSetting( '{{slug}}_data' );
 
 const render = () => {
 	return (

--- a/packages/js/extend-cart-checkout-block/webpack.config.js.mustache
+++ b/packages/js/extend-cart-checkout-block/webpack.config.js.mustache
@@ -10,6 +10,23 @@ const defaultRules = defaultConfig.module.rules.filter( ( rule ) => {
 
 module.exports = {
 	...defaultConfig,
+	entry: {
+		index: path.resolve(process.cwd(), 'src', 'js', 'index.js'),
+		'{{slug}}-checkout-newsletter-subscription-block': path.resolve(
+			process.cwd(),
+			'src',
+			'js',
+			'checkout-newsletter-subscription-block',
+			'index.js'
+		),
+		'{{slug}}-checkout-newsletter-subscription-block-frontend': path.resolve(
+			process.cwd(),
+			'src',
+			'js',
+			'checkout-newsletter-subscription-block',
+			'frontend.js'
+		),
+	},
 	module: {
 		...defaultConfig.module,
 		rules: [


### PR DESCRIPTION
Blocked until https://github.com/woocommerce/woocommerce-blocks/pull/6763 is merged

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR will update the `extend-checkout-block` package. The updates included here are:

- Add an example of a forced inner block to the WooCommerce Blocks Checkout Block (It will appear as an inner block of the Contact Information Block)
- Refactor the main integration file to split the script/style registration into inner block/main integration.
- Fix the `Internal Dependencies` section of `src/js/index.js.mustache`
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a (local) test site. Set up WooCommerce and import products.
2. Clone [WooCommerce Blocks](https://github.com/woocommerce/woocommerce-blocks) and ensure you're on `trunk`.
3. Build WooCommerce Blocks (instructions to do so are in the [repo readme](https://github.com/woocommerce/woocommerce-blocks)) and activate the plugin.
4. Create a page and add the Checkout Block. Notice the Contact Information Block within it doesn't have anything under the email box.
5. Save the page and keep this tab open for later.
6. Go to the `wp-content/plugins` directory and run `npx @wordpress/create-block -t ./woocommerce-monorepo/packages/js/extend-cart-checkout-block/ some-extension-name` (note you will need to change the path to this package if your WC repo is installed elsewhere, but this must be run from `wp-content/plugins`)
7. Go to the WP Dashboard -> Plugins and activate the `Some Extension Name` plugin.
8. Reload the editor page with the Checkout Block from step 4 and 5.
9. Observe the newsletter signup checkbox is now present. Ensure there is text accompanying it. ⚠️ **Do not re-save the page yet!**
10. Add some items to your cart then load the Checkout Block page on the front-end.
11. Ensure the newsletter signup checkbox is showing. Toggle it and ensure the validation warning shows.
12. Go back to the Checkout page in the editor and save it. Reload the page after successfully saving and ensure the checkbox is there.
13. Load it on the frontend and ensure the checkbox is there.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable? **Not applicable, manual testing is OK**
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`? **I added one by using `./vendor/bin/changelogger add`, but running `./vendor/bin/changelogger write --use-version=1.1.0` did nothing. When I ran the mentioned `pnpm` script it says `None of the selected packages has a "changelog" script` when I run it. I also don't know if I need to add an entry to `CHANGELOG.md` - please let me know if I do!**

📝 Note: this package is not going to be installed by `npm install` it is used only with `@wordpress/create-block` which is why I marked it as a patch version in the changelog.

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
