### PR TITLE
[COT] Initialize order date props during `read()` as GMT

### DIFF
--- a/plugins/woocommerce/changelog/fix-34147
+++ b/plugins/woocommerce/changelog/fix-34147
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Initialize order dates in the COT datastore using the correct timezone.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -828,11 +828,18 @@ SELECT type FROM {$this->get_orders_table_name()} WHERE id = %d;
 				if ( ! isset( $prop_details['name'] ) ) {
 					continue;
 				}
+
+				$prop_value = $order_data->{$prop_details['name']};
+
+				if ( 'date' === $prop_details['type'] ) {
+					$prop_value = $this->string_to_timestamp( $prop_value );
+				}
+
 				$prop_setter_function_name = "set_{$prop_details['name']}";
 				if ( is_callable( array( $order, $prop_setter_function_name ) ) ) {
-					$order->{$prop_setter_function_name}( $order_data->{$prop_details['name']} );
+					$order->{$prop_setter_function_name}( $prop_value );
 				} elseif ( is_callable( array( $this, $prop_setter_function_name ) ) ) {
-					$this->{$prop_setter_function_name}( $order, $order_data->{$prop_details['name']}, false );
+					$this->{$prop_setter_function_name}( $order, $prop_value, false );
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When setting date properties that are in GMT in order objects, [server's timezone is assumed](https://github.com/woocommerce/woocommerce/blob/2ce2b65959107dd5dffefc5767b6b5e679ffe1ca/plugins/woocommerce/includes/abstracts/abstract-wc-data.php#L811) (unless the date includes timezone information or is a timestamp). When orders are loaded in COT, data from date columns is stored a string (with no timezone info), thus orders are being initialized with incorrect dates.

This PR makes sure we convert the GMT date into a timestamp, which is technique [also used by the CPT datastore](https://github.com/woocommerce/woocommerce/blob/2ce2b65959107dd5dffefc5767b6b5e679ffe1ca/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php#L126-L127).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34147.

### How to test the changes in this Pull Request:

1. Enable COT and make authoritative.
2. Set your site's timezone to, say, UTC-5.
3. Create an order by purchasing something.
4. Confirm that the new order has correct created/updated dates in the `wc_orders` table and in UTC.
5. Confirm that:
   - On `trunk`, the list table on the WC > Orders screen reflects an incorrect date/time. This should be evident if no "human readable" time is shown for the order, but can also be confirmed by inspecting the `<time>` tag.
   - On this branch, the list table should show the correct date/time and (since the order is recent) a human-readable time diff.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
