### PR TITLE
Make qty input box visible when min_qty = max_qty

### DIFF
--- a/plugins/woocommerce/changelog/fix-GH-34280
+++ b/plugins/woocommerce/changelog/fix-GH-34280
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix qty input not showing when min_qty = max_qty

--- a/plugins/woocommerce/changelog/fix-GH-34280
+++ b/plugins/woocommerce/changelog/fix-GH-34280
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix qty input not showing when min_qty = max_qty
+When the minimum and maximum quantity are identical, render the quantity input and set it to disabled.

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -103,20 +103,24 @@ do_action( 'woocommerce_before_cart' ); ?>
 						<td class="product-quantity" data-title="<?php esc_attr_e( 'Quantity', 'woocommerce' ); ?>">
 						<?php
 						if ( $_product->is_sold_individually() ) {
-							$product_quantity = sprintf( '1 <input type="hidden" name="cart[%s][qty]" value="1" />', $cart_item_key );
+							$min_quantity = 1;
+							$max_quantity = 1;
 						} else {
-							$product_quantity = woocommerce_quantity_input(
-								array(
-									'input_name'   => "cart[{$cart_item_key}][qty]",
-									'input_value'  => $cart_item['quantity'],
-									'max_value'    => $_product->get_max_purchase_quantity(),
-									'min_value'    => '0',
-									'product_name' => $_product->get_name(),
-								),
-								$_product,
-								false
-							);
+							$min_quantity = 0;
+							$max_quantity = $_product->get_max_purchase_quantity();
 						}
+
+						$product_quantity = woocommerce_quantity_input(
+							array(
+								'input_name'   => "cart[{$cart_item_key}][qty]",
+								'input_value'  => $cart_item['quantity'],
+								'max_value'    => $max_quantity,
+								'min_value'    => $min_quantity,
+								'product_name' => $_product->get_name(),
+							),
+							$_product,
+							false
+						);
 
 						echo apply_filters( 'woocommerce_cart_item_quantity', $product_quantity, $cart_item_key, $cart_item ); // PHPCS: XSS ok.
 						?>

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,7 +33,7 @@ if ( $max_value && $min_value === $max_value ) {
 	/**
 	 * Hook to output something before the quantity input field.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 */
 	do_action( 'woocommerce_before_quantity_input_field' );
 	?>

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -23,29 +23,43 @@ if ( $max_value && $min_value === $max_value ) {
 		<input type="hidden" id="<?php echo esc_attr( $input_id ); ?>" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
 	</div>
 	<?php
-} else {
-	/* translators: %s: Quantity. */
-	$label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : esc_html__( 'Quantity', 'woocommerce' );
-	?>
-	<div class="quantity">
-		<?php do_action( 'woocommerce_before_quantity_input_field' ); ?>
-		<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
-		<input
-			type="number"
-			id="<?php echo esc_attr( $input_id ); ?>"
-			class="<?php echo esc_attr( join( ' ', (array) $classes ) ); ?>"
-			step="<?php echo esc_attr( $step ); ?>"
-			min="<?php echo esc_attr( $min_value ); ?>"
-			max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
-			name="<?php echo esc_attr( $input_name ); ?>"
-			value="<?php echo esc_attr( $input_value ); ?>"
-			title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ); ?>"
-			size="4"
-			placeholder="<?php echo esc_attr( $placeholder ); ?>"
-			inputmode="<?php echo esc_attr( $inputmode ); ?>"
-			autocomplete="<?php echo esc_attr( isset( $autocomplete ) ? $autocomplete : 'on' ); ?>"
-		/>
-		<?php do_action( 'woocommerce_after_quantity_input_field' ); ?>
-	</div>
-	<?php
 }
