### PR TITLE
Update in-app marketplace to display localized strings

### DIFF
--- a/plugins/woocommerce/changelog/update-34353-in-app-marketplace-i18n
+++ b/plugins/woocommerce/changelog/update-34353-in-app-marketplace-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update in-app marketplace to display localized strings

--- a/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-addons.php
@@ -26,7 +26,8 @@ class WC_Admin_Addons {
 	 * @return array of objects
 	 */
 	public static function get_featured() {
-		$featured = get_transient( 'wc_addons_featured_2' );
+		$locale   = get_user_locale();
+		$featured = self::get_locale_data_from_transient( 'wc_addons_featured_2', $locale );
 		if ( false === $featured ) {
 			$headers = array();
 			$auth    = WC_Helper_Options::get( 'auth' );
@@ -45,7 +46,7 @@ class WC_Admin_Addons {
 			if ( ! is_wp_error( $raw_featured ) ) {
 				$featured = json_decode( wp_remote_retrieve_body( $raw_featured ) );
 				if ( $featured ) {
-					set_transient( 'wc_addons_featured_2', $featured, DAY_IN_SECONDS );
+					self::set_locale_data_in_transient( 'wc_addons_featured_2', $featured, $locale, DAY_IN_SECONDS );
 				}
 			}
 		}
@@ -62,7 +63,8 @@ class WC_Admin_Addons {
 	 * @return void
 	 */
 	public static function render_featured() {
-		$featured = get_transient( 'wc_addons_featured' );
+		$locale   = get_user_locale();
+		$featured = self::get_locale_data_from_transient( 'wc_addons_featured', $locale );
 		if ( false === $featured ) {
 			$headers = array();
 			$auth    = WC_Helper_Options::get( 'auth' );
@@ -71,10 +73,10 @@ class WC_Admin_Addons {
 				$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
 			}
 
-			$parameter_string = '';
+			$parameter_string = '?' . http_build_query( array( 'locale' => get_user_locale() ) );
 			$country          = WC()->countries->get_base_country();
 			if ( ! empty( $country ) ) {
-				$parameter_string = '?' . http_build_query( array( 'country' => $country ) );
+				$parameter_string = $parameter_string . '&' . http_build_query( array( 'country' => $country ) );
 			}
 
 			// Important: WCCOM Extensions API v2.0 is used.
@@ -118,7 +120,7 @@ class WC_Admin_Addons {
 				return;
 			}
 
-			$featured      = json_decode( wp_remote_retrieve_body( $raw_featured ) );
+			$featured = json_decode( wp_remote_retrieve_body( $raw_featured ) );
 			if ( empty( $featured ) || ! is_array( $featured ) ) {
 				do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
 				$message = __( 'Our request to the featured API got a malformed response.', 'woocommerce' );
@@ -128,7 +130,7 @@ class WC_Admin_Addons {
 			}
 
 			if ( $featured ) {
-				set_transient( 'wc_addons_featured', $featured, DAY_IN_SECONDS );
+				self::set_locale_data_in_transient( 'wc_addons_featured', $featured, $locale, DAY_IN_SECONDS );
 			}
 		}
 
@@ -161,6 +163,7 @@ class WC_Admin_Addons {
 			'category' => $category,
 			'term'     => $term,
 			'country'  => $country,
+			'locale'   => get_user_locale(),
 		);
 
 		return '?' . http_build_query( $parameters );
@@ -216,7 +219,6 @@ class WC_Admin_Addons {
 			do_action( 'woocommerce_page_wc-addons_connection_error', 'Empty or malformed response' );
 			return new WP_Error( 'error', __( 'Our request to the search API got a malformed response.', 'woocommerce' ) );
 		}
-
 		return $addons;
 	}
 
@@ -226,15 +228,17 @@ class WC_Admin_Addons {
 	 * @return array of objects
 	 */
 	public static function get_sections() {
-		$addon_sections = get_transient( 'wc_addons_sections' );
+		$locale         = get_user_locale();
+		$addon_sections = self::get_locale_data_from_transient( 'wc_addons_sections', $locale );
 		if ( false === ( $addon_sections ) ) {
-			$raw_sections = wp_safe_remote_get(
-				'https://woocommerce.com/wp-json/wccom-extensions/1.0/categories'
+			$parameter_string = '?' . http_build_query( array( 'locale' => get_user_locale() ) );
+			$raw_sections     = wp_safe_remote_get(
+				'https://woocommerce.com/wp-json/wccom-extensions/1.0/categories' . $parameter_string
 			);
 			if ( ! is_wp_error( $raw_sections ) ) {
 				$addon_sections = json_decode( wp_remote_retrieve_body( $raw_sections ) );
 				if ( $addon_sections ) {
-					set_transient( 'wc_addons_sections', $addon_sections, WEEK_IN_SECONDS );
+					self::set_locale_data_in_transient( 'wc_addons_sections', $addon_sections, $locale, WEEK_IN_SECONDS );
 				}
 			}
 		}
@@ -1481,5 +1485,51 @@ class WC_Admin_Addons {
 			</li>
 			<?php
 		}
+	}
+
+	/**
+	 * Retrieves the locale data from a transient.
+	 *
+	 * Transient value is an array of locale data in the following format:
+	 * array(
+	 *    'en_US' => ...,
+	 *    'fr_FR' => ...,
+	 * )
+	 *
+	 * If the transient does not exist, does not have a value, or has expired,
+	 * then the return value will be false.
+	 *
+	 * @param string $transient Transient name. Expected to not be SQL-escaped.
+	 * @param string $locale  Locale to retrieve.
+	 * @return mixed Value of transient.
+	 */
+	private static function get_locale_data_from_transient( $transient, $locale ) {
+		$transient_value = get_transient( $transient );
+		$transient_value = is_array( $transient_value ) ? $transient_value : array();
+		return $transient_value[ $locale ] ?? false;
+	}
+
+	/**
+	 * Sets the locale data in a transient.
+	 *
+	 * Transient value is an array of locale data in the following format:
+	 * array(
+	 *    'en_US' => ...,
+	 *    'fr_FR' => ...,
+	 * )
+	 *
+	 * @param string $transient  Transient name. Expected to not be SQL-escaped.
+	 *                           Must be 172 characters or fewer in length.
+	 * @param mixed  $value      Transient value. Must be serializable if non-scalar.
+	 *                           Expected to not be SQL-escaped.
+	 * @param string $locale  Locale to set.
+	 * @param int    $expiration Optional. Time until expiration in seconds. Default 0 (no expiration).
+	 * @return bool True if the value was set, false otherwise.
+	 */
+	private static function set_locale_data_in_transient( $transient, $value, $locale, $expiration = 0 ) {
+		$transient_value            = get_transient( $transient );
+		$transient_value            = is_array( $transient_value ) ? $transient_value : array();
+		$transient_value[ $locale ] = $value;
+		return set_transient( $transient, $transient_value, $expiration );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34353.

This PR updates the in-app marketplace to display localized strings with the following changes:

- Send requests with a locale param
- Save response data in transient with format `array('en_US' => ...,  'fr_FR' => ...,)`

Note: Because `https://woocommerce.com/wp-json/wccom-extensions/1.0/search` does not support i18n yet, only the contents in the "featured tab" get translated.

### How to test the changes in this Pull Request:

1.  Go to `WooCommerce > Extensions`
2. Observe that Extensions are displayed properly.
3. Change the "Site Language" to `Español` on the **Setting**  page
4. Go back to `WooCommerce > Extensions`
5. Observe that Extensions are displayed in Spanish

![Screen Shot 2022-08-17 at 14 41 19](https://user-images.githubusercontent.com/4344253/185051984-2c6d8e4a-76a3-48e6-8a3d-217d762e7402.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
