### PR TITLE
Reduce e2e flakiness in CI

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -64,6 +64,7 @@ jobs:
               run: pnpx playwright install chromium
 
             - name: Run Playwright E2E tests.
+              timeout-minutes: 60
               id: run_playwright_e2e_tests
               if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
               run: pnpx playwright install chromium
 
             - name: Run Playwright E2E tests.
-              timeout-minutes: 60
+              timeout-minutes: 1 # debug CI
               id: run_playwright_e2e_tests
               if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
               run: pnpx playwright install chromium
 
             - name: Run Playwright E2E tests.
-              timeout-minutes: 1 # debug CI
+              timeout-minutes: 60
               id: run_playwright_e2e_tests
               if: fromJSON(env.E2E_PLAYWRIGHT)
               working-directory: plugins/woocommerce

--- a/plugins/woocommerce/changelog/22-07-increase-expect-timeout
+++ b/plugins/woocommerce/changelog/22-07-increase-expect-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Increase expect timeout to reduce e2e flakiness in CI

--- a/plugins/woocommerce/e2e/playwright.config.js
+++ b/plugins/woocommerce/e2e/playwright.config.js
@@ -2,7 +2,7 @@ const { devices } = require( '@playwright/test' );
 
 const config = {
 	timeout: 60 * 1000,
-	expect: { timeout: 10000 },
+	expect: { timeout: 20 * 1000 },
 	outputDir: './report',
 	globalSetup: require.resolve( './global-setup' ),
 	globalTeardown: require.resolve( './global-teardown' ),

--- a/plugins/woocommerce/e2e/playwright.config.js
+++ b/plugins/woocommerce/e2e/playwright.config.js
@@ -2,6 +2,7 @@ const { devices } = require( '@playwright/test' );
 
 const config = {
 	timeout: 60 * 1000,
+	expect: { timeout: 10000 },
 	outputDir: './report',
 	globalSetup: require.resolve( './global-setup' ),
 	globalTeardown: require.resolve( './global-teardown' ),

--- a/plugins/woocommerce/e2e/playwright.config.js
+++ b/plugins/woocommerce/e2e/playwright.config.js
@@ -1,7 +1,7 @@
 const { devices } = require( '@playwright/test' );
 
 const config = {
-	timeout: 60 * 1000,
+	timeout: 90 * 1000,
 	expect: { timeout: 20 * 1000 },
 	outputDir: './report',
 	globalSetup: require.resolve( './global-setup' ),


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR aims to reduce flakiness of e2e tests in CI.

- Increases `expect` timeout from 5s to 20s
- Increases individual test run timeout from 60s to 90s
- Add a global time limit to the tests of 1h

https://playwright.dev/docs/test-timeouts

Closes #33978 

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
