### PR TITLE
Split changelog steps from code-freeze action

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -58,13 +58,13 @@ jobs:
         id: rev-parse
         run: echo "::set-output name=hash::$(git rev-parse HEAD)"
         
-      - name: "Insert NEXT_CHANGELOG contents into readme"
+      - name: "Insert NEXT_CHANGELOG contents into readme.txt"
         run: php .github/workflows/scripts/release-changelog.php
       
-      - name: "git add changelog and readme files"
+      - name: "git add readme.txt"
         run: git add plugins/woocommerce/readme.txt
       
-      - name: "Commit changelog and readme files"
+      - name: "Commit readme"
         run: git commit -m "Update the readme files for the ${{ inputs.releaseVersion }} release"
         
       - name: "Push update branch to origin"

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -58,14 +58,14 @@ jobs:
         id: rev-parse
         run: echo "::set-output name=hash::$(git rev-parse HEAD)"
         
-      - name: "Insert NEXT_CHANGELOG contents into changelog and readme"
+      - name: "Insert NEXT_CHANGELOG contents into readme"
         run: php .github/workflows/scripts/release-changelog.php
       
       - name: "git add changelog and readme files"
-        run: git add changelog.txt plugins/woocommerce/readme.txt
+        run: git add plugins/woocommerce/readme.txt
       
       - name: "Commit changelog and readme files"
-        run: git commit -m "Update the changelog and readme files for the ${{ inputs.releaseVersion }} release"
+        run: git commit -m "Update the readme files for the ${{ inputs.releaseVersion }} release"
         
       - name: "Push update branch to origin"
         run: git push origin ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -1,0 +1,118 @@
+name: "Release: Generate changelog"
+on:
+  workflow_dispatch:
+    inputs:
+      releaseBranch:
+        description: 'The name of the release branch, in the format `release/x.y`'
+        required: true
+      releaseVersion:
+        description: 'The version of the release, in the format `x.y`'
+        required: true
+
+env:
+    GIT_COMMITTER_NAME: 'WooCommerce Bot'
+    GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
+    GIT_AUTHOR_NAME: 'WooCommerce Bot'
+    GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+
+jobs:
+  create-changelog-prs:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
+
+      - name: Install PNPM
+        run: npm install -g pnpm@^6.24.2
+
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+
+      - name: "Git fetch the release branch"
+        run: git fetch origin ${{ inputs.releaseBranch }}
+        
+      - name: "Checkout the release branch"
+        run: git checkout ${{ inputs.releaseBranch }}
+      
+      - name: "Create a new branch for the changelog update PR"
+        run: git checkout -b ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: "Generate the changelog file"
+        run: pnpm changelog --filter=woocommerce -- write --add-pr-num -n -vvv --use-version ${{ inputs.releaseVersion }}
+        
+      - name: "git rm deleted files"
+        run: git rm $(git ls-files --deleted)
+        
+      - name: "Commit deletion"
+        run: git commit -m "Delete changelog files from ${{ inputs.releaseVersion }} release"
+        
+      - name: "Remember the deletion commit hash"
+        id: rev-parse
+        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
+        
+      - name: "Insert NEXT_CHANGELOG contents into changelog and readme"
+        run: php .github/workflows/scripts/release-changelog.php
+      
+      - name: "git add changelog and readme files"
+        run: git add changelog.txt plugins/woocommerce/readme.txt
+      
+      - name: "Commit changelog and readme files"
+        run: git commit -m "Update the changelog and readme files for the ${{ inputs.releaseVersion }} release"
+        
+      - name: "Push update branch to origin"
+        run: git push origin ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}
+        
+      - name: "Stash any other undesired changes"
+        run: git stash
+        
+      - name: "Checkout trunk"
+        run: git checkout trunk
+      
+      - name: "Create a branch for the changelog files deletion"
+        run: git checkout -b ${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}
+        
+      - name: "Cherry-pick the deletion commit"
+        run: git cherry-pick ${{ steps.rev-parse.outputs.hash }}
+        
+      - name: "Push deletion branch to origin"
+        run: git push origin ${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}
+        
+      - name: "Create release branch PR"
+        id: release-pr
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const result = await github.rest.pulls.create( {
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ github.event.repository.name }}",
+              head: "${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}",
+              base: "${{ inputs.releaseBranch }}",
+              title: "${{ format( 'Release: Prepare the changelog for {0}', inputs.releaseVersion ) }}",
+              body: "${{ format( 'This pull request was automatically generated during the code freeze to prepare the changelog for {0}', inputs.releaseVersion ) }}"
+            } );
+            
+            return result.data.number;
+            
+      - name: "Create trunk PR"
+        id: trunk-pr
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const result = await github.rest.pulls.create( {
+              owner: "${{ github.repository_owner }}",
+              repo: "${{ github.event.repository.name }}",
+              head: "${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}",
+              base: "trunk",
+              title: "${{ format( 'Release: Remove {0} change files', inputs.releaseVersion ) }}",
+              body: "${{ format( 'This pull request was automatically generated during the code freeze to remove the changefiles from {0} that are compiled into the `{1}` branch via #{2}', inputs.releaseVersion, inputs.releaseBranch, steps.release-pr.outputs.result ) }}"
+            } );
+            
+            return result.data.number;

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -1,4 +1,4 @@
-name: "Enforce release code freeze"
+name: "Release: Code freeze"
 on:
   schedule:
     - cron: '0 16 * * 4' # Run at 1600 UTC on Thursdays.
