### PR TITLE
Enhance/34244 update data source poller for i18n

### DIFF
--- a/plugins/woocommerce/changelog/enhance-34244-data-source-poller-for-i18n
+++ b/plugins/woocommerce/changelog/enhance-34244-data-source-poller-for-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add i18n support for data source poller

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -7,7 +7,6 @@ namespace Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\RemoteInboxNotifications\SpecRunner;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DefaultPaymentGateways;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\PaymentGatewaysController;
 
@@ -25,7 +24,6 @@ class Init {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'change_locale', array( __CLASS__, 'delete_specs_transient' ) );
 		PaymentGatewaysController::init();
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/Init.php
@@ -19,7 +19,6 @@ class Init {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'change_locale', array( __CLASS__, 'delete_specs_transient' ) );
 		add_action( 'woocommerce_updated', array( __CLASS__, 'delete_specs_transient' ) );
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -24,8 +24,6 @@ class Init {
 	public function __construct() {
 		include_once __DIR__ . '/WCPaymentGatewayPreInstallWCPayPromotion.php';
 
-		add_action( 'change_locale', array( __CLASS__, 'delete_specs_transient' ) );
-
 		$is_payments_page = isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab']; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! wp_is_json_request() && ! $is_payments_page ) {
 			return;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/data-source-poller.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/data-source-poller.php
@@ -83,10 +83,6 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 	public function test_read_data_source() {
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
-		$locale             = get_locale();
-		$this->assertArrayHasKey( $locale, $data );
-
-		$data = $data[ $locale ];
 		$this->assertArrayHasKey( 'mock-gateway1', $data );
 		$this->assertArrayHasKey( 'mock-gateway2', $data );
 		$this->assertArrayNotHasKey( 'mock-gateway3', $data );
@@ -108,10 +104,6 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
-		$locale             = get_locale();
-		$this->assertArrayHasKey( $locale, $data );
-
-		$data = $data[ $locale ];
 		$this->assertEmpty( $data );
 	}
 
@@ -132,10 +124,6 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
-		$locale             = get_locale();
-		$this->assertArrayHasKey( $locale, $data );
-
-		$data = $data[ $locale ];
 		$this->assertArrayHasKey( 'mock-gateway1', $data );
 		$this->assertArrayHasKey( 'mock-gateway2', $data );
 		$this->assertArrayHasKey( 'mock-gateway3', $data );
@@ -170,16 +158,14 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
-		$locale             = get_locale();
+		$this->assertCount( 2, $data );
+
+		$data   = get_transient( 'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
+		$locale = get_locale();
 		$this->assertArrayHasKey( $locale, $data );
 
 		$data = $data[ $locale ];
 		$this->assertCount( 2, $data );
 
-		$data = get_transient( 'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
-		$this->assertArrayHasKey( $locale, $data );
-
-		$data = $data[ $locale ];
-		$this->assertCount( 2, $data );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/data-source-poller.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/data-source-poller.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Admin\Tests\PaymentGatewaySuggestions
  */
 
-use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as PaymentGatewaySuggestions;
 use Automattic\WooCommerce\Admin\DataSourcePoller;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\PaymentGatewaySuggestionsDataSourcePoller;
 
@@ -33,7 +32,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 			function( $pre, $parsed_args, $url ) {
 				$locale = get_locale();
 
-				if ( 'payment-gateway-suggestions-data-source.json?_locale=' . $locale === $url ) {
+				if ( $url === 'payment-gateway-suggestions-data-source.json?locale=' . $locale ) {
 					return array(
 						'body' => wp_json_encode(
 							array(
@@ -51,7 +50,7 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 					);
 				}
 
-				if ( 'payment-gateway-suggestions-data-source2.json?_locale=' . $locale === $url ) {
+				if ( $url === 'payment-gateway-suggestions-data-source2.json?locale=' . $locale ) {
 					return array(
 						'body' => wp_json_encode(
 							array(
@@ -84,6 +83,10 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 	public function test_read_data_source() {
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
+		$locale             = get_locale();
+		$this->assertArrayHasKey( $locale, $data );
+
+		$data = $data[ $locale ];
 		$this->assertArrayHasKey( 'mock-gateway1', $data );
 		$this->assertArrayHasKey( 'mock-gateway2', $data );
 		$this->assertArrayNotHasKey( 'mock-gateway3', $data );
@@ -105,6 +108,10 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
+		$locale             = get_locale();
+		$this->assertArrayHasKey( $locale, $data );
+
+		$data = $data[ $locale ];
 		$this->assertEmpty( $data );
 	}
 
@@ -125,6 +132,10 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
+		$locale             = get_locale();
+		$this->assertArrayHasKey( $locale, $data );
+
+		$data = $data[ $locale ];
 		$this->assertArrayHasKey( 'mock-gateway1', $data );
 		$this->assertArrayHasKey( 'mock-gateway2', $data );
 		$this->assertArrayHasKey( 'mock-gateway3', $data );
@@ -159,9 +170,16 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_DataSourcePoller extends WC_Unit_
 
 		$data_source_poller = PaymentGatewaySuggestionsDataSourcePoller::get_instance();
 		$data               = $data_source_poller->get_specs_from_data_sources();
+		$locale             = get_locale();
+		$this->assertArrayHasKey( $locale, $data );
+
+		$data = $data[ $locale ];
 		$this->assertCount( 2, $data );
 
 		$data = get_transient( 'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs' );
+		$this->assertArrayHasKey( $locale, $data );
+
+		$data = $data[ $locale ];
 		$this->assertCount( 2, $data );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/payment-gateway-suggestions/payment-gateway-suggestions.php
@@ -52,12 +52,14 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 	 */
 	public function get_mock_specs() {
 		return array(
-			array(
-				'id'         => 'mock-gateway',
-				'is_visible' => (object) array(
-					'type'      => 'base_location_country',
-					'value'     => 'ZA',
-					'operation' => '=',
+			'en_US' => array(
+				array(
+					'id'         => 'mock-gateway',
+					'is_visible' => (object) array(
+						'type'      => 'base_location_country',
+						'value'     => 'ZA',
+						'operation' => '=',
+					),
 				),
 			),
 		);
@@ -87,11 +89,13 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 		set_transient(
 			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
 			array(
-				array(
-					'id' => 'mock-gateway1',
-				),
-				array(
-					'id' => 'mock-gateway2',
+				'en_US' => array(
+					array(
+						'id' => 'mock-gateway1',
+					),
+					array(
+						'id' => 'mock-gateway2',
+					),
 				),
 			)
 		);
@@ -126,33 +130,33 @@ class WC_Admin_Tests_PaymentGatewaySuggestions_Init extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that the transient is deleted on locale change.
+	 * Test that matched locale specs are read from cache.
 	 */
-	public function test_delete_transient_on_locale_change() {
+	public function test_specs_locale_transient() {
 		set_transient(
 			'woocommerce_admin_' . PaymentGatewaySuggestionsDataSourcePoller::ID . '_specs',
 			array(
-				array(
-					'id' => 'mock-gateway',
+				'en_US' => array(
+					array(
+						'id' => 'mock-gateway',
+					),
+				),
+				'zh_TW' => array(
+					array(
+						'id' => 'default-gateway',
+					),
 				),
 			)
 		);
 
 		add_filter(
-			'get_available_languages',
-			function( $languages ) {
-				$languages[] = 'zh_TW';
-				return $languages;
+			'locale',
+			function( $_locale ) {
+				return 'zh_TW';
 			}
 		);
 
-		$wp_locale_switcher = new WP_Locale_switcher();
-		$wp_locale_switcher->switch_to_locale( 'zh_TW' );
-
 		$suggestions = PaymentGatewaySuggestions::get_suggestions();
-
-		$wp_locale_switcher->switch_to_locale( 'en_US' );
-
 		$this->assertEquals( 'default-gateway', $suggestions[0]->id );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34244.

Add the i18n support for data source poller:

1. Send a request to WCCOM endpoint with locale- `https://woocommerce.com/wp-json/wccom/my-endpoint?locale=zh_TW` if the locale data is not in the transient
2. Locale is stored in transient in associative array `array( 'en_US' => ...., 'zh_TW => ... )`
3. DataSourcePoller.php includes a logic to retrieve the correct locale based on site/user.


### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to OBW
3. Select a country where WCPay is not supported such as `Afghanistan`
4. Uncheck `Add recommended business features to my site`  in the Business details / free features step and finish the steps.
6. Go to the Setting page
7. Change site language to `Español`
8. Go to `Escritorio > Actualizaciones` (Dashboard > Updates)
9. Click on the Update Translations (`Traducciones`) button to download WooCommerce translation files.
10. Go to WooCommerce > Home
11. Click on `Configurar pagos` (payment) task 
12. Observe plugin descriptions are translated.
13. Go back to WooCommerce > Home
14. Click on `Consigue más ventas` (marketing) task
15. Observe plugin descriptions are translated.
16. Go to OBW > Business details / free features (http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details)
17. Click on `Detalles del negocio` tab
18. Expand the `Añade características de negocios recomendadas para mi sitio`
19. Observe plugin descriptions are translated.
20. Go to `Usuarios > Perfil` (User > Profile)
21. Change `Idioma` back to English
22. Repeat 10~19 and confirm that all texts are in English

![Screen Shot 2022-08-10 at 12 37 10](https://user-images.githubusercontent.com/4344253/183816934-006334b7-42f2-4741-9add-85f8ca193dfa.png)
![Screen Shot 2022-08-10 at 12 36 57](https://user-images.githubusercontent.com/4344253/183816942-3b7dad6a-ecd8-4c1c-b7d5-0b548430d4c0.png)
![Screen Shot 2022-08-10 at 12 36 47](https://user-images.githubusercontent.com/4344253/183816952-7cc7ff62-f799-44ea-8b60-028e747e4212.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
