### PR TITLE
Update changelogger pre-push hook to remove verbosity

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -23,4 +23,4 @@ if [ $PROTECTED_BRANCH = $CURRENT_BRANCH ]; then
 	exit 1
 fi
 
-php tools/monorepo/check-changelogger-use.php --debug $PROTECTED_BRANCH $CURRENT_BRANCH
+php tools/monorepo/check-changelogger-use.php $PROTECTED_BRANCH $CURRENT_BRANCH


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the verbosity flag from the changelogger check within the pre-push hook.

Closes # .

### How to test the changes in this Pull Request:

1. Before applying this PR, run `bin/pre-push.sh` from another branch (ahead of `trunk`) and notice that the output is verbose, and even if no changelog is required, you receive a lot of output.
2. Checkout this branch, and re-run `bin/pre-push.sh`. Notice that (assuming there are no issues) that the script simply exits with code 0.
3. Change a file that would require a changelog and make a commit locally. Re-run `bin/pre-push.sh` and verify that you receive an error as expected.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
