### PR TITLE
Turbo: Avoid caching result of `build:feature-config`

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -9,14 +9,13 @@
 		"url": "https://github.com:woocommerce/woocommerce.git"
 	},
 	"scripts": {
-		"turbo:build": "pnpm run clean && WC_ADMIN_PHASE=core pnpm run build:feature-config && cross-env NODE_ENV=production WC_ADMIN_PHASE=core webpack",
+		"turbo:build": "pnpm run clean && cross-env NODE_ENV=production WC_ADMIN_PHASE=core webpack",
 		"turbo:test": "pnpm run test:client",
 		"analyze": "cross-env NODE_ENV=production ANALYZE=true webpack",
 		"build": "pnpm -w exec turbo run turbo:build --filter=$npm_package_name -- --",
 		"test": "pnpm -w exec turbo run turbo:test --filter=$npm_package_name -- --",
 		"lint": "pnpm run lint:js && pnpm run lint:css",
 		"build:feature-config": "php ../woocommerce/bin/generate-feature-config.php",
-		"build:packages": "cross-env NODE_ENV=production pnpm -w run build --filter='./packages/js/*'",
 		"clean": "rimraf ../woocommerce/assets/client/admin/*",
 		"client:watch": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development webpack --watch",
 		"create-hook-reference": "node ./bin/hook-reference/index.js",

--- a/plugins/woocommerce/changelog/fix-turbo-features-cache
+++ b/plugins/woocommerce/changelog/fix-turbo-features-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Internal change to turbo caching such that feature config script is not cached
+
+

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -1,6 +1,6 @@
 {
 	"features": {
-		"activity-panels": false,
+		"activity-panels": true,
 		"analytics": true,
 		"coupons": true,
 		"customer-effort-score-tracks": true,

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -1,6 +1,6 @@
 {
 	"features": {
-		"activity-panels": true,
+		"activity-panels": false,
 		"analytics": true,
 		"coupons": true,
 		"customer-effort-score-tracks": true,

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -13,7 +13,7 @@
 		"build_step": "pnpm run build:zip"
 	},
 	"scripts": {
-		"turbo:build": "echo 'adfdf'",
+		"turbo:build": "WC_ADMIN_PHASE=core",
 		"e2e": "pnpm exec wc-e2e test:e2e",
 		"turbo:test": "pnpm test:unit",
 		"preinstall": "npx only-allow pnpm",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -13,7 +13,6 @@
 		"build_step": "pnpm run build:zip"
 	},
 	"scripts": {
-		"turbo:build": "WC_ADMIN_PHASE=core",
 		"e2e": "pnpm exec wc-e2e test:e2e",
 		"turbo:test": "pnpm test:unit",
 		"preinstall": "npx only-allow pnpm",

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -13,7 +13,7 @@
 		"build_step": "pnpm run build:zip"
 	},
 	"scripts": {
-		"turbo:build": "WC_ADMIN_PHASE=core pnpm run build:feature-config",
+		"turbo:build": "echo 'adfdf'",
 		"e2e": "pnpm exec wc-e2e test:e2e",
 		"turbo:test": "pnpm test:unit",
 		"preinstall": "npx only-allow pnpm",

--- a/turbo.json
+++ b/turbo.json
@@ -2,8 +2,11 @@
 	"$schema": "https://turborepo.org/schema.json",
 	"baseBranch": "origin/trunk",
 	"pipeline": {
+		"build:feature-config": {
+			"cache": false
+		},
 		"turbo:build": {
-			"dependsOn": [ "^turbo:build", "$WC_ADMIN_PHASE" ],
+			"dependsOn": [ "build:feature-config", "^turbo:build", "$WC_ADMIN_PHASE" ],
 			"inputs": [
 				"src/*.js",
 				"src/**/*.js",
@@ -30,6 +33,7 @@
 
 		"woocommerce#turbo:build": {
 			"dependsOn": [
+				"build:feature-config",
 				"^turbo:build",
 				"woocommerce/client/admin#turbo:build",
 				"woocommerce/client/legacy#turbo:build"
@@ -45,7 +49,7 @@
 		},
 
 		"woocommerce/client/admin#turbo:build": {
-			"dependsOn": [ "^turbo:build", "$WC_ADMIN_PHASE" ],
+			"dependsOn": [ "build:feature-config", "^turbo:build", "$WC_ADMIN_PHASE" ],
 			"outputs": [],
 			"inputs": [
 				"client/*.js",
@@ -63,7 +67,7 @@
 		},
 
 		"turbo:test": {
-			"dependsOn": [ "turbo:build" ],
+			"dependsOn": [ "build:feature-config", "turbo:build" ],
 			"inputs": [
 				"src/*.js",
 				"src/**/*.js",


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/33948

Usage of `build:feature-config` was being cached, but updating any of the configs did not bust the cache. As a result, any updates to the config were not being reflected in `pnpm run build`

### How to test the changes in this Pull Request:

1. Run `pnpm run build`
2. Open `plugins/woocommerce/client/admin/config/core.json` and change one of the config booleans
3. Run `pnpm run build` and see the cache in effect as it should be very quick.
4. Open `plugins/woocommerce/includes/react-admin/feature-config.php` and confirm the boolean you changed is now reflected in the feature configs.
5. Repeat the same process for `plugins/woocommerce/client/admin/config/development.json` with the command `cd plugins/woocommerce-admin && pnpm run start` to make sure dev environment configs are still being reflected.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
