### PR TITLE
[COT] Implement `query()` in the COT datastore

### DIFF
--- a/plugins/woocommerce/changelog/add-33613-cot-datastore-query
+++ b/plugins/woocommerce/changelog/add-33613-cot-datastore-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Implements `query()` for the orders table datastore.

--- a/plugins/woocommerce/includes/class-wc-data-store.php
+++ b/plugins/woocommerce/includes/class-wc-data-store.php
@@ -160,6 +160,23 @@ class WC_Data_Store {
 	}
 
 	/**
+	 * Reads multiple objects from the data store.
+	 *
+	 * @since 6.9.0
+	 * @param array[WC_Data] $objects Array of object instances to read.
+	 */
+	public function read_multiple( &$objects = array() ) {
+		// If the datastore allows for bulk-reading, use it.
+		if ( is_callable( array( $this->instance, 'read_multiple' ) ) ) {
+			$this->instance->read_multiple( $objects );
+		} else {
+			foreach ( $objects as &$obj ) {
+				$this->read( $obj );
+			}
+		}
+	}
+
+	/**
 	 * Create an object in the data store.
 	 *
 	 * @since 3.0.0

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -19,7 +19,7 @@ class WC_Order_Factory {
 	 * Get order.
 	 *
 	 * @param  mixed $order_id (default: false) Order ID to get.
-	 * @return WC_Order|bool
+	 * @return \WC_Order|bool
 	 */
 	public static function get_order( $order_id = false ) {
 		$order_id = self::get_order_id( $order_id );
@@ -28,18 +28,8 @@ class WC_Order_Factory {
 			return false;
 		}
 
-		$order_type      = WC_Data_Store::load( 'order' )->get_order_type( $order_id );
-		$order_type_data = wc_get_order_type( $order_type );
-		if ( $order_type_data ) {
-			$classname = $order_type_data['class_name'];
-		} else {
-			$classname = false;
-		}
-
-		// Filter classname so that the class can be overridden if extended.
-		$classname = apply_filters( 'woocommerce_order_class', $classname, $order_type, $order_id );
-
-		if ( ! class_exists( $classname ) ) {
+		$classname = self::get_class_name_for_order_id( $order_id );
+		if ( ! $classname ) {
 			return false;
 		}
 
@@ -49,6 +39,55 @@ class WC_Order_Factory {
 			wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
 			return false;
 		}
+	}
+
+	/**
+	 * Get multiple orders (by ID).
+	 *
+	 * @param array[mixed] $order_ids                     Array of order IDs to get.
+	 * @param boolean      $skip_invalid (default: false) TRUE if invalid IDs or orders should be ignored.
+	 * @return array[\WC_Order]
+	 *
+	 * @throws \Exception When an invalid order is found.
+	 */
+	public static function get_orders( $order_ids = array(), $skip_invalid = false ) {
+		$result    = array();
+		$order_ids = array_filter( array_map( array( __CLASS__, 'get_order_id' ), $order_ids ) );
+
+		foreach ( $order_ids as $order_id ) {
+			$classname = self::get_class_name_for_order_id( $order_id );
+
+			if ( ! $classname && ! $skip_invalid ) {
+				// translators: %d is an order ID.
+				throw new \Exception( sprintf( __( 'Could not find classname for order ID %d', 'woocommerce' ), $order_id ) );
+			}
+
+			try {
+				$obj = new $classname();
+				$obj->set_defaults();
+				$obj->set_id( $order_id );
+
+				$result[ $order_id ] = $obj;
+			} catch ( \Exception $e ) {
+				wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
+
+				if ( ! $skip_invalid ) {
+					throw $e;
+				}
+			}
+		}
+
+		try {
+			WC_Data_Store::load( 'order' )->read_multiple( $result );
+		} catch ( \Exception $e ) {
+			wc_caught_exception( $e, __FUNCTION__, $order_ids );
+
+			if ( ! $skip_invalid ) {
+				throw $e;
+			}
+		}
+
+		return $result;
 	}
 
 	/**
@@ -128,4 +167,37 @@ class WC_Order_Factory {
 			return false;
 		}
 	}
+
+	/**
+	 * Gets the class name an order instance should have based on its ID.
+	 *
+	 * @since 6.9.0
+	 * @param int $order_id The order ID.
+	 * @return string The class name or FALSE if the class does not exist.
+	 */
+	private static function get_class_name_for_order_id( $order_id ) {
+		$order_type      = WC_Data_Store::load( 'order' )->get_order_type( $order_id );
+		$order_type_data = wc_get_order_type( $order_type );
+		if ( $order_type_data ) {
+			$classname = $order_type_data['class_name'];
+		} else {
+			$classname = false;
+		}
+
+		/**
+		 * Filter classname so that the class can be overridden if extended.
+		 *
+		 * @param $classname  Order classname.
+		 * @param $order_type Order type.
+		 * @param $order_id   Order ID.
+		 */
+		$classname = apply_filters( 'woocommerce_order_class', $classname, $order_type, $order_id );
+
+		if ( ! class_exists( $classname ) ) {
+			return false;
+		}
+
+		return $classname;
+	}
+
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -990,6 +990,11 @@ LEFT JOIN {$operational_data_clauses['join']}
 				continue;
 			}
 
