### PR TITLE
Use the default payment suggestions when woocommerce_show_marketplace_suggestions is set to no

### DIFF
--- a/packages/js/data/changelog/add-force-default-suggestions-arg
+++ b/packages/js/data/changelog/add-force-default-suggestions-arg
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support force_default_suggestions argument.

--- a/packages/js/data/src/onboarding/resolvers.ts
+++ b/packages/js/data/src/onboarding/resolvers.ts
@@ -92,10 +92,16 @@ export function* getTask() {
 	yield resolveSelect( STORE_NAME, 'getTaskLists' );
 }
 
-export function* getPaymentGatewaySuggestions() {
+export function* getPaymentGatewaySuggestions(
+	forceDefaultSuggestions = false
+) {
+	let path = WC_ADMIN_NAMESPACE + '/payment-gateway-suggestions';
+	if ( forceDefaultSuggestions ) {
+		path += '?force_default_suggestions=true';
+	}
 	try {
 		const results: Plugin[] = yield apiFetch( {
-			path: WC_ADMIN_NAMESPACE + '/payment-gateway-suggestions',
+			path,
 			method: 'GET',
 		} );
 

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -58,7 +58,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			),
 			paymentGatewaySuggestions: select(
 				ONBOARDING_STORE_NAME
-			).getPaymentGatewaySuggestions(),
+			).getPaymentGatewaySuggestions( true ),
 			countryCode: getCountryCode( settings.woocommerce_default_country ),
 		};
 	}, [] );

--- a/plugins/woocommerce/changelog/fix-33958-blank-payment-task-when-marketplace-suggestion-is-disabled
+++ b/plugins/woocommerce/changelog/fix-33958-blank-payment-task-when-marketplace-suggestion-is-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use the default paymetn suggestions when woocommerce_show_marketplace_suggestions is set to no

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -31,10 +31,15 @@ class Init {
 
 	/**
 	 * Go through the specs and run them.
+	 *
+	 * @param array|null $specs payment suggestion spec array.
+	 * @return array
 	 */
-	public static function get_suggestions() {
+	public static function get_suggestions( array $specs = null ) {
 		$suggestions = array();
-		$specs       = self::get_specs();
+		if ( null === $specs ) {
+			$specs = self::get_specs();
+		}
 
 		foreach ( $specs as $spec ) {
 			$suggestion    = EvaluateSuggestion::evaluate( $spec );


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33958  .

This PR adds a new optional argument `force_default_suggestions` to the payment suggestions endpoint.

When the argument is set to true, the endpoint returns the default payment suggestions when both `woocommerce_show_marketplace_suggestions` and `woocommerce_setting_payments_recommendations_hidden` are set to `no`

It fixes the blank page described in the original issue.

### How to test the changes in this Pull Request:

1. Start with a fresh install and complete OBW without installing any plugins in the business step.
2. Set `woocommerce_show_marketplace_suggestions` option to `no`
3. Go to `WooCommerce -> Home` and choose `Set up payments` task.
4. Confirm the suggestions are rendered as expected




### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
