### PR TITLE
Fixes a WP nightly unity test

### DIFF
--- a/plugins/woocommerce/changelog/fix-unit-nightly
+++ b/plugins/woocommerce/changelog/fix-unit-nightly
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes a unit test for WP nightly. No functional change.
+
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/core/template-cache.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/core/template-cache.php
@@ -57,8 +57,10 @@ class WC_Template_Cache extends WC_Unit_Test_Case {
 		$cached_templates = wp_cache_get( 'cached_templates', 'woocommerce' );
 		wc_clear_template_cache();
 
-		foreach ( (array) $cached_templates as $template ) {
-			$this->assertEmpty( wp_cache_get( $template, 'woocommerce' ) );
+		if ( $cached_templates ) {
+			foreach ( (array) $cached_templates as $template ) {
+				$this->assertEmpty( wp_cache_get( $template, 'woocommerce' ) );
+			}
 		}
 		$this->assertEmpty( wp_cache_get( 'cached_templates', 'woocommerce' ) );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In WP 6.1, a new doing_it_wrong message is being added to prevent checking for cache with boolean key. Seems like we were accidentally using a boolean key in one of the test.

### How to test the changes in this Pull Request:

Make sure that tests pass.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
