### PR TITLE
Make Yoda conditions mandatory again

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,19 +32,6 @@
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />
 
-	<rule ref="WordPress.PHP">
-		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
-	</rule>
-
-	<rule ref="Generic.ControlStructures.DisallowYodaConditions" >
-		<include-pattern>includes/</include-pattern>
-		<type>warning</type>
-	</rule>
-
-	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" >
-		<exclude-pattern>includes/</exclude-pattern>
-	</rule>
-
 	<rule ref="WooCommerce.Functions.InternalInjectionMethod">
 		<include-pattern>src/</include-pattern>
 		<include-pattern>tests/php/src/</include-pattern>

--- a/plugins/woocommerce/bin/composer/phpcs/composer.json
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.json
@@ -1,8 +1,7 @@
 {
 	"require-dev": {
 		"woocommerce/woocommerce-sniffs": "^0.1.3",
-		"sirbrillig/phpcs-changed": "^2.10",
-		"slevomat/coding-standard": "^8.0"
+		"sirbrillig/phpcs-changed": "^2.10"
 	},
 	"config": {
 		"platform": {

--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a04f56dd1f49558a5e61384cb5370058",
+    "content-hash": "4df582a159fa9e6987962ca1917bb00c",
     "packages": [],
     "packages-dev": [
         {
@@ -255,51 +255,6 @@
             "time": "2021-12-30T16:37:40+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "1.6.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
-                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
-                "symfony/process": "^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "support": {
-                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
-            },
-            "time": "2022-06-26T13:09:08+00:00"
-        },
-        {
             "name": "sirbrillig/phpcs-changed",
             "version": "v2.10.0",
             "source": {
@@ -355,67 +310,6 @@
                 "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.10.0"
             },
             "time": "2022-03-09T18:16:50+00:00"
-        },
-        {
-            "name": "slevomat/coding-standard",
-            "version": "8.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "a14df437f2efe861ca9118508f304de9655957e4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/a14df437f2efe861ca9118508f304de9655957e4",
-                "reference": "a14df437f2efe861ca9118508f304de9655957e4",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.6.2",
-                "squizlabs/php_codesniffer": "^3.7.1"
-            },
-            "require-dev": {
-                "phing/phing": "2.17.4",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.10|1.8.1",
-                "phpstan/phpstan-deprecation-rules": "1.0.0",
-                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
-                "phpstan/phpstan-strict-rules": "1.3.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.21"
-            },
-            "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "support": {
-                "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/kukulich",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-07-16T11:59:39+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/plugins/woocommerce/changelog/unfix-yoda-conditions
+++ b/plugins/woocommerce/changelog/unfix-yoda-conditions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Make Yoda conditions mandatory again.


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reverts https://github.com/woocommerce/woocommerce/pull/34185 and https://github.com/woocommerce/woocommerce/pull/34204.

### How to test the changes in this Pull Request:

Verify that `phpcs` throws errors again for normal conditions for code in `includes`, `src`, `tests` and `templates`.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
