### PR TITLE
Add workflow to label community PRs and Issues.

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -1,0 +1,112 @@
+name: Add Community Label
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-20.04
+    outputs:
+      issueId: ${{ steps.check.outputs.issueId }}
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check if user is a community contributor
+        id: check
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const types = [ 'issue', 'pull_request' ];
+            const orgs = [ 'automattic', 'woocommerce' ];
+
+            let found = null; // null indicates we haven't done any checks.
+            let type, org, result;
+
+            for ( var typeIndex in types ) {
+              type = types[ typeIndex ];
+
+              if ( ! context.payload[ type ] || ! context.payload[ type ].user || ! context.payload[ type ].user.login ) {
+                // If we don't have the context for this type, move on to checking the next type.
+                console.log( 'No payload found for %s, continuing...', type );
+                continue;
+              }
+
+              if ( context.payload[ type ].user.type && context.payload[ type ].user.type === 'Bot' ) {
+                // Treat bots as non-community contributors.
+                console.log( 'User %s is a bot user. Skipping...', payload[ type ].user.login );
+                found = true;
+                break;
+              }
+
+              for ( var orgIndex in orgs ) {
+                org = orgs[ orgIndex ];
+
+                try {
+                  // First attempt to check memberships.
+                  result = await github.request( 'GET /orgs/{org}/memberships/{username}', {
+                    org,
+                    username: context.payload[ type ].user.login,
+                  } );
+                } catch ( error ) {
+                  if ( error.status === 404 ) {
+                    // This means the user wasn't found in the organization.
+                    found = false;
+                    continue;
+                  }
+
+                  // For any other error, we should also try checking public memberships.
+                  try {
+                    result = await github.request( 'GET /orgs/{org}/public_members/{username}', {
+                      org,
+                      username: context.payload[ type ].user.login,
+                    } );
+                  } catch ( error ) {
+                    if ( error.status === 404 ) {
+                      // This means the user wasn't found in the organization.
+                      found = false;
+                      continue;
+                    }
+                  }
+                }
+
+                if ( result && result.status === 204 ) {
+                  // User in in one of the orgs, and we don't need to check the rest.
+                  console.log( 'The user %s was found in the organization %s', context.payload[ type ].user.login, org );
+                  found = true;
+                  console.log()
+                  break;
+                }
+              }
+              if ( found ) {
+                break;
+              }
+            }
+
+            // We should only label this as a community PR if we didn't find the user in either org AND we did a check.
+            const run = ( found === false );
+            console.log( '::set-output name=run::%s', run ? 'true' : 'false' );
+            console.log( 'Label job run: %s', run ? 'true' : 'false' );
+
+  label_community:
+    name: Label Community Issues and PRs
+    runs-on: ubuntu-20.04
+    needs: verify
+    if: needs.verify.outputs.run == 'true'
+    steps:
+      - name: label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels( {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [ 'type: community contribution' ]
+            } );

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -18,81 +18,29 @@ jobs:
       issueId: ${{ steps.check.outputs.issueId }}
       run: ${{ steps.check.outputs.run }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Check if user is a community contributor
         id: check
         uses: actions/github-script@v6
         with:
           script: |
-            const types = [ 'issue', 'pull_request' ];
-            const orgs = [ 'automattic', 'woocommerce' ];
-
-            let found = null; // null indicates we haven't done any checks.
-            let type, org, result;
-
-            for ( var typeIndex in types ) {
-              type = types[ typeIndex ];
-
-              if ( ! context.payload[ type ] || ! context.payload[ type ].user || ! context.payload[ type ].user.login ) {
-                // If we don't have the context for this type, move on to checking the next type.
-                console.log( 'No payload found for %s, continuing...', type );
-                continue;
+            const isCommunityContributor = require( './.github/workflows/scripts/is-community-contributor.js' );
+            const config = {
+              types: [ 'pull_request', 'issue' ],
+              orgs: [ 'woocommerce', 'automattic' ],
+            };
+            
+            ( async ( { github, context, config } ) => {
+              try {
+                const isCommunity = await isCommunityContributor( { github, context, config } );
+                console.log( '::set-output name=run::%s', isCommunity ? 'true' : 'false' );
+              } catch ( e ) {
+                console.log( '::set-output name=run::false' );
               }
-
-              if ( context.payload[ type ].user.type && context.payload[ type ].user.type === 'Bot' ) {
-                // Treat bots as non-community contributors.
-                console.log( 'User %s is a bot user. Skipping...', payload[ type ].user.login );
-                found = true;
-                break;
-              }
-
-              for ( var orgIndex in orgs ) {
-                org = orgs[ orgIndex ];
-
-                try {
-                  // First attempt to check memberships.
-                  result = await github.request( 'GET /orgs/{org}/memberships/{username}', {
-                    org,
-                    username: context.payload[ type ].user.login,
-                  } );
-                } catch ( error ) {
-                  if ( error.status === 404 ) {
-                    // This means the user wasn't found in the organization.
-                    found = false;
-                    continue;
-                  }
-
-                  // For any other error, we should also try checking public memberships.
-                  try {
-                    result = await github.request( 'GET /orgs/{org}/public_members/{username}', {
-                      org,
-                      username: context.payload[ type ].user.login,
-                    } );
-                  } catch ( error ) {
-                    if ( error.status === 404 ) {
-                      // This means the user wasn't found in the organization.
-                      found = false;
-                      continue;
-                    }
-                  }
-                }
-
-                if ( result && result.status === 204 ) {
-                  // User in in one of the orgs, and we don't need to check the rest.
-                  console.log( 'The user %s was found in the organization %s', context.payload[ type ].user.login, org );
-                  found = true;
-                  console.log()
-                  break;
-                }
-              }
-              if ( found ) {
-                break;
-              }
-            }
-
-            // We should only label this as a community PR if we didn't find the user in either org AND we did a check.
-            const run = ( found === false );
-            console.log( '::set-output name=run::%s', run ? 'true' : 'false' );
-            console.log( 'Label job run: %s', run ? 'true' : 'false' );
+            } )( { github, context, config } );
+            
 
   label_community:
     name: Label Community Issues and PRs

--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -1,0 +1,92 @@
+const getUserFromContext = ( types, context ) => {
+	for ( const type of types ) {
+		if ( context.payload[ type ] && context.payload[ type ].user && context.payload[ type ].user.login ) {
+			return context.payload[ type ].user;
+		}
+	}
+	return false;
+};
+
+const userIsBot = user => user.type && user.type === 'Bot';
+
+const userInOrg = async ( github, username, org ) => {
+	console.log( 'Checking for user %s in org %s', username, org );
+	try {
+		// First attempt to check memberships.
+		const result = await github.request( 'GET /orgs/{org}/memberships/{username}', {
+			org,
+			username,
+		} );
+
+		if ( result && Math.floor( result.status / 100 ) === 2 ) {
+			console.log( 'User %s found in %s via membership check', username, org );
+			return true;
+		}
+	} catch ( error ) {
+		// A 404 status means the user is definitively not in the organization.
+		if ( error.status === 404 ) {
+			console.log( 'User %s NOT found in %s via membership check', username, org );
+			return false;
+		}
+
+		try {
+			// For anything else, we should also check public memberships.
+			const result = await github.request( 'GET /orgs/{org}/public_members/{username}', {
+				org,
+				username,
+			} );
+
+			if ( result && Math.floor( result.status / 100 ) === 2 ) {
+				console.log( 'User %s found in %s via public membership check', username, org );
+				return true;
+			}
+		} catch ( error ) {
+			if ( error.status === 404 ) {
+				console.log( 'User %s NOT found in %s via public membership check', username, org );
+				return false;
+			}
+		}
+	}
+	// If we've gotten to this point, status is unknown.
+	throw new Error( "Unable to determine user's membership in org" );
+};
+
+const userInNonCommunityOrgs = async ( orgs, github, username ) => {
+	let checked = 0;
+	for ( const org of orgs ) {
+		try {
+			const isUserInOrg = await userInOrg( github, username, org );
+			if ( isUserInOrg ) {
+				return true;
+			}
+			// If no error was thrown, increment checked.
+			checked++;
+		} catch( e ) {} // Do nothing.
+	}
+
+	if ( checked !== orgs.length ) {
+		throw new Error( "Unable to check user's membership in all orgs." );
+	}
+
+	return false;
+};
+
+const isCommunityContributor = async ( { github, context, config } ) => {
+	const user = getUserFromContext( config.types, context );
+	if ( ! user ) {
+		throw new Error( 'Unable to get user from context' );
+	}
+	console.log( 'Checking user %s', user.login );
+
+	if ( userIsBot( user ) ) {
+		// Bots are not community contributors.
+		console.log( 'User detected as bot, skipping' );
+		return false;
+	}
+
+	const isInNonCommunityOrgs = await userInNonCommunityOrgs( config.orgs, github, user.login );
+
+	return ! isInNonCommunityOrgs;
+};
+
+module.exports = isCommunityContributor;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR creates a new GitHub workflow that labels community PRs and Issues.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34197 .

### How to test the changes in this Pull Request:

1. Fork this repo. All the steps here on out will be done in your fork ONLY!
1. Enable Actions ( by default it is disabled ). `settings/actions`.
1. Optional: you may want to disable some of the non-related actions, as they'll slow down execution of this action.
1. Enable Issues `settings`. 
1. In `trunk` of your fork, merge this branch `fix/34197`.
1. Create an issue in your fork authored by a user in either the `automattic` or `woocommerce` organization. Verify that the action runs, but that it skips labeling the issue because of the user being in either organization.
1. Create a PR in your fork authored by a user in either the `automattic` or `woocommerce` organization. Verify that the action runs, but that it skips labeling the PR because of the user being in either organization.
1. Create an issue in your fork authored by a user in neither the `automattic` nor the `woocommerce` organization. Verify that the action runs and that the issue is labeled as a community issue because of the user being in neither organization.
1. Create a PR in your fork authored by a user in neither the `automattic` nor the `woocommerce` organization. Verify that the action runs and that the PR is labeled as a community issue because of the user being in neither organization.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
