### PR TITLE
Fix task list overlaps with the Ellipsis menu

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.scss
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.scss
@@ -2,6 +2,7 @@ $progress-complete-color: #007cba;
 
 .woocommerce-task-progress-header {
 	position: relative;
+	min-height: 28px;
 
 	@at-root .woocommerce-setup-panel & h1 {
 		font-size: 16px;

--- a/plugins/woocommerce/changelog/fix-overlaps-ellipsis-menu-with-task-list
+++ b/plugins/woocommerce/changelog/fix-overlaps-ellipsis-menu-with-task-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix task list overlaps with the Ellipsis menu


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33845.

This PR fixes the issue that "Setup Check List" overlaps with the Ellipsis menu after completing all the steps under the setup checklist on "Woocommerce > Home" page.

Set `min-height: 28px;` to `.woocommerce-task-progress-header` so that the gap between Ellipsis menu and task list card is ~`16px` when progress bar is hidden.


Before:

![Screen Shot 2022-07-14 at 11 58 04](https://user-images.githubusercontent.com/4344253/178895339-837700ea-5ef0-4b90-97a4-40d08a75af89.png)

After:


![Screen Shot 2022-07-14 at 12 03 52](https://user-images.githubusercontent.com/4344253/178896019-82cc2ae0-ce6d-4ca4-a198-281419088ce4.png)



### How to test the changes in this Pull Request:

1. Use a fresh site
2. Complete all task
3. Click on Ellipsis menu and select "Show the setup task list again"
 
![Screen Shot 2022-07-14 at 11 34 32](https://user-images.githubusercontent.com/4344253/178895487-d793dfae-0940-4067-8602-e827f7c8ed7c.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
