### PR TITLE
Prevent fatal errors during uninstall

### DIFF
--- a/plugins/woocommerce/changelog/fix-32915-resolve-fatal-on-uninstall
+++ b/plugins/woocommerce/changelog/fix-32915-resolve-fatal-on-uninstall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal errors during uninstall when `WC_REMOVE_ALL_DATA` is true.


### PR DESCRIPTION
When WooCommerce is uninstalled, and if the constant `WC_REMOVE_ALL_DATA` is defined and true, then WooCommerce is expected to remove all of its custom tables (and all of its data from regular WordPress tables). Currently, this is failing. Reasons:

- During uninstall, some services are now accessed through our container, but `wc_get_container()` is not defined (`uninstall.php` tries to be very lightweight and has not traditionally loaded all of WooCommerce). This leads to a fatal error.
- It expects `WC_PLUGIN_BASENAME` to be defined but it is not ... previously this only resulted in a warning, but as of PHP 8.0 it also leads to a fatal error.

Additionally, it does not take care of cleaning up our COT tables (if they exist), so this felt like a good opportunity to also address that.

Closes #32915.

### How to test the changes in this Pull Request:

1. Install and activate WooCommerce.
2. Visit **WooCommerce ▸ Status ▸ Tools** and create the Custom Order Tables.
3. Deactivate WooCommerce, then click on the `Delete` link (triggers the uninstall routine).
4. The plugin should (eventually) be deleted. 
    - Without this change, fatal errors occur.
    - With this change, those fatals (as noted in the description) should be resolved.
5. All WooCommerce tables, including COT tables, should have been removed (verify using a tool of choice ... for instance, you can do `wp db query "SHOW TABLES"`).

† Bear in mind when testing that WP may be unable to remove the plugin files for a wide variety of reasons, especially if you symlinked your plugin directory from the monorepo and if PHP executes as a user that does not have permission to modify those files, etc. 

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
