### PR TITLE
Update "Add store details" task complete logic

### DIFF
--- a/plugins/woocommerce/changelog/update-34182-store-details-completion-logic
+++ b/plugins/woocommerce/changelog/update-34182-store-details-completion-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update store details task complete logic

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -69,7 +69,8 @@ class StoreDetails extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		// Mark as completed if the store address and city are set. We don't need to check the country because it's set by default.
-		return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '';
+		// Mark as completed if the store address, city and postcode are set. We don't need to check the country because it's set by default.
+		return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '' &&
+		get_option( 'woocommerce_store_postcode', '' ) !== '';
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/store-details.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/store-details.php
@@ -53,6 +53,7 @@ class WC_Admin_Tests_OnboardingTasks_Task_StoreDetails extends WC_Unit_Test_Case
 	public function test_completed_task_get_title_with_use_completed_title_option() {
 		update_option( 'woocommerce_store_address', 'Market Street' );
 		update_option( 'woocommerce_store_city', 'San Francisco' );
+		update_option( 'woocommerce_store_postcode', '1234' );
 		$this->task_list->options['use_completed_title'] = true;
 		$this->assertEquals( 'You added store details', $this->task->get_title() );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34182.

This PR updates the "Add store details" task complete logic such that all address fields (post/zip code etc) are required to complete the task.

### How to test the changes in this Pull Request:

**Completes the task via onboarding wizard**

1. Use a fresh site
2. Go to OBW
3. Fills out all fields in step 1
4. Complete the onboarding wizard
5. Observe that  "Add store details" task is marked as completed

**Completes the task by filling out address fields on the setting page**

1. Use a fresh site
2. Go to OBW
3. Skips the onboarding wizard
4. Observe that "Add store details" task is not closed
5. Click the "Add store details" task
6. Fill out the **city, country, address1, and post code**
7. Go back to `WooCommerce > Home`
8. Observe that the "Add store details" task is marked as completed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
