### PR TITLE
Fix #32961 (Corrected the issue of memory limit when server configuration on -1)

### DIFF
--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -177,11 +177,12 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Cons
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The maximum amount of memory (RAM) that your site can use at one time.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
-				if ( $environment['wp_memory_limit'] < 67108864 ) {
+				$wp_memory_limit = wc_let_to_num($environment['wp_memory_limit']);
+				if ( $wp_memory_limit < 67108864 && $environment['wp_memory_limit'] != -1) {
 					/* Translators: %1$s: Memory limit, %2$s: Docs link. */
-					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend setting memory to at least 64MB. See: %2$s', 'woocommerce' ), esc_html( size_format( $environment['wp_memory_limit'] ) ), '<a href="https://wordpress.org/support/article/editing-wp-config-php/#increasing-memory-allocated-to-php" target="_blank">' . esc_html__( 'Increasing memory allocated to PHP', 'woocommerce' ) . '</a>' ) . '</mark>';
+					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend setting memory to at least 64MB. See: %2$s', 'woocommerce' ), esc_html($environment['wp_memory_limit'] ), '<a href="https://wordpress.org/support/article/editing-wp-config-php/#increasing-memory-allocated-to-php" target="_blank">' . esc_html__( 'Increasing memory allocated to PHP', 'woocommerce' ) . '</a>' ) . '</mark>';
 				} else {
-					echo '<mark class="yes">' . esc_html( size_format( $environment['wp_memory_limit'] ) ) . '</mark>';
+					echo '<mark class="yes">' . esc_html($environment['wp_memory_limit']) . '</mark>';
 				}
 				?>
 			</td>

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -42,8 +42,6 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	public static function register_cache_clean() {
 		// Clear the theme cache if we switch themes or our theme is upgraded.
 		add_action( 'switch_theme', array( __CLASS__, 'clean_theme_cache' ) );
-		add_action( 'activate_plugin', array( __CLASS__, 'clean_plugin_cache' ) );
-		add_action( 'deactivate_plugin', array( __CLASS__, 'clean_plugin_cache' ) );
 		add_action(
 			'upgrader_process_complete',
 			function( $upgrader, $extra ) {
@@ -54,7 +52,6 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				// Clear the cache if woocommerce is updated.
 				if ( 'plugin' === $extra['type'] ) {
 					\WC_REST_System_Status_V2_Controller::clean_theme_cache();
-					\WC_REST_System_Status_V2_Controller::clean_plugin_cache();
 					return;
 				}
 
@@ -726,9 +723,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		}
 
 		// WP memory limit.
-		$wp_memory_limit = wc_let_to_num( WP_MEMORY_LIMIT );
-		if ( function_exists( 'memory_get_usage' ) ) {
-			$wp_memory_limit = max( $wp_memory_limit, wc_let_to_num( @ini_get( 'memory_limit' ) ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( class_exists('WP_Site_Health') ) {
+			$wp_memory_limit = WP_Site_Health::get_instance()->php_memory_limit;
 		}
 
 		// Test POST requests.
@@ -945,29 +941,23 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_active_plugins() {
-		$active_plugins_data = get_transient( 'wc_system_status_active_plugins' );
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		if ( false === $active_plugins_data ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			return array();
+		}
 
-			if ( ! function_exists( 'get_plugin_data' ) ) {
-				return array();
-			}
+		$active_plugins = (array) get_option( 'active_plugins', array() );
+		if ( is_multisite() ) {
+			$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+			$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
+		}
 
-			$active_plugins = (array) get_option( 'active_plugins', array() );
-			if ( is_multisite() ) {
-				$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
-				$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
-			}
+		$active_plugins_data = array();
 
-			$active_plugins_data = array();
-
-			foreach ( $active_plugins as $plugin ) {
-				$data                  = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
-				$active_plugins_data[] = $this->format_plugin_data( $plugin, $data );
-			}
-
-			set_transient( 'wc_system_status_active_plugins', $active_plugins_data, HOUR_IN_SECONDS );
+		foreach ( $active_plugins as $plugin ) {
+			$data                  = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+			$active_plugins_data[] = $this->format_plugin_data( $plugin, $data );
 		}
 
 		return $active_plugins_data;
@@ -979,33 +969,27 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_inactive_plugins() {
-		$plugins_data = get_transient( 'wc_system_status_inactive_plugins' );
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		if ( false === $plugins_data ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		if ( ! function_exists( 'get_plugins' ) ) {
+			return array();
+		}
 
-			if ( ! function_exists( 'get_plugins' ) ) {
-				return array();
+		$plugins        = get_plugins();
+		$active_plugins = (array) get_option( 'active_plugins', array() );
+
+		if ( is_multisite() ) {
+			$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+			$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
+		}
+
+		$plugins_data = array();
+
+		foreach ( $plugins as $plugin => $data ) {
+			if ( in_array( $plugin, $active_plugins, true ) ) {
+				continue;
 			}
-
-			$plugins        = get_plugins();
-			$active_plugins = (array) get_option( 'active_plugins', array() );
-
-			if ( is_multisite() ) {
-				$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
-				$active_plugins            = array_merge( $active_plugins, $network_activated_plugins );
-			}
-
-			$plugins_data = array();
-
-			foreach ( $plugins as $plugin => $data ) {
-				if ( in_array( $plugin, $active_plugins, true ) ) {
-					continue;
-				}
-				$plugins_data[] = $this->format_plugin_data( $plugin, $data );
-			}
-
-			set_transient( 'wc_system_status_inactive_plugins', $plugins_data, HOUR_IN_SECONDS );
+			$plugins_data[] = $this->format_plugin_data( $plugin, $data );
 		}
 
 		return $plugins_data;
@@ -1057,36 +1041,29 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_dropins_mu_plugins() {
-		$plugins = get_transient( 'wc_system_status_dropins_mu_plugins' );
-
-		if ( false === $plugins ) {
-			$dropins = get_dropins();
-			$plugins = array(
-				'dropins'    => array(),
-				'mu_plugins' => array(),
+		$dropins = get_dropins();
+		$plugins = array(
+			'dropins'    => array(),
+			'mu_plugins' => array(),
+		);
+		foreach ( $dropins as $key => $dropin ) {
+			$plugins['dropins'][] = array(
+				'plugin' => $key,
+				'name'   => $dropin['Name'],
 			);
-			foreach ( $dropins as $key => $dropin ) {
-				$plugins['dropins'][] = array(
-					'plugin' => $key,
-					'name'   => $dropin['Name'],
-				);
-			}
-
-			$mu_plugins = get_mu_plugins();
-			foreach ( $mu_plugins as $plugin => $mu_plugin ) {
-				$plugins['mu_plugins'][] = array(
-					'plugin'      => $plugin,
-					'name'        => $mu_plugin['Name'],
-					'version'     => $mu_plugin['Version'],
-					'url'         => $mu_plugin['PluginURI'],
-					'author_name' => $mu_plugin['AuthorName'],
-					'author_url'  => esc_url_raw( $mu_plugin['AuthorURI'] ),
-				);
-			}
-
-			set_transient( 'wc_system_status_dropins_mu_plugins', $plugins, HOUR_IN_SECONDS );
 		}
 
+		$mu_plugins = get_mu_plugins();
+		foreach ( $mu_plugins as $plugin => $mu_plugin ) {
+			$plugins['mu_plugins'][] = array(
+				'plugin'      => $plugin,
+				'name'        => $mu_plugin['Name'],
+				'version'     => $mu_plugin['Version'],
+				'url'         => $mu_plugin['PluginURI'],
+				'author_name' => $mu_plugin['AuthorName'],
+				'author_url'  => esc_url_raw( $mu_plugin['AuthorURI'] ),
+			);
+		}
 		return $plugins;
 	}
 
@@ -1198,15 +1175,6 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 */
 	public static function clean_theme_cache() {
 		delete_transient( 'wc_system_status_theme_info' );
-	}
-
-	/**
-	 * Clear the system status plugin caches
-	 */
-	public static function clean_plugin_cache() {
-		delete_transient( 'wc_system_status_active_plugins' );
-		delete_transient( 'wc_system_status_inactive_plugins' );
-		delete_transient( 'wc_system_status_dropins_mu_plugins' );
 	}
 
 	/**


### PR DESCRIPTION
Fixed the issue by using native WordPress function:

https://developer.wordpress.org/reference/classes/wp_site_health/__construct/

Closes #32961

### All Submissions:

-   [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Change the PHP Memory Limit to -1
2. Go to WooCommerce > Status and check the memory limit.

### Other information:

-   [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ x] Have you written new tests for your changes, as applicable?
-   [ x] Have you successfully run tests with your changes locally?
-   [ x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
