### PR TITLE
Clear post cache after updating menu order for products.

### DIFF
--- a/plugins/woocommerce/changelog/fix-31389-menu-ordering
+++ b/plugins/woocommerce/changelog/fix-31389-menu-ordering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure changes to product order are reflected even when advanced post caching is in effect.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1905,7 +1905,11 @@ class WC_AJAX {
 			}
 			$index ++;
 			$menu_orders[ $id ] = $index;
-			$wpdb->update( $wpdb->posts, array( 'menu_order' => $index ), array( 'ID' => $id ) );
+
+			if ( $wpdb->update( $wpdb->posts, array( 'menu_order' => $index ), array( 'ID' => $id ) ) ) {
+				// We only need to clean the cache if the menu order was actually modified.
+				clean_post_cache( $id );
+			}
 
 			/**
 			 * When a single product has gotten it's ordering updated.
@@ -1923,7 +1927,10 @@ class WC_AJAX {
 			$menu_orders[ $sorting_id ] = 0;
 		}
 
-		$wpdb->update( $wpdb->posts, array( 'menu_order' => $menu_orders[ $sorting_id ] ), array( 'ID' => $sorting_id ) );
+		if ( $wpdb->update( $wpdb->posts, array( 'menu_order' => $menu_orders[ $sorting_id ] ), array( 'ID' => $sorting_id ) ) ) {
+			// We only need to clean the cache if the menu order was actually modified.
+			clean_post_cache( $sorting_id );
+		}
 
 		WC_Post_Data::delete_product_query_transients();
 


### PR DESCRIPTION
When Advanced Post Caching is in effect, changes made to product menu order appear not to take effect because the cached results (for the posts query) are not invalidated.

Closes #31389.

### How to test the changes in this Pull Request:

Please also refer to the [linked issue](https://github.com/woocommerce/woocommerce/issues/31389) which contains a good screencast and some solid testing instructions.

1. Start by setting up an environment where you can replicate the problem described in the linked issue:
    - You can achieve this by testing on an Atomic site.
    - Or, to test locally, grab a copy of Advanced Post Cache as used on WP.com (internal conversation p1659562709451669/1659534670.204749-slack-C0E1AV8T0 contains a link where you can grab a copy) and set it up as a mu-plugin. You will also need persistent object caching (Redis/Memcached) to be in place.
2. Navigate to **Products ▸ Categories** and pick a category associated with 1 or more products. Click on the link in the **Count** column.
4. You should now find yourself looking at a list table of products belonging to that category. Open the **Sorting** view.
5. Try reordering the products, then refresh the page. The change should persist.

### Demo

Here's how things work **without** the fix (note how after reordering the products I click on **Sorting** to refresh the page, and the order reverts to how it was at the start of the video):

https://user-images.githubusercontent.com/3594411/182959163-804ac77a-7401-49cd-8bbb-f7cac2835b54.mov

And here is how things work **with** the fix. This time, on refreshing, the new order persists:

https://user-images.githubusercontent.com/3594411/182959179-79f2fe79-727e-46a4-8a34-a6f90a6d2867.mov

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.