### PR TITLE
add: store address tour tracks

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
@@ -6,6 +6,7 @@ import { TourKit, TourKitTypes } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -36,6 +37,11 @@ const useShowStoreLocationTour = () => {
 		isLoading,
 		show: ! isLoading && ! hasReviewedStoreLocationSettings,
 	};
+};
+
+const isFieldFilled = ( fieldSelector: string ) => {
+	const field = document.querySelector< HTMLInputElement >( fieldSelector );
+	return !! field && field.value.length > 0;
 };
 
 const StoreAddressTourOverlay = () => {
@@ -77,7 +83,19 @@ const StoreAddressTourOverlay = () => {
 				},
 			},
 		},
-		closeHandler: () => {
+		closeHandler: ( _steps, _currentStepIndex, source ) => {
+			const fields_filled = {
+				address_1: isFieldFilled( 'input#woocommerce_store_address' ),
+				address_2: isFieldFilled( 'input#woocommerce_store_address_2' ),
+				city: isFieldFilled( 'input#woocommerce_store_city' ),
+				postcode: isFieldFilled( 'input#woocommerce_store_postcode' ),
+			};
+
+			recordEvent( 'settings_store_address_tour_dismiss', {
+				source, // 'close-btn' | 'done-btn'
+				fields_filled,
+			} );
+
 			updateOptions( {
 				[ REVIEWED_STORE_LOCATION_SETTINGS_OPTION ]: 'yes',
 			} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added tracks event for store location tour

Closes #32587 .

### How to test the changes in this Pull Request:

Same as #34137 , but with tracks events.

1. Start with a fresh install of WooCommerce, make sure tracking is allowed in the OBW
1. Open devtools and enable tracks debug message by running `localStorage.debug="*"`
1. Go to the task list and click on "You added store details" or "Add store details" in the tasklist (it might be struck through)
1. You should be redirected to the WooCommerce settings page, on the general tab and have a spotlight on the store location fields.
1. Observe that dismissing the tour either via the 'Got it' button or the 'x' dismiss icon should produce the respective tracks event.
1. The event should also show which fields have not been left empty at time of dismissal

The schema of the tracks object should look like:

```
'wcadmin_settings_store_address_tour_dismiss'
{
  source: 'done-btn' | 'close-btn',
  fields_filled: {
    address_1: boolean;
    address_2: boolean;
    city: boolean;
    postcode: boolean;
  }
}
```
### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
