### PR TITLE
Fix checkout validation errors for the case of no country provided for both shipping and billing

### DIFF
--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -856,7 +856,7 @@ class WC_Checkout {
 		}
 
 		if ( WC()->cart->needs_shipping() ) {
-			$shipping_country = isset( $data['shipping_country'] ) ? $data['shipping_country'] : WC()->customer->get_shipping_country();
+			$shipping_country = WC()->customer->get_shipping_country();
 
 			if ( empty( $shipping_country ) ) {
 				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

First of all, consider a case of a checkout form which has `shipping_country` and `billing_country` left empty, now consider there are other errors in the form too, but right now only one error regarding these too being left alone is shown and everything else is ignored!

I have many plugins written on top of woocommerce I updated my test website from 4.x to 6.x and found out everything was working properly, except the validation features on the checkout.

When I got to the bottom of the problem I realized that it was caused by this simple line which used to be like this in 4.x and was changed at https://github.com/woocommerce/woocommerce/commit/70202c35bdb1d3429270bcbda0d162c57963c445 however most of those changes in that pull request didn't make it to version 6, this one has however I'd supposed by accident.

Let me explain what exactly happens, when you don't pass a `billing_country` in data and also you don't pass a `shipping_country` here :

```php
	public function get_posted_data() {
        ...
		if ( in_array( 'shipping', $skipped, true ) && ( WC()->cart->needs_shipping_address() || wc_ship_to_billing_address_only() ) ) {
			foreach ( $this->get_checkout_fields( 'shipping' ) as $key => $field ) {
				$data[ $key ] = isset( $data[ 'billing_' . substr( $key, 9 ) ] ) ? $data[ 'billing_' . substr( $key, 9 ) ] : '';
			}
		}
```
The `shipping_country` will be filled with an empty string, now 

```php
			$shipping_country = isset( $data['shipping_country'] ) ? $data['shipping_country'] : WC()->customer->get_shipping_country();
```

This will be therefore an empty string causing 

```php
			if ( empty( $shipping_country ) ) {
				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );
```

To throw that error, but in my test, I am also not passing `billing_first_name` and `billing_last_name` and `billing_state` and ... all these other fields are ignored and only `Please enter an address to continue.` is returned in the error.

Making problems for my plugins which rely on the better behavior of returning all the fields errors.

example of errors with my change:

```
array:1 [
  "errors" => array:5 [
    "billing_first_name" => array:1 [
      0 => "<strong>Billing First name</strong> is a required field."
    ]
    "billing_last_name" => array:1 [
      0 => "<strong>Billing Last name</strong> is a required field."
    ]
    "billing_country" => array:1 [
      0 => "<strong>Billing Country / Region</strong> is a required field."
    ]
    "billing_state" => array:1 [
      0 => "<strong>Billing State / County</strong> is a required field."
    ]
    "billing_phone" => array:1 [
      0 => "<strong>Billing Phone</strong> is a required field."
    ]
  ]
]
```
example of errors before my change:

```
[
  "errors" => array:1 [
    0 => "Please enter an address to continue."
  ]
]
```

### How to test the changes in this Pull Request:

This won't make any changes actually since woocommerce does select a country for billing by default but all the plugins that build an API on top of woocommerce (Including mine) will be able to get all the validation errors instead of only one.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
