### PR TITLE
Code-analyzer: Perform build between checkouts to avoid failures

### DIFF
--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -126,11 +126,16 @@ export default class Analyzer extends Command {
 
 			const pluginPath = join( tmpRepoPath, 'plugins/woocommerce' );
 
-			// Note doing the minimal work to get a DB scan to work, avoiding full build for speed.
-			execSync( 'composer install', { cwd: pluginPath, stdio: [] } );
-			execSync( 'pnpm run build:feature-config --filter=woocommerce', {
-				cwd: pluginPath,
-			} );
+			const build = () => {
+				// Note doing the minimal work to get a DB scan to work, avoiding full build for speed.
+				execSync( 'composer install', { cwd: pluginPath, stdio: [] } );
+				execSync(
+					'pnpm run build:feature-config --filter=woocommerce',
+					{
+						cwd: pluginPath,
+					}
+				);
+			};
 
 			CliUx.ux.action.stop();
 			CliUx.ux.action.start(
@@ -141,6 +146,7 @@ export default class Analyzer extends Command {
 				tmpRepoPath,
 				compare,
 				base,
+				build,
 				( e: string ): void => this.error( e )
 			);
 

--- a/tools/code-analyzer/src/git.ts
+++ b/tools/code-analyzer/src/git.ts
@@ -215,6 +215,7 @@ export const getSchema = async (
  * @param {string}   tmpRepoPath Path to repository used to generate schema diff.
  * @param {string}   compare     Branch/commit hash to compare against the base.
  * @param {string}   base        Base branch/commit hash.
+ * @param            build       Build to perform between checkouts.
  * @param {Function} error       error print method.
  * @return {Object|void}     diff object.
  */
@@ -222,6 +223,7 @@ export const generateSchemaDiff = async (
 	tmpRepoPath: string,
 	compare: string,
 	base: string,
+	build: () => void,
 	error: ( s: string ) => void
 ): Promise< {
 	[ key: string ]: {
@@ -241,6 +243,7 @@ export const generateSchemaDiff = async (
 
 	// Force checkout because sometimes a build will generate a lockfile change.
 	await git.checkout( base, [ '--force' ] );
+	build();
 	const baseSchema = await getSchema(
 		tmpRepoPath,
 		( errorMessage: string ) => {
@@ -255,6 +258,7 @@ export const generateSchemaDiff = async (
 
 	// Force checkout because sometimes a build will generate a lockfile change.
 	await git.checkout( compare, [ '--force' ] );
+	build();
 	const compareSchema = await getSchema(
 		tmpRepoPath,
 		( errorMessage: string ) => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Because the build was only being performed for one checkout of the woo plugin it was failing on the second checkout with PHP errors. Performing the build on each checkout solves the issue.

Closes #34196 

### How to test the changes in this Pull Request:

1. Hopefully you can reproduce the bug in trunk which I was able to. Checkout trunk and run analyzer like `./tools/bin/dev analyzer "6.7.0" "6.8.0" -s "https://github.com/woocommerce/woocommerce.git"`
2. The command should fail due to PHP exception errors
3. Clean up docker containers not cleaned up by wp-env (I just remove all of them like `docker stop $(ps -a -q) && docker rm $(ps -a -q)` But take care if you have containers you want to keep around!
5. checkout this branch and re-run the command. It should complete successfully.

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
