### PR TITLE
Make sure get_current_screen() is available

### DIFF
--- a/plugins/woocommerce/changelog/fix-33989-fatal-error-with-get-current-screen
+++ b/plugins/woocommerce/changelog/fix-33989-fatal-error-with-get-current-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal when a block is used in the frontend #33989

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -52,7 +52,7 @@ class Homescreen {
 
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 
-		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
+		if ( Features::is_enabled( 'shipping-smart-defaults' ) && function_exists( 'get_current_screen' ) ) {
 			add_filter(
 				'woocommerce_admin_shared_settings',
 				array( $this, 'maybe_set_default_shipping_options_on_home' ),


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33989  .

This PR adds a guard to `maybe_set_default_shipping_options_on_home` function by making sure `get_current_screen` function exists

### How to test the changes in this Pull Request:

1. Start with a fresh install and finish OBW as usual.
2. Add a new page with `All Products` block.
3. Open an Incognito window and access the page
4. The page should render without an error.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
