### PR TITLE
Add changelog validation to pre push

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -22,3 +22,5 @@ if [ $PROTECTED_BRANCH = $CURRENT_BRANCH ]; then
 	echo
 	exit 1
 fi
+
+php tools/monorepo/check-changelogger-use.php --debug $PROTECTED_BRANCH $CURRENT_BRANCH


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/33900

This PR adds the check to see if changelog file has been added or not on a `git push`. Note that I did not implement the check to see if the changelog file itself is valid as per discussion (p1658171517325239-slack-C03MZFTR9DL) we've decided to either leave that out or should possibly combine that check with the check of whether the changelog file exists.

### How to test the changes in this Pull Request:

1. Checkout this PR.
2. Create a new branch based on this PR.
3. Make a change to `plugins/woocommerce/woocommerce.php` file and commit.
4. Try to push your new branch up.
5. Ensure you get an error stating you didn't include a changelog file.
6. Create a changelog file in `plugins/woocommerce/changelog` and commit it.
7.  Now try again to push your new branch up.
8. Ensure it is able to be pushed up without errors.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.