### PR TITLE
Prevent migration when sync is disabled for COT

### DIFF
--- a/plugins/woocommerce/changelog/fix-migrate-actions
+++ b/plugins/woocommerce/changelog/fix-migrate-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent migration from running when sync option is disabled.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -133,7 +133,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	public function get_sync_status() {
 		return array(
 			'initial_pending_count' => (int) get_option( self::INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION, 0 ),
-			'current_pending_count' => $this->get_total_pending_count(),
+			'current_pending_count' => $this->get_current_orders_pending_sync_count(),
 		);
 	}
 
@@ -283,6 +283,9 @@ WHERE
 	 * @return int Number of pending records.
 	 */
 	public function get_total_pending_count(): int {
+		if ( ! $this->data_sync_is_enabled() ) {
+			return 0;
+		}
 		return $this->get_current_orders_pending_sync_count();
 	}
 
@@ -294,6 +297,10 @@ WHERE
 	 * @return array Batch of records.
 	 */
 	public function get_next_batch_to_process( int $size ): array {
+		if ( ! $this->data_sync_is_enabled() ) {
+			return array();
+		}
+
 		if ( $this->custom_orders_table_is_authoritative() ) {
 			$order_ids = $this->get_ids_of_orders_pending_sync( self::ID_TYPE_MISSING_IN_POSTS_TABLE, $size );
 		} else {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Start migration with some orders. Go to WooCommerce > Settings > Advanced > Custom Data Stores and disable the sync while the migration is still running.
2. With this patch, migration will be stopped. Without it, it will keep on running.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
