### PR TITLE
Update documentation for two methods in abstract-wc-order.php

### DIFF
--- a/plugins/woocommerce/changelog/update-order-method-docblocks
+++ b/plugins/woocommerce/changelog/update-order-method-docblocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Updates and improves the docblocks for methods WC_Order::get_total() and WC_Order::get_subtotal().

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -417,7 +417,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Gets order grand total. incl. taxes. Used in gateways.
+	 * Gets order grand total including taxes, shipping cost, fees, and coupon discounts. Used in gateways.
 	 *
 	 * @param  string $context View or edit context.
 	 * @return float
@@ -458,7 +458,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Gets order subtotal.
+	 * Gets order subtotal. Order subtotal is the price of all items excluding taxes, fees, shipping cost, and coupon discounts.
+	 * If sale price is set on an item, the subtotal will include this sale discount. E.g. a product with a regular
+	 * price of $100 bought at a 50% discount will represent $50 of the subtotal for the order.
 	 *
 	 * @return float
 	 */


### PR DESCRIPTION
My attempt to make the documentation clearer for these two methods. It's almost impossible to remember all nuances here, so I constantly find myself testing this. Better to have it in the documentation.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
