### PR TITLE
[COT] `query()`: add support for the `customer` query var

### DIFF
--- a/plugins/woocommerce/changelog/add-cot-datastore-query-customer
+++ b/plugins/woocommerce/changelog/add-cot-datastore-query-customer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add support for the 'customer' query var to the COT datastore.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1031,7 +1031,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 
 			// 'status' is a little special (for backwards compat.).
 			if ( 'status' === $column ) {
-				$changes['status'] = 'wc-' . str_replace( 'wc-', '', $changes['status'] );
+				$changes['status'] = 'wc-' . str_replace( 'wc-', '', $changes['status'] ? $changes['status'] : 'pending' );
 			}
 
 			$row[ $column ]        = $this->database_util->format_object_value_for_db( $changes[ $details['name'] ], $details['type'] );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -251,12 +251,22 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		global $wpdb;
 
 		// Sync enabled implies a full post should be created.
-		add_filter( 'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, function() { return 'yes'; } );
+		add_filter(
+			'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+			function() {
+				return 'yes';
+			}
+		);
 		$order = $this->create_complex_cot_order();
 		$this->assertEquals( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE ID = %d AND post_type = %s", $order->get_id(), 'shop_order' ) ) );
 
 		// Sync disabled implies a placeholder post should be created.
-		add_filter( 'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, function() { return 'no'; } );
+		add_filter(
+			'pre_option_' . DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+			function() {
+				return 'no';
+			}
+		);
 		$order = $this->create_complex_cot_order();
 		$this->assertEquals( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->posts} WHERE ID = %d AND post_type = %s", $order->get_id(), DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE ) ) );
 	}
@@ -275,7 +285,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$order->delete();
 
 		$orders_table = $this->sut::get_orders_table_name();
-		$this->assertEquals( 'trash', $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$orders_table} WHERE id = %d", $order_id ) ) );
+		$this->assertEquals( 'trash', $wpdb->get_var( $wpdb->prepare( "SELECT status FROM {$orders_table} WHERE id = %d", $order_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		// Make sure order data persists in the database.
 		$this->assertNotEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d", $order_id ) ) );
@@ -285,7 +295,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				continue;
 			}
 
-			$this->assertNotEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE order_id = %d", $order_id ) ) );
+			$this->assertNotEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE order_id = %d", $order_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 
@@ -307,7 +317,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		foreach ( $this->sut->get_all_table_names() as $table ) {
 			$field_name = ( $table === $this->sut::get_orders_table_name() ) ? 'id' : 'order_id';
-			$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE {$field_name} = %d", $order_id ) ) );
+			$this->assertEmpty( $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE {$field_name} = %d", $order_id ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 
@@ -349,32 +359,32 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		// Get orders with a specific property.
 		$query_vars['prices_include_tax'] = 'no';
-		$query = new OrdersTableQuery( $query_vars );
+		$query                            = new OrdersTableQuery( $query_vars );
 		$this->assertEquals( 1, count( $query->orders ) );
 		$this->assertEquals( $query->orders[0], $order2->get_id() );
 
 		$query_vars['prices_include_tax'] = 'yes';
-		$query = new OrdersTableQuery( $query_vars );
+		$query                            = new OrdersTableQuery( $query_vars );
 		$this->assertEquals( 1, count( $query->orders ) );
 		$this->assertEquals( $query->orders[0], $order1->get_id() );
 
 		// Get orders with two specific properties.
 		$query_vars['total'] = '100.0';
-		$query = new OrdersTableQuery( $query_vars );
+		$query               = new OrdersTableQuery( $query_vars );
 		$this->assertEquals( 1, count( $query->orders ) );
 		$this->assertEquals( $query->orders[0], $order1->get_id() );
 
 		// Limit results.
 		unset( $query_vars['total'], $query_vars['prices_include_tax'] );
-		$query_vars['limit']    = 1;
-		$query = new OrdersTableQuery( $query_vars );
+		$query_vars['limit'] = 1;
+		$query               = new OrdersTableQuery( $query_vars );
 		$this->assertEquals( 1, count( $query->orders ) );
 
 		// By customer ID.
 		$query = new OrdersTableQuery(
 			array(
 				'status'      => 'all',
-				'customer_id' => $user_id
+				'customer_id' => $user_id,
 			)
 		);
 		$this->assertEquals( 1, count( $query->orders ) );
@@ -412,6 +422,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$order3->set_status( 'completed' );
 		$order3->save();
 
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query,WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+
 		// Orders with color=green.
 		$query = new OrdersTableQuery(
 			array(
@@ -419,8 +431,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 					array(
 						'key'   => 'color',
 						'value' => 'green',
-					)
-				)
+					),
+				),
 			)
 		);
 		$this->assertEquals( 2, count( $query->orders ) );
@@ -431,12 +443,12 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				'meta_query' => array(
 					array(
 						'key'   => 'animal',
-						'value' => 'lion'
+						'value' => 'lion',
 					),
 					array(
-						'key'   => 'movie',
-					)
-				)
+						'key' => 'movie',
+					),
+				),
 			)
 		);
 		$this->assertEquals( 2, count( $query->orders ) );
