### PR TITLE
Restore 'Contributing to WooCommerce' guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ This repository is not suitable for support. Please don't use our issue tracker 
 Support requests in issues on this repository will be closed on sight.
 
 ## Contributing to WooCommerce
-If you have a patch or have stumbled upon an issue with WooCommerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) for more information how you can do this.
+If you have a patch or have stumbled upon an issue with WooCommerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) for more information on how you can do this.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ This repository is not suitable for support. Please don't use our issue tracker 
 * For customizations, you may want to check our list of [WooExperts](https://woocommerce.com/experts/) or [Codeable](https://codeable.io/).
 
 Support requests in issues on this repository will be closed on sight.
+
+## Contributing to WooCommerce
+If you have a patch or have stumbled upon an issue with WooCommerce core, you can contribute this back to the code. Please read our [contributor guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) for more information how you can do this.

--- a/plugins/woocommerce/changelog/add-contributor-guidelines-link
+++ b/plugins/woocommerce/changelog/add-contributor-guidelines-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: No changelog needed, this tweaks the readme only very slightly, and there is probably little value in itemizing it.
+
+


### PR DESCRIPTION
Restores some guidance about contributing to the project that was inadvertently removed from the main project readme file.

Internal convo for reference: p1660841134967299-slack-C03CPM3UXDJ

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.