+			// 'status' is a little special (for backwards compat.).
+			if ( 'status' === $column ) {
+				$changes['status'] = 'wc-' . str_replace( 'wc-', '', $changes['status'] );
+			}
+
 			$row[ $column ]        = $this->database_util->format_object_value_for_db( $changes[ $details['name'] ], $details['type'] );
 			$row_format[ $column ] = $this->database_util->get_wpdb_format_for_type( $details['type'] );
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1021,7 +1021,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 	 * @return void
 	 */
 	public function delete( &$order, $args = array() ) {
-		$order_id  = $order->get_id();
+		$order_id = $order->get_id();
 
 		if ( ! $order_id ) {
 			return;
@@ -1243,12 +1243,18 @@ LEFT JOIN {$operational_data_clauses['join']}
 		}
 
 		if ( isset( $query_vars['anonymized'] ) ) {
-			$query_vars['meta_query'] = $query_vars['meta_query'] ?? array();
+			$query_vars['meta_query'] = $query_vars['meta_query'] ?? array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
 			if ( $query_vars['anonymized'] ) {
-				$query_vars['meta_query'][] = array( 'key' => '_anonymized', 'value' => 'yes' );
+				$query_vars['meta_query'][] = array(
+					'key'   => '_anonymized',
+					'value' => 'yes',
+				);
 			} else {
-				$query_vars['meta_query'][] = array( 'key' => '_anonymized', 'compare' => 'NOT EXISTS' );
+				$query_vars['meta_query'][] = array(
+					'key'     => '_anonymized',
+					'compare' => 'NOT EXISTS',
+				);
 			}
 		}
 
@@ -1265,8 +1271,6 @@ LEFT JOIN {$operational_data_clauses['join']}
 		if ( isset( $query_vars['return'] ) && 'ids' === $query_vars['return'] ) {
 			$orders = $query->orders;
 		} else {
-			//update_post_caches( $query->posts ); // We already fetching posts, might as well hydrate some caches.
-			//$orders    = $this->compile_orders( $order_ids, $query_vars, $query );
 			$orders = array_map( 'wc_get_order', $query->orders );
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -706,6 +706,10 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 * @return array|object|null DB Order objects or error.
 	 */
 	private function get_order_data_for_ids( $ids ) {
+		if ( ! $ids ) {
+			return array();
+		}
+
 		global $wpdb;
 		$order_table_query = $this->get_order_table_select_statement();
 		$id_placeholder    = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -106,7 +106,7 @@ class OrdersTableMetaQuery {
 			return;
 		}
 
-		$this->queries  = $this->sanitize_meta_query( $meta_query );
+		$this->queries = $this->sanitize_meta_query( $meta_query );
 
 		$this->meta_table   = $q->get_table_name( 'meta' );
 		$this->orders_table = $q->get_table_name( 'orders' );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -246,10 +246,17 @@ class OrdersTableMetaQuery {
 				continue;
 			}
 
-			$chunks[] = $this->flatten_where_clauses( $w );
+			$flattened = $this->flatten_where_clauses( $w );
+			if ( $flattened ) {
+				$chunks[] = $flattened;
+			}
 		}
 
-		return '(' . implode( " {$operator} ", $chunks ) . ')';
+		if ( $chunks ) {
+			return '(' . implode( " {$operator} ", $chunks ) . ')';
+		} else {
+			return '';
+		}
 	}
 
 	/**
@@ -265,6 +272,7 @@ class OrdersTableMetaQuery {
 		$queries     = $this->queries;
 		$sql_where   = $this->process( $queries );
 		$this->where = $sql_where;
+
 	}
 
 	/**
@@ -362,7 +370,7 @@ class OrdersTableMetaQuery {
 				continue;
 			}
 
-			if ( $this->is_operator_compatible_with_shared_join( $clause, $sibling, $parent_query['relation'] ) ) {
+			if ( $this->is_operator_compatible_with_shared_join( $clause, $sibling, $parent_query['relation'] ?? 'AND' ) ) {
 				$alias = $sibling['alias'];
 				break;
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -1,0 +1,558 @@
+<?php
+namespace Automattic\WooCommerce\Internal\DataStores\Orders;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class used to implement meta queries for the orders table datastore via {@see OrdersTableQuery}.
+ * Heavily inspired by WordPress' own `WP_Meta_Query` for backwards compatibility reasons.
+ *
+ * Parts of the implementation have been adapted from {@link https://core.trac.wordpress.org/browser/tags/6.0.1/src/wp-includes/class-wp-meta-query.php}.
+ */
+class OrdersTableMetaQuery {
+
+	/**
+	 * List of non-numeric SQL operators used for comparisons in meta queries.
+	 *
+	 * @var array
+	 */
+	private const NON_NUMERIC_OPERATORS = array(
+		'=',
+		'!=',
+		'LIKE',
+		'NOT LIKE',
+		'IN',
+		'NOT IN',
+		'EXISTS',
+		'NOT EXISTS',
+		'RLIKE',
+		'REGEXP',
+		'NOT REGEXP',
+	);
+
+	/**
+	 * List of numeric SQL operators used for comparisons in meta queries.
+	 *
+	 * @var array
+	 */
+	private const NUMERIC_OPERATORS = array(
+		'>',
+		'>=',
+		'<',
+		'<=',
+		'BETWEEN',
+		'NOT BETWEEN',
+
+	);
+
+	/**
+	 * Prefix used when generating aliases for the metadata table.
+	 *
+	 * @var string
+	 */
+	private const ALIAS_PREFIX = 'meta';
+
+	/**
+	 * Sanitized `meta_query`.
+	 *
+	 * @var array
+	 */
+	private $queries = array();
+
+	/**
+	 * JOIN clauses to add to the main SQL query.
+	 *
+	 * @var array
+	 */
+	private $join = array();
+
+	/**
+	 * WHERE clauses to add to the main SQL query.
+	 *
+	 * @var array
+	 */
+	private $where = array();
+
+	/**
+	 * Table aliases in use by the meta query. Used to optimize JOINs when possible.
+	 *
+	 * @var array
+	 */
+	private $table_aliases = array();
+
+	/**
+	 * The meta_query relation.
+	 *
+	 * @var string
+	 */
+	private $relation = 'AND';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param OrdersTableQuery $q The main query being performed.
+	 */
+	public function __construct( OrdersTableQuery $q ) {
+		$meta_query = $q->get( 'meta_query' );
+
+		if ( ! $meta_query ) {
+			return;
+		}
+
+		$this->queries  = $this->sanitize_meta_query( $meta_query );
+		$this->relation = $this->sanitize_relation( $meta_query['relation'] ?? 'AND' );
+
+		$this->meta_table   = $q->get_table_name( 'meta' );
+		$this->orders_table = $q->get_table_name( 'orders' );
+
+		$this->build_query();
+	}
+
+	/**
+	 * Returns JOIN and WHERE clauses to be appended to the main SQL query.
+	 *
+	 * @return array {
+	 *     @type string $join  JOIN clause.
+	 *     @type string $where WHERE clause.
+	 * }
+	 */
+	public function get_sql_clauses() {
+		return array(
+			'join'  => $this->sanitize_join( $this->join ),
+			'where' => $this->flatten_where_clauses( $this->where ),
+		);
+	}
+
+	/**
+	 * Checks whether a given meta_query clause is atomic or not (i.e. not nested).
+	 *
+	 * @param array $arg The meta_query clause.
+	 * @return boolean TRUE if atomic, FALSE otherwise.
+	 */
+	private static function is_atomic( $arg ) {
+		return isset( $arg['key'] ) || isset( $arg['value'] );
+	}
+
+	/**
+	 * Sanitizes the meta_query argument.
+	 *
+	 * @param array $q A meta_query array.
+	 * @return array A sanitized meta query array.
+	 */
+	private function sanitize_meta_query( $q ) {
+		$sanitized = array();
+
+		if ( self::is_atomic( $q ) ) {
+			if ( isset( $q['value'] ) && array() === $q['value'] ) {
+				unset( $q['value'] );
+			}
+
+			$q['compare']     = isset( $q['compare'] ) ? strtoupper( $q['compare'] ) : ( isset( $q['value'] ) && is_array( $q['value'] ) ? 'IN' : '=' );
+			$q['compare_key'] = isset( $q['compare_key'] ) ? strtoupper( $q['compare_key'] ) : ( isset( $q['key'] ) && is_array( $q['key'] ) ? 'IN' : '=' );
+
+			if ( ! in_array( $q['compare'], self::NON_NUMERIC_OPERATORS, true ) && ! in_array( $q['compare'], self::NUMERIC_OPERATORS, true ) ) {
+				$q['compare'] = '=';
+			}
+
+			if ( ! in_array( $q['compare_key'], self::NON_NUMERIC_OPERATORS, true ) ) {
+				$q['compare_key'] = '=';
+			}
+
+			return $q;
+		}
+
+		// Nested.
+		foreach ( $q as $key => $arg ) {
+			if ( 'relation' === $key ) {
+				$relation = $arg;
+			} elseif ( ! is_array( $arg ) ) {
+				continue;
+			} else {
+				$sanitized_arg = $this->sanitize_meta_query( $arg );
+
+				if ( $sanitized_arg ) {
+					$sanitized[ $key ] = $sanitized_arg;
+				}
+			}
+		}
+
+		if ( $sanitized ) {
+			$sanitized['relation'] = 1 === count( $sanitized ) ? 'OR' : $this->sanitize_relation( $relation ?? 'AND' );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Makes sure we use an AND or OR relation. Defaults to AND.
+	 *
+	 * @param string $relation An unsanitized relation prop.
+	 * @return string
+	 */
+	private function sanitize_relation( $relation ): string {
+		if ( ! empty( $relation ) && 'OR' === strtoupper( $relation ) ) {
+			return 'OR';
+		}
+
+		return 'AND';
+	}
+
+	/**
+	 * Returns the correct type for a given meta type.
+	 *
+	 * @param string $type MySQL type.
+	 * @return string MySQL type.
+	 */
+	private function sanitize_cast_type( $type = '' ): string {
+		$meta_type = strtoupper( $type );
+
+		if ( ! $meta_type || ! preg_match( '/^(?:BINARY|CHAR|DATE|DATETIME|SIGNED|UNSIGNED|TIME|NUMERIC(?:\(\d+(?:,\s?\d+)?\))?|DECIMAL(?:\(\d+(?:,\s?\d+)?\))?)$/', $meta_type ) ) {
+			return 'CHAR';
+		}
+
+		if ( 'NUMERIC' === $meta_type ) {
+			$meta_type = 'SIGNED';
+		}
+
+		return $meta_type;
+	}
+
+	/**
+	 * Makes sure a JOIN array does not have duplicates.
+	 *
+	 * @param array $join A JOIN array.
+	 * @return array A sanitized JOIN array.
+	 */
+	private function sanitize_join( $join ): array {
+		return array_filter( array_unique( array_map( 'trim', $join ) ) );
+	}
+
+	/**
+	 * Flattens a nested WHERE array.
+	 *
+	 * @param array $where A possibly nested WHERE array with AND/OR operators.
+	 * @return string An SQL WHERE clause.
+	 */
+	private function flatten_where_clauses( $where ): string {
+		if ( is_string( $where ) ) {
+			return trim( $where );
+		}
+
+		$chunks   = array();
+		$operator = $this->sanitize_relation( $where['operator'] ?? '' );
+
+		foreach ( $where as $key => $w ) {
+			if ( 'operator' === $key ) {
+				continue;
+			}
+
+			$chunks[] = $this->flatten_where_clauses( $w );
+		}
+
+		return '(' . implode( " {$operator} ", $chunks ) . ')';
+	}
+
+	/**
+	 * Builds all the required internal bits for this meta query.
+	 *
+	 * @return void
+	 */
+	private function build_query(): void {
+		if ( ! $this->queries ) {
+			return;
+		}
+
+		$queries     = $this->queries;
+		$sql_where   = $this->process( $queries );
+		$this->where = $sql_where;
+	}
+
+	/**
+	 * Processes meta_query entries and generates the necessary table aliases, JOIN statements and WHERE conditions.
+	 *
+	 * @param array      $arg    A meta query.
+	 * @param null|array $parent The parent of the element being processed.
+	 * @return array A nested array of WHERE conditions.
+	 */
+	private function process( &$arg, &$parent = null ) {
+		$where = array();
+
+		if ( self::is_atomic( $arg ) ) {
+			$arg['alias'] = $this->find_or_create_table_alias_for_clause( $arg, $parent );
+			$arg['cast']  = $this->sanitize_cast_type( $arg['type'] ?? '' );
+
+			$where = array_filter(
+				array(
+					$this->generate_where_for_clause_key( $arg ),
+					$this->generate_where_for_clause_value( $arg ),
+				)
+			);
+		} else {
+			// Nested.
+			$relation = $arg['relation'];
+			unset( $arg['relation'] );
+
+			foreach ( $arg as $key => &$clause ) {
+				$chunks[] = $this->process( $clause, $arg );
+			}
+
+			// Merge chunks of the form OR(m) with the surrounding clause.
+			if ( 1 === count( $chunks ) ) {
+				$where = $chunks[0];
+			} else {
+				$where = array_merge(
+					array(
+						'operator' => $relation,
+					),
+					$chunks
+				);
+			}
+		}
+
+		return $where;
+	}
+
+	/**
+	 * Generates a JOIN clause to handle an atomic meta_query clause.
+	 *
+	 * @param array  $clause An atomic meta_query clause.
+	 * @param string $alias  Metadata table alias to use.
+	 * @return string An SQL JOIN clause.
+	 */
+	private function generate_join_for_clause( $clause, $alias ) {
+		global $wpdb;
+
+		if ( 'NOT EXISTS' === $clause['compare'] ) {
+			if ( 'LIKE' === $clause['compare_key'] ) {
+				return $wpdb->prepare(
+					"LEFT JOIN {$this->meta_table} AS {$alias} ON ( {$this->orders_table}.id = {$alias}.order_id AND {$alias}.meta_key LIKE %s )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					'%' . $wpdb->esc_like( $clause['key'] ) . '%'
+				);
+			} else {
+				return $wpdb->prepare(
+					"LEFT JOIN {$this->meta_table} AS {$alias} ON ( {$this->orders_table}.id = {$alias}.order_id AND {$alias}.meta_key = %s )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$clause['key']
+				);
+			}
+		}
+
+		return "INNER JOIN {$this->meta_table} AS {$alias} ON ( {$this->orders_table}.id = {$alias}.order_id )";
+	}
+
+	/**
+	 * Finds a common table alias that the meta_query clause can use, or creates one.
+	 *
+	 * @param array $clause       An atomic meta_query clause.
+	 * @param array $parent_query The parent query this clause is in.
+	 * @return string A table alias for use in an SQL JOIN clause.
+	 */
+	private function find_or_create_table_alias_for_clause( $clause, $parent_query ): string {
+		if ( ! empty( $clause['alias'] ) ) {
+			return $clause['alias'];
+		}
+
+		$alias    = false;
+		$siblings = array_filter(
+			$parent_query,
+			array( __CLASS__, 'is_atomic' )
+		);
+
+		foreach ( $siblings as $sibling ) {
+			if ( empty( $sibling['alias'] ) ) {
+				continue;
+			}
+
+			if ( $this->is_operator_compatible_with_shared_join( $clause, $sibling, $parent_query['relation'] ) ) {
+				$alias = $sibling['alias'];
+				break;
+			}
+		}
+
+		if ( ! $alias ) {
+			$alias                 = self::ALIAS_PREFIX . count( $this->table_aliases );
+			$this->join[]          = $this->generate_join_for_clause( $clause, $alias );
+			$this->table_aliases[] = $alias;
+		}
+
+		return $alias;
+	}
+
+	/**
+	 * Checks whether two meta_query clauses can share a JOIN.
+	 *
+	 * @param array  $clause    An atomic meta_query clause.
+	 * @param array  $sibling   An atomic meta_query clause.
+	 * @param string $relation The relation involving both clauses.
+	 * @return boolean TRUE if the clauses can share a table alias, FALSE otherwise.
+	 */
+	private function is_operator_compatible_with_shared_join( $clause, $sibling, $relation = 'AND' ) {
+		if ( ! self::is_atomic( $clause ) || ! self::is_atomic( $sibling ) ) {
+			return false;
+		}
+
+		$valid_operators = array();
+
+		if ( 'OR' === $relation ) {
+			$valid_operators = array( '=', 'IN', 'BETWEEN', 'LIKE', 'REGEXP', 'RLIKE', '>', '>=', '<', '<=' );
+		} elseif ( isset( $sibling['key'] ) && isset( $clause['key'] ) && $sibling['key'] === $clause['key'] ) {
+			$valid_operators = array( '!=', 'NOT IN', 'NOT LIKE' );
+		}
+
+		return in_array( strtoupper( $clause['compare'] ), $valid_operators, true ) && in_array( strtoupper( $sibling['compare'] ), $valid_operators, true );
+	}
+
+	/**
+	 * Generates an SQL WHERE clause for a given meta_query atomic clause based on its meta key.
+	 * Adapted from WordPress' `WP_Meta_Query::get_sql_for_clause()` method.
+	 *
+	 * @param array $clause An atomic meta_query clause.
+	 * @return null|string An SQL WHERE clause or NULL if $clause is invalid.
+	 */
+	private function generate_where_for_clause_key( $clause ) {
+		global $wpdb;
+
+		if ( ! array_key_exists( 'key', $clause ) ) {
+			return;
+		}
+
+		if ( 'NOT EXISTS' === $clause['compare'] ) {
+			return "{$clause['alias']}.order_id IS NULL";
+		}
+
+		$alias = $clause['alias'];
+
+		if ( in_array( $clause['compare_key'], array( '!=', 'NOT IN', 'NOT LIKE', 'NOT EXISTS', 'NOT REGEXP' ), true ) ) {
+			$i                     = count( $this->table_aliases );
+			$subquery_alias        = self::ALIAS_PREFIX . $i;
+			$this->table_aliases[] = $subquery_alias;
+
+			$meta_compare_string_start  = 'NOT EXISTS (';
+			$meta_compare_string_start .= "SELECT 1 FROM {$this->meta_table} {$subquery_alias} ";
+			$meta_compare_string_start .= "WHERE {$subquery_alias}.order_id = {$alias}.order_id ";
+			$meta_compare_string_end    = 'LIMIT 1';
+			$meta_compare_string_end   .= ')';
+		}
+
+		switch ( $clause['compare_key'] ) {
+			case '=':
+			case 'EXISTS':
+				$where = $wpdb->prepare( "$alias.meta_key = %s", trim( $clause['key'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				break;
+			case 'LIKE':
+				$meta_compare_value = '%' . $wpdb->esc_like( trim( $clause['key'] ) ) . '%';
+				$where              = $wpdb->prepare( "$alias.meta_key LIKE %s", $meta_compare_value ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				break;
+			case 'IN':
+				$meta_compare_string = "$alias.meta_key IN (" . substr( str_repeat( ',%s', count( $clause['key'] ) ), 1 ) . ')';
+				$where               = $wpdb->prepare( $meta_compare_string, $clause['key'] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+			case 'RLIKE':
+			case 'REGEXP':
+				$operator = $clause['compare_key'];
+				if ( isset( $clause['type_key'] ) && 'BINARY' === strtoupper( $clause['type_key'] ) ) {
+					$cast = 'BINARY';
+				} else {
+					$cast = '';
+				}
+				$where = $wpdb->prepare( "$alias.meta_key $operator $cast %s", trim( $clause['key'] ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				break;
+			case '!=':
+			case 'NOT EXISTS':
+				$meta_compare_string = $meta_compare_string_start . "AND $subquery_alias.meta_key = %s " . $meta_compare_string_end;
+				$where               = $wpdb->prepare( $meta_compare_string, $clause['key'] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+			case 'NOT LIKE':
+				$meta_compare_string = $meta_compare_string_start . "AND $subquery_alias.meta_key LIKE %s " . $meta_compare_string_end;
+
+				$meta_compare_value = '%' . $wpdb->esc_like( trim( $clause['key'] ) ) . '%';
+				$where              = $wpdb->prepare( $meta_compare_string, $meta_compare_value ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+			case 'NOT IN':
+				$array_subclause     = '(' . substr( str_repeat( ',%s', count( $clause['key'] ) ), 1 ) . ') ';
+				$meta_compare_string = $meta_compare_string_start . "AND $subquery_alias.meta_key IN " . $array_subclause . $meta_compare_string_end;
+				$where               = $wpdb->prepare( $meta_compare_string, $clause['key'] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+			case 'NOT REGEXP':
+				$operator = $clause['compare_key'];
+				if ( isset( $clause['type_key'] ) && 'BINARY' === strtoupper( $clause['type_key'] ) ) {
+					$cast = 'BINARY';
+				} else {
+					$cast = '';
+				}
+
+				$meta_compare_string = $meta_compare_string_start . "AND $subquery_alias.meta_key REGEXP $cast %s " . $meta_compare_string_end;
+				$where               = $wpdb->prepare( $meta_compare_string, $clause['key'] ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+		}
+
+		return $where;
+	}
+
+	/**
+	 * Generates an SQL WHERE clause for a given meta_query atomic clause based on its meta value.
+	 * Adapted from WordPress' `WP_Meta_Query::get_sql_for_clause()` method.
+	 *
+	 * @param array $clause An atomic meta_query clause.
+	 * @return null|string An SQL WHERE clause or NULL if $clause is invalid.
+	 */
+	private function generate_where_for_clause_value( $clause ) {
+		global $wpdb;
+
+		if ( ! array_key_exists( 'value', $clause ) ) {
+			return;
+		}
+
+		$meta_value = $clause['value'];
+
+		if ( in_array( $clause['compare'], array( 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN' ), true ) ) {
+			if ( ! is_array( $meta_value ) ) {
+				$meta_value = preg_split( '/[,\s]+/', $meta_value );
+			}
+		} elseif ( is_string( $meta_value ) ) {
+			$meta_value = trim( $meta_value );
+		}
+
+		$meta_compare = $clause['compare'];
+
+		switch ( $meta_compare ) {
+			case 'IN':
+			case 'NOT IN':
+				$where = $wpdb->prepare( '(' . substr( str_repeat( ',%s', count( $meta_value ) ), 1 ) . ')', $meta_value ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+
+			case 'BETWEEN':
+			case 'NOT BETWEEN':
+				$where = $wpdb->prepare( '%s AND %s', $meta_value[0], $meta_value[1] );
+				break;
+
+			case 'LIKE':
+			case 'NOT LIKE':
+				$where = $wpdb->prepare( '%s', '%' . $wpdb->esc_like( $meta_value ) . '%' );
+				break;
+
+			// EXISTS with a value is interpreted as '='.
+			case 'EXISTS':
+				$meta_compare = '=';
+				$where        = $wpdb->prepare( '%s', $meta_value );
+				break;
+
+			// 'value' is ignored for NOT EXISTS.
+			case 'NOT EXISTS':
+				$where = '';
+				break;
+
+			default:
+				$where = $wpdb->prepare( '%s', $meta_value );
+				break;
+		}
+
+		if ( $where ) {
+			if ( 'CHAR' === $clause['cast'] ) {
+				return "{$clause['alias']}.meta_value {$meta_compare} {$where}";
+			} else {
+				return "CAST({$clause['alias']}.meta_value AS {$clause['cast']}) {$meta_compare} {$where}";
+			}
+		}
+	}
+
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1,35 +1,119 @@
 <?php
+// phpcs:disable Generic.Commenting.Todo.TaskFound
+/**
+ * OrdersTableQuery class file.
+ */
+
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 
-/** @package Automattic\WooCommerce\Internal\DataStores\Orders */
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class provides a `WP_Query`-like interface to custom order tables.
+ */
 class OrdersTableQuery {
 
+	/**
+	 * Values to ignore when parsing query arguments.
+	 */
 	private const SKIPPED_VALUES = array( '', array(), null );
 
-	public $sql;
-	public $max_num_pages = 0;
-	public $orders = array();
-	public $orders_count = 0;
-	public $found_orders = 0;
-
+	/**
+	 * Query vars set by the user.
+	 *
+	 * @var array
+	 */
 	private $original_args = array();
+
+	/**
+	 * Query vars after processing and sanitization.
+	 *
+	 * @var array
+	 */
 	private $args = array();
 
+	/**
+	 * Columns to be selected in the SELECT clause.
+	 *
+	 * @var array
+	 */
 	private $fields = array();
+
+	/**
+	 * Array of table aliases and conditions used to compute the JOIN clause of the query.
+	 *
+	 * @var array
+	 */
 	private $join = array();
+
+	/**
+	 * Array of fields and conditions used to compute the WHERE clause of the query.
+	 *
+	 * @var array
+	 */
 	private $where = array();
+
+	/**
+	 * Field to be used in the GROUP BY clause of the query.
+	 *
+	 * @var array
+	 */
 	private $groupby = array();
+
+	/**
+	 * Array of fields used to compute the ORDER BY clause of the query.
+	 *
+	 * @var array
+	 */
 	private $orderby = array();
+
+	/**
+	 * Limits used to compute the LIMIT clause of the query.
+	 *
+	 * @var array
+	 */
 	private $limits = array();
 
+	/**
+	 * Results (order IDs) for the current query.
+	 *
+	 * @var array
+	 */
+	private $results = array();
 
+	/**
+	 * Final SQL query to run after processing of args.
+	 *
+	 * @var string
+	 */
+	private $sql = '';
+
+	/**
+	 * The number of pages (when pagination is enabled).
+	 *
+	 * @var int
+	 */
+	private $max_num_pages = 0;
+
+	/**
+	 * The number of orders found.
+	 *
+	 * @var int
+	 */
+	private $found_orders = 0;
+
+	/**
+	 * Sets up and runs the query after processing arguments.
+	 *
+	 * @param array $args Array of query vars.
+	 */
 	public function __construct( $args = array() ) {
 		$datastore = wc_get_container()->get( OrdersTableDataStore::class );
 
 		// TODO: maybe OrdersTableDataStore::get_all_table_names() could return these keys/indices instead.
-		$this->tables = array(
+		$this->tables   = array(
 			'orders'           => $datastore::get_orders_table_name(),
 			'addresses'        => $datastore::get_addresses_table_name(),
 			'operational_data' => $datastore::get_operational_data_table_name(),
@@ -37,87 +121,21 @@ class OrdersTableQuery {
 		);
 		$this->mappings = $datastore->get_all_order_column_mappings();
 
-
 		$this->original_args = $args;
 		$this->args          = $args;
 
+		$this->remap_args();
 		$this->validate_args();
 		$this->build_query();
 		$this->run_query();
 	}
 
-	private function validate_args() {
-		$this->remap_args();
-
-		// status:
-		$valid_statuses = array_keys( wc_get_order_statuses() );
-
-		if ( empty( $this->args['status'] ) || 'any' === $this->args['status'] ) {
-			$this->args['status'] = $valid_statuses;
-		} else if ( 'all' === $this->args['status'] ) {
-			$this->args['status'] = array();
-		} else {
-			$this->args['status'] = is_array( $this->args['status'] ) ? $this->args['status'] : array( $this->args['status'] );
-
-			foreach ( $this->args['status'] as &$status ) {
-				$status = in_array( 'wc-' . $status, $valid_statuses, true ) ? 'wc-' . $status : $status;
-			}
-
-			$this->args['status'] = array_unique( array_filter( $this->args['status'] ) );
-		}
-
-		// order and orderby:
-		$this->args['order'] = $this->sanitize_order( $this->args['order'] ?? '' );
-		$this->sanitize_orderby( $this->args['orderby'] ?? 'date' );
-
-		// TODO: 'type', 'customer'.
-		// TODO: Keys from $this->internal_meta_keys (i.e. _key)
-		// TODO: meta_query
-		// TODO: customer_note, name.
-		unset( $this->args['type'], $this->args['customer'], $this->args['meta_query'], $this->args['customer_note'], $this->args['name'] );
-	}
-
-	private function sanitize_order( $order ) {
-		$order = strtoupper( is_string( $order ) ? $order : '' );
-
-		return in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'DESC';
-	}
-
-	private function sanitize_orderby() {
-		// Allowed keys.
-		// TODO: rand, metakeys, etc.
-		$allowed_keys = array( 'ID'  , 'id'  , 'type', 'date', 'modified', 'parent' );
-
-		// Translate $orderby to a valid field.
-		$mapping = array(
-			'ID'   => 'orders.id',
-			'id'   => 'orders.id',
-			'type' => 'orders.type',
-			'date' => 'orders.date_created_gmt',
-			'modified' => 'orders.date_updated_gmt',
-			'parent' => 'orders.parent_order_id',
-		);
-
-		$order   = $this->args['order'];
-		$orderby = $this->args['orderby'];
-
-		if ( 'none' === $orderby ) {
-			return;
-		}
-
-		if ( is_string( $orderby ) ) {
-			$orderby = array( $orderby => $order );
-		}
-
-		$this->args['orderby'] = array();
-		foreach ( $orderby as $order_key => $order ) {
-			if ( isset( $mapping[ $order_key ] ) ) {
-				$this->args['orderby'][ $mapping[ $order_key ] ] = $this->sanitize_order( $order );
-			}
-		}
-	}
-
-	private function remap_args() {
+	/**
+	 * Remaps some legacy and `WP_Query` specific query vars to vars available in the customer order table scheme.
+	 *
+	 * @return void
+	 */
+	private function remap_args(): void {
 		$mapping = array(
 			// WP_Query legacy.
 			'post_date'           => 'date_created_gmt',
@@ -170,18 +188,104 @@ class OrdersTableQuery {
 		}
 	}
 
-	private function build_query() {
-		$this->build_query_fields();
-		$this->build_query_WHERE();
-		$this->build_query_ORDERBY();
-		$this->build_query_LIMIT();
+	/**
+	 * Validates query vars.
+	 *
+	 * @return void
+	 */
+	private function validate_args(): void {
+		// Order statuses.
+		$valid_statuses = array_keys( wc_get_order_statuses() );
 
-		$distinct = '';
-		$groupby = '';
-		$orderby = 'ORDER BY ' . $this->orderby;
+		if ( empty( $this->args['status'] ) || 'any' === $this->args['status'] ) {
+			$this->args['status'] = $valid_statuses;
+		} elseif ( 'all' === $this->args['status'] ) {
+			$this->args['status'] = array();
+		} else {
+			$this->args['status'] = is_array( $this->args['status'] ) ? $this->args['status'] : array( $this->args['status'] );
+
+			foreach ( $this->args['status'] as &$status ) {
+				$status = in_array( 'wc-' . $status, $valid_statuses, true ) ? 'wc-' . $status : $status;
+			}
+
+			$this->args['status'] = array_unique( array_filter( $this->args['status'] ) );
+		}
+
+		// 'order' and 'orderby' vars.
+		$this->args['order'] = $this->sanitize_order( $this->args['order'] ?? '' );
+		$this->sanitize_orderby( $this->args['orderby'] ?? 'date' );
+
+		// TODO: 'type', 'customer'.
+		// TODO: Keys from $this->internal_meta_keys (i.e. _key)
+		// TODO: meta_query
+		// TODO: customer_note, name.
+		unset( $this->args['type'], $this->args['customer'], $this->args['meta_query'], $this->args['customer_note'], $this->args['name'] );
+	}
+
+	/**
+	 * Parses and sanitizes the 'orderby' query var.
+	 *
+	 * @return void
+	 */
+	private function sanitize_orderby(): void {
+		// Allowed keys.
+		// TODO: rand, metakeys, etc.
+		$allowed_keys = array( 'ID', 'id', 'type', 'date', 'modified', 'parent' );
+
+		// Translate $orderby to a valid field.
+		$mapping = array(
+			'ID'       => 'orders.id',
+			'id'       => 'orders.id',
+			'type'     => 'orders.type',
+			'date'     => 'orders.date_created_gmt',
+			'modified' => 'orders.date_updated_gmt',
+			'parent'   => 'orders.parent_order_id',
+		);
+
+		$order   = $this->args['order'];
+		$orderby = $this->args['orderby'];
+
+		if ( 'none' === $orderby ) {
+			return;
+		}
+
+		if ( is_string( $orderby ) ) {
+			$orderby = array( $orderby => $order );
+		}
+
+		$this->args['orderby'] = array();
+		foreach ( $orderby as $order_key => $order ) {
+			if ( isset( $mapping[ $order_key ] ) ) {
+				$this->args['orderby'][ $mapping[ $order_key ] ] = $this->sanitize_order( $order );
+			}
+		}
+	}
+
+	/**
+	 * Makes sure the order in an ORDER BY statement is either 'ASC' o 'DESC'.
+	 *
+	 * @param string $order The unsanitized order.
+	 * @return string The sanitized order.
+	 */
+	private function sanitize_order( string $order ): string {
+		$order = strtoupper( is_string( $order ) ? $order : '' );
+
+		return in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'DESC';
+	}
+
+	/**
+	 * Builds the final SQL query to be run.
+	 *
+	 * @return void
+	 */
+	private function build_query(): void {
+		$this->parse_core_fields();
+		$this->parse_orderby();
+		$this->parse_limit();
 
 		// SELECT [fields].
-		$fields = $this->fields;
+		$this->fields = 'orders.id';
+		$fields       = $this->fields;
 
 		// SQL_CALC_FOUND_ROWS.
 		if ( ( ! $this->arg_isset( 'no_found_rows' ) || ! $this->args['no_found_rows'] ) && $this->limits ) {
@@ -208,22 +312,31 @@ class OrdersTableQuery {
 			$where .= " AND ({$condition})";
 		}
 
+		// ORDER BY.
+		$orderby = 'ORDER BY ' . $this->orderby;
+
 		// LIMITS.
 		$limits = $this->limits ? 'LIMIT ' . implode( ',', $this->limits ) : '';
 
-	// 	$found_rows = '';
-	// 	$distinct = '';
-	// 	$fields = "orders.*";
-	// 	$join = '';
-	// 	$where = '';
-	// 	$groupby = '';
-	// 	$orderby = '';
-	// 	$limits = 'LIMIT 20';
+		$distinct = '';
+		$groupby  = '';
 
-		$this->sql = "SELECT $found_rows $distinct $fields FROM {$this->tables['orders']} orders $join WHERE $where $groupby $orderby $limits";
+		$orders_table = $this->tables['orders'];
+
+		$this->sql = "SELECT $found_rows $distinct $fields FROM $orders_table orders $join WHERE $where $groupby $orderby $limits";
 	}
 
-	private function get_where_condition( $table, $field, $value, $type, $operator = false ) {
+	/**
+	 * Generates a properly escaped and sanitized WHERE condition for a given field.
+	 *
+	 * @param string $table    The table the field belongs to.
+	 * @param string $field    The field or column name.
+	 * @param mixed  $value    The value.
+	 * @param string $type     The column type as specified in {@see OrdersTableDataStore} column mappings.
+	 * @param string $operator The operator to use in the condition. Defaults to '=' or 'IN' depending on $value.
+	 * @return string The resulting WHERE condition.
+	 */
+	private function get_where_condition( string $table, string $field, $value, string $type, string $operator = '' ): string {
 		global $wpdb;
 
 		$db_util  = wc_get_container()->get( DatabaseUtil::class );
@@ -238,7 +351,7 @@ class OrdersTableQuery {
 		// = and != can be shorthands for IN and NOT in for array values.
 		if ( is_array( $value ) && '=' === $operator ) {
 			$operator = 'IN';
-		} else if ( is_array( $value ) && '!=' === $operator ) {
+		} elseif ( is_array( $value ) && '!=' === $operator ) {
 			$operator = 'NOT IN';
 		}
 
@@ -253,49 +366,75 @@ class OrdersTableQuery {
 			$placeholder = $format;
 		}
 
-		$sql = $wpdb->prepare( "{$table}.{$field} {$operator} {$placeholder}", $value );
+		$sql = $wpdb->prepare( "{$table}.{$field} {$operator} {$placeholder}", $value ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 		return $sql;
 	}
 
-	private function build_query_fields() {
-		$this->fields = 'orders.id';
-	}
-
-	private function build_query_WHERE() {
+	/**
+	 * Processes query vars for all supported core fields from custom order tables.
+	 *
+	 * @return void
+	 */
+	private function parse_core_fields(): void {
 		global $wpdb;
 
-		// orders:
+		// Orders.
 		foreach ( array( 'id', 'status', 'type', 'currency', 'tax_amount', 'customer_id', 'billing_email', 'total_amount', 'parent_order_id', 'payment_method', 'payment_method_title', 'transaction_id', 'ip_address', 'user_agent' ) as $arg_key ) {
 			if ( ! $this->arg_isset( $arg_key ) ) {
 				continue;
 			}
 
-			$this->where[] = array( 'table'  => 'orders', 'field' => $arg_key, 'value' => $this->args[ $arg_key ], 'type' => $this->mappings['orders'][ $arg_key ]['type'] );
+			$this->where[] = array(
+				'table' => 'orders',
+				'field' => $arg_key,
+				'value' => $this->args[ $arg_key ],
+				'type'  => $this->mappings['orders'][ $arg_key ]['type'],
+			);
 		}
 
 		if ( $this->arg_isset( 'parent_exclude' ) ) {
-			$this->where[] = array( 'table'  => 'orders', 'field' => 'id', 'operator' => '!=', 'value' => $this->args['parent_exclude'], 'type' => 'int' );
+			$this->where[] = array(
+				'table'    => 'orders',
+				'field'    => 'id',
+				'operator' => '!=',
+				'value'    => $this->args['parent_exclude'],
+				'type'     => 'int',
+			);
 		}
 
 		if ( $this->arg_isset( 'exclude' ) ) {
-			$this->where[] = array( 'table'  => 'orders', 'field' => 'id', 'operator' => '!=', 'value' => $this->args['exclude'], 'type' => 'int' );
+			$this->where[] = array(
+				'table'    => 'orders',
+				'field'    => 'id',
+				'operator' => '!=',
+				'value'    => $this->args['exclude'],
+				'type'     => 'int',
+			);
 		}
 
-		// operational_data:
-		foreach( array( 'created_via', 'woocommerce_version', 'prices_include_tax', 'order_key', 'discount_total_amount', 'discount_tax_amount', 'shipping_total_amount', 'shipping_tax_amount' ) as $arg_key ) {
+		// Operational data.
+		foreach ( array( 'created_via', 'woocommerce_version', 'prices_include_tax', 'order_key', 'discount_total_amount', 'discount_tax_amount', 'shipping_total_amount', 'shipping_tax_amount' ) as $arg_key ) {
 			if ( ! $this->arg_isset( $arg_key ) ) {
 				continue;
 			}
 
 			if ( ! isset( $this->join['operational_data'] ) ) {
-				$this->join['operational_data'] = array( 'table' => $this->tables['operational_data'], 'on' => 'orders.id = operational_data.order_id' );
+				$this->join['operational_data'] = array(
+					'table' => $this->tables['operational_data'],
+					'on'    => 'orders.id = operational_data.order_id',
+				);
 			}
 
-			$this->where[] = array( 'table'  => 'operational_data', 'field' => $arg_key, 'value' => $this->args[ $arg_key ], 'type' => $this->mappings['orders'][ $arg_key ]['type'] );
+			$this->where[] = array(
+				'table' => 'operational_data',
+				'field' => $arg_key,
+				'value' => $this->args[ $arg_key ],
+				'type'  => $this->mappings['operational_data'][ $arg_key ]['type'],
+			);
 		}
 
-		// billing & shipping address fields (except email):
+		// Process billing & shipping address fields.
 		foreach ( array( 'billing', 'shipping' ) as $address_type ) {
 			foreach ( array( 'first_name', 'last_name', 'company', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country', 'phone' ) as $field_name ) {
 				if ( ! $this->arg_isset( "{$address_type}_{$field_name}" ) ) {
@@ -303,15 +442,28 @@ class OrdersTableQuery {
 				}
 
 				if ( ! isset( $this->join[ "{$address_type}_address" ] ) ) {
-					$this->join[ "{$address_type}_address" ] = array( 'table' => $this->tables['addresses'], 'on' => $wpdb->prepare( "orders.id = {$address_type}_address.order_id AND {$address_type}_address.address_type = %s", $address_type ) );
+					$this->join[ "{$address_type}_address" ] = array(
+						'table' => $this->tables['addresses'],
+						'on'    => $wpdb->prepare( "orders.id = {$address_type}_address.order_id AND {$address_type}_address.address_type = %s", $address_type ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					);
 				}
 
-				$this->where[] = array( 'table'  => "{$address_type}_address", 'field' => $field_name, 'value' => $this->args[ "{$address_type}_{$field_name}" ], 'type' => $this->mappings[ "{$address_type}_address" ][ $field_name ]['type'] );
+				$this->where[] = array(
+					'table' => "{$address_type}_address",
+					'field' => $field_name,
+					'value' => $this->args[ "{$address_type}_{$field_name}" ],
+					'type'  => $this->mappings[ "{$address_type}_address" ][ $field_name ]['type'],
+				);
 			}
 		}
 	}
 
-	private function build_query_ORDERBY() {
+	/**
+	 * Generates the ORDER BY clause.
+	 *
+	 * @return void
+	 */
+	private function parse_orderby(): void {
 		$orderby = $this->args['orderby'];
 
 		if ( 'none' === $orderby ) {
@@ -327,7 +479,12 @@ class OrdersTableQuery {
 		$this->orderby = implode( ', ', $orderby_array );
 	}
 
-	private function build_query_LIMIT() {
+	/**
+	 * Generates the limits to be used in the LIMIT clause.
+	 *
+	 * @return void
+	 */
+	private function parse_limit(): void {
 		$paginate = ( $this->arg_isset( 'paginate' ) ? (bool) $this->args['paginate'] : false );
 		$limit    = ( $this->arg_isset( 'limit' ) ? absint( $this->args['limit'] ) : false );
 		$page     = ( $this->arg_isset( 'page' ) ? absint( $this->args['page'] ) : 1 );
@@ -340,15 +497,26 @@ class OrdersTableQuery {
 		$this->limits = array( $offset ? $offset : absint( ( $page - 1 ) * $limit ), $limit );
 	}
 
-	private function arg_isset( $arg_key ) {
+	/**
+	 * Checks if a query var is set (i.e. not one of the "skipped values").
+	 *
+	 * @param string $arg_key Query var.
+	 * @return bool TRUE if query var is set.
+	 */
+	private function arg_isset( string $arg_key ): bool {
 		return ( isset( $this->args[ $arg_key ] ) && ! in_array( $this->args[ $arg_key ], self::SKIPPED_VALUES, true ) );
 	}
 
+	/**
+	 * Runs the SQL query.
+	 *
+	 * @return void
+	 */
 	private function run_query() {
 		global $wpdb;
 
 		// Run query.
-		$this->orders = array_map( 'absint', $wpdb->get_col( $this->sql ) );
+		$this->orders = array_map( 'absint', $wpdb->get_col( $this->sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		// Set max_num_pages and found_orders if necessary.
 		if ( ( $this->arg_isset( 'no_found_rows' ) && ! $this->args['no_found_rows'] ) || empty( $this->orders ) ) {
@@ -360,6 +528,27 @@ class OrdersTableQuery {
 			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
 		} else {
 			$this->found_orders = count( $this->orders );
+		}
+	}
+
+	/**
+	 * Make some private available for backwards compatibility.
+	 *
+	 * @param string $name Property to get.
+	 * @return mixed
+	 */
+	public function __get( string $name ) {
+		switch ( $name ) {
+			case 'found_orders':
+			case 'found_posts':
+				return $this->found_orders;
+			case 'max_num_pages':
+				return $this->max_num_pages;
+			case 'posts':
+			case 'orders':
+				return $this->results;
+			default:
+				break;
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -186,6 +186,8 @@ class OrdersTableQuery {
 		// SQL_CALC_FOUND_ROWS.
 		if ( ( ! $this->arg_isset( 'no_found_rows' ) || ! $this->args['no_found_rows'] ) && $this->limits ) {
 			$found_rows = 'SQL_CALC_FOUND_ROWS';
+		} else {
+			$found_rows = '';
 		}
 
 		// JOIN.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1,0 +1,364 @@
+<?php
+namespace Automattic\WooCommerce\Internal\DataStores\Orders;
+
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+
+/** @package Automattic\WooCommerce\Internal\DataStores\Orders */
+class OrdersTableQuery {
+
+	private const SKIPPED_VALUES = array( '', array(), null );
+
+	public $sql;
+	public $max_num_pages = 0;
+	public $orders = array();
+	public $orders_count = 0;
+	public $found_orders = 0;
+
+	private $original_args = array();
+	private $args = array();
+
+	private $fields = array();
+	private $join = array();
+	private $where = array();
+	private $groupby = array();
+	private $orderby = array();
+	private $limits = array();
+
+
+	public function __construct( $args = array() ) {
+		$datastore = wc_get_container()->get( OrdersTableDataStore::class );
+
+		// TODO: maybe OrdersTableDataStore::get_all_table_names() could return these keys/indices instead.
+		$this->tables = array(
+			'orders'           => $datastore::get_orders_table_name(),
+			'addresses'        => $datastore::get_addresses_table_name(),
+			'operational_data' => $datastore::get_operational_data_table_name(),
+			'meta'             => $datastore::get_meta_table_name(),
+		);
+		$this->mappings = $datastore->get_all_order_column_mappings();
+
+
+		$this->original_args = $args;
+		$this->args          = $args;
+
+		$this->validate_args();
+		$this->build_query();
+		$this->run_query();
+	}
+
+	private function validate_args() {
+		$this->remap_args();
+
+		// status:
+		$valid_statuses = array_keys( wc_get_order_statuses() );
+
+		if ( empty( $this->args['status'] ) || 'any' === $this->args['status'] ) {
+			$this->args['status'] = $valid_statuses;
+		} else if ( 'all' === $this->args['status'] ) {
+			$this->args['status'] = array();
+		} else {
+			$this->args['status'] = is_array( $this->args['status'] ) ? $this->args['status'] : array( $this->args['status'] );
+
+			foreach ( $this->args['status'] as &$status ) {
+				$status = in_array( 'wc-' . $status, $valid_statuses, true ) ? 'wc-' . $status : $status;
+			}
+
+			$this->args['status'] = array_unique( array_filter( $this->args['status'] ) );
+		}
+
+		// order and orderby:
+		$this->args['order'] = $this->sanitize_order( $this->args['order'] ?? '' );
+		$this->sanitize_orderby( $this->args['orderby'] ?? 'date' );
+
+		// TODO: 'type', 'customer'.
+		// TODO: Keys from $this->internal_meta_keys (i.e. _key)
+		// TODO: meta_query
+		// TODO: customer_note, name.
+		unset( $this->args['type'], $this->args['customer'], $this->args['meta_query'], $this->args['customer_note'], $this->args['name'] );
+	}
+
+	private function sanitize_order( $order ) {
+		$order = strtoupper( is_string( $order ) ? $order : '' );
+
+		return in_array( $order, array( 'ASC', 'DESC' ), true ) ? $order : 'DESC';
+	}
+
+	private function sanitize_orderby() {
+		// Allowed keys.
+		// TODO: rand, metakeys, etc.
+		$allowed_keys = array( 'ID'  , 'id'  , 'type', 'date', 'modified', 'parent' );
+
+		// Translate $orderby to a valid field.
+		$mapping = array(
+			'ID'   => 'orders.id',
+			'id'   => 'orders.id',
+			'type' => 'orders.type',
+			'date' => 'orders.date_created_gmt',
+			'modified' => 'orders.date_updated_gmt',
+			'parent' => 'orders.parent_order_id',
+		);
+
+		$order   = $this->args['order'];
+		$orderby = $this->args['orderby'];
+
+		if ( 'none' === $orderby ) {
+			return;
+		}
+
+		if ( is_string( $orderby ) ) {
+			$orderby = array( $orderby => $order );
+		}
+
+		$this->args['orderby'] = array();
+		foreach ( $orderby as $order_key => $order ) {
+			if ( isset( $mapping[ $order_key ] ) ) {
+				$this->args['orderby'][ $mapping[ $order_key ] ] = $this->sanitize_order( $order );
+			}
+		}
+	}
+
+	private function remap_args() {
+		$mapping = array(
+			// WP_Query legacy.
+			'post_date'           => 'date_created_gmt',
+			'post_modified'       => 'date_modified_gmt',
+			'post_status'         => 'status',
+			'_date_completed'     => 'date_completed_gmt',
+			'_date_paid'          => 'date_paid_gmt',
+			'paged'               => 'page',
+			'post_parent'         => 'parent_order_id',
+			'post_parent__in'     => 'parent_order_id',
+			'post_parent__not_in' => 'parent_exclude',
+			'post__not_in'        => 'exclude',
+			'posts_per_page'      => 'limit',
+			'p'                   => 'id',
+			'post__in'            => 'id',
+			'post_type'           => 'type',
+			'fields'              => 'return',
+
+			'customer_user'       => 'customer_id',
+			'order_currency'      => 'currency',
+			'order_version'       => 'woocommerce_version',
+			'cart_discount'       => 'discount_total_amount',
+			'cart_discount_tax'   => 'discount_tax_amount',
+			'order_shipping'      => 'shipping_total_amount',
+			'order_shipping_tax'  => 'shipping_tax_amount',
+			'order_tax'           => 'tax_amount',
+
+			// Translate from WC_Order_Query to table structure.
+			'version'             => 'woocommerce_version',
+			'date_created'        => 'date_created_gmt',
+			'date_modified'       => 'date_updated_gmt',
+			'date_completed'      => 'date_completed_gmt',
+			'date_paid'           => 'date_paid_gmt',
+			'discount_total'      => 'discount_total_amount',
+			'discount_tax'        => 'discount_tax_amount',
+			'shipping_total'      => 'shipping_total_amount',
+			'shipping_tax'        => 'shipping_tax_amount',
+			'cart_tax'            => 'tax_amount',
+			'total'               => 'total_amount',
+			'customer_ip_address' => 'ip_address',
+			'customer_user_agent' => 'user_agent',
+			'parent'              => 'parent_order_id',
+		);
+
+		foreach ( $mapping as $query_key => $table_field ) {
+			if ( isset( $this->args[ $query_key ] ) ) {
+				$this->args[ $table_field ] = $this->args[ $query_key ];
+				unset( $this->args[ $query_key ] );
+			}
+		}
+	}
+
+	private function build_query() {
+		$this->build_query_fields();
+		$this->build_query_WHERE();
+		$this->build_query_ORDERBY();
+		$this->build_query_LIMIT();
+
+		$distinct = '';
+		$groupby = '';
+		$orderby = 'ORDER BY ' . $this->orderby;
+
+		// SELECT [fields].
+		$fields = $this->fields;
+
+		// SQL_CALC_FOUND_ROWS.
+		if ( ( ! $this->arg_isset( 'no_found_rows' ) || ! $this->args['no_found_rows'] ) && $this->limits ) {
+			$found_rows = 'SQL_CALC_FOUND_ROWS';
+		}
+
+		// JOIN.
+		$join = '';
+		foreach ( $this->join as $alias => $_join ) {
+			$join .= " LEFT JOIN ${_join['table']} {$alias} ON ({$_join['on']})";
+		}
+
+		// WHERE.
+		$where = '1=1';
+		foreach ( $this->where as $_where ) {
+			$condition = $this->get_where_condition( $_where['table'], $_where['field'], $_where['value'], $_where['type'] ?? false, $_where['operator'] ?? false );
+
+			if ( ! $condition ) {
+				continue;
+			}
+
+			$where .= " AND ({$condition})";
+		}
+
+		// LIMITS.
+		$limits = $this->limits ? 'LIMIT ' . implode( ',', $this->limits ) : '';
+
+	// 	$found_rows = '';
+	// 	$distinct = '';
+	// 	$fields = "orders.*";
+	// 	$join = '';
+	// 	$where = '';
+	// 	$groupby = '';
+	// 	$orderby = '';
+	// 	$limits = 'LIMIT 20';
+
+		$this->sql = "SELECT $found_rows $distinct $fields FROM {$this->tables['orders']} orders $join WHERE $where $groupby $orderby $limits";
+	}
+
+	private function get_where_condition( $table, $field, $value, $type, $operator = false ) {
+		global $wpdb;
+
+		$db_util  = wc_get_container()->get( DatabaseUtil::class );
+		$operator = strtoupper( $operator ? $operator : '=' );
+
+		try {
+			$format = $db_util->get_wpdb_format_for_type( $type );
+		} catch ( \Exception $e ) {
+			$format = '%s';
+		}
+
+		// = and != can be shorthands for IN and NOT in for array values.
+		if ( is_array( $value ) && '=' === $operator ) {
+			$operator = 'IN';
+		} else if ( is_array( $value ) && '!=' === $operator ) {
+			$operator = 'NOT IN';
+		}
+
+		if ( ! in_array( $operator, array( '=', '!=', 'IN', 'NOT IN' ), true ) ) {
+			return false;
+		}
+
+		if ( is_array( $value ) ) {
+			$placeholder = array_fill( 0, count( $value ), $format );
+			$placeholder = '(' . implode( ',', $placeholder ) . ')';
+		} else {
+			$placeholder = $format;
+		}
+
+		$sql = $wpdb->prepare( "{$table}.{$field} {$operator} {$placeholder}", $value );
+
+		return $sql;
+	}
+
+	private function build_query_fields() {
+		$this->fields = 'orders.id';
+	}
+
+	private function build_query_WHERE() {
+		global $wpdb;
+
+		// orders:
+		foreach ( array( 'id', 'status', 'type', 'currency', 'tax_amount', 'customer_id', 'billing_email', 'total_amount', 'parent_order_id', 'payment_method', 'payment_method_title', 'transaction_id', 'ip_address', 'user_agent' ) as $arg_key ) {
+			if ( ! $this->arg_isset( $arg_key ) ) {
+				continue;
+			}
+
+			$this->where[] = array( 'table'  => 'orders', 'field' => $arg_key, 'value' => $this->args[ $arg_key ], 'type' => $this->mappings['orders'][ $arg_key ]['type'] );
+		}
+
+		if ( $this->arg_isset( 'parent_exclude' ) ) {
+			$this->where[] = array( 'table'  => 'orders', 'field' => 'id', 'operator' => '!=', 'value' => $this->args['parent_exclude'], 'type' => 'int' );
+		}
+
+		if ( $this->arg_isset( 'exclude' ) ) {
+			$this->where[] = array( 'table'  => 'orders', 'field' => 'id', 'operator' => '!=', 'value' => $this->args['exclude'], 'type' => 'int' );
+		}
+
+		// operational_data:
+		foreach( array( 'created_via', 'woocommerce_version', 'prices_include_tax', 'order_key', 'discount_total_amount', 'discount_tax_amount', 'shipping_total_amount', 'shipping_tax_amount' ) as $arg_key ) {
+			if ( ! $this->arg_isset( $arg_key ) ) {
+				continue;
+			}
+
+			if ( ! isset( $this->join['operational_data'] ) ) {
+				$this->join['operational_data'] = array( 'table' => $this->tables['operational_data'], 'on' => 'orders.id = operational_data.order_id' );
+			}
+
+			$this->where[] = array( 'table'  => 'operational_data', 'field' => $arg_key, 'value' => $this->args[ $arg_key ], 'type' => $this->mappings['orders'][ $arg_key ]['type'] );
+		}
+
+		// billing & shipping address fields (except email):
+		foreach ( array( 'billing', 'shipping' ) as $address_type ) {
+			foreach ( array( 'first_name', 'last_name', 'company', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country', 'phone' ) as $field_name ) {
+				if ( ! $this->arg_isset( "{$address_type}_{$field_name}" ) ) {
+					continue;
+				}
+
+				if ( ! isset( $this->join[ "{$address_type}_address" ] ) ) {
+					$this->join[ "{$address_type}_address" ] = array( 'table' => $this->tables['addresses'], 'on' => $wpdb->prepare( "orders.id = {$address_type}_address.order_id AND {$address_type}_address.address_type = %s", $address_type ) );
+				}
+
+				$this->where[] = array( 'table'  => "{$address_type}_address", 'field' => $field_name, 'value' => $this->args[ "{$address_type}_{$field_name}" ], 'type' => $this->mappings[ "{$address_type}_address" ][ $field_name ]['type'] );
+			}
+		}
+	}
+
+	private function build_query_ORDERBY() {
+		$orderby = $this->args['orderby'];
+
+		if ( 'none' === $orderby ) {
+			$this->orderby = '';
+			return;
+		}
+
+		$orderby_array = array();
+		foreach ( $this->args['orderby'] as $_orderby => $order ) {
+			$orderby_array[] = "{$_orderby} {$order}";
+		}
+
+		$this->orderby = implode( ', ', $orderby_array );
+	}
+
+	private function build_query_LIMIT() {
+		$paginate = ( $this->arg_isset( 'paginate' ) ? (bool) $this->args['paginate'] : false );
+		$limit    = ( $this->arg_isset( 'limit' ) ? absint( $this->args['limit'] ) : false );
+		$page     = ( $this->arg_isset( 'page' ) ? absint( $this->args['page'] ) : 1 );
+		$offset   = ( $this->arg_isset( 'offset' ) ? absint( $this->args['offset'] ) : false );
+
+		if ( ! $paginate ) {
+			return;
+		}
+
+		$this->limits = array( $offset ? $offset : absint( ( $page - 1 ) * $limit ), $limit );
+	}
+
+	private function arg_isset( $arg_key ) {
+		return ( isset( $this->args[ $arg_key ] ) && ! in_array( $this->args[ $arg_key ], self::SKIPPED_VALUES, true ) );
+	}
+
+	private function run_query() {
+		global $wpdb;
+
+		// Run query.
+		$this->orders = array_map( 'absint', $wpdb->get_col( $this->sql ) );
+
+		// Set max_num_pages and found_orders if necessary.
+		if ( ( $this->arg_isset( 'no_found_rows' ) && ! $this->args['no_found_rows'] ) || empty( $this->orders ) ) {
+			return;
+		}
+
+		if ( $this->limits ) {
+			$this->found_orders  = absint( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) );
+			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
+		} else {
+			$this->found_orders = count( $this->orders );
+		}
+	}
+
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -562,12 +562,11 @@ class OrdersTableQuery {
 	 * @return void
 	 */
 	private function process_limit(): void {
-		$paginate = ( $this->arg_isset( 'paginate' ) ? (bool) $this->args['paginate'] : false );
-		$limit    = ( $this->arg_isset( 'limit' ) ? absint( $this->args['limit'] ) : false );
-		$page     = ( $this->arg_isset( 'page' ) ? absint( $this->args['page'] ) : 1 );
-		$offset   = ( $this->arg_isset( 'offset' ) ? absint( $this->args['offset'] ) : false );
+		$limit  = ( $this->arg_isset( 'limit' ) ? absint( $this->args['limit'] ) : false );
+		$page   = ( $this->arg_isset( 'page' ) ? absint( $this->args['page'] ) : 1 );
+		$offset = ( $this->arg_isset( 'offset' ) ? absint( $this->args['offset'] ) : false );
 
-		if ( ! $paginate ) {
+		if ( ! $limit ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -136,7 +136,7 @@ class OrdersTableQuery {
 		);
 		$this->mappings = $datastore->get_all_order_column_mappings();
 
-		$this->args          = $args;
+		$this->args = $args;
 
 		// TODO: args to be implemented.
 		unset( $this->args['type'], $this->args['customer'], $this->args['customer_note'], $this->args['name'] );
@@ -372,9 +372,9 @@ class OrdersTableQuery {
 	 *
 	 * @param string $table    The table the field belongs to.
 	 * @param string $field    The field or column name.
+	 * @param string $operator The operator to use in the condition. Defaults to '=' or 'IN' depending on $value.
 	 * @param mixed  $value    The value.
 	 * @param string $type     The column type as specified in {@see OrdersTableDataStore} column mappings.
-	 * @param string $operator The operator to use in the condition. Defaults to '=' or 'IN' depending on $value.
 	 * @return string The resulting WHERE condition.
 	 */
 	public function where( string $table, string $field, string $operator, $value, string $type ): string {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3,6 +3,7 @@
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
 /**
@@ -308,6 +309,191 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			$field_name = ( $table === $this->sut::get_orders_table_name() ) ? 'id' : 'order_id';
 			$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE {$field_name} = %d", $order_id ) ) );
 		}
+	}
+
+	/**
+	 * Tests the `OrdersTableQuery` class on the COT datastore.
+	 */
+	public function test_cot_query_basic() {
+		// We bypass the `query()` method as it's mainly just a thin wrapper around
+		// `OrdersTableQuery`.
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'testname',
+				'user_pass'  => 'testpass',
+				'user_email' => 'email@example.com',
+			)
+		);
+
+		$order1 = new WC_Order();
+		$this->switch_data_store( $order1, $this->sut );
+		$order1->set_prices_include_tax( true );
+		$order1->set_total( '100.0' );
+		$order1->set_order_key( 'my-order-key' );
+		$order1->set_customer_id( $user_id );
+		$order1->save();
+
+		$order2 = new WC_Order();
+		$this->switch_data_store( $order2, $this->sut );
+		$order2->set_prices_include_tax( false );
+		$order2->set_total( '50.0' );
+		$order2->save();
+
+		$query_vars = array(
+			'status' => 'all',
+		);
+
+		// Get all orders.
+		$query = new OrdersTableQuery( $query_vars );
+		$this->assertEquals( 2, count( $query->orders ) );
+
+		// Get orders with a specific property.
+		$query_vars['prices_include_tax'] = 'no';
+		$query = new OrdersTableQuery( $query_vars );
+		$this->assertEquals( 1, count( $query->orders ) );
+		$this->assertEquals( $query->orders[0], $order2->get_id() );
+
+		$query_vars['prices_include_tax'] = 'yes';
+		$query = new OrdersTableQuery( $query_vars );
+		$this->assertEquals( 1, count( $query->orders ) );
+		$this->assertEquals( $query->orders[0], $order1->get_id() );
+
+		// Get orders with two specific properties.
+		$query_vars['total'] = '100.0';
+		$query = new OrdersTableQuery( $query_vars );
+		$this->assertEquals( 1, count( $query->orders ) );
+		$this->assertEquals( $query->orders[0], $order1->get_id() );
+
+		// Limit results.
+		unset( $query_vars['total'], $query_vars['prices_include_tax'] );
+		$query_vars['paginate'] = true;
+		$query_vars['limit']    = 1;
+		$query = new OrdersTableQuery( $query_vars );
+		$this->assertEquals( 1, count( $query->orders ) );
+
+		// By customer ID.
+		$query = new OrdersTableQuery(
+			array(
+				'status'      => 'all',
+				'customer_id' => $user_id
+			)
+		);
+		$this->assertEquals( 1, count( $query->orders ) );
+	}
+
+	/**
+	 * Tests meta queries in the `OrdersTableQuery` class.
+	 *
+	 * @return void
+	 */
+	public function test_cot_query_meta() {
+		$order1 = new WC_Order();
+		$this->switch_data_store( $order1, $this->sut );
+		$order1->add_meta_data( 'color', 'green', true );
+		$order1->add_meta_data( 'animal', 'lion', true );
+		$order1->add_meta_data( 'place', 'London', true );
+		$order1->add_meta_data( 'movie', 'Magnolia', true );
+		$order1->set_status( 'completed' );
+		$order1->save();
+
+		$order2 = new WC_Order();
+		$this->switch_data_store( $order2, $this->sut );
+		$order2->add_meta_data( 'color', 'blue', true );
+		$order2->add_meta_data( 'animal', 'cow', true );
+		$order2->add_meta_data( 'place', 'near London', true );
+		$order2->set_status( 'completed' );
+		$order2->save();
+
+		$order3 = new WC_Order();
+		$this->switch_data_store( $order3, $this->sut );
+		$order3->add_meta_data( 'color', 'green', true );
+		$order3->add_meta_data( 'animal', 'lion', true );
+		$order3->add_meta_data( 'place', 'Paris', true );
+		$order3->add_meta_data( 'movie', 'Citizen Kane', true );
+		$order3->set_status( 'completed' );
+		$order3->save();
+
+		// Orders with color=green.
+		$query = new OrdersTableQuery(
+			array(
+				'meta_query' => array(
+					array(
+						'key'   => 'color',
+						'value' => 'green',
+					)
+				)
+			)
+		);
+		$this->assertEquals( 2, count( $query->orders ) );
+
+		// Orders with a 'movie' meta (regardless of value) and animal=lion.
+		$query = new OrdersTableQuery(
+			array(
+				'meta_query' => array(
+					array(
+						'key'   => 'animal',
+						'value' => 'lion'
+					),
+					array(
+						'key'   => 'movie',
+					)
+				)
+			)
+		);
+		$this->assertEquals( 2, count( $query->orders ) );
+		$this->assertContains( $order1->get_id(), $query->orders );
+		$this->assertContains( $order3->get_id(), $query->orders );
+
+		// Orders with place ~London ("London" and "near London").
+		$query = new OrdersTableQuery(
+			array(
+				'meta_query' => array(
+					array(
+						'key'     => 'place',
+						'value'   => 'London',
+						'compare' => 'LIKE',
+					),
+				)
+			)
+		);
+		$this->assertEquals( 2, count( $query->orders ) );
+		$this->assertContains( $order1->get_id(), $query->orders );
+		$this->assertContains( $order2->get_id(), $query->orders );
+
+		// Orders with (color=blue OR place=Paris) AND 'animal' set.
+		$query = new OrdersTableQuery(
+			array(
+				'meta_query' => array(
+					array(
+						'key'     => 'animal',
+					),
+					array(
+						'relation' => 'OR',
+						array(
+							'key'   => 'color',
+							'value' => 'blue',
+						),
+						array(
+							'key'   => 'place',
+							'value' => 'Paris',
+						)
+					)
+				)
+			)
+		);
+		$this->assertEquals( 2, count( $query->orders ) );
+		$this->assertContains( $order2->get_id(), $query->orders );
+		$this->assertContains( $order3->get_id(), $query->orders );
+
+		// Orders with no 'movie' set (and using meta_key and meta_compare directly instead of meta_query as shortcut).
+		$query = new OrdersTableQuery(
+			array(
+				'meta_key'     => 'movie',
+				'meta_compare' => 'NOT EXISTS',
+			)
+		);
+		$this->assertEquals( 1, count( $query->orders ) );
+		$this->assertContains( $order2->get_id(), $query->orders );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -366,7 +366,6 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		// Limit results.
 		unset( $query_vars['total'], $query_vars['prices_include_tax'] );
-		$query_vars['paginate'] = true;
 		$query_vars['limit']    = 1;
 		$query = new OrdersTableQuery( $query_vars );
 		$this->assertEquals( 1, count( $query->orders ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR implements the `query()` method in the COT datastore by means of a new `OrdersTableQuery` class (and helper `OrdersTableMetaQuery` for handling meta queries).

- Some properties still need to be added to the querying mechanism as they haven't been fully implemented in the schema yet (`type`, [for example](https://github.com/woocommerce/woocommerce/issues/33771)). When those issues are addressed, we'll have to remember to update `OrdersTableQuery` too.
- Support for legacy query vars, extensibility, as well as some special handling for meta that is now stored in table columns is in the scope of other issues (see #33877, #33878, #33879). This PR deals with the basics of the `query()` implementation, supporting some of the core columns (across the various tables) and also includes a full implementation of meta queries, with the same flexibility offered by WP's own [`meta_query`](https://developer.wordpress.org/reference/classes/wp_meta_query/).
- Some query vars from [`WP_Query`](https://developer.wordpress.org/reference/classes/wp_query/) are supported and automatically translated to COT columns (examples are `post__in` or `post_date`).

Closes #33613 and #33876.

### How to test the changes in this Pull Request:

1. Enable the COT feature and make COT authoritative.
2. Migrate some orders over to COT to make sure we have data to work with.
3. Test the querying functionality via custom code:
   ```php
   $results = wc_get_orders( $args );
   // ... where `$args` is an array of query vars.
   ```

   <details>
      <summary>👀  More examples</summary>

      ```php
      // Orders  with customer_id = 1.
      $results = wc_get_orders(
	      array(
		      'customer_id' => 1,
	      )
      );
      
      // IDs of 10 on-hold orders.
      $results = wc_get_orders(
	      array(
		      'status'   => 'on-hold',
		      'limit'    => 10,
		      'return'   => 'ids',
	      )
      );
      
      // All orders (except for those with ID=1,2,3) with any status, a parent equal to 0 or 1, created via 'checkout' and with meta key my_meta=yes.
      $results = wc_get_orders(
	      array(
		      'status'      => 'all',
		      'exclude'     => array( 1, 2, 3 ),
		      'parent'      => array( 0, 1 ),
		      'meta_key'    => 'my_meta',
		      'meta_value'  => 'yes',
		      'created_via' => 'checkout',
	      )
      );
      
      // A more complex meta_query: orders where 'my_meta'='good' and either 'your_meta'='bad' or 'our_meta' is set (to any value).
      $results = wc_get_orders(
	      array(
		      'meta_query' => array(
			      'relation' => 'AND',
			      array(
				      'key'   => 'my_meta',
				      'value' => 'good',
			      ),
			      array(
				      'relation' => 'OR',
				      array(
					      'key'   => 'your_meta',
					      'value' => 'bad',
				      ),
				      array(
					      'key'   => 'our_meta'
				      )
			      )
		      ),
	      )
      );
      
      // Orders where meta key 'location' is set to something LIKE "London" and meta key 'no_meta' does not exist.
      $results = wc_get_orders(
	      array(
		      'meta_query' => array(
			      array(
				      'key'     => 'location',
				      'value'   => 'London',				
				      'compare' => 'LIKE',
			      ),
			      array(
				      'key'     => 'no_meta',
				      'compare' => 'NOT EXISTS',
			      )
		      ),
	      )
      );
      ```
   </details>
4. Repeat the above with different arguments (see more examples above). Keep in mind that syntax for the `meta_query` argument is the same as for WP's `WP_Query`. See [the docs](https://developer.wordpress.org/reference/classes/wp_query/#custom-field-post-meta-parameters).