### PR TITLE
Fix Customer Effort Score Tracks

### DIFF
--- a/plugins/woocommerce-admin/changelogs/fix-34172_customer_effort_tracks
+++ b/plugins/woocommerce-admin/changelogs/fix-34172_customer_effort_tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add support for sections in our TaskList class and create a new sectional task list component. #32302

--- a/plugins/woocommerce-admin/changelogs/fix-34172_customer_effort_tracks
+++ b/plugins/woocommerce-admin/changelogs/fix-34172_customer_effort_tracks
@@ -1,4 +1,4 @@
 Significance: minor
-Type: Add
+Type: Fix
 
-Add support for sections in our TaskList class and create a new sectional task list component. #32302
+Fix Customer Effort Score Tracks #34209

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -117,7 +117,7 @@ function CustomerEffortScoreTracks( {
 
 	return (
 		<CustomerEffortScore
-			onSelect={ recordScore }
+			recordScoreCallback={ recordScore }
 			label={ label }
 			onNoticeShownCallback={ onNoticeShown }
 			onNoticeDismissedCallback={ onNoticeDismissed }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR renames the prop that we were sending to the component `CustomerEffortScore`. The [component was expecting](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/customer-effort-score/src/customer-effort-score.tsx#L96) the prop `recordScoreCallback`, but it was receiving the prop `onSelect` instead.

The prop [was renamed](https://github.com/woocommerce/woocommerce/pull/32538/files#diff-881eac71b45d060ee4efcd12fea521ec3e1cd9f43321d3cc504b1f8401fd96ceL120) in [this PR](https://github.com/woocommerce/woocommerce/pull/32538).

Closes #34172.

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. Use the plugin [woocommerce-admin-test-helper](https://github.com/woocommerce/woocommerce-admin-test-helper) to delete the variable `woocommerce_ces_shown_for_actions`. The option is under `Tools` > `WCA Test Helper` > `Options`.
3. Go to `Tools` > `WCA Test Helper` > `Tools` and enable `wc-admin` Tracking.
4. Create a new product and confirm that a snackbar like the one below is being shown.


![Screen Shot 2022-08-05 at 11 52 39](https://user-images.githubusercontent.com/1314156/183106214-c107eb30-3323-4ae3-a1f8-15a8f185b94e.png)


5. Open the browser's console and check that the option `wcadmin_ces_snackbar_view` is being recorded.
6. Press `Give feedback` and verify that the option `wcadmin_ces_view` is being recorded.
7.  Select an option and press `Send`. The event `wcadmin_ces_feedback` should be recorded.
8. Now delete the option described in step 2 again and update the product.
9. Press the `X` and confirm that the event `wcadmin_ces_snackbar_dismiss` is being recorded. 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
