### PR TITLE
Update css for single product badge

### DIFF
--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -266,8 +266,8 @@ $tt2-gray: #f7f7f7;
 
 		> span.onsale {
 			position: absolute;
-			left: -1rem;
-			top: -1rem;
+			left: 0;
+			top: 0;
 			width: 1.8rem;
 			z-index: 1;
 		}


### PR DESCRIPTION
Go to single product page with Woocommerce and default WP Twenty Twenty Two theme.

Fixes #33993 