@@ -15,10 +15,6 @@ on:
 
 env:
     TIME_OVERRIDE: ${{ inputs.timeOverride }}
-    GIT_COMMITTER_NAME: 'WooCommerce Bot'
-    GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
-    GIT_AUTHOR_NAME: 'WooCommerce Bot'
-    GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
 jobs:
   maybe-create-next-milestone-and-release-branch:
@@ -58,90 +54,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_OUTPUTS: 1
 
-      - name: "Git fetch the newly created release branch"
-        run: git fetch origin ${{ steps.freeze.outputs.branch }}
-        
-      - name: "Checkout the release branch"
-        run: git checkout ${{ steps.freeze.outputs.branch }}
-      
-      - name: "Create a new branch for the changelog update PR"
-        run: git checkout -b ${{ format( 'update/{0}-changelog', steps.freeze.outputs.release_version ) }}
-
-      - name: "Generate the changelog file"
-        run: pnpm changelog --filter=woocommerce -- write --add-pr-num -n -vvv --use-version ${{ steps.freeze.outputs.release_version }}
-        
-      - name: "git rm deleted files"
-        run: git rm $(git ls-files --deleted)
-        
-      - name: "Commit deletion"
-        run: git commit -m "Delete changelog files from ${{ steps.freeze.outputs.release_version }} release"
-        
-      - name: "Remember the deletion commit hash"
-        id: rev-parse
-        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
-        
-      - name: "Insert NEXT_CHANGELOG contents into changelog and readme"
-        run: php .github/workflows/scripts/release-changelog.php
-      
-      - name: "git add changelog and readme files"
-        run: git add changelog.txt plugins/woocommerce/readme.txt
-      
-      - name: "Commit changelog and readme files"
-        run: git commit -m "Update the changelog and readme files for the ${{ steps.freeeze.outputs.release_version }} release"
-        
-      - name: "Push update branch to origin"
-        run: git push origin ${{ format( 'update/{0}-changelog', steps.freeze.outputs.release_version ) }}
-        
-      - name: "Stash any other undesired changes"
-        run: git stash
-        
-      - name: "Checkout trunk"
-        run: git checkout trunk
-      
-      - name: "Create a branch for the changelog files deletion"
-        run: git checkout -b ${{ format( 'delete/{0}-changelog', steps.freeze.outputs.release_version ) }}
-        
-      - name: "Cherry-pick the deletion commit"
-        run: git cherry-pick ${{ steps.rev-parse.outputs.hash }}
-        
-      - name: "Push deletion branch to origin"
-        run: git push origin ${{ format( 'delete/{0}-changelog', steps.freeze.outputs.release_version ) }}
-        
-      - name: "Create release branch PR"
-        id: release-pr
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const result = await github.rest.pulls.create( {
-              owner: "${{ github.repository_owner }}",
-              repo: "${{ github.event.repository.name }}",
-              head: "${{ format( 'update/{0}-changelog', steps.freeze.outputs.release_version ) }}",
-              base: "${{ steps.freeze.outputs.branch }}",
-              title: "${{ format( 'Release: Prepare the changelog for {0}', steps.freeze.outputs.release_version ) }}",
-              body: "${{ format( 'This pull request was automatically generated during the code freeze to prepare the changelog for {0}', steps.freeze.outputs.release_version ) }}"
-            } );
-            
-            return result.data.number;
-
-      - run: echo '${{ steps.release-pr.outputs.result }}'
-            
-      - name: "Create trunk PR"
-        id: trunk-pr
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const result = await github.rest.pulls.create( {
-              owner: "${{ github.repository_owner }}",
-              repo: "${{ github.event.repository.name }}",
-              head: "${{ format( 'delete/{0}-changelog', steps.freeze.outputs.release_version ) }}",
-              base: "trunk",
-              title: "${{ format( 'Release: Remove {0} change files', steps.freeze.outputs.release_version ) }}",
-              body: "${{ format( 'This pull request was automatically generated during the code freeze to remove the changefiles from {0} that are compiled into the `{1}` branch via #{2}', steps.freeze.outputs.release_version, steps.freeze.outputs.branch, steps.release-pr.outputs.result ) }}"
-            } );
-            
-            return result.data.number;
-        
-
   notify-slack:
     name: "Sends code freeze notification to Slack"
     if: ${{ inputs.skipSlackPing != true }}
