### PR TITLE
Fixed issues of spacing between author image and name

### DIFF
--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3249,7 +3249,7 @@ table.wp-list-table {
 	}
 
 	img {
-		margin: 1px 2px;
+		margin: 1px 10px 1px 2px;
 	}
 
 	.row-actions {


### PR DESCRIPTION
Solved the issue which is mention #34200 
In woocommerce reviews section author image and meta there is no gap is display.

