### PR TITLE
Fix: Smart shipping defaults bug

### DIFF
--- a/plugins/woocommerce/changelog/fix-34319-do-not-add-smart-shipping-defaults-when-shipping-setup-exist
+++ b/plugins/woocommerce/changelog/fix-34319-do-not-add-smart-shipping-defaults-when-shipping-setup-exist
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Do not create default shipping zones when a shipping zone already exists

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -90,6 +90,12 @@ class Homescreen {
 			return $settings;
 		}
 
+		$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
+		if ( $zone_count ) {
+			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+			return $settings;
+		}
+
 		$user_skipped_obw = $settings['onboarding']['profile']['skipped'] ?? false;
 		$store_address    = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
 		$product_types    = $settings['onboarding']['profile']['product_types'] ?? array();

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -85,15 +85,15 @@ class Homescreen {
 		}
 
 		// Abort if we already created the shipping options.
-		$already_created               = get_option( 'woocommerce_admin_created_default_shipping_zones' );
-		$skipped_default_shipping_zone = get_option( 'woocommerce_admin_skipped_creating_default_shipping_zones' );
-		if ( $already_created === 'yes' || $skipped_default_shipping_zone === 'yes' ) {
+		$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
+		if ( $already_created === 'yes' ) {
 			return $settings;
 		}
 
 		$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
 		if ( $zone_count ) {
-			update_option( 'woocommerce_admin_skipped_creating_default_shipping_zones', 'yes' );
+			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+			update_option( 'woocommerce_admin_reviewed_default_shipping_zones', 'yes' );
 			return $settings;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -85,14 +85,15 @@ class Homescreen {
 		}
 
 		// Abort if we already created the shipping options.
-		$already_created = get_option( 'woocommerce_admin_created_default_shipping_zones' );
-		if ( 'yes' === $already_created ) {
+		$already_created               = get_option( 'woocommerce_admin_created_default_shipping_zones' );
+		$skipped_default_shipping_zone = get_option( 'woocommerce_admin_skipped_creating_default_shipping_zones' );
+		if ( $already_created === 'yes' || $skipped_default_shipping_zone === 'yes' ) {
 			return $settings;
 		}
 
 		$zone_count = count( \WC_Data_Store::load( 'shipping-zone' )->get_zones() );
 		if ( $zone_count ) {
-			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
+			update_option( 'woocommerce_admin_skipped_creating_default_shipping_zones', 'yes' );
 			return $settings;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34319 

This PR fixes smart shipping defaults bug.

As noted in the issue, we should not create a new shipping zone when there is already one.

This PR counts # of shipping zones to make sure we don't create/override a shipping zone.

### How to test the changes in this Pull Request:

1. Start with a fresh install.
2. Do not initiate OBW yet.
3. Go to `WooCommerce -> Settings -> Shiping` and create a shipping zone.
4. Complete OBW and choose a country not that is not one of the US, CA, AU, or GB.
5. Navigate to `WooCommerce -> Home`
6. Navigate to `WooCommerce -> Settings -> Shiping` and confirm no extra shipping zone exist. 
7. Confirm `woocommerce_admin_created_default_shipping_zones` option has been created.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
