### PR TITLE
Add validations to `recordEvent`

### DIFF
--- a/plugins/woocommerce/changelog/add-validation-for-event-recording-on-client
+++ b/plugins/woocommerce/changelog/add-validation-for-event-recording-on-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add validations to recordEvent #33911

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -93,6 +93,16 @@ class WC_Site_Tracking {
 					delete( eventProperties._ui );
 					delete( eventProperties._ut );
 				}
+				// Verify the event name is correct
+				if ( ! /^(([a-z0-9]+)_){2}([a-z0-9_]+)$/.test( eventName ) ) {
+					throw new Error( `A valid event name must be specified. The event name: "${ eventName }" is not valid.` );
+				}
+				// Verify the properties are correct
+				for( prop in eventProperties ) {
+					if ( ! /^[a-z_][a-z0-9_]*$/.test( prop ) ) {
+						throw new Error( `A valid prop name must be specified. The property name: "${ prop }" is not valid.` );
+					}
+				}
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -95,12 +95,12 @@ class WC_Site_Tracking {
 				}
 				// Verify the event name is correct
 				if ( ! <?php echo esc_js( WC_Tracks_Event::EVENT_NAME_REGEX ); ?>.test( eventName ) ) {
-					throw new Error( `A valid event name must be specified. The event name: "${ eventName }" is not valid.` );
+					console.error( `A valid event name must be specified. The event name: "${ eventName }" is not valid.` );
 				}
 				// Verify the properties are correct
 				for( prop in eventProperties ) {
 					if ( ! <?php echo esc_js( WC_Tracks_Event::PROP_NAME_REGEX ); ?>.test( prop ) ) {
-						throw new Error( `A valid prop name must be specified. The property name: "${ prop }" is not valid.` );
+						console.error( `A valid prop name must be specified. The property name: "${ prop }" is not valid.` );
 					}
 				}
 				window._tkq = window._tkq || [];

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -94,12 +94,12 @@ class WC_Site_Tracking {
 					delete( eventProperties._ut );
 				}
 				// Verify the event name is correct
