### PR TITLE
Prep for cherry-pick 34120

### DIFF
--- a/plugins/woocommerce-admin/client/shipping/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/shipping/shipping-tour.tsx
@@ -11,7 +11,7 @@ import {
 	useRef,
 	createPortal,
 } from '@wordpress/element';
-import { OPTIONS_STORE_NAME, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 const REVIEWED_DEFAULTS_OPTION =
 	'woocommerce_admin_reviewed_default_shipping_zones';
@@ -200,9 +200,6 @@ const TourFloaterWrapper = ( { step }: { step: number } ) => {
 export const ShippingTour = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { show: showTour } = useShowShippingTour();
-	const activePlugins = useSelect( ( select ) =>
-		select( PLUGINS_STORE_NAME ).getActivePlugins()
-	);
 
 	const [ step, setStepNumber ] = useState( 0 );
 
@@ -281,8 +278,8 @@ export const ShippingTour = () => {
 
 	const isWcsSectionPresent = document.querySelector( WCS_LINK_SELECTOR );
 
-	const isShippingRecommendationsPresent = ! activePlugins.includes(
-		'woocommerce-services'
+	const isShippingRecommendationsPresent = document.querySelector(
+		SHIPPING_RECOMMENDATIONS_SELECTOR
 	);
 
 	if ( isWcsSectionPresent ) {

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -202,6 +202,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Fix - Update StoreDetails task action url to navigate to the setting page [#33671](https://github.com/woocommerce/woocommerce/pull/33671)
 * Fix - WooCommerce Admin plugin deactivation message was causing much unnecessary alarm and has been improved #33592 [#33643](https://github.com/woocommerce/woocommerce/pull/33643)
 * Fix - `WP_Background_Process` updated to work nicely with memory_limits expressed in units other than 'M'. [#30908](https://github.com/woocommerce/woocommerce/pull/30908)
+* Fix - Fixed wrong condition used for showing shipping recommendations tour step [#34120](https://github.com/woocommerce/woocommerce/pull/30908)
 * Add - Added a mechanism to customize the data being sent via AJAX by the order meta box [#33563](https://github.com/woocommerce/woocommerce/pull/33563)
 * Add - Added partial spotlight floater to shipping smart defaults tour. [#33772](https://github.com/woocommerce/woocommerce/pull/33772)
 * Add - Added tests for react admin translations [#33510](https://github.com/woocommerce/woocommerce/pull/33510)


### PR DESCRIPTION
This is a manual cherry pick for https://github.com/woocommerce/woocommerce/pull/34120

@rjchow Can you take a look at this please? I wasn't able to use the [Cherry Pick Tool](https://github.com/woocommerce/woocommerce/blob/trunk/tools/cherry-pick/README.md) due to a change to a file that doesn't exist on the release branch and made the changes manually.