### PR TITLE
Changelog removals due to 34133

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-recommendations-wrong-condition
+++ b/plugins/woocommerce/changelog/fix-shipping-recommendations-wrong-condition
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed wrong condition used for showing shipping recommendations tour step


### PR DESCRIPTION
As a result of this cherry pick https://github.com/woocommerce/woocommerce/pull/34133, remove the corresponding changelog file from trunk.