### PR TITLE
Fix store details fails to save store address after navigating back to the tab

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -109,9 +109,9 @@ export class StoreDetails extends Component {
 		);
 	}
 
-	onSubmit() {
+	onSubmit( values ) {
 		if ( this.props.allowTracking ) {
-			this.props.goToNextStep();
+			this.onContinue( values ).then( () => this.props.goToNextStep() );
 		} else {
 			this.setState( {
 				showUsageModal: true,

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -30,6 +30,13 @@ const testProps = {
 	},
 	getLocale: jest.fn(),
 	isLoading: false,
+	createNotice: jest.fn(),
+	profileItems: {},
+	updateAndPersistSettingsForGroup: jest.fn(),
+	goToNextStep: jest.fn(),
+	errorsRef: {
+		current: {},
+	},
 };
 
 jest.mock( '@wordpress/data', () => {
@@ -82,6 +89,28 @@ describe( 'StoreDetails', () => {
 		expect(
 			getByRole( 'button', { name: 'Continue' } )
 		).not.toBeDisabled();
+	} );
+
+	test( 'should call updateProfileItems when continue button is clicked given the allowTracking is true', async () => {
+		const updateProfileItems = jest.fn();
+		const { getByText } = render(
+			<StoreDetails
+				{ ...{
+					...testProps,
+					initialValues: {
+						...testProps.initialValues,
+						countryState: 'US',
+					},
+				} }
+				updateProfileItems={ updateProfileItems }
+				allowTracking={ true }
+			/>
+		);
+		const continueButton = getByText( 'Continue' );
+		userEvent.click( continueButton );
+		await waitFor( () => {
+			expect( updateProfileItems ).toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Email validation test cases', () => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34417.

This PR fixes a bug caused by the previous PR #34176. 

> "Store Details" fails to save the store address after navigating back to "Store Details" tab from "Industry" tab 

### How to test the changes in this Pull Request:

1. Use a fresh site
4. Install and activate Gutenberg plugins. (Optional. I've confirmed this is not related to Gutenberg)
5. Go to OBW
6. Choose a Country and enter the Store address.
8. Click on Continue button.
9. Allow tracking on usage modal
10. Navigating back to the "Store Details" tab from the "Industry" tab.
11. Observe that the "Store Details" saves the store address.
12. Change store address
13. Click on the Continue button.
14. Navigate back to the "Store Details" tab from the "Industry" tab.
15. Observe that the "Store Details" saves the store address.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
