### PR TITLE
Update "context" prop of task list click/view event

### DIFF
--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -127,8 +127,7 @@ const LayoutSwitchWrapper = ( props ) => {
 class _Layout extends Component {
 	memoizedLayoutContext = memoize( ( page ) =>
 		LayoutContextPrototype.getExtendedContext(
-			page?.breadcrumbs[ page.breadcrumbs.length - 1 ]?.toLowerCase() ||
-				'page'
+			page?.navArgs?.id?.toLowerCase() || 'page'
 		)
 	);
 

--- a/plugins/woocommerce/changelog/update-33992-event-context-prop
+++ b/plugins/woocommerce/changelog/update-33992-event-context-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update context prop of wcadmin_tasklist_click/view event


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33992.

This PR standardized the context prop by using the value of `page.navargs.id`.

### How to test the changes in this Pull Request:

1. Go to `WooCommerce > Home`
2. Open browser developer tool
3. Enable track logging: `window.localStorage.setItem( 'debug', 'wc-admin:*' )`
4. Turn on `preserve log` option

![https://i.stack.imgur.com/H4EQ9.png](https://i.stack.imgur.com/H4EQ9.png)

5. Click the "Add products" task
6. Observe that the `wcadmin_tasklist_click` event is fired with the `context: woocommerce-home`
7. Observe that the `wcadmin_tasklist_view` event is fired with the `context: woocommerce-home`
8. Go to WooCommerce > Settings
9. Click on "Finish setup" button 
10. Click the "Add products" task
11. Observe that the `wcadmin_tasklist_click` event is fired with the `context: page/activity-panel`
12. Observe that the `wcadmin_tasklist_view` event is fired with the `context: page/activity-panel`



### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
