### PR TITLE
Fixed "Unsupported operand types" error.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34224
+++ b/plugins/woocommerce/changelog/fix-34224
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed "Unsupported operand types" error.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -2029,7 +2029,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				}
 			}
 		} else {
-			$row_price        = $price * $quantity;
+			$row_price        = (float) $price * (float) $quantity;
 			$product_subtotal = wc_price( $row_price );
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34224 

### How to test the changes in this Pull Request:
As described in https://github.com/woocommerce/woocommerce/issues/33924.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
