### PR TITLE
Add cache priming to trunk

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./.github/actions/cache-deps
         with:

--- a/.github/workflows/prime-cache.yml
+++ b/.github/workflows/prime-cache.yml
@@ -1,0 +1,26 @@
+name: Prime caches against trunk
+on: 
+  push:
+    branches:
+      - trunk
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true  
+
+jobs:
+  prime:
+    name: Prime cache
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: true
+      matrix:
+        workflow: [ 'pr-unit-tests', 'pr-build-and-e2e-tests', 'pr-code-coverage', 'pr-code-sniff', 'pr-lint-test-js', 'pr-smoke-test' ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/cache-deps
+        with:
+          workflow_name: ${{ matrix.workflow }}
+          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is an attempt to fix the caching where even when the cache is successfully saved, it can't be restored possibly due to branch level restrictions. So this PR primes the caches against trunk branch so that subsequent PRs would have access to the same cache.

### How to test the changes in this Pull Request:

1. To test this we have to first merge this PR in unfortunately.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
