### PR TITLE
[COT] Fix editor trash link

### DIFF
--- a/plugins/woocommerce/changelog/fix-34375-editor-trash-link
+++ b/plugins/woocommerce/changelog/fix-34375-editor-trash-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Move-to-trash link (within the order editor) should also work with Custom Order Tables.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -66,7 +66,7 @@ class WC_Meta_Box_Order_Actions {
 							$delete_text = __( 'Move to Trash', 'woocommerce' );
 						}
 						?>
-						<a class="submitdelete deletion" href="<?php echo esc_url( get_delete_post_link( $order_id ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>
+						<a class="submitdelete deletion" href="<?php echo esc_url( self::get_trash_or_delete_order_link( $order_id ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>
 						<?php
 					}
 					?>
@@ -86,6 +86,31 @@ class WC_Meta_Box_Order_Actions {
 
 		</ul>
 		<?php
+	}
+
+	/**
+	 * Forms a trash/delete order URL.
+	 *
+	 * @param int $order_id The order ID for which we want a trash/delete URL.
+	 *
+	 * @return string
+	 */
+	private static function get_trash_or_delete_order_link( int $order_id ): string {
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$order_list_url  = admin_url( 'admin.php?page=wc-orders' );
+			$trash_order_url = add_query_arg(
+				array(
+					'action'           => 'trash',
+					'order'            => array( $order_id ),
+					'_wp_http_referer' => $order_list_url,
+				),
+				$order_list_url
+			);
+
+			return wp_nonce_url( $trash_order_url, 'bulk-orders' );
+		}
+
+		return get_delete_post_link( $order_id );
 	}
 
 	/**


### PR DESCRIPTION
The *"Move to Trash"* link in the COT-powered order editor should work as expected.

![move-to-trash](https://user-images.githubusercontent.com/3594411/186826780-8af99830-affa-4d25-b5cf-047228aa7b6e.gif)

Closes #34375.

### How to test the changes in this Pull Request:

Use the settings found in **WooCommerce ⏵ Settings ⏵ Advanced ⏵ Custom Data Stores** to test this once with custom order tables as the authoritative data-store, and then repeat with the posts table (to ensure nothing has inadverently broken there).

1. Edit an order.
2. Use the move-to-trash link.
3. The order should be trashed, and you should be returned to the orders list table.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
