### PR TITLE
Disable the WordPress.PHP.YodaConditions.NotYoda phpcs rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,6 +32,10 @@
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />
 
+	<rule ref="WordPress.PHP">
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+	</rule>
+
 	<rule ref="Generic.ControlStructures.DisallowYodaConditions" >
 		<include-pattern>includes/</include-pattern>
 		<type>warning</type>

--- a/plugins/woocommerce/changelog/disable-wordpress-yoda-conditions-rule
+++ b/plugins/woocommerce/changelog/disable-wordpress-yoda-conditions-rule
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Disable the WordPress.PHP.YodaConditions.NotYoda phpcs rule


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a follow-up to https://github.com/woocommerce/woocommerce/pull/34185.

Turns out that after `phpcbf` fixes the existing Yoda conditions, the `WordPress.PHP.YodaConditions.NotYoda` phpcs rule kicks in for some comparisons, but not for others (and by sheer bad luck https://github.com/woocommerce/woocommerce/pull/34185 was tested with one of the files that don't trigger the error). This pull request fixes this by disabling the WordPress rule altogether.

### How to test the changes in this Pull Request:

1. In `trunk`, run the following: `phpcbf plugins/woocommerce/src/Utilities/ArrayUtil.php`, it will fix four Yodas.
2. Repeat 1 but with `phpcs` instead. Now these four changed conditions trigger `WordPress.PHP.YodaConditions.NotYoda`.
3. Apply the fix and repeat 2, the errors are no more.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