@@ -158,3 +70,16 @@ jobs:
             :warning-8c: ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} Code Freeze :ice_cube:
             
             The automation to cut the release branch for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} has run. Any PRs that were not already merged will be a part of ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} by default. If you have something that needs to make ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} that hasn't yet been merged, please see the <${{ secrets.FG_LINK }}/code-freeze-for-woocommerce-core-release/|fieldguide page for the code freeze>.
+
+  trigger-changelog-action:
+    name: "Trigger changelog action"
+    runs-on: ubuntu-20.04
+    needs: maybe-create-next-milestone-and-release-branch
+    steps:
+      - run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.WC_BOT_TRIAGE_TOKEN }}" \
+            -d '{"ref":"refs/heads/trunk","inputs":{"releaseBranch":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.branch }}","releaseVersion":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }}"}}' \
+            https://api.github.com/repos/jonathansadowski/woocommerce/actions/workflows/release-changelog.yml/dispatches

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -82,4 +82,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.WC_BOT_TRIAGE_TOKEN }}" \
             -d '{"ref":"refs/heads/trunk","inputs":{"releaseBranch":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.branch }}","releaseVersion":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }}"}}' \
-            https://api.github.com/repos/jonathansadowski/woocommerce/actions/workflows/release-changelog.yml/dispatches
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-changelog.yml/dispatches

--- a/.github/workflows/scripts/release-changelog.php
+++ b/.github/workflows/scripts/release-changelog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Helper script for inserting NEXT_CHANGELOG contents into changelog.
+ * Helper script for inserting NEXT_CHANGELOG contents into readme.txt.
  */
 
 $now = time();
