### PR TITLE
Update product task experiment names to re-run 

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-create-product-by-type.ts
@@ -36,9 +36,12 @@ export const useCreateProductByType = () => {
 				{ _fields: [ 'id' ] }
 			);
 			if ( data && data.id ) {
-				const link = getAdminLink(
+				let link = getAdminLink(
 					`post.php?post=${ data.id }&action=edit&wc_onboarding_active_task=products&tutorial=true`
 				);
+				if ( type === 'physical' ) {
+					link += '&spotlight=true';
+				}
 				window.location.href = link;
 			} else {
 				throw new Error( 'Unexpected empty data response from server' );

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
@@ -8,9 +8,9 @@ type Layout = 'control' | 'card' | 'stacked';
 
 export const getProductLayoutExperiment = async (): Promise< Layout > => {
 	const [ cardAssignment, stackedAssignment ] = await Promise.all( [
-		loadExperimentAssignment( `woocommerce_products_task_layout_card_v2` ),
+		loadExperimentAssignment( `woocommerce_products_task_layout_card_v3` ),
 		loadExperimentAssignment(
-			`woocommerce_products_task_layout_stacked_v2`
+			`woocommerce_products_task_layout_stacked_v3`
 		),
 	] );
 	// This logic may look flawed as in both looks like they can be assigned treatment at the same time,

--- a/plugins/woocommerce/changelog/fix-re-run-product-task-experiment-v3
+++ b/plugins/woocommerce/changelog/fix-re-run-product-task-experiment-v3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update product task experiment names and add spotlight parameter to physical product template link

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -362,7 +362,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public static function is_experiment_product_task() {
 		$anon_id        = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : '';
-		$allow_tracking = 'yes' === get_option( 'woocommerce_allow_tracking' );
+		$allow_tracking = get_option( 'woocommerce_allow_tracking' ) === 'yes';
 		$abtest         = new \WooCommerce\Admin\Experimental_Abtest(
 			$anon_id,
 			'woocommerce',

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -368,8 +368,8 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			'woocommerce',
 			$allow_tracking
 		);
-		return $abtest->get_variation( 'woocommerce_products_task_layout_stacked_v2' ) === 'treatment' ||
-			$abtest->get_variation( 'woocommerce_products_task_layout_card_v2' ) === 'treatment';
+		return $abtest->get_variation( 'woocommerce_products_task_layout_stacked_v3' ) === 'treatment' ||
+			$abtest->get_variation( 'woocommerce_products_task_layout_card_v3' ) === 'treatment';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Partially closes 59-gh-woocommerce/team-ghidorah

In pbxNRc-1FL-p2#comment-3677, the results from experiment was affected by tracks bug in 6.8. As such, we want to re-run the experiment.

This change:
1. Updates the experiment slugs to the updated version
2. Add `spotlight` parameter to an entrypoint to another ongoing product tour experiment since originally the experiments were staggered. For reference, this is [an existing](https://github.com/woocommerce/woocommerce/blob/fix/re-run-product-task-experiment-v3/plugins/woocommerce-admin/client/tasks/fills/products/product-template-modal.js#L107) condition that does the same for control UI

### How to test the changes in this Pull Request:

1. Navigate to **Tools > WCA Test Helper > Experiments** and add `woocommerce_products_task_layout_card_v3`  to treatment
2. Go to **WooCommerce > Home > Add products**
3. Observe the [Card UI](https://d.pr/i/GOKsL3) is displayed
1. Navigate to **Tools > WCA Test Helper > Experiments** and add `woocommerce_products_task_layout_card_v3`  to control and `woocommerce_products_task_layout_stacked_v3` to treatment
2. Go to **WooCommerce > Home > Add products**
3. Observe the [Stacked UI](https://d.pr/i/LJ79Wh) is displayed

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.