### PR TITLE
Refactor inbox notes to have get_note method

### DIFF
--- a/plugins/woocommerce/changelog/update-34269-refactor-inbox-notes-to-have-get-notes-method
+++ b/plugins/woocommerce/changelog/update-34269-refactor-inbox-notes-to-have-get-notes-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Refactor inbox notes to have get_note method

--- a/plugins/woocommerce/src/Admin/Notes/Note.php
+++ b/plugins/woocommerce/src/Admin/Notes/Note.php
@@ -229,7 +229,7 @@ class Note extends \WC_Data {
 	 * Get note content data (i.e. values that would be needed for re-localization)
 	 *
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
-	 * @return array
+	 * @return object
 	 */
 	public function get_content_data( $context = 'view' ) {
 		return $this->get_prop( 'content_data', $context );

--- a/plugins/woocommerce/src/Internal/Admin/Notes/NewSalesRecord.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/NewSalesRecord.php
@@ -95,50 +95,85 @@ class NewSalesRecord {
 			update_option( self::RECORD_DATE_OPTION_KEY, $yesterday );
 			update_option( self::RECORD_AMOUNT_OPTION_KEY, $total );
 
-			// Use F jS (March 7th) format for English speaking countries.
-			if ( substr( get_locale(), 0, 2 ) === 'en' ) {
-				$date_format = 'F jS';
-			} else {
-				// otherwise, fallback to the system date format.
-				$date_format = get_option( 'date_format' );
-			}
-
-			$formatted_yesterday   = date_i18n( $date_format, strtotime( $yesterday ) );
-			$formatted_total       = html_entity_decode( wp_strip_all_tags( wc_price( $total ) ) );
-			$formatted_record_date = date_i18n( $date_format, strtotime( $record_date ) );
-			$formatted_record_amt  = html_entity_decode( wp_strip_all_tags( wc_price( $record_amt ) ) );
-
-			$content = sprintf(
-				/* translators: 1 and 4: Date (e.g. October 16th), 2 and 3: Amount (e.g. $160.00) */
-				__( 'Woohoo, %1$s was your record day for sales! Net sales was %2$s beating the previous record of %3$s set on %4$s.', 'woocommerce' ),
-				$formatted_yesterday,
-				$formatted_total,
-				$formatted_record_amt,
-				$formatted_record_date
-			);
-
-			$content_data = (object) array(
-				'old_record_date' => $record_date,
-				'old_record_amt'  => $record_amt,
-				'new_record_date' => $yesterday,
-				'new_record_amt'  => $total,
-			);
-
 			// We only want one sales record note at any time in the inbox, so we delete any other first.
 			Notes::delete_notes_with_name( self::NOTE_NAME );
 
-			$report_url = '?page=wc-admin&path=/analytics/revenue&period=custom&compare=previous_year&after=' . $yesterday . '&before=' . $yesterday;
-
-			// And now, create our new note.
-			$note = new Note();
-			$note->set_title( __( 'New sales record!', 'woocommerce' ) );
-			$note->set_content( $content );
-			$note->set_content_data( $content_data );
-			$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-			$note->set_name( self::NOTE_NAME );
-			$note->set_source( 'woocommerce-admin' );
-			$note->add_action( 'view-report', __( 'View report', 'woocommerce' ), $report_url );
+			$note = self::get_note_with_record_data( $record_date, $record_amt, $yesterday, $total );
 			$note->save();
 		}
+	}
+
+	/**
+	 * Get the note with record data.
+	 *
+	 * @param string $record_date record date Y-m-d.
+	 * @param float  $record_amt record amount.
+	 * @param string $yesterday yesterday's date Y-m-d.
+	 * @param string $total total sales for yesterday.
+	 *
+	 * @return Note
+	 */
+	public static function get_note_with_record_data( $record_date, $record_amt, $yesterday, $total ) {
+		// Use F jS (March 7th) format for English speaking countries.
+		if ( substr( get_user_locale(), 0, 2 ) === 'en' ) {
+			$date_format = 'F jS';
+		} else {
+			// otherwise, fallback to the system date format.
+			$date_format = get_option( 'date_format' );
+		}
+
+		$formatted_yesterday   = date_i18n( $date_format, strtotime( $yesterday ) );
+		$formatted_total       = html_entity_decode( wp_strip_all_tags( wc_price( $total ) ) );
+		$formatted_record_date = date_i18n( $date_format, strtotime( $record_date ) );
+		$formatted_record_amt  = html_entity_decode( wp_strip_all_tags( wc_price( $record_amt ) ) );
+
+		$content = sprintf(
+			/* translators: 1 and 4: Date (e.g. October 16th), 2 and 3: Amount (e.g. $160.00) */
+			__( 'Woohoo, %1$s was your record day for sales! Net sales was %2$s beating the previous record of %3$s set on %4$s.', 'woocommerce' ),
+			$formatted_yesterday,
+			$formatted_total,
+			$formatted_record_amt,
+			$formatted_record_date
+		);
+
+		$content_data = (object) array(
+			'old_record_date' => $record_date,
+			'old_record_amt'  => $record_amt,
+			'new_record_date' => $yesterday,
+			'new_record_amt'  => $total,
+		);
+
+		$report_url = '?page=wc-admin&path=/analytics/revenue&period=custom&compare=previous_year&after=' . $yesterday . '&before=' . $yesterday;
+
+		// And now, create our new note.
+		$note = new Note();
+		$note->set_title( __( 'New sales record!', 'woocommerce' ) );
+		$note->set_content( $content );
+		$note->set_content_data( $content_data );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'view-report', __( 'View report', 'woocommerce' ), $report_url );
+
+		return $note;
+	}
+
+	/**
+	 * Get the note. This is used for localizing the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$note = Notes::get_note_by_name( self::NOTE_NAME );
+		if ( ! $note ) {
+			return false;
+		}
+		$content_data = $note->get_content_data();
+		return self::get_note_with_record_data(
+			$content_data->old_record_date,
+			$content_data->old_record_amt,
+			$content_data->new_record_date,
+			$content_data->new_record_amt
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/OrderMilestones.php
@@ -11,7 +11,6 @@ defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Notes\Note;
 use \Automattic\WooCommerce\Admin\Notes\Notes;
-
 /**
  * Order_Milestones
  */
