### PR TITLE
Update get_product_data to send request with a locale query param for translation

### DIFF
--- a/plugins/woocommerce/changelog/update-get-product-data-i18n
+++ b/plugins/woocommerce/changelog/update-get-product-data-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update get_product_data to send request with a locale query param for translation

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -81,9 +81,12 @@ class OnboardingProducts {
 		$woocommerce_products = get_transient( self::PRODUCT_DATA_TRANSIENT );
 		if ( false === $woocommerce_products ) {
 			$woocommerce_products = wp_remote_get(
-				'https://woocommerce.com/wp-json/wccom-extensions/1.0/search',
-				array(
-					'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
+				add_query_arg(
+					array(
+						'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
+						'locale' => get_user_locale()
+					),
+					'https://woocommerce.com/wp-json/wccom-extensions/1.0/search'
 				)
 			);
 			if ( is_wp_error( $woocommerce_products ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -78,13 +78,18 @@ class OnboardingProducts {
 	 * @return array
 	 */
 	public static function get_product_data( $product_types ) {
-		$woocommerce_products = get_transient( self::PRODUCT_DATA_TRANSIENT );
+		$locale = get_user_locale();
+		// Transient value is an array of product data keyed by locale.
+		$transient_value      = get_transient( self::PRODUCT_DATA_TRANSIENT );
+		$transient_value      = is_array( $transient_value ) ? $transient_value : array();
+		$woocommerce_products = $transient_value[ $locale ] ?? false;
+
 		if ( false === $woocommerce_products ) {
 			$woocommerce_products = wp_remote_get(
 				add_query_arg(
 					array(
 						'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
-						'locale'     => get_user_locale(),
+						'locale'     => $locale,
 					),
 					'https://woocommerce.com/wp-json/wccom-extensions/1.0/search'
 				)
@@ -92,8 +97,8 @@ class OnboardingProducts {
 			if ( is_wp_error( $woocommerce_products ) ) {
 				return $product_types;
 			}
-
-			set_transient( self::PRODUCT_DATA_TRANSIENT, $woocommerce_products, DAY_IN_SECONDS );
+			$transient_value[ $locale ] = $woocommerce_products;
+			set_transient( self::PRODUCT_DATA_TRANSIENT, $transient_value, DAY_IN_SECONDS );
 		}
 
 		$data         = json_decode( $woocommerce_products['body'] );

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -84,7 +84,7 @@ class OnboardingProducts {
 				add_query_arg(
 					array(
 						'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
-						'locale' => get_user_locale()
+						'locale'     => get_user_locale(),
 					),
 					'https://woocommerce.com/wp-json/wccom-extensions/1.0/search'
 				)


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the `get_product_data` method to get translated contents from WCCOM.

### How to test the changes in this Pull Request:

1. Use a fresh site
2. Go to `Settings > General`
3. Change site language to `Español`
4. Go to OBW
5. Go to Product types step
6. Click on an info icon `(i)`
7. Observe that tooltip shows translated contents.

![Screen Shot 2022-09-01 at 10 50 08](https://user-images.githubusercontent.com/4344253/187822142-ac6107dd-979b-4263-a63d-62fb51685558.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
