### PR TITLE
Update code-freeze action to exit earlier without fail on non-release days

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -45,16 +45,16 @@ jobs:
 
           // If 26 days from now isn't the second Tuesday, then it's not code freeze day.
           if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
-            echo '::set-output name=freeze::0';
-          } else {
             echo '::set-output name=freeze::1';
+          } else {
+            echo '::set-output name=freeze::0';
           }
 
   maybe-create-next-milestone-and-release-branch:
     name: "Maybe create next milestone and release branch"
     runs-on: ubuntu-20.04
     needs: verify-code-freeze
-    if: needs.verify-code-freeze.outputs.freeze == 1
+    if: needs.verify-code-freeze.outputs.freeze == 0
     outputs:
       branch: ${{ steps.freeze.outputs.branch }}
       release_version: ${{ steps.freeze.outputs.release_version }}

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -17,9 +17,44 @@ env:
     TIME_OVERRIDE: ${{ inputs.timeOverride }}
 
 jobs:
+  verify-code-freeze:
+    name: "Verify that today is the day of the code freeze"
+    runs-on: ubuntu-20.04
+    outputs:
+      freeze: ${{ steps.check-freeze.outputs.freeze }}
+    steps:
+      - name: "Install PHP"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: "Check whether today is the code freeze day"
+        id: check-freeze
+        shell: php {0}
+        run: |
+          <?php
+          $now = time();
+          if ( getenv( 'TIME_OVERRIDE' ) ) {
+            $now = strtotime( getenv( 'TIME_OVERRIDE' ) );
+          }
+
+          // Code freeze comes 26 days prior to release day.
+          $release_time         = strtotime( '+26 days', $now );
+          $release_day_of_week  = date( 'l', $release_time );
+          $release_day_of_month = (int) date( 'j', $release_time );
+
+          // If 26 days from now isn't the second Tuesday, then it's not code freeze day.
+          if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
+            echo '::set-output name=freeze::0';
+          } else {
+            echo '::set-output name=freeze::1';
+          }
+
   maybe-create-next-milestone-and-release-branch:
     name: "Maybe create next milestone and release branch"
     runs-on: ubuntu-20.04
+    needs: verify-code-freeze
+    if: needs.verify-code-freeze.outputs.freeze == 1
     outputs:
       branch: ${{ steps.freeze.outputs.branch }}
       release_version: ${{ steps.freeze.outputs.release_version }}


### PR DESCRIPTION

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR copies the logic from the code freeze script to determine whether the current day is the day of the code freeze and executes it, setting an output, as a separate job.

Motivations:
* Previously, when it was a non-freeze Thursday, the automatic run of the job appeared to have "failed". This makes it harder to look at previous runs of the job and see any potential issues, as they are littered with false-positives.
* This update removes the necessity for a checkout of code. The choice to include the logic in-line was intentional, as on non-code-freeze Thursdays it exits quickly.

### How to test the changes in this Pull Request:

1. Manually run this action in the `update/freeze-no-fail-on-nonfreeze` branch. (If you happen to be reviewing this code on a Thursday, also make sure that the time override is set such that its a non-freeze Thursday)
2. Verify that the action succeeds, and that only the `verify-code-freeze` job is run. The rest should be skipped.
3. If you'd like to verify that the code freeze code still works, you can follow instructions similar to those in #34027 for testing that in a fork.


### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
