### PR TITLE
Use label prop on sale price input instead of separate label element

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -145,9 +145,8 @@ export const PricingSection: React.FC = () => {
 			</div>
 
 			<div className="woocommerce-product-form__custom-label-input">
-				<label htmlFor="sale_price">{ salePriceTitle }</label>
 				<InputControl
-					hideLabelFromVision={ true }
+					label={ salePriceTitle }
 					id="sale_price"
 					placeholder={ __( '8.59', 'woocommerce' ) }
 					{ ...getInputControlProps( {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates the implementation of the label for the sale price field to use the `label` prop instead of a separate `label` element, for consistency with how other labels are implemented in the form.

This is a follow up to https://github.com/woocommerce/woocommerce/pull/34382

### How to test the changes in this Pull Request:

1. Go to `Products` > `Add New (MVP)` and create a product.
2. Verify that the 'Sale price (optional)' label shows up correctly, with '(optional') styled with a lighter color than the rest of the label (no regression; style should be identical).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
