### PR TITLE
Keep the user in the marketing task after installing an extension

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
@@ -15,6 +15,7 @@ import { useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
+import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -92,7 +93,7 @@ export const getMarketingExtensionLists = (
 };
 
 export type MarketingProps = {
-	onComplete: ( bool?: boolean ) => void;
+	onComplete: ( option?: { redirectPath: string } ) => void;
 };
 
 const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
@@ -144,7 +145,9 @@ const Marketing: React.FC< MarketingProps > = ( { onComplete } ) => {
 
 				createNoticesFromResponse( response );
 				setCurrentPlugin( null );
-				onComplete();
+				onComplete( {
+					redirectPath: getNewPath( { task: 'marketing' } ),
+				} );
 			} )
 			.catch( ( response: { errors: Record< string, string > } ) => {
 				createNoticesFromResponse( response );

--- a/plugins/woocommerce/changelog/update-33846-tweak-marketing-task-flow-after-installing-a-plugin
+++ b/plugins/woocommerce/changelog/update-33846-tweak-marketing-task-flow-after-installing-a-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak the marketing task flow after installing a plugin


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33846.

As PR title, keep the user in the marketing task after installing an extension

### How to test the changes in this Pull Request:

1. Go to `WooCommerce > Home`
2. Go to "Add sales channels" task
3. Click on either one of the "Get Started" buttons under `Recommended marketing extensions` section.
4. Observe that after the plugin is installed, you're not redirected to other pages.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
