### PR TITLE
Retry login on e2e

### DIFF
--- a/plugins/woocommerce/changelog/22-07-retry-admin-login-e2e
+++ b/plugins/woocommerce/changelog/22-07-retry-admin-login-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Retry login in e2e to reduce flakiness

--- a/plugins/woocommerce/e2e/global-teardown.js
+++ b/plugins/woocommerce/e2e/global-teardown.js
@@ -2,15 +2,22 @@ const { chromium } = require( '@playwright/test' );
 
 module.exports = async ( config ) => {
 	const { baseURL } = config.projects[ 0 ].use;
-	// Clean up the consumer keys
+
 	const browser = await chromium.launch();
 	const adminPage = await browser.newPage();
-	await adminPage.goto( `${ baseURL }/wp-admin` );
-	await adminPage.fill( 'input[name="log"]', 'admin' );
-	await adminPage.fill( 'input[name="pwd"]', 'password' );
-	await adminPage.click( 'text=Log In' );
-	await adminPage.goto(
-		`${ baseURL }/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
-	);
-	await adminPage.dispatchEvent( 'a.submitdelete', 'click' );
+
+	// Clean up the consumer keys
+	const keysRetries = 5;
+	for ( let i = 0; i < keysRetries; i++ ) {
+		try {
+			await adminPage.goto( `${ baseURL }/wp-admin` );
+			await adminPage.fill( 'input[name="log"]', 'admin' );
+			await adminPage.fill( 'input[name="pwd"]', 'password' );
+			await adminPage.click( 'text=Log In' );
+			await adminPage.goto(
+				`${ baseURL }/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
+			);
+			await adminPage.dispatchEvent( 'a.submitdelete', 'click' );
+		} catch ( e ) {}
+	}
 };


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Retries login in e2e, because if it fails, all tests fail.

Closes #33996 .

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
