### PR TITLE
dev: refactor Homescreen component to use useQuery hook

### DIFF
--- a/packages/js/navigation/changelog/add-use-query-hook
+++ b/packages/js/navigation/changelog/add-use-query-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added useQuery hook for usage in React functional components

--- a/packages/js/navigation/src/index.js
+++ b/packages/js/navigation/src/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
+import {
+	createElement,
+	useState,
+	useEffect,
+	useLayoutEffect,
+} from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import { parse } from 'qs';
 import { pick } from 'lodash';
@@ -177,6 +182,30 @@ export function getQuery() {
 	}
 	return {};
 }
+
+/**
+ * Like getQuery but in useHook format for easy usage in React functional components
+ *
+ * @return {Record<string, string>} Current query object, defaults to empty object.
+ */
+export const useQuery = () => {
+	const [ queryState, setQueryState ] = useState( {} );
+	const [ locationChanged, setLocationChanged ] = useState( true );
+	useLayoutEffect( () => {
+		return addHistoryListener( () => {
+			setLocationChanged( true );
+		} );
+	}, [] );
+
+	useEffect( () => {
+		if ( locationChanged ) {
+			const query = getQuery();
+			setQueryState( query );
+			setLocationChanged( false );
+		}
+	}, [ locationChanged ] );
+	return queryState;
+};
 
 /**
  * This function returns an event handler for the given `param`

--- a/plugins/woocommerce-admin/client/homescreen/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/index.tsx
@@ -9,7 +9,7 @@ import {
 	withOnboardingHydration,
 	WCDataSelector,
 } from '@woocommerce/data';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getHistory, getNewPath, useQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
@@ -18,7 +18,6 @@ import { getAdminSetting } from '~/utils/admin-settings';
 
 type HomescreenProps = ReturnType< typeof withSelectHandler > & {
 	hasFinishedResolution: boolean;
-	query: Record< string, string >;
 };
 
 const Homescreen = ( {
@@ -27,12 +26,12 @@ const Homescreen = ( {
 		skipped: profilerSkipped,
 	} = {},
 	hasFinishedResolution,
-	query,
 }: HomescreenProps ) => {
 	if ( hasFinishedResolution && ! profilerCompleted && ! profilerSkipped ) {
 		getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
 	}
 
+	const query = useQuery();
 	// @ts-expect-error Layout is a pure JS component
 	return <Layout query={ query } />;
 };

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -67,7 +67,7 @@ export const Layout = ( {
 	const hasTwoColumnContent =
 		shouldShowStoreLinks || window.wcAdminFeatures.analytics;
 	const [ showInbox, setShowInbox ] = useState( true );
-	const isDashboardShown = ! query.task;
+	const isDashboardShown = ! query.task; // ?&task=<x> query param is used to show tasks instead of the homescreen
 	const activeSetupTaskList = useActiveSetupTasklist();
 
 	const twoColumns =

--- a/plugins/woocommerce/changelog/dev-refactor-homescreen-use-query
+++ b/plugins/woocommerce/changelog/dev-refactor-homescreen-use-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Refactored homescreen component to use useQuery hook


### PR DESCRIPTION
- added useQuery hook for usage in functional components
- refactored Homescreen component to useQuery instead of prop drilling

This refactor was triggered by a TS error while fixing types for pnpm 7 #34154 

As a properly written type definition to resolve this would be quite complex due to the layers of abstraction between the origin of the `query` prop (from react-router-dom's `<Router>`), it was decided to simply refactor the component to not rely on props from the parent instead.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Minor refactor of the Homescreen component to not use prop drilling, as it is possible to reduce the complexity of the data flow by using useHooks instead.

### How to test the changes in this Pull Request:

1. Install WooCommerce
2. Do a smoke test, with focus on ensuring that tasks in the tasklists are still navigable.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
