### PR TITLE
fix: typos in shipping settings

### DIFF
--- a/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
@@ -39,12 +39,12 @@ const WooCommerceServicesItem: React.FC< {
 				<img
 					className="woocommerce-services-item__logo"
 					src={ WooIcon }
-					alt="Woocommerce Service Logo"
+					alt="WooCommerce Service Logo"
 				/>
 			</div>
 			<div className="woocommerce-list__item-text">
 				<span className="woocommerce-list__item-title">
-					{ __( 'Woocommerce Shipping', 'woocommerce' ) }
+					{ __( 'WooCommerce Shipping', 'woocommerce' ) }
 					<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
 				</span>
 				<span className="woocommerce-list__item-content">

--- a/plugins/woocommerce-admin/client/shipping/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/shipping/shipping-tour.tsx
@@ -247,7 +247,7 @@ export const ShippingTour = () => {
 								<br />
 								<span>
 									{ __(
-										'A shipping zone is a geography area where a certain set of shippping methods are offered.',
+										'A shipping zone is a geographic area where a certain set of shipping methods are offered.',
 										'woocommerce'
 									) }
 								</span>
@@ -265,7 +265,7 @@ export const ShippingTour = () => {
 					heading: __( 'Shipping methods', 'woocommerce' ),
 					descriptions: {
 						desktop: __(
-							'We defaulted to some recommended shippping methods based on your store location, but you can manage them at any time within each shipping zone settings.',
+							'We defaulted to some recommended shipping methods based on your store location, but you can manage them at any time within each shipping zone settings.',
 							'woocommerce'
 						),
 					},
@@ -310,7 +310,7 @@ export const ShippingTour = () => {
 			},
 			meta: {
 				name: 'shipping-recommendations',
-				heading: __( 'Woocommerce Shipping', 'woocommerce' ),
+				heading: __( 'WooCommerce Shipping', 'woocommerce' ),
 				descriptions: {
 					desktop: __(
 						'If you’d like to speed up your process and print your shipping label straight from your WooCommerce dashboard, WooCommerce Shipping may be for you! ',

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -48,7 +48,7 @@ describe( 'ShippingRecommendations', () => {
 		render( <ShippingRecommendations /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -66,7 +66,7 @@ describe( 'ShippingRecommendations', () => {
 		render( <ShippingRecommendations /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -82,7 +82,7 @@ describe( 'ShippingRecommendations', () => {
 		render( <ShippingRecommendations /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -90,7 +90,7 @@ describe( 'ShippingRecommendations', () => {
 		render( <ShippingRecommendations /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -18,7 +18,7 @@ describe( 'WooCommerceServicesItem', () => {
 		render( <WooCommerceServicesItem isWCSInstalled={ false } /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).toBeInTheDocument();
 
 		expect(
@@ -30,7 +30,7 @@ describe( 'WooCommerceServicesItem', () => {
 		render( <WooCommerceServicesItem isWCSInstalled={ true } /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).toBeInTheDocument();
 
 		expect(

--- a/plugins/woocommerce-admin/client/shipping/test/shipping-recommendations-wrapper.test.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/shipping-recommendations-wrapper.test.tsx
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@wordpress/element', () => ( {
 	...jest.requireActual( '@wordpress/element' ),
-	Suspense: () => <div>Woocommerce Shipping</div>,
+	Suspense: () => <div>WooCommerce Shipping</div>,
 } ) );
 
 const eligibleSelectReturn = {
@@ -46,7 +46,7 @@ describe( 'ShippingRecommendations', () => {
 			/>
 		);
 
-		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'WooCommerce Shipping' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should not render when zone_id is not empty', () => {
@@ -59,7 +59,7 @@ describe( 'ShippingRecommendations', () => {
 			/>
 		);
 
-		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'WooCommerce Shipping' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should not render when woocommerce_show_marketplace_suggestions is "no"', () => {
@@ -77,7 +77,7 @@ describe( 'ShippingRecommendations', () => {
 				zone_id={ undefined }
 			/>
 		);
-		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'WooCommerce Shipping' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should not render when user is not allowed', () => {
@@ -98,7 +98,7 @@ describe( 'ShippingRecommendations', () => {
 				zone_id={ undefined }
 			/>
 		);
-		expect( queryByText( 'Woocommerce Shipping' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'WooCommerce Shipping' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render WCS', async () => {
@@ -111,6 +111,6 @@ describe( 'ShippingRecommendations', () => {
 			/>
 		);
 
-		expect( getByText( 'Woocommerce Shipping' ) ).toBeInTheDocument();
+		expect( getByText( 'WooCommerce Shipping' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce-admin/client/shipping/test/shipping-recommendations.test.js
+++ b/plugins/woocommerce-admin/client/shipping/test/shipping-recommendations.test.js
@@ -46,7 +46,7 @@ describe( 'ShippingRecommendations', () => {
 		render( <ShippingRecommendations /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -54,7 +54,7 @@ describe( 'ShippingRecommendations', () => {
 		render( <ShippingRecommendations /> );
 
 		expect(
-			screen.queryByText( 'Woocommerce Shipping' )
+			screen.queryByText( 'WooCommerce Shipping' )
 		).toBeInTheDocument();
 	} );
 

--- a/plugins/woocommerce-admin/client/shipping/woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/woocommerce-services-item.tsx
@@ -57,7 +57,7 @@ const WooCommerceServicesItem: React.FC< {
 			</div>
 			<div className="woocommerce-list__item-text">
 				<span className="woocommerce-list__item-title">
-					{ __( 'Woocommerce Shipping', 'woocommerce' ) }
+					{ __( 'WooCommerce Shipping', 'woocommerce' ) }
 					<Pill>{ __( 'Recommended', 'woocommerce' ) }</Pill>
 				</span>
 				<span className="woocommerce-list__item-content">

--- a/plugins/woocommerce/changelog/fix-typos-in-shipping-settings
+++ b/plugins/woocommerce/changelog/fix-typos-in-shipping-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed some incorrect spellings in the shipping settings areas.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some mis-capitalisation of 'WooCommerce' was pointed out and fixed - the search was run across the whole woocommerce-admin but there were no instances outside of this.

Also fixed two typos.

### How to test the changes in this Pull Request:
Same as https://github.com/woocommerce/woocommerce/pull/33801 but without the spelling and capitalisation mistakes.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
