### PR TITLE
Update WooCommerce blocks package to 8.3.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.3.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.3.1
@@ -1,0 +1,5 @@
+Significance: minor
+Type: update
+
+  Update WooCommerce Blocks to 8.3.1
+

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.0.0"
+		"woocommerce/woocommerce-blocks": "8.3.1"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15c3bc105340156959abfb26fc827185",
+    "content-hash": "5298ee4bda708dc014b02c6df681ffe8",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -385,59 +385,6 @@
             "time": "2021-09-16T16:22:04+00:00"
         },
         {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
-            },
-            "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
             "name": "sabberworm/php-css-parser",
             "version": "8.4.0",
             "source": {
@@ -681,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.0.0",
+            "version": "v8.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "47379270586de9d409200885883ec035dd4aceed"
+                "reference": "095d5efeeb87b53d1e795b5721a0d7c37632322f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/47379270586de9d409200885883ec035dd4aceed",
-                "reference": "47379270586de9d409200885883ec035dd4aceed",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/095d5efeeb87b53d1e795b5721a0d7c37632322f",
+                "reference": "095d5efeeb87b53d1e795b5721a0d7c37632322f",
                 "shasum": ""
             },
             "require": {
@@ -698,10 +645,10 @@
                 "composer/installers": "^1.7.0"
             },
             "require-dev": {
-                "johnbillion/wp-hooks-generator": "^0.7.0",
+                "johnbillion/wp-hooks-generator": "^0.9.0",
                 "mockery/mockery": "^1.4",
                 "woocommerce/woocommerce-sniffs": "0.1.0",
-                "wp-phpunit/wp-phpunit": "^5.4",
+                "wp-phpunit/wp-phpunit": "^6.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "wordpress-plugin",
@@ -734,9 +681,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.0.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.3.1"
             },
-            "time": "2022-07-05T15:54:39+00:00"
+            "time": "2022-08-17T11:37:02+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.3.1. It includes changes from WooCommerce Blocks 8.1.0-8.3.1 and is intended to target WooCommerce 6.9 for release.
Details from all the different releases included in this pull:


## Blocks 8.1.0

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/6693)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/810.md)
* [Release post](https://developer.woocommerce.com/2022/07/19/woocommerce-blocks-8-1-0-release-notes/)

## Blocks 8.2.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6806)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/820.md)
* [Release post](https://developer.woocommerce.com/2022/08/02/woocommerce-blocks-8-2-0-release-notes/)


## Blocks 8.2.1

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6826)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/821.md)
* [Release post](https://developer.woocommerce.com/2022/08/04/woocommerce-blocks-8-2-1-release-notes/)

## Blocks 8.3.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6897)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/830.md)

## Blocks 8.3.1

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6910)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/831.md)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements
- Enable the Cart and Checkout blocks when WooCommerce Blocks is bundled in WooCommerce Core.([6805](https://github.com/woocommerce/woocommerce-blocks/pull/6805))
- Refactor style-attributes hooks to add as global custom imports and remove relative import paths.([6870](https://github.com/woocommerce/woocommerce-blocks/pull/6870))
- Add the ability to register patterns by adding them under the "patterns" folder and add the new "WooCommerce Filters" pattern.([6861](https://github.com/woocommerce/woocommerce-blocks/pull/6861))
- Update: New block icon for the Mini Cart block.([6784](https://github.com/woocommerce/woocommerce-blocks/pull/6784))
- Update WooCommerce block template descriptions.([6667](https://github.com/woocommerce/woocommerce-blocks/pull/6667))
- Add filter URL support to filter blocks when filtering for All Products block.([6642](https://github.com/woocommerce/woocommerce-blocks/pull/6642))
- Add: Allow choosing between single and multiple sections.([6620](https://github.com/woocommerce/woocommerce-blocks/pull/6620))
- Cart endpoint for Store API (/wc/store/cart) now features cross-sell items based on cart contents.([6635](https://github.com/woocommerce/woocommerce-blocks/pull/6635))


#### Bug Fixes
- Refactor Product Categories block to use block.json.([6875](https://github.com/woocommerce/woocommerce-blocks/pull/6875))
- Fix: Add font-weight controls to the Mini Cart block text.([6760](https://github.com/woocommerce/woocommerce-blocks/pull/6760))
- Fix proceed to checkout button not working for custom links.([6804](https://github.com/woocommerce/woocommerce-blocks/pull/6804))
- Mini Cart block: Remove the compatibility notice.([6803](https://github.com/woocommerce/woocommerce-blocks/pull/6803))
- Fix: Render the product attribute archive page using the archive-product template.([6776](https://github.com/woocommerce/woocommerce-blocks/pull/6776))
- Select the correct inner button for the "Featured Item" button to update its URL.([6741](https://github.com/woocommerce/woocommerce-blocks/pull/6741))
- Fix: Navigate through Mini Cart contents with keyboard.([6731](https://github.com/woocommerce/woocommerce-blocks/pull/6731))
- Fix: Ensure add to cart notices are displayed on pages containing the Mini Cart block.([6728](https://github.com/woocommerce/woocommerce-blocks/pull/6728))
- Fixes an issue where search lists would not preserve the case of the original item.([6551](https://github.com/woocommerce/woocommerce-blocks/pull/6551))
- Prevent Featured Product block from breaking when product is out of stock + hidden from catalog.([6640](https://github.com/woocommerce/woocommerce-blocks/pull/6640))
- Contrast improvement for checkout error messages when displayed over a theme's dark mode.([6292](https://github.com/woocommerce/woocommerce-blocks/pull/6292))

### Changelog entry

> Dev - Update WooCommerce Blocks version to 8.3.1

