### PR TITLE
Enable WC Customizer panels in customize.php routes also for block themes

### DIFF
--- a/plugins/woocommerce/changelog/fix-enable-customizer-in-customize-php
+++ b/plugins/woocommerce/changelog/fix-enable-customizer-in-customize-php
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow accessing WooCommerce Customizer panels directly from customizer.php in block themes

--- a/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
+++ b/plugins/woocommerce/includes/customizer/class-wc-shop-customizer.php
@@ -885,6 +885,11 @@ class WC_Shop_Customizer {
 	}
 }
 
-if ( ! wc_current_theme_is_fse_theme() ) {
+global $pagenow;
+if (
+	$pagenow === 'customize.php' ||
+	isset( $_REQUEST['customize_theme'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	! wc_current_theme_is_fse_theme()
+) {
 	new WC_Shop_Customizer();
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

In #34022 we removed WooCommerce panels from the Customizer when the store has a block theme enabled. However, after some discussion (see https://github.com/woocommerce/woocommerce/issues/34430 and p1661253811959289-slack-C02FL3X7KR6) we decided to still register those panels when the Customizer route is accessed directly.

This way:

1. WooCommerce panels are present if there is another extension that registers panels in the Customizer.
2. Block theme users still have a way to access the customizer directly from the URL (currently, the work-around was to switch to a classic theme to make any modifications).

### How to test the changes in this Pull Request:

**With a classic theme (ie: Storefront)**
1. Verify links to the Customizer are shown in the admin top bar and under Appearance (in the admin sidebar).
2. Verify you can access the Customizer normally and modify settings under the WooCommerce panel.
3. Verify once you save the settings and reload the page, they are persisted.

**With a block theme (ie: Twenty Twenty Two)**
1. Verify there are no links to the Customizer anywhere: not in the admin top bar neither under Appearance (in the admin sidebar).
2. Verify you can access the Customizer if you write (`/wp-admin/customize.php` in the URL bar of your browser).
3. Verify you can modify settings under the WooCommerce panel.
3. Verify once you save the settings and reload the page, they are persisted.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.