### PR TITLE
Make use of GHA feature in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,17 +66,16 @@ jobs:
         run: pnpm build:feature-config --filter=woocommerce
 
       - name: Add PHP8 Compatibility.
+        if: ${{ matrix.php == '8.0' }}
         run: |
-          if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
-             cd plugins/woocommerce
-             curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-             unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-             composer bin phpunit config --unset platform
-             composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-             composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-             rm -rf ./vendor/phpunit/
-             composer dump-autoload
-           fi
+           cd plugins/woocommerce
+           curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
+           unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
+           composer bin phpunit config --unset platform
+           composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
+           composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
+           rm -rf ./vendor/phpunit/
+           composer dump-autoload
 
       - name: Init DB and WP
         working-directory: plugins/woocommerce


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Use GHA feature to detect PHP version.
I know, I know, it does not do a greater than check but future PHP versions could be added easily.

### How to test the changes in this Pull Request:

1. Run CI