-				if ( ! /^(([a-z0-9]+)_){2}([a-z0-9_]+)$/.test( eventName ) ) {
+				if ( ! <?php echo esc_js( WC_Tracks_Event::EVENT_NAME_REGEX ); ?>.test( eventName ) ) {
 					throw new Error( `A valid event name must be specified. The event name: "${ eventName }" is not valid.` );
 				}
 				// Verify the properties are correct
 				for( prop in eventProperties ) {
-					if ( ! /^[a-z_][a-z0-9_]*$/.test( prop ) ) {
+					if ( ! <?php echo esc_js( WC_Tracks_Event::PROP_NAME_REGEX ); ?>.test( prop ) ) {
 						throw new Error( `A valid prop name must be specified. The property name: "${ prop }" is not valid.` );
 					}
 				}

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php
@@ -17,12 +17,12 @@ class WC_Tracks_Event {
 	/**
 	 * Event name regex.
 	 */
-	const EVENT_NAME_REGEX = '/^(([a-z0-9]+)_){2}([a-z0-9_]+)$/';
+	public const EVENT_NAME_REGEX = '/^(([a-z0-9]+)_){2}([a-z0-9_]+)$/';
 
 	/**
 	 * Property name regex.
 	 */
-	const PROP_NAME_REGEX = '/^[a-z_][a-z0-9_]*$/';
+	public const PROP_NAME_REGEX = '/^[a-z_][a-z0-9_]*$/';
 
 	/**
 	 * Error message as WP_Error.
@@ -97,7 +97,7 @@ class WC_Tracks_Event {
 		}
 
 		foreach ( array_keys( (array) $_event ) as $key ) {
-			if ( ! self::prop_name_is_valid( $key ) ) {
+			if ( ! self::prop_name_is_valid( $key ) && '_en' !== $key ) {
 				return new WP_Error( 'invalid_prop_name', __( 'A valid prop name must be specified', 'woocommerce' ) );
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -62,9 +62,9 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the event validation and sanitization.
+	 * Test the event validation and sanitization with a valid event.
 	 */
-	public function test_event_validation_and_sanitization() {
+	public function test_event_validation_and_sanitization_valid_event() {
 		$event_props = array(
 			'_en'            => 'valid_event_name',
 			'_ts'            => WC_Tracks_Client::build_timestamp(),
@@ -78,6 +78,18 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( property_exists( $event, '_ts' ) );
 		$this->assertTrue( property_exists( $event, 'valid_property' ) );
 		$this->assertFalse( property_exists( $event, '_via_ip' ) );
+	}
+
+	/**
+	 * Test the event validation and sanitization with an invalid event.
+	 */
+	public function test_event_validation_and_sanitization_invalid_event_name() {
+		$event_props = array(
+			'_en'            => 'valid_event_name',
+			'_ts'            => WC_Tracks_Client::build_timestamp(),
+			'valid_property' => 'My value',
+			'_via_ip'        => '192.168.10.1',
+		);
 
 		// Invalid event name.
 		$event = \WC_Tracks_Event::validate_and_sanitize(

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -14,6 +14,7 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		parent::setUp();
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
 	}
 
 	/**
@@ -60,4 +61,58 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		$this->assertNotEquals( 'bad', $properties['_ut'] );
 	}
 
+	/**
+	 * Test the event validation and sanitization.
+	 */
+	public function test_event_validation_and_sanitization() {
+		$event_props = array(
+			'_en'            => 'valid_event_name',
+			'_ts'            => WC_Tracks_Client::build_timestamp(),
+			'valid_property' => 'My value',
+			'_via_ip'        => '192.168.10.1',
+		);
+
+		// Valid event and property names.
+		$event = \WC_Tracks_Event::validate_and_sanitize( $event_props );
+		$this->assertTrue( property_exists( $event, 'browser_type' ) );
+		$this->assertTrue( property_exists( $event, '_ts' ) );
+		$this->assertTrue( property_exists( $event, 'valid_property' ) );
+		$this->assertFalse( property_exists( $event, '_via_ip' ) );
+
+		// Invalid event name.
+		$event = \WC_Tracks_Event::validate_and_sanitize(
+			array(
+				...$event_props,
+				'_en' => 'invalidName',
+			)
+		);
+		$this->assertTrue( is_wp_error( $event ) );
+		$this->assertEquals( $event->get_error_code(), 'invalid_event_name' );
+		$event = \WC_Tracks_Event::validate_and_sanitize(
+			array(
+				...$event_props,
+				'_en' => 'invalid-name',
+			)
+		);
+		$this->assertTrue( is_wp_error( $event ) );
+		$this->assertEquals( $event->get_error_code(), 'invalid_event_name' );
+
+		// Invalid property name.
+		$event = \WC_Tracks_Event::validate_and_sanitize(
+			array(
+				...$event_props,
+				'invalid-property-name' => 'My value',
+			)
+		);
+		$this->assertTrue( is_wp_error( $event ) );
+		$this->assertEquals( $event->get_error_code(), 'invalid_prop_name' );
+		$event = \WC_Tracks_Event::validate_and_sanitize(
+			array(
+				...$event_props,
+				'invalid property name' => 'My value',
+			)
+		);
+		$this->assertTrue( is_wp_error( $event ) );
+		$this->assertEquals( $event->get_error_code(), 'invalid_prop_name' );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -93,17 +93,18 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 
 		// Invalid event name.
 		$event = \WC_Tracks_Event::validate_and_sanitize(
-			array(
-				...$event_props,
-				'_en' => 'invalidName',
+			array_merge(
+				$event_props,
+				array( '_en' => 'invalidName' )
 			)
 		);
 		$this->assertTrue( is_wp_error( $event ) );
 		$this->assertEquals( $event->get_error_code(), 'invalid_event_name' );
+
 		$event = \WC_Tracks_Event::validate_and_sanitize(
-			array(
-				...$event_props,
-				'_en' => 'invalid-name',
+			array_merge(
+				$event_props,
+				array( '_en' => 'invalid-name' )
 			)
 		);
 		$this->assertTrue( is_wp_error( $event ) );
@@ -111,17 +112,18 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 
 		// Invalid property name.
 		$event = \WC_Tracks_Event::validate_and_sanitize(
-			array(
-				...$event_props,
-				'invalid-property-name' => 'My value',
+			array_merge(
+				$event_props,
+				array( 'invalid-property-name' => 'My value' )
 			)
 		);
 		$this->assertTrue( is_wp_error( $event ) );
 		$this->assertEquals( $event->get_error_code(), 'invalid_prop_name' );
+
 		$event = \WC_Tracks_Event::validate_and_sanitize(
-			array(
-				...$event_props,
-				'invalid property name' => 'My value',
+			array_merge(
+				$event_props,
+				array( 'invalid property name' => 'My value' )
 			)
 		);
 		$this->assertTrue( is_wp_error( $event ) );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up PR to [this](https://github.com/woocommerce/woocommerce/pull/33704).
This PR adds the code to check if the event and property names that we are recording are correct. This validation throws a console error when the name has a forbidden character.

### How to test the changes in this Pull Request:

1. To test this PR you can install and activate [this plugin](https://gist.github.com/octaedro/4559dc2b81cc01e2395795241bbba638).
2. Open the browser's dev tools and go to the `Console` tab.
3. Go to `WooCommerce` > `Home`.
4. A prompt will be shown asking `Use broken props`.
5. If you press `Ok` the event `my_event` will be recorded with the prop `invalid-prop`.
6. If you press `Cancel` the prop `valid_prop_name` will be used instead.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
