### PR TITLE
Fix unusable historical import

### DIFF
--- a/packages/js/data/changelog/fix-34048-historical-import-unusable
+++ b/packages/js/data/changelog/fix-34048-historical-import-unusable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing resolver import in data/import

--- a/packages/js/data/src/import/index.ts
+++ b/packages/js/data/src/import/index.ts
@@ -11,6 +11,7 @@ import { Reducer, AnyAction } from 'redux';
 import { STORE_NAME } from './constants';
 import * as selectors from './selectors';
 import * as actions from './actions';
+import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { WPDataSelectors } from '../types';
 export * from './types';
@@ -21,6 +22,7 @@ registerStore< State >( STORE_NAME, {
 	actions,
 	controls,
 	selectors,
+	resolvers,
 } );
 
 export const IMPORT_STORE_NAME = STORE_NAME;

--- a/plugins/woocommerce/changelog/fix-34048-historical-import-unusable
+++ b/plugins/woocommerce/changelog/fix-34048-historical-import-unusable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix historical import data in analytics settings


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #34048

Fix missing resolver import for data package `import` module

### How to test the changes in this Pull Request:

1. Go to Analytics -> Settings
1. Open browser inspector
1. Refresh
1. Observe request to /reports/import/totals

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
