### PR TITLE
fix: e2e test on shipping task

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-task-e2e-test
+++ b/plugins/woocommerce/changelog/fix-shipping-task-e2e-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping task e2e test as the flow has been changed in #33533

--- a/plugins/woocommerce/e2e/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/e2e/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -297,18 +297,29 @@ test.describe( 'Store owner can go through setup Task List', () => {
 
 	test( 'can setup shipping', async ( { page } ) => {
 		await page.goto( '/wp-admin/admin.php?page=wc-admin' );
-		await page.click( ':nth-match(.woocommerce-task-list__item-title, 5)' );
+		await page.click( 'div >> text=Review Shipping Options' );
 
-		// check if this is the first time (or if the test is being retried)
-		const currPage = page.url();
-		if ( currPage.indexOf( 'page=wc-settings&tab=shipping' ) > 0 ) {
-			// click the Add shipping zone button on the shipping settings page
-			await page.locator( '.page-title-action' ).click();
-			await expect(
-				page.locator( 'div.woocommerce > form > h2' )
-			).toContainText( 'Shipping zones' );
-		} else {
-			await page.locator( 'button.components-button.is-primary' ).click();
+		// dismiss tourkit if visible
+		const tourkitVisible = await page
+			.locator( 'button.woocommerce-tour-kit-step-controls__close-btn' )
+			.isVisible();
+		if ( tourkitVisible ) {
+			await page.click(
+				'button.woocommerce-tour-kit-step-controls__close-btn'
+			);
 		}
+
+		// check for automatically added shipping zone
+		await expect(
+			page.locator( 'tr[data-id="1"] >> td.wc-shipping-zone-name > a' )
+		).toContainText( 'United States (US)' );
+		await expect(
+			page.locator( 'tr[data-id="1"] >> td.wc-shipping-zone-region' )
+		).toContainText( 'United States (US)' );
+		await expect(
+			page.locator(
+				'tr[data-id="1"] >> td.wc-shipping-zone-methods > div > ul > li'
+			)
+		).toContainText( 'Free shipping' );
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Shipping task was recently changed and shipping method is set up automatically now

### How to test the changes in this Pull Request:

1. Check that e2e test is sound and that it passes

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
