### PR TITLE
Clean up setup_experiment_1 and setup_experiment_2 experiments

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -123,11 +123,9 @@ export const Layout = ( {
 	const renderTaskList = () => {
 		return (
 			<Suspense fallback={ <TasksPlaceholder query={ query } /> }>
-				{ activeSetupTaskList &&
-					isDashboardShown &&
-					[ 'setup_experiment_1', 'setup_experiment_2' ].includes(
-						activeSetupTaskList
-					) && <ProgressTitle taskListId={ activeSetupTaskList } /> }
+				{ activeSetupTaskList && isDashboardShown && (
+					<ProgressTitle taskListId={ activeSetupTaskList } />
+				) }
 				<Tasks query={ query } />
 			</Suspense>
 		);

--- a/plugins/woocommerce-admin/client/tasks/hooks/useActiveSetupList.ts
+++ b/plugins/woocommerce-admin/client/tasks/hooks/useActiveSetupList.ts
@@ -8,7 +8,9 @@ export const useActiveSetupTasklist = () => {
 	const { activeSetuplist } = useSelect( ( select ) => {
 		const taskLists = select( ONBOARDING_STORE_NAME ).getTaskLists();
 
-		const visibleSetupList = taskLists.filter( ( list ) => list.isVisible );
+		const visibleSetupList = taskLists.filter(
+			( list ) => list.id === 'setup' && list.isVisible
+		);
 
 		return {
 			activeSetuplist: visibleSetupList.length

--- a/plugins/woocommerce-admin/client/tasks/hooks/useActiveSetupList.ts
+++ b/plugins/woocommerce-admin/client/tasks/hooks/useActiveSetupList.ts
@@ -8,15 +8,7 @@ export const useActiveSetupTasklist = () => {
 	const { activeSetuplist } = useSelect( ( select ) => {
 		const taskLists = select( ONBOARDING_STORE_NAME ).getTaskLists();
 
-		const visibleSetupList = taskLists
-			.filter( ( list ) => list.isVisible )
-			.filter( ( list ) =>
-				[
-					'setup_experiment_1',
-					'setup_experiment_2',
-					'setup',
-				].includes( list.id )
-			);
+		const visibleSetupList = taskLists.filter( ( list ) => list.isVisible );
 
 		return {
 			activeSetuplist: visibleSetupList.length

--- a/plugins/woocommerce-admin/client/tasks/tasks.scss
+++ b/plugins/woocommerce-admin/client/tasks/tasks.scss
@@ -234,7 +234,7 @@
 	margin-top: $gap;
 }
 
-.woocommerce-task-list__setup_experiment_1 {
+.woocommerce-task-list__setup {
 	.woocommerce-experimental-list .woocommerce-experimental-list__item.complete {
 		text-decoration: line-through;
 

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -99,8 +99,14 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		return null;
 	}
 
+	const taskListIds = getAdminSetting( 'visibleTaskListIds', [] );
+	const TaskListPlaceholderComponent =
+		taskListIds[ 0 ] === 'setup'
+			? TwoColumnTaskListPlaceholder
+			: TasksPlaceholder;
+
 	if ( isResolving ) {
-		return <TwoColumnTaskListPlaceholder query={ query } />;
+		return <TaskListPlaceholderComponent query={ query } />;
 	}
 
 	if ( currentTask ) {
@@ -120,10 +126,12 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 				.filter( ( { isVisible }: TaskListType ) => isVisible )
 				.map( ( taskList: TaskListType ) => {
 					const { id, isHidden, isToggleable } = taskList;
+					const TaskListComponent =
+						id === 'setup' ? TwoColumnTaskList : TaskList;
 
 					return (
 						<Fragment key={ id }>
-							<TwoColumnTaskList
+							<TaskListComponent
 								isExpandable={ false }
 								query={ query }
 								twoColumns={ false }

--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -35,30 +35,6 @@ export type TasksProps = {
 	context?: string;
 };
 
-function getTaskListComponent( taskListId: string ) {
-	switch ( taskListId ) {
-		case 'setup_experiment_1':
-			return TwoColumnTaskList;
-		case 'setup_experiment_2':
-			return SectionedTaskList;
-		default:
-			return TaskList;
-	}
-}
-
-function getTaskListPlaceholderComponent(
-	taskListId: string
-): React.FC< TasksPlaceholderProps > {
-	switch ( taskListId ) {
-		case 'setup_experiment_1':
-			return TwoColumnTaskListPlaceholder;
-		case 'setup_experiment_2':
-			return SectionedTaskListPlaceholder;
-		default:
-			return TasksPlaceholder;
-	}
-}
-
 export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 	const { task } = query;
 	const { hideTaskList } = useDispatch( ONBOARDING_STORE_NAME );
@@ -123,13 +99,8 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		return null;
 	}
 
-	const taskListIds = getAdminSetting( 'visibleTaskListIds', [] );
-	const TaskListPlaceholderComponent = getTaskListPlaceholderComponent(
-		taskListIds[ 0 ]
-	);
-
 	if ( isResolving ) {
-		return <TaskListPlaceholderComponent query={ query } />;
+		return <TwoColumnTaskListPlaceholder query={ query } />;
 	}
 
 	if ( currentTask ) {
@@ -150,10 +121,9 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 				.map( ( taskList: TaskListType ) => {
 					const { id, isHidden, isToggleable } = taskList;
 
-					const TaskListComponent = getTaskListComponent( id );
 					return (
 						<Fragment key={ id }>
-							<TaskListComponent
+							<TwoColumnTaskList
 								isExpandable={ false }
 								query={ query }
 								twoColumns={ false }

--- a/plugins/woocommerce-admin/client/tasks/test/tasks.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/tasks.test.tsx
@@ -91,7 +91,7 @@ describe( 'Task', () => {
 			expect( queryByText( 'task-list:main' ) ).toBeInTheDocument();
 			expect( queryByText( 'task-list:extended' ) ).toBeInTheDocument();
 			expect(
-				queryByText( 'two-column-list:setup_experiment_1' )
+				queryByText( 'two-column-list:setup' )
 			).not.toBeInTheDocument();
 		} );
 	} );
@@ -161,32 +161,6 @@ describe( 'Task', () => {
 			expect( updateOptions ).toHaveBeenCalledWith( {
 				woocommerce_task_list_prompt_shown: true,
 			} );
-		} );
-	} );
-
-	it( 'should render the two column set up task list when id is setup_experiment_1', () => {
-		( useSelect as jest.Mock ).mockImplementation( () => ( {
-			isResolving: false,
-			taskLists: [
-				{
-					id: 'setup_experiment_1',
-					eventPrefix: 'main_tasklist_',
-					isVisible: true,
-					tasks: [ { id: 'main-task-1' }, { id: 'main-task-2' } ],
-				},
-				{ id: 'extended', isVisible: true, tasks: [] },
-			],
-		} ) );
-		const { queryByText } = render(
-			<div>
-				<Tasks query={ {} } />
-			</div>
-		);
-		waitFor( () => {
-			expect(
-				queryByText( 'two-column-list:setup_experiment_1' )
-			).toBeInTheDocument();
-			expect( queryByText( 'task-list:extended' ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/style.scss
+++ b/plugins/woocommerce-admin/client/two-column-tasks/style.scss
@@ -108,10 +108,6 @@
 	margin: 0 auto;
 	justify-content: space-between;
 
-	&.woocommerce-task-list__setup_experiment_2 {
-		margin-bottom: $gap;
-	}
-
 	ul li.complete .woocommerce-task-list__item-title {
 		font-weight: 600;
 		color: $gray-600;

--- a/plugins/woocommerce/changelog/update-33746-setup-tasklist-experiment-cleanup
+++ b/plugins/woocommerce/changelog/update-33746-setup-tasklist-experiment-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Clean up setup_experiment_1 and setup_experiment_2 codes

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -107,28 +107,7 @@ class TaskLists {
 	public static function init_default_lists() {
 		self::add_list(
 			array(
-				'id'           => 'setup',
-				'title'        => __( 'Get ready to start selling', 'woocommerce' ),
-				'tasks'        => array(
-					'StoreDetails',
-					'Purchase',
-					'Products',
-					'WooCommercePayments',
-					'Payments',
-					'Tax',
-					'Shipping',
-					'Marketing',
-					'Appearance',
-				),
-				'event_prefix' => 'tasklist_',
-				'visible'      => false,
-			)
-		);
-
-		self::add_list(
-			array(
-				'id'                      => 'setup_experiment_1',
-				'hidden_id'               => 'setup',
+				'id'                      => 'setup',
 				'title'                   => __( 'Get ready to start selling', 'woocommerce' ),
 				'tasks'                   => array(
 					'StoreDetails',
@@ -147,64 +126,6 @@ class TaskLists {
 					'use_completed_title' => true,
 				),
 				'visible'                 => true,
-			)
-		);
-
-		self::add_list(
-			array(
-				'id'                      => 'setup_experiment_2',
-				'hidden_id'               => 'setup',
-				'title'                   => __( 'Get ready to start selling', 'woocommerce' ),
-				'tasks'                   => array(
-					'StoreCreation',
-					'StoreDetails',
-					'Purchase',
-					'Products',
-					'WooCommercePayments',
-					'Payments',
-					'Tax',
-					'Shipping',
-					'Marketing',
-					'Appearance',
-				),
-				'event_prefix'            => 'tasklist_',
-				'visible'                 => false,
-				'options'                 => array(
-					'use_completed_title' => true,
-				),
-				'display_progress_header' => true,
-				'sections'                => array(
-					array(
-						'id'          => 'basics',
-						'title'       => __( 'Cover the basics', 'woocommerce' ),
-						'description' => __( 'Make sure you’ve got everything you need to start selling—from business details to products.', 'woocommerce' ),
-						'image'       => plugins_url(
-							'/assets/images/task_list/basics-section-illustration.png',
-							WC_ADMIN_PLUGIN_FILE
-						),
-						'task_names'  => array( 'StoreCreation', 'StoreDetails', 'Purchase', 'Products', 'Payments', 'WooCommercePayments' ),
-					),
-					array(
-						'id'          => 'sales',
-						'title'       => __( 'Get ready to sell', 'woocommerce' ),
-						'description' => __( 'Easily set up the backbone of your store’s operations and get ready to accept first orders.', 'woocommerce' ),
-						'image'       => plugins_url(
-							'/assets/images/task_list/sales-section-illustration.png',
-							WC_ADMIN_PLUGIN_FILE
-						),
-						'task_names'  => array( 'Shipping', 'Tax' ),
-					),
-					array(
-						'id'          => 'expand',
-						'title'       => __( 'Customize & expand', 'woocommerce' ),
-						'description' => __( 'Personalize your store’s design and grow your business by enabling new sales channels.', 'woocommerce' ),
-						'image'       => plugins_url(
-							'/assets/images/task_list/expand-section-illustration.png',
-							WC_ADMIN_PLUGIN_FILE
-						),
-						'task_names'  => array( 'Appearance', 'Marketing' ),
-					),
-				),
 			)
 		);
 
@@ -497,10 +418,7 @@ class TaskLists {
 	 * @return number
 	 */
 	public static function setup_tasks_remaining() {
-
-		$active_list = self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_1' ) ? 'setup_experiment_1' : ( self::is_experiment_treatment( 'woocommerce_tasklist_setup_experiment_2' ) ? 'setup_experiment_2' : 'setup' );
-
-		$setup_list = self::get_list( $active_list );
+		$setup_list = self::get_list( 'setup' );
 
 		if ( ! $setup_list || $setup_list->is_hidden() || $setup_list->is_complete() ) {
 			return;


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33746 .

This PR removes `setup_experiment_1` and `setup_experiment_2` codebase.


### How to test the changes in this Pull Request:

1. Search codebase and make sure no trace of `setup_experiment_1` and `setup_experiment_2`
2. Go to `WooCommerce -> Home` and make sure the task header is still rendered.
3. Make sure the tasklist is working as expected.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
