### PR TITLE
[COT] `OrdersTableQuery`: ignore invalid elements in `meta_query`

### DIFF
--- a/plugins/woocommerce/changelog/fix-34346
+++ b/plugins/woocommerce/changelog/fix-34346
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add support for an atomic `meta_query` arg in COT's order query code.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -148,10 +148,6 @@ class OrdersTableMetaQuery {
 	private function sanitize_meta_query( array $q ): array {
 		$sanitized = array();
 
-		if ( ! is_array( $q ) ) {
-			return array();
-		}
-
 		foreach ( $q as $key => $arg ) {
 			if ( 'relation' === $key ) {
 				$relation = $arg;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -148,31 +148,32 @@ class OrdersTableMetaQuery {
 	private function sanitize_meta_query( array $q ): array {
 		$sanitized = array();
 
-		if ( $this->is_atomic( $q ) ) {
-			if ( isset( $q['value'] ) && array() === $q['value'] ) {
-				unset( $q['value'] );
-			}
-
-			$q['compare']     = isset( $q['compare'] ) ? strtoupper( $q['compare'] ) : ( isset( $q['value'] ) && is_array( $q['value'] ) ? 'IN' : '=' );
-			$q['compare_key'] = isset( $q['compare_key'] ) ? strtoupper( $q['compare_key'] ) : ( isset( $q['key'] ) && is_array( $q['key'] ) ? 'IN' : '=' );
-
-			if ( ! in_array( $q['compare'], self::NON_NUMERIC_OPERATORS, true ) && ! in_array( $q['compare'], self::NUMERIC_OPERATORS, true ) ) {
-				$q['compare'] = '=';
-			}
-
-			if ( ! in_array( $q['compare_key'], self::NON_NUMERIC_OPERATORS, true ) ) {
-				$q['compare_key'] = '=';
-			}
-
-			return $q;
+		if ( ! is_array( $q ) ) {
+			return array();
 		}
 
-		// Nested.
 		foreach ( $q as $key => $arg ) {
 			if ( 'relation' === $key ) {
 				$relation = $arg;
 			} elseif ( ! is_array( $arg ) ) {
 				continue;
+			} elseif ( $this->is_atomic( $arg ) ) {
+				if ( isset( $arg['value'] ) && array() === $arg['value'] ) {
+					unset( $arg['value'] );
+				}
+
+				$arg['compare']      = isset( $arg['compare'] ) ? strtoupper( $arg['compare'] ) : ( isset( $arg['value'] ) && is_array( $arg['value'] ) ? 'IN' : '=' );
+				$arg['compare_key']  = isset( $arg['compare_key'] ) ? strtoupper( $arg['compare_key'] ) : ( isset( $arg['key'] ) && is_array( $arg['key'] ) ? 'IN' : '=' );
+
+				if ( ! in_array( $arg['compare'], self::NON_NUMERIC_OPERATORS, true ) && ! in_array( $arg['compare'], self::NUMERIC_OPERATORS, true ) ) {
+					$arg['compare'] = '=';
+				}
+
+				if ( ! in_array( $arg['compare_key'], self::NON_NUMERIC_OPERATORS, true ) ) {
+					$arg['compare_key'] = '=';
+				}
+
+				$sanitized[ $key ] = $arg;
 			} else {
 				$sanitized_arg = $this->sanitize_meta_query( $arg );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -961,6 +961,8 @@ class OrdersTableQuery {
 			case 'posts':
 			case 'orders':
 				return $this->results;
+			case 'request':
+				return $this->sql;
 			default:
 				break;
 		}


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
While querying orders via `wc_get_orders()` (or directly via `OrdersTableQuery`), `meta_query` is expected to be an array of arrays, in line with `WP_Query`'s own `meta_query`. When this is not the case, a fatal error is thrown.

~This is a bit too much and directly specifying `key` and/or `value` under `meta_query` sounds like a reasonable thing to do (or an easy mistake). This PR adds support for such syntax.~
This PR makes it so invalid elements are silently ignored and prevents the fatal error from being thrown.

Closes #34346.

### How to test the changes in this Pull Request:

1. Enable COT and populate with some orders (and some metadata).
2. Confirm that on `trunk`, the following throws a fatal error:
   ```php
   $orders = wc_get_orders(
	   [
		   'meta_query' => [
			   'key'   => 'invalid_key',
			   'value' => 'invalid_value',
			   [
				   'key'   => 'meta_key',
				   'value' => 'meta_value',
			   ]
		   ]
	   ]
   );
   ```
3. Confirm that on this branch, the code above does not throw a fatal error and silently ignores the invalid values and only looks for orders matching `meta_key = meta_value`, as in the following (correct) example:
   ```php
   $orders = wc_get_orders(
	   [
		   'meta_query' => [
			   [
				   'key'   => 'meta_key',
				   'value' => 'meta_value',
			   ]
		   ]
	   ]
   );
   ```

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
