### PR TITLE
Update store location profiler

### DIFF
--- a/packages/js/admin-e2e-tests/changelog/update-32585-store-location-profiler
+++ b/packages/js/admin-e2e-tests/changelog/update-32585-store-location-profiler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update onboarding wizard store details tests

--- a/packages/js/admin-e2e-tests/src/sections/onboarding/StoreDetailsSection.ts
+++ b/packages/js/admin-e2e-tests/src/sections/onboarding/StoreDetailsSection.ts
@@ -44,12 +44,6 @@ export class StoreDetailsSection extends BasePage {
 				config.get( 'addresses.admin.store.addressfirstline' )
 		);
 
-		// Fill store's address - second line
-		await this.fillAddressLineTwo(
-			storeDetails.addressLine2 ||
-				config.get( 'addresses.admin.store.addresssecondline' )
-		);
-
 		// Type the requested country/region substring or 'cali' in the
 		// country/region select, then select the requested country/region
 		// substring or 'US:CA'.
@@ -87,10 +81,6 @@ export class StoreDetailsSection extends BasePage {
 		await clearAndFillInput( '#inspector-text-control-0', address );
 	}
 
-	async fillAddressLineTwo( address: string ): Promise< void > {
-		await clearAndFillInput( '#inspector-text-control-1', address );
-	}
-
 	async selectCountry( search: string, selector: string ): Promise< void > {
 		await this.countryDropdown.search( search );
 		await this.countryDropdown.select( selector );
@@ -105,11 +95,11 @@ export class StoreDetailsSection extends BasePage {
 	}
 
 	async fillPostalCode( postalCode: string ): Promise< void > {
-		await clearAndFillInput( '#inspector-text-control-3', postalCode );
+		await clearAndFillInput( '#inspector-text-control-1', postalCode );
 	}
 
 	async fillEmailAddress( email: string ): Promise< void > {
-		await clearAndFillInput( '#inspector-text-control-4', email );
+		await clearAndFillInput( '#inspector-text-control-3', email );
 	}
 
 	async checkMarketingCheckbox( selected: boolean ): Promise< void > {

--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -26,42 +26,6 @@ const storeAddressFields = [
 type Option = { key: string; label: string };
 
 /**
- * Type guard to ensure that the specified locale object has a .required property
- *
- * @param  fieldName field of Locale
- * @param  locale    unknown object to be checked
- * @return          Boolean indicating if locale has a .required property
- */
-const isLocaleRecord = (
-	fieldName: keyof Locale,
-	locale: unknown
-): locale is Record< keyof Locale, { required: boolean } > => {
-	return !! locale && has( locale, `${ fieldName }.required` );
-};
-
-/**
- * Check if a given address field is required for the locale.
- *
- * @param {string} fieldName Name of the field to check.
- * @param {Object} locale    Locale data.
- * @return {boolean} Field requirement.
- */
-export function isAddressFieldRequired(
-	fieldName: keyof Locale,
-	locale: Locale = {}
-): boolean {
-	if ( isLocaleRecord( fieldName, locale ) ) {
-		return locale[ fieldName ].required;
-	}
-
-	if ( fieldName === 'address_2' ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
  * Form validation.
  *
  * @param {Object} locale The store locale.
@@ -80,29 +44,11 @@ export function getStoreAddressValidator( locale: Locale = {} ) {
 		const errors: {
 			[ key: string ]: string;
 		} = {};
-		if (
-			isAddressFieldRequired( 'address_1', locale ) &&
-			! values.addressLine1.trim().length
-		) {
-			errors.addressLine1 = __( 'Please add an address', 'woocommerce' );
-		}
 		if ( ! values.countryState.trim().length ) {
 			errors.countryState = __(
 				'Please select a country / region',
 				'woocommerce'
 			);
-		}
-		if (
-			isAddressFieldRequired( 'city', locale ) &&
-			! values.city.trim().length
-		) {
-			errors.city = __( 'Please add a city', 'woocommerce' );
-		}
-		if (
-			isAddressFieldRequired( 'postcode', locale ) &&
-			! values.postCode.trim().length
-		) {
-			errors.postCode = __( 'Please add a post code', 'woocommerce' );
 		}
 
 		return errors;
@@ -407,32 +353,8 @@ export function StoreAddress( {
 
 	return (
 		<div className="woocommerce-store-address-fields">
-			{ ! locale?.address_1?.hidden && (
-				<TextControl
-					label={
-						locale?.address_1?.label ||
-						__( 'Address line 1', 'woocommerce' )
-					}
-					required={ isAddressFieldRequired( 'address_1', locale ) }
-					autoComplete="address-line1"
-					{ ...getInputProps( 'addressLine1' ) }
-				/>
-			) }
-
-			{ ! locale?.address_2?.hidden && (
-				<TextControl
-					label={
-						locale?.address_2?.label ||
-						__( 'Address line 2 (optional)', 'woocommerce' )
-					}
-					required={ isAddressFieldRequired( 'address_2', locale ) }
-					autoComplete="address-line2"
-					{ ...getInputProps( 'addressLine2' ) }
-				/>
-			) }
-
 			<SelectControl
-				label={ __( 'Country / Region', 'woocommerce' ) }
+				label={ __( 'Country / Region *', 'woocommerce' ) }
 				required
 				autoComplete="new-password" // disable autocomplete and autofill
 				options={ countryStateOptions }
@@ -445,12 +367,14 @@ export function StoreAddress( {
 				{ countryStateAutofill }
 			</SelectControl>
 
-			{ ! locale?.city?.hidden && (
+			{ ! locale?.address_1?.hidden && (
 				<TextControl
-					label={ locale?.city?.label || __( 'City', 'woocommerce' ) }
-					required={ isAddressFieldRequired( 'city', locale ) }
-					{ ...getInputProps( 'city' ) }
-					autoComplete="address-level2"
+					label={
+						locale?.address_1?.label ||
+						__( 'Address', 'woocommerce' )
+					}
+					autoComplete="address-line1"
+					{ ...getInputProps( 'addressLine1' ) }
 				/>
 			) }
 
@@ -460,9 +384,16 @@ export function StoreAddress( {
 						locale?.postcode?.label ||
 						__( 'Post code', 'woocommerce' )
 					}
-					required={ isAddressFieldRequired( 'postcode', locale ) }
 					autoComplete="postal-code"
 					{ ...getInputProps( 'postCode' ) }
+				/>
+			) }
+
+			{ ! locale?.city?.hidden && (
+				<TextControl
+					label={ locale?.city?.label || __( 'City', 'woocommerce' ) }
+					{ ...getInputProps( 'city' ) }
+					autoComplete="address-level2"
 				/>
 			) }
 		</div>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -64,7 +64,6 @@ export class StoreDetails extends Component {
 		this.state = {
 			showUsageModal: false,
 			skipping: false,
-			isStoreDetailsPopoverVisible: false,
 			isSkipSetupPopoverVisible: false,
 		};
 
@@ -245,12 +244,8 @@ export class StoreDetails extends Component {
 	}
 
 	render() {
-		const {
-			showUsageModal,
-			skipping,
-			isStoreDetailsPopoverVisible,
-			isSkipSetupPopoverVisible,
-		} = this.state;
+		const { showUsageModal, skipping, isSkipSetupPopoverVisible } =
+			this.state;
 		const {
 			skipProfiler,
 			isLoading,
@@ -262,11 +257,6 @@ export class StoreDetails extends Component {
 		/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 		const skipSetupText = __(
 			'Manual setup is only recommended for\n experienced WooCommerce users or developers.',
-			'woocommerce'
-		);
-
-		const configureCurrencyText = __(
-			'Your store address will help us configure currency\n options and shipping rules automatically.\n This information will not be publicly visible and can\n easily be changed later.',
 			'woocommerce'
 		);
 		/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
@@ -292,38 +282,10 @@ export class StoreDetails extends Component {
 					</Text>
 					<Text variant="body" as="p">
 						{ __(
-							"Tell us about your store and we'll get you set up in no time",
+							'Tell us where you run your business to help us configure currency, shipping, taxes, and more in a fully automated way.',
 							'woocommerce'
 						) }
-
-						<Button
-							isTertiary
-							label={ __(
-								'Learn more about store details',
-								'woocommerce'
-							) }
-							onClick={ () =>
-								this.setState( {
-									isStoreDetailsPopoverVisible: true,
-								} )
-							}
-						>
-							<Icon icon={ info } />
-						</Button>
 					</Text>
-					{ isStoreDetailsPopoverVisible && (
-						<Popover
-							focusOnMount="container"
-							position="top center"
-							onClose={ () =>
-								this.setState( {
-									isStoreDetailsPopoverVisible: false,
-								} )
-							}
-						>
-							{ configureCurrencyText }
-						</Popover>
-					) }
 				</div>
 
 				<Form

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -335,7 +335,7 @@ export class StoreDetails extends Component {
 													'woocommerce'
 											  )
 											: __(
-													'Email address (Optional)',
+													'Email address',
 													'woocommerce'
 											  )
 									}
@@ -367,7 +367,6 @@ export class StoreDetails extends Component {
 									</div>
 								</FlexItem>
 							</CardBody>
-
 							<CardFooter justify="center">
 								<Button
 									isPrimary

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
@@ -47,25 +47,7 @@ Object {
             data-wp-c16t="true"
             data-wp-component="Text"
           >
-            Tell us about your store and we'll get you set up in no time
-            <button
-              aria-label="Learn more about store details"
-              class="components-button is-tertiary"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"
-                />
-              </svg>
-            </button>
+            Tell us where you run your business to help us configure currency, shipping, taxes, and more in a fully automated way.
           </p>
         </div>
         <div
@@ -81,26 +63,143 @@ Object {
               data-wp-c16t="true"
               data-wp-component="CardBody"
             >
-              <svg
-                class="components-spinner css-1igdw1q-StyledSpinner e1bj2jdf2"
-                focusable="false"
-                role="presentation"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="woocommerce-store-address-fields"
               >
-                <circle
-                  class="css-mx768t-SpinnerTrack-commonPathProps e1bj2jdf1"
-                  cx="50"
-                  cy="50"
-                  r="50"
-                  vector-effect="non-scaling-stroke"
-                />
-                <path
-                  class="css-7c7ebc-SpinnerIndicator-commonPathProps e1bj2jdf0"
-                  d="m 50 0 a 50 50 0 0 1 50 50"
-                  vector-effect="non-scaling-stroke"
-                />
-              </svg>
+                <div>
+                  <div
+                    class="woocommerce-select-control is-searchable"
+                  >
+                    <input
+                      autocomplete="country"
+                      class="woocommerce-select-control__autofill-input"
+                      name="country"
+                      tabindex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <input
+                      autocomplete="address-level1"
+                      class="woocommerce-select-control__autofill-input"
+                      name="state"
+                      tabindex="-1"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="components-base-control woocommerce-select-control__control empty"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="woocommerce-select-control__control-icon"
+                        focusable="false"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"
+                        />
+                      </svg>
+                      <div
+                        class="components-base-control__field"
+                      >
+                        <label
+                          class="components-base-control__label"
+                          for="woocommerce-select-control-0__control-input"
+                        >
+                          Country / Region *
+                        </label>
+                        <input
+                          aria-autocomplete="list"
+                          aria-expanded="false"
+                          aria-haspopup="true"
+                          autocomplete="new-password"
+                          class="woocommerce-select-control__control-input"
+                          id="woocommerce-select-control-0__control-input"
+                          placeholder=""
+                          role="combobox"
+                          type="search"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    class="components-base-control muriel-component muriel-input-text empty css-wdf2ti-Wrapper e1puf3u4"
+                  >
+                    <div
+                      class="components-base-control__field css-igk9ll-StyledField e1puf3u3"
+                    >
+                      <label
+                        class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
+                        for="inspector-text-control-0"
+                      >
+                        Address
+                      </label>
+                      <input
+                        autocomplete="address-line1"
+                        class="components-text-control__input"
+                        id="inspector-text-control-0"
+                        placeholder="Address"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    class="components-base-control muriel-component muriel-input-text empty css-wdf2ti-Wrapper e1puf3u4"
+                  >
+                    <div
+                      class="components-base-control__field css-igk9ll-StyledField e1puf3u3"
+                    >
+                      <label
+                        class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
+                        for="inspector-text-control-1"
+                      >
+                        Post code
+                      </label>
+                      <input
+                        autocomplete="postal-code"
+                        class="components-text-control__input"
+                        id="inspector-text-control-1"
+                        placeholder="Post code"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    class="components-base-control muriel-component muriel-input-text empty css-wdf2ti-Wrapper e1puf3u4"
+                  >
+                    <div
+                      class="components-base-control__field css-igk9ll-StyledField e1puf3u3"
+                    >
+                      <label
+                        class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
+                        for="inspector-text-control-2"
+                      >
+                        City
+                      </label>
+                      <input
+                        autocomplete="address-level2"
+                        class="components-text-control__input"
+                        id="inspector-text-control-2"
+                        placeholder="City"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
               <div>
                 <div
                   class="components-base-control muriel-component muriel-input-text with-value css-wdf2ti-Wrapper e1puf3u4"
@@ -110,7 +209,7 @@ Object {
                   >
                     <label
                       class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
-                      for="inspector-text-control-0"
+                      for="inspector-text-control-3"
                     >
                       Email address
                     </label>
@@ -118,7 +217,7 @@ Object {
                       autocomplete="email"
                       checked=""
                       class="components-text-control__input"
-                      id="inspector-text-control-0"
+                      id="inspector-text-control-3"
                       placeholder="Email address"
                       required=""
                       type="text"
@@ -261,25 +360,7 @@ Object {
           data-wp-c16t="true"
           data-wp-component="Text"
         >
-          Tell us about your store and we'll get you set up in no time
-          <button
-            aria-label="Learn more about store details"
-            class="components-button is-tertiary"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"
-              />
-            </svg>
-          </button>
+          Tell us where you run your business to help us configure currency, shipping, taxes, and more in a fully automated way.
         </p>
       </div>
       <div
@@ -295,26 +376,143 @@ Object {
             data-wp-c16t="true"
             data-wp-component="CardBody"
           >
-            <svg
-              class="components-spinner css-1igdw1q-StyledSpinner e1bj2jdf2"
-              focusable="false"
-              role="presentation"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="woocommerce-store-address-fields"
             >
-              <circle
-                class="css-mx768t-SpinnerTrack-commonPathProps e1bj2jdf1"
-                cx="50"
-                cy="50"
-                r="50"
-                vector-effect="non-scaling-stroke"
-              />
-              <path
-                class="css-7c7ebc-SpinnerIndicator-commonPathProps e1bj2jdf0"
-                d="m 50 0 a 50 50 0 0 1 50 50"
-                vector-effect="non-scaling-stroke"
-              />
-            </svg>
+              <div>
+                <div
+                  class="woocommerce-select-control is-searchable"
+                >
+                  <input
+                    autocomplete="country"
+                    class="woocommerce-select-control__autofill-input"
+                    name="country"
+                    tabindex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <input
+                    autocomplete="address-level1"
+                    class="woocommerce-select-control__autofill-input"
+                    name="state"
+                    tabindex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="components-base-control woocommerce-select-control__control empty"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="woocommerce-select-control__control-icon"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"
+                      />
+                    </svg>
+                    <div
+                      class="components-base-control__field"
+                    >
+                      <label
+                        class="components-base-control__label"
+                        for="woocommerce-select-control-0__control-input"
+                      >
+                        Country / Region *
+                      </label>
+                      <input
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        autocomplete="new-password"
+                        class="woocommerce-select-control__control-input"
+                        id="woocommerce-select-control-0__control-input"
+                        placeholder=""
+                        role="combobox"
+                        type="search"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  class="components-base-control muriel-component muriel-input-text empty css-wdf2ti-Wrapper e1puf3u4"
+                >
+                  <div
+                    class="components-base-control__field css-igk9ll-StyledField e1puf3u3"
+                  >
+                    <label
+                      class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
+                      for="inspector-text-control-0"
+                    >
+                      Address
+                    </label>
+                    <input
+                      autocomplete="address-line1"
+                      class="components-text-control__input"
+                      id="inspector-text-control-0"
+                      placeholder="Address"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  class="components-base-control muriel-component muriel-input-text empty css-wdf2ti-Wrapper e1puf3u4"
+                >
+                  <div
+                    class="components-base-control__field css-igk9ll-StyledField e1puf3u3"
+                  >
+                    <label
+                      class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
+                      for="inspector-text-control-1"
+                    >
+                      Post code
+                    </label>
+                    <input
+                      autocomplete="postal-code"
+                      class="components-text-control__input"
+                      id="inspector-text-control-1"
+                      placeholder="Post code"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  class="components-base-control muriel-component muriel-input-text empty css-wdf2ti-Wrapper e1puf3u4"
+                >
+                  <div
+                    class="components-base-control__field css-igk9ll-StyledField e1puf3u3"
+                  >
+                    <label
+                      class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
+                      for="inspector-text-control-2"
+                    >
+                      City
+                    </label>
+                    <input
+                      autocomplete="address-level2"
+                      class="components-text-control__input"
+                      id="inspector-text-control-2"
+                      placeholder="City"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
             <div>
               <div
                 class="components-base-control muriel-component muriel-input-text with-value css-wdf2ti-Wrapper e1puf3u4"
@@ -324,7 +522,7 @@ Object {
                 >
                   <label
                     class="components-base-control__label css-eweeby-StyledLabel-labelStyles e1puf3u2"
-                    for="inspector-text-control-0"
+                    for="inspector-text-control-3"
                   >
                     Email address
                   </label>
@@ -332,7 +530,7 @@ Object {
                     autocomplete="email"
                     checked=""
                     class="components-text-control__input"
-                    id="inspector-text-control-0"
+                    id="inspector-text-control-3"
                     placeholder="Email address"
                     required=""
                     type="text"

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
@@ -32,6 +32,27 @@ const testProps = {
 	isLoading: false,
 };
 
+jest.mock( '@wordpress/data', () => {
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true,
+		...originalModule,
+		useSelect: jest.fn().mockReturnValue( {
+			locale: 'en_US',
+			countries: [
+				{
+					code: 'US',
+					name: 'United States',
+					states: [],
+				},
+			],
+			loadingCountries: false,
+			hasFinishedResolution: true,
+		} ),
+	};
+} );
+
 describe( 'StoreDetails', () => {
 	describe( 'Snapshot test', () => {
 		test( 'should match saved snapshot', () => {
@@ -39,6 +60,30 @@ describe( 'StoreDetails', () => {
 			expect( container ).toMatchSnapshot();
 		} );
 	} );
+
+	it( 'should disable the "Continue" button when the mandatory field (Country / Region) is empty', () => {
+		const { getByRole } = render( <StoreDetails { ...testProps } /> );
+		expect( getByRole( 'button', { name: 'Continue' } ) ).toBeDisabled();
+	} );
+
+	it( 'should enable the "Continue" button when the mandatory field (Country / Region) is filled', () => {
+		const { getByRole } = render(
+			<StoreDetails
+				{ ...{
+					...testProps,
+					initialValues: {
+						...testProps.initialValues,
+						countryState: 'US',
+					},
+				} }
+			/>
+		);
+
+		expect(
+			getByRole( 'button', { name: 'Continue' } )
+		).not.toBeDisabled();
+	} );
+
 	describe( 'Email validation test cases', () => {
 		test( 'should fail email validation and disable continue button when isAgreeMarketing is true and email is empty', async () => {
 			const container = render(

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/test/shipping-recommendation.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-shipping-recommendation/test/shipping-recommendation.tsx
@@ -131,6 +131,6 @@ describe( 'ShippingRecommendation', () => {
 		);
 
 		getByText( 'Set store location' ).click();
-		expect( getByText( 'Address line 1' ) ).toBeInTheDocument();
+		expect( getByText( 'Address' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/woocommerce/changelog/update-32585-store-location-profiler
+++ b/plugins/woocommerce/changelog/update-32585-store-location-profiler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update store location profiler

--- a/plugins/woocommerce/e2e/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/e2e/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -13,10 +13,6 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 		await page.goto(
 			'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
 		);
-		// Fill store's address - first line
-		await page.fill( '#inspector-text-control-0', 'addr 1' );
-		// Fill store's address - second line
-		await page.fill( '#inspector-text-control-1', 'addr 2' );
 		// Type the requested country/region
 		await page.click( '#woocommerce-select-control-0__control-input' );
 		await page.fill(
@@ -24,12 +20,14 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 			'United States (US) — California'
 		);
 		await page.click( 'button >> text=United States (US) — California' );
+		// Fill store's address - first line
+		await page.fill( '#inspector-text-control-0', 'addr 1' );
+		// Fill postcode of the store
+		await page.fill( '#inspector-text-control-1', '94107' );
 		// Fill the city where the store is located
 		await page.fill( '#inspector-text-control-2', 'San Francisco' );
-		// Fill postcode of the store
-		await page.fill( '#inspector-text-control-3', '94107' );
 		// Fill store's email address
-		await page.fill( '#inspector-text-control-4', adminEmail );
+		await page.fill( '#inspector-text-control-3', adminEmail );
 		// Verify that checkbox next to "Get tips, product updates and inspiration straight to your mailbox" is selected
 		await page.check( '#inspector-checkbox-control-0' );
 		// Click continue button

--- a/plugins/woocommerce/e2e/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/e2e/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -167,17 +167,16 @@ test.describe(
 			await page.goto(
 				'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
 			);
-			await page.fill( '#inspector-text-control-0', 'addr 1' );
-			await page.fill( '#inspector-text-control-1', 'addr 2' );
 			await page.click( '#woocommerce-select-control-0__control-input' );
 			await page.fill(
 				'#woocommerce-select-control-0__control-input',
 				'Malta'
 			);
 			await page.click( 'button >> text=Malta' );
+			await page.fill( '#inspector-text-control-0', 'addr 1' );
+			await page.fill( '#inspector-text-control-1', 'VLT 1011' );
 			await page.fill( '#inspector-text-control-2', 'Valletta' );
-			await page.fill( '#inspector-text-control-3', 'VLT 1011' );
-			await page.fill( '#inspector-text-control-4', adminEmail );
+			await page.fill( '#inspector-text-control-3', adminEmail );
 			await page.check( '#inspector-checkbox-control-0' );
 			await page.click( 'button >> text=Continue' );
 			await page.click( 'button >> text=No thanks' );
@@ -276,17 +275,16 @@ test.describe( 'Store owner can go through setup Task List', () => {
 		await page.goto(
 			'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
 		);
-		await page.fill( '#inspector-text-control-0', 'addr 1' );
-		await page.fill( '#inspector-text-control-1', 'addr 2' );
 		await page.click( '#woocommerce-select-control-0__control-input' );
 		await page.fill(
 			'#woocommerce-select-control-0__control-input',
 			'United States (US) — California'
 		);
 		await page.click( 'button >> text=United States (US) — California' );
+		await page.fill( '#inspector-text-control-0', 'addr 1' );
+		await page.fill( '#inspector-text-control-1', '94107' );
 		await page.fill( '#inspector-text-control-2', 'San Francisco' );
-		await page.fill( '#inspector-text-control-3', '94107' );
-		await page.fill( '#inspector-text-control-4', adminEmail );
+		await page.fill( '#inspector-text-control-3', adminEmail );
 		await page.check( '#inspector-checkbox-control-0' );
 		await page.click( 'button >> text=Continue' );
 		await page.click( 'button >> text=No thanks' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32585.

This PR updates the onboarding profiler store details step.

AC:

```
Feature: Onboarding Profiler

  Scenario: User starts step 1 of onboarding wizard
    When the user starts the onboarding wizard
    Then subheading should be "Tell us where you run your business to help us configure currency, shipping, taxes, and more in a fully automated way." without a tooltip.
    And the fields should appear in the order of Country / Region, Address, Post / Zip Code, City, Email Address.
    And the Country/Region is a mandatory field marked with an asterisk
    And the "Continue" button should appear below the fields.
    But is disabled unless the mandatory field (Country / Region) is completed.

  Scenario: Mandatory fields are completed
    When the user completes the mandatory field (Country / Region)
    Then the "Continue" button is enabled.
```

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to OBW
3. Observe that the subheading should be `"Tell us where you run your business to help us configure currency, shipping, taxes, and more in a fully automated way."` **without a tooltip.**
4. And the fields should appear in the order of `Country / Region, Address, Post / Zip Code, City, Email Address`.
5. And the Country/Region is a mandatory field marked with an asterisk
6. And the "Continue" button should appear below the fields. But is disabled unless the mandatory field (Country / Region) is completed.
7. Completes the mandatory field (Country / Region)
8. Observe that the "Continue" button is enabled. 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
