### PR TITLE
Fixed spacing issue single product gallery thumb image

### DIFF
--- a/plugins/woocommerce/changelog/update_woocommerce-thumb-issue
+++ b/plugins/woocommerce/changelog/update_woocommerce-thumb-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix product gallery images spcing in twenty-twenty theme

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -668,7 +668,7 @@ a.reset_variations {
 
 	.flex-control-thumbs li {
 		width: 14.2857142857%;
-		margin: 0 14.2857142857% 1.6em 0;
+		margin: 0 1em 1.6em 0;
 	}
 
 	.flex-control-thumbs li:nth-child(4n) {


### PR DESCRIPTION
I have solved the issue which is mentioned in #34253 
1)Activate twenty twenty theme.
2)Install woocommerce plugin and move on single product page.
3)Single product thumb image right spacing occur.