@@ -27,4 +27,4 @@ $next_log  = preg_replace( "/\[#(\d+)\]/", '[#$1](https://github.com/woocommerce
 
 $readme    = preg_replace( "/== Changelog ==\n(.*?)\[See changelog for all versions\]/s", "== Changelog ==\n\n{$next_log}\n\n[See changelog for all versions]", $readme );
 
-file_put_contents( $changelog_file, $changelog );
+file_put_contents( $readme_file, $readme );

--- a/.github/workflows/scripts/release-changelog.php
+++ b/.github/workflows/scripts/release-changelog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Helper script for inserting NEXT_CHANGELOG contents into changelog and readme files.
+ * Helper script for inserting NEXT_CHANGELOG contents into changelog.
  */
 
 $now = time();
@@ -14,11 +14,9 @@ $base_dir = dirname( dirname( dirname( __DIR__ ) ) );
 $release_time = strtotime( '+26 days', $now );
 $release_date = date( 'Y-m-d', $release_time );
 
-$changelog_file = $base_dir . '/changelog.txt';
 $readme_file    = $base_dir . '/plugins/woocommerce/readme.txt';
 $next_log_file  = $base_dir . '/plugins/woocommerce/NEXT_CHANGELOG.md';
 
-$changelog = file_get_contents( $changelog_file );
 $readme    = file_get_contents( $readme_file );
 $next_log  = file_get_contents( $next_log_file );
 
@@ -26,9 +24,7 @@ $next_log  = preg_replace( "/= (\d+\.\d+\.\d+) YYYY-mm-dd =/", "= \\1 {$release_
 
 // Convert PR number to markdown link.
 $next_log  = preg_replace( "/\[#(\d+)\]/", '[#$1](https://github.com/woocommerce/woocommerce/pull/$1)', $next_log );
-$changelog = preg_replace( "/^== Changelog ==\n\n/", "== Changelog ==\n\n{$next_log}\n", $changelog );
 
 $readme    = preg_replace( "/== Changelog ==\n(.*?)\[See changelog for all versions\]/s", "== Changelog ==\n\n{$next_log}\n\n[See changelog for all versions]", $readme );
 
 file_put_contents( $changelog_file, $changelog );
-file_put_contents( $readme_file, $readme );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR splits the changelog generation steps from the code-freeze action into a new action and calls that action from the code-freeze action. This allows the code-freeze action to succeed if there's something preventing the generation of the changelog and allows us to re-run the changelog script stand-alone should the need arise.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33906 .

### How to test the changes in this Pull Request:

1. Fork this repository and merge this PR into trunk of your fork.
1. Create a release in your repository (any version x.y.z, doesn't really matter)
1. Make sure issues are enabled in your fork (to allow for milestones) from https://github.com/YOURFORK/woocommerce/settings
1. Make sure workflows are enabled in your fork from https://github.com/YOURFORK/woocommerce/actions
1. Make sure that workflows are allowed to read and write, as well as create PRs from https://github.com/YOURFORK/woocommerce/settings/actions
1. Add a GitHub token named `WC_BOT_TRIAGE_TOKEN` to your secrets (https://github.com/YOURFORK/woocommerce/settings/secrets/actions), containing a GitHub token that has `repo` scope. I wasn't able to get triggering one action from another to work with the `GITHUB_TOKEN` secret, it just silently failed.
1. Enable the code freeze action in your fork from https://github.com/YOURFORK/woocommerce/actions/workflows/release-code-freeze.yml
1. Run the code freeze action in your fork (from trunk) using the value 2022-08-18 for the time override. You probably want to skip the slack ping.
1. Ensure the action runs, creates milestones, and release branches as expected (based on your x.y release version)
1. Ensure that after the action runs, it runs the release-changelog.yml action, and creates two PRs to create the changelog and delete entries from trunk
1. Close those two PRs without merging and delete their branches
1. Run the release-changelog.yml action directly providing the previously created release branch and its version from https://github.com/YOURFORK/woocommerce/actions/workflows/release-changelog.yml
1. Ensure that again two PRs were created to create the changelog and delete entries from trunk

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
