### PR TITLE
Add JSON report output to PW tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ changes.json
 /plugins/woocommerce/e2e/output
 /plugins/woocommerce/e2e/report
 /plugins/woocommerce/e2e/storage
+/plugins/woocommerce/e2e/test-results.json
 
 # Turborepo
 .turbo

--- a/plugins/woocommerce/changelog/add-pw-json-report
+++ b/plugins/woocommerce/changelog/add-pw-json-report
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: The changes in this PR are for Playwright tests which aren't bundled in woocommerce releases
+
+

--- a/plugins/woocommerce/e2e/playwright.config.js
+++ b/plugins/woocommerce/e2e/playwright.config.js
@@ -11,8 +11,15 @@ const config = {
 	workers: 4,
 	reporter: [
 		[ 'list' ],
-		[ 'html', { outputFolder: 'output' } ],
+		[
+			'html',
+			{
+				outputFolder: 'output',
+				open: process.env.CI ? 'never' : 'always',
+			},
+		],
 		[ 'allure-playwright', { outputFolder: 'e2e/allure-results' } ],
+		[ 'json', { outputFile: 'e2e/test-results.json' } ],
 	],
 	use: {
 		screenshot: 'only-on-failure',

--- a/plugins/woocommerce/e2e/tests/merchant/order-status-filter.spec.js
+++ b/plugins/woocommerce/e2e/tests/merchant/order-status-filter.spec.js
@@ -56,6 +56,7 @@ test.describe( 'WooCommerce Orders > Filter Order by Status', () => {
 		await page.goto( 'wp-admin/edit.php?post_type=shop_order' );
 
 		await page.click( 'li.all > a' );
+		await page.waitForLoadState( 'networkidle' );
 		// because tests are running in parallel, we can't know how many orders there
 		// are beyond the ones we created here.
 		for ( let i = 0; i < orderStatus.length; i++ ) {
@@ -72,6 +73,7 @@ test.describe( 'WooCommerce Orders > Filter Order by Status', () => {
 			await page.goto( 'wp-admin/edit.php?post_type=shop_order' );
 
 			await page.click( `li.${ orderStatus[ i ][ 1 ] }` );
+			await page.waitForLoadState( 'networkidle' );
 			const countElements = await page
 				.locator( statusColumnTextSelector )
 				.count();

--- a/plugins/woocommerce/e2e/tests/shopper/my-account.spec.js
+++ b/plugins/woocommerce/e2e/tests/shopper/my-account.spec.js
@@ -22,22 +22,28 @@ test.describe( 'My account page', () => {
 
 		// assert that navigation is visible
 		await expect(
-			page.locator( '.woocommerce-MyAccount-navigation-link >> nth=0' )
+			page.locator( '.woocommerce-MyAccount-navigation-link--dashboard' )
 		).toContainText( 'Dashboard' );
 		await expect(
-			page.locator( '.woocommerce-MyAccount-navigation-link >> nth=1' )
+			page.locator( '.woocommerce-MyAccount-navigation-link--orders' )
 		).toContainText( 'Orders' );
 		await expect(
-			page.locator( '.woocommerce-MyAccount-navigation-link >> nth=2' )
+			page.locator( '.woocommerce-MyAccount-navigation-link--downloads' )
 		).toContainText( 'Downloads' );
 		await expect(
-			page.locator( '.woocommerce-MyAccount-navigation-link >> nth=3' )
+			page.locator(
+				'.woocommerce-MyAccount-navigation-link--edit-address'
+			)
 		).toContainText( 'Addresses' );
 		await expect(
-			page.locator( '.woocommerce-MyAccount-navigation-link >> nth=4' )
+			page.locator(
+				'.woocommerce-MyAccount-navigation-link--edit-account'
+			)
 		).toContainText( 'Account details' );
 		await expect(
-			page.locator( '.woocommerce-MyAccount-navigation-link >> nth=5' )
+			page.locator(
+				'.woocommerce-MyAccount-navigation-link--customer-logout'
+			)
 		).toContainText( 'Logout' );
 	} );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a JSON report output for PW tests when running in CI. This PR also updates 2 test files to be more robust.

### How to test the changes in this Pull Request:

1. `pnpm env:test --filter=woocommerce`
2. `cd plugins/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=e2e/playwright.config.js`
3. Observe that all tests run an pass successfully

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
