### PR TITLE
Ensure that schema and DB changes are reported to the changes JSON file.

### DIFF
--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -140,9 +140,9 @@ export default class Analyzer extends Command {
 
 			CliUx.ux.action.stop();
 
-			this.scanChanges( diff, pluginData[ 0 ], flags, schemaDiff );
+			await this.scanChanges( diff, pluginData[ 0 ], flags, schemaDiff );
 		} else {
-			this.scanChanges( diff, pluginData[ 0 ], flags );
+			await this.scanChanges( diff, pluginData[ 0 ], flags );
 		}
 
 		// Clean up the temporary repo.
@@ -233,9 +233,11 @@ export default class Analyzer extends Command {
 	) {
 		const { output, file } = flags;
 		CliUx.ux.action.start( 'Generating changes' );
+
 		const templates = this.scanTemplates( content, version );
 		const hooks = this.scanHooks( content, version, output );
 		const databaseUpdates = this.scanDatabases( content );
+		let schemaDiffResult = {};
 
 		if ( templates.size ) {
 			printTemplateResults(
@@ -257,7 +259,7 @@ export default class Analyzer extends Command {
 		}
 
 		if ( ! areSchemasEqual( schemaDiff ) ) {
-			printSchemaChange(
+			schemaDiffResult = printSchemaChange(
 				schemaDiff,
 				version,
 				output,
@@ -281,7 +283,7 @@ export default class Analyzer extends Command {
 			templates: Object.fromEntries( templates.entries() ),
 			hooks: Object.fromEntries( hooks.entries() ),
 			db: databaseUpdates || {},
-			schema: schemaDiff || {},
+			schema: schemaDiffResult || {},
 		} );
 
 		CliUx.ux.action.stop();
@@ -446,11 +448,12 @@ export default class Analyzer extends Command {
 
 				const name = getHookName( hookName[ 3 ] );
 
-				const description = getHookDescription( raw, name );
+				const description = getHookDescription( raw, name ) || '';
 
 				if ( ! description ) {
 					this.error(
-						`Hook ${ name } has no description. Please add a description.`
+						`Hook ${ name } has no description. Please add a description.`,
+						{ exit: false }
 					);
 				}
 

--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -237,12 +237,6 @@ export default class Analyzer extends Command {
 		const hooks = this.scanHooks( content, version, output );
 		const databaseUpdates = this.scanDatabases( content );
 
-		await generateJSONFile( join( process.cwd(), file ), {
-			templates: Object.fromEntries( templates.entries() ),
-			hooks: Object.fromEntries( hooks.entries() ),
-			schema: databaseUpdates || {},
-		} );
-
 		if ( templates.size ) {
 			printTemplateResults(
 				templates,
@@ -282,6 +276,13 @@ export default class Analyzer extends Command {
 		} else {
 			this.log( 'No database updates found' );
 		}
+
+		await generateJSONFile( join( process.cwd(), file ), {
+			templates: Object.fromEntries( templates.entries() ),
+			hooks: Object.fromEntries( hooks.entries() ),
+			db: databaseUpdates || {},
+			schema: schemaDiff || {},
+		} );
 
 		CliUx.ux.action.stop();
 	}

--- a/tools/code-analyzer/src/print.ts
+++ b/tools/code-analyzer/src/print.ts
@@ -114,9 +114,10 @@ export const printSchemaChange = (
 	version: string,
 	output: string,
 	log: ( s: string ) => void
-): void => {
+): Record< string, string > => {
+	const diff: Record< string, string > = {};
 	if ( ! schemaDiff ) {
-		return;
+		return diff;
 	}
 	if ( output === 'github' ) {
 		let githubCommentContent = '\\n\\n### New schema changes:';
@@ -137,9 +138,11 @@ export const printSchemaChange = (
 					` NOTICE | Schema changes detected in ${ schemaDiff[ key ].method } as of ${ version }`
 				);
 				log( '---------------------------------------------------' );
+				diff[ key ] = schemaDiff[ key ].method;
 			}
 		} );
 	}
+	return diff;
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There was a mistake made (by me) originally when generating the changes json file for the code-analyzer. It added the DB changes to the `schema` prop and it didn't report schema changes. This resolves that ensuring that all the change data is added to the changes JSON file and under more correct prop names.

I have also as a follow up needed to refactor a few things to get this working:

1. `printSchemaChange` has the logic for reporting schema changes in it, I've adjusted it to return this information so we can store and output to the JSON file.

2. There was a bug where no `await` happened on `scanChanges`
3. There was a bug in `scanHooks`, it would exit with error if it found no description, I don't think that behaviour is desirable, we want to see all errors.

### How to test the changes in this Pull Request:

* Run code-analyzer from the `tools/code-analyzer` dir, e.g. `./bin/dev analyzer -s "https://github.com/woocommerce/woocommerce.git" "b7931409f2a553bea765f0fda421f182c58d8e4b"`
* See that the command generated a `changes.json` file containing changes with the following props: `schema`, `db`, `hooks`, `templates`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
