### PR TITLE
Fix set default homescreen layout after setup task completion or dismissal

### DIFF
--- a/plugins/woocommerce/changelog/fix-34149-set-default-homescreen-layout
+++ b/plugins/woocommerce/changelog/fix-34149-set-default-homescreen-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix regression setting homescreen default layout after setup task dismissal or completion

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -218,7 +218,7 @@ class TaskList {
 	 */
 	public function maybe_set_default_layout( $completed_or_hidden_tasklist_ids ) {
 		if ( in_array( 'setup', $completed_or_hidden_tasklist_ids ) ) {
-			update_option( 'woocommerce_default_homepage_layout', 'two_columns' );
+			update_option( 'woocommerce_default_homepage_layout', 'two_columns', true );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -207,7 +207,19 @@ class TaskList {
 
 		$hidden   = get_option( self::HIDDEN_OPTION, array() );
 		$hidden[] = $this->hidden_id ? $this->hidden_id : $this->id;
+		$this->maybe_set_default_layout( $hidden );
 		return update_option( self::HIDDEN_OPTION, array_unique( $hidden ) );
+	}
+
+	/**
+	 * Sets the default homepage layout to two_columns if "setup" tasklist is completed or hidden.
+	 *
+	 * @param array $completed_or_hidden_tasklist_ids Array of tasklist ids.
+	 */
+	public function maybe_set_default_layout( $completed_or_hidden_tasklist_ids ) {
+		if ( in_array( 'setup', $completed_or_hidden_tasklist_ids ) ) {
+			update_option( 'woocommerce_default_homepage_layout', 'two_columns' );
+		}
 	}
 
 	/**
@@ -326,6 +338,7 @@ class TaskList {
 		$completed_lists   = get_option( self::COMPLETED_OPTION, array() );
 		$completed_lists[] = $this->get_list_id();
 		update_option( self::COMPLETED_OPTION, $completed_lists );
+		$this->maybe_set_default_layout( $completed_lists );
 		$this->record_tracks_event( 'tasks_completed' );
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -217,8 +217,8 @@ class TaskList {
 	 * @param array $completed_or_hidden_tasklist_ids Array of tasklist ids.
 	 */
 	public function maybe_set_default_layout( $completed_or_hidden_tasklist_ids ) {
-		if ( in_array( 'setup', $completed_or_hidden_tasklist_ids ) ) {
-			update_option( 'woocommerce_default_homepage_layout', 'two_columns', true );
+		if ( in_array( 'setup', $completed_or_hidden_tasklist_ids, true ) ) {
+			update_option( 'woocommerce_default_homepage_layout', 'two_columns' );
 		}
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
@@ -423,7 +423,7 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test task list sort_tasks with custom config.
+	 * Test explicit behavior of defaulting to two_column layout after setup tasklist is hidden.
 	 */
 	public function test_default_layout_after_hide_setup_tasklist() {
 		$list = new TaskList(
@@ -433,5 +433,20 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 		);
 		$list->hide();
 		$this->assertEquals( get_option( 'woocommerce_default_homepage_layout', null ), 'two_columns' );
+		delete_option( 'woocommerce_default_homepage_layout' );
+	}
+
+	/**
+	 * Test explicit behavior of defaulting to two_column layout after setup tasklist is completed.
+	 */
+	public function test_default_layout_after_complete_setup_tasklist() {
+		$list = new TaskList(
+			array(
+				'id' => 'setup',
+			)
+		);
+		$list->possibly_track_completion();
+		$this->assertEquals( get_option( 'woocommerce_default_homepage_layout', null ), 'two_columns' );
+		delete_option( 'woocommerce_default_homepage_layout' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-list.php
@@ -421,4 +421,17 @@ class WC_Admin_Tests_OnboardingTasks_TaskList extends WC_Unit_Test_Case {
 	public function test_record_tracks_event() {
 		$this->assertEquals( 'setup_tasklist_test_event', $this->list->record_tracks_event( 'test_event' ) );
 	}
+
+	/**
+	 * Test task list sort_tasks with custom config.
+	 */
+	public function test_default_layout_after_hide_setup_tasklist() {
+		$list = new TaskList(
+			array(
+				'id' => 'setup',
+			)
+		);
+		$list->hide();
+		$this->assertEquals( get_option( 'woocommerce_default_homepage_layout', null ), 'two_columns' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

Closes #34149. Add back the functionality to set default homescreen layout to `two_columns` when setup tasklist is completed or dismissed.

### How to test the changes in this Pull Request:


**Test completion**
1. Set up a new store
2. Complete setup tasklist tasks
3. Refresh on WooCommerce > Home
4. Observe the homescreen layout is set to two columns

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/3747241/182855413-e8f61712-3188-4d72-bc6a-6842f8fe466a.png">

**Test dismissal**
1. Set up a new store
2. Hide setup tasklist
3. Refresh on WooCommerce > Home
4. Observe the homescreen layout is set to two columns
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/3747241/182858147-6198f4d8-cb45-4910-9778-63884db9be5b.png">

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