+/* translators: %s: Quantity. */
+$label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : esc_html__( 'Quantity', 'woocommerce' );
+?>
+<div class="quantity">
+	<?php
+	/**
+	 * Hook to output something before quantity input field
+	 *
+	 * @since 3.6.0
+	 */
+	do_action( 'woocommerce_before_quantity_input_field' );
+	?>
+	<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
+	<input
+		type="number"
+		<?php disabled( $max_value && $min_value === $max_value ); ?>
+		id="<?php echo esc_attr( $input_id ); ?>"
+		class="<?php echo esc_attr( join( ' ', (array) $classes ) ); ?>"
+		step="<?php echo esc_attr( $step ); ?>"
+		min="<?php echo esc_attr( $min_value ); ?>"
+		max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
+		name="<?php echo esc_attr( $input_name ); ?>"
+		value="<?php echo esc_attr( $input_value ); ?>"
+		title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ); ?>"
+		size="4"
+		placeholder="<?php echo esc_attr( $placeholder ); ?>"
+		inputmode="<?php echo esc_attr( $inputmode ); ?>"
+		autocomplete="<?php echo esc_attr( isset( $autocomplete ) ? $autocomplete : 'on' ); ?>"
+	/>
+	<?php
+	/**
+	 * Hook to output something after quantity input field
+	 *
+	 * @since 3.6.0
+	 */
+	do_action( 'woocommerce_after_quantity_input_field' );
+	?>
+</div>
+<?php

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -32,7 +32,7 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 	/**
 	 * Hook to output something before the quantity input field.
 	 *
-	 * @SInCE 7.0.0
+	 * @since 7.0.0
 	 */
 	do_action( 'woocommerce_before_quantity_input_field' );
 	?>

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -30,9 +30,9 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 <div class="quantity">
 	<?php
 	/**
-	 * Hook to output something before quantity input field
+	 * Hook to output something before the quantity input field.
 	 *
-	 * @since 3.6.0
+	 * @SInCE 7.0.0
 	 */
 	do_action( 'woocommerce_before_quantity_input_field' );
 	?>

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,46 +12,49 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.0.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
-if ( $max_value && $min_value === $max_value ) {
-	?>
-	<div class="quantity hidden">
-		<input type="hidden" id="<?php echo esc_attr( $input_id ); ?>" class="qty" name="<?php echo esc_attr( $input_name ); ?>" value="<?php echo esc_attr( $min_value ); ?>" />
-	</div>
-	<?php
-}
 /* translators: %s: Quantity. */
 $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : esc_html__( 'Quantity', 'woocommerce' );
+
+// In some cases we wish to display the quantity but not allow for it to be changed.
+if ( $max_value && $min_value === $max_value ) {
+	$is_readonly = true;
+	$input_value = $min_value;
+} else {
+	$is_readonly = false;
+}
 ?>
 <div class="quantity">
 	<?php
 	/**
 	 * Hook to output something before the quantity input field.
 	 *
-	 * @since 7.0.0
+	 * @since 7.1.0
 	 */
 	do_action( 'woocommerce_before_quantity_input_field' );
 	?>
 	<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
 	<input
-		type="number"
-		<?php disabled( $max_value && $min_value === $max_value ); ?>
+		type="<?php echo $is_readonly ? 'text' : 'number'; ?>"
+		<?php wp_readonly( $is_readonly ); ?>
 		id="<?php echo esc_attr( $input_id ); ?>"
 		class="<?php echo esc_attr( join( ' ', (array) $classes ) ); ?>"
-		step="<?php echo esc_attr( $step ); ?>"
-		min="<?php echo esc_attr( $min_value ); ?>"
-		max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
 		name="<?php echo esc_attr( $input_name ); ?>"
 		value="<?php echo esc_attr( $input_value ); ?>"
 		title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ); ?>"
 		size="4"
-		placeholder="<?php echo esc_attr( $placeholder ); ?>"
-		inputmode="<?php echo esc_attr( $inputmode ); ?>"
-		autocomplete="<?php echo esc_attr( isset( $autocomplete ) ? $autocomplete : 'on' ); ?>"
+		<?php if ( ! $is_readonly ): ?>
+			step="<?php echo esc_attr( $step ); ?>"
+			min="<?php echo esc_attr( $min_value ); ?>"
+			max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
+			placeholder="<?php echo esc_attr( $placeholder ); ?>"
+			inputmode="<?php echo esc_attr( $inputmode ); ?>"
+			autocomplete="<?php echo esc_attr( isset( $autocomplete ) ? $autocomplete : 'on' ); ?>"
+		<?php endif; ?>
 	/>
 	<?php
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change makes the input for quantity visible when `min_qty = max_qty`. The dropdown will be disabled so that users won't be able to change it. 

Closes #34280.

### How to test the changes in this Pull Request:

1. Add https://github.com/woocommerce/woocommerce-min-max-quantities.
2. Create a simple product with min_qty=max_qty. 
3. Go add the product page. You will be able to see the quantity input there.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
