### PR TITLE
Link backfilling to migration process

### DIFF
--- a/plugins/woocommerce/changelog/fix-34151
+++ b/plugins/woocommerce/changelog/fix-34151
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Link backfilling to the migration process.

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -224,9 +224,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
 
 		foreach ( $props_to_update as $meta_key => $prop ) {
-			if ( ! method_exists( $order, 'get_' . $prop ) ) {
-				continue;
-			}
 			$value = $order->{"get_$prop"}( 'edit' );
 			$value = is_string( $value ) ? wp_slash( $value ) : $value;
 			switch ( $prop ) {

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -224,6 +224,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$props_to_update = $this->get_props_to_update( $order, $meta_key_to_props );
 
 		foreach ( $props_to_update as $meta_key => $prop ) {
+			if ( ! method_exists( $order, 'get_' . $prop ) ) {
+				continue;
+			}
 			$value = $order->{"get_$prop"}( 'edit' );
 			$value = is_string( $value ) ? wp_slash( $value ) : $value;
 			switch ( $prop ) {
@@ -338,7 +341,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 				'post_status'   => $this->get_post_status( $order ),
 				'post_parent'   => $order->get_parent_id(),
-				'post_excerpt'  => $this->get_post_excerpt( $order ),
+				'post_excerpt'  => method_exists( $order, 'get_customer_note' ) ? $order->get_customer_note() : '',
 				'post_type'     => 'shop_order',
 			)
 		);

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -8,6 +8,8 @@
  * @version 3.4.0
  */
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -231,6 +233,13 @@ function wc_get_order_types( $for = '' ) {
 		case 'order-webhooks':
 			foreach ( $wc_order_types as $type => $args ) {
 				if ( ! $args['exclude_from_order_webhooks'] ) {
+					$order_types[] = $type;
+				}
+			}
+			break;
+		case 'cot-migration':
+			foreach ( $wc_order_types as $type => $args ) {
+				if ( DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE !== $type ) {
 					$order_types[] = $type;
 				}
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -479,10 +479,13 @@ class CustomOrdersTableController {
 			return $value;
 		}
 
+		/**
+		 * Commenting out for better testability.
 		$sync_is_pending = 0 !== $this->data_synchronizer->get_current_orders_pending_sync_count();
 		if ( $sync_is_pending ) {
 			throw new \Exception( "The authoritative table for orders storage can't be changed while there are orders out of sync" );
 		}
+		 */
 
 		return $value;
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -209,8 +209,8 @@ class CustomOrdersTableController {
 	/**
 	 * Gets the instance of the orders data store to use.
 	 *
-	 * @param WC_Object_Data_Store_Interface|string $default_data_store The default data store (as received via the woocommerce_order_data_store hooks).
-	 * @return WC_Object_Data_Store_Interface|string The actual data store to use.
+	 * @param \WC_Object_Data_Store_Interface|string $default_data_store The default data store (as received via the woocommerce_order_data_store hooks).
+	 * @return \WC_Object_Data_Store_Interface|string The actual data store to use.
 	 */
 	private function get_data_store_instance( $default_data_store ) {
 		if ( $this->is_feature_visible() && $this->custom_orders_table_usage_is_enabled() ) {
@@ -479,14 +479,10 @@ class CustomOrdersTableController {
 			return $value;
 		}
 
-		// TODO: Re-enable the following code once the COT to posts table sync is implemented (it's currently disabled to ease testing).
-
-		/*
 		$sync_is_pending = 0 !== $this->data_synchronizer->get_current_orders_pending_sync_count();
 		if ( $sync_is_pending ) {
 			throw new \Exception( "The authoritative table for orders storage can't be changed while there are orders out of sync" );
 		}
-		*/
 
 		return $value;
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -152,7 +152,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	public function get_current_orders_pending_sync_count(): int {
 		global $wpdb;
 
-		$orders_table                = $wpdb->prefix . 'wc_orders';
+		$orders_table                = $this->data_store::get_orders_table_name();
 		$order_post_types            = wc_get_order_types( 'cot-migration' );
 		$order_post_type_placeholder = implode( ', ', array_fill( 0, count( $order_post_types ), '%s' ) );
 
@@ -230,7 +230,7 @@ SELECT(
 			throw new \Exception( '$limit must be at least 1' );
 		}
 
-		$orders_table                 = $wpdb->prefix . 'wc_orders';
+		$orders_table                 = $this->data_store::get_orders_table_name();
 		$order_post_types             = wc_get_order_types( 'cot-migration' );
 		$order_post_type_placeholders = implode( ', ', array_fill( 0, count( $order_post_types ), '%s' ) );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -169,7 +169,7 @@ WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'";
 SELECT COUNT(1) FROM $wpdb->posts posts
 LEFT JOIN $orders_table orders ON posts.id=orders.id
 WHERE
-  posts.post_type in ($order_post_type_placeholder) AND
+  posts.post_type in ($order_post_type_placeholder)
   AND posts.post_status != 'auto-draft'
   AND orders.id IS NULL",
 				$order_post_types
@@ -178,7 +178,9 @@ WHERE
 			$operator = '<';
 		}
 
-		$sql = "
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $missing_orders_count_sql is prepared.
+		$sql = $wpdb->prepare(
+			"
 SELECT(
 	($missing_orders_count_sql)
 	+
@@ -189,7 +191,10 @@ SELECT(
 		  posts.post_type IN ($order_post_type_placeholder)
 		  AND orders.date_updated_gmt $operator posts.post_modified_gmt
 	) x)
-) count";
+) count",
+			$order_post_types
+		);
+		// phpcs:enable
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return (int) $wpdb->get_var( $sql );
@@ -201,7 +206,7 @@ SELECT(
 	 * @return bool Whether the custom orders table the authoritative data source for orders currently.
 	 */
 	public function custom_orders_table_is_authoritative(): bool {
-		return 'yes' === get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+		return wc_string_to_bool( get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -330,6 +330,12 @@ WHERE
 	 * @return int Default batch size.
 	 */
 	public function get_default_batch_size(): int {
+		$batch_size = self::ORDERS_SYNC_BATCH_SIZE;
+
+		if ( $this->custom_orders_table_is_authoritative() ) {
+			// Backfilling is slower then migration.
+			$batch_size = absint( self::ORDERS_SYNC_BATCH_SIZE / 10 ) + 1;
+		}
 		/**
 		 * Filter to customize the count of orders that will be synchronized in each step of the custom orders table to/from posts table synchronization process.
 		 *
@@ -337,7 +343,7 @@ WHERE
 		 *
 		 * @param int Default value for the count.
 		 */
-		return apply_filters( 'woocommerce_orders_cot_and_posts_sync_step_size', self::ORDERS_SYNC_BATCH_SIZE );
+		return apply_filters( 'woocommerce_orders_cot_and_posts_sync_step_size', $batch_size );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -139,12 +139,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 
 	/**
 	 * Calculate how many orders need to be synchronized currently.
-	 *
-	 * If an option whose name is given by self::FAKE_ORDERS_PENDING_SYNC_COUNT_OPTION exists,
-	 * then the value of that option is returned. This is temporary, to ease testing the feature
-	 * while it is in development.
-	 *
-	 * Otherwise a database query is performed to get how many orders match one of the following:
+	 * A database query is performed to get how many orders match one of the following:
 	 *
 	 * - Existing in the authoritative table but not in the backup table.
 	 * - Existing in both tables, but they have a different update date.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -333,7 +333,7 @@ WHERE
 		$batch_size = self::ORDERS_SYNC_BATCH_SIZE;
 
 		if ( $this->custom_orders_table_is_authoritative() ) {
-			// Backfilling is slower then migration.
+			// Back-filling is slower than migration.
 			$batch_size = absint( self::ORDERS_SYNC_BATCH_SIZE / 10 ) + 1;
 		}
 		/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1185,7 +1185,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
 
 		if ( ! $order->get_date_created( 'edit' ) ) {
-			$order->set_date_created( gmdate( 'Y-m-d H:i:s e' ) );
+			$order->set_date_created( time() );
 		}
 
 		$this->update_post_meta( $order );
@@ -1224,7 +1224,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		}
 
 		if ( null === $order->get_date_created( 'edit' ) ) {
-			$order->set_date_created( gmdate( 'Y-m-d H:i:s e' ) );
+			$order->set_date_created( time() );
 		}
 
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
@@ -1233,7 +1233,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		$changes = $order->get_changes();
 
 		if ( ! isset( $changes['date_modified'] ) ) {
-			$order->set_date_modified( gmdate( 'Y-m-d H:i:s e' ) );
+			$order->set_date_modified( time() );
 		}
 
 		$this->update_post_meta( $order );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1185,7 +1185,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
 
 		if ( ! $order->get_date_created( 'edit' ) ) {
-			$order->set_date_created( time() );
+			$order->set_date_created( gmdate( 'Y-m-d H:i:s e' ) );
 		}
 
 		$this->update_post_meta( $order );
@@ -1224,7 +1224,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		}
 
 		if ( null === $order->get_date_created( 'edit' ) ) {
-			$order->set_date_created( time() );
+			$order->set_date_created( gmdate( 'Y-m-d H:i:s e' ) );
 		}
 
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
@@ -1233,7 +1233,7 @@ LEFT JOIN {$operational_data_clauses['join']}
 		$changes = $order->get_changes();
 
 		if ( ! isset( $changes['date_modified'] ) ) {
-			$order->set_date_modified( gmdate( 'Y-m-d H:i:s' ) );
+			$order->set_date_modified( gmdate( 'Y-m-d H:i:s e' ) );
 		}
 
 		$this->update_post_meta( $order );

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Overrides\Order;
 use Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
@@ -42,8 +43,16 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 
 		$this->share( OrdersTableDataStore::class )->addArguments( array( OrdersTableDataStoreMeta::class, DatabaseUtil::class ) );
 		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, PostsToOrdersMigrationController::class ) );
-		$this->share( CustomOrdersTableController::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class, BatchProcessingController::class ) );
 		$this->share( OrdersTableDataStore::class );
+
+		$custom_orders_table_controller = new CustomOrdersTableController();
+		$custom_orders_table_controller->init(
+			wc_get_container()->get( OrdersTableDataStore::class ),
+			wc_get_container()->get( DataSynchronizer::class ),
+			wc_get_container()->get( BatchProcessingController::class )
+		);
+		$this->share( CustomOrdersTableController::class, $custom_orders_table_controller );
+
 		if ( Constants::is_defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->share( CLIRunner::class )->addArguments( array( CustomOrdersTableController::class, DataSynchronizer::class, PostsToOrdersMigrationController::class ) );
 		}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -6,7 +6,6 @@
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Admin\Overrides\Order;
 use Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable\CLIRunner;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
@@ -44,14 +43,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 		$this->share( OrdersTableDataStore::class )->addArguments( array( OrdersTableDataStoreMeta::class, DatabaseUtil::class ) );
 		$this->share( DataSynchronizer::class )->addArguments( array( OrdersTableDataStore::class, DatabaseUtil::class, PostsToOrdersMigrationController::class ) );
 		$this->share( OrdersTableDataStore::class );
-
-		$custom_orders_table_controller = new CustomOrdersTableController();
-		$custom_orders_table_controller->init(
-			wc_get_container()->get( OrdersTableDataStore::class ),
-			wc_get_container()->get( DataSynchronizer::class ),
-			wc_get_container()->get( BatchProcessingController::class )
-		);
-		$this->share( CustomOrdersTableController::class, $custom_orders_table_controller );
+		$this->share( CustomOrdersTableController::class )->addArguments( array( OrdersTableDataStore::class, DataSynchronizer::class, BatchProcessingController::class ) );
 
 		if ( Constants::is_defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->share( CLIRunner::class )->addArguments( array( CustomOrdersTableController::class, DataSynchronizer::class, PostsToOrdersMigrationController::class ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use WC_Mock_Payment_Gateway;
 use WC_Order;
 use WC_Product;
@@ -238,6 +239,84 @@ class OrderHelper {
 		$order->save_meta_data();
 
 		return $order->get_id();
+	}
+
+	/**
+	 * Helper method to allow switching data stores.
+	 *
+	 * @param WC_Order       $order Order object.
+	 * @param \WC_Data_Store $data_store Data store object to switch order to.
+	 */
+	public static function switch_data_store( $order, $data_store ) {
+		$update_data_store_func = function ( $data_store ) {
+			$this->data_store = $data_store;
+		};
+		$update_data_store_func->call( $order, $data_store );
+	}
+
+	/**
+	 * Creates a complex order with address info, line items, etc.
+	 *
+	 * @param \WC_Data_Store $data_store Data store object to use in creating order.
+	 *
+	 * @return \WC_Order Order object.
+	 */
+	public static function create_complex_data_store_order( $data_store = null ) {
+		$order = new WC_Order();
+		if ( ! $data_store ) {
+			$data_store = wc_get_container()->get( OrdersTableDataStore::class );
+		}
+		self::switch_data_store( $order, $data_store );
+
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+
+		$order->set_status( 'pending' );
+		$order->set_created_via( 'unit-tests' );
+		$order->set_currency( 'COP' );
+		$order->set_customer_ip_address( '127.0.0.1' );
+
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 2,
+				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 2 ) ),
+				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 2 ) ),
+			)
+		);
+
+		$order->add_item( $item );
+
+		$order->set_billing_first_name( 'Jeroen' );
+		$order->set_billing_last_name( 'Sormani' );
+		$order->set_billing_company( 'WooCompany' );
+		$order->set_billing_address_1( 'WooAddress' );
+		$order->set_billing_address_2( '' );
+		$order->set_billing_city( 'WooCity' );
+		$order->set_billing_state( 'NY' );
+		$order->set_billing_postcode( '123456' );
+		$order->set_billing_country( 'US' );
+		$order->set_billing_email( 'admin@example.org' );
+		$order->set_billing_phone( '555-32123' );
+
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		$order->set_payment_method( $payment_gateways['bacs'] );
+
+		$order->set_shipping_total( 5.0 );
+		$order->set_discount_total( 0.0 );
+		$order->set_discount_tax( 0.0 );
+		$order->set_cart_tax( 0.0 );
+		$order->set_shipping_tax( 0.0 );
+		$order->set_total( 25.0 );
+		$order->save();
+
+		$order->get_data_store()->set_stock_reduced( $order, true, false );
+
+		$order->update_meta_data( 'my_meta', rand( 0, 255 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+
+		$order->save();
+
+		return $order;
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -1,0 +1,107 @@
+<?php
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+
+/**
+ * Tests for DataSynchronizer class.
+ */
+class DataSynchronizerTests extends WC_Unit_Test_Case {
+
+	/**
+	 * @var DataSynchronizer
+	 */
+	private $sut;
+
+	/**
+	 * @var CustomOrdersTableController
+	 */
+	private $cot_controller;
+
+	/**
+	 * Initializes system under test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		OrderHelper::delete_order_custom_tables(); // We need this since non-temporary tables won't drop automatically.
+		OrderHelper::create_order_custom_table_if_not_exist();
+		$this->sut            = wc_get_container()->get( DataSynchronizer::class );
+		$this->cot_controller = wc_get_container()->get( CustomOrdersTableController::class );
+		$this->cot_controller->show_feature();
+	}
+
+	/**
+	 * Simulates a situation where there are orders to be synced in both directions. Ideally, we won't find ourselves in this situation ever, but this is helpful for testing.
+	 *
+	 * @param string $authoritative_source Authoritative source, could be cot or posts.
+	 *
+	 * @return array[]|void
+	 * @throws Exception When orders are not created as expected.
+	 */
+	private function init_dirty_orders( $authoritative_source ) {
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, false );
+		$post_data_store = WC_Data_Store::load( 'order' );
+
+		$cot_enabled = 'cot' === $authoritative_source ? 'yes' : 'no';
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, $cot_enabled );
+		update_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, 'no' );
+
+		$post_order1 = OrderHelper::create_complex_data_store_order( $post_data_store );
+		$post_order2 = OrderHelper::create_complex_data_store_order( $post_data_store );
+
+		assert( get_post_type( $post_order1->get_id() ) === 'shop_order' );
+		assert( get_post_type( $post_order2->get_id() ) === 'shop_order' );
+
+		$cot_order1 = OrderHelper::create_complex_data_store_order();
+		$cot_order2 = OrderHelper::create_complex_data_store_order();
+		$cot_order3 = OrderHelper::create_complex_data_store_order();
+
+		assert( get_post_type( $cot_order1->get_id() ) === DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE );
+		assert( get_post_type( $cot_order2->get_id() ) === DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE );
+		assert( get_post_type( $cot_order3->get_id() ) === DataSynchronizer::PLACEHOLDER_ORDER_POST_TYPE );
+
+		return array(
+			'cot_orders'  => array( $cot_order1->get_id(), $cot_order2->get_id(), $cot_order3->get_id() ),
+			'post_orders' => array( $post_order1->get_id(), $post_order2->get_id() ),
+		);
+	}
+
+	/**
+	 * Destroys system under test.
+	 */
+	public function tearDown(): void {
+		// Add back removed filter.
+		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that orders are synced properly where there are orders to migrate from posts table.
+	 */
+	public function test_get_ids_orders_pending_sync_migration() {
+		$order_collection = $this->init_dirty_orders( 'posts' );
+		$this->assertEquals( 2, $this->sut->get_current_orders_pending_sync_count() );
+		$this->assertArraySubset( $order_collection['post_orders'], $this->sut->get_next_batch_to_process( 10 ) );
+
+		$this->sut->process_batch( $order_collection['post_orders'] );
+		$this->assertEquals( 0, $this->sut->get_current_orders_pending_sync_count() );
+	}
+
+	/**
+	 * Test that orders are synced properly when there are orders to backfill into posts table.
+	 */
+	public function test_get_ids_orders_pending_sync_backfill() {
+		$order_collection = $this->init_dirty_orders( 'cot' );
+		$this->assertEquals( 3, $this->sut->get_current_orders_pending_sync_count() );
+		$this->assertArraySubset( $order_collection['cot_orders'], $this->sut->get_next_batch_to_process( 10 ) );
+
+		$this->sut->process_batch( $order_collection['cot_orders'] );
+		$this->assertEquals( 0, $this->sut->get_current_orders_pending_sync_count() );
+	}
+
+}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -46,7 +46,7 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, false );
 		$post_data_store = WC_Data_Store::load( 'order' );
 
-		$cot_enabled = 'cot' === $authoritative_source ? 'yes' : 'no';
+		$cot_enabled = $authoritative_source === 'cot' ? 'yes' : 'no';
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, $cot_enabled );
 		update_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, 'no' );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -86,11 +86,17 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$post_order_id = OrderHelper::create_complex_wp_post_order();
 		$this->migrator->migrate_orders( array( $post_order_id ) );
 
-		$post_data      = get_post( $post_order_id, ARRAY_A );
-		$post_meta_data = get_post_meta( $post_order_id );
-		// TODO: Remove `_recorded_sales` from exempted keys after https://github.com/woocommerce/woocommerce/issues/32843.
-		$exempted_keys         = array( 'post_modified', 'post_modified_gmt', '_recorded_sales' );
-		$convert_to_float_keys = array( '_cart_discount_tax', '_order_shipping', '_order_shipping_tax', '_order_tax', '_cart_discount', 'cart_tax' );
+		$post_data             = get_post( $post_order_id, ARRAY_A );
+		$post_meta_data        = get_post_meta( $post_order_id );
+		$exempted_keys         = array( 'post_modified', 'post_modified_gmt' );
+		$convert_to_float_keys = array(
+			'_cart_discount_tax',
+			'_order_shipping',
+			'_order_shipping_tax',
+			'_order_tax',
+			'_cart_discount',
+			'cart_tax',
+		);
 		$exempted_keys         = array_flip( array_merge( $exempted_keys, $convert_to_float_keys ) );
 
 		$post_data_float      = array_intersect_key( $post_data, array_flip( $convert_to_float_keys ) );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -855,10 +855,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * @param WC_Data_Store $data_store Data store object to switch order to.
 	 */
 	private function switch_data_store( $order, $data_store ) {
-		$update_data_store_func = function ( $data_store ) {
-			$this->data_store = $data_store;
-		};
-		$update_data_store_func->call( $order, $data_store );
+		OrderHelper::switch_data_store( $order, $data_store );
 	}
 
 	/**
@@ -866,58 +863,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * @return \WC_Order
 	 */
 	private function create_complex_cot_order() {
-		$order = new WC_Order();
-		$this->switch_data_store( $order, $this->sut );
-
-		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
-
-		$order->set_status( 'pending' );
-		$order->set_created_via( 'unit-tests' );
-		$order->set_currency( 'COP' );
-		$order->set_customer_ip_address( '127.0.0.1' );
-
-		$item = new WC_Order_Item_Product();
-		$item->set_props(
-			array(
-				'product'  => $product,
-				'quantity' => 2,
-				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 2 ) ),
-				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 2 ) ),
-			)
-		);
-
-		$order->add_item( $item );
-
-		$order->set_billing_first_name( 'Jeroen' );
-		$order->set_billing_last_name( 'Sormani' );
-		$order->set_billing_company( 'WooCompany' );
-		$order->set_billing_address_1( 'WooAddress' );
-		$order->set_billing_address_2( '' );
-		$order->set_billing_city( 'WooCity' );
-		$order->set_billing_state( 'NY' );
-		$order->set_billing_postcode( '123456' );
-		$order->set_billing_country( 'US' );
-		$order->set_billing_email( 'admin@example.org' );
-		$order->set_billing_phone( '555-32123' );
-
-		$payment_gateways = WC()->payment_gateways->payment_gateways();
-		$order->set_payment_method( $payment_gateways['bacs'] );
-
-		$order->set_shipping_total( 5.0 );
-		$order->set_discount_total( 0.0 );
-		$order->set_discount_tax( 0.0 );
-		$order->set_cart_tax( 0.0 );
-		$order->set_shipping_tax( 0.0 );
-		$order->set_total( 25.0 );
-		$order->save();
-
-		$order->get_data_store()->set_stock_reduced( $order, true, false );
-
-		$order->update_meta_data( 'my_meta', rand( 0, 255 ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-
-		$order->save();
-
-		return $order;
+		return OrderHelper::create_complex_data_store_order( $this->sut );
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Links backfilling to the sync process so that backfilling is executed when needed. Earlier, we had already linked migration but backfilling wasn't happening. So if there are new orders after COT became authoritative and sync was off, then there was no way to get the orders backfilled into posts.

Closes #34151 

### How to test the changes in this Pull Request:

1. Make COT authoritative, and disable sync.
2. Add a new order. If you go to the migration setting page again, it should display one order pending migration.
3. Run the migration by clicking on `Save setting button` (will take a minute for scheduled action to run).
4. Switch back to the post store. Check that the order you added when COT was active is present and has all the details.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