@@ -452,7 +464,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 						'value'   => 'London',
 						'compare' => 'LIKE',
 					),
-				)
+				),
 			)
 		);
 		$this->assertEquals( 2, count( $query->orders ) );
@@ -464,7 +476,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			array(
 				'meta_query' => array(
 					array(
-						'key'     => 'animal',
+						'key' => 'animal',
 					),
 					array(
 						'relation' => 'OR',
@@ -475,9 +487,9 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 						array(
 							'key'   => 'place',
 							'value' => 'Paris',
-						)
-					)
-				)
+						),
+					),
+				),
 			)
 		);
 		$this->assertEquals( 2, count( $query->orders ) );
@@ -493,6 +505,9 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( 1, count( $query->orders ) );
 		$this->assertContains( $order2->get_id(), $query->orders );
+
+		// phpcs:enable
+	}
 	}
 
 	/**
@@ -518,6 +533,10 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$update_data_store_func->call( $order, $data_store );
 	}
 
+	/**
+	 * Creates a complex COT order with address info, line items, etc.
+	 * @return \WC_Order
+	 */
 	private function create_complex_cot_order() {
 		$order = new WC_Order();
 		$this->switch_data_store( $order, $this->sut );
@@ -566,7 +585,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		$order->get_data_store()->set_stock_reduced( $order, true, false );
 
-		$order->update_meta_data( 'my_meta', rand( 0, 255 ) );
+		$order->update_meta_data( 'my_meta', rand( 0, 255 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
 
 		$order->save();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds support for queries involving the `customer` query var, which permits searching for orders involving certain billing e-mails and/or user IDs. In the CPT datastore, this is implemented via `meta_query` but it's now been translated into a query on certain fields in `wc_orders`.

The PR also fixes some code style issues within the COT tests.

### How to test the changes in this Pull Request:

#### Option 1
Run unit tests.

#### Option 2
1. On `trunk`, go to **My Account > Orders** and notice that it includes all orders (not just yours).
2. Check out this branch, and confirm that now only your orders appear.

#### Option 3
1. Enable COT and make it authoritative.
2. Run some queries using `wc_get_orders()` and involving the `customer` arg. See examples below.3. 

   <details>
	   <summary>Some examples...</summary>
   
      ```php
         // Customer ID has ID 1 or 2 or e-mail 'user@example.test'.
         $results = wc_get_orders(
	         array(
		         'return'   => 'ids',
		         'customer' => array( 1, 2, 'user@example.test' ),
	         )
         );
         
         // Customer ID = 0 AND email = user@example.test
         $results = wc_get_orders(
	         array(
		         'return'   => 'ids',
		         'customer' => array( array( 0, 'user@example.test' ) ),
	         )
         );
       ```
   </details>
