### PR TITLE
Prevent double build on unit test workflow in CI

### DIFF
--- a/.github/actions/install-build/action.yml
+++ b/.github/actions/install-build/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install
-      uses: ./../install
+      uses: ./.github/actions/install
 
     - name: Run build
       shell: bash

--- a/.github/actions/install-build/action.yml
+++ b/.github/actions/install-build/action.yml
@@ -9,15 +9,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install PNPM
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-      run: npm install -g pnpm@^6.24.2
-
-    - name: Install dependencies
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-      run: COMPOSER_NO_DEV=1 pnpm install
+    - name: Install
+      uses: ./../install
 
     - name: Run build
       shell: bash

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,20 @@
+name: Install
+description: Installs WooCommerce.
+inputs:
+  working_directory:
+    required: false
+    description: The directory to target.
+    default: ./
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install PNPM
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: npm install -g pnpm@^6.24.2
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: COMPOSER_NO_DEV=1 pnpm install

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -55,8 +55,8 @@ jobs:
           php --version
           composer --version
 
-      - name: Install and Build
-        uses: ./.github/actions/install-build
+      - name: Install
+        uses: ./.github/actions/install
 
       - name: Build Admin feature config
         run: |


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The workflow "[Run unit tests on PR](https://github.com/woocommerce/woocommerce/actions/workflows/pr-unit-tests.yml)" runs the build step twice. One in the [workflow](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/pr-unit-tests.yml#L58-L59) itself, and one due to a turbo.json [dependsOn](https://github.com/woocommerce/woocommerce/blob/trunk/turbo.json#L52).

This PR aims to prevent the double-build while keeping a few consideriations in mind:

- Preserve the `build` pre-step of `test` in local
- Keep install logic centralized in CI workflows
- Allow for workflows to only install without build, for similar use-cases

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
