### PR TITLE
Upload API and E2E test reports to S3 bucket

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -33,8 +33,8 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpm exec wc-e2e docker:up
 
-            - name: Run tests command.
-              if: fromJSON(env.E2E_PLAYWRIGHT)
+            - name: Run Puppeteer E2E tests.
+              if: fromJSON(env.E2E_PLAYWRIGHT) != true
               id: run-puppeteer-e2e-tests
               working-directory: plugins/woocommerce
               env:
@@ -46,7 +46,7 @@ jobs:
             - name: Archive Puppeteer E2E test results
               if: |
                   always() &&
-                  fromJSON(env.E2E_PLAYWRIGHT) &&
+                  fromJSON(env.E2E_PLAYWRIGHT) != true &&
                   (
                     steps.run-puppeteer-e2e-tests.conclusion != 'cancelled' ||
                     steps.run-puppeteer-e2e-tests.conclusion != 'skipped' 

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -63,13 +63,13 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpx playwright install chromium
 
-            - name: Run (Playwright) tests command.
+            - name: Run Playwright E2E tests.
               id: run_playwright_e2e_tests
               if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce
               run: pnpx playwright test --config=e2e/playwright.config.js
 
-            - name: Generate (Playwright) E2E Test report.
+            - name: Generate Playwright E2E Test report.
               id: generate_e2e_report
               if: |
                   always() && 
@@ -81,7 +81,7 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
 
-            - name: Archive (Playwright) E2E test report
+            - name: Archive Playwright E2E test report
               if: |
                   always() &&
                   fromJSON(env.E2E_PLAYWRIGHT) &&
@@ -95,7 +95,7 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 5
 
-            - name: Archive E2E test screenshots
+            - name: Archive Puppeteer E2E test screenshots
               uses: actions/upload-artifact@v3
               if: always()
               with:

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -294,6 +294,7 @@ jobs:
               env:
                   API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
                   E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
+                  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
               run: |
                   gh workflow run publish-test-reports-pr.yml \
                     -f run_id=$RUN_ID \
@@ -301,4 +302,5 @@ jobs:
                     -f e2e_artifact=$E2E_ARTIFACT \
                     -f pr_number=$PR_NUMBER \
                     -f commit_sha=$COMMIT_SHA \
+                    -f commit_message="$COMMIT_MESSAGE" \
                     --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -291,8 +291,7 @@ jobs:
                   API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
                   E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
               run: |
-                  gh workflow run publish-reports.yml \
-                    -f test_workflow=pr \
+                  gh workflow run publish-reports-pr.yml \
                     -f run_id=$RUN_ID \
                     -f api_artifact=$API_ARTIFACT \
                     -f e2e_artifact=$E2E_ARTIFACT \

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -8,7 +8,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-  E2E_PLAYWRIGHT: true
+    E2E_PLAYWRIGHT: true
 
 jobs:
     e2e-tests-run:
@@ -97,7 +97,11 @@ jobs:
 
             - name: Archive Puppeteer E2E test screenshots
               uses: actions/upload-artifact@v3
-              if: always()
+              if: |
+                  always() &&
+                  (
+                    fromJSON(env.E2E_PLAYWRIGHT) != true
+                  )
               with:
                   name: E2E Screenshots
                   path: plugins/woocommerce/tests/e2e/screenshots

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -295,7 +295,7 @@ jobs:
                   API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
                   E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
               run: |
-                  gh workflow run publish-reports-pr.yml \
+                  gh workflow run publish-test-reports-pr.yml \
                     -f run_id=$RUN_ID \
                     -f api_artifact=$API_ARTIFACT \
                     -f e2e_artifact=$E2E_ARTIFACT \

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
               id: run_playwright_e2e_tests
               if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce
-              run: pnpx playwright test --config=e2e/playwright.config.js ./e2e/tests/basic.spec.js
+              run: pnpx playwright test --config=e2e/playwright.config.js
 
             - name: Generate Playwright E2E Test report.
               id: generate_e2e_report

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -67,7 +67,7 @@ jobs:
               id: run_playwright_e2e_tests
               if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce
-              run: pnpx playwright test --config=e2e/playwright.config.js
+              run: pnpx playwright test --config=e2e/playwright.config.js ./e2e/tests/basic.spec.js
 
             - name: Generate Playwright E2E Test report.
               id: generate_e2e_report

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -8,7 +8,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-  E2E_PLAYWRIGHT: ${{ true }}
+  E2E_PLAYWRIGHT: true
 
 jobs:
     e2e-tests-run:
@@ -34,7 +34,7 @@ jobs:
               run: pnpm exec wc-e2e docker:up
 
             - name: Run tests command.
-              if: env.E2E_PLAYWRIGHT != 'true'
+              if: fromJSON(env.E2E_PLAYWRIGHT)
               id: run-puppeteer-e2e-tests
               working-directory: plugins/woocommerce
               env:
@@ -46,7 +46,7 @@ jobs:
             - name: Archive Puppeteer E2E test results
               if: |
                   always() &&
-                  env.E2E_PLAYWRIGHT != 'true' &&
+                  fromJSON(env.E2E_PLAYWRIGHT) &&
                   (
                     steps.run-puppeteer-e2e-tests.conclusion != 'cancelled' ||
                     steps.run-puppeteer-e2e-tests.conclusion != 'skipped' 
@@ -59,13 +59,13 @@ jobs:
                   retention-days: 5
 
             - name: Download and install Chromium browser.
-              if: env.E2E_PLAYWRIGHT == 'true'
+              if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce
               run: pnpx playwright install chromium
 
             - name: Run (Playwright) tests command.
               id: run_playwright_e2e_tests
-              if: env.E2E_PLAYWRIGHT == 'true'
+              if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce
               run: pnpx playwright test --config=e2e/playwright.config.js
 
@@ -73,7 +73,7 @@ jobs:
               id: generate_e2e_report
               if: |
                   always() && 
-                  ( env.E2E_PLAYWRIGHT == 'true' ) &&
+                  fromJSON(env.E2E_PLAYWRIGHT) &&
                   (
                     steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
                     steps.run_playwright_e2e_tests.conclusion != 'skipped' 
@@ -84,7 +84,7 @@ jobs:
             - name: Archive (Playwright) E2E test report
               if: |
                   always() &&
-                  env.E2E_PLAYWRIGHT == 'true' &&
+                  fromJSON(env.E2E_PLAYWRIGHT) &&
                   steps.generate_e2e_report.conclusion == 'success'
               uses: actions/upload-artifact@v3
               with:
@@ -211,14 +211,14 @@ jobs:
                   path: artifacts/api
 
             - name: Download Playwright E2E test report artifact
-              if: env.E2E_PLAYWRIGHT == 'true'
+              if: fromJSON(env.E2E_PLAYWRIGHT)
               uses: actions/download-artifact@v3
               with:
                   name: e2e-test-report---pr-${{ github.event.number }}
                   path: artifacts/e2e
 
             - name: Download Puppeteer E2E test report artifact
-              if: env.E2E_PLAYWRIGHT != 'true'
+              if: fromJSON(env.E2E_PLAYWRIGHT) != true
               uses: actions/download-artifact@v3
               with:
                   name: pptr-e2e-test-results
@@ -272,7 +272,7 @@ jobs:
             COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         steps:
             - name: Publish API test report
-              if: env.E2E_PLAYWRIGHT != 'true'
+              if: fromJSON(env.E2E_PLAYWRIGHT) != true
               env:
                   ARTIFACT_NAME: api-test-report---pr-${{ github.event.number }}
               run: |
@@ -285,8 +285,8 @@ jobs:
                     -f commit_sha=$COMMIT_SHA \
                     --repo woocommerce/woocommerce-test-reports
 
-            - name: Publish API and (Playwright) E2E test reports
-              if: env.E2E_PLAYWRIGHT == 'true'
+            - name: Publish test reports
+              if: fromJSON(env.E2E_PLAYWRIGHT)
               env:
                   API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
                   E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -294,7 +294,6 @@ jobs:
               env:
                   API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
                   E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
-                  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
               run: |
                   gh workflow run publish-test-reports-pr.yml \
                     -f run_id=$RUN_ID \
@@ -302,5 +301,4 @@ jobs:
                     -f e2e_artifact=$E2E_ARTIFACT \
                     -f pr_number=$PR_NUMBER \
                     -f commit_sha=$COMMIT_SHA \
-                    -f commit_message="$COMMIT_MESSAGE" \
                     --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -301,5 +301,5 @@ jobs:
                     -f e2e_artifact=$E2E_ARTIFACT \
                     -f pr_number=$PR_NUMBER \
                     -f commit_sha=$COMMIT_SHA \
-                    -f root_dir=public \
+                    -f s3_root=public \
                     --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -301,4 +301,5 @@ jobs:
                     -f e2e_artifact=$E2E_ARTIFACT \
                     -f pr_number=$PR_NUMBER \
                     -f commit_sha=$COMMIT_SHA \
+                    -f root_dir=public \
                     --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/scripts/prepare-test-summary.js
+++ b/.github/workflows/scripts/prepare-test-summary.js
@@ -133,12 +133,12 @@ module.exports = async ( { core } ) => {
 		.addRaw( 'To view the full E2E test report, click ' )
 		.addLink(
 			'here.',
-			'https://woocommerce.github.io/woocommerce-test-reports'
+			`https://woocommerce.github.io/woocommerce-test-reports/pr/${ PR_NUMBER }/e2e/`
 		)
 		.addBreak()
 		.addRaw( 'To view all test reports, visit the ' )
 		.addLink(
-			'WooCommerce Test Reports Dashboard',
+			'WooCommerce Test Reports Dashboard.',
 			'https://woocommerce.github.io/woocommerce-test-reports/'
 		)
 		.stringify();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request makes use of a new workflow in the [WooCommerce Test Reports repository](https://github.com/woocommerce/woocommerce-test-reports) that uploads API and E2E test reports to our S3 bucket where they would be hosted from this point on. 

It also updates the links to the full API and E2E test reports in the "Test Results Summary" PR comment and in the [WooCommerce Test Reports Dashboard](https://woocommerce.github.io/woocommerce-test-reports/).

Closes woocommerce/woocommerce-quality#282.

### How to test the changes in this Pull Request:

1. Re-run the [`Run tests against PR`](https://github.com/woocommerce/woocommerce/blob/e2e/rep-s3-pr/.github/workflows/pr-build-and-e2e-tests.yml#L1) workflow in this Pull Request. Alternatively, you can duplicate this branch and PR and run the workflow from there.
2. Wait for the "Publish test reports" job to finish. This job will trigger the "Publish PR test reports" workflow in the Woo Test Reports repo.
    <img width="651" alt="Screen Shot 2022-07-14 at 5 53 43 PM" src="https://user-images.githubusercontent.com/4509348/178955873-e7cda83d-fab2-4682-8874-d49d1d46b33c.png">
3. Navigate to https://github.com/woocommerce/woocommerce-test-reports/actions. You should see a "Publish PR test reports" workflow being triggered. Wait for it to finish.
4. Afterwards, you should see a `pages-build-deployment` workflow. Wait for it to finish too.
    <img width="432" alt="Screen Shot 2022-07-14 at 6 04 01 PM" src="https://user-images.githubusercontent.com/4509348/178959030-77c7ac6d-f1f7-47ac-b826-418ebc308a0c.png">
6. Head over to the Woo Test Reports [dashboard](https://woocommerce.github.io/woocommerce-test-reports/) and notice that the PR now has a link to both the API and E2E test reports:
    <img width="261" alt="Screen Shot 2022-07-14 at 6 01 22 PM" src="https://user-images.githubusercontent.com/4509348/178957392-fb605ec4-5c6e-465b-ab94-c63c65f61582.png">
7. Click on these API and E2E links. They should redirect you to the API/E2E test reports which are now hosted on `s3.amazonaws.com`.
8. Navigate back to the PR and check the API and E2E links in the Test Results Summary also take you to the S3-hosted test reports.
    <img width="426" alt="Screen Shot 2022-07-14 at 6 09 19 PM" src="https://user-images.githubusercontent.com/4509348/178958833-ef276397-cc07-475c-aabf-6608bb183bbd.png">



### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.