### PR TITLE
[COT] Make sure status is correctly prefixed for saving

### DIFF
--- a/plugins/woocommerce/changelog/fix-cot-fix-status-prefixing
+++ b/plugins/woocommerce/changelog/fix-cot-fix-status-prefixing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure order status is correctly prefixed in COT tables.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1021,17 +1021,17 @@ LEFT JOIN {$operational_data_clauses['join']}
 			$changes[ $key ] = $this->{"get_$key"}( $order );
 		}
 
+		// Make sure 'status' is correct.
+		if ( array_key_exists( 'status', $column_mapping ) ) {
+			$changes['status'] = $this->get_post_status( $order );
+		}
+
 		$row        = array();
 		$row_format = array();
 
 		foreach ( $column_mapping as $column => $details ) {
 			if ( ! isset( $details['name'] ) || ! array_key_exists( $details['name'], $changes ) ) {
 				continue;
-			}
-
-			// 'status' is a little special (for backwards compat.).
-			if ( 'status' === $column ) {
-				$changes['status'] = 'wc-' . str_replace( 'wc-', '', $changes['status'] ? $changes['status'] : 'pending' );
 			}
 
 			$row[ $column ]        = $this->database_util->format_object_value_for_db( $changes[ $details['name'] ], $details['type'] );


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

While testing #33848 I noticed that the 'auto-draft' status was being persisted to the database as 'wc-auto-draft', and similarly with other "standard WP" statuses (such as "trash").

This PR make sure 'status' is prefixed only when necessary, respecting pre-COT behavior.

### How to test the changes in this Pull Request:

#### Option 1
1. Follow testing instructions in #33848 and notice that the new order is persisted to the `wc_orders` table with status 'wc-auto-draft' instead of just 'auto-draft'.
2. Check out this branch and confirm that the above doesn't happen.

#### Option 2
Programmatically create some orders and check the results in trunk vs this branch. For example:

   ```php
   <?php
   // status should be 'wc-pending' in the database.
   $order = new \WC_Order();
   $order->save();
   
   // status should be 'trash' in the db. In `trunk` it incorrectly shows as 'wc-trash'.
   $order = new \WC_Order();
   $order->set_status( 'trash' );
   $order->save();
   
   // status should be 'auto-draft' in the db. In `trunk` it incorrectly shows as 'wc-auto-draft'.
   $order = new \WC_Order();
   $order->set_status( 'auto-draft' );
   $order->save();
   
   // status should be 'wc-cancelled' in the db.
   $order = new \WC_Order();
   $order->set_status( 'cancelled' );
   $order->save();
   ```

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
