### PR TITLE
Add include_meta and exclude_meta params for orders and products

### DIFF
--- a/plugins/woocommerce/changelog/fix-34243-rest-meta-keys
+++ b/plugins/woocommerce/changelog/fix-34243-rest-meta-keys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add include_meta and exclude_meta collection params to the orders and products WC REST API endpoints. These allow for limiting which meta keys are included in the meta_data response.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -216,10 +216,10 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Add SKU, PRICE, and IMAGE to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
-			$data['sku']       = $item->get_product() ? $item->get_product()->get_sku() : null;
-			$data['price']     = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
+			$data['price'] = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
 
-			$image_id = $item->get_product() ? $item->get_product()->get_image_id() : 0;
+			$image_id      = $item->get_product() ? $item->get_product()->get_image_id() : 0;
 			$data['image'] = array(
 				'id'  => $image_id,
 				'src' => $image_id ? wp_get_attachment_image_url( $image_id, 'full' ) : '',
@@ -330,9 +330,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function get_formatted_item_data( $order ) {
-		$extra_fields      = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url', 'is_editable', 'needs_payment', 'needs_processing' );
-		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
-		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
+		$extra_fields   = array( 'meta_data', 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds', 'payment_url', 'is_editable', 'needs_payment', 'needs_processing' );
+		$format_decimal = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
+		$format_date    = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
 		// These fields are dependent on other fields.
 		$dependent_fields = array(
 			'date_created_gmt'   => 'date_created',
@@ -1514,12 +1514,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'properties'  => array(
 									'type'       => 'object',
 									'properties' => array(
-										'id'                => array(
+										'id'  => array(
 											'description' => __( 'Image ID.', 'woocommerce' ),
 											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 										),
-										'src'               => array(
+										'src' => array(
 											'description' => __( 'Image URL.', 'woocommerce' ),
 											'type'        => 'string',
 											'format'      => 'uri',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -363,7 +363,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		foreach ( $extra_fields as $field ) {
 			switch ( $field ) {
 				case 'meta_data':
-					$data['meta_data'] = $order->get_meta_data();
+					$meta_data         = $order->get_meta_data();
+					$data['meta_data'] = $this->get_meta_data_for_response( $this->request, $meta_data );
 					break;
 				case 'line_items':
 					$data['line_items'] = $order->get_items( 'line_item' );
@@ -1929,7 +1930,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
 
-		$params['status']   = array(
+		$params['status']                  = array(
 			'default'           => 'any',
 			'description'       => __( 'Limit result set to orders assigned a specific status.', 'woocommerce' ),
 			'type'              => 'string',
@@ -1937,19 +1938,19 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['customer'] = array(
+		$params['customer']                = array(
 			'description'       => __( 'Limit result set to orders assigned a specific customer.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product']  = array(
+		$params['product']                 = array(
 			'description'       => __( 'Limit result set to orders assigned a specific product.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['dp']       = array(
+		$params['dp']                      = array(
 			'default'           => wc_get_price_decimals(),
 			'description'       => __( 'Number of decimal points to use in each resource.', 'woocommerce' ),
 			'type'              => 'integer',
@@ -1957,11 +1958,29 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order_item_display_meta'] = array(
-			'default' => false,
-			'description' => __( 'Only show meta which is meant to be displayed for an order.', 'woocommerce' ),
-			'type' => 'boolean',
+			'default'           => false,
+			'description'       => __( 'Only show meta which is meant to be displayed for an order.', 'woocommerce' ),
+			'type'              => 'boolean',
 			'sanitize_callback' => 'rest_sanitize_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['include_meta']            = array(
+			'default'           => array(),
+			'description'       => __( 'Limit meta_data to specific keys.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+			),
+			'sanitize_callback' => 'wp_parse_list',
+		);
+		$params['exclude_meta']            = array(
+			'default'           => array(),
+			'description'       => __( 'Ensure meta_data excludes specific keys.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+			),
+			'sanitize_callback' => 'wp_parse_list',
 		);
 
 		return $params;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -625,6 +625,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	protected function api_get_meta_data( $product, $context ) {
 		$meta_data = $product->get_meta_data();
 
+		if ( ! isset( $this->request ) || ! $this->request instanceof WP_REST_Request ) {
+			return $meta_data;
+		}
+
 		return $this->get_meta_data_for_response( $this->request, $meta_data );
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -623,7 +623,9 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	protected function api_get_meta_data( $product, $context ) {
-		return $product->get_meta_data();
+		$meta_data = $product->get_meta_data();
+
+		return $this->get_meta_data_for_response( $this->request, $meta_data );
 	}
 
 	/**
@@ -2355,29 +2357,47 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 			);
 		}
 
-		$params['in_stock']  = array(
+		$params['in_stock']     = array(
 			'description'       => __( 'Limit result set to products in stock or out of stock.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['on_sale']   = array(
+		$params['on_sale']      = array(
 			'description'       => __( 'Limit result set to products on sale.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['min_price'] = array(
+		$params['min_price']    = array(
 			'description'       => __( 'Limit result set to products based on a minimum price.', 'woocommerce' ),
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['max_price'] = array(
+		$params['max_price']    = array(
 			'description'       => __( 'Limit result set to products based on a maximum price.', 'woocommerce' ),
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['include_meta'] = array(
+			'default'           => array(),
+			'description'       => __( 'Limit meta_data to specific keys.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+			),
+			'sanitize_callback' => 'wp_parse_list',
+		);
+		$params['exclude_meta'] = array(
+			'default'           => array(),
+			'description'       => __( 'Ensure meta_data excludes specific keys.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+			),
+			'sanitize_callback' => 'wp_parse_list',
 		);
 
 		return $params;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -596,4 +596,45 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		);
 		return $this->_fields;
 	}
+
+	/**
+	 * Limit the contents of the meta_data property based on certain request parameters.
+	 *
+	 * Note that if both `include_meta` and `exclude_meta` are present in the request,
+	 * `include_meta` will take precedence.
+	 *
+	 * @param \WP_REST_Request $request   The request.
+	 * @param array            $meta_data All of the meta data for an object.
+	 *
+	 * @return array
+	 */
+	public function get_meta_data_for_response( $request, $meta_data ) {
+		$fields = $this->get_fields_for_response( $request );
+		if ( ! in_array( 'meta_data', $fields, true ) ) {
+			return array();
+		}
+
+		$include = (array) $request['include_meta'];
+		$exclude = (array) $request['exclude_meta'];
+
+		if ( ! empty( $include ) ) {
+			return array_filter(
+				$meta_data,
+				function( WC_Meta_Data $item ) use ( $include ) {
+					$data = $item->get_data();
+					return in_array( $data['key'], $include, true );
+				}
+			);
+		} elseif ( ! empty( $exclude ) ) {
+			return array_filter(
+				$meta_data,
+				function( WC_Meta_Data $item ) use ( $exclude ) {
+					$data = $item->get_data();
+					return ! in_array( $data['key'], $exclude, true );
+				}
+			);
+		}
+
+		return $meta_data;
+	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -608,7 +608,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 *
 	 * @return array
 	 */
-	public function get_meta_data_for_response( $request, $meta_data ) {
+	protected function get_meta_data_for_response( $request, $meta_data ) {
 		$fields = $this->get_fields_for_response( $request );
 		if ( ! in_array( 'meta_data', $fields, true ) ) {
 			return array();

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -81,7 +81,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	public function test_orders_api_get_all_fields_v2() {
 		$expected_response_fields = $this->get_expected_response_fields();
 
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
+		$order    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() ) );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -98,7 +98,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	 */
 	public function test_orders_get_each_field_one_by_one_v2() {
 		$expected_response_fields = $this->get_expected_response_fields();
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
+		$order                    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 
 		foreach ( $expected_response_fields as $field ) {
 			$request = new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -17,6 +17,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 				'role' => 'administrator',
 			)
 		);
+		wp_set_current_user( $this->user );
 	}
 
 	/**
@@ -78,7 +79,6 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 */
 	public function test_orders_api_get_all_fields_v2() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
@@ -97,7 +97,6 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	 * Test that all fields are returned when requested one by one.
 	 */
 	public function test_orders_get_each_field_one_by_one_v2() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 
@@ -121,5 +120,138 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 		$response = ( new WC_REST_Orders_V2_Controller() )->prepare_object_for_response( $order, new WP_REST_Request() );
 		$this->assertArrayHasKey( 'id', $response->data );
 		$this->assertEquals( $order->get_id(), $response->data['id'] );
+	}
+
+	/**
+	 * Test that the `include_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_include_meta() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param is skipped when empty.
+	 */
+	public function test_collection_param_include_meta_empty() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', '' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+			$this->assertContains( 'test2', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `exclude_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_exclude_meta() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test2', $meta_keys );
+			$this->assertNotContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param overrides the `exclude_meta` param.
+	 */
+	public function test_collection_param_include_meta_override() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', 'test1' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -5,59 +5,6 @@
  * Orders controller test.
  */
 class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
-	/**
-	 * A customer user ID.
-	 *
-	 * @var int|null
-	 */
-	protected static $customer = null;
-
-	/**
-	 * An array of test orders.
-	 *
-	 * @var WC_Order[]
-	 */
-	protected static $orders = array();
-
-	/**
-	 * Create orders for tests.
-	 *
-	 * @param WP_UnitTest_Factory $factory Factory class for creating WP objects.
-	 *
-	 * @return void
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$customer = $factory->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-
-		$order1 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( self::$customer );
-		$order1->add_meta_data( 'test1', 'test1', true );
-		$order1->add_meta_data( 'test2', 'test2', true );
-		$order1->save();
-
-		$order2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( self::$customer );
-		$order2->add_meta_data( 'test1', 'test1', true );
-		$order2->add_meta_data( 'test2', 'test2', true );
-		$order2->save();
-
-		self::$orders = array( $order1, $order2 );
-	}
-
-	/**
-	 * Clean up orders after tests.
-	 *
-	 * @return void
-	 */
-	public static function wpTearDownAfterClass() {
-		foreach ( self::$orders as $order ) {
-			$order->delete( true );
-		}
-
-		wp_delete_user( self::$customer );
-	}
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -65,7 +12,11 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Orders_V2_Controller();
-		wp_set_current_user( self::$customer );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -127,9 +78,10 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 */
 	public function test_orders_api_get_all_fields_v2() {
+		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
-		$order    = reset( self::$orders );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() ) );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -145,8 +97,9 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	 * Test that all fields are returned when requested one by one.
 	 */
 	public function test_orders_get_each_field_one_by_one_v2() {
+		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
-		$order                    = reset( self::$orders );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 
 		foreach ( $expected_response_fields as $field ) {
 			$request = new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() );
@@ -163,107 +116,10 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 	 * Test that `prepare_object_for_response` method works.
 	 */
 	public function test_prepare_object_for_response() {
-		$order    = reset( self::$orders );
+		$order = WC_Helper_Order::create_order();
+		$order->save();
 		$response = ( new WC_REST_Orders_V2_Controller() )->prepare_object_for_response( $order, new WP_REST_Request() );
 		$this->assertArrayHasKey( 'id', $response->data );
 		$this->assertEquals( $order->get_id(), $response->data['id'] );
-	}
-
-	/**
-	 * Test that the `include_meta` param filters the `meta_data` prop correctly.
-	 */
-	public function test_collection_param_include_meta() {
-		$expected_meta_key = 'test1';
-
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'include_meta', 'test1' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 1, count( $order['meta_data'] ) );
-			$meta = reset( $order['meta_data'] );
-			$this->assertEquals( $expected_meta_key, $meta->get_data()['key'] );
-		}
-	}
-
-	/**
-	 * Test that the `include_meta` param is skipped when empty.
-	 */
-	public function test_collection_param_include_meta_empty() {
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'include_meta', '' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 2, count( $order['meta_data'] ) );
-		}
-	}
-
-	/**
-	 * Test that the `exclude_meta` param filters the `meta_data` prop correctly.
-	 */
-	public function test_collection_param_exclude_meta() {
-		$expected_meta_key = 'test2';
-
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'exclude_meta', 'test1' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 1, count( $order['meta_data'] ) );
-			$meta = reset( $order['meta_data'] );
-			$this->assertEquals( $expected_meta_key, $meta->get_data()['key'] );
-		}
-	}
-
-	/**
-	 * Test that the `exclude_meta` param is skipped when empty.
-	 */
-	public function test_collection_param_exclude_meta_empty() {
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'exclude_meta', '' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 2, count( $order['meta_data'] ) );
-		}
-	}
-
-	/**
-	 * Test that the `include_meta` param overrides the `exclude_meta` param.
-	 */
-	public function test_collection_param_include_meta_override() {
-		$expected_meta_key = 'test1';
-
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'include_meta', 'test1' );
-		$request->set_param( 'exclude_meta', 'test1' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 1, count( $order['meta_data'] ) );
-			$meta = reset( $order['meta_data'] );
-			$this->assertEquals( $expected_meta_key, $meta->get_data()['key'] );
-		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -134,7 +134,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			$order->save();
 		}
 
-		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
 		$request->set_param( 'include_meta', 'test1' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -167,7 +167,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			$order->save();
 		}
 
-		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
 		$request->set_param( 'include_meta', '' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -200,7 +200,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			$order->save();
 		}
 
-		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
 		$request->set_param( 'exclude_meta', 'test1' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -233,7 +233,7 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			$order->save();
 		}
 
-		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
 		$request->set_param( 'include_meta', 'test1' );
 		$request->set_param( 'exclude_meta', 'test1' );
 		$response = $this->server->dispatch( $request );

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -5,6 +5,38 @@
  * Product Controller tests for V2 REST API.
  */
 class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
+	/**
+	 * @var WC_Product_Simple[]
+	 */
+	protected static $products = array();
+
+	/**
+	 * Create products for tests.
+	 *
+	 * @return void
+	 */
+	public static function wpSetUpBeforeClass() {
+		for ( $i = 1; $i <= 4; $i ++ ) {
+			self::$products[] = WC_Helper_Product::create_simple_product();
+		}
+
+		foreach ( self::$products as $product ) {
+			$product->add_meta_data( 'test1', 'test1', true );
+			$product->add_meta_data( 'test2', 'test2', true );
+			$product->save();
+		}
+	}
+
+	/**
+	 * Clean up products after tests.
+	 *
+	 * @return void
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$products as $product ) {
+			WC_Helper_Product::delete_product( $product->get_id() );
+		}
+	}
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -17,6 +49,7 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+		wp_set_current_user( $this->user );
 	}
 
 	/**
@@ -97,7 +130,6 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 */
 	public function test_product_api_get_all_fields_v2() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
@@ -131,7 +163,6 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 	 * Test that all fields are returned when requested one by one.
 	 */
 	public function test_products_get_each_field_one_by_one_v2() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 
@@ -143,6 +174,107 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 			$response_fields = array_keys( $response->get_data() );
 
 			$this->assertContains( $field, $response_fields, "Field $field was expected but not present in product API V2 response." );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_include_meta() {
+		$request = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request->set_param( 'include_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param is skipped when empty.
+	 */
+	public function test_collection_param_include_meta_empty() {
+		$request = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request->set_param( 'include_meta', '' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+			$this->assertContains( 'test2', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `exclude_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_exclude_meta() {
+		$request = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test2', $meta_keys );
+			$this->assertNotContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param overrides the `exclude_meta` param.
+	 */
+	public function test_collection_param_include_meta_override() {
+		$request = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request->set_param( 'include_meta', 'test1' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -81,7 +81,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	public function test_orders_api_get_all_fields() {
 		$expected_response_fields = $this->get_expected_response_fields();
 
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
+		$order    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() ) );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -98,7 +98,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_orders_get_each_field_one_by_one() {
 		$expected_response_fields = $this->get_expected_response_fields();
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
+		$order                    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 
 		foreach ( $expected_response_fields as $field ) {
 			$request = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() );
@@ -148,7 +148,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		$time_after_orders = time() + HOUR_IN_SECONDS;
 
-		$request  = new \WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request = new \WP_REST_Request( 'GET', '/wc/v3/orders' );
 		$request->set_param( 'dates_are_gmt', 1 );
 
 		// No date params should return all orders.
@@ -164,7 +164,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 
 		// All orders are before `$time_after_orders`.
 		$request->set_param( 'before', gmdate( DateTime::ATOM, $time_after_orders ) );
-		$response = $this->server-> dispatch( $request );
+		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 5, $response->get_data() );
 	}

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -17,6 +17,7 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+		wp_set_current_user( $this->user );
 	}
 
 	/**
@@ -78,7 +79,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 */
 	public function test_orders_api_get_all_fields() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
@@ -97,7 +97,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Test that all fields are returned when requested one by one.
 	 */
 	public function test_orders_get_each_field_one_by_one() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 
@@ -118,8 +117,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_orders_get_all(): void {
-		wp_set_current_user( $this->user );
-
 		// Create a few orders.
 		foreach ( range( 1, 5 ) as $i ) {
 			$order = new \WC_Order();
@@ -138,8 +135,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_orders_date_filtering(): void {
-		wp_set_current_user( $this->user );
-
 		$time_before_orders = time();
 
 		// Create a few orders for testing.
@@ -178,8 +173,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Tests creating an order.
 	 */
 	public function test_orders_create(): void {
-		wp_set_current_user( $this->user );
-
 		$product                  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 		$order_params             = array(
 			'payment_method'       => 'bacs',
@@ -234,8 +227,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Tests deleting an order.
 	 */
 	public function test_orders_delete(): void {
-		wp_set_current_user( $this->user );
-
 		$order = new \WC_Order();
 		$order->set_status( 'completed' );
 		$order->save();
@@ -258,4 +249,136 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'trash', $order->get_status( 'edit' ) );
 	}
 
+	/**
+	 * Test that the `include_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_include_meta() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param is skipped when empty.
+	 */
+	public function test_collection_param_include_meta_empty() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', '' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+			$this->assertContains( 'test2', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `exclude_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_exclude_meta() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test2', $meta_keys );
+			$this->assertNotContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param overrides the `exclude_meta` param.
+	 */
+	public function test_collection_param_include_meta_override() {
+		// Create 3 orders.
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$order = new \WC_Order();
+			$order->add_meta_data( 'test1', 'test1', true );
+			$order->add_meta_data( 'test2', 'test2', true );
+			$order->save();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', 'test1' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 3, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -5,90 +5,6 @@
  * Orders Controller tests for V3 REST API.
  */
 class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
-	/**
-	 * A customer user ID.
-	 *
-	 * @var int|null
-	 */
-	protected static $customer = null;
-
-	/**
-	 * An array of test orders.
-	 *
-	 * @var WC_Order[]
-	 */
-	protected static $orders = array();
-
-	/**
-	 * An array of test products.
-	 *
-	 * @var WC_Product_Simple[]
-	 */
-	protected static $products = array();
-
-	/**
-	 * Timestamp before test orders are created.
-	 *
-	 * @var int
-	 */
-	protected static $time_before_orders = 0;
-
-	/**
-	 * Timestamp after test orders are created.
-	 *
-	 * @var int
-	 */
-	protected static $time_after_orders = 0;
-
-	/**
-	 * Create orders for tests.
-	 *
-	 * @param WP_UnitTest_Factory $factory Factory class for creating WP objects.
-	 *
-	 * @return void
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$customer = $factory->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-
-		self::$time_before_orders = time();
-
-		$order1 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( self::$customer );
-		$order1->add_meta_data( 'test1', 'test1', true );
-		$order1->add_meta_data( 'test2', 'test2', true );
-		$order1->save();
-
-		$order2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( self::$customer );
-		$order2->add_meta_data( 'test1', 'test1', true );
-		$order2->add_meta_data( 'test2', 'test2', true );
-		$order2->save();
-
-		self::$orders = array( $order1, $order2 );
-
-		self::$time_after_orders = time() + HOUR_IN_SECONDS;
-
-		self::$products[] = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
-	}
-
-	/**
-	 * Clean up orders after tests.
-	 *
-	 * @return void
-	 */
-	public static function wpTearDownAfterClass() {
-		foreach ( self::$orders as $order ) {
-			$order->delete( true );
-		}
-
-		foreach ( self::$products as $product ) {
-			$product->delete( true );
-		}
-
-		wp_delete_user( self::$customer );
-	}
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -96,7 +12,11 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Orders_Controller();
-		wp_set_current_user( self::$customer );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -158,9 +78,10 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 */
 	public function test_orders_api_get_all_fields() {
+		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
-		$order    = reset( self::$orders );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() ) );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -176,8 +97,9 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Test that all fields are returned when requested one by one.
 	 */
 	public function test_orders_get_each_field_one_by_one() {
+		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
-		$order                    = reset( self::$orders );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
 
 		foreach ( $expected_response_fields as $field ) {
 			$request = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() );
@@ -196,10 +118,18 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_orders_get_all(): void {
+		wp_set_current_user( $this->user );
+
+		// Create a few orders.
+		foreach ( range( 1, 5 ) as $i ) {
+			$order = new \WC_Order();
+			$order->save();
+		}
+
 		$request  = new \WP_REST_Request( 'GET', '/wc/v3/orders' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 2, $response->get_data() );
+		$this->assertCount( 5, $response->get_data() );
 	}
 
 	/**
@@ -208,32 +138,49 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_orders_date_filtering(): void {
-		$request = new \WP_REST_Request( 'GET', '/wc/v3/orders' );
+		wp_set_current_user( $this->user );
+
+		$time_before_orders = time();
+
+		// Create a few orders for testing.
+		$order_ids = array();
+		foreach ( range( 1, 5 ) as $i ) {
+			$order = new \WC_Order();
+			$order->save();
+
+			$order_ids[] = $order->get_id();
+		}
+
+		$time_after_orders = time() + HOUR_IN_SECONDS;
+
+		$request  = new \WP_REST_Request( 'GET', '/wc/v3/orders' );
 		$request->set_param( 'dates_are_gmt', 1 );
 
 		// No date params should return all orders.
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 2, $response->get_data() );
+		$this->assertCount( 5, $response->get_data() );
 
 		// There are no orders before `$time_before_orders`.
-		$request->set_param( 'before', gmdate( DateTime::ATOM, self::$time_before_orders ) );
+		$request->set_param( 'before', gmdate( DateTime::ATOM, $time_before_orders ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 0, $response->get_data() );
 
 		// All orders are before `$time_after_orders`.
-		$request->set_param( 'before', gmdate( DateTime::ATOM, self::$time_after_orders ) );
-		$response = $this->server->dispatch( $request );
+		$request->set_param( 'before', gmdate( DateTime::ATOM, $time_after_orders ) );
+		$response = $this->server-> dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 2, $response->get_data() );
+		$this->assertCount( 5, $response->get_data() );
 	}
 
 	/**
 	 * Tests creating an order.
 	 */
 	public function test_orders_create(): void {
-		$product                  = reset( self::$products );
+		wp_set_current_user( $this->user );
+
+		$product                  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 		$order_params             = array(
 			'payment_method'       => 'bacs',
 			'payment_method_title' => 'Direct Bank Transfer',
@@ -281,14 +228,14 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		foreach ( array_keys( $order_params['billing'] ) as $address_key ) {
 			$this->assertEquals( $order_params['billing'][ $address_key ], $order->{"get_billing_{$address_key}"}( 'edit' ) );
 		}
-
-		$order->delete( true ); // Clean up.
 	}
 
 	/**
 	 * Tests deleting an order.
 	 */
 	public function test_orders_delete(): void {
+		wp_set_current_user( $this->user );
+
 		$order = new \WC_Order();
 		$order->set_status( 'completed' );
 		$order->save();
@@ -309,105 +256,6 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 		// Check the order was actually deleted.
 		$order = wc_get_order( $order->get_id() );
 		$this->assertEquals( 'trash', $order->get_status( 'edit' ) );
-
-		$order->delete( true ); // Clean up.
 	}
 
-	/**
-	 * Test that the `include_meta` param filters the `meta_data` prop correctly.
-	 */
-	public function test_collection_param_include_meta() {
-		$expected_meta_key = 'test1';
-
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'include_meta', 'test1' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 1, count( $order['meta_data'] ) );
-			$meta = reset( $order['meta_data'] );
-			$this->assertEquals( $expected_meta_key, $meta->get_data()['key'] );
-		}
-	}
-
-	/**
-	 * Test that the `include_meta` param is skipped when empty.
-	 */
-	public function test_collection_param_include_meta_empty() {
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'include_meta', '' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 2, count( $order['meta_data'] ) );
-		}
-	}
-
-	/**
-	 * Test that the `exclude_meta` param filters the `meta_data` prop correctly.
-	 */
-	public function test_collection_param_exclude_meta() {
-		$expected_meta_key = 'test2';
-
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'exclude_meta', 'test1' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 1, count( $order['meta_data'] ) );
-			$meta = reset( $order['meta_data'] );
-			$this->assertEquals( $expected_meta_key, $meta->get_data()['key'] );
-		}
-	}
-
-	/**
-	 * Test that the `exclude_meta` param is skipped when empty.
-	 */
-	public function test_collection_param_exclude_meta_empty() {
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'exclude_meta', '' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 2, count( $order['meta_data'] ) );
-		}
-	}
-
-	/**
-	 * Test that the `include_meta` param overrides the `exclude_meta` param.
-	 */
-	public function test_collection_param_include_meta_override() {
-		$expected_meta_key = 'test1';
-
-		$request = new WP_REST_Request( 'GET', '/wc/v2/orders' );
-		$request->set_param( 'include_meta', 'test1' );
-		$request->set_param( 'exclude_meta', 'test1' );
-		$response = $this->server->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_data = $response->get_data();
-
-		foreach ( $response_data as $order ) {
-			$this->assertArrayHasKey( 'meta_data', $order );
-			$this->assertEquals( 1, count( $order['meta_data'] ) );
-			$meta = reset( $order['meta_data'] );
-			$this->assertEquals( $expected_meta_key, $meta->get_data()['key'] );
-		}
-	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -44,6 +44,12 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 				'sku'  => 'waffle-3',
 			)
 		);
+
+		foreach ( self::$products as $product ) {
+			$product->add_meta_data( 'test1', 'test1', true );
+			$product->add_meta_data( 'test2', 'test2', true );
+			$product->save();
+		}
 	}
 
 	/**
@@ -68,6 +74,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 				'role' => 'administrator',
 			)
 		);
+		wp_set_current_user( $this->user );
 	}
 
 	/**
@@ -150,7 +157,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Note: This has fields hardcoded intentionally instead of fetching from schema to test for any bugs in schema result. Add new fields manually when added to schema.
 	 */
 	public function test_product_api_get_all_fields() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
@@ -184,7 +190,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * Test that all fields are returned when requested one by one.
 	 */
 	public function test_products_get_each_field_one_by_one() {
-		wp_set_current_user( $this->user );
 		$expected_response_fields = $this->get_expected_response_fields();
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 
@@ -205,8 +210,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_products_search_with_search_param_only() {
-		wp_set_current_user( $this->user );
-
 		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$request->set_query_params(
 			array(
@@ -232,8 +235,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_products_search_with_search_sku_param_only() {
-		wp_set_current_user( $this->user );
-
 		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$request->set_query_params(
 			array(
@@ -259,8 +260,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_products_search_with_search_and_search_sku_param() {
-		wp_set_current_user( $this->user );
-
 		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$request->set_query_params(
 			array(
@@ -285,8 +284,6 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_products_search_with_search_sku_when_skus_disabled() {
-		wp_set_current_user( $this->user );
-
 		add_filter( 'wc_product_sku_enabled', '__return_false' );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
@@ -309,5 +306,106 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $response_products[1]['sku'], 'waffle-3' );
 
 		remove_filter( 'wc_product_sku_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that the `include_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_include_meta() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'include_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param is skipped when empty.
+	 */
+	public function test_collection_param_include_meta_empty() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'include_meta', '' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+			$this->assertContains( 'test2', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `exclude_meta` param filters the `meta_data` prop correctly.
+	 */
+	public function test_collection_param_exclude_meta() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test2', $meta_keys );
+			$this->assertNotContains( 'test1', $meta_keys );
+		}
+	}
+
+	/**
+	 * Test that the `include_meta` param overrides the `exclude_meta` param.
+	 */
+	public function test_collection_param_include_meta_override() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'include_meta', 'test1' );
+		$request->set_param( 'exclude_meta', 'test1' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data = $response->get_data();
+		$this->assertCount( 4, $response_data );
+
+		foreach ( $response_data as $order ) {
+			$this->assertArrayHasKey( 'meta_data', $order );
+			$this->assertEquals( 1, count( $order['meta_data'] ) );
+			$meta_keys = array_map(
+				function( $meta_item ) {
+					return $meta_item->get_data()['key'];
+				},
+				$order['meta_data']
+			);
+			$this->assertContains( 'test1', $meta_keys );
+		}
 	}
 }


### PR DESCRIPTION
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Introduces two new collection params for v2 and v3 orders and products REST API endpoints. These params allow for limiting which meta keys are included in the `meta_data` property of the API responses.

Fixes #34243

### How to test the changes in this Pull Request:

1. Create some products and orders in your test environment.
2. On at least one order and at least one product, add at least two postmeta key/value pairs using the Custom Fields box. E.g. `test1` and `test2`.
3. Using a REST client like Insomnia, make a request to `wc/v3/orders` and check that the postmeta keys you added are showing up under the `meta_data` property of the order in the response. Do the same for `wc/v3/products`. It's easier to find the data you're looking for if you use the `_fields` request param to limit which fields are in the response to something like `id,meta_data`.
4. Add the `include_meta` param to your requests with a value that is only one of the postmeta keys you added, e.g. `test1`. Now the response should only include `test1` in the `meta_data` prop.
5. Switch the param to `exclude_meta`. Now the response should only include `test2` in the `meta_data` prop.
6. Try using both `include_meta` and `exclude_meta` params in the request. The `include` one should be honored, while the `exclude` one is ignored.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
