### PR TITLE
Add `wp_version` prop to storeprofiler_store_business_details_continue track

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -402,6 +402,7 @@ class BusinessDetails extends Component {
 			used_platform: otherPlatform,
 			used_platform_name: otherPlatformName,
 			setup_client: isSetupClient,
+			wp_version: getSetting( 'wpVersion' ),
 		} );
 		recordEvent( 'storeprofiler_step_complete', {
 			step: BUSINESS_DETAILS_TAB_NAME,

--- a/plugins/woocommerce/changelog/add-wp-version-prop-to-business-details-continue-track
+++ b/plugins/woocommerce/changelog/add-wp-version-prop-to-business-details-continue-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add wp_version prop to storeprofiler_store_business_details_continue track


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #32267

> Jetpack's minimum version requirement is quite strict, requiring users to be on Wordpress 5.6. But WC min version is 5.4.
> If the user's WP version doesn't meet requirements when they tick "install Jetpack" during OBW it will fail without a good explanation of the issue, which is gonna be frustrating for users.

As a first step, this PR adds a prop identifying the WP version to the wcadmin_storeprofiler_store_business_details_continue, so we identify the % of users affected by this (https://github.com/woocommerce/woocommerce/issues/32267#issuecomment-1072896473). 

Ideally, new users should use the latest WP, and they should not encounter this issue so we might not need to fix this.

### How to test the changes in this Pull Request:

1. Go to OBW > Business Details
2. Enable logging `window.localStorage.setItem( 'debug', 'wc-admin:*' )`
3. Fill out the form
4. Click on "Continue" button
5. Observe that `wcadmin_storeprofiler_store_business_details_continue_variant` event is triggered with a `wp_version` prop.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
