### PR TITLE
Integrates the COT admin list table and COT-based search.

### DIFF
--- a/plugins/woocommerce/changelog/add-33197-admin-order-search
+++ b/plugins/woocommerce/changelog/add-33197-admin-order-search
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Integrates (COT) order search with the admin list table for orders.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -282,6 +282,7 @@ class ListTable extends WP_List_Table {
 
 		if ( ! empty( $search_term ) ) {
 			$this->order_query_args['s'] = $search_term;
+			$this->has_filter            = true;
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -180,6 +180,7 @@ class ListTable extends WP_List_Table {
 		$this->set_order_args();
 		$this->set_date_args();
 		$this->set_customer_args();
+		$this->set_search_args();
 
 		/**
 		 * Provides an opportunity to modify the query arguments used in the (Custom Order Table-powered) order list
@@ -271,6 +272,17 @@ class ListTable extends WP_List_Table {
 		}
 
 		$this->order_query_args['status'] = $query_statuses;
+	}
+
+	/**
+	 * Implements order search.
+	 */
+	private function set_search_args(): void {
+		$search_term = trim( sanitize_text_field( wp_unslash( $_REQUEST['s'] ?? '' ) ) );
+
+		if ( ! empty( $search_term ) ) {
+			$this->order_query_args['s'] = $search_term;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Builds on https://github.com/woocommerce/woocommerce/pull/34405 and integrates search with the admin list table for (COT) orders.

Closes #33197.

### How to test the changes in this Pull Request:

You will need a range of test orders, complete with order items and a range of billing/shipping addresses. Confirm the following aspects of search work as expected.

1. Searching for a specific ID such as `123` should result in that order being included in the search results (assuming, of course, that it exists). Other orders may also be returned if, for example, they feature the text `123` within a shipping or billing address.
2. Search for a product name. For instance, if `Vee-Neck T-Shirt` is the name of an order item, `Shirt` should surface that order in the search results.
3. Search for part of a billing or shipping address, or for a billing email.
4. If a search yields more orders than the number-of-items-per-page setting, then you should be able to page through the results.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
