### PR TITLE
Fix free features is still rendered when no recommendation

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -13,6 +13,7 @@ import {
 	__experimentalText as Text,
 	FlexItem,
 	CheckboxControl,
+	Spinner,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { SelectControl, Form, TextControl } from '@woocommerce/components';
@@ -725,27 +726,33 @@ class BusinessDetails extends Component {
 
 	render() {
 		const tabs = [];
-		if ( this.props.hasFinishedGetFreeExtensionsResolution ) {
+		if ( ! this.props.hasFinishedGetFreeExtensionsResolution ) {
+			return (
+				<div className="woocommerce-admin__business-details__spinner">
+					<Spinner />
+				</div>
+			);
+		}
+
+		tabs.push( {
+			name:
+				this.state.currentTab === BUSINESS_DETAILS_TAB_NAME
+					? 'current-tab'
+					: BUSINESS_DETAILS_TAB_NAME,
+			id: BUSINESS_DETAILS_TAB_NAME,
+			title: __( 'Business details', 'woocommerce' ),
+		} );
+
+		if ( this.props.hasInstallableExtensions ) {
 			tabs.push( {
 				name:
-					this.state.currentTab === BUSINESS_DETAILS_TAB_NAME
+					this.state.currentTab === BUSINESS_FEATURES_TAB_NAME
 						? 'current-tab'
-						: BUSINESS_DETAILS_TAB_NAME,
-				id: BUSINESS_DETAILS_TAB_NAME,
-				title: __( 'Business details', 'woocommerce' ),
+						: BUSINESS_FEATURES_TAB_NAME,
+				id: BUSINESS_FEATURES_TAB_NAME,
+				title: __( 'Free features', 'woocommerce' ),
+				className: this.state.isValid ? '' : 'is-disabled',
 			} );
-
-			if ( this.props.hasInstallableExtensions ) {
-				tabs.push( {
-					name:
-						this.state.currentTab === BUSINESS_FEATURES_TAB_NAME
-							? 'current-tab'
-							: BUSINESS_FEATURES_TAB_NAME,
-					id: BUSINESS_FEATURES_TAB_NAME,
-					title: __( 'Free features', 'woocommerce' ),
-					className: this.state.isValid ? '' : 'is-disabled',
-				} );
-			}
 		}
 
 		// There is a hack here to help us manage the selected tab programmatically.

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -435,13 +435,19 @@ class BusinessDetails extends Component {
 			<Form
 				initialValues={ this.state.savedValues.businessDetailsTab }
 				onSubmit={ ( values ) => {
-					this.setState( {
-						savedValues: {
-							...this.state.savedValues,
-							businessDetailsTab: values,
-						},
-						currentTab: BUSINESS_FEATURES_TAB_NAME,
-					} );
+					if ( this.props.hasInstallableExtensions ) {
+						this.setState( {
+							savedValues: {
+								...this.state.savedValues,
+								businessDetailsTab: values,
+							},
+							currentTab: BUSINESS_FEATURES_TAB_NAME,
+						} );
+					} else {
+						goToNextStep( {
+							step: BUSINESS_FEATURES_TAB_NAME,
+						} );
+					}
 
 					this.trackBusinessDetailsStep( values );
 					recordEvent( 'storeprofiler_step_view', {
@@ -729,12 +735,7 @@ class BusinessDetails extends Component {
 				title: __( 'Business details', 'woocommerce' ),
 			} );
 
-			const hasInstallableExtensions =
-				this.props.installableExtensions.some(
-					( { plugins } ) => plugins.length > 0
-				);
-
-			if ( hasInstallableExtensions ) {
+			if ( this.props.hasInstallableExtensions ) {
 				tabs.push( {
 					name:
 						this.state.currentTab === BUSINESS_FEATURES_TAB_NAME
@@ -805,25 +806,31 @@ export const BusinessFeaturesList = compose(
 			? settings.woocommerce_default_country
 			: null;
 
+		const installableExtensions = freeExtensions
+			? getInstallableExtensions( {
+					freeExtensionBundleByCategory: freeExtensions,
+					country,
+					productTypes: profileItems.product_types,
+			  } )
+			: [];
+		const hasInstallableExtensions = installableExtensions.some(
+			( { plugins } ) => plugins.length > 0
+		);
+
 		return {
 			hasInstallActivateError:
 				getPluginsError( 'installPlugins' ) ||
 				getPluginsError( 'activatePlugins' ),
-			installableExtensions: freeExtensions
-				? getInstallableExtensions( {
-						freeExtensionBundleByCategory: freeExtensions,
-						country,
-						productTypes: profileItems.product_types,
-				  } )
-				: [],
+			hasInstallableExtensions,
+			hasFinishedGetFreeExtensionsResolution:
+				hasFinishedResolution( 'getFreeExtensions' ),
+			installableExtensions,
 			isError: Boolean( getOnboardingError( 'updateProfileItems' ) ),
 			isSettingsError: Boolean( getSettingsError( 'general' ) ),
 			isInstallingActivating:
 				isPluginsRequesting( 'installPlugins' ) ||
 				isPluginsRequesting( 'activatePlugins' ) ||
 				isPluginsRequesting( 'getJetpackConnectUrl' ),
-			hasFinishedGetFreeExtensionsResolution:
-				hasFinishedResolution( 'getFreeExtensions' ),
 			profileItems,
 			settings,
 		};

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import { useSelect, useDispatch } from '@wordpress/data';
 import userEvent from '@testing-library/user-event';
 import { pluginNames } from '@woocommerce/data';
 
@@ -15,25 +14,21 @@ jest.mock( '../../app-illustration', () => ( {
 	AppIllustration: jest.fn().mockReturnValue( '[illustration]' ),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	...jest.requireActual( '@wordpress/data' ),
-	useSelect: jest.fn(),
-	useDispatch: jest.fn().mockImplementation( () => ( {
-		updateOptions: jest.fn(),
-		installAndActivatePlugins: jest.fn(),
-	} ) ),
-} ) );
-
-jest.mock( '@woocommerce/data', () => ( {
-	pluginNames: {
-		'woocommerce-payments': 'WooCommerce Payments',
-		mailpoet: 'Mailpoet',
-		random: 'Random',
-		'google-listings-and-ads': 'Google Listings and Ads',
-	},
-} ) );
-
 const freeExtensions = [
+	{
+		key: 'task-list/reach',
+		title: 'Reach out to customers',
+		plugins: [
+			{
+				key: 'random',
+				name: 'Random',
+				description: 'Random description',
+				manage_url: 'admin.php?page=mailpoet-newsletters',
+				is_visible: true,
+				is_installed: true,
+			},
+		],
+	},
 	{
 		key: 'obw/basics',
 		title: 'Get the basics',
@@ -47,20 +42,6 @@ const freeExtensions = [
 			{
 				key: 'mailpoet',
 				description: 'Mailpoet Description',
-				manage_url: 'admin.php?page=mailpoet-newsletters',
-				is_visible: true,
-				is_installed: true,
-			},
-		],
-	},
-	{
-		key: 'task-list/reach',
-		title: 'Reach out to customers',
-		plugins: [
-			{
-				key: 'random',
-				name: 'Random',
-				description: 'Random description',
 				manage_url: 'admin.php?page=mailpoet-newsletters',
 				is_visible: true,
 				is_installed: true,
@@ -84,23 +65,13 @@ const freeExtensions = [
 ];
 
 describe( 'Selective extensions bundle', () => {
-	beforeAll( () => {
-		useSelect.mockReturnValue( {
-			freeExtensions,
-			isResolving: false,
-		} );
-
-		useDispatch.mockReturnValue( {
-			invalidateResolutionForStoreSelector: () => {},
-		} );
-	} );
-
 	it( 'should list installable free extensions from obw/basics and obw/grow', () => {
 		const mockSetInstallExtensionOptions = jest.fn();
 		// Render once to get installExtensionOptions
 		render(
 			<SelectiveExtensionsBundle
 				isInstallingActivating={ false }
+				installableExtensions={ freeExtensions.slice( 1 ) }
 				setInstallExtensionOptions={ mockSetInstallExtensionOptions }
 			/>
 		);
@@ -109,6 +80,7 @@ describe( 'Selective extensions bundle', () => {
 			<SelectiveExtensionsBundle
 				isInstallingActivating={ false }
 				setInstallExtensionOptions={ mockSetInstallExtensionOptions }
+				installableExtensions={ freeExtensions.slice( 1 ) }
 				installExtensionOptions={
 					mockSetInstallExtensionOptions.mock.calls[ 0 ][ 0 ]
 				}
@@ -126,15 +98,14 @@ describe( 'Selective extensions bundle', () => {
 				new RegExp( pluginNames[ 'google-listings-and-ads' ] )
 			)
 		).toBeInTheDocument();
-		expect(
-			queryByText( new RegExp( pluginNames.random ) )
-		).not.toBeInTheDocument();
+		expect( queryByText( new RegExp( 'Random' ) ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should list installable extensions when dropdown is clicked', () => {
 		const { getAllByRole, getByText, queryByText } = render(
 			<SelectiveExtensionsBundle
 				isInstallingActivating={ false }
+				installableExtensions={ freeExtensions }
 				setInstallExtensionOptions={ jest.fn() }
 			/>
 		);

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { Spinner } from '@woocommerce/components';
+import { Spinner } from '@wordpress/components';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
 
 /**

--- a/plugins/woocommerce/changelog/fix-free-features-is-still-rendered-when-no-recommendation
+++ b/plugins/woocommerce/changelog/fix-free-features-is-still-rendered-when-no-recommendation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix free features is still rendered when there is no recommendation


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33915.

This PR adds a check `hasInstallableExtensions` before component rendering to not render free features tab when no recommendation.

To make it, I moved the `getFreeExtensions` function call from `<SelectiveExtensionsBundle>` to `<BusinessDetails>`, as well as `getInstallableExtensions`.

![Screen Shot 2022-07-15 at 12 28 48](https://user-images.githubusercontent.com/4344253/179153343-7aca85f6-ff20-4351-a92a-fd647eafc244.png)

### How to test the changes in this Pull Request:
1. Start with a fresh install
2. Start OBW and use the following selections and click Continue

- Store Details.country/region: Afghanistan
- Industry: Food and drink
- Product Types: Physical products
- Business Details[how many products do you plan to display]: 1-10
- Business Details[currently selling else where?]: Yes, on another platform
- Business Details[How many employees do you have]: <10
- Business Details[What's your current annual revenue?]: Up to 3.000
- Business Details[Which platform is the store using?] BigCommerce

3. On the `Free features` tab, make a note of the plugins. You should see `MailPoet` and `Google Listings and Ads` only (when Jetpack is already installed).
4. Open a new tab and install and active the plugins listed on `Free features` manually.
5. Refresh `Free features` tab
6. Observe that the FreeFeatures tab is **not** rendered.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
