### PR TITLE
Update "Refund Returns" note to display localized strings

### DIFF
--- a/plugins/woocommerce/changelog/update-34268-admin-notes-i18n
+++ b/plugins/woocommerce/changelog/update-34268-admin-notes-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WC_Notes_Refund_Returns note to display localized strings

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -9,7 +9,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
@@ -20,6 +19,15 @@ class WC_Notes_Refund_Returns {
 	 * Name of the note for use in the database.
 	 */
 	const NOTE_NAME = 'wc-refund-returns-page';
+
+
+	/**
+	 * Attach hooks.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
+	}
+
 
 	/**
 	 * Maybe add a note to the inbox.
@@ -68,5 +76,33 @@ class WC_Notes_Refund_Returns {
 		);
 
 		return $note;
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @param Note $note_from_db The note object from the database.
+	 * @return Note $note The note object.
+	 */
+	public static function get_note_from_db( $note_from_db ) {
+		if ( ! $note_from_db instanceof Note ) {
+			return $note_from_db;
+		}
+
+		if ( self::NOTE_NAME === $note_from_db->get_name() ) {
+			$note = self::get_note( 0 );
+			$note_from_db->set_title( $note->get_title() );
+			$note_from_db->set_content( $note->get_content() );
+
+			$action_from_db    = $note_from_db->get_action( 'notify-refund-returns-page' );
+			$action_from_class = $note->get_action( 'notify-refund-returns-page' );
+
+			if ( $action_from_db && $action_from_class ) {
+				$action_from_db->label = $action_from_class->label;
+				$note_from_db->set_actions( array( $action_from_db ) );
+			}
+		}
+
+		return $note_from_db;
 	}
 }

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -85,7 +85,7 @@ class WC_Notes_Refund_Returns {
 	 * @return Note $note The note object.
 	 */
 	public static function get_note_from_db( $note_from_db ) {
-		if ( ! $note_from_db instanceof Note ) {
+		if ( ! $note_from_db instanceof Note || get_user_locale() === $note_from_db->get_locale() ) {
 			return $note_from_db;
 		}
 

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -28,7 +28,6 @@ class WC_Notes_Refund_Returns {
 		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
 	}
 
-
 	/**
 	 * Maybe add a note to the inbox.
 	 *

--- a/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
+++ b/plugins/woocommerce/includes/admin/notes/class-wc-notes-refund-returns.php
@@ -20,7 +20,6 @@ class WC_Notes_Refund_Returns {
 	 */
 	const NOTE_NAME = 'wc-refund-returns-page';
 
-
 	/**
 	 * Attach hooks.
 	 */

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -300,7 +300,7 @@ class Note extends \WC_Data {
 	 *
 	 * @param  string $action_name The action name.
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
-	 * @return array the action.
+	 * @return object the action.
 	 */
 	public function get_action( $action_name, $context = 'view' ) {
 		$actions = $this->get_prop( 'actions', $context );

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -143,6 +143,9 @@ class Events {
 	public function init() {
 		add_action( 'wc_admin_daily', array( $this, 'do_wc_admin_daily' ) );
 		add_filter( 'woocommerce_get_note_from_db', array( $this, 'get_note_from_db' ), 10, 1 );
+
+		// Initialize the WC_Notes_Refund_Returns Note to attach hook.
+		\WC_Notes_Refund_Returns::init();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-refund-returns.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-refund-returns.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class WC_Notes_Refund_Returns file.
+ *
+ * @package WooCommerce\Tests\Admin\Notes
+ */
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+
+/**
+ * Tests for the WC_Notes_Refund_Returns class.
+ */
+class WC_Tests_Notes_Refund_Returns extends WC_Unit_Test_Case {
+	/**
+	 * Test get_note_from_db method with a invalid db note.
+	 */
+	public function test_get_note_from_db_with_invalid_note() {
+		$note_from_db = array();
+		$this->assertEquals( WC_Notes_Refund_Returns::get_note_from_db( $note_from_db ), $note_from_db );
+	}
+
+	/**
+	 * Test get_note_from_db method when the note locale is the same as user's locale.
+	 */
+	public function test_get_note_from_db_when_note_locale_is_the_same() {
+		$note_from_db = new Note();
+		$locale       = get_user_locale();
+		$note_from_db->set_locale( $locale );
+		$this->assertEquals( WC_Notes_Refund_Returns::get_note_from_db( $note_from_db ), $note_from_db );
+	}
+
+	/**
+	 * Test get_note_from_db method when the note name is not wc-refund-returns-page.
+	 */
+	public function test_get_note_from_db_when_note_name_not_match() {
+		$note_from_db = new Note();
+		$note_from_db->set_name( 'test' );
+		$note_from_db->set_locale( 'zh_TW' );
+		$this->assertEquals( WC_Notes_Refund_Returns::get_note_from_db( $note_from_db ), $note_from_db );
+	}
+
+	/**
+	 * Test get_note_from_db method should return a updated note.
+	 */
+	public function test_get_note_from_db_return_updated_note() {
+		$note_from_db = new Note();
+		$note_from_db->set_name( WC_Notes_Refund_Returns::NOTE_NAME );
+		$note_from_db->set_locale( 'zh_TW' );
+		$note = WC_Notes_Refund_Returns::get_note_from_db( $note_from_db );
+		$this->assertEquals( $note->get_title(), 'Setup a Refund and Returns Policy page to boost your store\'s credibility.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34268.

This PR updates the "Refund Returns" note to display the localized strings, and fixes the wrong return type of the `get_action` method.

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to `WooCommerce > Home`
3. Skip OBW
4. Observe that `Setup a Refund and Returns Policy page to boost your store's credibility.` note is displayed
5. Change the "Site Language" to `Español` on the **Setting**  page
6. Go to `Dashboard > Updates`
7. Scroll to page bottom and make sure "Translations (Traducciones)" are all up to updated 
8. Go to `WooCommerce > Home`
9. Observe that `Connect to WooCommerce.com` note is translated to `Configura una página de política de devoluciones y reembolsos para aumentar la credibilidad de tu tienda.`.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
