### PR TITLE
Fix docblock type annotations for `$meta_value` parameter.

### DIFF
--- a/plugins/woocommerce/changelog/fix-docblock-type-annotation
+++ b/plugins/woocommerce/changelog/fix-docblock-type-annotation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix docblock type annotations for $meta_value.

--- a/plugins/woocommerce/includes/class-wc-post-data.php
+++ b/plugins/woocommerce/includes/class-wc-post-data.php
@@ -502,7 +502,7 @@ class WC_Post_Data {
 	 * @param  int    $meta_id    Meta ID.
 	 * @param  int    $object_id  Object ID.
 	 * @param  string $meta_key   Meta key.
-	 * @param  string $meta_value Meta value.
+	 * @param  mixed  $meta_value Meta value.
 	 */
 	public static function flush_object_meta_cache( $meta_id, $object_id, $meta_key, $meta_value ) {
 		WC_Cache_Helper::invalidate_cache_group( 'object_' . $object_id );

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-item-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-item-data-store.php
@@ -113,7 +113,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @since  3.0.0
 	 * @param  int    $item_id Item ID.
 	 * @param  string $meta_key Meta key.
-	 * @param  string $meta_value (default: '').
+	 * @param  mixed  $meta_value (default: '').
 	 * @param  bool   $delete_all (default: false).
 	 * @return bool
 	 */

--- a/plugins/woocommerce/includes/interfaces/class-wc-order-item-data-store-interface.php
+++ b/plugins/woocommerce/includes/interfaces/class-wc-order-item-data-store-interface.php
@@ -68,7 +68,7 @@ interface WC_Order_Item_Data_Store_Interface {
 	 *
 	 * @param  int    $item_id Item ID.
 	 * @param  string $meta_key Meta key.
-	 * @param  string $meta_value Meta value (default: '').
+	 * @param  mixed  $meta_value Meta value (default: '').
 	 * @param  bool   $delete_all Delete all matching entries? (default: false).
 	 * @return bool
 	 */

--- a/plugins/woocommerce/includes/wc-deprecated-functions.php
+++ b/plugins/woocommerce/includes/wc-deprecated-functions.php
@@ -1098,7 +1098,7 @@ function add_woocommerce_term_meta( $term_id, $meta_key, $meta_value, $unique = 
  * @deprecated 3.6.0
  * @param int    $term_id    Term ID.
  * @param string $meta_key   Meta key.
- * @param string $meta_value Meta value (default: '').
+ * @param mixed  $meta_value Meta value (default: '').
  * @param bool   $deprecated Deprecated param (default: false).
  * @return bool
  */

--- a/plugins/woocommerce/includes/wc-order-item-functions.php
+++ b/plugins/woocommerce/includes/wc-order-item-functions.php
@@ -95,7 +95,7 @@ function wc_delete_order_item( $item_id ) {
  *
  * @param int    $item_id    Item ID.
  * @param string $meta_key   Meta key.
- * @param string $meta_value Meta value.
+ * @param mixed  $meta_value Meta value.
  * @param string $prev_value Previous value (default: '').
  *
  * @throws Exception         When `WC_Data_Store::load` validation fails.
@@ -115,7 +115,7 @@ function wc_update_order_item_meta( $item_id, $meta_key, $meta_value, $prev_valu
  *
  * @param int    $item_id    Item ID.
  * @param string $meta_key   Meta key.
- * @param string $meta_value Meta value.
+ * @param mixed  $meta_value Meta value.
  * @param bool   $unique     If meta data should be unique (default: false).
  *
  * @throws Exception         When `WC_Data_Store::load` validation fails.
@@ -137,7 +137,7 @@ function wc_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique = fal
  *
  * @param int    $item_id    Item ID.
  * @param string $meta_key   Meta key.
- * @param string $meta_value Meta value (default: '').
+ * @param mixed  $meta_value Meta value (default: '').
  * @param bool   $delete_all Delete all meta data, defaults to `false`.
  *
  * @throws Exception         When `WC_Data_Store::load` validation fails.

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -779,7 +779,7 @@ add_action( 'profile_update', 'wc_update_profile_last_update_time', 10, 2 );
  * @param int    $meta_id     ID of the meta object that was changed.
  * @param int    $user_id     The user that was updated.
  * @param string $meta_key    Name of the meta key that was changed.
- * @param string $_meta_value Value of the meta that was changed.
+ * @param mixed  $_meta_value Value of the meta that was changed.
  */
 function wc_meta_update_last_update_time( $meta_id, $user_id, $meta_key, $_meta_value ) {
 	$keys_to_track = apply_filters( 'woocommerce_user_last_update_fields', array( 'first_name', 'last_name' ) );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add correct type annotations for several `$meta_value` parameters which were wrongly typed as `string`.

### How to test the changes in this Pull Request:

psalm

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
