### PR TITLE
Liechtenstein Checkout: Hide Municipality Field with empty states array

### DIFF
--- a/plugins/woocommerce/i18n/states.php
+++ b/plugins/woocommerce/i18n/states.php
@@ -1104,6 +1104,7 @@ return array(
 		'XS' => __( 'Xaisomboun', 'woocommerce' ),
 	),
 	'LB' => array(),
+	'LI' => array(),
 	'LR' => array( // Liberian provinces.
 		'BM' => __( 'Bomi', 'woocommerce' ),
 		'BN' => __( 'Bong', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Send an empy States array for Country Liechtenstein to hide municipality field
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34188 .

### How to test the changes in this Pull Request:

1. Go to Checkout - choose Liechtenstein as country
2. check if Municipality Field doesnt show next to city field

BEFORE PULL
![image](https://user-images.githubusercontent.com/6242098/182838588-c49be444-863e-470f-8dd5-5f0515569f04.png)

AFTER PULL
![image](https://user-images.githubusercontent.com/6242098/182838632-caa53df0-7c7d-4d4b-bf84-655978ecc11c.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
