### PR TITLE
Cat dashboard loading time

### DIFF
--- a/plugins/woocommerce/changelog/improve-cat-dashboard-loading-time
+++ b/plugins/woocommerce/changelog/improve-cat-dashboard-loading-time
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Improve the loading time of WooCommerce setup widget for large databases

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -187,7 +187,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 				return false;
 			}
 
-			if ( ! $this->get_task_list() || $this->get_task_list()->is_complete() || $this->get_task_list()->is_hidden() ) {
+			if ( ! $this->get_task_list() || $this->get_task_list()->is_hidden() || $this->get_task_list()->is_complete() ) {
 				return false;
 			}
 

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -19,7 +19,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		// Set default country to non-US so that 'payments' task gets added but 'woocommerce-payments' doesn't,
 		// by default it won't be considered completed but we can manually change that as needed.
 		update_option( 'woocommerce_default_country', 'JP' );
-		$password   = wp_generate_password( 8, false, false );
+		$password    = wp_generate_password( 8, false, false );
 		$this->admin = wp_insert_user(
 			array(
 				'user_login' => "test_admin$password",
@@ -88,11 +88,16 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 	 * Tests widget does not display when task list is complete.
 	 */
 	public function test_widget_does_not_display_when_task_list_complete() {
-		$task_list = new class {
+		// phpcs:disable Squiz.Commenting
+		$task_list = new class() {
 			public function is_complete() {
 				return true;
 			}
+			public function is_hidden() {
+				return false;
+			}
 		};
+		// phpcs:enable Squiz.Commenting
 		$widget    = $this->get_widget();
 		$widget->set_task_list( $task_list );
 


### PR DESCRIPTION
The checks whether the WooCommerce setup widget should be displayed can take up quite some time.
Rearranging the conditions can cut down the loading time to half.

In my test environment with a quite big and historically grown database the TTFB before the changes was at ~2.0s. After applying the changes the loading time was cut down to 0.5s while the logic behind wether or not the widget should be displayed should still be preserved.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. You should use a rather big and old WC database
2. Open the dashboard of an installation with an unfinished setup
3. Hopefully notice the changes in performance

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
