### PR TITLE
Fix "1 of 2 steps" is shown for the first step in a 3 step tour

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -200,8 +200,7 @@ const TourFloaterWrapper = ( { step }: { step: number } ) => {
 
 export const ShippingTour: React.FC< {
 	showShippingRecommendationsStep: boolean;
-	showWcsSectionStep: boolean;
-} > = ( { showShippingRecommendationsStep, showWcsSectionStep } ) => {
+} > = ( { showShippingRecommendationsStep } ) => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { show: showTour } = useShowShippingTour();
 	const [ step, setStepNumber ] = useState( 0 );
@@ -279,7 +278,9 @@ export const ShippingTour: React.FC< {
 		},
 	};
 
-	if ( showWcsSectionStep ) {
+	const isWcsSectionPresent = document.querySelector( WCS_LINK_SELECTOR );
+
+	if ( isWcsSectionPresent ) {
 		tourConfig.steps.push( {
 			referenceElements: {
 				desktop: WCS_LINK_SELECTOR,

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -200,8 +200,8 @@ const TourFloaterWrapper = ( { step }: { step: number } ) => {
 
 export const ShippingTour: React.FC< {
 	showShippingRecommendationsStep: boolean;
-	showWcsSectionPresent: boolean;
-} > = ( { showShippingRecommendationsStep, showWcsSectionPresent } ) => {
+	showWcsSectionStep: boolean;
+} > = ( { showShippingRecommendationsStep, showWcsSectionStep } ) => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { show: showTour } = useShowShippingTour();
 	const [ step, setStepNumber ] = useState( 0 );
@@ -279,7 +279,7 @@ export const ShippingTour: React.FC< {
 		},
 	};
 
-	if ( showWcsSectionPresent ) {
+	if ( showWcsSectionStep ) {
 		tourConfig.steps.push( {
 			referenceElements: {
 				desktop: WCS_LINK_SELECTOR,

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -59,6 +59,7 @@ const useShowShippingTour = () => {
 	return {
 		isLoading,
 		show:
+			window.wcAdminFeatures[ 'shipping-setting-tour' ] &&
 			! isLoading &&
 			hasCreatedDefaultShippingZones &&
 			! hasReviewedDefaultShippingOptions,
@@ -197,7 +198,10 @@ const TourFloaterWrapper = ( { step }: { step: number } ) => {
 	);
 };
 
-export const ShippingTour = () => {
+export const ShippingTour: React.FC< {
+	showShippingRecommendationsStep: boolean;
+	showWcsSectionPresent: boolean;
+} > = ( { showShippingRecommendationsStep, showWcsSectionPresent } ) => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { show: showTour } = useShowShippingTour();
 	const [ step, setStepNumber ] = useState( 0 );
@@ -275,13 +279,7 @@ export const ShippingTour = () => {
 		},
 	};
 
-	const isWcsSectionPresent = document.querySelector( WCS_LINK_SELECTOR );
-
-	const isShippingRecommendationsPresent = document.querySelector(
-		SHIPPING_RECOMMENDATIONS_SELECTOR
-	);
-
-	if ( isWcsSectionPresent ) {
+	if ( showWcsSectionPresent ) {
 		tourConfig.steps.push( {
 			referenceElements: {
 				desktop: WCS_LINK_SELECTOR,
@@ -299,7 +297,7 @@ export const ShippingTour = () => {
 		} );
 	}
 
-	if ( isShippingRecommendationsPresent ) {
+	if ( showShippingRecommendationsStep ) {
 		tourConfig.steps.push( {
 			referenceElements: {
 				desktop: SHIPPING_RECOMMENDATIONS_SELECTOR,

--- a/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -53,29 +53,16 @@ const ShippingRecommendations: React.FC = () => {
 		activePlugins.includes( 'woocommerce-services' ) &&
 		isJetpackConnected
 	) {
-		return (
-			<ShippingTour
-				showShippingRecommendationsStep={ false }
-				showWcsSectionStep={ true }
-			/>
-		);
+		return <ShippingTour showShippingRecommendationsStep={ false } />;
 	}
 
 	if ( countryCode !== 'US' || isSellingDigitalProductsOnly ) {
-		return (
-			<ShippingTour
-				showShippingRecommendationsStep={ false }
-				showWcsSectionStep={ false }
-			/>
-		);
+		return <ShippingTour showShippingRecommendationsStep={ false } />;
 	}
 
 	return (
 		<>
-			<ShippingTour
-				showShippingRecommendationsStep={ true }
-				showWcsSectionStep={ false }
-			/>
+			<ShippingTour showShippingRecommendationsStep={ true } />
 			<ShippingRecommendationsList>
 				<WooCommerceServicesItem
 					isWCSInstalled={ installedPlugins.includes(

--- a/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -56,7 +56,7 @@ const ShippingRecommendations: React.FC = () => {
 		return (
 			<ShippingTour
 				showShippingRecommendationsStep={ false }
-				showWcsSectionPresent={ true }
+				showWcsSectionStep={ true }
 			/>
 		);
 	}
@@ -65,7 +65,7 @@ const ShippingRecommendations: React.FC = () => {
 		return (
 			<ShippingTour
 				showShippingRecommendationsStep={ false }
-				showWcsSectionPresent={ false }
+				showWcsSectionStep={ false }
 			/>
 		);
 	}
@@ -74,7 +74,7 @@ const ShippingRecommendations: React.FC = () => {
 		<>
 			<ShippingTour
 				showShippingRecommendationsStep={ true }
-				showWcsSectionPresent={ false }
+				showWcsSectionStep={ false }
 			/>
 			<ShippingRecommendationsList>
 				<WooCommerceServicesItem

--- a/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-shipping-recommendations.tsx
@@ -16,6 +16,7 @@ import { getCountryCode } from '~/dashboard/utils';
 import WooCommerceServicesItem from './experimental-woocommerce-services-item';
 import { ShippingRecommendationsList } from './shipping-recommendations';
 import './shipping-recommendations.scss';
+import { ShippingTour } from '../guided-tours/shipping-tour';
 
 const ShippingRecommendations: React.FC = () => {
 	const {
@@ -52,21 +53,37 @@ const ShippingRecommendations: React.FC = () => {
 		activePlugins.includes( 'woocommerce-services' ) &&
 		isJetpackConnected
 	) {
-		return null;
+		return (
+			<ShippingTour
+				showShippingRecommendationsStep={ false }
+				showWcsSectionPresent={ true }
+			/>
+		);
 	}
 
 	if ( countryCode !== 'US' || isSellingDigitalProductsOnly ) {
-		return null;
+		return (
+			<ShippingTour
+				showShippingRecommendationsStep={ false }
+				showWcsSectionPresent={ false }
+			/>
+		);
 	}
 
 	return (
-		<ShippingRecommendationsList>
-			<WooCommerceServicesItem
-				isWCSInstalled={ installedPlugins.includes(
-					'woocommerce-services'
-				) }
+		<>
+			<ShippingTour
+				showShippingRecommendationsStep={ true }
+				showWcsSectionPresent={ false }
 			/>
-		</ShippingRecommendationsList>
+			<ShippingRecommendationsList>
+				<WooCommerceServicesItem
+					isWCSInstalled={ installedPlugins.includes(
+						'woocommerce-services'
+					) }
+				/>
+			</ShippingRecommendationsList>
+		</>
 	);
 };
 

--- a/plugins/woocommerce-admin/client/shipping/shipping-recommendations-wrapper.tsx
+++ b/plugins/woocommerce-admin/client/shipping/shipping-recommendations-wrapper.tsx
@@ -8,7 +8,6 @@ import { lazy, Suspense } from '@wordpress/element';
  */
 import { EmbeddedBodyProps } from '../embedded-body-layout/embedded-body-props';
 import RecommendationsEligibilityWrapper from '../settings-recommendations/recommendations-eligibility-wrapper';
-import { ShippingTour } from '../guided-tours/shipping-tour';
 
 const ShippingRecommendationsLoader = lazy( () => {
 	if ( window.wcAdminFeatures[ 'shipping-smart-defaults' ] ) {
@@ -47,9 +46,6 @@ export const ShippingRecommendations: React.FC< EmbeddedBodyProps > = ( {
 	return (
 		<RecommendationsEligibilityWrapper>
 			<Suspense fallback={ null }>
-				{ window.wcAdminFeatures[ 'shipping-setting-tour' ] && (
-					<ShippingTour />
-				) }
 				<ShippingRecommendationsLoader />
 			</Suspense>
 		</RecommendationsEligibilityWrapper>

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -28,6 +28,8 @@ const defaultSelectReturn = {
 		},
 	} ),
 	getProfileItems: () => ( {} ),
+	hasFinishedResolution: jest.fn(),
+	getOption: jest.fn(),
 };
 
 describe( 'ShippingRecommendations', () => {

--- a/plugins/woocommerce/changelog/fix-34194-shipping-tour-step-num
+++ b/plugins/woocommerce/changelog/fix-34194-shipping-tour-step-num
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "1 of 2 steps" is shown for the first step in a 3 step tour


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34194.

This PR fixes the wrong step info of the shipping tour.

Before:

<img width="1392" alt="182948809-ee1db5ee-21e4-4f19-9c33-31a58aaa853b" src="https://user-images.githubusercontent.com/4344253/185830786-b3298ce2-c34b-4203-8018-7016f3743960.png">

After

![Screen Shot 2022-08-22 at 11 06 31](https://user-images.githubusercontent.com/4344253/185830798-cddd4c50-2b3c-4e8c-a8e2-472502767f8d.png)

### How to test the changes in this Pull Request:

**Case 1: The store sells physical products and is located in the US, but JP and WCS are not installed.**

1. Start OBW and choose United States as store country
2. Choose "Physical products"
3. Complete the OBW without installing anything from the Business Details tab.
4. Navigate to WooCommerce -> Settings -> Shipping
5. "United States (US)" zone should be created with Free shipping method
6. Observe that the 3 step tour is displayed, with step one showing "Step 1 of 3"
7. There should be 3 steps in the tour, covering shipping zones, shipping methods and recommended shipping options
8. The tour should not appear again upon revisit or refresh of the page, if you complete the tour


**Case 2: The store sells physical products, has JP and WCS installed and connected, and is located in the US.**

1. Start OBW and choose United States as store country
2. Choose "Physical products"
3. Install Jetpack and WooCommerce Shipping from the Business Details tab.
4. Complete the OBW
5. Connect and approve Jetpack when prompted.
6. Navigate to WooCommerce -> Settings -> Shipping
7. "United States (US)" zone should be created with Free shipping method
8. Observe that the 3 step tour is displayed, with step one showing "Step 1 of 3"
9. There should be 3 steps in the tour, with the third one highlighting the WooCommerce Shipping section
10. The tour should not appear again upon revisit or refresh of the page, if you complete the tour


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
