### PR TITLE
Update stable tag for 6.7.0 release

### DIFF
--- a/plugins/woocommerce/changelog/update-6.7.0-stable-tag
+++ b/plugins/woocommerce/changelog/update-6.7.0-stable-tag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This PR just updates the stable tag, and doesn't require a changelog entry
+
+

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.8
 Tested up to: 6.0
 Requires PHP: 7.2
-Stable tag: 6.6.1
+Stable tag: 6.7.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR updates the stable tag to reflect that 6.7.0 has been released.