### PR TITLE
Remove the send-release-notification job, its no longer needed.

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,18 +61,4 @@ jobs:
           token: ${{ secrets.E2E_WORKFLOW_GH_TOKEN }}
           ref: refs/heads/trunk
           inputs: '{ "release_id": "${{ github.event.release.id }}" }'
-  send-release-notification:
-    if: github.event.release.prerelease == true && github.event.release.draft == false && github.event.release.tag_name != 'nightly' 
-    name: Send Release Notification
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Invoke Pre-Release Event
-        uses: aurelien-baudet/workflow-dispatch@v2
-        with:
-          workflow: ${{ secrets.CD_RELEASE_NOTIFICATION_WORKFLOW }}
-          repo: ${{ secrets.CD_NOTIFICATION_REPO }}
-          token: ${{ secrets.CD_GH_TOKEN }}
-          ref: refs/heads/trunk
-          inputs: '{ "tag_name": "${{ github.event.release.tag_name }}" }'
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After some discussion with @MrJnrman it was concluded that this job is not needed any more and can be removed. Also note that if/when this is merged we can remove the associated secrets from the repository.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
