### PR TITLE
Fix country field is empty when navigating back to the store details tab

### DIFF
--- a/packages/js/data/changelog/fix-34460-country-field-is-empty-when-navigating-back
+++ b/packages/js/data/changelog/fix-34460-country-field-is-empty-when-navigating-back
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add is_store_country_set field to profileItems

--- a/packages/js/data/src/onboarding/reducer.ts
+++ b/packages/js/data/src/onboarding/reducer.ts
@@ -31,6 +31,7 @@ export const defaultState: OnboardingState = {
 		wccom_connected: null,
 		is_agree_marketing: null,
 		store_email: null,
+		is_store_country_set: null,
 	},
 	emailPrefill: '',
 	paymentMethods: [],

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -142,6 +142,7 @@ export type ProfileItems = {
 	wccom_connected?: boolean | null;
 	is_agree_marketing?: boolean | null;
 	store_email?: string | null;
+	is_store_country_set?: boolean | null;
 };
 
 export type FieldLocale = {

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -166,6 +166,9 @@ export class StoreDetails extends Component {
 		const profileItemsToUpdate = {
 			is_agree_marketing: values.isAgreeMarketing,
 			store_email: values.storeEmail,
+			is_store_country_set:
+				typeof values.countryState === 'string' &&
+				values.countryState !== '',
 		};
 
 		const region = getCurrencyRegion( values.countryState );
@@ -464,12 +467,12 @@ export default compose(
 		errorsRef.current = {
 			settings: getSettingsError( 'general' ),
 		};
-		// Check if a store address is set so that we don't default
-		// to WooCommerce's default country of the UK.
-		const countryState =
-			( settings.woocommerce_store_address &&
-				settings.woocommerce_default_country ) ||
-			'';
+		// Check if a store country is set so that we don't default
+		// to WooCommerce's default country of the US:CA.
+		const countryState = profileItems.is_store_country_set
+			? settings.woocommerce_default_country
+			: '';
+
 		getCountries();
 		getLocales();
 

--- a/plugins/woocommerce/changelog/fix-34460-country-field-is-empty-when-navigating-back
+++ b/plugins/woocommerce/changelog/fix-34460-country-field-is-empty-when-navigating-back
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix country field is empty when navigating back to "Store Details" tab

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -261,21 +261,21 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
-			'completed'           => array(
+			'completed'            => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'skipped'             => array(
+			'skipped'              => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'industry'            => array(
+			'industry'             => array(
 				'type'              => 'array',
 				'description'       => __( 'Industry.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -285,7 +285,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'object',
 				),
 			),
-			'product_types'       => array(
+			'product_types'        => array(
 				'type'              => 'array',
 				'description'       => __( 'Types of products sold.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -297,7 +297,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'string',
 				),
 			),
-			'product_count'       => array(
+			'product_count'        => array(
 				'type'              => 'string',
 				'description'       => __( 'Number of products to be added.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -311,7 +311,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'1000+',
 				),
 			),
-			'selling_venues'      => array(
+			'selling_venues'       => array(
 				'type'              => 'string',
 				'description'       => __( 'Other places the store is selling products.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -325,7 +325,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'other-woocommerce',
 				),
 			),
-			'number_employees'    => array(
+			'number_employees'     => array(
 				'type'              => 'string',
 				'description'       => __( 'Number of employees of the store.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -340,7 +340,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'not specified',
 				),
 			),
-			'revenue'             => array(
+			'revenue'              => array(
 				'type'              => 'string',
 				'description'       => __( 'Current annual revenue of the store.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -356,7 +356,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'rather-not-say',
 				),
 			),
-			'other_platform'      => array(
+			'other_platform'       => array(
 				'type'              => 'string',
 				'description'       => __( 'Name of other platform used to sell.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -374,14 +374,14 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'other',
 				),
 			),
-			'other_platform_name' => array(
+			'other_platform_name'  => array(
 				'type'              => 'string',
 				'description'       => __( 'Name of other platform used to sell (not listed).', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'business_extensions' => array(
+			'business_extensions'  => array(
 				'type'              => 'array',
 				'description'       => __( 'Extra business extensions to install.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -402,7 +402,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'string',
 				),
 			),
-			'theme'               => array(
+			'theme'                => array(
 				'type'              => 'string',
 				'description'       => __( 'Selected store theme.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -410,33 +410,40 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'sanitize_callback' => 'sanitize_title_with_dashes',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'setup_client'        => array(
+			'setup_client'         => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'wccom_connected'     => array(
+			'wccom_connected'      => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'is_agree_marketing'  => array(
+			'is_agree_marketing'   => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store agreed to receiving marketing contents from WooCommerce.com.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'store_email'         => array(
+			'store_email'          => array(
 				'type'              => 'string',
 				'description'       => __( 'Store email address.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => array( __CLASS__, 'rest_validate_marketing_email' ),
+			),
+			'is_store_country_set' => array(
+				'type'              => 'boolean',
+				'description'       => __( 'Whether or not this store country is set via onboarding profiler.', 'woocommerce' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => array( __CLASS__, 'rest_validate_request_arg' ),
 			),
 		);
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
@@ -107,7 +107,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 16, $properties );
+		$this->assertCount( 17, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
@@ -124,6 +124,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'setup_client', $properties );
 		$this->assertArrayHasKey( 'is_agree_marketing', $properties );
 		$this->assertArrayHasKey( 'store_email', $properties );
+		$this->assertArrayHasKey( 'is_store_country_set', $properties );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34460.

This PR adds a new value `is_store_country_set` to profiler items to check if store country is set via onboarding profiler to fix the issue.

### How to test the changes in this Pull Request:

1. Go to OBW
2. Select a "Country", but NOT fill the "Address"
3. Click `Continue` and go to the next step
4. Click on `(1) Store Details` in the header
5. Observe that the Country field is filled 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
