### PR TITLE
Fix fatal error when bulk editing sale price to empty value in PHP 8

### DIFF
--- a/plugins/woocommerce/changelog/fix-error-when-builk-updating-sale-price
+++ b/plugins/woocommerce/changelog/fix-error-when-builk-updating-sale-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix fatal error when bulk editing sale price to empty value in PHP 8

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -965,7 +965,7 @@ class WC_Admin_Post_Types {
 					$percent   = $price / 100;
 					$new_price = max( 0, $regular_price - ( NumberUtil::round( $regular_price * $percent, wc_get_price_decimals() ) ) );
 				} else {
-					$new_price = max( 0, $regular_price - $price );
+					$new_price = max( 0, (float)$regular_price - (float)$price );
 				}
 				break;
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -965,7 +965,7 @@ class WC_Admin_Post_Types {
 					$percent   = $price / 100;
 					$new_price = max( 0, $regular_price - ( NumberUtil::round( $regular_price * $percent, wc_get_price_decimals() ) ) );
 				} else {
-					$new_price = max( 0, (float)$regular_price - (float)$price );
+					$new_price = max( 0, (float) $regular_price - (float) $price );
 				}
 				break;
 


### PR DESCRIPTION
#31947 fixed the issue by type casting from string to float.

### All Submissions:

-   [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31947.

### How to test the changes in this Pull Request:

Under PHP 8 follow the testing instructions of #31947.

### Other information:

-   [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x ] Have you written new tests for your changes, as applicable?
-   [ x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
