### PR TITLE
Fix texts in wp-admin-scripts not translated

### DIFF
--- a/plugins/woocommerce/changelog/fix-34370-texts-in-admin-scripts-not-translated
+++ b/plugins/woocommerce/changelog/fix-34370-texts-in-admin-scripts-not-translated
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix texts in wca client/wp-admin-scripts are not translated

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
@@ -77,16 +77,7 @@ class WC_Admin_Pointers {
 			$labels          = $wp_post_types['product']->labels;
 			$labels->add_new = __( 'Enable guided mode', 'woocommerce' );
 
-			$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-homepage-notice' );
-			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-			wp_enqueue_script(
-				'product-tutorial',
-				WCAdminAssets::get_url( 'wp-admin-scripts/product-tour', 'js' ),
-				array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-				WC_VERSION,
-				true
-			);
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'product-tour', true );
 			return;
 		}
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -341,17 +341,7 @@ class WC_Products_Tracking {
 			return;
 		}
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'product-tracking' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'wc-admin-product-tracking',
-			WCAdminAssets::get_url( 'wp-admin-scripts/product-tracking', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
-
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'product-tracking', false );
 		wp_localize_script(
 			'wc-admin-product-tracking',
 			'productScreen',
@@ -377,16 +367,7 @@ class WC_Products_Tracking {
 		}
 		// phpcs:enable
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'attributes-tracking' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'wc-admin-attributes-tracking',
-			WCAdminAssets::get_url( 'wp-admin-scripts/attributes-tracking', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'attributes-tracking', false );
 	}
 
 	/**
@@ -410,17 +391,7 @@ class WC_Products_Tracking {
 			isset( $_GET['taxonomy'] ) &&
 			'product_tag' === wp_unslash( $_GET['taxonomy'] )
 		) {
-			// phpcs:enable
-			$tags_script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'tags-tracking' );
-			$tags_script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $tags_script_assets_filename;
-
-			wp_enqueue_script(
-				'wc-admin-tags-tracking',
-				WCAdminAssets::get_url( 'wp-admin-scripts/tags-tracking', 'js' ),
-				array_merge( array( WC_ADMIN_APP ), $tags_script_assets ['dependencies'] ),
-				WCAdminAssets::get_file_version( 'js' ),
-				true
-			);
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'tags-tracking', false );
 			return;
 		}
 
@@ -429,29 +400,9 @@ class WC_Products_Tracking {
 			isset( $_GET['taxonomy'] ) &&
 			'product_cat' === wp_unslash( $_GET['taxonomy'] )
 		) {
-			// phpcs:enable
-			$category_script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'category-tracking' );
-			$category_script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $category_script_assets_filename;
-
-			wp_enqueue_script(
-				'wc-admin-category-tracking',
-				WCAdminAssets::get_url( 'wp-admin-scripts/category-tracking', 'js' ),
-				array_merge( array( WC_ADMIN_APP ), $category_script_assets ['dependencies'] ),
-				WCAdminAssets::get_file_version( 'js' ),
-				true
-			);
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'category-tracking', false );
 			return;
 		}
-
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'add-term-tracking' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'wc-admin-add-term-tracking',
-			WCAdminAssets::get_url( 'wp-admin-scripts/add-term-tracking', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'add-term-tracking', false );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
@@ -119,7 +119,7 @@ class Init {
 			return;
 		}
 
-		if ( 'yes' !== $value ) {
+		if ( $value !== 'yes' ) {
 			update_option( 'woocommerce_navigation_show_opt_out', 'yes' );
 		}
 
@@ -142,7 +142,7 @@ class Init {
 	 * Enqueue the opt out scripts.
 	 */
 	public function maybe_enqueue_opt_out_scripts() {
-		if ( 'yes' !== get_option( 'woocommerce_navigation_show_opt_out', 'no' ) ) {
+		if ( get_option( 'woocommerce_navigation_show_opt_out', 'no' ) !== 'yes' ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
@@ -155,6 +155,13 @@ class Init {
 		);
 
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'navigation-opt-out', true );
+		wp_localize_script(
+			'wc-admin-navigation-opt-out',
+			'surveyData',
+			array(
+				'url' => Survey::get_url( '/new-navigation-opt-out' ),
+			)
+		);
 		delete_option( 'woocommerce_navigation_show_opt_out' );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Init.php
@@ -154,25 +154,7 @@ class Init {
 			WCAdminAssets::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'navigation-opt-out' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'wc-admin-navigation-opt-out',
-			WCAdminAssets::get_url( 'wp-admin-scripts/navigation-opt-out', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
-
-		wp_localize_script(
-			'wc-admin-navigation-opt-out',
-			'surveyData',
-			array(
-				'url' => Survey::get_url( '/new-navigation-opt-out' ),
-			)
-		);
-
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'navigation-opt-out', true );
 		delete_option( 'woocommerce_navigation_show_opt_out' );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
@@ -117,16 +117,7 @@ class Appearance extends Task {
 			return;
 		}
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-homepage-notice' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'onboarding-homepage-notice',
-			WCAdminAssets::get_url( 'wp-admin-scripts/onboarding-homepage-notice', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_VERSION,
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'onboarding-homepage-notice', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
@@ -42,7 +42,7 @@ class Appearance extends Task {
 		if ( count( $this->task_list->get_sections() ) > 0 && ! $this->is_complete() ) {
 			return __( 'Make your store stand out with unique design', 'woocommerce' );
 		}
-		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
+		if ( $this->get_parent_option( 'use_completed_title' ) === true ) {
 			if ( $this->is_complete() ) {
 				return __( 'You personalized your store', 'woocommerce' );
 			}
@@ -109,7 +109,7 @@ class Appearance extends Task {
 	public function possibly_add_return_notice_script( $hook ) {
 		global $post;
 
-		if ( 'post.php' !== $hook || 'page' !== $post->post_type ) {
+		if ( $hook !== 'post.php' || $post->post_type !== 'page' ) {
 			return;
 		}
 
@@ -124,7 +124,7 @@ class Appearance extends Task {
 	 * Check if the site has a homepage set up.
 	 */
 	public static function has_homepage() {
-		if ( 'classic' === get_option( 'classic-editor-replace' ) ) {
+		if ( get_option( 'classic-editor-replace' ) === 'classic' ) {
 			return true;
 		}
 
@@ -135,7 +135,7 @@ class Appearance extends Task {
 		}
 
 		$post      = get_post( $homepage_id );
-		$completed = $post && 'publish' === $post->post_status;
+		$completed = $post && $post->post_status === 'publish';
 
 		return $completed;
 	}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -109,16 +109,7 @@ class Products extends Task {
 			return;
 		}
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-notice' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'onboarding-product-notice',
-			WCAdminAssets::get_url( 'wp-admin-scripts/onboarding-product-notice', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_VERSION,
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'onboarding-product-notice', true );
 
 		// Clear the active task transient to only show notice once per active session.
 		delete_transient( self::ACTIVE_TASK_TRANSIENT );
@@ -140,16 +131,7 @@ class Products extends Task {
 			return;
 		}
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-import-notice' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'onboarding-product-import-notice',
-			WCAdminAssets::get_url( 'wp-admin-scripts/onboarding-product-import-notice', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_VERSION,
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'onboarding-product-import-notice', true );
 	}
 
 	/**
@@ -176,16 +158,7 @@ class Products extends Task {
 			return;
 		}
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-product-notice' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'onboarding-load-sample-products-notice',
-			WCAdminAssets::get_url( 'wp-admin-scripts/onboarding-load-sample-products-notice', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_VERSION,
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'onboarding-load-sample-products-notice', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -40,7 +40,7 @@ class Products extends Task {
 		if ( count( $this->task_list->get_sections() ) > 0 && ! $this->is_complete() ) {
 			return __( 'Create or upload your first products', 'woocommerce' );
 		}
-		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
+		if ( $this->get_parent_option( 'use_completed_title' ) === true ) {
 			if ( $this->is_complete() ) {
 				return __( 'You added products', 'woocommerce' );
 			}
@@ -101,7 +101,7 @@ class Products extends Task {
 	 */
 	public function possibly_add_manual_return_notice_script( $hook ) {
 		global $post;
-		if ( 'post.php' !== $hook || 'product' !== $post->post_type ) {
+		if ( $hook !== 'post.php' || $post->post_type !== 'product' ) {
 			return;
 		}
 
@@ -123,7 +123,7 @@ class Products extends Task {
 	public function possibly_add_import_return_notice_script( $hook ) {
 		$step = isset( $_GET['step'] ) ? $_GET['step'] : ''; // phpcs:ignore csrf ok, sanitization ok.
 
-		if ( 'product_page_product_importer' !== $hook || 'done' !== $step ) {
+		if ( $hook !== 'product_page_product_importer' || $step !== 'done' ) {
 			return;
 		}
 
@@ -140,12 +140,12 @@ class Products extends Task {
 	 * @param string $hook Page hook.
 	 */
 	public function possibly_add_load_sample_return_notice_script( $hook ) {
-		if ( 'edit.php' !== $hook || 'product' !== get_query_var( 'post_type' ) ) {
+		if ( $hook !== 'edit.php' || get_query_var( 'post_type' ) !== 'product' ) {
 			return;
 		}
 
 		$referer = wp_get_referer();
-		if ( ! $referer || 0 !== strpos( $referer, wc_admin_url() ) ) {
+		if ( ! $referer || strpos( $referer, wc_admin_url() ) !== 0 ) {
 			return;
 		}
 
@@ -176,6 +176,6 @@ class Products extends Task {
 		);
 		$products      = $product_query->get_products();
 
-		return 0 !== count( $products );
+		return count( $products ) !== 0;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -38,16 +38,7 @@ class Tax extends Task {
 			return;
 		}
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'onboarding-tax-notice' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'onboarding-tax-notice',
-			WCAdminAssets::get_url( 'wp-admin-scripts/onboarding-tax-notice', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WC_VERSION,
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'onboarding-tax-notice', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -30,7 +30,7 @@ class Tax extends Task {
 		$page = isset( $_GET['page'] ) ? $_GET['page'] : ''; // phpcs:ignore csrf ok, sanitization ok.
 		$tab  = isset( $_GET['tab'] ) ? $_GET['tab'] : ''; // phpcs:ignore csrf ok, sanitization ok.
 
-		if ( 'wc-settings' !== $page || 'tax' !== $tab ) {
+		if ( $page !== 'wc-settings' || $tab !== 'tax' ) {
 			return;
 		}
 
@@ -59,7 +59,7 @@ class Tax extends Task {
 		if ( count( $this->task_list->get_sections() ) > 0 && ! $this->is_complete() ) {
 			return __( 'Get taxes out of your mind', 'woocommerce' );
 		}
-		if ( true === $this->get_parent_option( 'use_completed_title' ) ) {
+		if ( $this->get_parent_option( 'use_completed_title' ) === true ) {
 			if ( $this->is_complete() ) {
 				return __( 'You added tax rates', 'woocommerce' );
 			}
@@ -116,7 +116,7 @@ class Tax extends Task {
 	public function is_complete() {
 		return get_option( 'wc_connect_taxes_enabled' ) ||
 			count( TaxDataStore::get_taxes( array() ) ) > 0 ||
-			false !== get_option( 'woocommerce_no_sales_tax' );
+			get_option( 'woocommerce_no_sales_tax' ) !== false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Coupons.php
+++ b/plugins/woocommerce/src/Internal/Admin/Coupons.php
@@ -103,7 +103,7 @@ class Coupons {
 	public function fix_coupon_menu_highlight() {
 		global $parent_file, $post_type;
 
-		if ( 'shop_coupon' === $post_type ) {
+		if ( $post_type === 'shop_coupon' ) {
 			$parent_file = 'woocommerce-marketing'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride
 		}
 	}
@@ -113,7 +113,7 @@ class Coupons {
 	 */
 	public function maybe_add_marketing_coupon_script() {
 		$curent_screen = PageController::get_instance()->get_current_page();
-		if ( ! isset( $curent_screen['id'] ) || 'woocommerce-coupons' !== $curent_screen['id'] ) {
+		if ( ! isset( $curent_screen['id'] ) || $curent_screen['id'] !== 'woocommerce-coupons' ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Coupons.php
+++ b/plugins/woocommerce/src/Internal/Admin/Coupons.php
@@ -126,15 +126,6 @@ class Coupons {
 			WCAdminAssets::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'marketing-coupons' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'wc-admin-marketing-coupons',
-			WCAdminAssets::get_url( 'wp-admin-scripts/marketing-coupons', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'marketing-coupons', true );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -133,16 +133,7 @@ class ShippingLabelBanner {
 			WCAdminAssets::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'print-shipping-label-banner' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'print-shipping-label-banner',
-			WCAdminAssets::get_url( 'wp-admin-scripts/print-shipping-label-banner', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'print-shipping-label-banner', true );
 
 		$payload = array(
 			'nonce'                 => wp_create_nonce( 'wp_rest' ),

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -381,7 +381,7 @@ class WCAdminAssets {
 	}
 
 	/**
-	 * Loads the a script
+	 * Loads a script
 	 *
 	 * @param string $script_path_name The script path name.
 	 * @param string $script_name Filename of the script to load.

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -51,7 +51,7 @@ class WCAdminAssets {
 	 * @return string Folder path of asset.
 	 */
 	public static function get_path( $ext ) {
-		return ( 'css' === $ext ) ? WC_ADMIN_DIST_CSS_FOLDER : WC_ADMIN_DIST_JS_FOLDER;
+		return ( $ext === 'css' ) ? WC_ADMIN_DIST_CSS_FOLDER : WC_ADMIN_DIST_JS_FOLDER;
 	}
 
 	/**
@@ -81,7 +81,7 @@ class WCAdminAssets {
 		$suffix = '';
 
 		// Potentially enqueue minified JavaScript.
-		if ( 'js' === $ext ) {
+		if ( $ext === 'js' ) {
 			$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 			$suffix       = self::should_use_minified_js_file( $script_debug ) ? '.min' : '';
 		}
@@ -168,9 +168,9 @@ class WCAdminAssets {
 	 * @param array  $allowlist Optional. List of allowed dependency handles.
 	 */
 	private function output_header_preload_tags_for_type( $type, $allowlist = array() ) {
-		if ( 'script' === $type ) {
+		if ( $type === 'script' ) {
 			$dependencies_of_type = wp_scripts();
-		} elseif ( 'style' === $type ) {
+		} elseif ( $type === 'style' ) {
 			$dependencies_of_type = wp_styles();
 		} else {
 			return;
@@ -179,7 +179,7 @@ class WCAdminAssets {
 		foreach ( $dependencies_of_type->queue as $dependency_handle ) {
 			$dependency = $dependencies_of_type->query( $dependency_handle, 'registered' );
 
-			if ( false === $dependency ) {
+			if ( $dependency === false ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -385,7 +385,7 @@ class WCAdminAssets {
 	 *
 	 * @param string $script_path_name The script path name.
 	 * @param string $script_name Filename of the script to load.
-	 * @param string $need_translation Whether the script need translations.
+	 * @param bool   $need_translation Whether the script need translations.
 	 */
 	public static function register_script( $script_path_name, $script_name, $need_translation = false ) {
 		$script_assets_filename = self::get_script_asset_filename( $script_path_name, $script_name );

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -379,4 +379,27 @@ class WCAdminAssets {
 			}
 		}
 	}
+
+	/**
+	 * Loads the a script
+	 *
+	 * @param string $script_path_name The script path name.
+	 * @param string $script_name Filename of the script to load.
+	 * @param string $need_translation Whether the script need translations.
+	 */
+	public static function register_script( $script_path_name, $script_name, $need_translation = false ) {
+		$script_assets_filename = self::get_script_asset_filename( $script_path_name, $script_name );
+		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
+
+		wp_enqueue_script(
+			'wc-admin-' . $script_name,
+			self::get_url( $script_path_name . '/' . $script_name, 'js' ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			self::get_file_version( 'js' ),
+			true
+		);
+		if ( $need_translation ) {
+			wp_set_script_translations( 'wc-admin-' . $script_name, 'woocommerce' );
+		}
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -24,7 +24,7 @@ class Init {
 	public function __construct() {
 		include_once __DIR__ . '/WCPaymentGatewayPreInstallWCPayPromotion.php';
 
-		$is_payments_page = isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab']; // phpcs:ignore WordPress.Security.NonceVerification
+		$is_payments_page = isset( $_GET['page'] ) && $_GET['page'] === 'wc-settings' && isset( $_GET['tab'] ) && $_GET['tab'] === 'checkout'; // phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! wp_is_json_request() && ! $is_payments_page ) {
 			return;
 		}
@@ -68,7 +68,7 @@ class Init {
 		if ( class_exists( '\WC_Payments' ) ) {
 			return false;
 		}
-		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
+		if ( get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) === 'no' ) {
 			return false;
 		}
 		if ( ! apply_filters( 'woocommerce_allow_marketplace_suggestions', true ) ) {
@@ -95,7 +95,7 @@ class Init {
 		$id       = WCPaymentGatewayPreInstallWCPayPromotion::GATEWAY_ID;
 		// Only tweak the ordering if the list hasn't been reordered with WooCommerce Payments in it already.
 		if ( ! isset( $ordering[ $id ] ) || ! is_numeric( $ordering[ $id ] ) ) {
-			$is_empty        = empty( $ordering ) || ( 1 === count( $ordering ) && false === $ordering[0] );
+			$is_empty        = empty( $ordering ) || ( count( $ordering ) === 1 && $ordering[0] === false );
 			$ordering[ $id ] = $is_empty ? 0 : ( min( $ordering ) - 1 );
 		}
 		return $ordering;
@@ -152,7 +152,7 @@ class Init {
 	 * Get specs or fetch remotely if they don't exist.
 	 */
 	public static function get_specs() {
-		if ( 'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) ) {
+		if ( get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) === 'no' ) {
 			return array();
 		}
 		return WCPayPromotionDataSourcePoller::get_instance()->get_specs_from_data_sources();

--- a/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php
@@ -42,16 +42,7 @@ class Init {
 			WCAdminAssets::get_file_version( 'css' )
 		);
 
-		$script_assets_filename = WCAdminAssets::get_script_asset_filename( 'wp-admin-scripts', 'payment-method-promotions' );
-		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . 'wp-admin-scripts/' . $script_assets_filename;
-
-		wp_enqueue_script(
-			'wc-admin-payment-method-promotions',
-			WCAdminAssets::get_url( 'wp-admin-scripts/payment-method-promotions', 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
-			WCAdminAssets::get_file_version( 'js' ),
-			true
-		);
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'payment-method-promotions', true );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34370.

This PR fixes a bug that texts in wp-admin-scripts are not translated.

Changes:

- Create a util method `register_script` to register admin scripts
- Call `wp_set_script_translations` to get scripts translated

### How to test the changes in this Pull Request:

**Prerequisites**

1.  Switch the site language to `Español`
2. Go to `Escritorio > Actualizaciones` (Dashboard > Updates)
3. Scroll to page bottom and make sure "Translations (Traducciones)" are all up to updated
4. Enable logging `localStorage.setItem( 'debug', 'wc-admin:*' )`

**Test product-tour, product-tracking and onboarding-product-notice**

1. Manually add `experiment woocommerce_products_tour` and set it to treatment via `WooCommerce Admin Test Helper`
2. Experiments woocommerce_products_task_layout_card_v2 and woocommerce_products_task_layout_stacked_v2 should be set to control
3. `Go to WooCommerce > Inicio (Home)` 
4. Skip OBW
5. Go to `Añadir productos`
6. Select physical product template `Producto físico`
7. Observe that texts on the product tour step 1 are translated `Empieza a escribir aquí el nombre de tu nuevo producto. Este será el que verán los clientes en tu tienda.`
8. Observe that `wcadmin_product_edit_view` event is triggered
9. Dismiss the product tour
10. Create the product
11. Observe that `🎉¡Felicidades por haber añadido tu primer producto!` notice is dispalyed.

**Test marketing-coupons**

1. Go to Marketing > Cupones
2. Observe that `Aprende los entresijos de un marketing de éxito de los expertos de WooCommerce.` text is displayed.

**Test navigation-opt-out**

1. Go to `Ajustes > Avanzado > Características` (Settings > Advanced > Features)
2. Enable Navegación
3. Disable Navegación
5. Observe that a modal "Ayúdanos a mejorar" is displayed.

**Test onboarding-tax-notice**

1. Go to WooCommerce > Home
2. Go to `Añade tarifas de impuestos` (tax task)
3. Click `Configura los impuestos manualmente`
4. Add a tax 
6. Observe that a notice `¡Has añadido tu primera tasa de impuestos!` is displayed. 

---

Since the changes are similar, I think the above tests should be enough, but free feel to test the other admin scripts

- payment-method-promotions
- print-shipping-label-banner
- onboarding-homepage-notice

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
