### PR TITLE
Revert skip button changes on the OBW pages

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -42,7 +42,6 @@ import {
 } from './selective-extensions-bundle';
 import { getPluginSlug, getPluginTrackKey, getTimeFrame } from '~/utils';
 import './style.scss';
-import SkipButton from '../../../skip-button';
 
 const BUSINESS_DETAILS_TAB_NAME = 'business-details';
 const BUSINESS_FEATURES_TAB_NAME = 'business-features';
@@ -650,13 +649,6 @@ class BusinessDetails extends Component {
 									) }
 								</CardFooter>
 							</Card>
-							<SkipButton
-								onSkipped={ () => {
-									recordEvent(
-										'storeprofiler_store_business_details_skip'
-									);
-								} }
-							/>
 						</>
 					);
 				} }

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -19,7 +19,6 @@ import './style.scss';
 import sanitizeHTML from '~/lib/sanitize-html';
 import { setAllPropsToValue } from '~/lib/collections';
 import { getCountryCode } from '../../../../../../dashboard/utils';
-import SkipButton from '../../../../skip-button';
 
 const ALLOWED_PLUGIN_CATEGORIES = [ 'obw/basics', 'obw/grow' ];
 
@@ -396,13 +395,6 @@ export const SelectiveExtensionsBundle = ( {
 				installExtensionOptions,
 				isInstallingActivating
 			) }
-			<SkipButton
-				onSkipped={ () => {
-					recordEvent(
-						'storeprofiler_store_business_details_free_features_skip'
-					);
-				} }
-			/>
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -23,7 +23,6 @@ import { Text } from '@woocommerce/experimental';
  */
 import { getCurrencyRegion } from '../../dashboard/utils';
 import { getAdminSetting } from '~/utils/admin-settings';
-import SkipButton from './skip-button';
 
 const onboarding = getAdminSetting( 'onboarding', {} );
 
@@ -281,11 +280,6 @@ class Industry extends Component {
 						</Button>
 					</CardFooter>
 				</Card>
-				<SkipButton
-					onSkipped={ () => {
-						recordEvent( 'storeprofiler_store_industry_skip' );
-					} }
-				/>
 			</Fragment>
 		);
 	}

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
@@ -30,7 +30,6 @@ import { createNoticesFromResponse } from '~/lib/notices';
 import { getCountryCode } from '../../../dashboard/utils';
 import ProductTypeLabel from './label';
 import './style.scss';
-import SkipButton from '../skip-button';
 
 export class ProductTypes extends Component {
 	constructor() {
@@ -338,11 +337,6 @@ export class ProductTypes extends Component {
 							</Text>
 						) }
 				</div>
-				<SkipButton
-					onSkipped={ () => {
-						recordEvent( 'storeprofiler_store_product_type_skip' );
-					} }
-				/>
 			</div>
 		);
 	}

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
@@ -191,35 +191,6 @@ you can purchase and install it later.
         Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.
       </span>
     </div>
