### PR TITLE
check if post_type exists

### DIFF
--- a/plugins/woocommerce/changelog/fix-new-post-type-check
+++ b/plugins/woocommerce/changelog/fix-new-post-type-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Resolve an error in the product tracking code by testing to see if the `post_type` query var is set before checking its value.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -317,6 +317,7 @@ class WC_Products_Tracking {
 
 		if (
 			'post-new.php' === $hook &&
+			isset( $_GET['post_type'] ) &&
 			'product' === wp_unslash( $_GET['post_type'] )
 		) {
 			return 'new';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Enable tracking via **WooCommerce ▸ Settings ▸ Advanced ▸ WooCommerce.com**.
2. Optionally, install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/) (makes it easy to see errors—but you can use some other tool or method if you prefer).
    - If you do choose to use Query Monitor, you will probably also want to ensure you can see your admin toolbar while in the block editor.
    - To do this, configure the editor so it is **not** operating in full-screen mode:

<img width="325" alt="blocks-full-screen" src="https://user-images.githubusercontent.com/3594411/204659210-ead425e6-c5d8-4f4f-b974-d74558e2a8fb.png">

3. Try adding a new post via **Posts ▸ Add New**.
    - With this change, everything should be fine!
    - Without this change, you may observe a warning about **Undefined array key "post_type"**:

<img width="542" alt="undefined-array-key" src="https://user-images.githubusercontent.com/3594411/204659314-31125267-7ae3-4945-b024-548c5e2e7390.png">

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
