### PR TITLE
Update inbox notes to display localized strings when locale changed

### DIFF
--- a/plugins/woocommerce/changelog/update-display-localized-inbox-notes-when-locale-changed
+++ b/plugins/woocommerce/changelog/update-display-localized-inbox-notes-when-locale-changed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update inbox notes to display localized note when the locale is changed

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -43,7 +43,7 @@ class Notes {
 				$note = new Note( $raw_note );
 				if ( $user_locale !== $note->get_locale() ) {
 					/**
-					 * Filter the note. This is used to modify the note before it is returned when the user's locale does not match the note's locale.
+					 * Filter the note from db. This is used to modify the note before it is returned when the user's locale does not match the note's locale.
 					 *
 					 * @since 6.9.0
 					 * @param Note $note The note object from the database.

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -34,22 +34,19 @@ class Notes {
 	 * @return array Array of arrays.
 	 */
 	public static function get_notes( $context = 'edit', $args = array() ) {
-		$data_store  = self::load_data_store();
-		$raw_notes   = $data_store->get_notes( $args );
-		$notes       = array();
-		$user_locale = get_user_locale();
+		$data_store = self::load_data_store();
+		$raw_notes  = $data_store->get_notes( $args );
+		$notes      = array();
 		foreach ( (array) $raw_notes as $raw_note ) {
 			try {
 				$note = new Note( $raw_note );
-				if ( $user_locale !== $note->get_locale() ) {
-					/**
-					 * Filter the note from db. This is used to modify the note before it is returned when the user's locale does not match the note's locale.
-					 *
-					 * @since 6.9.0
-					 * @param Note $note The note object from the database.
-					 */
-					$note = apply_filters( 'woocommerce_get_note_from_db', $note );
-				}
+				/**
+				 * Filter the note from db. This is used to modify the note before it is returned when the user's locale does not match the note's locale.
+				 *
+				 * @since 6.9.0
+				 * @param Note $note The note object from the database.
+				 */
+				$note                               = apply_filters( 'woocommerce_get_note_from_db', $note );
 				$note_id                            = $note->get_id();
 				$notes[ $note_id ]                  = $note->get_data();
 				$notes[ $note_id ]['name']          = $note->get_name( $context );

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -34,12 +34,22 @@ class Notes {
 	 * @return array Array of arrays.
 	 */
 	public static function get_notes( $context = 'edit', $args = array() ) {
-		$data_store = self::load_data_store();
-		$raw_notes  = $data_store->get_notes( $args );
-		$notes      = array();
+		$data_store  = self::load_data_store();
+		$raw_notes   = $data_store->get_notes( $args );
+		$notes       = array();
+		$user_locale = get_user_locale();
 		foreach ( (array) $raw_notes as $raw_note ) {
 			try {
-				$note                               = new Note( $raw_note );
+				$note = new Note( $raw_note );
+				if ( $user_locale !== $note->get_locale() ) {
+					/**
+					 * Filter the note. This is used to modify the note before it is returned when the user's locale does not match the note's locale.
+					 *
+					 * @since 6.9.0
+					 * @param Note $note The note object from the database.
+					 */
+					$note = apply_filters( 'woocommerce_get_note', $note );
+				}
 				$note_id                            = $note->get_id();
 				$notes[ $note_id ]                  = $note->get_data();
 				$notes[ $note_id ]['name']          = $note->get_name( $context );

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -41,7 +41,7 @@ class Notes {
 			try {
 				$note = new Note( $raw_note );
 				/**
-				 * Filter the note from db. This is used to modify the note before it is returned when the user's locale does not match the note's locale.
+				 * Filter the note from db. This is used to modify the note before it is returned.
 				 *
 				 * @since 6.9.0
 				 * @param Note $note The note object from the database.

--- a/plugins/woocommerce/src/Admin/Notes/Notes.php
+++ b/plugins/woocommerce/src/Admin/Notes/Notes.php
@@ -48,7 +48,7 @@ class Notes {
 					 * @since 6.9.0
 					 * @param Note $note The note object from the database.
 					 */
-					$note = apply_filters( 'woocommerce_get_note', $note );
+					$note = apply_filters( 'woocommerce_get_note_from_db', $note );
 				}
 				$note_id                            = $note->get_id();
 				$notes[ $note_id ]                  = $note->get_data();

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -190,8 +190,11 @@ class RemoteInboxNotificationsEngine {
 	 * @return Note The note.
 	 */
 	public static function get_note_from_db( $note_from_db ) {
-		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
+		if ( get_user_locale() === $note_from_db->get_locale() ) {
+			return;
+		}
 
+		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
 		if ( false === $specs || 0 === count( $specs ) ) {
 			return $note_from_db;
 		}
@@ -207,11 +210,9 @@ class RemoteInboxNotificationsEngine {
 				break;
 			}
 
-			$note = clone $note_from_db;
-			$note->set_title( $locale->title );
-			$note->set_content( $locale->content );
-			$note->set_actions( SpecRunner::get_actions( $spec ) );
-			return $note;
+			$note_from_db->set_title( $locale->title );
+			$note_from_db->set_content( $locale->content );
+			$note_from_db->set_actions( SpecRunner::get_actions( $spec ) );
 		}
 
 		return $note_from_db;

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\PluginsProvider\PluginsProvider;
 use \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
+use \Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
  * Remote Inbox Notifications engine.
@@ -190,8 +191,8 @@ class RemoteInboxNotificationsEngine {
 	 * @return Note The note.
 	 */
 	public static function get_note_from_db( $note_from_db ) {
-		if ( get_user_locale() === $note_from_db->get_locale() ) {
-			return;
+		if ( ! $note_from_db instanceof Note || get_user_locale() === $note_from_db->get_locale() ) {
+			return $note_from_db;
 		}
 
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -58,7 +58,7 @@ class RemoteInboxNotificationsEngine {
 			}
 		);
 
-		add_filter( 'woocommerce_get_note', array( __CLASS__, 'get_note' ), 10, 1 );
+		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
 	}
 
 	/**
@@ -189,7 +189,7 @@ class RemoteInboxNotificationsEngine {
 	 * @param Note $note_from_db The note object created from db.
 	 * @return Note The note.
 	 */
-	public static function get_note( $note_from_db ) {
+	public static function get_note_from_db( $note_from_db ) {
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
 
 		if ( false === $specs || 0 === count( $specs ) ) {
@@ -201,7 +201,7 @@ class RemoteInboxNotificationsEngine {
 				continue;
 			}
 
-			$locale = SpecRunner::get_locale( $spec->locales );
+			$locale = SpecRunner::get_locale( $spec->locales, true );
 			if ( null === $locale ) {
 				// No locale found, so don't update the note.
 				break;

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -194,17 +194,11 @@ class RemoteInboxNotificationsEngine {
 		if ( ! $note_from_db instanceof Note || get_user_locale() === $note_from_db->get_locale() ) {
 			return $note_from_db;
 		}
-
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
-		if ( $specs === false || count( $specs ) === 0 ) {
-			return $note_from_db;
-		}
-
 		foreach ( $specs as $spec ) {
 			if ( $spec->slug !== $note_from_db->get_name() ) {
 				continue;
 			}
-
 			$locale = SpecRunner::get_locale( $spec->locales, true );
 			if ( $locale === null ) {
 				// No locale found, so don't update the note.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -48,7 +48,7 @@ class RemoteInboxNotificationsEngine {
 					array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
 					'woocommerce-remote-inbox-engine'
 				);
-				if ( null === $next_hook ) {
+				if ( $next_hook === null ) {
 					WC()->queue()->schedule_single(
 						time(),
 						'woocommerce_run_on_woocommerce_admin_updated',
@@ -111,7 +111,7 @@ class RemoteInboxNotificationsEngine {
 	public static function run() {
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
 
-		if ( false === $specs || 0 === count( $specs ) ) {
+		if ( $specs === false || count( $specs ) === 0 ) {
 			return;
 		}
 
@@ -144,7 +144,7 @@ class RemoteInboxNotificationsEngine {
 	public static function get_stored_state() {
 		$stored_state = get_option( self::STORED_STATE_OPTION_NAME );
 
-		if ( false === $stored_state ) {
+		if ( $stored_state === false ) {
 			$stored_state = new \stdClass();
 
 			$stored_state = StoredStateSetupForProducts::init_stored_state(
@@ -196,7 +196,7 @@ class RemoteInboxNotificationsEngine {
 		}
 
 		$specs = DataSourcePoller::get_instance()->get_specs_from_data_sources();
-		if ( false === $specs || 0 === count( $specs ) ) {
+		if ( $specs === false || count( $specs ) === 0 ) {
 			return $note_from_db;
 		}
 
@@ -206,7 +206,7 @@ class RemoteInboxNotificationsEngine {
 			}
 
 			$locale = SpecRunner::get_locale( $spec->locales, true );
-			if ( null === $locale ) {
+			if ( $locale === null ) {
 				// No locale found, so don't update the note.
 				break;
 			}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -104,7 +104,7 @@ class SpecRunner {
 	 * @returns object The locale that was found, or null if no matching locale was found.
 	 */
 	public static function get_locale( $locales ) {
-		$wp_locale           = get_locale();
+		$wp_locale           = get_user_locale();
 		$matching_wp_locales = array_values(
 			array_filter(
 				$locales,
@@ -144,7 +144,7 @@ class SpecRunner {
 	 * @return object The matching locale, or the en_US fallback locale, or null if neither was found.
 	 */
 	public static function get_action_locale( $action_locales ) {
-		$wp_locale           = get_locale();
+		$wp_locale           = get_user_locale();
 		$matching_wp_locales = array_values(
 			array_filter(
 				$action_locales,

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -25,12 +25,12 @@ class SpecRunner {
 
 		// Create or update the note.
 		$existing_note_ids = $data_store->get_notes_with_name( $spec->slug );
-		if ( 0 === count( $existing_note_ids ) ) {
+		if ( count( $existing_note_ids ) === 0 ) {
 			$note = new Note();
 			$note->set_status( Note::E_WC_ADMIN_NOTE_PENDING );
 		} else {
 			$note = Notes::get_note( $existing_note_ids[0] );
-			if ( false === $note ) {
+			if ( $note === false ) {
 				return;
 			}
 		}
@@ -52,7 +52,7 @@ class SpecRunner {
 		// Get the matching locale or fall back to en-US.
 		$locale = self::get_locale( $spec->locales );
 
-		if ( null === $locale ) {
+		if ( $locale === null ) {
 			return;
 		}
 
@@ -114,7 +114,7 @@ class SpecRunner {
 			)
 		);
 
-		if ( 0 !== count( $matching_wp_locales ) ) {
+		if ( count( $matching_wp_locales ) !== 0 ) {
 			return $matching_wp_locales[0];
 		}
 
@@ -123,12 +123,12 @@ class SpecRunner {
 			array_filter(
 				$locales,
 				function( $l ) {
-					return 'en_US' === $l->locale;
+					return $l->locale === 'en_US';
 				}
 			)
 		);
 
-		if ( 0 !== count( $en_us_locales ) ) {
+		if ( count( $en_us_locales ) !== 0 ) {
 			return $en_us_locales[0];
 		}
 
@@ -154,7 +154,7 @@ class SpecRunner {
 			)
 		);
 
-		if ( 0 !== count( $matching_wp_locales ) ) {
+		if ( count( $matching_wp_locales ) !== 0 ) {
 			return $matching_wp_locales[0];
 		}
 
@@ -163,12 +163,12 @@ class SpecRunner {
 			array_filter(
 				$action_locales,
 				function( $l ) {
-					return 'en_US' === $l->locale;
+					return $l->locale === 'en_US';
 				}
 			)
 		);
 
-		if ( 0 !== count( $en_us_locales ) ) {
+		if ( count( $en_us_locales ) !== 0 ) {
 			return $en_us_locales[0];
 		}
 
@@ -192,7 +192,7 @@ class SpecRunner {
 
 			$note->add_action(
 				$action->name,
-				( null === $action_locale || ! isset( $action_locale->label ) )
+				( $action_locale === null || ! isset( $action_locale->label ) )
 					? ''
 					: $action_locale->label,
 				$url,

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/SpecRunner.php
@@ -67,23 +67,8 @@ class SpecRunner {
 			$note->set_source( $spec->source );
 		}
 
-		// Clear then create actions.
-		$note->clear_actions();
-		$actions = isset( $spec->actions ) ? $spec->actions : array();
-		foreach ( $actions as $action ) {
-			$action_locale = self::get_action_locale( $action->locales );
-
-			$url = self::get_url( $action );
-
-			$note->add_action(
-				$action->name,
-				( null === $action_locale || ! isset( $action_locale->label ) )
-					? ''
-					: $action_locale->label,
-				$url,
-				$action->status
-			);
-		}
+		// Recreate actions.
+		$note->set_actions( self::get_actions( $spec ) );
 
 		$note->save();
 	}
@@ -188,5 +173,32 @@ class SpecRunner {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get the actions for a note.
+	 *
+	 * @param object $spec The spec.
+	 *
+	 * @return array The actions.
+	 */
+	public static function get_actions( $spec ) {
+		$note    = new Note();
+		$actions = isset( $spec->actions ) ? $spec->actions : array();
+		foreach ( $actions as $action ) {
+			$action_locale = self::get_action_locale( $action->locales );
+
+			$url = self::get_url( $action );
+
+			$note->add_action(
+				$action->name,
+				( null === $action_locale || ! isset( $action_locale->label ) )
+					? ''
+					: $action_locale->label,
+				$url,
+				$action->status
+			);
+		}
+		return $note->get_actions();
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -174,6 +174,10 @@ class Events {
 	 * @param Note $note_from_db The note object from the database.
 	 */
 	public function get_note_from_db( $note_from_db ) {
+		if ( get_user_locale() === $note_from_db->get_locale() ) {
+			return;
+		}
+
 		$note_classes = array_merge( self::$note_classes_to_added_or_updated, self::$other_note_classes );
 		foreach ( $note_classes as $note_class ) {
 			if ( defined( "$note_class::NOTE_NAME" ) && $note_class::NOTE_NAME === $note_from_db->get_name() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -176,7 +176,7 @@ class Events {
 	public function get_note( $note_from_db ) {
 		$note_classes = array_merge( self::$note_classes_to_added_or_updated, self::$other_note_classes );
 		foreach ( $note_classes as $note_class ) {
-			if ( $note_class::NOTE_NAME === $note_from_db->get_name() ) {
+			if ( defined( "$note_class::NOTE_NAME" ) && $note_class::NOTE_NAME === $note_from_db->get_name() ) {
 				if ( method_exists( $note_class, 'get_note' ) ) {
 					$note_from_class = $note_class::get_note();
 					$note            = clone $note_from_db;

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -8,40 +8,48 @@ namespace Automattic\WooCommerce\Internal\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Features\Features;
-use \Automattic\WooCommerce\Internal\Admin\Notes\AddingAndManangingProducts;
-use \Automattic\WooCommerce\Internal\Admin\Notes\ChoosingTheme;
-use \Automattic\WooCommerce\Internal\Admin\Notes\CustomizingProductCatalog;
-use \Automattic\WooCommerce\Internal\Admin\Notes\FirstDownlaodableProduct;
-use \Automattic\WooCommerce\Internal\Admin\Notes\InsightFirstProductAndPayment;
-use \Automattic\WooCommerce\Internal\Admin\Notes\MobileApp;
-use \Automattic\WooCommerce\Internal\Admin\Notes\NewSalesRecord;
-use \Automattic\WooCommerce\Internal\Admin\Notes\TrackingOptIn;
-use \Automattic\WooCommerce\Internal\Admin\Notes\OnboardingPayments;
-use \Automattic\WooCommerce\Internal\Admin\Notes\PersonalizeStore;
-use \Automattic\WooCommerce\Internal\Admin\Notes\EUVATNumber;
-use \Automattic\WooCommerce\Internal\Admin\Notes\WooCommercePayments;
-use \Automattic\WooCommerce\Internal\Admin\Notes\MarketingJetpack;
-use \Automattic\WooCommerce\Internal\Admin\Notes\WooCommerceSubscriptions;
-use \Automattic\WooCommerce\Internal\Admin\Notes\MigrateFromShopify;
-use \Automattic\WooCommerce\Internal\Admin\Notes\LaunchChecklist;
-use \Automattic\WooCommerce\Internal\Admin\Notes\RealTimeOrderAlerts;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
 use \Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
-use \Automattic\WooCommerce\Internal\Admin\Notes\MerchantEmailNotifications;
-use \Automattic\WooCommerce\Internal\Admin\Notes\InsightFirstSale;
-use \Automattic\WooCommerce\Internal\Admin\Notes\OnlineClothingStore;
-use \Automattic\WooCommerce\Internal\Admin\Notes\FirstProduct;
-use \Automattic\WooCommerce\Internal\Admin\Notes\CustomizeStoreWithBlocks;
-use \Automattic\WooCommerce\Internal\Admin\Notes\TestCheckout;
-use \Automattic\WooCommerce\Internal\Admin\Notes\EditProductsOnTheMove;
-use \Automattic\WooCommerce\Internal\Admin\Notes\PerformanceOnMobile;
-use \Automattic\WooCommerce\Internal\Admin\Notes\ManageOrdersOnTheGo;
 use \Automattic\WooCommerce\Internal\Admin\Notes\AddFirstProduct;
-use \Automattic\WooCommerce\Internal\Admin\Schedulers\MailchimpScheduler;
+use \Automattic\WooCommerce\Internal\Admin\Notes\AddingAndManangingProducts;
+use \Automattic\WooCommerce\Internal\Admin\Notes\ChoosingTheme;
 use \Automattic\WooCommerce\Internal\Admin\Notes\CompleteStoreDetails;
-use \Automattic\WooCommerce\Internal\Admin\Notes\UpdateStoreDetails;
-use \Automattic\WooCommerce\Internal\Admin\Notes\PaymentsRemindMeLater;
+use \Automattic\WooCommerce\Internal\Admin\Notes\CouponPageMoved;
+use \Automattic\WooCommerce\Internal\Admin\Notes\CustomizeStoreWithBlocks;
+use \Automattic\WooCommerce\Internal\Admin\Notes\CustomizingProductCatalog;
+use \Automattic\WooCommerce\Internal\Admin\Notes\EditProductsOnTheMove;
+use \Automattic\WooCommerce\Internal\Admin\Notes\EUVATNumber;
+use \Automattic\WooCommerce\Internal\Admin\Notes\FirstDownlaodableProduct;
+use \Automattic\WooCommerce\Internal\Admin\Notes\FirstProduct;
+use \Automattic\WooCommerce\Internal\Admin\Notes\InsightFirstProductAndPayment;
+use \Automattic\WooCommerce\Internal\Admin\Notes\InsightFirstSale;
+use \Automattic\WooCommerce\Internal\Admin\Notes\InstallJPAndWCSPlugins;
+use \Automattic\WooCommerce\Internal\Admin\Notes\LaunchChecklist;
 use \Automattic\WooCommerce\Internal\Admin\Notes\MagentoMigration;
+use \Automattic\WooCommerce\Internal\Admin\Notes\ManageOrdersOnTheGo;
+use \Automattic\WooCommerce\Internal\Admin\Notes\ManageStoreActivityFromHomeScreen;
+use \Automattic\WooCommerce\Internal\Admin\Notes\MarketingJetpack;
+use \Automattic\WooCommerce\Internal\Admin\Notes\MerchantEmailNotifications;
+use \Automattic\WooCommerce\Internal\Admin\Notes\MigrateFromShopify;
+use \Automattic\WooCommerce\Internal\Admin\Notes\MobileApp;
+use \Automattic\WooCommerce\Internal\Admin\Notes\NewSalesRecord;
+use \Automattic\WooCommerce\Internal\Admin\Notes\OnboardingPayments;
+use \Automattic\WooCommerce\Internal\Admin\Notes\OnlineClothingStore;
+use \Automattic\WooCommerce\Internal\Admin\Notes\OrderMilestones;
+use \Automattic\WooCommerce\Internal\Admin\Notes\PaymentsRemindMeLater;
+use \Automattic\WooCommerce\Internal\Admin\Notes\PerformanceOnMobile;
+use \Automattic\WooCommerce\Internal\Admin\Notes\PersonalizeStore;
+use \Automattic\WooCommerce\Internal\Admin\Notes\RealTimeOrderAlerts;
+use \Automattic\WooCommerce\Internal\Admin\Notes\SellingOnlineCourses;
+use \Automattic\WooCommerce\Internal\Admin\Notes\TestCheckout;
+use \Automattic\WooCommerce\Internal\Admin\Notes\TrackingOptIn;
+use \Automattic\WooCommerce\Internal\Admin\Notes\UnsecuredReportFiles;
+use \Automattic\WooCommerce\Internal\Admin\Notes\UpdateStoreDetails;
+use \Automattic\WooCommerce\Internal\Admin\Notes\WelcomeToWooCommerceForStoreUsers;
+use \Automattic\WooCommerce\Internal\Admin\Notes\WooCommercePayments;
+use \Automattic\WooCommerce\Internal\Admin\Notes\WooCommerceSubscriptions;
+use \Automattic\WooCommerce\Internal\Admin\Notes\WooSubscriptionsNotes;
+use \Automattic\WooCommerce\Internal\Admin\Schedulers\MailchimpScheduler;
 
 /**
  * Events Class.
@@ -62,6 +70,61 @@ class Events {
 	protected function __construct() {}
 
 	/**
+	 * Array of note class to be added or updated.
+	 *
+	 * @var array
+	 */
+	private static $note_classes_to_added_or_updated = array(
+		AddFirstProduct::class,
+		AddingAndManangingProducts::class,
+		ChoosingTheme::class,
+		CompleteStoreDetails::class,
+		CustomizeStoreWithBlocks::class,
+		CustomizingProductCatalog::class,
+		EditProductsOnTheMove::class,
+		EUVATNumber::class,
+		FirstDownlaodableProduct::class,
+		FirstProduct::class,
+		InsightFirstProductAndPayment::class,
+		InsightFirstSale::class,
+		LaunchChecklist::class,
+		MagentoMigration::class,
+		ManageOrdersOnTheGo::class,
+		MarketingJetpack::class,
+		MigrateFromShopify::class,
+		MobileApp::class,
+		NewSalesRecord::class,
+		OnboardingPayments::class,
+		OnlineClothingStore::class,
+		PaymentsRemindMeLater::class,
+		PerformanceOnMobile::class,
+		PersonalizeStore::class,
+		RealTimeOrderAlerts::class,
+		TestCheckout::class,
+		TrackingOptIn::class,
+		UpdateStoreDetails::class,
+		WooCommercePayments::class,
+		WooCommerceSubscriptions::class,
+	);
+
+	/**
+	 * The other note classes that are added in other places.
+	 *
+	 * @var array
+	 */
+	private static $other_note_classes = array(
+		CouponPageMoved::class,
+		InstallJPAndWCSPlugins::class,
+		ManageStoreActivityFromHomeScreen::class,
+		OrderMilestones::class,
+		SellingOnlineCourses::class,
+		UnsecuredReportFiles::class,
+		WelcomeToWooCommerceForStoreUsers::class,
+		WooSubscriptionsNotes::class,
+	);
+
+
+	/**
 	 * Get class instance.
 	 *
 	 * @return object Instance.
@@ -78,6 +141,7 @@ class Events {
 	 */
 	public function init() {
 		add_action( 'wc_admin_daily', array( $this, 'do_wc_admin_daily' ) );
+		add_filter( 'woocommerce_get_note', array( $this, 'get_note' ), 10, 1 );
 	}
 
 	/**
@@ -105,39 +169,37 @@ class Events {
 	}
 
 	/**
+	 * Get note.
+	 *
+	 * @param Note $note_from_db The note object from the database.
+	 */
+	public function get_note( $note_from_db ) {
+		$note_classes = array_merge( self::$note_classes_to_added_or_updated, self::$other_note_classes );
+		foreach ( $note_classes as $note_class ) {
+			if ( $note_class::NOTE_NAME === $note_from_db->get_name() ) {
+				if ( method_exists( $note_class, 'get_note' ) ) {
+					$note_from_class = $note_class::get_note();
+					$note            = clone $note_from_db;
+					$note->set_title( $note_from_class->get_title() );
+					$note->set_content( $note_from_class->get_content() );
+					$note->set_actions( $note_from_class->get_actions() );
+					return $note;
+				}
+				break;
+			}
+		}
+		return $note_from_db;
+	}
+
+	/**
 	 * Adds notes that should be added.
 	 */
 	protected function possibly_add_notes() {
-		NewSalesRecord::possibly_add_note();
-		MobileApp::possibly_add_note();
-		TrackingOptIn::possibly_add_note();
-		OnboardingPayments::possibly_add_note();
-		PersonalizeStore::possibly_add_note();
-		WooCommercePayments::possibly_add_note();
-		EUVATNumber::possibly_add_note();
-		MarketingJetpack::possibly_add_note();
-		WooCommerceSubscriptions::possibly_add_note();
-		MigrateFromShopify::possibly_add_note();
-		InsightFirstSale::possibly_add_note();
-		LaunchChecklist::possibly_add_note();
-		OnlineClothingStore::possibly_add_note();
-		FirstProduct::possibly_add_note();
-		RealTimeOrderAlerts::possibly_add_note();
-		CustomizeStoreWithBlocks::possibly_add_note();
-		TestCheckout::possibly_add_note();
-		EditProductsOnTheMove::possibly_add_note();
-		PerformanceOnMobile::possibly_add_note();
-		ManageOrdersOnTheGo::possibly_add_note();
-		ChoosingTheme::possibly_add_note();
-		InsightFirstProductAndPayment::possibly_add_note();
-		AddFirstProduct::possibly_add_note();
-		AddingAndManangingProducts::possibly_add_note();
-		CustomizingProductCatalog::possibly_add_note();
-		FirstDownlaodableProduct::possibly_add_note();
-		CompleteStoreDetails::possibly_add_note();
-		UpdateStoreDetails::possibly_add_note();
-		PaymentsRemindMeLater::possibly_add_note();
-		MagentoMigration::possibly_add_note();
+		foreach ( self::$note_classes_to_added_or_updated as $note_class ) {
+			if ( method_exists( $note_class, 'possibly_add_note' ) ) {
+				$note_class::possibly_add_note();
+			}
+		}
 	}
 
 	/**
@@ -151,36 +213,11 @@ class Events {
 	 * Updates notes that should be updated.
 	 */
 	protected function possibly_update_notes() {
-		NewSalesRecord::possibly_update_note();
-		MobileApp::possibly_update_note();
-		TrackingOptIn::possibly_update_note();
-		OnboardingPayments::possibly_update_note();
-		PersonalizeStore::possibly_update_note();
-		WooCommercePayments::possibly_update_note();
-		EUVATNumber::possibly_update_note();
-		MarketingJetpack::possibly_update_note();
-		WooCommerceSubscriptions::possibly_update_note();
-		MigrateFromShopify::possibly_update_note();
-		InsightFirstSale::possibly_update_note();
-		LaunchChecklist::possibly_update_note();
-		OnlineClothingStore::possibly_update_note();
-		FirstProduct::possibly_update_note();
-		RealTimeOrderAlerts::possibly_update_note();
-		CustomizeStoreWithBlocks::possibly_update_note();
-		TestCheckout::possibly_update_note();
-		EditProductsOnTheMove::possibly_update_note();
-		PerformanceOnMobile::possibly_update_note();
-		ManageOrdersOnTheGo::possibly_update_note();
-		ChoosingTheme::possibly_update_note();
-		InsightFirstProductAndPayment::possibly_update_note();
-		AddFirstProduct::possibly_update_note();
-		AddingAndManangingProducts::possibly_update_note();
-		CustomizingProductCatalog::possibly_update_note();
-		FirstDownlaodableProduct::possibly_update_note();
-		CompleteStoreDetails::possibly_update_note();
-		UpdateStoreDetails::possibly_update_note();
-		PaymentsRemindMeLater::possibly_update_note();
-		MagentoMigration::possibly_update_note();
+		foreach ( self::$note_classes_to_added_or_updated as $note_class ) {
+			if ( method_exists( $note_class, 'possibly_update_note' ) ) {
+				$note_class::possibly_update_note();
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -50,6 +50,7 @@ use \Automattic\WooCommerce\Internal\Admin\Notes\WooCommercePayments;
 use \Automattic\WooCommerce\Internal\Admin\Notes\WooCommerceSubscriptions;
 use \Automattic\WooCommerce\Internal\Admin\Notes\WooSubscriptionsNotes;
 use \Automattic\WooCommerce\Internal\Admin\Schedulers\MailchimpScheduler;
+use \Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
  * Events Class.
@@ -174,8 +175,8 @@ class Events {
 	 * @param Note $note_from_db The note object from the database.
 	 */
 	public function get_note_from_db( $note_from_db ) {
-		if ( get_user_locale() === $note_from_db->get_locale() ) {
-			return;
+		if ( ! $note_from_db instanceof Note || get_user_locale() === $note_from_db->get_locale() ) {
+			return $note_from_db;
 		}
 
 		$note_classes = array_merge( self::$note_classes_to_added_or_updated, self::$other_note_classes );

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -141,7 +141,7 @@ class Events {
 	 */
 	public function init() {
 		add_action( 'wc_admin_daily', array( $this, 'do_wc_admin_daily' ) );
-		add_filter( 'woocommerce_get_note', array( $this, 'get_note' ), 10, 1 );
+		add_filter( 'woocommerce_get_note_from_db', array( $this, 'get_note_from_db' ), 10, 1 );
 	}
 
 	/**
@@ -173,7 +173,7 @@ class Events {
 	 *
 	 * @param Note $note_from_db The note object from the database.
 	 */
-	public function get_note( $note_from_db ) {
+	public function get_note_from_db( $note_from_db ) {
 		$note_classes = array_merge( self::$note_classes_to_added_or_updated, self::$other_note_classes );
 		foreach ( $note_classes as $note_class ) {
 			if ( defined( "$note_class::NOTE_NAME" ) && $note_class::NOTE_NAME === $note_from_db->get_name() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -131,7 +131,7 @@ class Events {
 	 * @return object Instance.
 	 */
 	final public static function instance() {
-		if ( null === static::$instance ) {
+		if ( static::$instance === null ) {
 			static::$instance = new static();
 		}
 		return static::$instance;
@@ -182,9 +182,10 @@ class Events {
 		$note_classes = array_merge( self::$note_classes_to_added_or_updated, self::$other_note_classes );
 		foreach ( $note_classes as $note_class ) {
 			if ( defined( "$note_class::NOTE_NAME" ) && $note_class::NOTE_NAME === $note_from_db->get_name() ) {
-				if ( method_exists( $note_class, 'get_note' ) ) {
-					$note_from_class = $note_class::get_note();
-					$note            = clone $note_from_db;
+				$note_from_class = method_exists( $note_class, 'get_note' ) ? $note_class::get_note() : null;
+
+				if ( $note_from_class instanceof Note ) {
+					$note = clone $note_from_db;
 					$note->set_title( $note_from_class->get_title() );
 					$note->set_content( $note_from_class->get_content() );
 					$note->set_actions( $note_from_class->get_actions() );
@@ -237,7 +238,7 @@ class Events {
 		}
 
 		// Check if the site has opted out of marketplace suggestions.
-		if ( 'yes' !== get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
+		if ( get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) !== 'yes' ) {
 			return false;
 		}
 
@@ -252,7 +253,7 @@ class Events {
 	 */
 	protected function is_merchant_email_notifications_enabled() {
 		// Check if the feature flag is disabled.
-		if ( 'yes' !== get_option( 'woocommerce_merchant_email_notifications', 'no' ) ) {
+		if ( get_option( 'woocommerce_merchant_email_notifications', 'no' ) !== 'yes' ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Notes/ChoosingTheme.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/ChoosingTheme.php
@@ -31,7 +31,7 @@ class ChoosingTheme {
 	 *
 	 * @return Note
 	 */
-	protected static function get_note() {
+	public static function get_note() {
 		// We need to show choosing a theme notification after 1 day of install.
 		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', DAY_IN_SECONDS ) ) {
 			return;

--- a/plugins/woocommerce/src/Internal/Admin/Notes/GivingFeedbackNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/GivingFeedbackNotes.php
@@ -32,7 +32,7 @@ class GivingFeedbackNotes {
 	 *
 	 * @return Note
 	 */
-	protected static function get_note() {
+	public static function get_note() {
 		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
@@ -17,11 +17,10 @@ use \Automattic\WooCommerce\Admin\Notes\Notes;
  */
 class WooSubscriptionsNotes {
 	const LAST_REFRESH_OPTION_KEY = 'woocommerce_admin-wc-helper-last-refresh';
-	// TODO: split this class into separate classes for each note.
-	const NOTE_NAME              = 'wc-admin-wc-helper-connection';
-	const CONNECTION_NOTE_NAME   = 'wc-admin-wc-helper-connection';
-	const SUBSCRIPTION_NOTE_NAME = 'wc-admin-wc-helper-subscription';
-	const NOTIFY_WHEN_DAYS_LEFT  = 60;
+	const NOTE_NAME               = 'wc-admin-wc-helper-connection';
+	const CONNECTION_NOTE_NAME    = 'wc-admin-wc-helper-connection';
+	const SUBSCRIPTION_NOTE_NAME  = 'wc-admin-wc-helper-subscription';
+	const NOTIFY_WHEN_DAYS_LEFT   = 60;
 
 	/**
 	 * We want to bubble up expiration notices when they cross certain age

--- a/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/WooSubscriptionsNotes.php
@@ -17,9 +17,11 @@ use \Automattic\WooCommerce\Admin\Notes\Notes;
  */
 class WooSubscriptionsNotes {
 	const LAST_REFRESH_OPTION_KEY = 'woocommerce_admin-wc-helper-last-refresh';
-	const CONNECTION_NOTE_NAME    = 'wc-admin-wc-helper-connection';
-	const SUBSCRIPTION_NOTE_NAME  = 'wc-admin-wc-helper-subscription';
-	const NOTIFY_WHEN_DAYS_LEFT   = 60;
+	// TODO: split this class into separate classes for each note.
+	const NOTE_NAME              = 'wc-admin-wc-helper-connection';
+	const CONNECTION_NOTE_NAME   = 'wc-admin-wc-helper-connection';
+	const SUBSCRIPTION_NOTE_NAME = 'wc-admin-wc-helper-subscription';
+	const NOTIFY_WHEN_DAYS_LEFT  = 60;
 
 	/**
 	 * We want to bubble up expiration notices when they cross certain age
@@ -181,6 +183,14 @@ class WooSubscriptionsNotes {
 	 * Adds a note prompting to connect to WooCommerce.com.
 	 */
 	public function add_no_connection_note() {
+		$note = self::get_note();
+		$note->save();
+	}
+
+	/**
+	 * Get the WooCommerce.com connection note
+	 */
+	public static function get_note() {
 		$note = new Note();
 		$note->set_title( __( 'Connect to WooCommerce.com', 'woocommerce' ) );
 		$note->set_content( __( 'Connect to get important product notifications and updates.', 'woocommerce' ) );
@@ -194,7 +204,7 @@ class WooSubscriptionsNotes {
 			'?page=wc-addons&section=helper',
 			Note::E_WC_ADMIN_NOTE_UNACTIONED
 		);
-		$note->save();
+		return $note;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/remote-inbox-notifications-engine.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/remote-inbox-notifications-engine.php
@@ -26,8 +26,9 @@ class WC_Admin_Tests_RemoteInboxNotifications_RemoteInboxNotificationsEngine ext
 				if ( $value ) {
 					return $value;
 				}
-				$specs = json_decode(
-					'[{
+				$specs = array(
+					'zh_TW' => json_decode(
+						'[{
 						"slug": "test",
 						"status": "unactioned",
 						"type": "info",
@@ -49,6 +50,7 @@ class WC_Admin_Tests_RemoteInboxNotifications_RemoteInboxNotificationsEngine ext
 							"status": "unactioned"
 						}]
 					}]'
+					),
 				);
 
 				return $specs;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/remote-inbox-notifications-engine.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/remote-inbox-notifications-engine.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * RemoteInboxNotificationsEngine tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\RemoteInboxNotificationsEngine;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\DataSourcePoller;
+use \Automattic\WooCommerce\Admin\Notes\Note;
+
+/**
+ * class WC_Admin_Tests_RemoteInboxNotifications_SpecRunner
+ */
+class WC_Admin_Tests_RemoteInboxNotifications_RemoteInboxNotificationsEngine extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter(
+			'transient_woocommerce_admin_' . DataSourcePoller::ID . '_specs',
+			function( $value ) {
+				if ( $value ) {
+					return $value;
+				}
+				$specs = json_decode(
+					'[{
+						"slug": "test",
+						"status": "unactioned",
+						"type": "info",
+						"locales": [{
+							"locale": "zh_TW",
+							"title": "名稱",
+							"content": "內容"
+						}],
+						"rules": [],
+						"actions": [ {
+							"name": "test-action",
+							 "locales": [
+							 {
+								"locale": "zh_TW",
+								"label": "標籤"
+							}],
+							"url": "test",
+							"url_is_admin_query": false,
+							"status": "unactioned"
+						}]
+					}]'
+				);
+
+				return $specs;
+			}
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_transient( 'woocommerce_admin_' . DataSourcePoller::ID . '_specs' );
+		remove_all_filters( 'transient_woocommerce_admin_' . DataSourcePoller::ID . '_specs' );
+	}
+
+
+	/**
+	 * Tests get_note_from_db function with a invalid note.
+	 *
+	 */
+	public function test_get_note_from_db_with_invalid_note() {
+		$invalid_note = array(
+			'note_name' => 'invalid',
+		);
+		$this->assertEquals( RemoteInboxNotificationsEngine::get_note_from_db( $invalid_note ), $invalid_note );
+	}
+
+	/**
+	 * Tests get_note_from_db function when locale is the same
+	 *
+	 */
+	public function test_get_note_from_db_when_the_locale_is_the_same() {
+		$note = new Note();
+		$note->set_locale( get_user_locale() );
+		$this->assertEquals( RemoteInboxNotificationsEngine::get_note_from_db( $note ), $note );
+	}
+
+	/**
+	 * Tests get_note_from_db function when locales are different
+	 *
+	 */
+	public function test_get_note_from_db_when_locales_are_different() {
+		$note_from_db = new Note();
+		$note_from_db->set_locale( 'en_US' );
+		$note_from_db->set_name( 'test' );
+
+		add_filter(
+			'locale',
+			function( $locale ) {
+				return 'zh_TW';
+			}
+		);
+
+		$note = RemoteInboxNotificationsEngine::get_note_from_db( $note_from_db );
+		$this->assertEquals( $note->get_title(), '名稱' );
+		$this->assertEquals( $note->get_content(), '內容' );
+		$this->assertEquals( $note->get_actions()[0]->label, '標籤' );
+	}
+}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/spec-runner.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/spec-runner.php
@@ -87,4 +87,33 @@ class WC_Admin_Tests_RemoteInboxNotifications_SpecRunner extends WC_Unit_Test_Ca
 		$action = $note->get_action( 'test-action' );
 		$this->assertEquals( 'http://test.com', $action->query );
 	}
+
+	/**
+	 * Tests get actions function.
+	 *
+	 * @group fast
+	 */
+	public function test_get_actions() {
+		$spec    = $this->get_spec( 'http://test.com', false );
+		$actions = SpecRunner::get_actions( $spec );
+		$this->assertCount( 1, $actions );
+		$this->assertEquals( $actions[0]->name, 'test-action' );
+	}
+
+	/**
+	 * Tests get actions function with no actions in specs.
+	 *
+	 * @group fast
+	 */
+	public function test_get_actions_with_empty_specs() {
+		$actions = SpecRunner::get_actions( array() );
+		$this->assertCount( 0, $actions );
+
+		$actions = SpecRunner::get_actions(
+			array(
+				'actions' => array(),
+			)
+		);
+		$this->assertCount( 0, $actions );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33957.

This PR update inbox notes to display localized strings when a user changes the locale.

- Introduce `woocommerce_get_note_from_db` filter in `get_notes` method to modify the note before it is returned
- Add `woocommerce_get_note_from_db` filter in Events.php and RemoteInboxNotificationsEngine.php

We still need to update some notes that have no`get_note` method or notes in [plugins/woocommerce/includes/admin/notes/](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/includes/admin/notes) to support this i18n feature. I'll create follow-up issues for them.

### How to test the changes in this Pull Request:

**Test admin notes**

1. Use a fresh site
2. Go to `WooCommerce > Home`
3. Skip OBW
4. Observe that `Connect to WooCommerce.com` note is displayed
5. Change the "Site Language" to `Español` on the **Setting**  page
6. Go to `Dashboard > Updates`
7. Scroll to page bottom and make sure "Translations (Traducciones)" are all up to updated 
8. Go to `WooCommerce > Home`
9. Observe that `Connect to WooCommerce.com` note is translated to `Conectar con WooCommerce.com`.

**Test remote inbox notes** 

1. Use a fresh site
2. Change [this URL](https://github.com/woocommerce/woocommerce/blob/d8dd9853b60d6bd0c1eb0fe5426c56698bbec07b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php#L18) to `https://gist.githubusercontent.com/chihsuan/e2aff67165428d2fd749b68cb7c75e74/raw/50a5adf7250240c6e667966b098d0001ef6c8faa/test_remote_inbox_specs`
4. Delete `_transient_woocommerce_admin_remote_inbox_notifications_specs` if it exists
5. Go to WooCommerce > Home
6. Skip OBW
7. Observer that `We want to know what matters most to you` note is displayed.
8. Change the "Site Language" to `Español` on the **Setting**  page
9. Go to `WooCommerce > Home`
10. Observer that `We want to know what matters most to you` note  is translated to `Queremos saber qué es lo que más te importa`.




### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
