### PR TITLE
chore: Unify imports syntax in admin-e2e, add missing dependencies

### DIFF
--- a/packages/js/admin-e2e-tests/README.md
+++ b/packages/js/admin-e2e-tests/README.md
@@ -15,7 +15,7 @@ pnpm install @woocommerce/admin-e2e-tests --save
 Create a E2E test specification file under `/tests/e2e/specs/example.test.js`:
 
 ```js
-const { testAdminBasicSetup } = require( '@woocommerce/admin-e2e-tests' );
+import { testAdminBasicSetup } from '@woocommerce/admin-e2e-tests';
 
 testAdminBasicSetup();
 ```

--- a/packages/js/admin-e2e-tests/changelog/update-admin-e2e-imports
+++ b/packages/js/admin-e2e-tests/changelog/update-admin-e2e-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Unify imports syntax, add missing dependencies.

--- a/packages/js/admin-e2e-tests/package.json
+++ b/packages/js/admin-e2e-tests/package.json
@@ -24,6 +24,7 @@
 	"dependencies": {
 		"@jest/globals": "^26.6.2",
 		"@types/jest": "^27.4.1",
+		"@woocommerce/e2e-utils": "workspace:*",
 		"config": "^3.3.7"
 	},
 	"peerDependencies": {
@@ -33,6 +34,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.17.5",
+		"@types/config": "0.0.41",
 		"@types/expect-puppeteer": "^4.4.7",
 		"@types/puppeteer": "^5.4.5",
 		"@typescript-eslint/eslint-plugin": "^5.14.0",

--- a/packages/js/admin-e2e-tests/src/elements/DropdownTypeaheadField.ts
+++ b/packages/js/admin-e2e-tests/src/elements/DropdownTypeaheadField.ts
@@ -1,11 +1,11 @@
 /**
+ * External dependencies
+ */
+import { clearAndFillInput } from '@woocommerce/e2e-utils';
+/**
  * Internal dependencies
  */
 import { BaseElement } from './BaseElement';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { clearAndFillInput } = require( '@woocommerce/e2e-utils' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export class DropdownTypeaheadField extends BaseElement {
 	async search( text: string ): Promise< void > {

--- a/packages/js/admin-e2e-tests/src/fixtures/http-client.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/http-client.ts
@@ -6,11 +6,11 @@ import config from 'config';
 
 // Prepare the HTTP client that will be consumed by the repository.
 // This is necessary so that it can make requests to the REST API.
-const admin = config.get( 'users.admin' ) as {
+const admin = config.get< {
 	username: string;
 	password: string;
-};
-const url = config.get( 'url' ) as string;
+} >( 'users.admin' );
+const url = config.get< string >( 'url' );
 
 export const httpClient = HTTPClientFactory.build( url )
 	.withBasicAuth( admin.username, admin.password )

--- a/packages/js/admin-e2e-tests/src/fixtures/http-client.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/http-client.ts
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { HTTPClientFactory } from '@woocommerce/api';
-/* eslint-disable @typescript-eslint/no-var-requires */
-const config = require( 'config' );
+import config from 'config';
 
 // Prepare the HTTP client that will be consumed by the repository.
 // This is necessary so that it can make requests to the REST API.

--- a/packages/js/admin-e2e-tests/src/fixtures/http-client.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/http-client.ts
@@ -6,8 +6,11 @@ import config from 'config';
 
 // Prepare the HTTP client that will be consumed by the repository.
 // This is necessary so that it can make requests to the REST API.
-const admin = config.get( 'users.admin' );
-const url = config.get( 'url' );
+const admin = config.get( 'users.admin' ) as {
+	username: string;
+	password: string;
+};
+const url = config.get( 'url' ) as string;
 
 export const httpClient = HTTPClientFactory.build( url )
 	.withBasicAuth( admin.username, admin.password )

--- a/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/plugins.ts
@@ -1,10 +1,11 @@
 /**
+ * External dependencies
+ */
+import { utils } from '@woocommerce/e2e-utils';
+/**
  * Internal dependencies
  */
 import { httpClient } from './http-client';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { utils } = require( '@woocommerce/e2e-utils' );
 
 const wpPluginsEndpoint = '/wp/v2/plugins';
 

--- a/packages/js/admin-e2e-tests/src/fixtures/reset.ts
+++ b/packages/js/admin-e2e-tests/src/fixtures/reset.ts
@@ -1,11 +1,12 @@
 /**
+ * External dependencies
+ */
+import { utils } from '@woocommerce/e2e-utils';
+/**
  * Internal dependencies
  */
 import { httpClient } from './http-client';
 import { deactivateAndDeleteAllPlugins } from './plugins';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { utils } = require( '@woocommerce/e2e-utils' );
 
 const { PLUGIN_NAME } = process.env;
 

--- a/packages/js/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/js/admin-e2e-tests/src/pages/BasePage.ts
@@ -15,7 +15,7 @@ import { DropdownTypeaheadField } from '../elements/DropdownTypeaheadField';
 import { FormToggle } from '../elements/FormToggle';
 import { getElementByText, waitForTimeout } from '../utils/actions';
 
-const baseUrl = config.get( 'url' );
+const baseUrl = config.get( 'url' ) as string;
 
 // Represents a page that can be navigated to
 export abstract class BasePage {

--- a/packages/js/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/js/admin-e2e-tests/src/pages/BasePage.ts
@@ -15,7 +15,7 @@ import { DropdownTypeaheadField } from '../elements/DropdownTypeaheadField';
 import { FormToggle } from '../elements/FormToggle';
 import { getElementByText, waitForTimeout } from '../utils/actions';
 
-const baseUrl = config.get( 'url' ) as string;
+const baseUrl = config.get< string >( 'url' );
 
 // Represents a page that can be navigated to
 export abstract class BasePage {

--- a/packages/js/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/js/admin-e2e-tests/src/pages/BasePage.ts
@@ -4,6 +4,10 @@
 import { ElementHandle, Page } from 'puppeteer';
 
 /**
+ * External dependencies
+ */
+import config from 'config';
+/**
  * Internal dependencies
  */
 import { DropdownField } from '../elements/DropdownField';
@@ -11,9 +15,6 @@ import { DropdownTypeaheadField } from '../elements/DropdownTypeaheadField';
 import { FormToggle } from '../elements/FormToggle';
 import { getElementByText, waitForTimeout } from '../utils/actions';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-const config = require( 'config' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 const baseUrl = config.get( 'url' );
 
 // Represents a page that can be navigated to

--- a/packages/js/admin-e2e-tests/src/pages/Login.ts
+++ b/packages/js/admin-e2e-tests/src/pages/Login.ts
@@ -1,12 +1,13 @@
 /**
+ * External dependencies
+ */
+import { clearAndFillInput } from '@woocommerce/e2e-utils';
+import config from 'config';
+/**
  * Internal dependencies
  */
 import { getElementByText } from '../utils/actions';
 import { BasePage } from './BasePage';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { clearAndFillInput } = require( '@woocommerce/e2e-utils' );
-const config = require( 'config' );
 
 export class Login extends BasePage {
 	url = 'wp-login.php';

--- a/packages/js/admin-e2e-tests/src/pages/OnboardingWizard.ts
+++ b/packages/js/admin-e2e-tests/src/pages/OnboardingWizard.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from '@jest/globals';
 import config from 'config';
 import { Page } from 'puppeteer';
 

--- a/packages/js/admin-e2e-tests/src/pages/OnboardingWizard.ts
+++ b/packages/js/admin-e2e-tests/src/pages/OnboardingWizard.ts
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { expect } from '@jest/globals';
+import config from 'config';
 import { Page } from 'puppeteer';
 
 /**
@@ -15,10 +17,6 @@ import {
 } from '../sections/onboarding/StoreDetailsSection';
 import { ThemeSection } from '../sections/onboarding/ThemeSection';
 import { BasePage } from './BasePage';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { expect } = require( '@jest/globals' );
-const config = require( 'config' );
 
 export class OnboardingWizard extends BasePage {
 	url = 'wp-admin/admin.php?page=wc-admin&path=/setup-wizard';

--- a/packages/js/admin-e2e-tests/src/pages/WcSettings.ts
+++ b/packages/js/admin-e2e-tests/src/pages/WcSettings.ts
@@ -1,12 +1,12 @@
 /**
+ * External dependencies
+ */
+import { setCheckbox } from '@woocommerce/e2e-utils';
+/**
  * Internal dependencies
  */
 import { getAttribute, hasClass, waitForElementByText } from '../utils/actions';
 import { BasePage } from './BasePage';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { setCheckbox } = require( '@woocommerce/e2e-utils' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export class WcSettings extends BasePage {
 	url = 'wp-admin/admin.php?page=wc-settings';

--- a/packages/js/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
+++ b/packages/js/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts
@@ -1,17 +1,17 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { BasePage } from '../../pages/BasePage';
-import { waitForElementByText } from '../../utils/actions';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const {
+import {
 	setCheckbox,
 	unsetCheckbox,
 	verifyCheckboxIsSet,
 	verifyCheckboxIsUnset,
-} = require( '@woocommerce/e2e-utils' );
-/* eslint-enable @typescript-eslint/no-var-requires */
+} from '@woocommerce/e2e-utils';
+/**
+ * Internal dependencies
+ */
+import { BasePage } from '../../pages/BasePage';
+import { waitForElementByText } from '../../utils/actions';
 
 export class BusinessSection extends BasePage {
 	async isDisplayed(): Promise< void > {

--- a/packages/js/admin-e2e-tests/src/sections/onboarding/StoreDetailsSection.ts
+++ b/packages/js/admin-e2e-tests/src/sections/onboarding/StoreDetailsSection.ts
@@ -1,18 +1,18 @@
 /**
+ * External dependencies
+ */
+import {
+	clearAndFillInput,
+	verifyCheckboxIsSet,
+	verifyCheckboxIsUnset,
+} from '@woocommerce/e2e-utils';
+import config from 'config';
+/**
  * Internal dependencies
  */
 import { DropdownTypeaheadField } from '../../elements/DropdownTypeaheadField';
 import { BasePage } from '../../pages/BasePage';
 import { waitForElementByText } from '../../utils/actions';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const {
-	clearAndFillInput,
-	verifyCheckboxIsSet,
-	verifyCheckboxIsUnset,
-} = require( '@woocommerce/e2e-utils' );
-const config = require( 'config' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export interface StoreDetails {
 	addressLine1?: string;

--- a/packages/js/admin-e2e-tests/src/sections/payment-setup/BankAccountTransferSetup.ts
+++ b/packages/js/admin-e2e-tests/src/sections/payment-setup/BankAccountTransferSetup.ts
@@ -1,11 +1,11 @@
 /**
+ * External dependencies
+ */
+import { clearAndFillInput } from '@woocommerce/e2e-utils';
+/**
  * Internal dependencies
  */
 import { BasePage } from '../../pages/BasePage';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { clearAndFillInput } = require( '@woocommerce/e2e-utils' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 type AccountDetails = {
 	accountName: string;

--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/basic-setup.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/basic-setup.ts
@@ -19,7 +19,7 @@ const {
 } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const testAdminBasicSetup = () => {
+export const testAdminBasicSetup = () => {
 	describe( 'Store owner can finish initial store setup', () => {
 		const wcSettings = new WcSettings( page );
 		const wpSettings = new WpSettings( page );
@@ -80,5 +80,3 @@ const testAdminBasicSetup = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminBasicSetup };

--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/basic-setup.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/basic-setup.ts
@@ -5,7 +5,7 @@ import {
 	clearAndFillInput,
 	verifyValueOfInputField,
 } from '@woocommerce/e2e-utils';
-import { afterAll, beforeAll, describe, it, expect } from '@jest/globals';
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
 /**
  * Internal dependencies
  */

--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/basic-setup.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/basic-setup.ts
@@ -1,23 +1,17 @@
 /**
+ * External dependencies
+ */
+import {
+	clearAndFillInput,
+	verifyValueOfInputField,
+} from '@woocommerce/e2e-utils';
+import { afterAll, beforeAll, describe, it, expect } from '@jest/globals';
+/**
  * Internal dependencies
  */
 import { WcSettings } from '../../pages/WcSettings';
 import { WpSettings } from '../../pages/WpSettings';
 import { Login } from '../../pages/Login';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const {
-	clearAndFillInput,
-	verifyValueOfInputField,
-} = require( '@woocommerce/e2e-utils' );
-const {
-	afterAll,
-	beforeAll,
-	describe,
-	it,
-	expect,
-} = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const testAdminBasicSetup = () => {
 	describe( 'Store owner can finish initial store setup', () => {

--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -25,7 +25,7 @@ const { verifyValueOfInputField } = require( '@woocommerce/e2e-utils' );
 /**
  * This tests a default, happy path for the onboarding wizard.
  */
-const testAdminOnboardingWizard = () => {
+export const testAdminOnboardingWizard = () => {
 	describe( 'Store owner can complete onboarding wizard', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const login = new Login( page );
@@ -127,7 +127,7 @@ const testAdminOnboardingWizard = () => {
 	} );
 };
 
-const testSelectiveBundleWCPay = () => {
+export const testSelectiveBundleWCPay = () => {
 	describe( 'A japanese store can complete the selective bundle install but does not include WCPay.', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const login = new Login( page );
@@ -229,7 +229,7 @@ const testSelectiveBundleWCPay = () => {
 	} );
 };
 
-const testDifferentStoreCurrenciesWCPay = () => {
+export const testDifferentStoreCurrenciesWCPay = () => {
 	const testCountryCurrencyPairs = [
 		{
 			countryRegionSubstring: 'australia',
@@ -359,7 +359,7 @@ const testDifferentStoreCurrenciesWCPay = () => {
 	} );
 };
 
-const testSubscriptionsInclusion = () => {
+export const testSubscriptionsInclusion = () => {
 	describe( 'A non-US store will not see the Subscriptions inclusion', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const login = new Login( page );
@@ -521,7 +521,7 @@ const testSubscriptionsInclusion = () => {
 	} );
 };
 
-const testBusinessDetailsForm = () => {
+export const testBusinessDetailsForm = () => {
 	describe( 'A store that is selling elsewhere will see the "Number of employees” dropdown menu', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const login = new Login( page );
@@ -595,7 +595,7 @@ const testBusinessDetailsForm = () => {
 	} );
 };
 
-const testAdminHomescreen = () => {
+export const testAdminHomescreen = () => {
 	describe( 'Homescreen', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const homeScreen = new WcHomescreen( page );
@@ -619,13 +619,4 @@ const testAdminHomescreen = () => {
 			);
 		} );
 	} );
-};
-
-module.exports = {
-	testAdminOnboardingWizard,
-	testSelectiveBundleWCPay,
-	testDifferentStoreCurrenciesWCPay,
-	testSubscriptionsInclusion,
-	testBusinessDetailsForm,
-	testAdminHomescreen,
 };

--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, it, expect } from '@jest/globals';
+import { verifyValueOfInputField } from '@woocommerce/e2e-utils';
+import config from 'config';
+/**
  * Internal dependencies
  */
 import { OnboardingWizard } from '../../pages/OnboardingWizard';
@@ -8,19 +14,6 @@ import { Login } from '../../pages/Login';
 import { WcSettings } from '../../pages/WcSettings';
 import { ProductsSetup } from '../../pages/ProductsSetup';
 import { resetWooCommerceState } from '../../fixtures/reset';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const {
-	afterAll,
-	beforeAll,
-	describe,
-	it,
-	expect,
-} = require( '@jest/globals' );
-const config = require( 'config' );
-
-const { verifyValueOfInputField } = require( '@woocommerce/e2e-utils' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 /**
  * This tests a default, happy path for the onboarding wizard.

--- a/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/js/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { afterAll, beforeAll, describe, it, expect } from '@jest/globals';
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
 import { verifyValueOfInputField } from '@woocommerce/e2e-utils';
 import config from 'config';
 /**

--- a/packages/js/admin-e2e-tests/src/specs/analytics/analytics-overview.ts
+++ b/packages/js/admin-e2e-tests/src/specs/analytics/analytics-overview.ts
@@ -1,11 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
+/**
  * Internal dependencies
  */
 import { AnalyticsOverview } from '../../pages/AnalyticsOverview';
 import { Login } from '../../pages/Login';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 
 export const testAdminAnalyticsOverview = () => {
 	describe( 'Analytics pages', () => {

--- a/packages/js/admin-e2e-tests/src/specs/analytics/analytics-overview.ts
+++ b/packages/js/admin-e2e-tests/src/specs/analytics/analytics-overview.ts
@@ -7,7 +7,7 @@ import { Login } from '../../pages/Login';
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 
-const testAdminAnalyticsOverview = () => {
+export const testAdminAnalyticsOverview = () => {
 	describe( 'Analytics pages', () => {
 		const analyticsPage = new AnalyticsOverview( page );
 		const login = new Login( page );
@@ -94,5 +94,3 @@ const testAdminAnalyticsOverview = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminAnalyticsOverview };

--- a/packages/js/admin-e2e-tests/src/specs/analytics/analytics.ts
+++ b/packages/js/admin-e2e-tests/src/specs/analytics/analytics.ts
@@ -8,7 +8,7 @@ import { Login } from '../../pages/Login';
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 
-const testAdminAnalyticsPages = () => {
+export const testAdminAnalyticsPages = () => {
 	describe( 'Analytics pages', () => {
 		const analyticsPage = new Analytics( page );
 		const customersPage = new Customers( page );
@@ -82,5 +82,3 @@ const testAdminAnalyticsPages = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminAnalyticsPages };

--- a/packages/js/admin-e2e-tests/src/specs/analytics/analytics.ts
+++ b/packages/js/admin-e2e-tests/src/specs/analytics/analytics.ts
@@ -1,12 +1,13 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
+/**
  * Internal dependencies
  */
 import { Analytics } from '../../pages/Analytics';
 import { Customers } from '../../pages/Customers';
 import { Login } from '../../pages/Login';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 
 export const testAdminAnalyticsPages = () => {
 	describe( 'Analytics pages', () => {

--- a/packages/js/admin-e2e-tests/src/specs/homescreen/activity-panel.ts
+++ b/packages/js/admin-e2e-tests/src/specs/homescreen/activity-panel.ts
@@ -25,7 +25,7 @@ const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 const simpleProductName = 'Simple order';
-const testAdminHomescreenActivityPanel = () => {
+export const testAdminHomescreenActivityPanel = () => {
 	describe( 'Homescreen activity panel', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const homeScreen = new WcHomescreen( page );
@@ -131,5 +131,3 @@ const testAdminHomescreenActivityPanel = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminHomescreenActivityPanel };

--- a/packages/js/admin-e2e-tests/src/specs/homescreen/activity-panel.ts
+++ b/packages/js/admin-e2e-tests/src/specs/homescreen/activity-panel.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
 import { createSimpleProduct, withRestApi } from '@woocommerce/e2e-utils';
 
 /**
@@ -19,10 +20,6 @@ import {
 } from '../../fixtures';
 import { OrdersActivityPanel } from '../../elements/OrdersActivityPanel';
 import { addReviewToProduct, waitForElementByText } from '../../utils/actions';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 const simpleProductName = 'Simple order';
 export const testAdminHomescreenActivityPanel = () => {

--- a/packages/js/admin-e2e-tests/src/specs/homescreen/task-list.ts
+++ b/packages/js/admin-e2e-tests/src/specs/homescreen/task-list.ts
@@ -18,7 +18,7 @@ import { resetWooCommerceState, unhideTaskList } from '../../fixtures';
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const testAdminHomescreenTasklist = () => {
+export const testAdminHomescreenTasklist = () => {
 	describe( 'Homescreen task list', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const homeScreen = new WcHomescreen( page );
@@ -73,5 +73,3 @@ const testAdminHomescreenTasklist = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminHomescreenTasklist };

--- a/packages/js/admin-e2e-tests/src/specs/homescreen/task-list.ts
+++ b/packages/js/admin-e2e-tests/src/specs/homescreen/task-list.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
 import { takeScreenshotFor } from '@woocommerce/e2e-environment';
 
 /**
@@ -13,10 +14,6 @@ import { TaskTitles } from '../../constants/taskTitles';
 import { HelpMenu } from '../../elements/HelpMenu';
 import { WcSettings } from '../../pages/WcSettings';
 import { resetWooCommerceState, unhideTaskList } from '../../fixtures';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const testAdminHomescreenTasklist = () => {
 	describe( 'Homescreen task list', () => {

--- a/packages/js/admin-e2e-tests/src/specs/marketing/coupons.ts
+++ b/packages/js/admin-e2e-tests/src/specs/marketing/coupons.ts
@@ -1,12 +1,12 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
+/**
  * Internal dependencies
  */
 import { Coupons } from '../../pages/Coupons';
 import { Login } from '../../pages/Login';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const testAdminCouponsPage = () => {
 	describe( 'Coupons page', () => {

--- a/packages/js/admin-e2e-tests/src/specs/marketing/coupons.ts
+++ b/packages/js/admin-e2e-tests/src/specs/marketing/coupons.ts
@@ -8,7 +8,7 @@ import { Login } from '../../pages/Login';
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const testAdminCouponsPage = () => {
+export const testAdminCouponsPage = () => {
 	describe( 'Coupons page', () => {
 		const couponsPage = new Coupons( page );
 		const login = new Login( page );
@@ -26,5 +26,3 @@ const testAdminCouponsPage = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminCouponsPage };

--- a/packages/js/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/js/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -18,7 +18,7 @@ import { WcSettings } from '../../pages/WcSettings';
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const testAdminPaymentSetupTask = () => {
+export const testAdminPaymentSetupTask = () => {
 	describe( 'Payment setup task', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const homeScreen = new WcHomescreen( page );
@@ -86,5 +86,3 @@ const testAdminPaymentSetupTask = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminPaymentSetupTask };

--- a/packages/js/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/js/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
 import { takeScreenshotFor } from '@woocommerce/e2e-environment';
 
 /**
@@ -13,10 +14,6 @@ import { WcHomescreen } from '../../pages/WcHomescreen';
 import { BankAccountTransferSetup } from '../../sections/payment-setup/BankAccountTransferSetup';
 import { waitForTimeout } from '../../utils/actions';
 import { WcSettings } from '../../pages/WcSettings';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const testAdminPaymentSetupTask = () => {
 	describe( 'Payment setup task', () => {

--- a/packages/js/admin-e2e-tests/src/specs/tasks/purchase.ts
+++ b/packages/js/admin-e2e-tests/src/specs/tasks/purchase.ts
@@ -11,7 +11,7 @@ import { getElementByText, waitForElementByText } from '../../utils/actions';
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const testAdminPurchaseSetupTask = () => {
+export const testAdminPurchaseSetupTask = () => {
 	describe( 'Purchase setup task', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const homeScreen = new WcHomescreen( page );
@@ -96,5 +96,3 @@ const testAdminPurchaseSetupTask = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminPurchaseSetupTask };

--- a/packages/js/admin-e2e-tests/src/specs/tasks/purchase.ts
+++ b/packages/js/admin-e2e-tests/src/specs/tasks/purchase.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, it } from '@jest/globals';
+/**
  * Internal dependencies
  */
 import { resetWooCommerceState } from '../../fixtures';
@@ -6,10 +10,6 @@ import { Login } from '../../pages/Login';
 import { OnboardingWizard } from '../../pages/OnboardingWizard';
 import { WcHomescreen } from '../../pages/WcHomescreen';
 import { getElementByText, waitForElementByText } from '../../utils/actions';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const testAdminPurchaseSetupTask = () => {
 	describe( 'Purchase setup task', () => {

--- a/packages/js/admin-e2e-tests/src/specs/translations.ts
+++ b/packages/js/admin-e2e-tests/src/specs/translations.ts
@@ -11,7 +11,7 @@ import { switchLanguage } from '../fixtures';
 const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const testAdminTranslations = () => {
+export const testAdminTranslations = () => {
 	describe( 'Test client, package, and PHP class translations,', () => {
 		const profileWizard = new OnboardingWizard( page );
 		const homeScreen = new WcHomescreen( page );
@@ -81,5 +81,3 @@ const testAdminTranslations = () => {
 		} );
 	} );
 };
-
-module.exports = { testAdminTranslations };

--- a/packages/js/admin-e2e-tests/src/specs/translations.ts
+++ b/packages/js/admin-e2e-tests/src/specs/translations.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { afterAll, beforeAll, describe, it } from '@woocommerce/e2e-utils';
+/**
  * Internal dependencies
  */
 import { Login } from '../pages/Login';
@@ -6,10 +10,6 @@ import { OnboardingWizard } from '../pages/OnboardingWizard';
 import { WcHomescreen } from '../pages/WcHomescreen';
 import { Analytics } from '../pages/Analytics';
 import { switchLanguage } from '../fixtures';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { afterAll, beforeAll, describe, it } = require( '@jest/globals' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 export const testAdminTranslations = () => {
 	describe( 'Test client, package, and PHP class translations,', () => {

--- a/packages/js/admin-e2e-tests/src/utils/actions.ts
+++ b/packages/js/admin-e2e-tests/src/utils/actions.ts
@@ -1,17 +1,14 @@
 /**
  * External dependencies
  */
+import { expect } from '@jest/globals';
+import config from 'config';
 import { ElementHandle } from 'puppeteer';
 
 /**
  * Internal dependencies
  */
 import { Login } from '../pages/Login';
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { expect } = require( '@jest/globals' );
-const config = require( 'config' );
-/* eslint-enable @typescript-eslint/no-var-requires */
 
 /**
  * Wait for UI blocking to end.

--- a/packages/js/admin-e2e-tests/src/utils/actions.ts
+++ b/packages/js/admin-e2e-tests/src/utils/actions.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from '@jest/globals';
 import config from 'config';
 import { ElementHandle } from 'puppeteer';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,11 +118,13 @@ importers:
     specifiers:
       '@babel/core': ^7.17.5
       '@jest/globals': ^26.6.2
+      '@types/config': 0.0.41
       '@types/expect-puppeteer': ^4.4.7
       '@types/jest': ^27.4.1
       '@types/puppeteer': ^5.4.5
       '@typescript-eslint/eslint-plugin': ^5.14.0
       '@woocommerce/api': ^0.2.0
+      '@woocommerce/e2e-utils': workspace:*
       '@woocommerce/eslint-plugin': workspace:*
       config: ^3.3.7
       eslint: ^8.12.0
@@ -135,9 +137,11 @@ importers:
     dependencies:
       '@jest/globals': 26.6.2
       '@types/jest': 27.4.1
+      '@woocommerce/e2e-utils': link:../e2e-utils
       config: 3.3.7
     devDependencies:
       '@babel/core': 7.17.8
+      '@types/config': 0.0.41
       '@types/expect-puppeteer': 4.4.7
       '@types/puppeteer': 5.4.5
       '@typescript-eslint/eslint-plugin': 5.15.0_eslint@8.12.0+typescript@4.6.2
@@ -13218,6 +13222,10 @@ packages:
     resolution: {integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==}
     dev: true
 
+  /@types/config/0.0.41:
+    resolution: {integrity: sha512-HjXUmIld0gwvyG8MU/17QtLzOyuMX4jbGuijmS9sWsob5xxgZ/hY9cbRCaHIHqTQ3HMLhwS3F8uXq3Bt9zgzHA==}
+    dev: true
+
   /@types/cookie/0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
@@ -18340,7 +18348,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0
     dev: true
 
   /babel-loader/8.2.3_d3f6fe5812216e437b67a6bf164a056c:
@@ -18370,7 +18378,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.70.0_webpack-cli@4.9.2
+      webpack: 5.70.0
     dev: true
 
   /babel-messages/6.23.0:
@@ -20831,7 +20839,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0
     dev: true
 
   /css-loader/3.6.0_webpack@5.70.0:
@@ -37881,7 +37889,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.46.0_webpack-cli@3.3.12
+      webpack: 4.46.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -37992,7 +38000,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0_acorn@8.7.0
-      webpack: 5.70.0_webpack-cli@3.3.12
+      webpack: 5.70.0
     transitivePeerDependencies:
       - acorn
     dev: true


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Unify the import syntax to use ESM `import/export` over legacy CJS `require`. This not only makes the code easier to read and lets devs avoid switching between conventions, but also improves static analysis, therefore IDE annotations and linter. 

That helped to find missing dependencies, and also highlight another problem:
![image](https://user-images.githubusercontent.com/17435/179018705-3c2dc93d-4469-43ed-9108-18b1e2cedffa.png)

that may be related to the problems I face in #33852 

### How to test the changes in this Pull Request:

1. Run the build
2. Run tests

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
