### PR TITLE
Fix shipping zone fails to create after installing Jetpack and WCS

### DIFF
--- a/plugins/woocommerce/changelog/fix-34018-shipping-zone-fails-to-create
+++ b/plugins/woocommerce/changelog/fix-34018-shipping-zone-fails-to-create
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping zone fails to create after installing jetpack and wcs

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -52,7 +52,7 @@ class Homescreen {
 
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 
-		if ( Features::is_enabled( 'shipping-smart-defaults' ) && function_exists( 'get_current_screen' ) ) {
+		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
 			add_filter(
 				'woocommerce_admin_shared_settings',
 				array( $this, 'maybe_set_default_shipping_options_on_home' ),
@@ -73,6 +73,10 @@ class Homescreen {
 	 * @return array
 	 */
 	public function maybe_set_default_shipping_options_on_home( $settings ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $settings;
+		}
+
 		$current_screen = get_current_screen();
 
 		// Abort if it's not the homescreen.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34018.

This PR fixes a bug introduced in the [previous fix PR](https://github.com/woocommerce/woocommerce/pull/33990).

### How to test the changes in this Pull Request:

[release zip file](https://github.com/woocommerce/woocommerce/suites/7541539993/artifacts/311045596)


1. Create any test site using the JN site.
2. Install and activate all the required plugins.
3. Install and activate WooCommerce.
4. Start OBW and choose `United States` as store country.
5. Choose "Physical products".
6. Install Jetpack and WooCommerce Shipping from the Business Details tab.
7. Complete the OBW
8. Connect and approve Jetpack when prompted.
9. Go to `WooCommerce -> Settings -> Shipping`
10. Observe that the "United States (US)" shipping zone fails to create with "Free shipping" method after installing "Jetpack and WooCommerce Shipping" from the "Business Details" tab.

Please also follow the test instructions in https://github.com/woocommerce/woocommerce/pull/33990 to ensure not cause a Fatal error on other pages.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
