### PR TITLE
Fix Tracks event in Review Shipping task

### DIFF
--- a/plugins/woocommerce/changelog/fix-review-shipping-track
+++ b/plugins/woocommerce/changelog/fix-review-shipping-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect name in Review Shipping Task tracks event

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -286,7 +286,7 @@ class TaskLists {
 			self::add_list(
 				array(
 					'id'           => 'secret_tasklist',
-					'hidden_id'    => 'secret',
+					'hidden_id'    => 'setup',
 					'tasks'        => array(
 						'ExperimentalShippingRecommendation',
 					),


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/33994 .

This change ensures the correct task list is populated in the Tracks event when the "Review Shipping Options" task is completed.

### How to test the changes in this Pull Request:

With a new store,

1. Select United States as a country.
2. Continue through the onboarding wizard without installing free business features.
3. On the "Things to do next" task list, choose "Review Shipping Options".
4. Complete the spotlight tour on the settings page.. 
5. Navigate to WooCommerce > Home
6. See that the "Review Shipping Options" task is completed.7. 
7. Navigate to WooCommercer > Status > Logs
8. Choose the Tracks log for the current date.    
9. Confirm the Tracks event is in the log:

```
2022-07-27T13:47:15+00:00 DEBUG wcadmin_extended_tasklist_task_completed
2022-07-27T13:47:15+00:00 DEBUG   - task_name: review-shipping
```

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
