### PR TITLE
Require tracking opt in before polling data

### DIFF
--- a/plugins/woocommerce/changelog/fix-data-source-poller-opt-in
+++ b/plugins/woocommerce/changelog/fix-data-source-poller-opt-in
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Require tracking opt in before polling data

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -120,6 +120,10 @@ abstract class DataSourcePoller {
 	 * @return bool Whether any specs were read.
 	 */
 	public function read_specs_from_data_sources() {
+		if ( 'yes' !== get_option( 'woocommerce_allow_tracking' ) ) {
+			return false;
+		}
+
 		$specs        = array();
 		$data_sources = apply_filters( self::FILTER_NAME, $this->data_sources, $this->id );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Users who are not opted into tracking should not be polling any data.  This PR prevents data from ever being polled within the data source pollers (payment promotions, inbox notifications, payment suggestions, free extensions).

### How to test the changes in this Pull Request:

1. On a fresh site, do not opt in to tracking (i.e., make sure that `woocommerce_allow_tracking` is set to `no` in your options.
2. Install a plugin like [Crontrol](https://wordpress.org/plugins/wp-crontrol/) to manually run cron events.
3. Run the `wc_admin_daily` cron event.
4. Check that remote inbox notifications are not added to your site.
5. Opt in to tracking at `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
6. Run the `wc_admin_daily` cron event.
7. Check that remote inbox notifications are now shown on your site.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
