### PR TITLE
Validate React Admin Changelog Files

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -9,6 +9,7 @@
 		"url": "https://github.com:woocommerce/woocommerce.git"
 	},
 	"scripts": {
+		"changelog": "pnpm run changelog --filter=woocommerce --",
 		"turbo:build": "pnpm run clean && cross-env NODE_ENV=production WC_ADMIN_PHASE=core webpack",
 		"turbo:test": "pnpm run test:client",
 		"analyze": "cross-env NODE_ENV=production ANALYZE=true webpack",

--- a/plugins/woocommerce/changelog/add-project-component-changelogs
+++ b/plugins/woocommerce/changelog/add-project-component-changelogs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+This change only impacts the validation of changelog files.

--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -130,7 +130,7 @@ foreach ( $composer_projects as $project_path ) {
 
 // Support centralizing the changelogs for multiple components and validating them together.
 $project_component_map = array(
-	'plugins/woocommerce-admin' => 'plugins/woocommerce'
+	'plugins/woocommerce-admin' => 'plugins/woocommerce',
 );
 
 // Process the diff.

--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -128,6 +128,11 @@ foreach ( $composer_projects as $project_path ) {
 	$changelogger_projects[ $project_path ] = $data;
 }
 
+// Support centralizing the changelogs for multiple components and validating them together.
+$project_component_map = array(
+	'plugins/woocommerce-admin' => 'plugins/woocommerce'
+);
+
 // Process the diff.
 debug( 'Checking diff from %s...%s.', $base, $head );
 $pipes = null;
@@ -152,6 +157,17 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 		if ( substr( $line, 0, strlen( $path ) + 1 ) === $path . '/' ) {
 			$project_match = $path;
 			break;
+		}
+	}
+
+	// Also try to match to project components.
+	if ( false === $project_match ) {
+		foreach ( $project_component_map as $path => $project ) {
+			if ( substr( $line, 0, strlen( $path ) + 1 ) === $path . '/' ) {
+				debug( 'Mapping %s to project %s.', $line, $project );
+				$project_match = $project;
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request changes the changelogger use validation a little to support mapping component projects back to parent projects. In the case of `plugins/woocommerce-admin`, we removed the Jetpack Changelogger because it didn't necessarily make sense for something to have a changelog that wasn't shipped independently. As a consequence of this, however, we also stopped requiring changelog entries for code in `plugins/woocommerce-admin`.

I had considered an alternative using a relative path for the changelog directory configuration, but, it would still require a fair bit of work to the `check-changelogger-use.php` script to support. Given that we're only doing this for a single project, it seems reasonable to just go with this less robust approach.

Closes #34111.

### How to test the changes in this Pull Request:

1. Check out the branch locally and create a new branch from it.
2. Make a change in `plugins/woocommerce-admin` somewhere and commit that change.
3. Run ``php tools/monorepo/check-changelogger-use.php --debug add/project-component-changelogs `git branch --show-current` ``. It _should_ print that it was not changed.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
