### PR TITLE
Beta Tester: Update composer lock file

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/update-beta-tester-lock-file
+++ b/plugins/woocommerce-beta-tester/changelog/update-beta-tester-lock-file
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update Composer lock file

--- a/plugins/woocommerce-beta-tester/composer.lock
+++ b/plugins/woocommerce-beta-tester/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "352e9d11e8b6eea9d16b6384f9b1539f",
+    "content-hash": "f1e75252dada3cbba14f5c9b474ace42",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm getting out-of-date error messages concerning vendor packages when trying to release Beta Tester via Woorelease. This leads me to believe updating the Composer lock file may solve the issue.

### How to test the changes in this Pull Request:

1. The changes are the product of `composer update`, so I'm not sure there is any way to test.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
