### PR TITLE
Fix review shipping option task title

### DIFF
--- a/plugins/woocommerce/changelog/fix-34270-review-shipping-option-task-title
+++ b/plugins/woocommerce/changelog/fix-34270-review-shipping-option-task-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Review Shipping Options task title

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -23,7 +23,7 @@ class ReviewShippingOptions extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Review Shipping Options', 'woocommerce' );
+		return __( 'Review shipping options', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/ReviewShippingOptions.php
@@ -50,7 +50,7 @@ class ReviewShippingOptions extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return 'yes' === get_option( 'woocommerce_admin_reviewed_default_shipping_zones' );
+		return get_option( 'woocommerce_admin_reviewed_default_shipping_zones' ) === 'yes';
 	}
 
 	/**
@@ -59,7 +59,7 @@ class ReviewShippingOptions extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		return 'yes' === get_option( 'woocommerce_admin_created_default_shipping_zones' );
+		return get_option( 'woocommerce_admin_created_default_shipping_zones' ) === 'yes';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34270.

This PR updates the task title from `Review Shipping Option` to `Review shipping option`

### How to test the changes in this Pull Request:

1. Start with a fresh install
2. Start OBW and choose United States as store country and fill out the "Address" field
3. Choose "Physical products"
4. Complete the OBW without installing anything from the Business Details tab.
5. Go to WooCommerce > Home
6. Observe that the shipping task appear with the title `Review shipping options` under "Things to do next"

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
