### PR TITLE
Fix: product attributes lookup table usage enabled on each upgrade

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-attributes-lookup-table-usage-enabled-on-each-install
+++ b/plugins/woocommerce/changelog/fix-product-attributes-lookup-table-usage-enabled-on-each-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stop re-enabling product attributes lookup table usage after each install

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -519,7 +519,8 @@ class DataRegenerator {
 		// If the lookup table has data, or if it's empty because there are no products yet, we're good.
 		// Otherwise (lookup table is empty but products exist) we need to initiate a regeneration if one isn't already in progress.
 		if ( $this->data_store->lookup_table_has_data() || ! $this->get_last_existing_product_id() ) {
-			$this->finalize_regeneration( true );
+			$must_enable = 'no' !== get_option( 'woocommerce_attribute_lookup_enabled' );
+			$this->finalize_regeneration( $must_enable );
 		} else {
 			$this->initiate_regeneration();
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -188,6 +188,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		update_option( 'woocommerce_attribute_lookup_processed_count', 7 );
 
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( array( 1, 2, 3 ), $this->lookup_data_store->passed_products );
@@ -241,6 +242,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 		$this->queue->clear_methods_called();
 
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		remove_all_filters( ' woocommerce_attribute_lookup_regeneration_step_size' );
@@ -274,6 +276,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 		$this->queue->clear_methods_called();
 
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( $product_ids, $this->lookup_data_store->passed_products );
@@ -281,5 +284,29 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_processed_count' ) );
 		$this->assertEquals( 'yes', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
+	}
+
+	/**
+	 * @testdox After WooCommerce is installed the table usage is enabled only if it hadn't been explicitly disabled by an admin.
+	 *
+	 * @testWith [null, "yes"]
+	 *           ["yes", "yes"]
+	 *           ["no", "no"]
+	 *
+	 * @param string|null $previous_option_value Initial value of the attribute usage option.
+	 * @param string      $expected_final_option_value Expected final value of the attribute usage option.
+	 */
+	public function test_after_install_table_usage_is_enabled_if_it_wasnt_disabled( ?string $previous_option_value, string $expected_final_option_value ) {
+		if ( null === $previous_option_value ) {
+			delete_option( 'woocommerce_attribute_lookup_enabled' );
+		} else {
+			update_option( 'woocommerce_attribute_lookup_enabled', $previous_option_value );
+		}
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( 'woocommerce_installed' );
+
+		$actual_final_option_value = get_option( 'woocommerce_attribute_lookup_enabled' );
+		$this->assertEquals( $expected_final_option_value, $actual_final_option_value );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The product attributes lookup table usage was being enabled every time WooCommerce was upgraded to a new version, even after an admin had explicitly disabled it. Now the option will be enabled only if it didn't exist before (meaning it's a new install).

Closes #34013.

### How to test the changes in this Pull Request:

This can be tested using the `wp` tool from the terminal:

1. Run `wp option set woocommerce_attribute_lookup_enabled no`
2. Run `wp eval "do_action( 'woocommerce_installed' );"`
3. Run `wp option get woocommerce_attribute_lookup_enabled`. Without the fix you'll get `yes`, with the fix you'll get `no`
4. Try again but setting the option to `yes` in 1 or deleting it instead (`wp option delete woocommerce_attribute_lookup_enabled`). In both cases you should get `yes` in 3.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
