### PR TITLE
Disallow/discourage Yoda comparisons in the WooCommerce codebase

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,6 +32,15 @@
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />
 
+	<rule ref="Generic.ControlStructures.DisallowYodaConditions" >
+		<include-pattern>includes/</include-pattern>
+		<type>warning</type>
+	</rule>
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" >
+		<exclude-pattern>includes/</exclude-pattern>
+	</rule>
+
 	<rule ref="WooCommerce.Functions.InternalInjectionMethod">
 		<include-pattern>src/</include-pattern>
 		<include-pattern>tests/php/src/</include-pattern>

--- a/plugins/woocommerce/bin/composer/phpcs/composer.json
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.json
@@ -1,11 +1,12 @@
 {
 	"require-dev": {
 		"woocommerce/woocommerce-sniffs": "^0.1.3",
-		"sirbrillig/phpcs-changed": "^2.10"
+		"sirbrillig/phpcs-changed": "^2.10",
+		"slevomat/coding-standard": "^8.0"
 	},
 	"config": {
 		"platform": {
-			"php": "7.4"
+			"php": "7.2"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true

--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df66db582a7c00ab0a701277e962ecce",
+    "content-hash": "a04f56dd1f49558a5e61384cb5370058",
     "packages": [],
     "packages-dev": [
         {
@@ -255,6 +255,51 @@
             "time": "2021-12-30T16:37:40+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
+            },
+            "time": "2022-06-26T13:09:08+00:00"
+        },
+        {
             "name": "sirbrillig/phpcs-changed",
             "version": "v2.10.0",
             "source": {
@@ -310,6 +355,67 @@
                 "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.10.0"
             },
             "time": "2022-03-09T18:16:50+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "a14df437f2efe861ca9118508f304de9655957e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/a14df437f2efe861ca9118508f304de9655957e4",
+                "reference": "a14df437f2efe861ca9118508f304de9655957e4",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.6.2",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.8.1",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.3.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.21"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-16T11:59:39+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -471,7 +577,7 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4"
+        "php": "7.2"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/plugins/woocommerce/changelog/disallow-yoda-conditions-in-src
+++ b/plugins/woocommerce/changelog/disallow-yoda-conditions-in-src
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Alter the PHPCS settings to disallow Yoda conditions (except in "includes")


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implementation of the change proposed in p7bje6-4fh-p2.

1. **Discourage** the usage of Yoda comparisons in `includes`, by having them flagged as as warnings by phpcs.
2. **Disallow** the usage of Yoda comparisons in `src`, `tests` and `templates`.

No existing comparisons are changed in this pull request.

The [Slevomat coding standard package](https://github.com/slevomat/coding-standard) is used for the disallowing part, as it supports automatic fixing of existing comparisons via phpcbf. 

### How to test the changes in this Pull Request:

1. Run `composer install` once you have checked out the branch of this pull request.
2. Run phpcs on any file of `includes` that has comparisons, e.g. `phpcs plugins/woocommerce/includes/class-wc-api.php`, verify that you get warnings for the comparisons.
3. Run phpcs on any file of `src` that has comparisons, e.g. `phpcs plugins/woocommerce/src/Utilities/StringUtil.php`, verify that you get errors for the comparisons.
4. Repeat 3 but with `phpcbf`,  verify that the comparisons are now properly reversed.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
