### PR TITLE
Generate a JSON file with changes from code-analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ phpcs-report.xml
 allure-report
 allure-results
 
+# Code analyzer output
+changes.json
+
 # Playwright output & working files
 /plugins/woocommerce/e2e/output
 /plugins/woocommerce/e2e/report

--- a/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -51,7 +51,8 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
 
         throw new ContainerException(
             'A service provider must be a fully qualified class name or instance ' .
-            'of (\Automattic\WooCommerce\Vendor\League\Container\ServiceProvider\ServiceProviderInterface)'
+            'of (\Automattic\WooCommerce\Vendor\League\Container\ServiceProvider\ServiceProviderInterface)' .
+            $provider . ' given.'
         );
     }
 

--- a/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
+++ b/plugins/woocommerce/lib/packages/League/Container/ServiceProvider/ServiceProviderAggregate.php
@@ -51,8 +51,7 @@ class ServiceProviderAggregate implements ServiceProviderAggregateInterface
 
         throw new ContainerException(
             'A service provider must be a fully qualified class name or instance ' .
-            'of (\Automattic\WooCommerce\Vendor\League\Container\ServiceProvider\ServiceProviderInterface)' .
-            $provider . ' given.'
+            'of (\Automattic\WooCommerce\Vendor\League\Container\ServiceProvider\ServiceProviderInterface)'
         );
     }
 

--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -93,8 +93,6 @@ export default class Analyzer extends Command {
 	 */
 	async run(): Promise< void > {
 		const { args, flags } = await this.parse( Analyzer );
-		const bar = await this.parse( Analyzer );
-		const bex = bar.flags;
 
 		CliUx.ux.action.start(
 			`Making a temporary clone of '${ flags.source }'`

--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -139,9 +139,15 @@ export default class Analyzer extends Command {
 
 			CliUx.ux.action.stop();
 
-			this.scanChanges( diff, pluginData[ 0 ], flags.output, schemaDiff );
+			this.scanChanges(
+				diff,
+				pluginData[ 0 ],
+				flags.output,
+				flags.file,
+				schemaDiff
+			);
 		} else {
-			this.scanChanges( diff, pluginData[ 0 ], flags.output );
+			this.scanChanges( diff, pluginData[ 0 ], flags.output, flags.file );
 		}
 
 		// Clean up the temporary repo.
@@ -210,15 +216,17 @@ export default class Analyzer extends Command {
 	/**
 	 * Scan patches for changes in templates, hooks and database schema
 	 *
-	 * @param {string}  content        Patch content.
-	 * @param {string}  version        Current product version.
-	 * @param {string}  output         Output style.
-	 * @param {boolean} schemaEquality if schemas are equal between branches.
+	 * @param {string}  content         Patch content.
+	 * @param {string}  version         Current product version.
+	 * @param {string}  output          Output style.
+	 * @param {string}  changesFileName Name of a file to output change information to.
+	 * @param {boolean} schemaEquality  if schemas are equal between branches.
 	 */
 	private async scanChanges(
 		content: string,
 		version: string,
 		output: string,
+		changesFileName: string,
 		schemaDiff: {
 			[ key: string ]: {
 				description: string;
@@ -229,14 +237,12 @@ export default class Analyzer extends Command {
 			};
 		} | void
 	) {
-		const { flags } = await this.parse( Analyzer );
-
 		CliUx.ux.action.start( 'Generating changes' );
 		const templates = this.scanTemplates( content, version );
 		const hooks = this.scanHooks( content, version, output );
 		const databaseUpdates = this.scanDatabases( content );
 
-		await generateJSONFile( join( process.cwd(), flags.file ), {
+		await generateJSONFile( join( process.cwd(), changesFileName ), {
 			templates: Object.fromEntries( templates.entries() ),
 			hooks: Object.fromEntries( hooks.entries() ),
 			schema: databaseUpdates || {},

--- a/tools/code-analyzer/src/utils.ts
+++ b/tools/code-analyzer/src/utils.ts
@@ -4,6 +4,7 @@
 import { createServer, Server } from 'net';
 import { execSync } from 'child_process';
 import { join } from 'path';
+import { writeFile } from 'fs/promises';
 
 /**
  * Format version string for regex.
@@ -233,4 +234,18 @@ export const getHookChangeType = ( diff: string ): 'Updated' | 'New' => {
 	const sinces = diff.match( sincesRegex ) || [];
 	// If there is more than one 'since' in the diff, it means that line was updated meaning the hook already exists.
 	return sinces.length > 1 ? 'Updated' : 'New';
+};
+
+export const generateJSONFile = ( filePath: string, data: unknown ) => {
+	const json = JSON.stringify(
+		data,
+		function replacer( key, value ) {
+			if ( value instanceof Map ) {
+				return Array.from( value.entries() );
+			}
+			return value;
+		},
+		2
+	);
+	return writeFile( filePath, json );
 };


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Generate a JSON file listing changes from scanning hooks, templates and DB. The JSON file can be used by any consuming tool to notify of changes. I have generated the structure of the objects exactly as they're used in the code right now. In future we may consider restructuring the data, but I'm not exactly sure how we'll use it right now.

### How to test the changes in this Pull Request:

1. Run code analyzer with known hash comparisons that generate changes on either DB, templates or hooks
2. See that the command generated a changes.json file containing those changes.
3. For bonus points generate a file with custom filename with the `-f` flag.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
