### PR TITLE
Remove query for products type in Shipping Task

### DIFF
--- a/plugins/woocommerce/changelog/update-shipping-task-view-logic
+++ b/plugins/woocommerce/changelog/update-shipping-task-view-logic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Improve performance of Shipping Task.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -174,15 +174,7 @@ class Shipping extends Task {
 		$profiler_data = get_option( OnboardingProfile::DATA_OPTION, array() );
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 
-		return in_array( 'physical', $product_types, true ) ||
-			count(
-				wc_get_products(
-					array(
-						'virtual' => false,
-						'limit'   => 1,
-					)
-				)
-			) > 0;
+		return in_array( 'physical', $product_types, true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
@@ -73,7 +73,7 @@ class WC_Admin_Tests_OnboardingTasks_Task_Shipping extends WC_Unit_Test_Case {
 				),
 			)
 		);
-		$this->assertEquals( $this->task->can_view(), false );
+		$this->assertEquals( $this->task->can_view(), true );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/shipping.php
@@ -62,6 +62,37 @@ class WC_Admin_Tests_OnboardingTasks_Task_Shipping extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test can_view function of task when store only sells physical products.
+	 */
+	public function test_can_view_return_true_when_sell_only_physical_type() {
+		update_option(
+			OnboardingProfile::DATA_OPTION,
+			array(
+				'product_types' => array(
+					'physical',
+				),
+			)
+		);
+		$this->assertEquals( $this->task->can_view(), false );
+	}
+
+	/**
+	 * Test can_view function of task when store sells physical and digital products.
+	 */
+	public function test_can_view_return_true_when_sell_physical_and_digital_type() {
+		update_option(
+			OnboardingProfile::DATA_OPTION,
+			array(
+				'product_types' => array(
+					'physical',
+					'digital',
+				),
+			)
+		);
+		$this->assertEquals( $this->task->can_view(), true );
+	}
+
+	/**
 	 * Test can_view function of task when store only sells digital products.
 	 */
 	public function test_can_view_return_false_when_sell_only_digital_type() {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33883.

This removes the query on products in the Shipping Task, which determines if physical products is sold. This is no longer required as the data from the profiler is now considered the source of truth. 

It also provides a performance benefit for sites with larger amounts of products.

### How to test the changes in this Pull Request:

With a fresh site, 

1. Select US store and physical products in the onboarding wizard.
2. Confirm the Shipping Task appears.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
