### PR TITLE
Fix/34018 default shipping smart does not work

### DIFF
--- a/plugins/woocommerce/changelog/fix-34018-default-shipping-smart-does-not-work
+++ b/plugins/woocommerce/changelog/fix-34018-default-shipping-smart-does-not-work
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fix default smart shipping not working by moving function check point to the correct place

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -52,7 +52,7 @@ class Homescreen {
 
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 
-		if ( Features::is_enabled( 'shipping-smart-defaults' ) && function_exists( 'get_current_screen' ) ) {
+		if ( Features::is_enabled( 'shipping-smart-defaults' ) ) {
 			add_filter(
 				'woocommerce_admin_shared_settings',
 				array( $this, 'maybe_set_default_shipping_options_on_home' ),
@@ -73,6 +73,9 @@ class Homescreen {
 	 * @return array
 	 */
 	public function maybe_set_default_shipping_options_on_home( $settings ) {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
 		$current_screen = get_current_screen();
 
 		// Abort if it's not the homescreen.


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34018  .

This PR fixes the default smart shipping logic by moving `get_current_screen` check to the callback.

The previous fix did not work because `get_current_screen` isn't available in the Homescreen's constructor all the time.

### How to test the changes in this Pull Request:

1. Perform test instructions from https://github.com/woocommerce/woocommerce/pull/33547
2. Perform test instructions from https://github.com/woocommerce/woocommerce/pull/33990


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
