### PR TITLE
Modify the extensions that show up in "Installed marketing extensions" card

### DIFF
--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -34,6 +34,7 @@ class InstalledExtensions {
 		$jetpack_crm   = self::get_jetpack_crm_extension_data();
 		$zapier        = self::get_zapier_extension_data();
 		$salesforce    = self::get_salesforce_extension_data();
+		$vimeo         = self::get_vimeo_extension_data();
 
 		if ( $automatewoo ) {
 			$data[] = $automatewoo;
@@ -89,6 +90,10 @@ class InstalledExtensions {
 
 		if ( $salesforce ) {
 			$data[] = $salesforce;
+		}
+
+		if ( $vimeo ) {
+			$data[] = $vimeo;
 		}
 
 		return $data;
@@ -498,6 +503,39 @@ class InstalledExtensions {
 			$data['settingsUrl'] = admin_url( 'admin.php?page=integration-with-salesforce' );
 			$data['docsUrl']     = 'https://woocommerce.com/document/salesforce-integration/';
 			$data['supportUrl']  = 'https://wpswings.com/submit-query/?utm_source=wpswings-salesforce-woo&utm_medium=woo-backend&utm_campaign=submit-query';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get Vimeo extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_vimeo_extension_data() {
+		$slug = 'vimeo';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/vimeo.jpg';
+
+		if ( 'activated' === $data['status'] && class_exists( '\Tribe\Vimeo_WP\Vimeo\Vimeo_Auth' ) ) {
+			if ( method_exists( '\Tribe\Vimeo_WP\Vimeo\Vimeo_Auth', 'has_access_token' ) ) {
+				$vimeo_auth = new \Tribe\Vimeo_WP\Vimeo\Vimeo_Auth();
+				if ( $vimeo_auth->has_access_token() ) {
+					$data['status'] = 'configured';
+				}
+			} else {
+				$data['status'] = 'configured';
+			}
+
+			$data['settingsUrl'] = admin_url( 'options-general.php?page=vimeo_settings' );
+			$data['docsUrl']     = 'https://woocommerce.com/document/vimeo/';
+			$data['supportUrl']  = 'https://vimeo.com/help/contact';
 		}
 
 		return $data;

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -5,7 +5,6 @@
 
 namespace Automattic\WooCommerce\Admin\Marketing;
 
-use Automattic\WooCommerce\Internal\Admin\Loader;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 
 /**
@@ -21,17 +20,32 @@ class InstalledExtensions {
 	public static function get_data() {
 		$data = [];
 
-		$automatewoo = self::get_automatewoo_extension_data();
-		$mailchimp   = self::get_mailchimp_extension_data();
+		$automatewoo   = self::get_automatewoo_extension_data();
+		$aw_referral   = self::get_aw_referral_extension_data();
+		$aw_birthdays  = self::get_aw_birthdays_extension_data();
+		$mailchimp     = self::get_mailchimp_extension_data();
 		$facebook    = self::get_facebook_extension_data();
-		$pinterest   = self::get_pinterest_extension_data();
-		$google      = self::get_google_extension_data();
-		$hubspot     = self::get_hubspot_extension_data();
-		$amazon_ebay = self::get_amazon_ebay_extension_data();
-		$mailpoet    = self::get_mailpoet_extension_data();
+		$pinterest     = self::get_pinterest_extension_data();
+		$google        = self::get_google_extension_data();
+		$hubspot       = self::get_hubspot_extension_data();
+		$amazon_ebay   = self::get_amazon_ebay_extension_data();
+		$mailpoet      = self::get_mailpoet_extension_data();
+		$creative_mail = self::get_creative_mail_extension_data();
+		$tiktok        = self::get_tiktok_extension_data();
+		$jetpack_crm   = self::get_jetpack_crm_extension_data();
+		$zapier        = self::get_zapier_extension_data();
+		$salesforce    = self::get_salesforce_extension_data();
 
 		if ( $automatewoo ) {
 			$data[] = $automatewoo;
+		}
+
+		if ( $aw_referral ) {
+			$data[] = $aw_referral;
+		}
+
+		if ( $aw_birthdays ) {
+			$data[] = $aw_birthdays;
 		}
 
 		if ( $mailchimp ) {
@@ -60,6 +74,26 @@ class InstalledExtensions {
 
 		if ( $mailpoet ) {
 			$data[] = $mailpoet;
+		}
+
+		if ( $creative_mail ) {
+			$data[] = $creative_mail;
+		}
+
+		if ( $tiktok ) {
+			$data[] = $tiktok;
+		}
+
+		if ( $jetpack_crm ) {
+			$data[] = $jetpack_crm;
+		}
+
+		if ( $zapier ) {
+			$data[] = $zapier;
+		}
+
+		if ( $salesforce ) {
+			$data[] = $salesforce;
 		}
 
 		return $data;
@@ -103,6 +137,54 @@ class InstalledExtensions {
 			$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings' );
 			$data['docsUrl']     = 'https://automatewoo.com/docs/';
 			$data['status']      = 'configured'; // Currently no configuration step.
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get AutomateWoo Refer a Friend extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_aw_referral_extension_data() {
+		$slug = 'automatewoo-referrals';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/automatewoo.svg';
+
+		if ( 'activated' === $data['status'] && function_exists( 'AW_Referrals' ) ) {
+			$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings&tab=referrals' );
+			$data['docsUrl']     = 'https://automatewoo.com/docs/refer-a-friend/';
+			$data['status']      = 'configured';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get AutomateWoo Birthdays extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_aw_birthdays_extension_data() {
+		$slug = 'automatewoo-birthdays';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/automatewoo.svg';
+
+		if ( 'activated' === $data['status'] && function_exists( 'AW_Birthdays' ) ) {
+			$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings&tab=birthdays' );
+			$data['docsUrl']     = 'https://automatewoo.com/docs/getting-started-with-birthdays/';
+			$data['status']      = 'configured';
 		}
 
 		return $data;
@@ -314,6 +396,142 @@ class InstalledExtensions {
 
 			$data['docsUrl']    = 'https://kb.mailpoet.com/';
 			$data['supportUrl'] = 'https://www.mailpoet.com/support/';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get Creative Mail for WooCommerce extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_creative_mail_extension_data() {
+		$slug = 'creative-mail-by-constant-contact';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/creative-mail-by-constant-contact.png';
+
+		if ( 'activated' === $data['status'] && class_exists( '\CreativeMail\Helpers\OptionsHelper' ) ) {
+			if ( ! method_exists( '\CreativeMail\Helpers\OptionsHelper', 'get_instance_id' ) || \CreativeMail\Helpers\OptionsHelper::get_instance_id() !== null ) {
+				$data['status']      = 'configured';
+				$data['settingsUrl'] = admin_url( 'admin.php?page=creativemail_settings' );
+			} else {
+				$data['settingsUrl'] = admin_url( 'admin.php?page=creativemail' );
+			}
+
+			$data['docsUrl']    = 'https://app.creativemail.com/kb/help/WooCommerce';
+			$data['supportUrl'] = 'https://app.creativemail.com/kb/help/';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get TikTok for WooCommerce extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_tiktok_extension_data() {
+		$slug = 'tiktok-for-business';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/tiktok.jpg';
+
+		if ( 'activated' === $data['status'] ) {
+			if ( false !== get_option( 'tt4b_access_token' ) ) {
+				$data['status'] = 'configured';
+			}
+
+			$data['settingsUrl'] = admin_url( 'admin.php?page=tiktok' );
+			$data['docsUrl']     = 'https://woocommerce.com/document/tiktok-for-woocommerce/';
+			$data['supportUrl']  = 'https://ads.tiktok.com/athena/user-feedback/?identify_key=6a1e079024806640c5e1e695d13db80949525168a052299b4970f9c99cb5ac78';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get Jetpack CRM for WooCommerce extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_jetpack_crm_extension_data() {
+		$slug = 'zero-bs-crm';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/jetpack-crm.png';
+
+		if ( 'activated' === $data['status'] ) {
+			$data['status']      = 'configured';
+			$data['settingsUrl'] = admin_url( 'admin.php?page=zerobscrm-plugin-settings' );
+			$data['docsUrl']     = 'https://kb.jetpackcrm.com/';
+			$data['supportUrl']  = 'https://kb.jetpackcrm.com/crm-support/';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get WooCommerce Zapier extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_zapier_extension_data() {
+		$slug = 'woocommerce-zapier';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/zapier.png';
+
+		if ( 'activated' === $data['status'] ) {
+			$data['status']      = 'configured';
+			$data['settingsUrl'] = admin_url( 'admin.php?page=wc-settings&tab=wc_zapier' );
+			$data['docsUrl']     = 'https://docs.om4.io/woocommerce-zapier/';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get Salesforce extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_salesforce_extension_data() {
+		$slug = 'integration-with-salesforce';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/salesforce.jpg';
+
+
+		if ( 'activated' === $data['status'] && class_exists( '\Integration_With_Salesforce_Admin' ) ) {
+			if ( ! method_exists( '\Integration_With_Salesforce_Admin', 'get_connection_status' ) || \Integration_With_Salesforce_Admin::get_connection_status() ) {
+				$data['status'] = 'configured';
+			}
+
+			$data['settingsUrl'] = admin_url( 'admin.php?page=integration-with-salesforce' );
+			$data['docsUrl']     = 'https://woocommerce.com/document/salesforce-integration/';
+			$data['supportUrl']  = 'https://wpswings.com/submit-query/?utm_source=wpswings-salesforce-woo&utm_medium=woo-backend&utm_campaign=submit-query';
 		}
 
 		return $data;

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -24,7 +24,7 @@ class InstalledExtensions {
 		$aw_referral   = self::get_aw_referral_extension_data();
 		$aw_birthdays  = self::get_aw_birthdays_extension_data();
 		$mailchimp     = self::get_mailchimp_extension_data();
-		$facebook    = self::get_facebook_extension_data();
+		$facebook      = self::get_facebook_extension_data();
 		$pinterest     = self::get_pinterest_extension_data();
 		$google        = self::get_google_extension_data();
 		$amazon_ebay   = self::get_amazon_ebay_extension_data();

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -27,7 +27,6 @@ class InstalledExtensions {
 		$facebook    = self::get_facebook_extension_data();
 		$pinterest     = self::get_pinterest_extension_data();
 		$google        = self::get_google_extension_data();
-		$hubspot       = self::get_hubspot_extension_data();
 		$amazon_ebay   = self::get_amazon_ebay_extension_data();
 		$mailpoet      = self::get_mailpoet_extension_data();
 		$creative_mail = self::get_creative_mail_extension_data();
@@ -62,10 +61,6 @@ class InstalledExtensions {
 
 		if ( $google ) {
 			$data[] = $google;
-		}
-
-		if ( $hubspot ) {
-			$data[] = $hubspot;
 		}
 
 		if ( $amazon_ebay ) {
@@ -304,35 +299,6 @@ class InstalledExtensions {
 			}
 
 			$data['docsUrl'] = 'https://woocommerce.com/document/google-listings-and-ads/?utm_medium=product';
-		}
-
-		return $data;
-	}
-
-	/**
-	 * Get Hubspot extension data.
-	 *
-	 * @return array|bool
-	 */
-	protected static function get_hubspot_extension_data() {
-		$slug = 'hubspot-for-woocommerce';
-
-		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
-			return false;
-		}
-
-		$data         = self::get_extension_base_data( $slug );
-		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/hubspot.svg';
-
-		if ( 'activated' === $data['status'] && class_exists( '\Hubwoo' ) ) {
-
-			// Use same check as HubWoo admin.
-			if ( \Hubwoo::is_setup_completed() ) {
-				$data['status'] = 'configured';
-			}
-
-			$data['settingsUrl'] = admin_url( 'admin.php?page=hubwoo' );
-			$data['docsUrl']     = 'https://docs.makewebbetter.com/hubspot-integration-for-woocommerce/';
 		}
 
 		return $data;

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -162,10 +162,12 @@ class InstalledExtensions {
 		$data         = self::get_extension_base_data( $slug );
 		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/automatewoo.svg';
 
-		if ( 'activated' === $data['status'] && function_exists( 'AW_Referrals' ) ) {
-			$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings&tab=referrals' );
-			$data['docsUrl']     = 'https://automatewoo.com/docs/refer-a-friend/';
-			$data['status']      = 'configured';
+		if ( 'activated' === $data['status'] ) {
+			$data['docsUrl'] = 'https://automatewoo.com/docs/refer-a-friend/';
+			$data['status']  = 'configured';
+			if ( function_exists( 'AW_Referrals' ) ) {
+				$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings&tab=referrals' );
+			}
 		}
 
 		return $data;
@@ -186,10 +188,12 @@ class InstalledExtensions {
 		$data         = self::get_extension_base_data( $slug );
 		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/automatewoo.svg';
 
-		if ( 'activated' === $data['status'] && function_exists( 'AW_Birthdays' ) ) {
-			$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings&tab=birthdays' );
-			$data['docsUrl']     = 'https://automatewoo.com/docs/getting-started-with-birthdays/';
-			$data['status']      = 'configured';
+		if ( 'activated' === $data['status'] ) {
+			$data['docsUrl'] = 'https://automatewoo.com/docs/getting-started-with-birthdays/';
+			$data['status']  = 'configured';
+			if ( function_exists( 'AW_Birthdays' ) ) {
+				$data['settingsUrl'] = admin_url( 'admin.php?page=automatewoo-settings&tab=birthdays' );
+			}
 		}
 
 		return $data;

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -526,7 +526,7 @@ class InstalledExtensions {
 		}
 
 		$data         = self::get_extension_base_data( $slug );
-		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/vimeo.jpg';
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/vimeo.png';
 
 		if ( 'activated' === $data['status'] && class_exists( '\Tribe\Vimeo_WP\Vimeo\Vimeo_Auth' ) ) {
 			if ( method_exists( '\Tribe\Vimeo_WP\Vimeo\Vimeo_Auth', 'has_access_token' ) ) {

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -35,6 +35,7 @@ class InstalledExtensions {
 		$zapier        = self::get_zapier_extension_data();
 		$salesforce    = self::get_salesforce_extension_data();
 		$vimeo         = self::get_vimeo_extension_data();
+		$trustpilot    = self::get_trustpilot_extension_data();
 
 		if ( $automatewoo ) {
 			$data[] = $automatewoo;
@@ -94,6 +95,10 @@ class InstalledExtensions {
 
 		if ( $vimeo ) {
 			$data[] = $vimeo;
+		}
+
+		if ( $trustpilot ) {
+			$data[] = $trustpilot;
 		}
 
 		return $data;
@@ -536,6 +541,31 @@ class InstalledExtensions {
 			$data['settingsUrl'] = admin_url( 'options-general.php?page=vimeo_settings' );
 			$data['docsUrl']     = 'https://woocommerce.com/document/vimeo/';
 			$data['supportUrl']  = 'https://vimeo.com/help/contact';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get Trustpilot extension data.
+	 *
+	 * @return array|bool
+	 */
+	protected static function get_trustpilot_extension_data() {
+		$slug = 'trustpilot-reviews';
+
+		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
+			return false;
+		}
+
+		$data         = self::get_extension_base_data( $slug );
+		$data['icon'] = WC_ADMIN_IMAGES_FOLDER_URL . '/marketing/trustpilot.png';
+
+		if ( 'activated' === $data['status'] ) {
+			$data['status'] = 'configured';
+			$data['settingsUrl'] = admin_url( 'admin.php?page=woocommerce-trustpilot-settings-page' );
+			$data['docsUrl']     = 'https://woocommerce.com/document/trustpilot-reviews/';
+			$data['supportUrl']  = 'https://support.trustpilot.com/hc/en-us/requests/new';
 		}
 
 		return $data;

--- a/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
+++ b/plugins/woocommerce/src/Admin/Marketing/InstalledExtensions.php
@@ -507,7 +507,7 @@ class InstalledExtensions {
 
 			$data['settingsUrl'] = admin_url( 'admin.php?page=integration-with-salesforce' );
 			$data['docsUrl']     = 'https://woocommerce.com/document/salesforce-integration/';
-			$data['supportUrl']  = 'https://wpswings.com/submit-query/?utm_source=wpswings-salesforce-woo&utm_medium=woo-backend&utm_campaign=submit-query';
+			$data['supportUrl']  = 'https://wpswings.com/submit-query/';
 		}
 
 		return $data;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34431.

This PR adds seven new extensions to the "Installed marketing extensions" list on the `Marketing > Overview` page. These extensions appear on the list when the user installs and activates them. The added extensions are:

- [AutomateWoo Referrals](https://woocommerce.com/products/automatewoo-refer-a-friend/)
- [AutomateWoo Birthdays](https://woocommerce.com/products/automatewoo-birthdays/)
- [Creative Mail by Constant Contact](https://woocommerce.com/products/creative-mail-for-woocommerce/)
- [Jetpack CRM](https://woocommerce.com/products/jetpack-crm/)
- [Salesforce](https://woocommerce.com/products/integration-with-salesforce-for-woocommerce/)
- [Tiktok](https://woocommerce.com/products/tiktok-for-woocommerce/)
- [Zapier](https://woocommerce.com/products/woocommerce-zapier/)
- [Vimeo for WooCommerce](https://woocommerce.com/products/trustpilot-reviews/)
- [Trustpilot Reviews](https://woocommerce.com/products/trustpilot-reviews/)

Moreover, I have removed the [HubSpot](https://woocommerce.com/products/hubspot-for-woocommerce/) extension from the list based on the requirements defined in #34431.

This PR is based on Gan's PR #34415 and uses the extension icons introduced there.

Note: The `InstalledExtensions.php` file needed some cleanup/refactoring; however, I did not modify it because we will implement a new method for getting this data in the Multi-channel feature (pe2C5g-dl-p2) that will deprecate this class.

### How to test the changes in this Pull Request:

- General tests:

  1. Go to `WooCommerce Settings > Advanced > Features` and turn off the multichannel marketing feature.
  2. Install the seven extensions mentioned above
  3. Install AutomateWoo
  4. Go to the `Marketing > Overview` page and confirm their names appear in the "Installed marketing extensions" section
  5. Confirm that the "Get Support" and "Docs" links are correct and point to each extension's support page and documentation

- For [AutomateWoo Referrals](https://woocommerce.com/products/automatewoo-refer-a-friend/), [AutomateWoo Birthdays](https://woocommerce.com/products/automatewoo-birthdays/), [Jetpack CRM](https://woocommerce.com/products/jetpack-crm/), and [Zapier](https://woocommerce.com/products/woocommerce-zapier/):

  1. Confirm that the "Settings" link works and redirects the user to the extension's settings page.

- For [Creative Mail by Constant Contact](https://woocommerce.com/products/creative-mail-for-woocommerce/), [Salesforce](https://woocommerce.com/products/integration-with-salesforce-for-woocommerce/), [Vimeo for WooCommerce](https://woocommerce.com/products/trustpilot-reviews/), and [Tiktok](https://woocommerce.com/products/tiktok-for-woocommerce/):

  1. Ensure you have not set up the extension or completed onboarding. If you have, reset the extension data.
  2. Confirm that a link to "Finish setup" is displayed next to each extension name if it has not been set up and links to their onboarding/setup process.
  3. Once you complete setup/onboarding, confirm that the "Finish setup" link is replaced with the "Settings" link and points to the extension's settings page.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, i.e.` pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
