### PR TITLE
Exclude e2e folder from build

### DIFF
--- a/plugins/woocommerce/.distignore
+++ b/plugins/woocommerce/.distignore
@@ -8,6 +8,7 @@
 /changelog/
 /node_modules/
 /tests/
+/e2e/
 babel.config.js
 changelog.txt
 composer.*

--- a/plugins/woocommerce/changelog/exclde-e2e-from-build
+++ b/plugins/woocommerce/changelog/exclde-e2e-from-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Exclude "e2e" directory from build


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

Excludes the `e2e` folder from being included in the distributable zip version of WooCommerce.

I am not familiar with the build/deploy process. Can someone please confirm that this change alone is enough to exclude the e2e folder from being shipped/included in the release zip?

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
