### PR TITLE
[COT] feat/34436: implement column_default for ListTable

### DIFF
--- a/plugins/woocommerce/changelog/feat-34436
+++ b/plugins/woocommerce/changelog/feat-34436
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Implement default columns in COT table

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -57,6 +57,22 @@ class ListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Handles output for the default column.
+	 *
+	 * @param \WC_Order $order       Current WooCommerce order object.
+	 * @param string    $column_name Identifier for the custom column.
+	 */
+	public function column_default( $order, $column_name ) {
+		/**
+		 * Fires for each custom column in the Custom Order Table in the administrative screen.
+		 *
+		 * @param string    $column_name Identifier for the custom column.
+		 * @param \WC_Order $order       Current WooCommerce order object.
+		 */
+		do_action( "manage_{$this->screen->id}_custom_column", $column_name, $order );
+	}
+
+	/**
 	 * Sets up an items-per-page control.
 	 */
 	private function items_per_page(): void {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -48,7 +48,7 @@ class ListTable extends WP_List_Table {
 	 */
 	public function setup(): void {
 		add_action( 'admin_notices', array( $this, 'bulk_action_notices' ) );
-		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'get_columns' ) );
+		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'get_columns' ), 0 );
 		add_filter( 'set_screen_option_edit_orders_per_page', array( $this, 'set_items_per_page' ), 10, 3 );
 		add_filter( 'default_hidden_columns', array( $this, 'default_hidden_columns' ), 10, 2 );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR:

- Implements the `column_default` method.
- Adds a hook `"manage_{$this->screen->id}_custom_column"`

Third party developers can use this hook to add custom columns to the custom order table.

Closes #34436 .

**Note:** The linting is failing because I did not add `@since` in the docblock as I wasn't sure.

### How to test the changes in this Pull Request:

1. Add a custom column to the Custom Order Table by using the `manage_woocommerce_page_wc-orders_columns` filter.
2. Add data to the custom column by using the `manage_woocommerce_page_wc-orders_custom_column` action hook.
3. Verify the data for custom column and data is correctly shown in `/wp-admin/admin.php?page=wc-orders`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
