### PR TITLE
Skip thumbnail regeneration when Photon Image CDN handles it externally.

### DIFF
--- a/plugins/woocommerce/changelog/fix-30379
+++ b/plugins/woocommerce/changelog/fix-30379
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip thumbnail regeneration when Photon Image CDN handles it externally.

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -229,8 +229,8 @@ class WC_Regenerate_Images {
 		}
 
 		// Skip resizing if the image is too large to be loaded into the memory. A heuristic to prevent out of memory errors.
-		$full_size               = self::get_full_size_image_dimensions( $attachment_id );
-		$gd_image_size_in_memory = 0;
+		$full_size                = self::get_full_size_image_dimensions( $attachment_id );
+		$gd_image_size_in_memory  = 0;
 		$available_memory         = self::get_image_memory_limit();
 		if ( is_int( $full_size['width'] ) && is_int( $full_size['height'] ) ) {
 			$gd_image_size_in_memory = $full_size['width'] * $full_size['height'] * 5; // 5 bytes per pixel, https://stackoverflow.com/questions/18465390/php-fatal-error-out-of-memory-when-creating-an-image#comment27312125_18465539
@@ -514,7 +514,7 @@ class WC_Regenerate_Images {
 		$mem_limit       = self::_get_wp_image_memory_limit();
 
 		if ( $mem_limit === false ) {
-			$mem_limit     = ini_get( 'memory_limit' );
+			$mem_limit = ini_get( 'memory_limit' );
 		}
 
 		if ( $mem_limit ) {
@@ -534,7 +534,7 @@ class WC_Regenerate_Images {
 	 *
 	 * @return false|int|string
 	 */
-	private static function _get_wp_image_memory_limit() {
+	private static function get_wp_image_memory_limit() {
 		if ( false === wp_is_ini_value_changeable( 'memory_limit' ) ) {
 			return false;
 		}
@@ -550,7 +550,9 @@ class WC_Regenerate_Images {
 		$wp_max_limit_int = wp_convert_hr_to_bytes( $wp_max_limit );
 		$filtered_limit   = $wp_max_limit;
 
-		// This is a WP core filter.
+		/**
+		 * This is a WP core filter from wp_raise_memory_limit().
+		 */
 		$filtered_limit = apply_filters( 'image_memory_limit', $filtered_limit );
 
 		$filtered_limit_int = wp_convert_hr_to_bytes( $filtered_limit );

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -36,12 +36,13 @@ class WC_Regenerate_Images {
 	public static function init() {
 		add_action( 'image_get_intermediate_size', array( __CLASS__, 'filter_image_get_intermediate_size' ), 10, 3 );
 		add_filter( 'wp_generate_attachment_metadata', array( __CLASS__, 'add_uncropped_metadata' ) );
-		add_filter( 'wp_get_attachment_image_src', array( __CLASS__, 'maybe_resize_image' ), 10, 4 );
 
 		// Not required when Jetpack Photon is in use.
-		if ( method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'photon' ) ) {
+		if ( self::is_photon_active() ) {
 			return;
 		}
+
+		add_filter( 'wp_get_attachment_image_src', array( __CLASS__, 'maybe_resize_image' ), 10, 4 );
 
 		if ( apply_filters( 'woocommerce_background_image_regeneration', true ) ) {
 			include_once WC_ABSPATH . 'includes/class-wc-regenerate-images-request.php';

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -230,9 +230,9 @@ class WC_Regenerate_Images {
 
 		// Skip resizing if the image is too large to be loaded into the memory. A heuristic to prevent out of memory errors.
 		// Once https://core.trac.wordpress.org/ticket/23127 is merged, we can catch the error from GD instead.
-		$full_size                = self::get_full_size_image_dimensions( $attachment_id );
-		$gd_image_size_in_memory  = 0;
-		$available_memory         = self::get_image_memory_limit();
+		$full_size               = self::get_full_size_image_dimensions( $attachment_id );
+		$gd_image_size_in_memory = 0;
+		$available_memory        = self::get_image_memory_limit();
 		if ( is_int( $full_size['width'] ) && is_int( $full_size['height'] ) ) {
 			$gd_image_size_in_memory = $full_size['width'] * $full_size['height'] * 5; // 5 bytes per pixel, https://stackoverflow.com/questions/18465390/php-fatal-error-out-of-memory-when-creating-an-image#comment27312125_18465539
 		}
@@ -553,6 +553,17 @@ class WC_Regenerate_Images {
 
 		/**
 		 * This is a WP core filter from wp_raise_memory_limit().
+		 *
+		 * Filters the memory limit allocated for image manipulation.
+		 *
+		 * @since 3.5.0
+		 * @since 4.6.0 The default now takes the original `memory_limit` into account.
+		 *
+		 * @param int|string $filtered_limit Maximum memory limit to allocate for images.
+		 *                                   Default `WP_MAX_MEMORY_LIMIT` or the original
+		 *                                   php.ini `memory_limit`, whichever is higher.
+		 *                                   Accepts an integer (bytes), or a shorthand string
+		 *                                   notation, such as '256M'.
 		 */
 		$filtered_limit = apply_filters( 'image_memory_limit', $filtered_limit );
 

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -229,6 +229,7 @@ class WC_Regenerate_Images {
 		}
 
 		// Skip resizing if the image is too large to be loaded into the memory. A heuristic to prevent out of memory errors.
+		// Once https://core.trac.wordpress.org/ticket/23127 is merged, we can catch the error from GD instead.
 		$full_size                = self::get_full_size_image_dimensions( $attachment_id );
 		$gd_image_size_in_memory  = 0;
 		$available_memory         = self::get_image_memory_limit();
@@ -511,7 +512,7 @@ class WC_Regenerate_Images {
 	 */
 	protected static function get_image_memory_limit() {
 		$mem_limit_bytes = 0;
-		$mem_limit       = self::_get_wp_image_memory_limit();
+		$mem_limit       = self::get_wp_image_memory_limit();
 
 		if ( $mem_limit === false ) {
 			$mem_limit = ini_get( 'memory_limit' );

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -71,7 +71,7 @@ class WC_Regenerate_Images {
 	 * https://developer.wordpress.com/docs/photon/
 	 */
 	protected static function is_photon_active() {
-		return class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'get_active_modules' ) && in_array( 'photon', Jetpack::get_active_modules() );
+		return class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'get_active_modules' ) && in_array( 'photon', Jetpack::get_active_modules(), true );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
+++ b/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
@@ -8,6 +8,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\ImageProcessing;
+
 /**
  * WC_Shop_Customizer class.
  */
@@ -523,7 +525,7 @@ class WC_Shop_Customizer {
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
 	private function add_product_images_section( $wp_customize ) {
-		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
+		if ( ImageProcessing::is_photon_active() ) {
 			$regen_description = ''; // Nothing to report; Jetpack will handle magically.
 		} elseif ( apply_filters( 'woocommerce_background_image_regeneration', true ) && ! is_multisite() ) {
 			$regen_description = __( 'After publishing your changes, new image sizes will be generated automatically.', 'woocommerce' );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -8,6 +8,8 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Internal\ImageProcessing;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -220,7 +222,13 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 		}
 
 		// Jetpack does the image resizing heavy lifting so you don't have to.
-		if ( ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) || ! apply_filters( 'woocommerce_background_image_regeneration', true ) ) {
+		/**
+		 * Allow disabling background image regeneration.
+		 *
+		 * @since 3.3.0
+		 * @param bool Flag indicating whether to regenerate images in the background. Default: true.
+		 */
+		if ( ImageProcessing::is_photon_active() || ! apply_filters( 'woocommerce_background_image_regeneration', true ) ) {
 			unset( $tools['regenerate_thumbnails'] );
 		}
 

--- a/plugins/woocommerce/src/Internal/Utilities/ImageProcessing.php
+++ b/plugins/woocommerce/src/Internal/Utilities/ImageProcessing.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WooCommerce Image Processing Utilities.
+ */
+
+namespace Automattic\WooCommerce\Internal;
+
+/**
+ * Contains backend logic for the activity panel feature.
+ */
+class ImageProcessing {
+
+	/**
+	 * Returns true if Photon image CDN is active on the site
+	 *
+	 * In case Photon is active, don't attempt to generate thumbnails, as those are generated on the fly
+	 * and served from the Photon CDN. Thus, they're unnecessary and just take disk space and CPU cycles to generate.
+	 * Additionally, when Photon is active, WP will accept even pretty large images and attempting to resize them
+	 * will crash the image processing library.
+	 *
+	 * https://developer.wordpress.com/docs/photon/
+	 *
+	 * @return bool true if Photon image CDN is active on the site, false otherwise
+	 */
+	public static function is_photon_active(): bool {
+		return class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'get_active_modules' ) && in_array( 'photon', Jetpack::get_active_modules(), true );
+	}
+
+	/**
+	 * Return the memory limit used for image processing in WP.
+	 *
+	 * @return int Number of bytes of available memory for the PHP process.
+	 */
+	public static function get_image_memory_limit(): int {
+		$mem_limit_bytes = 0;
+		$mem_limit       = self::get_wp_image_memory_limit();
+
+		if ( false === $mem_limit ) {
+			$mem_limit = ini_get( 'memory_limit' );
+		}
+
+		if ( $mem_limit ) {
+			$mem_limit_bytes = wp_convert_hr_to_bytes( $mem_limit );
+		}
+
+		return $mem_limit_bytes;
+	}
+
+	/**
+	 * Returns the memory limit that would be used after running wp_raise_memory_limit( 'image' ) function,
+	 * without changing the limit.
+	 *
+	 * This is a reduced copy of core's wp_raise_memory_limit.
+	 * It would be great if there was a way to call wp_raise_memory_limit that would return the new memory limit
+	 * with no change in the memory limit, but there isn't one.
+	 *
+	 * @see wp_raise_memory_limit
+	 *
+	 * @return false|int|string
+	 */
+	public static function get_wp_image_memory_limit() {
+		if ( false === wp_is_ini_value_changeable( 'memory_limit' ) ) {
+			return false;
+		}
+
+		$current_limit     = ini_get( 'memory_limit' );
+		$current_limit_int = wp_convert_hr_to_bytes( $current_limit );
+
+		if ( -1 === $current_limit_int ) {
+			return false;
+		}
+
+		$wp_max_limit     = WP_MAX_MEMORY_LIMIT;
+		$wp_max_limit_int = wp_convert_hr_to_bytes( $wp_max_limit );
+		$filtered_limit   = $wp_max_limit;
+
+		/**
+		 * This is a WP core filter from wp_raise_memory_limit().
+		 *
+		 * Filters the memory limit allocated for image manipulation.
+		 *
+		 * @since 3.5.0
+		 * @since 4.6.0 The default now takes the original `memory_limit` into account.
+		 *
+		 * @param int|string $filtered_limit Maximum memory limit to allocate for images.
+		 *                                   Default `WP_MAX_MEMORY_LIMIT` or the original
+		 *                                   php.ini `memory_limit`, whichever is higher.
+		 *                                   Accepts an integer (bytes), or a shorthand string
+		 *                                   notation, such as '256M'.
+		 */
+		$filtered_limit = apply_filters( 'image_memory_limit', $filtered_limit );
+
+		$filtered_limit_int = wp_convert_hr_to_bytes( $filtered_limit );
+
+		if ( -1 === $filtered_limit_int || ( $filtered_limit_int > $wp_max_limit_int && $filtered_limit_int > $current_limit_int ) ) {
+			return $filtered_limit;
+		} elseif ( -1 === $wp_max_limit_int || $wp_max_limit_int > $current_limit_int ) {
+			return $wp_max_limit;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30379  .

tl;dr is that this change skips thumbnail regeneration when Photon Image CDN is active, since it's not needed and it will just take disk space and use CPU cycles unnecessarily, as image requests are redirected to the CDN.

### How to test the changes in this Pull Request:

1. Create a new product, or use an existing one. Go to Product > Set product image
2. Upload an image with large dimensions (size can be modest, e.g. this gradient compresses quite well and it's 16.5k pixels wide)
![16_25k](https://user-images.githubusercontent.com/2207451/183035110-25fe92f4-3f9d-4647-ac96-e345008e0318.jpg)
3. On a Photon non-enabled environment (such as local dev env), you will most likely see an error saying that the image could not be processed (as WP attempts to scale down the image and generate thumbnails)
4. Create a business site on wordpress.com (which is Photon enabled), and retry steps 1-3. (If you need help to create a dev site, please see my comment on p9F6qB-9VL-p2). After a couple of attempts, you should be able to upload the image.
5. Try to assign the image to the product
6. Add the Hand picked products block to any post, save it.
7. Try to open the post in WP Admin, it would crash (either the block itself, or the whole site), with an error saying `PHP Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 61440 bytes) in /srv/htdocs/__wp__/wp-includes/class-wp-image-editor-gd.php on line 111`
8. Apply the patch
9. Test that on Photon non-enabled site, thumbnails have been generated fine. Also test that regenerating thumbnails from WC > Status > Tools works fine (should we switch it to Action Scheduler?)
10. Test that on Photon enabled site, steps 1-7 should work without any problems and it should serve the image via Photon (ie the image comes from `i0.wp.com` and has some parameters at the end, e.g. `?w=1600&ssl=1` or `?fit=1800&ssl=1` or similar, for details, please see https://developer.wordpress.com/docs/photon/)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
