### PR TITLE
Add `wc com disconnect` command

### DIFF
--- a/plugins/woocommerce/changelog/add-wc-com-disconnect-command
+++ b/plugins/woocommerce/changelog/add-wc-com-disconnect-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Adds `wc com disconnect` command to allow store being disconnected from WooCommerce.com via CLI

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -884,18 +884,7 @@ class WC_Helper {
 			admin_url( 'admin.php' )
 		);
 
-		WC_Helper_API::post(
-			'oauth/invalidate_token',
-			array(
-				'authenticated' => true,
-			)
-		);
-
-		WC_Helper_Options::update( 'auth', array() );
-		WC_Helper_Options::update( 'auth_user_data', array() );
-
-		self::_flush_subscriptions_cache();
-		self::_flush_updates_cache();
+		self::disconnect();
 
 		wp_safe_redirect( $redirect_uri );
 		die();
@@ -1675,6 +1664,26 @@ class WC_Helper {
 		}
 
 		self::$log->log( $level, $message, array( 'source' => 'helper' ) );
+	}
+
+	/**
+	 * Handles WC Helper disconnect tasks.
+	 *
+	 * @return void
+	 */
+	public static function disconnect() {
+		WC_Helper_API::post(
+			'oauth/invalidate_token',
+			array(
+				'authenticated' => true,
+			)
+		);
+
+		WC_Helper_Options::update( 'auth', array() );
+		WC_Helper_Options::update( 'auth_user_data', array() );
+
+		self::_flush_subscriptions_cache();
+		self::_flush_updates_cache();
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -71,7 +71,7 @@ class WC_Helper {
 		$notices = self::_get_return_notices();
 
 		// No active connection.
-		if ( empty( $auth['access_token'] ) ) {
+		if ( ! self::is_site_connected() ) {
 			$connect_url = add_query_arg(
 				array(
 					'page'              => 'wc-addons',
@@ -1684,6 +1684,18 @@ class WC_Helper {
 
 		self::_flush_subscriptions_cache();
 		self::_flush_updates_cache();
+	}
+
+	/**
+	 * Checks if `access_token` exists in `auth` option.
+	 *
+	 * @return bool
+	 */
+	public static function is_site_connected(): bool {
+		$auth = WC_Helper_Options::get( 'auth' );
+
+		// If `access_token` is empty, there's no active connection.
+		return ! empty( $auth['access_token'] );
 	}
 }
 

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
@@ -101,11 +101,11 @@ class WC_CLI_COM_Command {
 	 *     # Disconnect without prompt for confirmation.
 	 *     $ wp wc com disconnect --yes
 	 *
-	 * @param  array  $args
-	 * @param  array  $assoc_args
-	 *
+	 * @param array $args Positional arguments to include when calling the command.
+	 * @param array $assoc_args Associative arguments to include when calling the command.
+
 	 * @return void
-	 * @throws \WP_CLI\ExitException
+	 * @throws \WP_CLI\ExitException If WP_CLI::$capture_exit is true.
 	 */
 	public static function disconnect( array $args, array $assoc_args ) {
 		if ( ! WC_Helper::is_site_connected() ) {

--- a/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
+++ b/plugins/woocommerce/includes/cli/class-wc-cli-com-command.php
@@ -21,6 +21,7 @@ class WC_CLI_COM_Command {
 	 */
 	public static function register_commands() {
 		WP_CLI::add_command( 'wc com extension list', array( 'WC_CLI_COM_Command', 'list_extensions' ) );
+		WP_CLI::add_command( 'wc com disconnect', array( 'WC_CLI_COM_Command', 'disconnect' ) );
 	}
 
 	/**
@@ -84,5 +85,35 @@ class WC_CLI_COM_Command {
 		);
 
 		$formatter->display_items( $data );
+	}
+
+	/**
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Do not prompt for confirmation.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Disconnect from site.
+	 *     $ wp wc com disconnect
+	 *
+	 *     # Disconnect without prompt for confirmation.
+	 *     $ wp wc com disconnect --yes
+	 *
+	 * @param  array  $args
+	 * @param  array  $assoc_args
+	 *
+	 * @return void
+	 * @throws \WP_CLI\ExitException
+	 */
+	public static function disconnect( array $args, array $assoc_args ) {
+		if ( ! WC_Helper::is_site_connected() ) {
+			WP_CLI::error( 'Your store is not connected to WooCommerce.com. Run `wp wc com connect` command.' );
+		}
+
+		WP_CLI::confirm( 'Are you sure you want to disconnect your store from WooCommerce.com?', $assoc_args );
+		WC_Helper::disconnect();
+		WP_CLI::success( 'You have successfully disconnected your store from WooCommerce.com' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/13870.

### How to test the changes in this Pull Request:

1. Having a test site connected to WooCommerce.com ('http://localhost/wp-admin/admin.php?page=wc-addons&section=helper')
2. From terminal run `wp wc com disconnect`, the site should be disconnected
<img width="631" alt="Screen Shot 2022-07-20 at 10 50 46" src="https://user-images.githubusercontent.com/532402/180038771-f4881234-6bd8-4caf-af55-f8dc0365332a.png">

4. Confirm from 'http://localhost/wp-admin/admin.php?page=wc-addons&section=helper' that the site is correctly disconnected and that the connect screen is shown
<img width="875" alt="Screen Shot 2022-07-20 at 10 51 48" src="https://user-images.githubusercontent.com/532402/180038957-0c463bd5-e8b4-4c5b-97fa-c01fe7e5ecb1.png">

5. From the terminal, run `wp wc com disconnect` again. An error message should be shown
<img width="689" alt="Screen Shot 2022-07-20 at 10 52 38" src="https://user-images.githubusercontent.com/532402/180039161-53c2bf16-88eb-4edb-adc9-567e83a9b8c1.png">


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
