### PR TITLE
fix: removed Step 1 of 1 for 1 step tours

### DIFF
--- a/packages/js/components/changelog/fix-tour-kit-1-step-controls
+++ b/packages/js/components/changelog/fix-tour-kit-1-step-controls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Removed Step 1 of 1 step description for 1 step tours

--- a/packages/js/components/src/tour-kit/components/step-navigation.tsx
+++ b/packages/js/components/src/tour-kit/components/step-navigation.tsx
@@ -83,12 +83,14 @@ const StepNavigation: React.FunctionComponent< Props > = ( {
 	return (
 		<div className="woocommerce-tour-kit-step-navigation">
 			<div className="woocommerce-tour-kit-step-navigation__step">
-				{ sprintf(
-					/* translators: current progress in tour, eg: "Step 2 of 4" */
-					__( 'Step %1$d of %2$d', 'woocommerce' ),
-					currentStepIndex + 1,
-					steps.length
-				) }
+				{ steps.length > 1
+					? sprintf(
+							/* translators: current progress in tour, eg: "Step 2 of 4" */
+							__( 'Step %1$d of %2$d', 'woocommerce' ),
+							currentStepIndex + 1,
+							steps.length
+					  )
+					: null }
 			</div>
 			{ renderButtons() }
 		</div>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

In the existing tour kit, we show a 'Step 1 of 1' for 1 step tours. This is unsightly and was requested to be removed in one of the calls 😀 

![image](https://user-images.githubusercontent.com/27843274/183846949-c3d6b358-9c36-49ff-9af9-76a709b6c890.png)

### Changes proposed in this Pull Request:

Checks steps.length > 1, otherwise do not render the step count text

### How to test the changes in this Pull Request:

1. Install WooCommerce, no need to complete onboarding wizard
2. Click on "Add store details" in the task list to see the store location details tour
3. There should not be a 'Step 1 of 1' text.

![image](https://user-images.githubusercontent.com/27843274/183847511-e6f2779f-00a6-44d7-ac4b-bcb0a0bdaa39.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
