### PR TITLE
Customer Notes for COT

### DIFF
--- a/plugins/woocommerce/changelog/fix-34148-cot-order-notes
+++ b/plugins/woocommerce/changelog/fix-34148-cot-order-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure customer notes can be set, retrieved and edited when using COT.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -526,8 +526,8 @@ class WC_Meta_Box_Order_Data {
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) :
 								?>
 								<p class="form-field form-field-wide">
-									<label for="excerpt"><?php _e( 'Customer provided note', 'woocommerce' ); ?>:</label>
-									<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses_post( $order->get_customer_note() ); ?></textarea>
+									<label for="customer_note"><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?>:</label>
+									<textarea rows="1" cols="40" name="customer_note" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses_post( $order->get_customer_note() ); ?></textarea>
 								</p>
 							<?php endif; ?>
 						</div>
@@ -655,6 +655,11 @@ class WC_Meta_Box_Order_Data {
 		// Set created via prop if new post.
 		if ( isset( $_POST['original_post_status'] ) && 'auto-draft' === $_POST['original_post_status'] ) {
 			$props['created_via'] = 'admin';
+		}
+
+		// Customer note.
+		if ( isset( $_POST['customer_note'] ) ) {
+			$props['customer_note'] = sanitize_text_field( wp_unslash( $_POST['customer_note'] ) );
 		}
 
 		// Save order data.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
@@ -23,7 +23,7 @@ class WC_Meta_Box_Product_Short_Description {
 	public static function output( $post ) {
 
 		$settings = array(
-			'textarea_name' => 'excerpt',
+			'textarea_name' => 'customer_note',
 			'quicktags'     => array( 'buttons' => 'em,strong,link' ),
 			'tinymce'       => array(
 				'theme_advanced_buttons1' => 'bold,italic,strikethrough,separator,bullist,numlist,separator,blockquote,separator,justifyleft,justifycenter,justifyright,separator,link,unlink,separator,undo,redo,separator',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
@@ -84,6 +84,10 @@ class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 				'type'        => 'string',
 				'destination' => 'type',
 			),
+			'post_excerpt'      => array(
+				'type'        => 'string',
+				'destination' => 'customer_note',
+			),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -171,6 +171,10 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 			'type' => 'string',
 			'name' => 'customer_user_agent',
 		),
+		'customer_note'        => array(
+			'type' => 'string',
+			'name' => 'customer_note',
+		),
 	);
 
 	/**
@@ -1556,6 +1560,7 @@ CREATE TABLE $orders_table_name (
 	transaction_id varchar(100) null,
 	ip_address varchar(100) null,
 	user_agent text null,
+	customer_note text null,
 	PRIMARY KEY (id),
 	KEY status (status),
 	KEY date_created (date_created_gmt),

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -206,6 +206,7 @@ class OrderHelper {
 
 		$order->set_customer_ip_address( '1.1.1.1' );
 		$order->set_customer_user_agent( 'wc_unit_tests' );
+		$order->set_customer_note( 'Please be careful' );
 
 		$order->save();
 

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
@@ -244,6 +244,7 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$this->assertEquals( $order->get_customer_ip_address(), $db_order->ip_address );
 		$this->assertEquals( $order->get_customer_user_agent(), $db_order->user_agent );
 		$this->assertEquals( $order->get_type(), $db_order->type );
+		$this->assertEquals( $order->get_customer_note(), $db_order->customer_note );
 	}
 
 	/**


### PR DESCRIPTION
Adds support for Customer Notes to Custom Order Tables.

As a quick reminder, from a UI perspective, customer notes surface both in the order editor and the checkout page, as in the following screenshot:

<table>
<thead>
<tr>
<th>Editor screen</th>
<th>Checkout page</th>
</tr>
</thead>
<tbody>
<td><img src="https://user-images.githubusercontent.com/3594411/186778242-32e286f7-319d-4817-a04d-9cdb71a2a03c.png" alt="Editor screen, showing the Customer Note field" /></td>
<td><img src="https://user-images.githubusercontent.com/3594411/186778241-1f99a380-4c47-44f3-ac34-56538cbe97bd.png" alt="Checkout page, showing the Customer Note field" /></td>
</tbody>
</table>

Traditionally/under the CPT data-store, these notes have been stored in the `post_excerpt` field of the `wp_posts` table.

Closes #34148.

### How to test the changes in this Pull Request:

**Start by testing migrations.**

1. Disable the COT feature (via **WooCommerce ‣ Settings ‣ Advanced ‣ Custom Data Stores**) and delete your Custom Order Tables (via **WooCommerce ‣ Status ‣ Tools**).
2. Create some test orders, and set customer notes for some of them.
3. Re-enable the COT feature (but leave the posts table authoritative for the time being), re-generate the tables, and run the migration (`wp wc cot migrate`).
4. Once the migration completes, inspect the `wp_wc_orders` table. You should see a `customer_note` column and the value of this column should match what you see in the `post_excerpt` column for the corresponding rows from the `wp_posts` table:

![query-customer-notes-excerpts](https://user-images.githubusercontent.com/3594411/186780230-e0ff52ec-ba0e-4a18-aae5-5c5a87346c40.png)

**Ensure we can still edit customer notes.**

1. At this stage, the posts table should still be authoritative. Also check that *Keep the posts table and the orders tables synchronized* is enabled (both these things are managed via **WooCommerce ‣ Settings ‣ Advanced ‣ Custom Data Stores**).
2. Edit one of the orders then edit the customer note. Save/update.
3. The change should have persisted.
4. Now change the authoritative tables to COT and repeat the test (since a change was made to the meta box templates—which are shared by both the CPT and COT editors—I want to check editor-based updates of this field work for COT as well as CPT).

**Now test the COT data-store as a customer.**

1. With COT enabled (again: COT tables should be authoritative, synchronization with posts should be enabled) visit the storefront and place an order.
2. On the checkout screen, specify a Customer Note. Place the order.
3. As site administrator, edit the order and make sure you can see the Customer Note.
4. Using a DB tool of your choosing, ensure the matching row in `wp_posts` has the same Customer Note (but, stored in the `post_excerpt` field).

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
