### PR TITLE
Exclude asterisk from Country / Region translation string

### DIFF
--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -354,7 +354,7 @@ export function StoreAddress( {
 	return (
 		<div className="woocommerce-store-address-fields">
 			<SelectControl
-				label={ __( 'Country / Region *', 'woocommerce' ) }
+				label={ __( 'Country / Region', 'woocommerce' ) + ' *' }
 				required
 				autoComplete="new-password" // disable autocomplete and autofill
 				options={ countryStateOptions }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the Country / Region label to exclude asterisk from the translation string since it doesn't need to be translated.

### How to test the changes in this Pull Request:

1. Go to OBW
2. Observe that `Country/Region` is still displayed with an asterisk

**Optional**

1. Change site language to Spanish
2. Go to WP dashboard
3. Download the woocommerce translation files 
4. Go to OBW
5. Observe that `Country/Region` is translated.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
