### PR TITLE
Fix marketing task placeholder flash after a plugin is installed

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/tasks.tsx
+++ b/plugins/woocommerce-admin/client/tasks/tasks.tsx
@@ -99,6 +99,14 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 		return null;
 	}
 
+	if ( currentTask ) {
+		return (
+			<div className="woocommerce-task-dashboard__container">
+				<Task query={ query } task={ currentTask } />
+			</div>
+		);
+	}
+
 	const taskListIds = getAdminSetting( 'visibleTaskListIds', [] );
 	const TaskListPlaceholderComponent =
 		taskListIds[ 0 ] === 'setup'
@@ -107,14 +115,6 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 
 	if ( isResolving ) {
 		return <TaskListPlaceholderComponent query={ query } />;
-	}
-
-	if ( currentTask ) {
-		return (
-			<div className="woocommerce-task-dashboard__container">
-				<Task query={ query } task={ currentTask } />
-			</div>
-		);
 	}
 
 	return (


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34273

Change the `<TaskListPlaceholderComponent />` render order to fix the bug since the `<TaskListPlaceholderComponent />` was introduced in [this PR](https://github.com/woocommerce/woocommerce/pull/32473) for task list only, not the task.

### How to test the changes in this Pull Request:

1. Go to `WooCommerce > Home`
2. It should show a task list placeholder before the task list is loaded.
4. Go to "Get more sales" task
5. Click on either one of "Get Started" buttons.
6. Observe that the page is refreshed without showing a task placeholder flash after a plugin is installed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
