### PR TITLE
Add unit tests for orders milestone note

### DIFF
--- a/plugins/woocommerce/changelog/add-34250-unit-tests-for-orders-milestone-note
+++ b/plugins/woocommerce/changelog/add-34250-unit-tests-for-orders-milestone-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Refactor and add unit tests for "Orders Milestones" note

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -83,7 +83,7 @@ class Events {
 	/**
 	 * Daily events to run.
 	 *
-	 * Note: Order_Milestones::other_milestones is hooked to this as well.
+	 * Note: Order_Milestones::possibly_add_note is hooked to this as well.
 	 */
 	public function do_wc_admin_daily() {
 		$this->possibly_add_notes();

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
@@ -96,7 +96,7 @@ class OrderMilestones {
 
 		add_action( 'wc_admin_installed', array( $this, 'backfill_last_milestone' ) );
 
-		add_action( self::PROCESS_ORDERS_MILESTONE_HOOK, array( $this, 'other_milestones' ) );
+		add_action( self::PROCESS_ORDERS_MILESTONE_HOOK, array( $this, 'possibly_add_note' ) );
 	}
 
 	/**
@@ -289,35 +289,58 @@ class OrderMilestones {
 	}
 
 	/**
-	 * Add milestone notes for other significant thresholds.
+	 * Get the note by milestones.
+	 *
+	 * @param int $current_milestone Current milestone.
+	 *
+	 * @return Note
 	 */
-	public function other_milestones() {
-		// If the milestone notes have been disabled via filter, bail.
-		if ( ! $this->are_milestones_enabled() ) {
-			return;
-		}
-
-		$last_milestone    = $this->get_last_milestone();
-		$current_milestone = $this->get_current_milestone();
-
-		if ( $current_milestone <= $last_milestone ) {
-			return;
-		}
-
-		$this->set_last_milestone( $current_milestone );
-
-		// We only want one milestone note at any time.
-		Notes::delete_notes_with_name( self::NOTE_NAME );
-
+	public static function get_note_by_milestone( $current_milestone ) {
 		// Add the milestone note.
 		$note = new Note();
-		$note->set_title( $this->get_note_title_for_milestone( $current_milestone ) );
-		$note->set_content( $this->get_note_content_for_milestone( $current_milestone ) );
-		$note_action = $this->get_note_action_for_milestone( $current_milestone );
+		$note->set_title( self::get_note_title_for_milestone( $current_milestone ) );
+		$note->set_content( self::get_note_content_for_milestone( $current_milestone ) );
+		$note_action = self::get_note_action_for_milestone( $current_milestone );
 		$note->add_action( $note_action['name'], $note_action['label'], $note_action['query'] );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
+		return $note;
+	}
+
+	/**
+	 * Checks if a note can and should be added.
+	 *
+	 * @return bool
+	 */
+	public function can_be_added() {
+		// If the milestone notes have been disabled via filter, bail.
+		if ( ! $this->are_milestones_enabled() ) {
+			return false;
+		}
+
+		$current_milestone = $this->get_current_milestone();
+		$last_milestone    = $this->get_last_milestone();
+		if ( $current_milestone <= $last_milestone ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add milestone notes for other significant thresholds.
+	 */
+	public function possibly_add_note() {
+		if ( ! self::can_be_added() ) {
+			return;
+		}
+		$current_milestone = $this->get_current_milestone();
+		$this->set_last_milestone( $current_milestone );
+
+		// We only want one milestone note at any time.
+		Notes::delete_notes_with_name( self::NOTE_NAME );
+		$note = $this->get_note_by_milestone( $current_milestone );
 		$note->save();
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
@@ -296,7 +296,6 @@ class OrderMilestones {
 	 * @return Note
 	 */
 	public static function get_note_by_milestone( $current_milestone ) {
-		// Add the milestone note.
 		$note = new Note();
 		$note->set_title( self::get_note_title_for_milestone( $current_milestone ) );
 		$note->set_content( self::get_note_content_for_milestone( $current_milestone ) );
@@ -319,8 +318,9 @@ class OrderMilestones {
 			return false;
 		}
 
-		$current_milestone = $this->get_current_milestone();
 		$last_milestone    = $this->get_last_milestone();
+		$current_milestone = $this->get_current_milestone();
+
 		if ( $current_milestone <= $last_milestone ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
@@ -295,7 +295,7 @@ class OrderMilestones {
 	 *
 	 * @return Note
 	 */
-	public static function get_note_by_milestone( $current_milestone ) {
+	public function get_note_by_milestone( $current_milestone ) {
 		$note = new Note();
 		$note->set_title( self::get_note_title_for_milestone( $current_milestone ) );
 		$note->set_content( self::get_note_content_for_milestone( $current_milestone ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-test-order-milestones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-test-order-milestones.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * OrderMilestones note tests
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use \Automattic\WooCommerce\Internal\Admin\Notes\OrderMilestones;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+
+/**
+ * Class WC_Admin_Tests_Marketing_Notes
+ */
+class WC_Admin_Tests_Order_Milestones extends WC_Unit_Test_Case {
+
+	/**
+	 * @var OrderMilestones
+	 */
+	private $instance;
+
+	/**
+	 * setUp
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->instance = new OrderMilestones();
+	}
+
+	/**
+	 * Tests can_be_added method return false when woocommerce_admin_order_milestones_enabled is false.
+	 */
+	public function test_can_be_added_when_milestones_disabled() {
+		add_filter(
+			'woocommerce_admin_order_milestones_enabled',
+			function ( $enabled ) {
+				return false;
+			}
+		);
+		$this->assertFalse( $this->instance->can_be_added() );
+	}
+
+	/**
+	 * Tests can_be_added method return false when no orders received.
+	 */
+	public function test_can_be_added_when_no_orders_received() {
+		$this->assertFalse( $this->instance->can_be_added() );
+	}
+
+	/**
+	 * Tests can_be_added method return true when one orders received.
+	 */
+	public function test_can_be_added_when_orders_received() {
+		WC_Helper_Order::create_order();
+		$this->assertTrue( $this->instance->can_be_added() );
+	}
+
+	/**
+	 * Tests get_note_by_milestone method when milestone is 1.
+	 */
+	public function test_get_note_by_milestone_when_milestone_is_1() {
+		$note = $this->instance->get_note_by_milestone( 1 );
+		$this->assertEquals( $note->get_title(), 'First order received' );
+		$this->assertEquals( $note->get_content(), 'Congratulations on getting your first order! Now is a great time to learn how to manage your orders.' );
+		$this->assertEquals( $note->get_actions()[0]->label, 'Learn more' );
+	}
+
+	/**
+	 * Tests get_note_by_milestone method when no milestone is 10.
+	 */
+	public function test_get_note_by_milestone_when_milestone_is_10() {
+		$note = $this->instance->get_note_by_milestone( 10 );
+		$this->assertEquals( $note->get_title(), 'Congratulations on processing 10 orders!' );
+		$this->assertEquals( $note->get_content(), "You've hit the 10 orders milestone! Look at you go. Browse some WooCommerce success stories for inspiration." );
+		$this->assertEquals( $note->get_actions()[0]->label, 'Browse' );
+	}
+
+	/**
+	 * Tests get_note_by_milestone method when no milestone is 100.
+	 */
+	public function test_get_note_by_milestone_when_milestone_is_100() {
+		$note = $this->instance->get_note_by_milestone( 100 );
+		$this->assertEquals( $note->get_title(), 'Congratulations on processing 100 orders!' );
+		$this->assertEquals( $note->get_content(), 'Another order milestone! Take a look at your Orders Report to review your orders to date.' );
+		$this->assertEquals( $note->get_actions()[0]->label, 'Review your orders' );
+	}
+
+	/**
+	 * Tests possibly_add_note method when no orders received.
+	 */
+	public function test_possibly_add_note_when_no_orders_received() {
+		$this->instance->possibly_add_note();
+		$this->assertFalse( Notes::get_note_by_name( OrderMilestones::NOTE_NAME ) );
+	}
+
+	/**
+	 * Tests possibly_add_note method when no orders received.
+	 */
+	public function test_possibly_add_note_when_first_order_received() {
+		WC_Helper_Order::create_order();
+		$this->instance->possibly_add_note();
+		$note = Notes::get_note_by_name( OrderMilestones::NOTE_NAME );
+		$this->assertEquals( $note->get_title(), 'First order received' );
+	}
+
+	/**
+	 * Tests possibly_add_note method when tenth order received.
+	 */
+	public function test_possibly_add_note_when_tenth_order_received() {
+		for ( $i = 0; $i < 10; $i++ ) {
+			WC_Helper_Order::create_order();
+		}
+		$this->instance->possibly_add_note();
+		$note = Notes::get_note_by_name( OrderMilestones::NOTE_NAME );
+		$this->assertEquals( $note->get_content(), "You've hit the 10 orders milestone! Look at you go. Browse some WooCommerce success stories for inspiration." );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34250.

This PR adds unit tests for the orders milestone note, and refactors it to have `get_note` and `possibly_add_note` methods.

### How to test the changes in this Pull Request:

All actions should pass, except for [PHP 7.4 WP nightly](https://github.com/woocommerce/woocommerce/runs/7799898634?check_suite_focus=true). It's failing but it's irrelevant to this PR:

```
woocommerce:turbo:test: There was 1 error:
woocommerce:turbo:test: 
woocommerce:turbo:test: 1) WC_Admin_Tests_Plugins_Helper::test_get_plugin_data
woocommerce:turbo:test: PHPUnit\Framework\Exception: Argument #2 (No Value) of PHPUnit\Framework\Assert::assertArrayHasKey() must be a array or ArrayAccess
woocommerce:turbo:test: 
woocommerce:turbo:test: /home/runner/work/woocommerce/woocommerce/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php:133
woocommerce:turbo:test: phpvfscomposer:///home/runner/work/woocommerce/woocommerce/plugins/woocommerce/vendor/phpunit/phpunit/phpunit:60
woocommerce:turbo:test: 
woocommerce:turbo:test: --
```


1. Use a fresh site
2. Add an order manually or via Smooth Generator.
3. Run the cron event `wc_admin_process_orders_milestone`.
5. See the `First order received` note on the Home screen!

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
