### PR TITLE
Remove deprecation notice from e2e readmes

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-deprecation-notice
+++ b/plugins/woocommerce/changelog/fix-remove-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Removed deprecation notice from readme files

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -27,7 +27,7 @@ If you are using Windows, we recommend using [Windows Subsystem for Linux (WSL)]
 
 ### Introduction
 
-End-to-end tests are powered by Playwright. The test site is spinned up using `wp-env` (recommended), but we also temporarily support `e2e-environment` (deprecated).
+End-to-end tests are powered by Playwright. The test site is spinned up using `wp-env` (recommended), but we also temporarily support `e2e-environment`.
 
 **Running tests for the first time:**
 

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -27,7 +27,7 @@ If you are using Windows, we recommend using [Windows Subsystem for Linux (WSL)]
 
 ### Introduction
 
-End-to-end tests are powered by Playwright. The test site is spinned up using `wp-env` (recommended), but we also temporarily support `e2e-environment`.
+End-to-end tests are powered by Playwright. The test site is spinned up using `wp-env` (recommended), but we will continue to support `e2e-environment` in the meantime.
 
 **Running tests for the first time:**
 

--- a/plugins/woocommerce/tests/e2e/README.md
+++ b/plugins/woocommerce/tests/e2e/README.md
@@ -1,8 +1,8 @@
-# WooCommerce Puppeteer End to End Tests (Deprecated)
+# WooCommerce Puppeteer End to End Tests
 
-**Deprecated. Please check the new E2E setup based on [Playwright + wp-env](./../../e2e).**
+**Please check the new E2E setup based on [Playwright + wp-env](./../../e2e).**
 
-This package uses `Puppeteer` as test runner and `e2e-environment` to spin up a test site. **It has been deprecated.** [Please check the new setup](./../../e2e), using `Playwright` as test runner and `wp-env` to spin up a test site.
+This package uses `Puppeteer` as test runner and `e2e-environment` to spin up a test site. [Please check the new setup](./../../e2e), using `Playwright` as test runner and `wp-env` to spin up a test site.
 
 ## Table of contents
 


### PR DESCRIPTION
This PR removes the wording on the deprecation of the `e2e-environment` package. Though we plan to do so in the future, the package has not yet been deprecated.