### PR TITLE
Hide finish setup button when task list is disabled

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -170,7 +170,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const setupList = getTaskList( activeSetupList );
 
-		const isSetupTaskListHidden = setupList ? setupList.isHidden : true;
+		const isSetupTaskListHidden = setupList?.isHidden ?? true;
 		const setupVisibleTasks = getVisibleTasks( setupList?.tasks || [] );
 		const extendedTaskList = getTaskList( 'extended' );
 

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -170,7 +170,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const setupList = getTaskList( activeSetupList );
 
-		const isSetupTaskListHidden = setupList?.isHidden;
+		const isSetupTaskListHidden = setupList ? setupList.isHidden : true;
 		const setupVisibleTasks = getVisibleTasks( setupList?.tasks || [] );
 		const extendedTaskList = getTaskList( 'extended' );
 

--- a/plugins/woocommerce/changelog/fix-34143-hide-finish-setup-button-when-task-list-is-disabled
+++ b/plugins/woocommerce/changelog/fix-34143-hide-finish-setup-button-when-task-list-is-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide finish setup button when task list is disabled


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34143.

The setup button is still shown when the task list is disabled. This PR fixes the wrong logic of `isSetupTaskListHidden`.


### How to test the changes in this Pull Request:

1. Make sure the task list has not been completed or use a fresh installation
2. Go to `WooCommerce > Settings > Help > Setup Wizard`
3. Click `Disable` under `Task List`
4. Go to `WooCommerce > Orders`
5. Observe that `Finish Setup` button is not shown on the right of the header bar

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
