### PR TITLE
[COT] Add unique key constraints for the addresses and operational data tables

### DIFF
--- a/plugins/woocommerce/changelog/add-unique_key_constraints_for_cot_tables
+++ b/plugins/woocommerce/changelog/add-unique_key_constraints_for_cot_tables
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add unique constraints to the COT addresses and operational tables

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1383,7 +1383,7 @@ CREATE TABLE $addresses_table_name (
 	email varchar(320) null,
 	phone varchar(100) null,
 	KEY order_id (order_id),
-	KEY address_type_order_id (address_type, order_id)
+	UNIQUE KEY address_type_order_id (address_type, order_id)
 ) $collate;
 CREATE TABLE $operational_data_table_name (
 	id bigint(20) unsigned auto_increment primary key,
@@ -1404,8 +1404,8 @@ CREATE TABLE $operational_data_table_name (
 	discount_tax_amount decimal(26, 8) NULL,
 	discount_total_amount decimal(26, 8) NULL,
 	recorded_sales tinyint(1) NULL,
-	KEY order_id (order_id),
-	KEY order_key (order_key)
+	UNIQUE KEY order_id (order_id),
+	UNIQUE KEY order_key (order_key)
 ) $collate;
 CREATE TABLE $meta_table (
 	id bigint(20) unsigned auto_increment primary key,


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Turn the keys in the COT addresses and operational data into unique keys, to prevent the accidental addition of more than one record for a given order in each table.

Closes #34123.

### How to test the changes in this Pull Request:

1. Enable the feature by adding the code snippet from [this pull request](https://github.com/woocommerce/woocommerce/pull/32817), if you haven't done it already.
2. If the COT tables already exist in your database, delete them (WooCommerce - Tools - "Delete the custom orders tables") and recreate them ("Create the custom orders tables" in the same page).

Alternatively to 2 (if you have data in the tables that you want to preserve) you can run the following in CLI:

```
wp db query 'drop index order_id on wp_wc_order_operational_data'
wp db query 'drop index order_key on wp_wc_order_operational_data'
wp db query 'drop index address_type_order_id on wp_wc_order_addresses'
wp eval 'wc_get_container()->get(Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class)->create_database_tables();'
```

The last command will throw an error if you already have duplicate records in the tables, you'll have to delete these records manually and then re-run the command.

3. Try to insert duplicate records in the operational data table, you should get an error:

```
select order_id from wp_wc_order_operational_data limit 1
# Take note of the order id and use it in the next command
insert into wp_wc_order_operational_data (order_id) values (<order_id>)
```

4. Same as 3 but with the addresses table:

```
select order_id,address_type from wp_wc_order_addresses limit 1
# Take note of the order id and address type use them in the next command
insert into wp_wc_order_addresses (order_id,address_type) values (<order_id>,'<address_type>')
```

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
