### PR TITLE
Pass the version argument explicitly to code-analyzer, introduce a new command that determines latest major/minor

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -13,7 +13,7 @@ jobs:
               run: |
                   npm install -g pnpm@^6.24.2
                   npm -g i @wordpress/env@5.1.0
-                  pnpm install
+                  pnpm install --filter code-analyzer
             - name: Run analyzer
               id: run
               run: |

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Run analyzer
               id: run
               run: |
-                version=$(./tools/code-analyzer/bin/dev major_minor "${{ github.head_ref || github.ref_name }}")
+                version=$(./tools/code-analyzer/bin/dev major_minor "${{ github.head_ref || github.ref_name }}" "plugins/woocommerce/woocommerce.php")
                 ./tools/code-analyzer/bin/dev analyzer "$GITHUB_HEAD_REF" $version
             - name: Print results
               id: results

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Run analyzer
               id: run
               run: |
-                version=$(./tools/code-analyzer/bin/dev major_minor "${{ github.ref_name }}")
+                version=$(./tools/code-analyzer/bin/dev major_minor "${{ github.head_ref || github.ref_name }}")
                 ./tools/code-analyzer/bin/dev analyzer "$GITHUB_HEAD_REF" $version
             - name: Print results
               id: results

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -16,7 +16,9 @@ jobs:
                   pnpm install
             - name: Run analyzer
               id: run
-              run: ./tools/code-analyzer/bin/dev analyzer "$GITHUB_HEAD_REF"
+              run: |
+                version=$(./tools/code-analyzer/bin/dev major_minor "${{ github.ref_name }}")
+                ./tools/code-analyzer/bin/dev analyzer "$GITHUB_HEAD_REF" $version
             - name: Print results
               id: results
               run: echo "::set-output name=results::${{ steps.run.outputs.templates }}${{ steps.run.outputs.wphooks }}${{ steps.run.outputs.schema }}${{ steps.run.outputs.database }}"

--- a/tools/code-analyzer/README.md
+++ b/tools/code-analyzer/README.md
@@ -1,0 +1,32 @@
+# Code Analyzer
+
+## Description
+
+`code-analyzer` is a CLI tool designed to analyze change information about plugins in the WooCommerce monorepo.
+
+## Commands
+
+Currently there are just 2 commands:
+
+1. `analyzer`. Analyzer serves 2 roles currently, as a linter for PRs to check if introduced hook/template/db changes have associated changelog entries and also to provide file output of changes between
+WooCommerce versions for the purpose of automating release processes (such as generating release posts.)
+
+Here is an example `analyzer` command:
+
+`./bin/dev analyzer release/6.8 "6.8.0" -b=release/6.7`
+
+In this command we compare the `release/6.7` and `release/6.8` branches to find differences, and we're looking for changes introduced since `6.8.0` (using the `@since` tag).
+
+To find out more about the other arguments to the command you can run `./bin/dev analyzer --help`
+
+2. `major_minor`. This simple CLI tool gives you the latest `.0` major/minor released version of a plugin's mainfile based on Woo release conventions. 
+
+Here is an example `major_minor` command:
+
+`./bin/dev major_minor release/6.8 "plugins/woocommerce/woocommerce.php"`
+
+In this command we checkout the branch `release/6.8` and check the version of the woocommerce.php mainfile located at the path passed. Note that at the time of
+writing the main file in this particular branch reports `6.8.1` so the output of this command is `6.8.0`.
+
+This command is particularly useful combined with the analyzer, allowing you to determine the last major/minor.0 version of a branch or ref before passing that as the
+version argument to `analyzer`.

--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -51,6 +51,7 @@ export default class Analyzer extends Command {
 			name: 'sinceVersion',
 			description:
 				'Specify the version used to determine which changes are included (version listed in @since code doc).',
+			required: true,
 		},
 	];
 