@@ -179,7 +178,7 @@ class OrderMilestones {
 	 * @param int $milestone Order milestone.
 	 * @return string Note title for the milestone.
 	 */
-	public function get_note_title_for_milestone( $milestone ) {
+	public static function get_note_title_for_milestone( $milestone ) {
 		switch ( $milestone ) {
 			case 1:
 				return __( 'First order received', 'woocommerce' );
@@ -208,7 +207,7 @@ class OrderMilestones {
 	 * @param int $milestone Order milestone.
 	 * @return string Note content for the milestone.
 	 */
-	public function get_note_content_for_milestone( $milestone ) {
+	public static function get_note_content_for_milestone( $milestone ) {
 		switch ( $milestone ) {
 			case 1:
 				return __( 'Congratulations on getting your first order! Now is a great time to learn how to manage your orders.', 'woocommerce' );
@@ -234,7 +233,7 @@ class OrderMilestones {
 	 * @param int $milestone Order milestone.
 	 * @return array Note actoion (name, label, query) for the milestone.
 	 */
-	public function get_note_action_for_milestone( $milestone ) {
+	public static function get_note_action_for_milestone( $milestone ) {
 		switch ( $milestone ) {
 			case 1:
 				return array(
@@ -289,21 +288,45 @@ class OrderMilestones {
 	}
 
 	/**
+	 * Get the note. This is used for localizing the note.
+	 *
+	 * @return Note
+	 */
+	public static function get_note() {
+		$note = Notes::get_note_by_name( self::NOTE_NAME );
+		if ( ! $note ) {
+			return false;
+		}
+		$content_data = $note->get_content_data();
+		if ( ! isset( $content_data->current_milestone ) ) {
+			return false;
+		}
+		return self::get_note_by_milestone(
+			$content_data->current_milestone
+		);
+	}
+
+	/**
 	 * Get the note by milestones.
 	 *
 	 * @param int $current_milestone Current milestone.
 	 *
 	 * @return Note
 	 */
-	public function get_note_by_milestone( $current_milestone ) {
+	public static function get_note_by_milestone( $current_milestone ) {
+		$content_data = (object) array(
+			'current_milestone' => $current_milestone,
+		);
+
 		$note = new Note();
 		$note->set_title( self::get_note_title_for_milestone( $current_milestone ) );
 		$note->set_content( self::get_note_content_for_milestone( $current_milestone ) );
-		$note_action = self::get_note_action_for_milestone( $current_milestone );
-		$note->add_action( $note_action['name'], $note_action['label'], $note_action['query'] );
+		$note->set_content_data( $content_data );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
+		$note_action = self::get_note_action_for_milestone( $current_milestone );
+		$note->add_action( $note_action['name'], $note_action['label'], $note_action['query'] );
 		return $note;
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-test-order-milestones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-test-order-milestones.php
@@ -9,7 +9,7 @@ use \Automattic\WooCommerce\Internal\Admin\Notes\OrderMilestones;
 use Automattic\WooCommerce\Admin\Notes\Notes;
 
 /**
- * Class WC_Admin_Tests_Marketing_Notes
+ * Class WC_Admin_Tests_Order_Milestones
  */
 class WC_Admin_Tests_Order_Milestones extends WC_Unit_Test_Case {
 
@@ -112,5 +112,23 @@ class WC_Admin_Tests_Order_Milestones extends WC_Unit_Test_Case {
 		$this->instance->possibly_add_note();
 		$note = Notes::get_note_by_name( OrderMilestones::NOTE_NAME );
 		$this->assertEquals( $note->get_content(), "You've hit the 10 orders milestone! Look at you go. Browse some WooCommerce success stories for inspiration." );
+	}
+
+
+	/**
+	 * Tests get_note method return false when note does not exist in db.
+	 */
+	public function test_get_note_when_note_not_exist_in_db() {
+		$this->assertFalse( OrderMilestones::get_note() );
+	}
+
+	/**
+	 * Tests get_note method return note when note exists in db.
+	 */
+	public function test_get_note_when_note_exists_in_db() {
+		WC_Helper_Order::create_order();
+		$this->instance->possibly_add_note();
+		$note = OrderMilestones::get_note();
+		$this->assertEquals( $note->get_title(), 'First order received' );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-new-sales-record.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/notes/class-wc-tests-new-sales-record.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * NewSalesRecord note tests
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use \Automattic\WooCommerce\Internal\Admin\Notes\NewSalesRecord;
+
+/**
+ * Class WC_Admin_New_Sales_Record
+ */
+class WC_Admin_Tests_New_Sales_Record extends WC_Unit_Test_Case {
+	/**
+	 * Tests get_note method return false when note does not exist in db.
+	 */
+	public function test_get_note_when_note_not_exist_in_db() {
+		$this->assertFalse( NewSalesRecord::get_note() );
+	}
+
+	/**
+	 * Tests get_note method return note when note exists in db.
+	 */
+	public function test_get_note_when_note_exists_in_db() {
+		$record_date   = '2022-08-15';
+		$record_amount = 100;
+		$yesterday     = '2022-08-16';
+		$total         = 200;
+		$note          = NewSalesRecord::get_note_with_record_data( $record_date, $record_amount, $yesterday, $total );
+		$note->save();
+
+		$note = NewSalesRecord::get_note();
+		$this->assertEquals( $note->get_content(), 'Woohoo, August 16th was your record day for sales! Net sales was $200.00 beating the previous record of $100.00 set on August 15th.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34269.

This PR refactors `OrderMilestones` and `NewSalesRecord` notes to have `get_note` method so that we can use it to display localized notes.


### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to Products
3. Create a product with the sale price > 0.
4. Go to `WooCommerce > Orders > Add orders`
5. Set `Date created` to yesterday.
6. Set `status` to "Completed"
7. Add an item with the product you just created.
8. Create the order
9. Go to `Tools > Cron Events`
10. Run `wc_admin_daily` and `wc_admin_process_orders_milestone`
11. Create another order with steps 4~8 
12. Run `wc_admin_daily` again
13. Go to `WooCommerce > Home`
14. Observe that `First order received` and `New sales record!` notes are displayed.
15. Change the "Site Language" to `Español` on the **Setting**  page
16. Go to `Dashboard > Updates`
17. Scroll to page bottom and make sure "Translations (Traducciones)" are all up to update 
18. Go to `WooCommerce > Home`
19. Observe that `First order received` and `New sales record!`  notes are translated.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
