### PR TITLE
Remove cherry-picked 34209 changelogs

### DIFF
--- a/plugins/woocommerce-admin/changelogs/add-require-turbo
+++ b/plugins/woocommerce-admin/changelogs/add-require-turbo
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: This PR updates repository tooling and doesn't require a changelog entry.
-
-

--- a/plugins/woocommerce-admin/changelogs/feature-32164_new_task_list_version_2
+++ b/plugins/woocommerce-admin/changelogs/feature-32164_new_task_list_version_2
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Add
-
-Add support for sections in our TaskList class and create a new sectional task list component. #32302

--- a/plugins/woocommerce-admin/changelogs/feature-32697_wc_payment_gateways_banner
+++ b/plugins/woocommerce-admin/changelogs/feature-32697_wc_payment_gateways_banner
@@ -1,6 +1,0 @@
-Significance: minor
-Type: feature
-
-Added slotfill for payment gateway banner in settings page 
-Refactored payment methods icons in payments-welcome
-Added experiment for showing payment banner in payment settings page #32697

--- a/plugins/woocommerce-admin/changelogs/fix-34172_customer_effort_tracks
+++ b/plugins/woocommerce-admin/changelogs/fix-34172_customer_effort_tracks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: Fix
-
-Fix Customer Effort Score Tracks #34209


### PR DESCRIPTION
Changelog for https://github.com/woocommerce/woocommerce/pull/34209 are removed from trunk due to cherry picking into `release/6.8`

This PR also removes the entire `plugins/woocommerce-admin/changelogs` folder because it is no longer used. The changelog entries in the folder are either many months outdated, subject of cherry-picking, or just a comment.

https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-admin/changelogs