### PR TITLE
Fix/34271 unlimited results

### DIFF
--- a/plugins/woocommerce/changelog/fix-34271-unlimited-results
+++ b/plugins/woocommerce/changelog/fix-34271-unlimited-results
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure COT order queries respect unlimited ('-1') as a pagination limit.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -12,6 +12,12 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * This class provides a `WP_Query`-like interface to custom order tables.
+ *
+ * @property-read int   $found_orders  Number of found orders.
+ * @property-read int   $found_posts   Alias of the `$found_orders` property.
+ * @property-read int   $max_num_pages Max number of pages matching the current query.
+ * @property-read array $orders        Order objects, or order IDs.
+ * @property-read array $posts         Alias of the $orders property.
  */
 class OrdersTableQuery {
 
@@ -26,7 +32,9 @@ class OrdersTableQuery {
 	public const REGEX_SHORTHAND_DATES = '/([^.<>]*)(>=|<=|>|<|\.\.\.)([^.<>]+)/';
 
 	/**
-	 * Highest possible unsigned bigint (which is the type of the `id` column.
+	 * Highest possible unsigned bigint value (unsigned bigints being the type of the `id` column).
+	 *
+	 * This is deliberately held as a string, rather than a numeric type, for inclusion within queries.
 	 */
 	private const MYSQL_MAX_UNSIGNED_BIGINT = '18446744073709551615';
 


### PR DESCRIPTION
As described in [this wiki entry](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query), it should be possible to supply a limit of `(int) -1` when querying for orders, as a way of indicating there should be no limit.

This change adds support for this idea to COT order queries.

Closes #34271.

### How to test the changes in this Pull Request:

1. Review newly added assertions relating to pagination of COT queries.
2. Optionally, write some order queries of your own, focusing on use of `'limit'`, `'paged'`, and `'offset'`.
3. Optionally, review the COT Admin Order List Table: the order counts in the subsubsub links should show real values (at time of writing, with latest `trunk`, this does not happen):

<img width="506" alt="cot-order-counts-subsubsub-links" src="https://user-images.githubusercontent.com/3594411/184192092-a9aa79eb-e417-459d-8354-7c7309ab9668.png">

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
