### PR TITLE
[COT] Respect status flags `show_in_admin_(all|status)_list` in orders list table

### DIFF
--- a/plugins/woocommerce/changelog/fix-34145
+++ b/plugins/woocommerce/changelog/fix-34145
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Honor 'show_in_admin_all_list' and 'show_in_admin_status_list' in COT orders list table.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -280,8 +280,6 @@ class ListTable extends WP_List_Table {
 	 * @return array
 	 */
 	public function get_views() {
-		global $wp_post_statuses;
-
 		$view_counts = array();
 		$view_links  = array();
 		$statuses    = wc_get_order_statuses();
@@ -289,9 +287,7 @@ class ListTable extends WP_List_Table {
 
 		// Add 'draft' and 'trash' to list.
 		foreach ( array( 'draft', 'trash' ) as $wp_status ) {
-			if ( isset( $wp_post_statuses[ $wp_status ] ) ) {
-				$statuses[ $wp_status ] = $wp_post_statuses[ $wp_status ]->label;
-			}
+			$statuses[ $wp_status ] = ( get_post_status_object( $wp_status ) )->label;
 		}
 
 		$statuses_in_list = array_intersect( array_keys( $statuses ), get_post_stati( array( 'show_in_admin_status_list' => true ) ) );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -317,8 +317,6 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Count orders by status.
 	 *
-	 * @todo review and replace (probably not ideal to do this work here).
-	 *
 	 * @param string $status The order status we are interested in.
 	 *
 	 * @return int
@@ -379,11 +377,11 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Render the months filter dropdown.
 	 *
-	 * @todo [review] we may prefer to move this logic outside of the ListTable class
-	 *
 	 * @return void
 	 */
 	private function months_filter() {
+		// XXX: [review] we may prefer to move this logic outside of the ListTable class.
+
 		global $wp_locale;
 		global $wpdb;
 
@@ -834,10 +832,10 @@ class ListTable extends WP_List_Table {
 		$report_action = '';
 		$changed       = 0;
 
-		if ( 'remove_personal_data' === $action ) {
+		if ( $action === 'remove_personal_data' ) {
 			$report_action = 'removed_personal_data';
 			$changed       = $this->do_bulk_action_remove_personal_data( $ids );
-		} elseif ( false !== strpos( $action, 'mark_' ) ) {
+		} elseif ( strpos( $action, 'mark_' ) !== false ) {
 			$order_statuses = wc_get_order_statuses();
 			$new_status     = substr( $action, 5 );
 			$report_action  = 'marked_' . $new_status;
@@ -935,7 +933,7 @@ class ListTable extends WP_List_Table {
 			}
 		}
 
-		if ( 'removed_personal_data' === $bulk_action ) { // WPCS: input var ok, CSRF ok.
+		if ( $bulk_action === 'removed_personal_data' ) { // WPCS: input var ok, CSRF ok.
 			/* translators: %s: orders count */
 			$message = sprintf( _n( 'Removed personal data from %s order.', 'Removed personal data from %s orders.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 			echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -260,7 +260,7 @@ class ListTable extends WP_List_Table {
 		$status         = trim( sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ) );
 		$query_statuses = array();
 
-		if ( empty( $status ) || $status === 'all' ) {
+		if ( empty( $status ) || 'all' === $status ) {
 			$query_statuses = array_intersect(
 				array_keys( wc_get_order_statuses() ),
 				get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
@@ -301,7 +301,7 @@ class ListTable extends WP_List_Table {
 		}
 
 		$all_count         = array_sum( $view_counts );
-		$view_links['all'] = $this->get_view_link( 'all', __( 'All', 'woocommerce' ), $all_count, $current === '' || $current === 'all' );
+		$view_links['all'] = $this->get_view_link( 'all', __( 'All', 'woocommerce' ), $all_count, '' === $current || 'all' === $current );
 
 		foreach ( $view_counts as $slug => $count ) {
 			$view_links[ $slug ] = $this->get_view_link( $slug, $statuses[ $slug ], $count, $slug === $current );
@@ -828,10 +828,10 @@ class ListTable extends WP_List_Table {
 		$report_action = '';
 		$changed       = 0;
 
-		if ( $action === 'remove_personal_data' ) {
+		if ( 'remove_personal_data' === $action ) {
 			$report_action = 'removed_personal_data';
 			$changed       = $this->do_bulk_action_remove_personal_data( $ids );
-		} elseif ( strpos( $action, 'mark_' ) !== false ) {
+		} elseif ( false !== strpos( $action, 'mark_' ) ) {
 			$order_statuses = wc_get_order_statuses();
 			$new_status     = substr( $action, 5 );
 			$report_action  = 'marked_' . $new_status;
@@ -929,7 +929,7 @@ class ListTable extends WP_List_Table {
 			}
 		}
 
-		if ( $bulk_action === 'removed_personal_data' ) { // WPCS: input var ok, CSRF ok.
+		if ( 'removed_personal_data' === $bulk_action ) { // WPCS: input var ok, CSRF ok.
 			/* translators: %s: orders count */
 			$message = sprintf( _n( 'Removed personal data from %s order.', 'Removed personal data from %s orders.', $number, 'woocommerce' ), number_format_i18n( $number ) );
 			echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -643,10 +643,17 @@ class ListTable extends WP_List_Table {
 			}
 		}
 
-		if ( $tooltip ) {
-			printf( '<mark class="order-status %s tips" data-tip="%s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $order->get_status() ) ), wp_kses_post( $tooltip ), esc_html( wc_get_order_status_name( $order->get_status() ) ) );
+		// Gracefully handle legacy statuses.
+		if ( in_array( $order->get_status(), array( 'trash', 'draft' ), true ) ) {
+			$status_name = ( get_post_status_object( $order->get_status() ) )->label;
 		} else {
-			printf( '<mark class="order-status %s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $order->get_status() ) ), esc_html( wc_get_order_status_name( $order->get_status() ) ) );
+			$status_name = wc_get_order_status_name( $order->get_status() );
+		}
+
+		if ( $tooltip ) {
+			printf( '<mark class="order-status %s tips" data-tip="%s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $order->get_status() ) ), wp_kses_post( $tooltip ), esc_html( $status_name ) );
+		} else {
+			printf( '<mark class="order-status %s"><span>%s</span></mark>', esc_attr( sanitize_html_class( 'status-' . $order->get_status() ) ), esc_html( $status_name ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -173,10 +173,10 @@ class ListTable extends WP_List_Table {
 			'limit'    => $limit,
 			'page'     => $this->get_pagenum(),
 			'paginate' => true,
-			'status'   => sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? 'any' ) ),
 			'type'     => 'shop_order',
 		);
 
+		$this->set_status_args();
 		$this->set_order_args();
 		$this->set_date_args();
 		$this->set_customer_args();
@@ -251,6 +251,26 @@ class ListTable extends WP_List_Table {
 
 		$this->order_query_args['customer'] = $customer;
 		$this->has_filter                   = true;
+	}
+
+	/**
+	 * Implements filtering of orders by status.
+	 */
+	private function set_status_args() {
+		$status         = trim( sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ) );
+		$query_statuses = array();
+
+		if ( empty( $status ) || $status === 'all' ) {
+			$query_statuses = array_intersect(
+				array_keys( wc_get_order_statuses() ),
+				get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
+			);
+		} else {
+			$query_statuses[] = $status;
+			$this->has_filter = true;
+		}
+
+		$this->order_query_args['status'] = $query_statuses;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, the orders list table (COT) doesn't honor the `show_in_admin_status_list` or `show_in_admin_all_list` status flags that determine when a particular status should appear in the "Views" filter or included in the default view.

This PR implements support for these flags and also fixes a tiny error in `OrdersTableQuery`'s handling of pagination.

Closes #34145.

### How to test the changes in this Pull Request:

1. Enable COT support and make COT authoritative.
2. Either migrate some post-based orders or populate the table with some new.
3. Manually alter the `wc_orders` table (easier than the alternative) by setting the `status` column in some rows to `trash` and `wc-checkout-draft`.
3. Go to WooCommerce > Orders.
4. Confirm that:
   - On `trunk`, the default view incorrectly includes orders with `wc-checkout-draft`. Also, status "Trash" doesn't appear in the status filter.
   - On this branch, the default view correctly omits orders with trash or draft status. Also, "Trash" is listed in the filter.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
