### PR TITLE
Update e2e core tests to pass lint checks

### DIFF
--- a/packages/js/e2e-core-tests/src/specs/activate-and-setup/activate.test.js
+++ b/packages/js/e2e-core-tests/src/specs/activate-and-setup/activate.test.js
@@ -37,4 +37,5 @@ const runActivationTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runActivationTest;

--- a/packages/js/e2e-core-tests/src/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/packages/js/e2e-core-tests/src/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -77,7 +77,7 @@ const runTaskListTest = () => {
 			expect( taskListItems.length ).toBeInRange( 5, 6 );
 
 			// Work around for https://github.com/woocommerce/woocommerce-admin/issues/6761
-			if ( taskListItems.length == 6 ) {
+			if ( taskListItems.length === 6 ) {
 				// Click on "Set up shipping" task to move to the next step
 				const [ setupTaskListItem ] = await page.$x(
 					'//div[contains(text(),"Set up shipping")]'
@@ -101,6 +101,7 @@ const runTaskListTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = {
 	runOnboardingFlowTest,
 	runTaskListTest,

--- a/packages/js/e2e-core-tests/src/specs/activate-and-setup/setup.test.js
+++ b/packages/js/e2e-core-tests/src/specs/activate-and-setup/setup.test.js
@@ -108,4 +108,5 @@ const runInitialStoreSettingsTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runInitialStoreSettingsTest;

--- a/packages/js/e2e-core-tests/src/specs/api/coupon.test.js
+++ b/packages/js/e2e-core-tests/src/specs/api/coupon.test.js
@@ -87,4 +87,5 @@ const runCouponApiTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCouponApiTest;

--- a/packages/js/e2e-core-tests/src/specs/api/external-product.test.js
+++ b/packages/js/e2e-core-tests/src/specs/api/external-product.test.js
@@ -80,4 +80,5 @@ const runExternalProductAPITest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runExternalProductAPITest;

--- a/packages/js/e2e-core-tests/src/specs/api/grouped-product.test.js
+++ b/packages/js/e2e-core-tests/src/specs/api/grouped-product.test.js
@@ -101,4 +101,5 @@ const runGroupedProductAPITest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runGroupedProductAPITest;

--- a/packages/js/e2e-core-tests/src/specs/api/order.test.js
+++ b/packages/js/e2e-core-tests/src/specs/api/order.test.js
@@ -78,4 +78,5 @@ const runOrderApiTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runOrderApiTest;

--- a/packages/js/e2e-core-tests/src/specs/api/telemetry.test.js
+++ b/packages/js/e2e-core-tests/src/specs/api/telemetry.test.js
@@ -50,4 +50,5 @@ const runTelemetryAPITest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runTelemetryAPITest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-analytics-page-loads.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-analytics-page-loads.test.js
@@ -16,9 +16,9 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Quick check for page title and no data message.
  *
- * @param  pageTitle   Page title in H1.
- * @param  element     Defaults to '.d3-chart__empty-message'
- * @param  elementText Defaults to 'No data for the selected date range'
+ * @param {string} pageTitle   Page title in H1.
+ * @param {string} element     Defaults to '.d3-chart__empty-message'
+ * @param {string} elementText Defaults to 'No data for the selected date range'
  */
 const checkHeadingAndElement = async (
 	pageTitle,

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-coupon-new.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-coupon-new.test.js
@@ -60,4 +60,5 @@ const runCreateCouponTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCreateCouponTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-extensions-connect-wccom.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-extensions-connect-wccom.test.js
@@ -41,4 +41,5 @@ const runInitiateWccomConnectionTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runInitiateWccomConnectionTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -36,6 +36,7 @@ const runOrderApplyCouponTest = () => {
 			await page.removeAllListeners( 'dialog' );
 
 			// Make sure the simple product price is greater than the coupon amount
+			// eslint-disable-next-line jest/no-standalone-expect
 			await expect( Number( simpleProductPrice ) ).toBeGreaterThan( 5.0 );
 		} );
 
@@ -68,9 +69,7 @@ const runOrderApplyCouponTest = () => {
 			await expect( page ).toMatchElement( '.wc-order-item-discount', {
 				text: '5.00',
 			} );
-			await expect(
-				page
-			).toMatchElement(
+			await expect( page ).toMatchElement(
 				'.line_cost > .view > .woocommerce-Price-amount',
 				{ text: discountedPrice }
 			);
@@ -102,17 +101,13 @@ const runOrderApplyCouponTest = () => {
 				'.wc-order-item-discount',
 				{ text: '5.00' }
 			);
-			await expect(
-				page
-			).not.toMatchElement(
+			await expect( page ).not.toMatchElement(
 				'.line-cost .view .woocommerce-Price-amount',
 				{ text: discountedPrice }
 			);
 
 			// Verify the original price is the order total
-			await expect(
-				page
-			).toMatchElement(
+			await expect( page ).toMatchElement(
 				'.line_cost > .view > .woocommerce-Price-amount',
 				{ text: simpleProductPrice }
 			);
@@ -120,4 +115,5 @@ const runOrderApplyCouponTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runOrderApplyCouponTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -98,4 +98,5 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runMerchantOrdersCustomerPaymentPage;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-edit.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-edit.test.js
@@ -264,4 +264,5 @@ const runEditOrderTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runEditOrderTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-emails.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-emails.test.js
@@ -33,6 +33,7 @@ const runMerchantOrderEmailsTest = () => {
 				await page.click(
 					'div.order_data_column:nth-child(2) > h3:nth-child(1) > a:nth-child(1)'
 				),
+				// eslint-disable-next-line jest/no-standalone-expect
 				await expect( page ).toFill( '#_billing_email', customerEmail ),
 				await clickUpdateOrder( 'Order updated.' ),
 			] );
@@ -82,4 +83,5 @@ const runMerchantOrderEmailsTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runMerchantOrderEmailsTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-new.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-new.test.js
@@ -201,8 +201,7 @@ const runCreateOrderTest = () => {
 			await expect( page ).toMatchElement(
 				'#woocommerce-order-notes .note_content',
 				{
-					text:
-						'Order status changed from Pending payment to Processing.',
+					text: 'Order status changed from Pending payment to Processing.',
 				}
 			);
 		} );
@@ -285,4 +284,5 @@ const runCreateOrderTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCreateOrderTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-refund-restock.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-refund-restock.test.js
@@ -114,4 +114,5 @@ const runOrderRefundRestockTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runOrderRefundRestockTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-refund.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-refund.test.js
@@ -129,4 +129,5 @@ const runRefundOrderTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runRefundOrderTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-searching.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-searching.test.js
@@ -42,7 +42,7 @@ const customerShipping = {
 /**
  * Set the billing fields for the customer account for this test suite.
  *
- * @return {Promise<number>}
+ * @return {Promise<number>} Returns the updated customer's ID
  */
 const updateCustomerBilling = async () => {
 	const client = factories.api.withDefaultPermalinks;
@@ -130,4 +130,5 @@ const runOrderSearchingTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runOrderSearchingTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-status-filters.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-status-filters.test.js
@@ -63,6 +63,7 @@ const runOrderStatusFiltersTest = () => {
 				const shownStatus = { text: statusText };
 				const hiddenStatuses = orderStatus
 					.filter( ( pair ) => ! pair.includes( statusText ) )
+					// eslint-disable-next-line no-shadow
 					.map( ( [ statusText ] ) => {
 						return { text: statusText };
 					} );
@@ -97,4 +98,5 @@ const runOrderStatusFiltersTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runOrderStatusFiltersTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-edit-details.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-edit-details.test.js
@@ -78,6 +78,7 @@ const runProductEditDetailsTest = () => {
 			await withRestApi.deleteProduct( productId );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		it( 'can edit just a single attribute of a product variation', async () => {
 			const expectedVariationDetails = {
 				regularPrice: '10',
@@ -92,6 +93,7 @@ const runProductEditDetailsTest = () => {
 			await merchant.verifyVariationDetails( expectedVariationDetails );
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		it( 'can edit multiple attributes of a product variation', async () => {
 			const expectedVariationDetails = {
 				sku: 'ABCD0123',

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-new.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-product-new.test.js
@@ -39,7 +39,7 @@ const openNewProductAndVerify = async () => {
 /**
  * Select a variation action from the actions menu.
  *
- * @param  action item you selected from the variation actions menu
+ * @param {string} action item you selected from the variation actions menu
  */
 const selectVariationAction = async ( action ) => {
 	await waitForSelector( page, 'select.variation_actions:not(:disabled)' );
@@ -472,6 +472,7 @@ const runAddVariableProductTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = {
 	runAddSimpleProductTest,
 	runAddVariableProductTest,

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-general.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-general.test.js
@@ -59,9 +59,7 @@ const runUpdateGeneralSettingsTest = () => {
 				expect( page ).toMatchElement( '#message', {
 					text: 'Your settings have been saved.',
 				} ),
-				expect(
-					page
-				).toMatchElement(
+				expect( page ).toMatchElement(
 					'select[name="woocommerce_default_country"]',
 					{ text: 'United States (US) — California' }
 				),
@@ -88,9 +86,7 @@ const runUpdateGeneralSettingsTest = () => {
 					'#woocommerce_allowed_countries',
 					{ text: 'Sell to specific countries' }
 				),
-				expect(
-					page
-				).toMatchElement(
+				expect( page ).toMatchElement(
 					'select[name="woocommerce_specific_allowed_countries[]"]',
 					{ text: 'United States (US)' }
 				),

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-shipping-classes.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-shipping-classes.test.js
@@ -73,4 +73,5 @@ const runAddShippingClassesTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runAddShippingClassesTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -167,4 +167,5 @@ const runAddNewShippingZoneTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runAddNewShippingZoneTest;

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-tax.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-settings-tax.test.js
@@ -264,4 +264,5 @@ const runTaxSettingsTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runTaxSettingsTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-and-checkout-consistent-shipping.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-and-checkout-consistent-shipping.test.js
@@ -168,8 +168,7 @@ const runCartAndCheckoutConsistentShippingTest = () => {
 				{
 					// Test fails here because actual text is 'Enter your address to view shipping options.'
 					// Logged in GitHub as issue #33205
-					text:
-						'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.',
+					text: 'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.',
 				}
 			);
 		} );

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -174,4 +174,5 @@ const runCartCalculateShippingTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCartCalculateShippingTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-coupons.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-coupons.test.js
@@ -91,4 +91,5 @@ const runCartApplyCouponsTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCartApplyCouponsTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-redirection.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart-redirection.test.js
@@ -69,4 +69,5 @@ const runCartRedirectionTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCartRedirectionTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-cart.test.js
@@ -106,4 +106,5 @@ const runCartPageTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCartPageTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-coupons.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-coupons.test.js
@@ -95,4 +95,5 @@ const runCheckoutApplyCouponsTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCheckoutApplyCouponsTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-create-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-create-account.test.js
@@ -78,4 +78,5 @@ const runCheckoutCreateAccountTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCheckoutCreateAccountTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-login-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout-login-account.test.js
@@ -86,4 +86,5 @@ const runCheckoutLoginAccountTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCheckoutLoginAccountTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-checkout.test.js
@@ -259,4 +259,5 @@ const runCheckoutPageTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runCheckoutPageTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account-create-account.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-my-account-create-account.test.js
@@ -55,4 +55,5 @@ const runMyAccountCreateAccountTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runMyAccountCreateAccountTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-product-browse-search-sort.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-product-browse-search-sort.test.js
@@ -116,4 +116,5 @@ const runProductBrowseSearchSortTest = () => {
 	);
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runProductBrowseSearchSortTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-single-product.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-single-product.test.js
@@ -119,8 +119,7 @@ const runSingleProductPageTest = () => {
 			await page.waitForSelector( 'form.grouped_form' );
 			await shopper.addToCart();
 			await expect( page ).toMatchElement( '.woocommerce-error', {
-				text:
-					'Please choose the quantity of items you wish to add to your cart…',
+				text: 'Please choose the quantity of items you wish to add to your cart…',
 			} );
 			const quantityFields = await page.$$( 'div.quantity input.qty' );
 			await quantityFields[ 0 ].click( { clickCount: 3 } );
@@ -167,4 +166,5 @@ const runSingleProductPageTest = () => {
 	} );
 };
 
+// eslint-disable-next-line jest/no-export
 module.exports = runSingleProductPageTest;

--- a/packages/js/e2e-core-tests/src/specs/shopper/front-end-variable-product-updates.test.js
+++ b/packages/js/e2e-core-tests/src/specs/shopper/front-end-variable-product-updates.test.js
@@ -66,9 +66,7 @@ const runVariableProductUpdateTest = () => {
 					text: '200 kg',
 				}
 			);
-			await expect(
-				page
-			).toMatchElement(
+			await expect( page ).toMatchElement(
 				'.woocommerce-product-attributes-item--dimensions',
 				{ text: '10 × 20 × 15 cm' }
 			);


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes `e2e-core-tests` linting errors. `warning  Test has no assertions` warning still exist, but those are fine given that those tests in question use methods that have assetions within.


### How to test the changes in this Pull Request:

Run `pnpm -- turbo run lint --filter="@woocommerce/e2e-core-tests"`

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
