### PR TITLE
Reduce the amount of terms shown in attributes page

### DIFF
--- a/plugins/woocommerce/changelog/reduce-terms-shown-in-attributes-page
+++ b/plugins/woocommerce/changelog/reduce-terms-shown-in-attributes-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Reduce the amount of terms shown in attributes page


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As mentioned in https://github.com/woocommerce/woocommerce/issues/26539#issuecomment-1033535560, the product attributes page lists all the existing product attributes together with all the existing terms for each one. In order to improve the performance of that page, the number of terms shown for each attribute is now limited to 100 by default, but this value can be customized by using the newly introduced `woocommerce_max_terms_displayed_in_attributes_page` filter.

Additionally, the `get_terms( $taxonomy)` call is changed into `get_terms(['taxonomy'   => $taxonomy, 'fields' => 'names'])` so that only term names are retrieved instead of the full set of terms information.

The UI is adjusted accordingly as well. This is how it looks like when the filter returns 3:

![image](https://user-images.githubusercontent.com/937723/179541189-398552d9-d637-4935-b20c-5cfdc397e1f1.png)

And this is with the filter returning zero:

![image](https://user-images.githubusercontent.com/937723/179541333-b56671ff-17aa-4bdb-9291-865b4c029b94.png)


### How to test the changes in this Pull Request:

1. Add the following snippet: `add_filter('woocommerce_max_terms_displayed_in_attributes_page', function() {return 3;});`
2. Create attributes with 0, 1, 2, 3, 4 and 10 terms, and verify that the attributes list displays as in the first screenshot above.
3. Change the filter to return zero, and verify that the attributes list displays as in the second screenshot above.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
