### PR TITLE
Tests for foreign key removal

### DIFF
--- a/plugins/woocommerce/changelog/fix-tests-for-34318
+++ b/plugins/woocommerce/changelog/fix-tests-for-34318
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Added tests to account for removal of foreign key for download log.

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-customer-download-log-data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-customer-download-log-data-store.php
@@ -52,4 +52,130 @@ class WC_Tests_Customer_Download_Log_Data_Store extends WC_Unit_Test_Case {
 		$expected_result = array( (string) $download_log_2->get_id(), (string) $download_log_1->get_id() );
 		$this->assertEquals( $expected_result, $logs );
 	}
+
+	/**
+	 * @testdox Delete the log entries and also the related permission id.
+	 */
+	public function test_delete_by_permission_id() {
+		global $wpdb;
+		// Customer 1.
+		$customer = array(
+			'id'    => 1,
+			'email' => 'test_1@example.com',
+		);
+
+		$download_permission = new WC_Customer_Download();
+		$download_permission->set_user_id( $customer['id'] );
+		$download_permission->set_user_email( $customer['email'] );
+		$download_permission->set_order_id( $customer['id'] );
+		$download_permission->set_access_granted( '2018-01-22 00:00:00' );
+		$p_id = $download_permission->save();
+
+		$download_log = new WC_Customer_Download_Log();
+		$download_log->set_permission_id( $p_id );
+		$download_log->set_user_id( $customer['id'] );
+		$download_log->set_user_ip_address( '1.2.3.4' );
+		$download_log->save();
+
+		$download_log_2 = new WC_Customer_Download_Log();
+		$download_log_2->set_permission_id( $p_id );
+		$download_log_2->set_user_id( $customer['id'] );
+		$download_log_2->set_user_ip_address( '1.2.3.4' );
+		$download_log_2->save();
+
+		// Check that the download log records are gone.
+		$data_store = WC_Data_Store::load( 'customer-download-log' );
+		$data_store->delete_by_permission_id( $p_id );
+		$this->assertEmpty(
+			$data_store->get_download_logs(
+				array(
+					'return'        => 'ids',
+					'permission_id' => $p_id,
+				)
+			)
+		);
+
+		/** Check that the download permission is gone, too.
+		 *
+		 * I could try to instantiate WC_Customer_Download( $permission ) here as well,
+		 * but the thrown exception is ambiguous, so opted for a direct query here.
+		 */
+		$this->assertEquals( 0, $wpdb->query( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE permission_id = %d", $p_id ) ) );
+	}
+
+	/**
+	 * @testdox Delete only log records related to the particular id.
+	 */
+	public function test_delete_by_permission_id_not_all() {
+		global $wpdb;
+		// Customer 1.
+		$customers   = array();
+		$customers[] = array(
+			'id'    => 1,
+			'email' => 'test_1@example.com',
+		);
+
+		// Customer 2.
+		$customers[] = array(
+			'id'    => 2,
+			'email' => 'test_2@example.com',
+		);
+
+		$download_permissions = array();
+		$dp_ids               = array();
+		foreach ( $customers as $customer ) {
+			$download_permission = new WC_Customer_Download();
+			$download_permission->set_user_id( $customer['id'] );
+			$download_permission->set_user_email( $customer['email'] );
+			$download_permission->set_order_id( $customer['id'] );
+			$download_permission->set_access_granted( '2018-01-22 00:00:00' );
+			$dp_ids[]                               = $download_permission->save();
+			$download_permissions[ end( $dp_ids ) ] = $download_permission;
+
+		}
+
+		$download_log = new WC_Customer_Download_Log();
+		$download_log->set_permission_id( $dp_ids[0] );
+		$download_log->set_user_id( $customers[0]['id'] );
+		$download_log->set_user_ip_address( '1.2.3.4' );
+		$download_log->save();
+
+		$download_log_2 = new WC_Customer_Download_Log();
+		$download_log_2->set_permission_id( $dp_ids[1] );
+		$download_log_2->set_user_id( $customers[1]['id'] );
+		$download_log_2->set_user_ip_address( '1.2.3.5' );
+		$download_log_2->save();
+
+		// Check that the download log records are gone for Customer 1...
+		$data_store = WC_Data_Store::load( 'customer-download-log' );
+		$data_store->delete_by_permission_id( $dp_ids[0] );
+		$this->assertEmpty(
+			$data_store->get_download_logs(
+				array(
+					'return'        => 'ids',
+					'permission_id' => $dp_ids[0],
+				)
+			)
+		);
+
+		// ...but still present for Customer 2.
+		$this->assertEquals(
+			array(
+				(string) $download_log_2->get_id(),
+			),
+			$data_store->get_download_logs(
+				array(
+					'return'        => 'ids',
+					'permission_id' => $dp_ids[1],
+				)
+			)
+		);
+
+		// Check that the download permission is gone for Customer 1 and still intact for Customer 2.
+		$this->assertEquals( 0, $wpdb->query( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE permission_id = %d", $dp_ids[0] ) ) );
+		$this->assertEquals( 1, $wpdb->query( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE permission_id = %d", $dp_ids[1] ) ) );
+
+		// Clean up the rest.
+		$data_store->delete_by_permission_id( $dp_ids[1] );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-customer-download-log-data-store.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-customer-download-log-data-store.php
@@ -98,6 +98,7 @@ class WC_Tests_Customer_Download_Log_Data_Store extends WC_Unit_Test_Case {
 		/** Check that the download permission is gone, too.
 		 *
 		 * I could try to instantiate WC_Customer_Download( $permission ) here as well,
+		 * or use the WC_Customer_Download::read(),
 		 * but the thrown exception is ambiguous, so opted for a direct query here.
 		 */
 		$this->assertEquals( 0, $wpdb->query( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE permission_id = %d", $p_id ) ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-tests-customer-download.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/customer/class-wc-tests-customer-download.php
@@ -130,5 +130,7 @@ class WC_Tests_Customer_Download extends WC_Unit_Test_Case {
 			)
 		);
 		$this->assertEquals( $expected_result, $downloads );
+
+		$download_2->delete();
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-download-data-store-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-customer-download-data-store-test.php
@@ -1,0 +1,523 @@
+<?php
+
+/**
+ * Class WC_Customer_Download_Data_Store_Test.
+ */
+class WC_Customer_Download_Data_Store_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Array of Download objects used for testing.
+	 *
+	 * @var Array(WC_Customer_Download)
+	 */
+	private $downloads;
+
+	/**
+	 * Array of test customer.
+	 *
+	 * @var Array(Array)
+	 */
+	private $customers;
+
+	/**
+	 * Array of download logs.
+	 *
+	 * @var Array(WC_Customer_Download_Log)
+	 */
+	private $download_logs;
+
+	/**
+	 * Array of downloads per order.
+	 *
+	 * @var Array(WC_Customer_Download)
+	 */
+	private $download_for_order;
+
+	/**
+	 * Array of downloads per customer.
+	 *
+	 * @var Array(WC_Customer_Download)
+	 */
+	private $download_for_customer;
+
+	/**
+	 * Array of downloads per download_id.
+	 *
+	 * @var Array(WC_Customer_Download)
+	 */
+	private $download_for_download_id;
+
+
+	/**
+	 * Tests set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Customer 1.
+		$this->customers[] = array(
+			'id'     => 1,
+			'email'  => 'test_1@example.com',
+			'orders' => array(
+				1,
+				2,
+			),
+		);
+
+		// Customer 2.
+		$this->customers[] = array(
+			'id'     => 2,
+			'email'  => 'test_2@example.com',
+			'orders' => array(
+				3,
+				4,
+			),
+		);
+
+		// Create a download permission for each customer.
+		foreach ( $this->customers as $customer ) {
+			$this->download_for_customer[ $customer['id'] ] = array();
+
+			foreach ( $customer['orders'] as $order_id ) {
+				$download_id = "{$customer['id']}-{$order_id}_1";
+				$this->create_download( $customer, $order_id, $download_id );
+
+				// Every other order has 2 downloads.
+				if ( $order_id % 2 ) {
+					$download_id = "{$customer['id']}-{$order_id}_2";
+					$this->create_download( $customer, $order_id, $download_id );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Create download to store some data in the db.
+	 *
+	 * @param array  $customer Associative array with an id, email and an array of orders for a customer.
+	 * @param int    $order_id Order id.
+	 * @param string $download_id Download id.
+	 *
+	 * @return void
+	 */
+	private function create_download( array $customer, int $order_id, string $download_id ) {
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $customer['id'] );
+		$download->set_user_email( $customer['email'] );
+		$download->set_order_id( $order_id );
+		$download->set_download_id( $download_id );
+		$download->set_access_granted( '2018-01-22 00:00:00' );
+		$d_id                                    = $download->save();
+		$this->downloads[ $d_id ]                = $download;
+		$this->download_for_order[ $order_id ][] = $download;
+		$this->download_for_customer[ $customer['id'] ][] = $download;
+		if ( isset( $this->download_for_download_id[ $download_id ] ) && is_array( $this->download_for_download_id[ $download_id ] ) ) {
+			$this->download_for_download_id[ $download_id ][] = $download;
+		} else {
+			$this->download_for_download_id[ $download_id ] = array( $download );
+		}
+	}
+
+	/**
+	 * Test clean up.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Clean up Customer Downloads.
+		foreach ( $this->downloads as $download ) {
+			$download->delete();
+		}
+
+		// Clear temp instance variables.
+		$this->customers                = array();
+		$this->downloads                = array();
+		$this->download_logs            = array();
+		$this->download_for_order       = array();
+		$this->download_for_customer    = array();
+		$this->download_for_download_id = array();
+	}
+
+	/**
+	 * Create $max_logs download log entries for each download permission record from $this->downloads[].
+	 *
+	 * @param int $max_logs Number of logs per download permission.
+	 *
+	 * @return void
+	 */
+	private function create_download_logs( int $max_logs ) {
+		foreach ( $this->downloads as $download ) {
+			for ( $i = 0; $i < $max_logs; $i ++ ) {
+				$download_log = new WC_Customer_Download_Log();
+				$download_log->set_permission_id( $download->get_id() );
+				$download_log->set_user_id( $download->get_user_id() );
+				$download_log->set_user_ip_address( '1.2.3.4' );
+				$dl_id                         = $download_log->save();
+				$this->download_logs[ $dl_id ] = $download_log;
+			}
+		}
+	}
+
+	/**
+	 * @testdox Deletes the download permission record and related download logs.
+	 */
+	public function test_delete() {
+		$logs_per_permission = 2;
+		$this->create_download_logs( $logs_per_permission );
+		$data_store = WC_Data_Store::load( 'customer-download' );
+
+		$download_ids = array_keys( $this->downloads );
+		$downloads    = array_values( $this->downloads );
+
+		$data_store->delete( $downloads[0] );
+		// Id is set to 0 after delete.
+		$this->assertEquals( 0, $downloads[0]->get_id() );
+
+		// Try to (re)load the deleted download again, it shouldn't exist anymore.
+		$this->expectException( \Exception::class );
+		$cd = $data_store->read( $downloads[0] );
+
+		// Test that respective download logs are also gone.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_ids[0] ) );
+
+		// But the other download permissions and logs are still intact.
+		$rest_of_download_ids = array_slice( $download_ids, 1, null, true );
+		foreach ( $rest_of_download_ids as $download_id ) {
+			$reread_download = $data_store->read( $this->downloads[ $download_id ] );
+			$this->assertEquals( $this->downloads[ $download_id ]->get_id(), $reread_download->get_id() );
+			$this->assertEquals( $logs_per_permission, $log_data_store->get_download_logs_for_permission( $download_id ) );
+
+		}
+
+		// Clean up.
+		$count_download_ids = count( $download_ids );
+		for ( $i = 1; $i < $count_download_ids; $i ++ ) {
+			$data_store->delete( $downloads[ $i ] );
+			$this->assertEquals( 0, $downloads[ $i ]->get_id() );
+			$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_ids[ $i ] ) );
+		}
+	}
+
+	/**
+	 * @testdox Deletes the download permission record and related download logs referred to by permission id.
+	 */
+	public function test_delete_by_id() {
+		$logs_per_permission = 2;
+		$this->create_download_logs( $logs_per_permission );
+		$data_store = WC_Data_Store::load( 'customer-download' );
+
+		$download_ids = array_keys( $this->downloads );
+		$downloads    = array_values( $this->downloads );
+
+		$data_store->delete_by_id( $download_ids[0] );
+
+		/**
+		 * It is rather odd that only delete() sets the download's id to 0, other delete_* methods don't.
+		 * Instead, try to (re)load the deleted download again, it shouldn't exist anymore.
+		 */
+		$this->expectException( \Exception::class );
+		$not_used = $data_store->read( $downloads[0] );
+
+		// Test that respective download logs are also gone.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_ids[0] ) );
+
+		// But the other download permissions and logs are still intact.
+		$rest_of_download_ids = array_slice( $download_ids, 1, null, true );
+		foreach ( $rest_of_download_ids as $download_id ) {
+			$reread_download = $data_store->read( $this->downloads[ $download_id ] );
+			$this->assertEquals( $this->downloads[ $download_id ]->get_id(), $reread_download->get_id() );
+			$this->assertEquals( $logs_per_permission, $log_data_store->get_download_logs_for_permission( $download_id ) );
+		}
+
+		// Clean up.
+		$count_download_ids = count( $download_ids );
+		for ( $i = 1; $i < $count_download_ids; $i ++ ) {
+			$data_store->delete_by_id( $download_ids[ $i ] );
+			$this->assertEquals( 0, $downloads[ $i ]->get_id() );
+			$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_ids[ $i ] ) );
+		}
+	}
+
+	/**
+	 * @testdox Deletes the download permission record and related download logs referred to by order id.
+	 */
+	public function test_delete_by_order_id() {
+		$logs_per_permission = 2;
+		$this->create_download_logs( $logs_per_permission );
+		$data_store = WC_Data_Store::load( 'customer-download' );
+
+		$downloads = array_values( $this->downloads );
+
+		$first_order_id = $downloads[0]->get_order_id();
+		$data_store->delete_by_order_id( $first_order_id );
+		/**
+		 * It is rather odd that only delete() sets the download's id to 0, other delete_* methods don't.
+		 * Instead, try to (re)load the deleted download again, it shouldn't exist anymore.
+		 */
+		$this->assertEmpty(
+			$data_store->get_downloads(
+				array(
+					'order_id' => $first_order_id,
+				)
+			)
+		);
+
+		// Test that respective download logs are also gone.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		foreach ( $this->download_for_order[ $first_order_id ] as $download_permission ) {
+			$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+		}
+
+		// Test that the other downloads and download logs are intact.
+		foreach ( $this->download_for_order as $order_id => $download_permissions ) {
+			if ( $first_order_id === $order_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+
+			$dp_for_order = $data_store->get_downloads(
+				array(
+					'order_id' => $order_id,
+				)
+			);
+			$this->assertEquals( count( $download_permissions ), count( $dp_for_order ) );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEquals( $logs_per_permission, count( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) ) );
+			}
+		}
+
+		// Clean up, order by order.
+		foreach ( $this->download_for_order as $order_id => $download_permissions ) {
+			if ( $first_order_id === $order_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+
+			$data_store->delete_by_order_id( $order_id );
+			$dp_for_order = $data_store->get_downloads(
+				array(
+					'order_id' => $order_id,
+				)
+			);
+			$this->assertEmpty( $dp_for_order );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Deletes the download permission record and related download logs referred to by download id.
+	 */
+	public function test_delete_by_download_id() {
+		$logs_per_permission = 2;
+		$this->create_download_logs( $logs_per_permission );
+		$data_store = WC_Data_Store::load( 'customer-download' );
+
+		$downloads = array_values( $this->downloads );
+
+		$first_download_id = $downloads[0]->get_download_id();
+		$data_store->delete_by_download_id( $first_download_id );
+		/**
+		 * It is rather odd that only delete() sets the download's id to 0, other delete_* methods don't.
+		 * Instead, try to (re)load the deleted download again, it shouldn't exist anymore.
+		 */
+		$this->assertEmpty(
+			$data_store->get_downloads(
+				array(
+					'download_id' => $first_download_id,
+				)
+			)
+		);
+
+		// Test that respective download logs are also gone.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		foreach ( $this->download_for_download_id[ $first_download_id ] as $download_permission ) {
+			$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+		}
+
+		// Test that the other downloads and download logs are intact.
+		foreach ( $this->download_for_download_id as $download_id => $download_permissions ) {
+			if ( $first_download_id === $download_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+
+			$dp_for_download_id = $data_store->get_downloads(
+				array(
+					'download_id' => $download_id,
+				)
+			);
+			$this->assertEquals( count( $download_permissions ), count( $dp_for_download_id ) );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEquals( $logs_per_permission, count( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) ) );
+			}
+		}
+
+		// Clean up.
+		foreach ( $this->download_for_download_id as $download_id => $download_permissions ) {
+			if ( $first_download_id === $download_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+
+			$data_store->delete_by_download_id( $download_id );
+			$dp_for_download_id = $data_store->get_downloads(
+				array(
+					'download_id' => $download_id,
+				)
+			);
+			$this->assertEmpty( $dp_for_download_id );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Deletes the download permission record and related download logs referred to by user id.
+	 */
+	public function test_delete_by_user_id() {
+		$logs_per_permission = 2;
+		$this->create_download_logs( $logs_per_permission );
+		$data_store = WC_Data_Store::load( 'customer-download' );
+
+		$downloads = array_values( $this->downloads );
+
+		$first_user_id = $downloads[0]->get_user_id();
+		$data_store->delete_by_user_id( $first_user_id );
+		/**
+		 * It is rather odd that only delete() sets the download's id to 0, other delete_* methods don't.
+		 * Instead, try to (re)load the deleted download again, it shouldn't exist anymore.
+		 */
+		$this->assertEmpty(
+			$data_store->get_downloads(
+				array(
+					'user_id' => $first_user_id,
+				)
+			)
+		);
+
+		// Test that respective download logs are also gone.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		foreach ( $this->download_for_customer[ $first_user_id ] as $download_permission ) {
+			$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+		}
+
+		// Test that the other downloads and download logs are intact.
+		foreach ( $this->download_for_customer as $user_id => $download_permissions ) {
+			if ( $first_user_id === $user_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+
+			$dp_for_user = $data_store->get_downloads(
+				array(
+					'user_id' => $user_id,
+				)
+			);
+			$this->assertEquals( count( $download_permissions ), count( $dp_for_user ) );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEquals( $logs_per_permission, count( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) ) );
+			}
+		}
+
+		// Clean up.
+		foreach ( $this->download_for_customer as $user_id => $download_permissions ) {
+			if ( $first_user_id === $user_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+
+			$data_store->delete_by_user_id( $user_id );
+			$dp_for_user = $data_store->get_downloads(
+				array(
+					'user_id' => $user_id,
+				)
+			);
+			$this->assertEmpty( $dp_for_user );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+			}
+		}
+	}
+
+	/**
+	 * @testdox Deletes the download permission record and related download logs referred to by user email.
+	 */
+	public function test_delete_by_user_email() {
+		$logs_per_permission = 2;
+		$this->create_download_logs( $logs_per_permission );
+		$data_store = WC_Data_Store::load( 'customer-download' );
+
+		$downloads = array_values( $this->downloads );
+
+		$first_user_email = $downloads[0]->get_user_email();
+		$first_user_id    = $downloads[0]->get_user_id();
+		$data_store->delete_by_user_email( $first_user_email );
+		/**
+		 * It is rather odd that only delete() sets the download's id to 0, other delete_* methods don't.
+		 * Instead, try to (re)load the deleted download again, it shouldn't exist anymore.
+		 */
+		$this->assertEmpty(
+			$data_store->get_downloads(
+				array(
+					'user_email' => $first_user_email,
+				)
+			)
+		);
+
+		// Test that respective download logs are also gone.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		foreach ( $this->download_for_customer[ $first_user_id ] as $download_permission ) {
+			$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+		}
+
+		// Test that the other downloads and download logs are intact.
+		foreach ( $this->download_for_customer as $user_id => $download_permissions ) {
+			if ( $first_user_id === $user_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+			$user_email  = $download_permissions[0]->get_user_email();
+			$dp_for_user = $data_store->get_downloads(
+				array(
+					'user_email' => $user_email,
+				)
+			);
+			$this->assertEquals( count( $download_permissions ), count( $dp_for_user ) );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEquals( $logs_per_permission, count( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) ) );
+			}
+		}
+
+		// Clean up.
+		foreach ( $this->download_for_customer as $user_id => $download_permissions ) {
+			if ( $first_user_id === $user_id ) {
+				// Already checked and deleted.
+				continue;
+			}
+			$user_email = $download_permissions[0]->get_user_email();
+			$data_store->delete_by_user_email( $user_email );
+			$dp_for_user = $data_store->get_downloads(
+				array(
+					'user_email' => $user_email,
+				)
+			);
+			$this->assertEmpty( $dp_for_user );
+
+			foreach ( $download_permissions as $download_permission ) {
+				$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $download_permission->get_id() ) );
+			}
+		}
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller-test.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Class WC_REST_System_Status_Tools_V2_Controller.
+ */
+class WC_REST_System_Status_Tools_V2_Controller_Test extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Array of Download objects used for testing.
+	 *
+	 * @var Array(WC_Customer_Download)
+	 */
+	private $downloads;
+
+	/**
+	 * Setup our test server, endpoints, and user info.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->endpoint = new WC_REST_System_Status_Tools_V2_Controller();
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Create download permissions and download logs for 'clear_expired_download_permissions' test.
+	 * @return array Keys and values to expect in the REST response.
+	 */
+	private function create_data_for_expired_download_permissions_test() {
+		$customer = array(
+			'id'    => 1,
+			'email' => 'test_1@example.com',
+		);
+
+		// Expired permission.
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $customer['id'] );
+		$download->set_user_email( $customer['email'] );
+		$download->set_access_granted( '2018-01-22 00:00:00' );
+		$download->set_access_expires( '2020-01-01 00:00:00' );
+		$d_id              = $download->save();
+		$this->downloads[] = $d_id;
+
+		// 2 downloads log for the expired download permission.
+		$download_log_1 = new WC_Customer_Download_Log();
+		$download_log_1->set_permission_id( $download->get_id() );
+		$download_log_1->set_user_id( $customer['id'] );
+		$download_log_1->set_user_ip_address( '1.2.3.4' );
+		$download_log_1->save();
+
+		$download_log_2 = new WC_Customer_Download_Log();
+		$download_log_2->set_permission_id( $download->get_id() );
+		$download_log_2->set_user_id( $customer['id'] );
+		$download_log_2->set_user_ip_address( '1.2.3.4' );
+		$download_log_2->save();
+
+		// Non-expired permission.
+		$download = new WC_Customer_Download();
+		$download->set_user_id( $customer['id'] );
+		$download->set_user_email( $customer['email'] );
+		$download->set_access_granted( '2018-01-22 00:00:00' );
+		// This will hopefully be always in the future, at least as long as the servers are on Earth?
+		$download->set_access_expires( gmdate( 'Y-m-d H:i:s', time() + WEEK_IN_SECONDS ) );
+		$d_id              = $download->save();
+		$this->downloads[] = $d_id;
+
+		// 1 download log for the non-expired download permission.
+		$download_log_3 = new WC_Customer_Download_Log();
+		$download_log_3->set_permission_id( $download->get_id() );
+		$download_log_3->set_user_id( $customer['id'] );
+		$download_log_3->set_user_ip_address( '1.2.3.4' );
+		$download_log_3->save();
+
+		return array(
+			'success' => true,
+			'message' => '1 permissions deleted',
+		);
+	}
+
+	/**
+	 * Clean up db after create_data_for_expired_download_permissions_test.
+	 *
+	 * @return void
+	 */
+	private function cleanup_data_for_expired_download_permissions_test() {
+		$this->downloads[1]->delete();
+	}
+
+	/**
+	 * @testdox Expired download permissions are removed via the respective tool.
+	 */
+	public function test_execute_tool_clear_expired_download_permissions() {
+		wp_set_current_user( $this->user );
+		$expected_response_values = $this->create_data_for_expired_download_permissions_test();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'PUT', '/wc/v2/system_status/tools/clear_expired_download_permissions' ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response = $response->get_data();
+		foreach ( $expected_response_values as $key => $expected_value ) {
+			$this->assertTrue( isset( $response[ $key ] ) );
+			$this->assertEquals( $expected_value, $response[ $key ] );
+
+		}
+
+		// Test that the download logs for the permission have been deleted.
+		$log_data_store = WC_Data_Store::load( 'customer-download-log' );
+		$this->assertEmpty( $log_data_store->get_download_logs_for_permission( $this->downloads[0] ) );
+
+		$this->cleanup_data_for_expired_download_permissions_test();
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller-test.php
@@ -86,7 +86,8 @@ class WC_REST_System_Status_Tools_V2_Controller_Test extends WC_REST_Unit_Test_C
 	 * @return void
 	 */
 	private function cleanup_data_for_expired_download_permissions_test() {
-		$this->downloads[1]->delete();
+		$download = new WC_Customer_Download( $this->downloads[1] );
+		$download->delete();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I want to merge the tests to verify and check the foreign key behaviour before https://github.com/woocommerce/woocommerce/pull/34318 to make sure nothing has changed. Once this is merged, I'll rebase #34318 so that the tests will verify the changes.

### How to test the changes in this Pull Request:

1. See the CI results for unit tests. Green means good.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
