### PR TITLE
Doc improvements for Playwright e2e

### DIFF
--- a/plugins/woocommerce/e2e/README.md
+++ b/plugins/woocommerce/e2e/README.md
@@ -1,25 +1,13 @@
 # WooCommerce Playwright End to End Tests
 
- This is still a work in progress. Feel free to add a test here. We will gradually deprecate [Puppeteer](../tests/e2e).
+This is the documentation for the new e2e testing setup based on Playwright and wp-env. It superseedes the Puppeteer and e2e-environment [setup](../tests/e2e), which we will gradually deprecate.
 
 ## Table of contents
 
 - [Pre-requisites](#pre-requisites)
-  - [Install Node.js](#install-nodejs)
-  - [Install NVM](#install-nvm)
-  - [Install Docker](#install-pnpm)
-  - [Install Docker](#install-docker)
-- [Configuration](#configuration)
-  - [Test Environment](#test-environment)
-  - [Test Variables](#test-variables)
-- [Running tests](#running-tests)
-  - [Prep work for running tests](#prep-work-for-running-tests)
-  - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode) 
-  - [How to run tests in non-headless mode](#how-to-run-tests-in-non-headless-mode)
-  - [How to run tests in debug mode](#how-to-run-tests-in-debug-mode)
-  - [How to run an individual test](#how-to-run-an-individual-test)
-  - [How to skip tests](#how-to-skip-tests)
-  - [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress-php-and-mariadb-versions)
+- [Introduction](#introduction)
+- [About the Environment](#about-the-environment)
+- [Test Variables](#test-variables)
 - [Guide for writing e2e tests](#guide-for-writing-e2e-tests)
   - [Tools for writing tests](#tools-for-writing-tests)
   - [Creating test structure](#creating-test-structure)
@@ -28,36 +16,51 @@
 
 ## Pre-requisites
 
-### Install Node.js
+- Node.js ([Installation instructions](https://nodejs.org/en/download/))
+- NVM ([Installation instructions](https://github.com/nvm-sh/nvm))
+- PNPM ([Installation instructions](https://pnpm.io/installation))
+- Docker and Docker Compose ([Installation instructions](https://docs.docker.com/engine/install/))
 
-Follow [instructions on the node.js site](https://nodejs.org/en/download/) to install Node.js.
+Note, that if you are on Mac and you install docker through other methods such as homebrew, for example, your steps to set it up might be different. The commands listed in steps below may also vary.
 
-### Install NVM
+If you are using Windows, we recommend using [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) for running E2E tests. Follow the [WSL Setup Instructions](../tests/e2e/WSL_SETUP_INSTRUCTIONS.md) first before proceeding with the steps below.
 
-Follow instructions in the [NVM repository](https://github.com/nvm-sh/nvm) to install NVM.
+### Introduction
 
-### Install pnpm
+End-to-end tests are powered by Playwright. The test site is spinned up using `wp-env` (recommended), but we also temporarily support `e2e-environment` (deprecated).
 
-Follow [instructions on pnpm.io site](https://pnpm.io/installation) to install pnpm.
+**Running tests for the first time:**
 
-### Install Docker
+- `nvm use`
+- `pnpm install`
+- `pnpm -- turbo run build --filter=woocommerce`
+- `pnpm env:test --filter=woocommerce`
 
-Install Docker Desktop if you don't have it installed:
+To run the test again, re-create the environment to start with a fresh state:
 
-- [Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/)
-- [Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/install/)
+- `pnpm env:destroy --filter=woocommerce`
+- `pnpm env:test --filter=woocommerce`
 
-Once installed, you should see `Docker Desktop is running` message with the green light next to it indicating that everything is working as expected.
+Running tests afterwards:
 
-Note, that if you install docker through other methods such as homebrew, for example, your steps to set it up will be different. The commands listed in steps below may also vary.
+- `pnpm env:test --filter=woocommerce` (headless)
+- `cd plugin/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=e2e/playwright.config.js --headed` (headed)
+- `cd plugins/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=e2e/playwright.config.js --debug` (debug)
+- `cd plugins/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=e2e/playwright.config.js ./e2e/tests/activate-and-setup/basic-setup.spec.js` (running a single test)
 
-## Configuration
+To see all options, run `cd plugins/woocommerce && pnpm playwright test --help`
 
-This section explains how e2e tests are working behind the scenes. These are not instructions on how to build environment for running e2e tests and run them. If you are looking for instructions on how to run e2e tests, jump to [Running tests](#running-tests).
+### About the environment
 
-### Test Environment
+The default values are:
 
-Playwright tests can be executed in environments created by the `e2e-environment` or `wp-env` packages. Both packages use Docker for running tests locally in order for the test environment to match the setup on GitHub CI (where Docker is also used for running tests). [An official WordPress Docker image](https://github.com/docker-library/docs/blob/master/wordpress/README.md) is used to build the site. Once the site using the WP Docker image is built, the current WooCommerce dev branch is mapped into the `plugins` folder of that newly built test site.
+- Latest stable WordPress version
+- PHP 7.4
+- MariaDB
+- URL: `http://localhost:8086/`
+- Admin credentials: `admin/password`
+
+If you want to customize these, check the [Test Variables](#test-variables) section.
 
 
 For more information how to configure the test environment for `wp-env`, please checkout the [documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/env) documentation.
@@ -90,180 +93,16 @@ Edit [.wp-env.json](https://github.com/woocommerce/woocommerce/blob/trunk/plugin
 
 **Modiify port for e2e-environment**
 
-Edit [tests/e2e/config/default.json](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/config/default.json).
+Edit [tests/e2e/config/default.json](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/config/default.json).****
 
-## Running tests
+### Starting/stopping the environment
 
-If you are using Windows, we recommend using [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) for End-to-end testing. Follow the [WSL Setup Instructions](../tests/e2e/WSL_SETUP_INSTRUCTIONS.md) first before proceeding with the steps below.
+After you run a test, it's best to restart the environment to start from a fresh state. We are currently working to reset the state more efficiently to avoid the restart being needed, but this is a work-in-progress.
 
-### Prep work for running tests
-
-Run the following in a terminal/command line window
-
-- `cd` to the WooCommerce monorepo folder
-
-- `git checkout trunk` (or the branch where you need to run tests) 
-
-- `nvm use`
-
-- `pnpm install`
-
-- `pnpm dlx playwright install chromium` to install chromium.
-
-- `pnpm -- turbo run build --filter=woocommerce`
-
-- `pnpm env:test --filter=woocommerce`( for `wp-env` ) or  `pnpm docker:up --filter=woocommerce`( for `e2e-environment` )
-
-- Use `docker ps` to confirm that the Docker containers are running. You should see a log similar to one below indicating that everything had been built as expected:
-
-### WP-ENV containers
-
-```bash
-CONTAINER ID   IMAGE              COMMAND                  CREATED          STATUS          PORTS                     NAMES
-98b4d2355897   wordpress:php7.4   "docker-entrypoint.s…"   18 minutes ago   Up 18 minutes   0.0.0.0:8888->80/tcp      8ad7f70fb764617b334080e46db4686a_wordpress_1
-63e79ea05eb2   mariadb            "docker-entrypoint.s…"   18 minutes ago   Up 18 minutes   0.0.0.0:61888->3306/tcp   8ad7f70fb764617b334080e46db4686a_mysql_1
-dc2e7259907d   wordpress:php7.4   "docker-entrypoint.s…"   18 minutes ago   Up 18 minutes   0.0.0.0:8889->80/tcp      8ad7f70fb764617b334080e46db4686a_tests-wordpress_1
-8211d54c5c62   mariadb            "docker-entrypoint.s…"   18 minutes ago   Up 18 minutes   0.0.0.0:61839->3306/tcp   8ad7f70fb764617b334080e46db4686a_tests-mysql_1
-```
-
-### E2E-ENVIRONMENT containers
-
-```bash
-CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                  NAMES
-c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago       Up 5 seconds                               woocommerce_e2e_wordpress-cli
-2ab8e8439e9f        wordpress:5.5.1     "docker-entrypoint.s…"   8 seconds ago       Up 7 seconds        0.0.0.0:8086->80/tcp   woocommerce_e2e_wordpress-www
-4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_e2e_db
-```
-
-Note that by default, both `wp-env` and `e2e-environment` will use PHP version 7.4 and latest versrions available for WordPress and MariaDB.
-
-See [How to run tests using custom WordPress, PHP and MariaDB versions with e2e-environment](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.  
-
-- Navigate to `http://localhost:8086/`
-
-If everything went well, you should be able to access the site. If you changed the port to something other than `8086` as per [Test Variables](#test-variables) section, use the appropriate port to access your site.
-
-As noted in [Test Variables](#test-variables) section, use the following Admin user details to login:
-
-```
-Username: admin
-PW: password
-```
-**Stopping WP-ENV**
-
-- `pnpm env:down --filter=woocommerce` when you are done with running e2e test
-
-Running `pnpm env:destroy --filter=woocommerce` before making any changes to test site configuration in `.wp-env.json` and then `pnpm env:test --filter=woocommerce` re-initializes the test container with your new configurations.
-
-**Stopping e2e-environment**
-
-- Run `pnpm docker:down --filter=woocommerce` when you are done with running e2e tests and before making any changes to test site configuration.
-
-Running `pnpm docker:down --filter=woocommerce` and then `pnpm docker:up --filter=woocommerce` re-initializes the test container.
-
-### How to run tests in headless mode against `e2e-environment`
-
-To run e2e tests in headless mode use the following command:
-
-```bash
-cd plugins/woocommerce
-pnpm playwright test --config=e2e/playwright.config.js
-```
-
-### How to run tests in headless mode against `wp-env`
-
-To run e2e tests in headless mode use the following command:
-
-```bash
-cd plugins/woocommerce
-USE_WP_ENV=1 pnpm playwright test --config=e2e/playwright.config.js
-```
-
-Note that `USE_WP_ENV` is set to `1` in the command above. This must be set in order for all tests to work correctly against the the `wp-env` environment.
-
-### How to run tests in non-headless mode
-
-Tests run in headless mode by default. However, sometimes it's useful to observe the browser while running or developing tests. To do so, you can run tests in a non-headless (dev) mode:
-
-```bash
-cd plugins/woocommerce
-pnpm playwright test --config=e2e/playwright.config.js --headed
-```
-
-## How to retry failed tests
-
-Sometimes tests may fail for different reasons such as network issues, or lost connection. To mitigate against test flakiess, failed tests are rerun up to 1 times before being marked as failed. The amount of retry attempts can be adjusted by passing the `--retries` variable when running tests. For example:
-
-```bash
-cd plugins/woocommerce
-pnpm playwright test --config=e2e/playwright.config.js --retries 3
-```
-
-### How to run tests in debug mode
-
-Tests run in headless mode by default. While writing tests it may be useful to have the debugger loaded while running a test in non-headless mode. To run tests in debug mode:
-
-```bash
-cd plugins/woocommerce
-pnpm playwright test --config=e2e/playwright.config.js --debug
-```
-
-Playwright Inspector window will be opened and the script will be paused on the first Playwright statement. You can step over each action using the "Step over" action or resume script without further pauses.
-
-## How to run an individual test
-
-To run an individual test, use the direct path to the spec. For example:
-
-```bash
-cd plugins/woocommerce
-pnpm playwright test --config=e2e/playwright.config.js ./e2e/tests/activate-and-setup/basic-setup.spec.js
-```
-
-## How to disable parallelization
-
-To run an individual test, use the direct path to the spec. For example:
-
-```bash
-cd plugins/woocommerce
-pnpm playwright test --config=e2e/playwright.config.js --workers=1
-```
-
-## How to skip tests
-
-To skip the tests, use `.only` in the relevant test entry to specify the tests that you do want to run. For example:
-
-```js
-test.only( 'Can login', async () => {} )
-```
-
-```js
-test.only( 'Can make sure WooCommerce is activated. If not, activate it', async () => {} )
-```
-
-You can also use `.skip` in the same fashion. For example:
-
-```js
-test.skip( 'Can start Setup Wizard', async () => {} )
-```
-
-### How to run tests using custom WordPress, PHP and MariaDB versions
-
-The following variables can be used to specify the versions of WordPress, PHP and MariaDB that you'd like to use to build your test site with Docker:
-- `WP_VERSION`
-- `TRAVIS_PHP_VERSION`
-- `TRAVIS_MARIADB_VERSION`  
-The full command to build the site will look as follows:
-```bash
-TRAVIS_MARIADB_VERSION=10.5.3 TRAVIS_PHP_VERSION=7.4.5 WP_VERSION=5.4.1 pnpm docker:up --filter=woocommerce
-```
+- `pnpm env:down --filter=woocommerce` to stop the environment
+- `pnpm env:destroy --filter=woocommerce` when you make changes to `.wp-env.json`
 
 ## Guide for writing e2e tests
-
-### Tools for writing tests
-
-We use the following tools to write e2e tests:
-
-- [Playwright](https://playwright.dev/docs/intro) – a tool enables reliable end-to-end testing for modern web apps.
 
 ### Creating test structure
 
@@ -273,7 +112,7 @@ It is a good practice to start working on the test by identifying what needs to 
   - Merchant can log in
   - Merchant can create virtual product
   - Merchant can verify that virtual product was created
-  
+
 Once you identify the structure of the test, you can move on to writing it.
 
 ### Writing the test
@@ -281,23 +120,23 @@ Once you identify the structure of the test, you can move on to writing it.
 The structure of the test serves as a skeleton for the test itself. You can turn it into a test by using `describe()` and `it()` methods of Playwright:
 
 - [`test.describe()`](https://playwright.dev/docs/api/class-test#test-describe) - creates a block that groups together several related tests;
-- [`test()`](https://playwright.dev/docs/api/class-test#test-call) - actual method that runs the test. 
+- [`test()`](https://playwright.dev/docs/api/class-test#test-call) - actual method that runs the test.
 
 Based on our example, the test skeleton would look as follows:
 
 ```js
 test.describe( 'Merchant can create virtual product', () => {
-	test( 'merchant can log in', async () => {
+  test( 'merchant can log in', async () => {
 
-	} );
+  } );
 
-	test( 'merchant can create virtual product', async () => {
+  test( 'merchant can create virtual product', async () => {
 
-	} );
+  } );
 
-	test( 'merchant can verify that virtual product was created', async () => {
+  test( 'merchant can verify that virtual product was created', async () => {
 
-	} );
+  } );
 } );
 ```
 

--- a/plugins/woocommerce/e2e/README.md
+++ b/plugins/woocommerce/e2e/README.md
@@ -126,19 +126,18 @@ Based on our example, the test skeleton would look as follows:
 
 ```js
 test.describe( 'Merchant can create virtual product', () => {
-  test( 'merchant can log in', async () => {
+	test( 'merchant can log in', async () => {
 
-  } );
+	} );
 
-  test( 'merchant can create virtual product', async () => {
+	test( 'merchant can create virtual product', async () => {
 
-  } );
+	} );
 
-  test( 'merchant can verify that virtual product was created', async () => {
+	test( 'merchant can verify that virtual product was created', async () => {
 
-  } );
+	} );
 } );
-```
 
 ## Debugging tests
 

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -17,13 +17,13 @@ This package uses `Puppeteer` as test runner and `e2e-environment` to spin up a 
   - [Chromium Download](#chromium-download)
 - [Running tests](#running-tests)
   - [Prep work for running tests](#prep-work-for-running-tests)
-  - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode)
+  - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode) 
   - [How to run tests in non-headless mode](#how-to-run-tests-in-non-headless-mode)
   - [How to run tests in debug mode](#how-to-run-tests-in-debug-mode)
   - [How to run an individual test](#how-to-run-an-individual-test)
   - [How to skip tests](#how-to-skip-tests)
   - [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions)
-- [Guide for writing e2e tests](#guide-for-writing-e2e-tests)
+- [Guide for writing e2e tests](#guide-for-writing-e2e-tests) 
   - [Tools for writing tests](#tools-for-writing-tests)
   - [Creating test structure](#creating-test-structure)
   - [Writing the test](#writing-the-test)
@@ -39,11 +39,11 @@ Follow [instructions on pnpm.io site](https://pnpm.io/installation) to install p
 
 ### Install Node.js
 
-Follow [instructions on the node.js site](https://nodejs.org/en/download/) to install Node.js.
+Follow [instructions on the node.js site](https://nodejs.org/en/download/) to install Node.js. 
 
 ### Install NVM
 
-Follow instructions in the [NVM repository](https://github.com/nvm-sh/nvm) to install NVM.
+Follow instructions in the [NVM repository](https://github.com/nvm-sh/nvm) to install NVM. 
 
 ### Install Docker
 
@@ -58,7 +58,7 @@ Note, that if you install docker through other methods such as homebrew, for exa
 
 ## Configuration
 
-This section explains how e2e tests are working behind the scenes. These are not instructions on how to build environment for running e2e tests and run them. If you are looking for instructions on how to run e2e tests, jump to [Running tests](#running-tests).
+This section explains how e2e tests are working behind the scenes. These are not instructions on how to build environment for running e2e tests and run them. If you are looking for instructions on how to run e2e tests, jump to [Running tests](#running-tests). 
 
 ### Test Environment
 
@@ -114,7 +114,7 @@ Run the following in a terminal/command line window
 
 - `cd` to the WooCommerce monorepo folder
 
-- `git checkout trunk` (or the branch where you need to run tests)
+- `git checkout trunk` (or the branch where you need to run tests) 
 
 - `nvm use`
 
@@ -135,13 +135,13 @@ c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago  
 4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_e2e_db
 ```
 
-Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used.
+Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used. 
 
-See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.
+See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.  
 
 - Navigate to `http://localhost:8086/`
 
-If everything went well, you should be able to access the site. If you changed the port to something other than `8086` as per [Test Variables](#test-variables) section, use the appropriate port to access your site.
+If everything went well, you should be able to access the site. If you changed the port to something other than `8086` as per [Test Variables](#test-variables) section, use the appropriate port to access your site. 
 
 As noted in [Test Variables](#test-variables) section, use the following Admin user details to login:
 
@@ -178,7 +178,7 @@ By default, SlowMo mode adds a 50 millisecond delay between test steps. If you'd
 PUPPETEER_SLOWMO=10 pnpm -- turbo run e2e:dev --filter=woocommerce
 ```
 
-The faster you want the tests to run, the lower the value should be of `PUPPETEER_SLOWMO` should be.
+The faster you want the tests to run, the lower the value should be of `PUPPETEER_SLOWMO` should be. 
 
 For example:
 
@@ -197,7 +197,7 @@ E2E_RETRY_TIMES=2 pnpm exec wc-e2e test:e2e
 ### How to run tests in debug mode
 
 Tests run in headless mode by default. While writing tests it may be useful to have the debugger loaded while running a test in non-headless mode. To run tests in debug mode:
-
+            
 ```bash
 pnpm -- turbo run e2e:debug --filter=woocommerce
 ```
@@ -215,7 +215,7 @@ pnpm -- wc-e2e test:e2e ./tests/e2e/specs/wp-admin/create-order.test.js
 
 ### How to skip tests
 
-To skip the tests, use `.only` in the relevant test entry to specify the tests that you do want to run.
+To skip the tests, use `.only` in the relevant test entry to specify the tests that you do want to run. 
 
 For example, in order to skip Setup Wizard tests, add `.only` to the login and activation tests as follows in the `setup-wizard.test.js`:
 
@@ -265,7 +265,7 @@ The following variables can be used to specify the versions of WordPress, PHP an
 
 - `WP_VERSION`
 - `TRAVIS_PHP_VERSION`
-- `TRAVIS_MARIADB_VERSION`
+- `TRAVIS_MARIADB_VERSION`  
 
 The full command to build the site will look as follows:
 
@@ -297,16 +297,16 @@ It is a good practice to start working on the test by identifying what needs to 
 - Merchant can create virtual product
   - Merchant can log in
   - Merchant can create virtual product
-  - Merchant can verify that virtual product was created
-
-Once you identify the structure of the test, you can move on to writing it.
+  - Merchant can verify that virtual product was created   
+  
+Once you identify the structure of the test, you can move on to writing it. 
 
 ### Writing the test
 
 The structure of the test serves as a skeleton for the test itself. You can turn it into a test by using `describe()` and `it()` methods of Jest:
 
 - [`describe()`](https://jestjs.io/docs/en/api#describename-fn) - creates a block that groups together several related tests;
-- [`it()`](https://jestjs.io/docs/en/api#testname-fn-timeout) - actual method that runs the test.
+- [`it()`](https://jestjs.io/docs/en/api#testname-fn-timeout) - actual method that runs the test. 
 
 Based on our example, the test skeleton would look as follows:
 
@@ -336,7 +336,7 @@ it( 'merchant can log in', async () => {
 
 Moving to the next section where we need to actually create a product. You will find that we have a reusable function such as `createSimpleProduct()` in the `components.js` of `@woocommerce/e2e-utils` package. However, note that this function should not be used for testing creating a product because the simple product is created using WooCommerce REST API. This is not how the merchant would typically create a virtual product, we would need to test it by writing actual steps for creating a product in the test.
 
-`createSimpleProduct()` should be used in tests where you need to test something else than creating a simple product. In other words, this function exists in order to quickly fill the site with test data required for running tests. For example, if you want to write a test that will verify that shopper can place a product to the cart on the site, you can use `createSimpleProduct()` to create a product to test the cart.
+`createSimpleProduct()` should be used in tests where you need to test something else than creating a simple product. In other words, this function exists in order to quickly fill the site with test data required for running tests. For example, if you want to write a test that will verify that shopper can place a product to the cart on the site, you can use `createSimpleProduct()` to create a product to test the cart. 
 
 Because `createSimpleProduct()` can't be used in the case of our example test, we'd need to navigate to the page where the user would usually create a product. To do that, there is `openNewProduct()` function of the `merchant` object that we already used above. As a result, that part of the test will look as follows:
 
@@ -346,7 +346,7 @@ it( 'merchant can create virtual product', async () => {
 	} );
 ```
 
-You would then continue writing the test using utilities where possible.
+You would then continue writing the test using utilities where possible. 
 
 Make sure to utilize the functions of the `@automattic/puppeteer-utils` package where possible. For example, if you need to wait for a certain element to be ready to be clicked on and then click on it, you can use `waitAndClick()` function:
 
@@ -368,7 +368,7 @@ FAIL ../specs/front-end/front-end-my-account.test.js (9.219s)
     ✓ allows customer to see account details (1066ms)
 ```
 
-In the example above, you can see that `allows customer to see downloads` part of the test failed and can start looking at it right away. Without steps the test goes through being detailed, it is more difficult to debug it.
+In the example above, you can see that `allows customer to see downloads` part of the test failed and can start looking at it right away. Without steps the test goes through being detailed, it is more difficult to debug it. 
 
 ### Writing tests for WooCommerce extensions
 

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -1,6 +1,8 @@
-# WooCommerce End to End Tests
+# WooCommerce Puppeteer End to End Tests with Puppeteer (Deprecated)
 
-Automated end-to-end tests for WooCommerce.
+**Deprecated. Please check the new E2E setup based on [Playwright + wp-env](./../../e2e).**
+
+This package uses `Puppeteer` as test runner and `e2e-environment` to spin up a test site. **It has been deprecated.** [Please check the new setup](./../../e2e), using `Playwright` as test runner and `wp-env` to spin up a test site.
 
 ## Table of contents
 
@@ -15,13 +17,13 @@ Automated end-to-end tests for WooCommerce.
   - [Chromium Download](#chromium-download)
 - [Running tests](#running-tests)
   - [Prep work for running tests](#prep-work-for-running-tests)
-  - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode) 
+  - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode)
   - [How to run tests in non-headless mode](#how-to-run-tests-in-non-headless-mode)
   - [How to run tests in debug mode](#how-to-run-tests-in-debug-mode)
   - [How to run an individual test](#how-to-run-an-individual-test)
   - [How to skip tests](#how-to-skip-tests)
   - [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions)
-- [Guide for writing e2e tests](#guide-for-writing-e2e-tests) 
+- [Guide for writing e2e tests](#guide-for-writing-e2e-tests)
   - [Tools for writing tests](#tools-for-writing-tests)
   - [Creating test structure](#creating-test-structure)
   - [Writing the test](#writing-the-test)
@@ -37,11 +39,11 @@ Follow [instructions on pnpm.io site](https://pnpm.io/installation) to install p
 
 ### Install Node.js
 
-Follow [instructions on the node.js site](https://nodejs.org/en/download/) to install Node.js. 
+Follow [instructions on the node.js site](https://nodejs.org/en/download/) to install Node.js.
 
 ### Install NVM
 
-Follow instructions in the [NVM repository](https://github.com/nvm-sh/nvm) to install NVM. 
+Follow instructions in the [NVM repository](https://github.com/nvm-sh/nvm) to install NVM.
 
 ### Install Docker
 
@@ -56,7 +58,7 @@ Note, that if you install docker through other methods such as homebrew, for exa
 
 ## Configuration
 
-This section explains how e2e tests are working behind the scenes. These are not instructions on how to build environment for running e2e tests and run them. If you are looking for instructions on how to run e2e tests, jump to [Running tests](#running-tests). 
+This section explains how e2e tests are working behind the scenes. These are not instructions on how to build environment for running e2e tests and run them. If you are looking for instructions on how to run e2e tests, jump to [Running tests](#running-tests).
 
 ### Test Environment
 
@@ -112,7 +114,7 @@ Run the following in a terminal/command line window
 
 - `cd` to the WooCommerce monorepo folder
 
-- `git checkout trunk` (or the branch where you need to run tests) 
+- `git checkout trunk` (or the branch where you need to run tests)
 
 - `nvm use`
 
@@ -133,13 +135,13 @@ c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago  
 4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_e2e_db
 ```
 
-Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used. 
+Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used.
 
-See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.  
+See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.
 
 - Navigate to `http://localhost:8086/`
 
-If everything went well, you should be able to access the site. If you changed the port to something other than `8086` as per [Test Variables](#test-variables) section, use the appropriate port to access your site. 
+If everything went well, you should be able to access the site. If you changed the port to something other than `8086` as per [Test Variables](#test-variables) section, use the appropriate port to access your site.
 
 As noted in [Test Variables](#test-variables) section, use the following Admin user details to login:
 
@@ -176,7 +178,7 @@ By default, SlowMo mode adds a 50 millisecond delay between test steps. If you'd
 PUPPETEER_SLOWMO=10 pnpm -- turbo run e2e:dev --filter=woocommerce
 ```
 
-The faster you want the tests to run, the lower the value should be of `PUPPETEER_SLOWMO` should be. 
+The faster you want the tests to run, the lower the value should be of `PUPPETEER_SLOWMO` should be.
 
 For example:
 
@@ -195,7 +197,7 @@ E2E_RETRY_TIMES=2 pnpm exec wc-e2e test:e2e
 ### How to run tests in debug mode
 
 Tests run in headless mode by default. While writing tests it may be useful to have the debugger loaded while running a test in non-headless mode. To run tests in debug mode:
-            
+
 ```bash
 pnpm -- turbo run e2e:debug --filter=woocommerce
 ```
@@ -213,7 +215,7 @@ pnpm -- wc-e2e test:e2e ./tests/e2e/specs/wp-admin/create-order.test.js
 
 ### How to skip tests
 
-To skip the tests, use `.only` in the relevant test entry to specify the tests that you do want to run. 
+To skip the tests, use `.only` in the relevant test entry to specify the tests that you do want to run.
 
 For example, in order to skip Setup Wizard tests, add `.only` to the login and activation tests as follows in the `setup-wizard.test.js`:
 
@@ -263,7 +265,7 @@ The following variables can be used to specify the versions of WordPress, PHP an
 
 - `WP_VERSION`
 - `TRAVIS_PHP_VERSION`
-- `TRAVIS_MARIADB_VERSION`  
+- `TRAVIS_MARIADB_VERSION`
 
 The full command to build the site will look as follows:
 
@@ -295,16 +297,16 @@ It is a good practice to start working on the test by identifying what needs to 
 - Merchant can create virtual product
   - Merchant can log in
   - Merchant can create virtual product
-  - Merchant can verify that virtual product was created   
-  
-Once you identify the structure of the test, you can move on to writing it. 
+  - Merchant can verify that virtual product was created
+
+Once you identify the structure of the test, you can move on to writing it.
 
 ### Writing the test
 
 The structure of the test serves as a skeleton for the test itself. You can turn it into a test by using `describe()` and `it()` methods of Jest:
 
 - [`describe()`](https://jestjs.io/docs/en/api#describename-fn) - creates a block that groups together several related tests;
-- [`it()`](https://jestjs.io/docs/en/api#testname-fn-timeout) - actual method that runs the test. 
+- [`it()`](https://jestjs.io/docs/en/api#testname-fn-timeout) - actual method that runs the test.
 
 Based on our example, the test skeleton would look as follows:
 
@@ -334,7 +336,7 @@ it( 'merchant can log in', async () => {
 
 Moving to the next section where we need to actually create a product. You will find that we have a reusable function such as `createSimpleProduct()` in the `components.js` of `@woocommerce/e2e-utils` package. However, note that this function should not be used for testing creating a product because the simple product is created using WooCommerce REST API. This is not how the merchant would typically create a virtual product, we would need to test it by writing actual steps for creating a product in the test.
 
-`createSimpleProduct()` should be used in tests where you need to test something else than creating a simple product. In other words, this function exists in order to quickly fill the site with test data required for running tests. For example, if you want to write a test that will verify that shopper can place a product to the cart on the site, you can use `createSimpleProduct()` to create a product to test the cart. 
+`createSimpleProduct()` should be used in tests where you need to test something else than creating a simple product. In other words, this function exists in order to quickly fill the site with test data required for running tests. For example, if you want to write a test that will verify that shopper can place a product to the cart on the site, you can use `createSimpleProduct()` to create a product to test the cart.
 
 Because `createSimpleProduct()` can't be used in the case of our example test, we'd need to navigate to the page where the user would usually create a product. To do that, there is `openNewProduct()` function of the `merchant` object that we already used above. As a result, that part of the test will look as follows:
 
@@ -344,7 +346,7 @@ it( 'merchant can create virtual product', async () => {
 	} );
 ```
 
-You would then continue writing the test using utilities where possible. 
+You would then continue writing the test using utilities where possible.
 
 Make sure to utilize the functions of the `@automattic/puppeteer-utils` package where possible. For example, if you need to wait for a certain element to be ready to be clicked on and then click on it, you can use `waitAndClick()` function:
 
@@ -366,7 +368,7 @@ FAIL ../specs/front-end/front-end-my-account.test.js (9.219s)
     ✓ allows customer to see account details (1066ms)
 ```
 
-In the example above, you can see that `allows customer to see downloads` part of the test failed and can start looking at it right away. Without steps the test goes through being detailed, it is more difficult to debug it. 
+In the example above, you can see that `allows customer to see downloads` part of the test failed and can start looking at it right away. Without steps the test goes through being detailed, it is more difficult to debug it.
 
 ### Writing tests for WooCommerce extensions
 


### PR DESCRIPTION
Documentation improvements for Playwright e2e setup:

- Focus the documentation on Playwright + wp-env
- Leave a reference to the old Puppeteer + e2e-environment docs if someone needs it
- Add a deprecation notice to the documentation in `plugins/woocommerce/tests/e2e` (Puppeeteer + e2e-environment), pointing to the new tests using Playwright + wp-env
- Reduces verbosity of Playwright + wp-env documentation
- Add instructions to destroy env to repeat test locally