### PR TITLE
Add order edit rendering when creating new order

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-add-order-32741
+++ b/plugins/woocommerce/changelog/enhancement-add-order-32741
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Generate ID when creating a new order in COT for consistency with posts.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -141,26 +141,29 @@ class PageController {
 	 */
 	private function setup_action_edit_order(): void {
 		global $theorder;
-		switch ( $this->current_action ) {
-			case 'edit_order':
-				$this->order = wc_get_order( absint( isset( $_GET['id'] ) ? $_GET['id'] : 0 ) );
-				if ( 'edit_order' === $this->current_action && ( ! isset( $this->order ) || ! $this->order ) ) {
-					wp_die( esc_html__( 'You attempted to edit an item that does not exist. Perhaps it was deleted?', 'woocommerce' ) );
-				}
-				if ( ! current_user_can( 'edit_others_shop_orders' ) && ! current_user_can( 'manage_woocommerce' ) ) {
-					wp_die( esc_html__( 'You do not have permission to edit this order', 'woocommerce' ) );
-				}
-				break;
-			case 'new_order':
-				$this->order = new \WC_Order();
-				if ( ! current_user_can( 'publish_shop_orders' ) && ! current_user_can( 'manage_woocommerce' ) ) {
-					wp_die( esc_html__( 'You don\'t have permission to create a new order', 'woocommerce' ) );
-				}
-				break;
-			default:
-				wp_safe_redirect( admin_url( 'admin.php?page=wc-orders' ) );
-				exit;
+		$this->order = wc_get_order( absint( isset( $_GET['id'] ) ? $_GET['id'] : 0 ) );
+		if ( 'edit_order' === $this->current_action && ( ! isset( $this->order ) || ! $this->order ) ) {
+			wp_die( esc_html__( 'You attempted to edit an item that does not exist. Perhaps it was deleted?', 'woocommerce' ) );
 		}
+		if ( ! current_user_can( 'edit_others_shop_orders' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to edit this order', 'woocommerce' ) );
+		}
+		$theorder = $this->order;
+	}
+
+	/**
+	 * Handles initialization of the orders edit form with a new order.
+	 *
+	 * @return void
+	 */
+	private function setup_action_new_order(): void {
+		global $theorder;
+		if ( ! current_user_can( 'publish_shop_orders' ) && ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You don\'t have permission to create a new order', 'woocommerce' ) );
+		}
+		$this->order = new \WC_Order();
+		$this->order->set_status( 'auto-draft' );
+		$this->order->save();
 		$theorder = $this->order;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -28,6 +28,13 @@ class PageController {
 	private $current_action = '';
 
 	/**
+	 * Order object to be used in edit/new form.
+	 *
+	 * @var \WC_Order
+	 */
+	private $order;
+
+	/**
 	 * Sets up the page controller, including registering the menu item.
 	 *
 	 * @return void
@@ -162,6 +169,7 @@ class PageController {
 			wp_die( esc_html__( 'You don\'t have permission to create a new order', 'woocommerce' ) );
 		}
 		$this->order = new \WC_Order();
+		$this->order->set_object_read( false );
 		$this->order->set_status( 'auto-draft' );
 		$this->order->save();
 		$theorder = $this->order;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Enhancement to #32471. When creating a new order, in WP_Posts, a new post with `auto-draft` status would be created and is presented with ID. This PR we add this functionality by creating a new order with auto-draft status when opening a new order for consistency with WP_Post behavior.

### How to test the changes in this Pull Request:

1. Use the instructions in https://github.com/woocommerce/woocommerce/pull/32864 to enable the COT-based UI. 
2. Open edit form on any order by going to `wp-admin/admin.php?page=wc-orders&action=new`
3. Edit form with blank order will be opened.
4. Check that this new edit form is rendered correctly. Note that this PR does not implement saving an order yet, which is targetted by #33972

Note that since this uses a lot of current code with some changes, it's also necessary to test out the current order edit screen. To do that:

1. Switch back to post-based data store from Settings > Advanced > DataStores.
2. Open the new order page for custom post types by going to `wp-admin/admin.php?page=wc-orders&action=new`
3. Create a new order, you should be able to create it without issues.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
