### PR TITLE
support single_select_page_with_search in WC REST API

### DIFF
--- a/plugins/woocommerce/changelog/add-select-with-seach-to-store-api
+++ b/plugins/woocommerce/changelog/add-select-with-seach-to-store-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support Cart/Checkout/My accounts/Terms settings in WC REST API

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
@@ -102,7 +102,7 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 			} elseif ( 'single_select_country' === $setting['type'] ) {
 				$setting['type']    = 'select';
 				$setting['options'] = $this->get_countries_and_states();
-			} elseif ( 'single_select_page' === $setting['type'] || 'single_select_page_with_search' === $setting['type'] ) {
+			} elseif ( $setting['type'] === 'single_select_page' || $setting['type'] === 'single_select_page_with_search' ) {
 				$pages   = get_pages(
 					array(
 						'sort_column'  => 'menu_order',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
@@ -102,7 +102,7 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 			} elseif ( 'single_select_country' === $setting['type'] ) {
 				$setting['type']    = 'select';
 				$setting['options'] = $this->get_countries_and_states();
-			} elseif ( 'single_select_page' === $setting['type'] ) {
+			} elseif ( 'single_select_page' === $setting['type'] || 'single_select_page_with_search' === $setting['type'] ) {
 				$pages   = get_pages(
 					array(
 						'sort_column'  => 'menu_order',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds support for `single_select_page_with_search` in WooCommerce REST API. This is the setting type used for Cart, Checkout, My Account, and Terms and Conditions pages in WooCommerce settings.

Previously, querying `wc/v3/settings/advanced` would not return those values, you also can't set them or access them.
This is because they were refactored last year from using `single_select_page` to using `single_select_page_with_search` in #29181 but the API handling was not updated.

`single_select_page` works exactly like `single_select_page_with_search` where the first just lists pages, and the second attempts to allow you to search them ahead of printing everything.

Common wisdom would say to refactor the `Shop page` to use `single_select_page_with_search` as well, because whatever concerns with those pages, it also exists with Shop Page. Let me know if this can happen in a follow up.

Another follow up would be to not list all possible options in the REST API, but just validate incoming POST requests, however, that would also require adding specific handling for `single_select_page_with_search`, grounds for a follow up, let me know if this something you all want to do.

### How to test the changes in this Pull Request:

1. On trunk, hit `v3/settings/advanced/woocommerce_cart_page_id` you will get `rest_setting_setting_invalid` error.
2. Hit the same path on this PR, you will get a full response with options and all
3. Now, `PUT` into the same request, using a body of `{ "value": "42" }` where 42 is some public page id, your setting should persist.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
