### PR TITLE
Add the woocommerce_cart_session_initialize-hook

### DIFF
--- a/plugins/woocommerce/changelog/add-woocommerce_cart_session_initialize-hook
+++ b/plugins/woocommerce/changelog/add-woocommerce_cart_session_initialize-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the woocommerce_cart_session_initialize-hook

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -45,6 +45,19 @@ final class WC_Cart_Session {
 	 * Register methods for this object on the appropriate WordPress hooks.
 	 */
 	public function init() {
+		/**
+		 * Filters whether hooks should be initialized for the current cart session.
+		 *
+		 * @param bool $must_initialize Will be passed as true, meaning that the cart hooks should be initialized.
+		 * @param bool $session The WC_Cart_Session object that is being initialized.
+		 * @returns bool True if the cart hooks should be actually initialized, false if not.
+		 *
+		 * @since 6.9.0
+		 */
+		if ( ! apply_filters( 'woocommerce_cart_session_initialize', true, $this ) ) {
+			return;
+		}
+
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ), 1000 );


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a new `woocommerce_cart_session_initialize` hook that allows to skip the hooking performed during the initialization of the `WC_Cart_Session` object, thus enhancing performance. The object itself is passed as an argument to the hook, so client code can selectively rehook as appropriate.

Closes #26630.

### How to test the changes in this Pull Request:

1. Open an incognito window, and without logging in into WordPress go to the shop and add a product to the cart.
2. Go to the cart and verify that the product is there. Empty the cart.
3. Add the following snippet: `add_filter('woocommerce_cart_session_initialize', '__return_false');`
4. Repeat 1 and 2, but now notice how the cart is empty.
5. Replace the snippet with this one:

```php
add_filter('woocommerce_cart_session_initialize', function( $must_initialize, $session ) {
	add_action( 'wp_loaded', array( $session, 'get_cart_from_session' ) );
	add_action( 'woocommerce_cart_emptied', array( $session, 'destroy_cart_session' ) );
	add_action( 'woocommerce_after_calculate_totals', array( $session, 'set_session' ), 1000 );
	add_action( 'woocommerce_cart_loaded_from_session', array( $session, 'set_session' ) );
	add_action( 'woocommerce_removed_coupon', array( $session, 'set_session' ) );
	add_action( 'woocommerce_add_to_cart', array( $session, 'persistent_cart_update' ) );
	add_action( 'woocommerce_cart_item_removed', array( $session, 'persistent_cart_update' ) );
	add_action( 'woocommerce_cart_item_restored', array( $session, 'persistent_cart_update' ) );
	add_action( 'woocommerce_cart_item_set_quantity', array( $session, 'persistent_cart_update' ) );
	add_action( 'woocommerce_add_to_cart', array( $session, 'maybe_set_cart_cookies' ) );
	add_action( 'wp', array( $session, 'maybe_set_cart_cookies' ), 99 );
	add_action( 'shutdown', array( $session, 'maybe_set_cart_cookies' ), 0 );

	return false;
}, 10, 2);
```

6. Repeat 1 and 2, verify that the cart works again as expected and the product is there.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
