### PR TITLE
Get plugin data from tmp repo clone

### DIFF
--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -8,7 +8,6 @@ import { readFileSync, rmSync } from 'fs';
 /**
  * Internal dependencies
  */
-import { MONOREPO_ROOT } from '../../const';
 import {
 	printTemplateResults,
 	printHookResults,
@@ -105,7 +104,7 @@ export default class Analyzer extends Command {
 		);
 		CliUx.ux.action.stop();
 
-		const pluginData = this.getPluginData( flags.plugin );
+		const pluginData = this.getPluginData( tmpRepoPath, flags.plugin );
 		this.log( `${ pluginData[ 1 ] } Version: ${ pluginData[ 0 ] }` );
 
 		// Run schema diffs only in the monorepo.
@@ -151,7 +150,7 @@ export default class Analyzer extends Command {
 	 * @param {string} plugin Plugin slug.
 	 * @return {string[]} Promise.
 	 */
-	private getPluginData( plugin: string ): string[] {
+	private getPluginData( tmpRepoPath: string, plugin: string ): string[] {
 		/**
 		 * List of plugins from our monorepo.
 		 */
@@ -159,7 +158,7 @@ export default class Analyzer extends Command {
 			core: {
 				name: 'WooCommerce',
 				mainFile: join(
-					MONOREPO_ROOT,
+					tmpRepoPath,
 					'plugins',
 					'woocommerce',
 					'woocommerce.php'
@@ -168,7 +167,7 @@ export default class Analyzer extends Command {
 			admin: {
 				name: 'WooCommerce Admin',
 				mainFile: join(
-					MONOREPO_ROOT,
+					tmpRepoPath,
 					'plugins',
 					'woocommerce-admin',
 					'woocommerce-admin.php'
@@ -177,7 +176,7 @@ export default class Analyzer extends Command {
 			beta: {
 				name: 'WooCommerce Beta Tester',
 				mainFile: join(
-					MONOREPO_ROOT,
+					tmpRepoPath,
 					'plugins',
 					'woocommerce-beta-tester',
 					'woocommerce-beta-tester.php'

--- a/tools/code-analyzer/src/const.ts
+++ b/tools/code-analyzer/src/const.ts
@@ -1,7 +1,0 @@
-/**
- * External dependencies
- */
-import { dirname } from 'path';
-
-// Escape from ./tools/monorepo-merge/src
-export const MONOREPO_ROOT = dirname( dirname( dirname( __dirname ) ) );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

One thing I missed in the db scan PR was the need to get plugin data from the tmp repo rather than assuming we have woo locally. This fixes that issue.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Run a analyzer command you know the output for such as `./tools/code-analyzer/bin/dev analyzer -b=2e167ca088a6aae5443f1084f7359c53c1bad61a a80e0fe20390ba0ccd995168bd7e23358eb8dcbc`
2. Confirm the output is correct.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
