### PR TITLE
Fix "Orders" Plurality

### DIFF
--- a/plugins/woocommerce-admin/client/analytics/report/products/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/products/table.js
@@ -307,7 +307,7 @@ class ProductsReportTable extends Component {
 				value: formatAmount( netRevenue ),
 			},
 			{
-				label: _n( 'Orders', 'Orders', ordersCount, 'woocommerce' ),
+				label: _n( 'Order', 'Orders', ordersCount, 'woocommerce' ),
 				value: formatValue( currency, 'number', ordersCount ),
 			},
 		];

--- a/plugins/woocommerce/changelog/fix-orders-plural
+++ b/plugins/woocommerce/changelog/fix-orders-plural
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects the plurality of an "Orders" string to fix the `.pot` file


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull request fixes an incorrect `_n()` call where both the singular and plural arguments were the same. This was causing the `msgid "Orders"` to be seen as plural, leading to a confusing `.pot` file. By adjusting the `_n()` call, the `.pot` file presents the `"Orders"` string as a normal translation string instead of a plural one.

Closes #34300.

### How to test the changes in this Pull Request:

1. Use `TURBO_FORCE=true pnpm run build --filter=woocommerce` to make sure that everything is built correctly.
2. Run `pnpm run makepot --filter=woocommerce`
3. Check `plugins/woocommerce/i18n/languages/woocommerce.pot`. Without this pull request, you will note that `#: includes/wc-account-functions.php:100` is associated with a plural `"Orders"`. With this pull request, you will note that it is a normal translation string.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
