### PR TITLE
Fix "undefined offset" warning notice on payment settings page

### DIFF
--- a/plugins/woocommerce/changelog/fix-33920-warning-notice-on-payment-settings-page
+++ b/plugins/woocommerce/changelog/fix-33920-warning-notice-on-payment-settings-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix undefined offset notice on payment settings page

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -244,7 +244,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 							$plugin_suggestions = array_filter(
 								$plugin_suggestions,
 								function( $plugin ) use ( $country, $filter_by, $active_plugins ) {
-									if ( ! isset( $plugin->{$filter_by} ) || ! isset( $plugin->image_72x72 ) || ! isset( $plugin->plugins ) || in_array( $plugin->plugins[0], $active_plugins, true ) ) {
+									if ( ! isset( $plugin->{$filter_by} ) || ! isset( $plugin->image_72x72 ) || ! isset( $plugin->plugins[0] ) || in_array( $plugin->plugins[0], $active_plugins, true ) ) {
 										return false;
 									}
 									return in_array( $country, $plugin->{$filter_by}, true );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33920.

Fixes `Notice: Undefined offset: 0 in /var/www/html/wp-content/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php on line 247` on WooCommerce > Settings > Payments page 

### How to test the changes in this Pull Request:

1. Set up a store with address in the US
2. Go to `Settings > Payments`
3. Observe the warning notice is not displayed.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
