### PR TITLE
Add util methods to get order edit and create URLs

### DIFF
--- a/plugins/woocommerce/changelog/fix-34228
+++ b/plugins/woocommerce/changelog/fix-34228
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add util functions for getting order update and create links.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -45,7 +45,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->orders_list_table = new ListTable();
+		$this->orders_list_table = wc_get_container()->get( ListTable::class );
 		add_action( 'admin_notices', array( $this, 'bulk_admin_notices' ) );
 		add_action( 'admin_footer', array( $this, 'order_preview_template' ) );
 		add_filter( 'get_search_query', array( $this, 'search_label' ) );

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -1688,7 +1688,13 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_edit_order_url() {
-		return apply_filters( 'woocommerce_get_edit_order_url', get_admin_url( null, 'post.php?post=' . $this->get_id() . '&action=edit' ), $this );
+		$edit_url = \Automattic\WooCommerce\Utilities\OrderUtil::get_order_admin_edit_url( $this->get_id() );
+		/**
+		 * Filter the URL to edit the order in the backend.
+		 *
+		 * @since 3.3.0
+		 */
+		return apply_filters( 'woocommerce_get_edit_order_url', $edit_url, $this );
 	}
 
 	/*

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\COTMig
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\DownloadPermissionsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\AssignDefaultCategoryServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OrdersControllersServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OrderAdminServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OrderMetaBoxServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\ObjectCacheServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OrdersDataStoreServiceProvider;
@@ -61,6 +62,7 @@ final class Container {
 		ObjectCacheServiceProvider::class,
 		BatchProcessingServiceProvider::class,
 		OrderMetaBoxServiceProvider::class,
+		OrderAdminServiceProvider::class,
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -191,13 +191,15 @@ class Edit {
 		$edit_page_url = admin_url( 'admin.php?page=wc-orders&action=edit&id=' . $this->order->get_id() );
 		$form_action   = 'edit_order';
 		$referer       = wp_get_referer();
+		$new_page_url  = wc_get_container()->get( PageController::class )->get_new_page_url();
+
 		?>
 		<div class="wrap">
 		<h1 class="wp-heading-inline">
 			<?php echo esc_html( 'Edit order' ); ?>
 		</h1>
 		<?php
-		echo ' <a href="' . esc_url( admin_url( 'admin.php?page=wc-orders&action=new' ) ) . '" class="page-title-action"> Add order </a>';
+		echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action"> Add order </a>';
 		?>
 		<hr class="wp-header-end">
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -233,7 +233,9 @@ class PageController {
 	 * @return string
 	 */
 	public function get_new_page_url() : string {
-		return esc_url( admin_url( 'admin.php?page=wc-orders&action=new' ) );
+		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ?
+			admin_url( 'admin.php?page=wc-orders&action=new' ) :
+			admin_url( 'post-new.php?post_type=shop_order' );
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
 /**
  * Controls the different pages/screens associated to the "Orders" menu page.
  */
@@ -161,7 +163,7 @@ class PageController {
 	 * @return void
 	 */
 	private function setup_action_list_orders(): void {
-		$this->orders_table = new ListTable();
+		$this->orders_table = wc_get_container()->get( ListTable::class );
 		$this->orders_table->setup();
 		if ( $this->orders_table->current_action() ) {
 			$this->orders_table->handle_bulk_actions();
@@ -211,4 +213,27 @@ class PageController {
 		$this->order->save();
 		$theorder = $this->order;
 	}
+
+	/**
+	 * Helper method to generate edit link for an order.
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return string Edit link.
+	 */
+	public function get_edit_url( int $order_id ) : string {
+		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ?
+			admin_url( 'admin.php?page=wc-orders&id=' . absint( $order_id ) ) . '&action=edit' :
+			admin_url( 'post.php?post=' . absint( $order_id ) ) . '&action=edit';
+	}
+
+	/**
+	 * Helper method to generate a link for creating order.
+	 *
+	 * @return string
+	 */
+	public function get_new_page_url() : string {
+		return esc_url( admin_url( 'admin.php?page=wc-orders&action=new' ) );
+	}
+
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -151,7 +151,9 @@ class DataSynchronizer implements BatchProcessorInterface {
 			$missing_orders_count_sql = "
 SELECT COUNT(1) FROM $wpdb->posts posts
 INNER JOIN $orders_table orders ON posts.id=orders.id
-WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'";
+WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'
+ AND orders.status not in ( 'auto-draft' )
+";
 			$operator                 = '>';
 		} else {
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_post_type_placeholder is prepared.
@@ -242,7 +244,9 @@ WHERE
 				$sql = "
 SELECT posts.ID FROM $wpdb->posts posts
 INNER JOIN $orders_table orders ON posts.id=orders.id
-WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'";
+WHERE posts.post_type = '" . self::PLACEHOLDER_ORDER_POST_TYPE . "'
+AND orders.status not in ( 'auto-draft' )
+";
 				break;
 			case self::ID_TYPE_DIFFERENT_UPDATE_DATE:
 				$operator = $this->custom_orders_table_is_authoritative() ? '>' : '<';
@@ -253,7 +257,8 @@ SELECT orders.id FROM $orders_table orders
 JOIN $wpdb->posts posts on posts.ID = orders.id
 WHERE
   posts.post_type IN ($order_post_type_placeholders)
-  AND orders.date_updated_gmt $operator posts.post_modified_gmt",
+  AND orders.date_updated_gmt $operator posts.post_modified_gmt
+",
 					$order_post_types
 				);
 				// phpcs:enable

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Service provider for various order admin classes.
+ */
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\Admin\Orders\Edit;
+use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+
+/**
+ * OrderAdminServiceProvider class.
+ */
+class OrderAdminServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * List services provided by this class.
+	 *
+	 * @var string[]
+	 */
+	protected $provides = array(
+		PageController::class,
+		Edit::class,
+		ListTable::class,
+	);
+
+	/**
+	 * Registers services provided by this class.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->share( PageController::class );
+		$this->share( Edit::class )->addArgument( PageController::class );
+		$this->share( ListTable::class )->addArgument( PageController::class );
+	}
+}

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -112,7 +112,9 @@ final class OrderUtil {
 	 * @return string Admin url for an order.
 	 */
 	public static function get_order_admin_edit_url( int $order_id ) : string {
-		return wc_get_container()->get( PageController::class )->get_edit_link( $order_id );
+		return self::custom_orders_table_usage_is_enabled() ?
+			wc_get_container()->get( PageController::class )->get_edit_link( $order_id ) :
+			esc_url( admin_url( 'post.php?post=' . absint( $order_id ) . '&action=edit' ) );
 	}
 
 	/**
@@ -121,6 +123,8 @@ final class OrderUtil {
 	 * @return string Link for new order.
 	 */
 	public static function get_order_admin_new_url() : string {
-		return wc_get_container()->get( PageController::class )->get_new_link();
+		return self::custom_orders_table_usage_is_enabled() ?
+			wc_get_container()->get( PageController::class )->get_new_page_url() :
+			esc_url( admin_url( 'post-new.php?post_type=shop_order' ) );
 	}
 }

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Utilities;
 
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\Utilities\COTMigrationUtil;
 use WC_Order;
@@ -101,5 +102,25 @@ final class OrderUtil {
 	 */
 	public static function get_order_type( $order_id ) {
 		return wc_get_container()->get( COTMigrationUtil::class )->get_order_type( $order_id );
+	}
+
+	/**
+	 * Helper method to generate admin url for an order.
+	 *
+	 * @param int $order_id Order ID.
+	 *
+	 * @return string Admin url for an order.
+	 */
+	public static function get_order_admin_edit_url( int $order_id ) : string {
+		return wc_get_container()->get( PageController::class )->get_edit_link( $order_id );
+	}
+
+	/**
+	 * Helper method to generate admin URL for new order.
+	 *
+	 * @return string Link for new order.
+	 */
+	public static function get_order_admin_new_url() : string {
+		return wc_get_container()->get( PageController::class )->get_new_link();
 	}
 }

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -112,9 +112,7 @@ final class OrderUtil {
 	 * @return string Admin url for an order.
 	 */
 	public static function get_order_admin_edit_url( int $order_id ) : string {
-		return self::custom_orders_table_usage_is_enabled() ?
-			wc_get_container()->get( PageController::class )->get_edit_url( $order_id ) :
-			esc_url( admin_url( 'post.php?post=' . absint( $order_id ) . '&action=edit' ) );
+		return wc_get_container()->get( PageController::class )->get_edit_url( $order_id );
 	}
 
 	/**
@@ -123,8 +121,6 @@ final class OrderUtil {
 	 * @return string Link for new order.
 	 */
 	public static function get_order_admin_new_url() : string {
-		return self::custom_orders_table_usage_is_enabled() ?
-			wc_get_container()->get( PageController::class )->get_new_page_url() :
-			esc_url( admin_url( 'post-new.php?post_type=shop_order' ) );
+		return wc_get_container()->get( PageController::class )->get_new_page_url();
 	}
 }

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -113,7 +113,7 @@ final class OrderUtil {
 	 */
 	public static function get_order_admin_edit_url( int $order_id ) : string {
 		return self::custom_orders_table_usage_is_enabled() ?
-			wc_get_container()->get( PageController::class )->get_edit_link( $order_id ) :
+			wc_get_container()->get( PageController::class )->get_edit_url( $order_id ) :
 			esc_url( admin_url( 'post.php?post=' . absint( $order_id ) . '&action=edit' ) );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds util methods to get edit and create links for orders.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34228 and  #34232.

### How to test the changes in this Pull Request:

For 34232

1.  Click on the "Add Order" button on the order edit page and order listing page. Both should lead to new order page.

For 34228

1. In a WP Shell run the following commands for an order id `$order_id`:

```php
>> Automattic\WooCommerce\Utilities\OrderUtil::get_order_admin_edit_url( $order_id )
=> "http://w.test/wp-admin/admin.php?page=wc-orders&id=32&action=edit" //should return proper order edit page.
```

and

```php
>>> Automattic\WooCommerce\Utilities\OrderUtil::get_order_admin_new_url()
=> "http://w.test/wp-admin/admin.php?page=wc-orders&#038;action=new" // should return new order page.
```


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
