### PR TITLE
Fix missing product task add product track via product templates

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/test/index.tsx
@@ -150,7 +150,7 @@ describe( 'Products', () => {
 		expect( queryByText( 'Subscription product' ) ).toBeInTheDocument();
 	} );
 
-	it( 'clicking on suggested product should fire event tasklist_product_template_selection with is_suggested:true and task_completion_time', () => {
+	it( 'clicking on suggested product should fire event tasklist_add_product with method: product_template, tasklist_product_template_selection with is_suggested:true and task_completion_time', () => {
 		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
 			profile: {
 				product_types: [ 'downloads' ],
@@ -166,17 +166,22 @@ describe( 'Products', () => {
 
 		expect( recordEvent ).toHaveBeenNthCalledWith(
 			1,
+			'tasklist_add_product',
+			{ method: 'product_template' }
+		);
+		expect( recordEvent ).toHaveBeenNthCalledWith(
+			2,
 			'tasklist_product_template_selection',
 			{ is_suggested: true, product_type: 'digital' }
 		);
 		expect( recordEvent ).toHaveBeenNthCalledWith(
-			2,
+			3,
 			'task_completion_time',
 			{ task_name: 'products', time: '0-2s' }
 		);
 	} );
 
-	it( 'clicking on not-suggested product should fire event tasklist_product_template_selection with is_suggested:false and task_completion_time', async () => {
+	it( 'clicking on not-suggested product should fire event tasklist_add_product with method: product_template, tasklist_product_template_selection with is_suggested:false and task_completion_time', async () => {
 		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
 			profile: {
 				product_types: [ 'downloads' ],
@@ -207,11 +212,16 @@ describe( 'Products', () => {
 		);
 		expect( recordEvent ).toHaveBeenNthCalledWith(
 			2,
+			'tasklist_add_product',
+			{ method: 'product_template' }
+		);
+		expect( recordEvent ).toHaveBeenNthCalledWith(
+			3,
 			'tasklist_product_template_selection',
 			{ is_suggested: false, product_type: 'grouped' }
 		);
 		expect( recordEvent ).toHaveBeenNthCalledWith(
-			3,
+			4,
 			'task_completion_time',
 			{ task_name: 'products', time: '0-2s' }
 		);

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-types-list-items.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-types-list-items.tsx
@@ -27,6 +27,9 @@ const useProductTypeListItems = (
 				...productType,
 				onClick: () => {
 					createProductByType( productType.key );
+					recordEvent( 'tasklist_add_product', {
+						method: 'product_template',
+					} );
 					recordEvent( 'tasklist_product_template_selection', {
 						product_type: productType.key,
 						is_suggested: suggestedProductTypes.includes(

--- a/plugins/woocommerce/changelog/fix-34060-missing-product-task-add-track
+++ b/plugins/woocommerce/changelog/fix-34060-missing-product-task-add-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add back missing tracks in add product task


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #34060

This PR fixes missing `tasklist_add_product` track fired when clicking on any of the product templates:

<img src="https://user-images.githubusercontent.com/3747241/180907818-a0a6d70d-f053-4f74-a6b0-6fb1e0c0924f.png" width="350">

<img src="https://user-images.githubusercontent.com/3747241/180907826-fc9bed24-09b9-4447-911f-06453a034260.png" width="350">

### How to test the changes in this Pull Request:

1. Navigate to **Tools > WCA Test Helper > Experiments** and add `woocommerce_products_task_layout_card_v2`  to treatment
1. Make sure your site has `woocommerce_allow_tracking` option set to yes
2. Enable tracks debugging with `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Go to WooCommerce > Home > Add my products
3. Click on any of the product templates while having browser console open
4. Observe `wcadmin_tasklist_add_product` with `{ method: product_template }` is fired
5. Repeat steps with setting `woocommerce_products_task_layout_stacked_v2` experiment to treatment and `woocommerce_products_task_layout_card_v2` to control

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
