### PR TITLE
Update Guernsey state field to non-required

### DIFF
--- a/plugins/woocommerce/changelog/fix-32876-2
+++ b/plugins/woocommerce/changelog/fix-32876-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update Guernsey state field to non-required.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1040,7 +1040,7 @@ class WC_Countries {
 					'GG' => array(
  						'state' => array(
  							'required' => false,
- 							'hidden'   => true,
+ 							'label' => __( 'Parish', 'woocommerce' ),
  						),
  					),
 					'GH' => array(

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1037,6 +1037,12 @@ class WC_Countries {
 							'hidden'   => true,
 						),
 					),
+					'GG' => array(
+ 						'state' => array(
+ 							'required' => false,
+ 							'hidden'   => true,
+ 						),
+ 					),
 					'GH' => array(
 						'postcode' => array(
 							'required' => false,


### PR DESCRIPTION
Replay of https://github.com/woocommerce/woocommerce/pull/32946, but with changelog.