### PR TITLE
Add Pinterest to Onboarding Wizard

### DIFF
--- a/plugins/woocommerce/changelog/update-obw-pinterest
+++ b/plugins/woocommerce/changelog/update-obw-pinterest
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add Pinterest for WooCommerce to free extensions list

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -397,6 +397,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 						'creative-mail-by-constant-contact',
 						'facebook-for-woocommerce',
 						'google-listings-and-ads',
+						'pinterest-for-woocommerce',
 						'mailpoet',
 					),
 					'type' => 'string',

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -38,6 +38,7 @@ class DefaultFreeExtensions {
 				'plugins' => [
 					self::get_plugin( 'mailpoet' ),
 					self::get_plugin( 'google-listings-and-ads' ),
+					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
 				],
 			],
 			[
@@ -105,6 +106,13 @@ class DefaultFreeExtensions {
 			'pinterest-for-woocommerce'         => [
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
+				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
+				'is_built_by_wc' => true,
+			],
+			'pinterest-for-woocommerce:alt'     => [
+				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
+				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Connect your WooCommerce store to make your entire catalog browsable', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
 				'is_built_by_wc' => true,

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -38,7 +38,7 @@ class DefaultFreeExtensions {
 				'plugins' => [
 					self::get_plugin( 'mailpoet' ),
 					self::get_plugin( 'google-listings-and-ads' ),
-					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
+					self::get_plugin( 'pinterest-for-woocommerce' ),
 				],
 			],
 			[
@@ -56,7 +56,7 @@ class DefaultFreeExtensions {
 				'plugins' => [
 					self::get_plugin( 'google-listings-and-ads:alt' ),
 					self::get_plugin( 'tiktok-for-business' ),
-					self::get_plugin( 'pinterest-for-woocommerce' ),
+					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
 				],
 			],
 		];
@@ -105,14 +105,14 @@ class DefaultFreeExtensions {
 			],
 			'pinterest-for-woocommerce'         => [
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
-				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
+				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Connect your WooCommerce store to make your entire catalog browsable', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
 				'is_built_by_wc' => true,
 			],
 			'pinterest-for-woocommerce:alt'     => [
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
-				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Connect your WooCommerce store to make your entire catalog browsable', 'woocommerce' ),
+				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
 				'is_built_by_wc' => true,


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes (partially) #34302 

Adds Pinterest for WooCommerce to Onboarding Wizard.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
