### PR TITLE
Use method_exists instead of throwing in AbstractServiceProvider::reflect_class_or_callable

### DIFF
--- a/plugins/woocommerce/changelog/fix-29465
+++ b/plugins/woocommerce/changelog/fix-29465
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use method_exists instead of throwing in AbstractServiceProvider::reflect_class_or_callable

--- a/plugins/woocommerce/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -73,11 +73,6 @@ abstract class AbstractServiceProvider extends BaseServiceProvider {
 	 * @return \ReflectionClass|null The class of the parameter, or null if it hasn't any.
 	 */
 	private function get_class( \ReflectionParameter $parameter ) {
-		// TODO: Remove this 'if' block once minimum PHP version for WooCommerce is bumped to at least 7.1.
-		if ( version_compare( PHP_VERSION, '7.1', '<' ) ) {
-			return $parameter->getClass();
-		}
-
 		return $parameter->getType() && ! $parameter->getType()->isBuiltin()
 			? new \ReflectionClass( $parameter->getType()->getName() )
 			: null;
@@ -95,28 +90,26 @@ abstract class AbstractServiceProvider extends BaseServiceProvider {
 	 */
 	private function reflect_class_or_callable( string $class_name, $concrete ) {
 		if ( ! isset( $concrete ) || is_string( $concrete ) && class_exists( $concrete ) ) {
-			try {
-				$class  = $concrete ?? $class_name;
-				$method = new \ReflectionMethod( $class, Definition::INJECTION_METHOD );
-				if ( ! isset( $method ) ) {
-					return null;
-				}
+			$class = $concrete ?? $class_name;
 
-				$missing_modifiers = array();
-				if ( ! $method->isFinal() ) {
-					$missing_modifiers[] = 'final';
-				}
-				if ( ! $method->isPublic() ) {
-					$missing_modifiers[] = 'public';
-				}
-				if ( ! empty( $missing_modifiers ) ) {
-					throw new ContainerException( "Method '" . Definition::INJECTION_METHOD . "' of class '$class' isn't '" . implode( ' ', $missing_modifiers ) . "', instances can't be created." );
-				}
-
-				return $method;
-			} catch ( \ReflectionException $ex ) {
+			if ( ! method_exists( $class, Definition::INJECTION_METHOD ) ) {
 				return null;
 			}
+
+			$method = new \ReflectionMethod( $class, Definition::INJECTION_METHOD );
+
+			$missing_modifiers = array();
+			if ( ! $method->isFinal() ) {
+				$missing_modifiers[] = 'final';
+			}
+			if ( ! $method->isPublic() ) {
+				$missing_modifiers[] = 'public';
+			}
+			if ( ! empty( $missing_modifiers ) ) {
+				throw new ContainerException( "Method '" . Definition::INJECTION_METHOD . "' of class '$class' isn't '" . implode( ' ', $missing_modifiers ) . "', instances can't be created." );
+			}
+
+			return $method;
 		} elseif ( is_callable( $concrete ) ) {
 			try {
 				return new \ReflectionFunction( $concrete );


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In `AbstractServiceProvider::reflect_class_or_callable` we were detecting whether a 'init' method exists in the class or not via
doing `new ReflectionMethod` and catching the exception. This caused problems with XDebug, which is bad enough, but additionally, throwing an exception when it's not abosultely necessary is a bad practice in general.

As a bonus, this pull request also removes a small piece of code that wasn't needed anymore since the upgrade to PHP 7.2.

Closes #29465.

### How to test the changes in this Pull Request:

1. Verify that the following snippet still works as expected: `wc_get_container()->get(\Automattic\WooCommerce\Proxies\LegacyProxy::class);`
2. Verify that XDebug doesn't throw `ReflectionException` anymore as reported in [#29465](https://github.com/woocommerce/woocommerce/issues/29465).

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