--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -27,6 +27,7 @@ import {
 import { cloneRepo, generateDiff, generateSchemaDiff } from '../../git';
 import { execSync } from 'child_process';
 import { OutputFlags } from '@oclif/core/lib/interfaces';
+import simpleGit from 'simple-git';
 
 /**
  * Analyzer class
@@ -111,7 +112,12 @@ export default class Analyzer extends Command {
 		);
 		CliUx.ux.action.stop();
 
-		const pluginData = this.getPluginData( tmpRepoPath, flags.plugin );
+		const pluginData = await this.getPluginData(
+			tmpRepoPath,
+			flags.plugin,
+			args.compare
+		);
+
 		this.log( `${ pluginData[ 1 ] } Version: ${ pluginData[ 0 ] }` );
 
 		// Run schema diffs only in the monorepo.
@@ -157,7 +163,15 @@ export default class Analyzer extends Command {
 	 * @param {string} plugin Plugin slug.
 	 * @return {string[]} Promise.
 	 */
-	private getPluginData( tmpRepoPath: string, plugin: string ): string[] {
+	private async getPluginData(
+		tmpRepoPath: string,
+		plugin: string,
+		hashOrBranch: string
+	): Promise< string[] > {
+		const git = simpleGit( { baseDir: tmpRepoPath } );
+
+		await git.checkout( [ hashOrBranch ] );
+
 		/**
 		 * List of plugins from our monorepo.
 		 */

--- a/tools/code-analyzer/src/commands/major_minor/index.ts
+++ b/tools/code-analyzer/src/commands/major_minor/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CliUx, Command } from '@oclif/core';
+import { CliUx, Command, Flags } from '@oclif/core';
 import { join } from 'path';
 import { readFileSync, rmSync } from 'fs';
 import simpleGit from 'simple-git';
@@ -37,16 +37,27 @@ export default class MajorMinor extends Command {
 	];
 
 	/**
+	 * CLI flags.
+	 */
+	static flags = {
+		source: Flags.string( {
+			char: 's',
+			description: 'Git repo url or local path to a git repo.',
+			default: process.cwd(),
+		} ),
+	};
+
+	/**
 	 * This method is called to execute the command
 	 */
 	async run(): Promise< void > {
-		const { args } = await this.parse( MajorMinor );
+		const { args, flags } = await this.parse( MajorMinor );
+		const { source } = flags;
 		const { branch, pathToMainFile } = args;
-		const repo = process.cwd();
 
 		CliUx.ux.action.start( `Making a temporary clone of '${ branch }'` );
 
-		const tmpRepoPath = await cloneRepo( repo );
+		const tmpRepoPath = await cloneRepo( source );
 		const version = await this.getPluginData(
 			tmpRepoPath,
 			pathToMainFile,

--- a/tools/code-analyzer/src/commands/major_minor/index.ts
+++ b/tools/code-analyzer/src/commands/major_minor/index.ts
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { CliUx, Command } from '@oclif/core';
+import { join } from 'path';
+import { readFileSync, rmSync } from 'fs';
+import simpleGit from 'simple-git';
+
+/**
+ * Internal dependencies
+ */
+import { cloneRepo } from '../../git';
+
+/**
+ * MajorMinor command class
+ */
+export default class MajorMinor extends Command {
+	/**
+	 * CLI description
+	 */
+	static description = 'Determine major/minor version of WooCommerce plugin';
+
+	/**
+	 * CLI arguments
+	 */
+	static args = [
+		{
+			name: 'branch',
+			description: 'GitHub branch to use to determine version',
+			required: true,
+		},
+	];
+
+	/**
+	 * This method is called to execute the command
+	 */
+	async run(): Promise< void > {
+		const { args } = await this.parse( MajorMinor );
+		const { branch } = args;
+		const repo = process.cwd();
+
+		CliUx.ux.action.start( `Making a temporary clone of '${ branch }'` );
+
+		const tmpRepoPath = await cloneRepo( repo );
+		const version = await this.getPluginData( tmpRepoPath, branch );
+
+		// Clean up the temporary repo.
+		rmSync( tmpRepoPath, { force: true, recursive: true } );
+
+		this.log( version );
+		CliUx.ux.action.stop();
+	}
+
+	/**
+	 * Get plugin data
+	 *
+	 * @param {string} tmpRepoPath  - Path to repo.
+	 * @param {string} hashOrBranch - Hash or branch to checkout.
+	 * @return {Promise<string>} - Promise containing version as string.
+	 */
+	private async getPluginData(
+		tmpRepoPath: string,
+		hashOrBranch: string
+	): Promise< string > {
+		const git = simpleGit( { baseDir: tmpRepoPath } );
+		await git.checkout( [ hashOrBranch ] );
+
+		const pluginData = {
+			name: 'WooCommerce',
+			mainFile: join(
+				tmpRepoPath,
+				'plugins',
+				'woocommerce',
+				'woocommerce.php'
+			),
+		};
+
+		CliUx.ux.action.start( `Getting ${ pluginData.name } version` );
+
+		const content = readFileSync( pluginData.mainFile ).toString();
+		const rawVer = content.match( /^\s+\*\s+Version:\s+(.*)/m );
+
+		if ( ! rawVer ) {
+			this.error( 'Failed to find plugin version!' );
+		}
+		const version = rawVer[ 1 ].replace( /\-.*/, '' );
+
+		CliUx.ux.action.stop();
+
+		const [ major, minor ] = version.split( '.' );
+
+		return `${ major }.${ minor }.0`;
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There was a bug introduced by me in the `code-analyzer` where `getPluginData` no longer worked with the approach to do temporary clones of the repo being analyzed.

Because of this, changes were not properly being detected because the version is used to determine template and hook changes. But we also found that relying on version reporting from the way it was done before was unreliable anyway due to the fact that some branches get minors patched to them. 

Now we determine the latest major/minor in a separate command and pass that as a required argument to the `code-analyzer` in our lint CI job. This will also allow us to pass a version argument explicitly when using this command to determine what changes to include in the release post.

### How to test the changes in this Pull Request:

1. Run the `code-analyzer` comparing against release/6.8 branch which is version `6.8.1` of WooCommerce. And enforce that you're looking for changes from `6.8.0`.

Example command to run: `./tools/code-analyzer/bin/dev analyzer release/6.8 "6.8.0" -b=release/6.7`

This will output some relevant changes from `6.8.0`, example output:

```
## HOOKS:
---------------------------------------------------
FILE: /plugins/woocommerce/includes/abstracts/abstract-wc-order.php
---------------------------------------------------
HOOK: woocommerce_apply_base_tax_for_local_pickup: Filters whether apply base tax for local pickup shipping method or not.
---------------------------------------------------
 NOTICE | New filter found | **woocommerce_apply_base_tax_for_local_pickup** introduced in 6.8.0
---------------------------------------------------
FILE: /plugins/woocommerce/includes/export/abstract-wc-csv-batch-exporter.php
---------------------------------------------------
HOOK: woocommerce_csv_exporter_fopen_mode: Filters the mode parameter which specifies the type of access you require to the stream (used during filewriting for CSV exports). Defaults to 'a' (which supports both reading and writing, and places the filepointer at the end of the file). @see   https://www.php.net/manual/en/function.fopen.php
---------------------------------------------------
 NOTICE | New filter found | **woocommerce_csv_exporter_fopen_mode** introduced in 6.8.0
---------------------------------------------------
FILE: /plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
---------------------------------------------------
HOOK: woocommerce_orders_table_datastore_extra_db_rows_for_order: Allow third parties to include rows that need to be inserted/updated in custom tables when persisting an order.
---------------------------------------------------
 NOTICE | New filter found | **woocommerce_orders_table_datastore_extra_db_rows_for_order** introduced in 6.8.0
---------------------------------------------------
```



### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
