### PR TITLE
Fix shipping zone count transient reset

### DIFF
--- a/plugins/woocommerce/changelog/fix-34098-zone-count-transient-reset
+++ b/plugins/woocommerce/changelog/fix-34098-zone-count-transient-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping zone transient not cleared when adding via smart defaults

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -24,13 +24,8 @@ class Shipping extends Task {
 		// wp_ajax_woocommerce_shipping_zone_methods_save_changes
 		// and wp_ajax_woocommerce_shipping_zones_save_changes get fired
 		// when a new zone is added or an existing one has been changed.
-		// Delete the zone count transient used in has_shipping_zones() method
-		// to refresh the cache.
-		$delete_transient = function() {
-			delete_transient( self::ZONE_COUNT_TRANSIENT_NAME );
-		};
-		add_action( 'wp_ajax_woocommerce_shipping_zones_save_changes', $delete_transient, 9 );
-		add_action( 'wp_ajax_woocommerce_shipping_zone_methods_save_changes', $delete_transient, 9 );
+		add_action( 'wp_ajax_woocommerce_shipping_zones_save_changes', array( __CLASS__, 'delete_zone_count_transient' ), 9 );
+		add_action( 'wp_ajax_woocommerce_shipping_zone_methods_save_changes', array( __CLASS__, 'delete_zone_count_transient' ), 9 );
 	}
 
 	/**
@@ -175,6 +170,16 @@ class Shipping extends Task {
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 
 		return in_array( 'physical', $product_types, true );
+	}
+
+	/**
+	 * Delete the zone count transient used in has_shipping_zones() method
+	 * to refresh the cache.
+	 *
+	 * @return bool
+	 */
+	public static function delete_zone_count_transient() {
+		delete_transient( self::ZONE_COUNT_TRANSIENT_NAME );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -176,7 +176,6 @@ class Shipping extends Task {
 	 * Delete the zone count transient used in has_shipping_zones() method
 	 * to refresh the cache.
 	 *
-	 * @return bool
 	 */
 	public static function delete_zone_count_transient() {
 		delete_transient( self::ZONE_COUNT_TRANSIENT_NAME );

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -175,7 +175,6 @@ class Shipping extends Task {
 	/**
 	 * Delete the zone count transient used in has_shipping_zones() method
 	 * to refresh the cache.
-	 *
 	 */
 	public static function delete_zone_count_transient() {
 		delete_transient( self::ZONE_COUNT_TRANSIENT_NAME );

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -7,6 +7,7 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping;
 
 /**
  * Contains backend logic for the homescreen feature.
@@ -129,6 +130,7 @@ class Homescreen {
 			$zone->add_location( $country_code, 'country' );
 			$zone->add_shipping_method( 'free_shipping' );
 			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+			Shipping::delete_zone_count_transient();
 		}
 
 		return $settings;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34098

This PR fixes shipping zone transient not being cleared after a shipping zone is added via smart defaults

### How to test the changes in this Pull Request:

1. Create a new store based in US
2. Go to WooCommerce > Home to trigger transient call
3. Look for the value of `woocommerce_shipping_task_zone_count_transient` transient and observe the value is 1 while there is shipping zone already created

#### Regression test on shipping zone
1. Go to WooCommerce > Settings > Shipping
2. Add shipping zone
3. Put any random value and save
4. Observe the shipping zone creation is successful

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
