### PR TITLE
[COT] Add remove_processor method in batch processing controller, use it when disabling orders sync

### DIFF
--- a/plugins/woocommerce/changelog/add-remove_processor_in_batch_processing_controller
+++ b/plugins/woocommerce/changelog/add-remove_processor_in_batch_processing_controller
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add remove_processor method in batch processing controller, use it when disabling orders sync

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -57,6 +57,13 @@ class CustomOrdersTableController {
 	private $data_synchronizer;
 
 	/**
+	 * The batch processing controller to use.
+	 *
+	 * @var BatchProcessingController
+	 */
+	private $batch_processing_controller;
+
+	/**
 	 * Is the feature visible?
 	 *
 	 * @var bool
@@ -156,12 +163,14 @@ class CustomOrdersTableController {
 	 * Class initialization, invoked by the DI container.
 	 *
 	 * @internal
-	 * @param OrdersTableDataStore $data_store The data store to use.
-	 * @param DataSynchronizer     $data_synchronizer The data synchronizer to use.
+	 * @param OrdersTableDataStore      $data_store The data store to use.
+	 * @param DataSynchronizer          $data_synchronizer The data synchronizer to use.
+	 * @param BatchProcessingController $batch_processing_controller The batch processing controller to use.
 	 */
-	final public function init( OrdersTableDataStore $data_store, DataSynchronizer $data_synchronizer ) {
-		$this->data_store        = $data_store;
-		$this->data_synchronizer = $data_synchronizer;
+	final public function init( OrdersTableDataStore $data_store, DataSynchronizer $data_synchronizer, BatchProcessingController $batch_processing_controller ) {
+		$this->data_store                  = $data_store;
+		$this->data_synchronizer           = $data_synchronizer;
+		$this->batch_processing_controller = $batch_processing_controller;
 	}
 
 	/**
@@ -316,7 +325,6 @@ class CustomOrdersTableController {
 		if ( ! $this->is_feature_visible() || 'custom_data_stores' !== $section_id ) {
 			return $settings;
 		}
-		$updates_controller = wc_get_container()->get( BatchProcessingController::class );
 
 		if ( $this->data_synchronizer->check_orders_table_exists() ) {
 			$settings[] = array(
@@ -364,7 +372,7 @@ class CustomOrdersTableController {
 						sprintf( _n( 'There\'s %s order pending sync!', 'There are %s orders pending sync!', $current_pending_count, 'woocommerce' ), $current_pending_count, 'woocommerce' );
 				}
 
-				if ( $updates_controller->is_enqueued( get_class( $this->data_synchronizer ) ) ) {
+				if ( $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) ) ) {
 					$text .= __( "<br/>Synchronization for these orders is currently in progress.<br/>The authoritative table can't be changed until sync completes.", 'woocommerce' );
 				} else {
 					$text .= __( "<br/>The authoritative table can't be changed until these orders are synchronized.", 'woocommerce' );
@@ -521,13 +529,15 @@ class CustomOrdersTableController {
 			update_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
 		}
 
-		// Enabling the sync implies starting it too, if needed.
+		// Enabling/disabling the sync implies starting/stopping it too, if needed.
 		// We do this check here, and not in process_pre_update_option, so that if for some reason
 		// the setting is enabled but no sync is in process, sync will start by just saving the
-		// settings even without modifying them.
+		// settings even without modifying them (and the opposite: sync will be stopped if for
+		// some reason it was ongoing while it was disabled).
 		if ( $data_sync_is_enabled ) {
-			$update_controller = wc_get_container()->get( BatchProcessingController::class );
-			$update_controller->enqueue_processor( DataSynchronizer::class );
+			$this->batch_processing_controller->enqueue_processor( DataSynchronizer::class );
+		} else {
+			$this->batch_processing_controller->remove_processor( DataSynchronizer::class );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
@@ -41,7 +42,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 
 		$this->share( OrdersTableDataStore::class )->addArguments( array( OrdersTableDataStoreMeta::class, DatabaseUtil::class ) );
 		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, PostsToOrdersMigrationController::class ) );
-		$this->share( CustomOrdersTableController::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class ) );
+		$this->share( CustomOrdersTableController::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class, BatchProcessingController::class ) );
 		$this->share( OrdersTableDataStore::class );
 		if ( Constants::is_defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->share( CLIRunner::class )->addArguments( array( CustomOrdersTableController::class, DataSynchronizer::class, PostsToOrdersMigrationController::class ) );

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -4,6 +4,7 @@
  */
 
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 
 /**
@@ -41,6 +42,87 @@ class BatchProcessingControllerTests extends WC_Unit_Test_Case {
 
 		$this->sut->enqueue_processor( get_class( $this->test_process ) );
 		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+	}
+
+	/**
+	 * @testdox 'remove_processor' dequeues and unschedules a processor, but the watchdog is kept alive if more processors are still enqueued.
+	 */
+	public function test_remove_processor_when_others_are_still_enqueued() {
+		$second_processor = $this->get_processor_stub();
+
+		$this->sut->enqueue_processor( get_class( $this->test_process ) );
+		$this->sut->enqueue_processor( get_class( $second_processor ) );
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::WATCHDOG_ACTION_NAME );
+
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $second_processor ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $second_processor ) ) );
+		$this->assertTrue( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+
+		$this->sut->remove_processor( get_class( $second_processor ) );
+
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertFalse( $this->sut->is_enqueued( get_class( $second_processor ) ) );
+		$this->assertFalse( $this->sut->is_scheduled( get_class( $second_processor ) ) );
+		$this->assertTrue( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+	}
+
+	/**
+	 * @testdox 'remove_processor' dequeues and unschedules a processor, and unschedules the watchdog if no more more processors are enqueued.
+	 */
+	public function test_remove_processor_when_no_others_remain_enqueued() {
+		$this->sut->enqueue_processor( get_class( $this->test_process ) );
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::WATCHDOG_ACTION_NAME );
+
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertTrue( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+
+		$this->sut->remove_processor( get_class( $this->test_process ) );
+
+		$this->assertFalse( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertFalse( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+	}
+
+	/**
+	 * Get a no-op batch processor.
+	 *
+	 * @return BatchProcessorInterface
+	 */
+	private function get_processor_stub(): BatchProcessorInterface {
+		//phpcs:disable Squiz.Commenting
+		return new class() implements BatchProcessorInterface {
+			public function get_name(): string {
+				return '';
+			}
+
+			public function get_description(): string {
+				return '';
+			}
+
+			public function get_total_pending_count(): int {
+				return 1;
+			}
+
+			public function get_next_batch_to_process( int $size ): array {
+				return array();
+			}
+
+			public function process_batch( array $batch ): void {
+			}
+
+			public function get_default_batch_size(): int {
+				return 1;
+			}
+		};
+		//phpcs:enable Squiz.Commenting
 	}
 
 	/**
@@ -99,5 +181,32 @@ class BatchProcessingControllerTests extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
 		$this->assertFalse( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+	}
+
+	/**
+	 * @testdox 'test_force_clear_all_processes' dequeues and unschedules all the processors, and unschedules the watchdog.
+	 */
+	public function test_force_clear_all_processes() {
+		$second_processor = $this->get_processor_stub();
+
+		$this->sut->enqueue_processor( get_class( $this->test_process ) );
+		$this->sut->enqueue_processor( get_class( $second_processor ) );
+
+		//phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		do_action( $this->sut::WATCHDOG_ACTION_NAME );
+
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertTrue( $this->sut->is_enqueued( get_class( $second_processor ) ) );
+		$this->assertTrue( $this->sut->is_scheduled( get_class( $second_processor ) ) );
+		$this->assertTrue( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
+
+		$this->sut->force_clear_all_processes();
+
+		$this->assertFalse( $this->sut->is_enqueued( get_class( $this->test_process ) ) );
+		$this->assertFalse( $this->sut->is_scheduled( get_class( $this->test_process ) ) );
+		$this->assertFalse( $this->sut->is_enqueued( get_class( $second_processor ) ) );
+		$this->assertFalse( $this->sut->is_scheduled( get_class( $second_processor ) ) );
+		$this->assertFalse( as_has_scheduled_action( $this->sut::WATCHDOG_ACTION_NAME ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request adds a new `remove_processor` method to `BatchProcessingController`, it unschedules and dequeues one single processor.

Also, `CustomOrdersTableController` will use the new method when the "Keep the posts table and the orders tables synchronized" setting in the _Advanced - Custom data stores_ page is disabled and settings are saved (this complements the already existing functionality of enablig the sync when the setting is enabled).

### How to test the changes in this Pull Request:

1. Make sure that there are orders pending sync (e.g. by deleting some records in the `wp_wc_orders` table).
2. Go to the _Advanced - Custom data stores_ page and enable the "Keep the posts table and the orders tables synchronized" setting if it's disabled.
3. Click "Save" (even if you didn't modify anything).
4. Run the following in the console, you should get an array with the full name of the `DataSynchronizer` class:

```
wp eval 'var_dump(wc_get_container()->get("Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController")->get_enqueued_processors());'
```

5. Disable the setting from 2 and save.
6. Run the command from 4 again, now you should get an empty array.

Closes (replaces) https://github.com/woocommerce/woocommerce/pull/34056

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
