### PR TITLE
Fix API triggered tracks not firing

### DIFF
--- a/plugins/woocommerce/changelog/fix-tasklist_tracks
+++ b/plugins/woocommerce/changelog/fix-tasklist_tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix tracks not including required properties when triggered by API requests. #33872

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -16,6 +16,57 @@ class WC_Tracks {
 	const PREFIX = 'wcadmin_';
 
 	/**
+	 * Get total product counts.
+	 *
+	 * @return int Number of products.
+	 */
+	public static function get_products_count() {
+		$product_counts = WC_Tracker::get_product_counts();
+		return $product_counts['total'];
+	}
+
+	/**
+	 * Gather blog related properties.
+	 *
+	 * @param int $user_id User id.
+	 * @return array Blog details.
+	 */
+	public static function get_blog_details( $user_id ) {
+		$blog_details = get_transient( 'wc_tracks_blog_details' );
+		if ( false === $blog_details ) {
+			$blog_details = array(
+				'url'            => home_url(),
+				'blog_lang'      => get_user_locale( $user_id ),
+				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
+				'products_count' => self::get_products_count(),
+				'wc_version'     => WC()->version,
+			);
+			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
+		}
+		return $blog_details;
+	}
+
+	/**
+	 * Gather details from the request to the server.
+	 *
+	 * @return array Server details.
+	 */
+	public static function get_server_details() {
+		$data = array();
+
+		$data['_via_ua'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+		$data['_via_ip'] = isset( $_SERVER['REMOTE_ADDR'] ) ? wc_clean( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		$data['_lg']     = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
+		$data['_dr']     = isset( $_SERVER['HTTP_REFERER'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+
+		$uri         = isset( $_SERVER['REQUEST_URI'] ) ? wc_clean( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$host        = isset( $_SERVER['HTTP_HOST'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+		$data['_dl'] = isset( $_SERVER['REQUEST_SCHEME'] ) ? wc_clean( wp_unslash( $_SERVER['REQUEST_SCHEME'] ) ) . '://' . $host . $uri : '';
+
+		return $data;
+	}
+
+	/**
 	 * Record an event in Tracks - this is the preferred way to record events from PHP.
 	 * Note: the event request won't be made if $properties has a member called `error`.
 	 *
@@ -69,6 +120,16 @@ class WC_Tracks {
 		unset( $properties['_ui'] );
 		unset( $properties['_ut'] );
 
-		return array_merge( $properties, $identity );
+		$data = $event_name
+			? array(
+				'_en' => $event_name,
+				'_ts' => WC_Tracks_Client::build_timestamp(),
+			)
+			: array();
+
+		$server_details = self::get_server_details();
+		$blog_details   = self::get_blog_details( $user->ID );
+
+		return array_merge( $properties, $data, $server_details, $identity, $blog_details );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `WC_Site_Tracking` class is only being instantiated on admin pages and not during API calls. We moved a filter to this class that add's **required** properties to tracks. We trigger tracks through the Task list API, which were not being triggered anymore because of the missing required properties.

In this PR I Revert back the track property changes to the WC_tracks class that were moved as part of this PR: #32690

### How to test the changes in this Pull Request:

1. Build this branch locally with `pnpm -- turbo run build` or create a zip and use it on Jurassic `pnpm build:zip --filter=woocommerce`
2. Finish the onboarding and make sure you enable tracking
3. Finish a couple of the tasks in the task list
4. Open your console and refresh the page, and look for a `t.gif` request and look for the `_ui` value in it's payload, something like: `woo:H9GVvYzv87roVhdITRasdfCHE` also check if the payload still contains the `wc_version`, `products_count`, and `blog_id`
5. Now use the anon id gotten in the above step and use it to search for tracks in the mc live tracks (you might have to wait ~10min for tracks to show)
6. Make sure that front end tracks show up like `tasklist_view` and `tasklist_click`
7. Check if the back end tracks also show up like `tasklist_task_completed`
8. Now click the check box to filter rejected events, and make sure it finds none.
9. You can also complete the full task list and make sure `wcadmin_tasklist_completed` gets emitted (you have to hide the task list when finished)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
