### PR TITLE
Add a helper function to simplify ExPlat call in PHP

### DIFF
--- a/plugins/woocommerce/changelog/update-add-helper-function-for-explat-backend
+++ b/plugins/woocommerce/changelog/update-add-helper-function-for-explat-backend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add a helper function to simplify ExPlat call

--- a/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
+++ b/plugins/woocommerce/includes/react-admin/class-experimental-abtest.php
@@ -35,6 +35,11 @@ use Automattic\WooCommerce\Admin\WCAdminHelper;
  *      $allow_tracking
  * );
  *
+ * OR use the helper function:
+ *
+ * WooCommerce\Admin\Experimental_Abtest::in_treatment('experiment_name');
+ *
+ *
  * $isTreatment = $abtest->get_variation('your-experiment-name') === 'treatment';
  *
  * @internal This class is experimental and should not be used externally due to planned breaking changes.
@@ -89,6 +94,26 @@ final class Experimental_Abtest {
 		$this->platform           = $platform;
 		$this->consent            = $consent;
 		$this->as_auth_wpcom_user = $as_auth_wpcom_user;
+	}
+
+	/**
+	 * Returns true if the current user is in the treatment group of the given experiment.
+	 *
+	 * @param string $experiment_name Name of the experiment.
+	 * @param bool   $as_auth_wpcom_user Request variation as a auth wp user or not.
+	 * @return bool
+	 */
+	public static function in_treatment( string $experiment_name, bool $as_auth_wpcom_user = false ) {
+		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
+		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
+		$abtest         = new self(
+			$anon_id,
+			'woocommerce',
+			$allow_tracking,
+			$as_auth_wpcom_user
+		);
+
+		return $abtest->get_variation( $experiment_name ) === 'treatment';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a helper function to Experimental_Abtest class to simplify the call.

I've observed that we have used the following snippet in multiple places.

**Before:** 

```
$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
	$anon_id,
	'woocommerce',
	$allow_tracking
);

$date            = new \DateTime( 'now', wp_timezone() );
$experiment_name = strtr(
	self::EXPERIMENT_NAME_BASE,
	array(
		':yyyy' => $date->format( 'Y' ),
		':mm'   => $date->format( 'm' ),
	)
);

return $abtest->get_variation( $experiment_name ) === 'treatment';
```

It can be simplified with a helper function.

**New:** 

```
return WooCommerce\Admin\Experimental_Abtest::in_treatment('experiment_name');
```


### How to test the changes in this Pull Request:

No visual change. Make sure the code makes sense.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
