### PR TITLE
Fixed categories thumb column overlap with categories name

### DIFF
--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3181,7 +3181,7 @@ ul.order_notes {
 table.wp-list-table {
 
 	.column-thumb {
-		width: 52px;
+		width: 100px;
 		text-align: center;
 		white-space: nowrap;
 	}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -668,7 +668,7 @@ a.reset_variations {
 
 	.flex-control-thumbs li {
 		width: 14.2857142857%;
-		margin: 0 14.2857142857% 1.6em 0;
+		margin: 0 1em 1.6em 0;
 	}
 
 	.flex-control-thumbs li:nth-child(4n) {


### PR DESCRIPTION
Solved the issue which is mention #34169 
Product categories alternate thumbnail image column overlap with categories name.