-    <div
-      class="woocommerce-profile-wizard__footer"
-    >
-      <button
-        class="components-button woocommerce-profile-wizard__footer-link is-link"
-        type="button"
-      >
-        Skip
-      </button>
-      <button
-        aria-label="Manual setup is only recommended for
- experienced WooCommerce users or developers."
-        class="components-button is-tertiary"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"
-          />
-        </svg>
-      </button>
-    </div>
   </div>
 </div>
 `;
@@ -414,35 +385,6 @@ you can purchase and install it later.
       >
         Billing is annual. All purchases are covered by our 30 day money back guarantee and include access to support and updates. Extensions will be added to a cart for you to purchase later.
       </span>
-    </div>
-    <div
-      class="woocommerce-profile-wizard__footer"
-    >
-      <button
-        class="components-button woocommerce-profile-wizard__footer-link is-link"
-        type="button"
-      >
-        Skip
-      </button>
-      <button
-        aria-label="Manual setup is only recommended for
- experienced WooCommerce users or developers."
-        class="components-button is-tertiary"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"
-          />
-        </svg>
-      </button>
     </div>
   </div>
 </div>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/style.scss
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/style.scss
@@ -1,3 +1,14 @@
+.woocommerce-profile-wizard__store-details {
+	.woocommerce-admin__store-details__spinner {
+		display: flex;
+		justify-content: center;
+	}
+
+	.components-popover .components-popover__content {
+		min-width: 360px;
+	}
+}
+
 .woocommerce-profile-wizard__newsletter-signup {
 	.components-base-control__field {
 		display: flex;

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
@@ -316,7 +316,7 @@ Object {
             class="components-button woocommerce-profile-wizard__footer-link is-link"
             type="button"
           >
-            Skip
+            Skip setup store details
           </button>
           <button
             aria-label="Manual setup is only recommended for
@@ -629,7 +629,7 @@ Object {
           class="components-button woocommerce-profile-wizard__footer-link is-link"
           type="button"
         >
-          Skip
+          Skip setup store details
         </button>
         <button
           aria-label="Manual setup is only recommended for

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -89,28 +89,6 @@ describe( 'StoreDetails', () => {
 		expect(
 			getByRole( 'button', { name: 'Continue' } )
 		).not.toBeDisabled();
-	} );
-
-	test( 'should call updateProfileItems when continue button is clicked given the allowTracking is true', async () => {
-		const updateProfileItems = jest.fn();
-		const { getByText } = render(
-			<StoreDetails
-				{ ...{
-					...testProps,
-					initialValues: {
-						...testProps.initialValues,
-						countryState: 'US',
-					},
-				} }
-				updateProfileItems={ updateProfileItems }
-				allowTracking={ true }
-			/>
-		);
-		const continueButton = getByText( 'Continue' );
-		userEvent.click( continueButton );
-		await waitFor( () => {
-			expect( updateProfileItems ).toHaveBeenCalled();
-		} );
 	} );
 
 	describe( 'Email validation test cases', () => {

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/theme/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/theme/index.js
@@ -29,7 +29,6 @@ import ThemeUploader from './uploader';
 import ThemePreview from './preview';
 import { getPriceValue } from '../../../dashboard/utils';
 import { getAdminSetting, setAdminSetting } from '~/utils/admin-settings';
-import SkipButton from '../skip-button';
 
 class Theme extends Component {
 	constructor() {
@@ -47,6 +46,7 @@ class Theme extends Component {
 		this.onClosePreview = this.onClosePreview.bind( this );
 		this.onSelectTab = this.onSelectTab.bind( this );
 		this.openDemo = this.openDemo.bind( this );
+		this.skipStep = this.skipStep.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -79,6 +79,12 @@ class Theme extends Component {
 				)
 			);
 		}
+	}
+
+	skipStep() {
+		const { activeTheme = '' } = getAdminSetting( 'onboarding', {} );
+		recordEvent( 'storeprofiler_store_theme_skip_step', { activeTheme } );
+		this.props.goToNextStep();
 	}
 
 	onChoose( theme, location = '' ) {
@@ -397,18 +403,15 @@ class Theme extends Component {
 					/>
 				) }
 				{ activeThemeSupportsWooCommerce && (
-					<SkipButton
-						onSkipped={ () => {
-							const { activeTheme = '' } = getAdminSetting(
-								'onboarding',
-								{}
-							);
-							recordEvent(
-								'storeprofiler_store_theme_skip_step',
-								{ activeTheme }
-							);
-						} }
-					/>
+					<p className="woocommerce-profile-wizard__themes-skip-this-step">
+						<Button
+							isLink
+							className="woocommerce-profile-wizard__skip"
+							onClick={ () => this.skipStep() }
+						>
+							{ __( 'Skip this step', 'woocommerce' ) }
+						</Button>
+					</p>
 				) }
 			</Fragment>
 		);

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
@@ -101,6 +101,7 @@ class UsageModal extends Component {
 		if ( allowTracking ) {
 			onClose();
 			onContinue();
+			return null;
 		}
 
 		const {

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
@@ -99,7 +99,8 @@ class UsageModal extends Component {
 
 		// Bail if site has already opted in to tracking
 		if ( allowTracking ) {
-			return null;
+			onClose();
+			onContinue();
 		}
 
 		const {
@@ -158,8 +159,6 @@ class UsageModal extends Component {
 							onClick={ () => {
 								this.setState( { selectedAction: 'accept' } );
 								this.updateTracking( { allowTracking: true } );
-								onClose();
-								onContinue();
 							} }
 						>
 							{ acceptActionText }

--- a/plugins/woocommerce-admin/client/profile-wizard/style.scss
+++ b/plugins/woocommerce-admin/client/profile-wizard/style.scss
@@ -292,14 +292,14 @@
 		box-shadow: $shadow-popover;
 
 		&.is-active {
-			border-color: var( --wp-admin-theme-color );
+			border-color: var(--wp-admin-theme-color);
 		}
 
 		.components-base-control__label {
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
-			max-width: calc( 100% - #{$gap * 2} - 24px );
+			max-width: calc(100% - #{$gap * 2} - 24px);
 		}
 
 		&::after {

--- a/plugins/woocommerce-admin/client/profile-wizard/style.scss
+++ b/plugins/woocommerce-admin/client/profile-wizard/style.scss
@@ -81,9 +81,6 @@
 			margin: 34px auto;
 			display: flex;
 			justify-content: center;
-			.components-popover .components-popover__content {
-				min-width: 360px;
-			}
 		}
 
 		.woocommerce-profile-wizard__footer-link {
@@ -295,14 +292,14 @@
 		box-shadow: $shadow-popover;
 
 		&.is-active {
-			border-color: var(--wp-admin-theme-color);
+			border-color: var( --wp-admin-theme-color );
 		}
 
 		.components-base-control__label {
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
-			max-width: calc(100% - #{$gap * 2} - 24px);
+			max-width: calc( 100% - #{$gap * 2} - 24px );
 		}
 
 		&::after {

--- a/plugins/woocommerce/changelog/update-34451-revert-skip-button-on-obw
+++ b/plugins/woocommerce/changelog/update-34451-revert-skip-button-on-obw
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Revert skip button changes on the OBW pages

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
@@ -8,7 +8,7 @@ test.describe( 'Payment setup task', () => {
 		await page.goto(
 			'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
 		);
-		await page.click( 'button:has-text("Skip")' );
+		await page.click( 'text=Skip setup store details' );
 		await page.click( 'text=No thanks' );
 		await page.waitForLoadState( 'networkidle' );
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -61,7 +61,7 @@ for ( const currentPage of wcPages ) {
 						await page.goto(
 							'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
 						);
-						await page.click( 'button:has-text("Skip")' );
+						await page.click( 'text=Skip setup store details' );
 						await page.click( 'text=No thanks' );
 						await page.waitForLoadState( 'networkidle' );
 						await page.goto( 'wp-admin/admin.php?page=wc-admin' );


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34451  .

This PR reverts the skip button changes from https://github.com/woocommerce/woocommerce/pull/34176

### How to test the changes in this Pull Request:

1. Compare the changes in this PR against https://github.com/woocommerce/woocommerce/pull/34176 and make sure everything is reverted.
2. Start with a fresh site
3. Start OBW ane make sure skip button has been removed, except from the first page. 

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
