### PR TITLE
Add utils for testing tracks in backend

### DIFF
--- a/plugins/woocommerce/changelog/add-tracks-test-utils
+++ b/plugins/woocommerce/changelog/add-tracks-test-utils
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add utils for testing backend tracks events

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-footer-pixel.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-footer-pixel.php
@@ -110,4 +110,18 @@ class WC_Tracks_Footer_Pixel {
 			WC_Tracks_Client::record_event( $event );
 		}
 	}
+
+	/**
+	 * Get all events.
+	 */
+	public static function get_events() {
+		return self::instance()->events;
+	}
+
+	/**
+	 * Clear all queued events.
+	 */
+	public static function clear_events() {
+		self::instance()->events = array();
+	}
 }

--- a/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/plugins/woocommerce/tests/legacy/framework/class-wc-unit-test-case.php
@@ -349,4 +349,43 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 			$this->markTestSkipped( 'Waiting for WordPress compatibility with PHP 8.1' );
 		}
 	}
+
+	/**
+	 * Get recorded tracks event by name.
+	 *
+	 * @param string $event_name Event name.
+	 * @return WC_Tracks_Event|null
+	 */
+	public function get_tracks_events( $event_name ) {
+		$events  = WC_Tracks_Footer_Pixel::get_events();
+		$matches = array();
+
+		foreach ( $events as $event ) {
+			if ( $event->_en === $event_name ) {
+				$matches[] = $event;
+			}
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Assert that a valid tracks event has been recorded.
+	 *
+	 * @param string $event_name Event name.
+	 */
+	public function assertRecordedTracksEvent( $event_name ): void {
+		$events = self::get_tracks_events( $event_name );
+		$this->assertNotEmpty( $events );
+	}
+
+	/**
+	 * Assert that a tracks event has not been recorded.
+	 *
+	 * @param string $event_name Event name.
+	 */
+	public function assertNotRecordedTracksEvent( $event_name ): void {
+		$events = self::get_tracks_events( $event_name );
+		$this->assertEmpty( $events );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
@@ -28,11 +28,23 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+
 		$this->list = new TaskList(
 			array(
 				'id' => 'setup',
 			)
 		);
+	}
+
+	/**
+	 * Tear down test data. Called after every test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		WC_Tracks_Footer_Pixel::clear_events();
 	}
 
 	/**
@@ -75,6 +87,7 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 	public function test_hide() {
 		$this->list->hide();
 		$this->assertTrue( $this->list->is_hidden() );
+		$this->assertRecordedTracksEvent( 'wcadmin_setup_tasklist_completed' );
 	}
 
 	/**
@@ -197,6 +210,8 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 			)
 		);
 		$this->assertTrue( $this->list->is_complete() );
+		$this->list->get_json();
+		$this->assertRecordedTracksEvent( 'wcadmin_setup_tasklist_tasks_completed' );
 	}
 
 	/**
@@ -221,8 +236,10 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 				)
 			)
 		);
+		$this->assertNotRecordedTracksEvent( 'wcadmin_setup_tasklist_tasks_completed' );
 		$this->assertFalse( $this->list->has_previously_completed() );
 		$this->list->get_json();
+		$this->assertRecordedTracksEvent( 'wcadmin_setup_tasklist_tasks_completed' );
 		$this->assertTrue( $this->list->has_previously_completed() );
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
@@ -5,6 +5,9 @@
  * @package WooCommerce\Admin\Tests\OnboardingTasks
  */
 
+/**
+ * Test task fixture.
+ */
 require_once __DIR__ . '/test-task.php';
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32188 .

This PR adds in some key utilities to test that tracks have been recorded.  In any unit test file extending `WC_Unit_Test_Case` we can now:

* `$this->assertRecordedTracksEvent( $event_name )`
* `$this->assertNotRecordedTracksEvent( $event_name )`
* `$events = self::get_tracks_events( $event_name )`

This gives us some basic assertion methods to see if events have fired and also direct access to the events in case we need to check specific properties or if the event has fired multiple times.

A couple notes about this:

* Events should be valid given they've already been sanitized and validated by the time they get to the tracking pixel.  Should sanity check this though.
* This does not work over ajax or REST requests yet since that does not use the footer tracking pixel.  This is probably more of an edge case for the sake of testing so we can save for a follow-up if needed.

### How to test the changes in this Pull Request:

1. Check that tests pass
2. Consider various use cases to make sure utils work

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
