### PR TITLE
Add flag to state it is in dev mode so tools are installed like phpun…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Install and Build
         uses: ./.github/actions/install-build
+        with:
+          composer_no_dev: 0
 
       - name: Build Admin feature config
         run: pnpm build:feature-config --filter=woocommerce


### PR DESCRIPTION
…it closes #34158

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34158 

This PR fixes the failing PHPUnit CI tests. The issue was that `install and build` step was not including the PHPUnit tool because by default, it uses the `no-dev` flag for composer. The apparent fix was to add the flag to `0` signifying we want it to include dev tools.

### How to test the changes in this Pull Request:

1. Manually run the test here https://github.com/woocommerce/woocommerce/actions/workflows/ci.yml by clicking on `Run workflow` and selecting this branch to test against. `fix/phpunit-ci`
2. Witness the PHPUnit tests run successfully.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
