### PR TITLE
[COT] `query()` method: add support for field queries

### DIFF
--- a/plugins/woocommerce/changelog/cot-field_query
+++ b/plugins/woocommerce/changelog/cot-field_query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for complex field queries for orders.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableFieldQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableFieldQuery.php
@@ -284,9 +284,9 @@ class OrdersTableFieldQuery {
 
 		if ( $where ) {
 			if ( 'CHAR' === $clause['cast'] ) {
-				return "{$clause['alias']}.{$clause['column']} {$clause_compare} {$where}";
+				return "`{$clause['alias']}`.`{$clause['column']}` {$clause_compare} {$where}";
 			} else {
-				return "CAST({$clause['alias']}.{$clause['column']} AS {$clause['cast']}) {$clause_compare} {$where}";
+				return "CAST(`{$clause['alias']}`.`{$clause['column']}` AS {$clause['cast']}) {$clause_compare} {$where}";
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableFieldQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableFieldQuery.php
@@ -1,0 +1,311 @@
+<?php
+namespace Automattic\WooCommerce\Internal\DataStores\Orders;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provides the implementation for `field_query` in {@see OrdersTableQuery} used to build
+ * complex queries against order fields in the database.
+ *
+ * @internal
+ */
+class OrdersTableFieldQuery {
+
+	/**
+	 * The original query object.
+	 *
+	 * @var OrdersTableQuery
+	 */
+	private $query = null;
+
+	/**
+	 * Holds a sanitized version of the `field_query`.
+	 *
+	 * @var array
+	 */
+	private $queries = array();
+
+	/**
+	 * JOIN clauses to add to the main SQL query.
+	 *
+	 * @var array
+	 */
+	private $join = array();
+
+	/**
+	 * WHERE clauses to add to the main SQL query.
+	 *
+	 * @var array
+	 */
+	private $where = array();
+
+	/**
+	 * Table aliases in use by the field query. Used to keep track of JOINs and optimize when possible.
+	 *
+	 * @var array
+	 */
+	private $table_aliases = array();
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param OrdersTableQuery $q The main query being performed.
+	 */
+	public function __construct( OrdersTableQuery $q ) {
+		$field_query = $q->get( 'field_query' );
+
+		if ( ! $field_query || ! is_array( $field_query ) ) {
+			return;
+		}
+
+		$this->query   = $q;
+		$this->queries = $this->sanitize_query( $field_query );
+		$this->where   = $this->process( $this->queries );
+	}
+
+	/**
+	 * Sanitizes the field_query argument.
+	 *
+	 * @param array $q A field_query array.
+	 * @return array A sanitized field query array.
+	 * @throws \Exception When field table info is missing.
+	 */
+	private function sanitize_query( array $q ) {
+		$sanitized = array();
+
+		foreach ( $q as $key => $arg ) {
+			if ( 'relation' === $key ) {
+				$relation = $arg;
+			} elseif ( ! is_array( $arg ) ) {
+				continue;
+			} elseif ( $this->is_atomic( $arg ) ) {
+				if ( isset( $arg['value'] ) && array() === $arg['value'] ) {
+					continue;
+				}
+
+				$arg['compare'] = isset( $arg['compare'] ) ? strtoupper( $arg['compare'] ) : ( isset( $arg['value'] ) && is_array( $arg['value'] ) ? 'IN' : '=' );
+				$arg['cast']    = $this->sanitize_cast_type( $arg['type'] ?? '' );
+
+				$field_info = $this->query->get_field_mapping_info( $arg['field'] );
+				if ( ! $field_info ) {
+					continue;
+				}
+
+				$arg = array_merge( $arg, $field_info );
+
+				$sanitized[ $key ] = $arg;
+			} else {
+				$sanitized_arg = $this->sanitize_query( $arg );
+
+				if ( $sanitized_arg ) {
+					$sanitized[ $key ] = $sanitized_arg;
+				}
+			}
+		}
+
+		if ( $sanitized ) {
+			$sanitized['relation'] = 1 === count( $sanitized ) ? 'OR' : $this->sanitize_relation( $relation ?? 'AND' );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Makes sure we use an AND or OR relation. Defaults to AND.
+	 *
+	 * @param string $relation An unsanitized relation prop.
+	 * @return string
+	 */
+	private function sanitize_relation( string $relation ): string {
+		if ( ! empty( $relation ) && 'OR' === strtoupper( $relation ) ) {
+			return 'OR';
+		}
+
+		return 'AND';
+	}
+
+	/**
+	 * Processes field_query entries and generates the necessary table aliases, JOIN statements and WHERE conditions.
+	 *
+	 * @param array $q A field query.
+	 * @return string An SQL WHERE statement.
+	 */
+	private function process( array $q ) {
+		$where = '';
+
+		if ( $this->is_atomic( $q ) ) {
+			$q['alias'] = $this->find_or_create_table_alias_for_clause( $q );
+			$where      = $this->generate_where_for_clause( $q );
+		} else {
+			$relation = $q['relation'];
+			unset( $q['relation'] );
+
+			foreach ( $q as $query ) {
+				$chunks[] = $this->process( $query );
+			}
+
+			if ( 1 === count( $chunks ) ) {
+				$where = $chunks[0];
+			} else {
+				$where = '(' . implode( " {$relation} ", $chunks ) . ')';
+			}
+		}
+
+		return $where;
+	}
+
+	/**
+	 * Checks whether a given field_query clause is atomic or not (i.e. not nested).
+	 *
+	 * @param array $q The field_query clause.
+	 * @return boolean TRUE if atomic, FALSE otherwise.
+	 */
+	private function is_atomic( $q ) {
+		return isset( $q['field'] );
+	}
+
+	/**
+	 * Finds a common table alias that the field_query clause can use, or creates one.
+	 *
+	 * @param array $q       An atomic field_query clause.
+	 * @return string A table alias for use in an SQL JOIN clause.
+	 * @throws \Exception When table info for clause is missing.
+	 */
+	private function find_or_create_table_alias_for_clause( $q ) {
+		global $wpdb;
+
+		if ( ! empty( $q['alias'] ) ) {
+			return $q['alias'];
+		}
+
+		if ( empty( $q['table'] ) || empty( $q['column'] ) ) {
+			throw new \Exception( __( 'Missing table info for query arg.', 'woocommerce' ) );
+		}
+
+		$join = '';
+
+		if ( isset( $q['mapping_id'] ) ) {
+			// Re-use JOINs and aliases from OrdersTableQuery for core tables.
+			$alias = $this->query->get_core_mapping_alias( $q['mapping_id'] );
+			$join  = $this->query->get_core_mapping_join( $q['mapping_id'] );
+		} else {
+			$alias = $q['table'];
+			$join  = '';
+		}
+
+		if ( in_array( $alias, $this->table_aliases, true ) ) {
+			return $alias;
+		}
+
+		$this->table_aliases[] = $alias;
+
+		if ( $join ) {
+			$this->join[] = $join;
+		}
+
+		return $alias;
+	}
+
+	/**
+	 * Returns the correct type for a given clause 'type'.
+	 *
+	 * @param string $type MySQL type.
+	 * @return string MySQL type.
+	 */
+	private function sanitize_cast_type( $type ) {
+		$clause_type = strtoupper( $type );
+
+		if ( ! $clause_type || ! preg_match( '/^(?:BINARY|CHAR|DATE|DATETIME|SIGNED|UNSIGNED|TIME|NUMERIC(?:\(\d+(?:,\s?\d+)?\))?|DECIMAL(?:\(\d+(?:,\s?\d+)?\))?)$/', $clause_type ) ) {
+			return 'CHAR';
+		}
+
+		if ( 'NUMERIC' === $clause_type ) {
+			$clause_type = 'SIGNED';
+		}
+
+		return $clause_type;
+	}
+
+	/**
+	 * Generates an SQL WHERE clause for a given field_query atomic clause.
+	 *
+	 * @param array $clause An atomic field_query clause.
+	 * @return string An SQL WHERE clause or an empty string if $clause is invalid.
+	 */
+	private function generate_where_for_clause( $clause ): string {
+		global $wpdb;
+
+		$clause_value = $clause['value'] ?? '';
+
+		if ( in_array( $clause['compare'], array( 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN' ), true ) ) {
+			if ( ! is_array( $clause_value ) ) {
+				$clause_value = preg_split( '/[,\s]+/', $clause_value );
+			}
+		} elseif ( is_string( $clause_value ) ) {
+			$clause_value = trim( $clause_value );
+		}
+
+		$clause_compare = $clause['compare'];
+
+		switch ( $clause_compare ) {
+			case 'IN':
+			case 'NOT IN':
+				$where = $wpdb->prepare( '(' . substr( str_repeat( ',%s', count( $clause_value ) ), 1 ) . ')', $clause_value ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+			case 'BETWEEN':
+			case 'NOT BETWEEN':
+				$where = $wpdb->prepare( '%s AND %s', $clause_value[0], $clause_value[1] );
+				break;
+			case 'LIKE':
+			case 'NOT LIKE':
+				$where = $wpdb->prepare( '%s', '%' . $wpdb->esc_like( $clause_value ) . '%' );
+				break;
+			case 'EXISTS':
+				// EXISTS with a value is interpreted as '='.
+				if ( $clause_value ) {
+					$clause_compare = '=';
+					$where          = $wpdb->prepare( '%s', $clause_value );
+				} else {
+					$clause_compare = 'IS NOT';
+					$where          = 'NULL';
+				}
+
+				break;
+			case 'NOT EXISTS':
+				// 'value' is ignored for NOT EXISTS.
+				$clause_compare = 'IS';
+				$where          = 'NULL';
+				break;
+			default:
+				$where = $wpdb->prepare( '%s', $clause_value );
+				break;
+		}
+
+		if ( $where ) {
+			if ( 'CHAR' === $clause['cast'] ) {
+				return "{$clause['alias']}.{$clause['column']} {$clause_compare} {$where}";
+			} else {
+				return "CAST({$clause['alias']}.{$clause['column']} AS {$clause['cast']}) {$clause_compare} {$where}";
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Returns JOIN and WHERE clauses to be appended to the main SQL query.
+	 *
+	 * @return array {
+	 *     @type string $join  JOIN clause.
+	 *     @type string $where WHERE clause.
+	 * }
+	 */
+	public function get_sql_clauses() {
+		return array(
+			'join'  => $this->join,
+			'where' => array( $this->where ),
+		);
+	}
+
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -130,6 +130,13 @@ class OrdersTableQuery {
 	private $found_orders = 0;
 
 	/**
+	 * Field query parser.
+	 *
+	 * @var OrdersTableFieldQuery
+	 */
+	private $field_query = null;
+
+	/**
 	 * Meta query parser.
 	 *
 	 * @var OrdersTableMetaQuery
@@ -527,6 +534,14 @@ class OrdersTableQuery {
 	private function build_query(): void {
 		$this->maybe_remap_args();
 
+		// Field queries.
+		if ( ! empty( $this->args['field_query'] ) ) {
+			$this->field_query = new OrdersTableFieldQuery( $this );
+			$sql               = $this->field_query->get_sql_clauses();
+			$this->join        = $sql['join'] ? array_merge( $this->join, $sql['join'] ) : $this->join;
+			$this->where       = $sql['where'] ? array_merge( $this->where, $sql['where'] ) : $this->where;
+		}
+
 		// Build query.
 		$this->process_date_args();
 		$this->process_orders_table_query_args();
@@ -578,7 +593,7 @@ class OrdersTableQuery {
 		}
 
 		// JOIN.
-		$join = implode( ' ', $this->join );
+		$join = implode( ' ', array_unique( array_filter( array_map( 'trim', $this->join ) ) ) );
 
 		// WHERE.
 		$where = '1=1';

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -594,7 +594,7 @@ class OrdersTableQuery {
 
 		if ( ! empty( $this->limits ) && count( $this->limits ) === 2 ) {
 			list( $offset, $row_count ) = $this->limits;
-			$row_count                  = $row_count === -1 ? self::MYSQL_MAX_UNSIGNED_BIGINT : (int) $row_count;
+			$row_count                  = -1 === $row_count ? self::MYSQL_MAX_UNSIGNED_BIGINT : (int) $row_count;
 			$limits                     = 'LIMIT ' . (int) $offset . ', ' . $row_count;
 		}
 
@@ -912,11 +912,11 @@ class OrdersTableQuery {
 		$offset    = ( $this->arg_isset( 'offset' ) ? absint( $this->args['offset'] ) : false );
 
 		// Bool false indicates no limit was specified; less than -1 means an invalid value was passed (such as -3).
-		if ( $row_count === false || $row_count < -1 ) {
+		if ( false === $row_count || $row_count < -1 ) {
 			return;
 		}
 
-		if ( $offset === false && $row_count > -1 ) {
+		if ( false === $offset && $row_count > -1 ) {
 			$offset = (int) ( ( $page - 1 ) * $row_count );
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -655,14 +655,14 @@ class OrdersTableQuery {
 		$join    = '';
 		$join_on = '';
 
-		$join .= "INNER JOIN {$table}" . ( $alias !== $table ? " AS {$alias}" : '' );
+		$join .= "INNER JOIN `{$table}`" . ( $alias !== $table ? " AS `{$alias}`" : '' );
 
 		if ( isset( $this->mappings[ $mapping_id ]['order_id'] ) ) {
-			$join_on .= "{$this->tables['orders']}.id = {$alias}.order_id";
+			$join_on .= "`{$this->tables['orders']}`.id = `{$alias}`.order_id";
 		}
 
 		if ( $is_address_mapping ) {
-			$join_on .= $wpdb->prepare( " AND {$alias}.address_type = %s", substr( $mapping_id, 0, -8 ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$join_on .= $wpdb->prepare( " AND `{$alias}`.address_type = %s", substr( $mapping_id, 0, -8 ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 
 		return $join . ( $join_on ? " ON ( {$join_on} )" : '' );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1088,6 +1088,105 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Ensure field_query works as expected.
+	 */
+	public function test_cot_query_field_query(): void {
+		$orders_test_data = array(
+			array( 'Werner', 'Heisenberg', 'Unknown', 'werner_heisenberg_1', '15.0' ),
+			array( 'Max', 'Planck', 'Quanta', 'planck_1', '16.0' ),
+			array( 'Édouard', 'Roche', 'Tidal', 'roche_3', '9.99' ),
+		);
+		$order_ids       = array();
+
+		// Create some test orders.
+		foreach ( $orders_test_data as $order_data ) {
+			$order = new \WC_Order();
+			$this->switch_data_store( $order, $this->sut );
+			$order->set_status( 'wc-completed' );
+			$order->set_billing_first_name( $order_data[0] );
+			$order->set_billing_last_name( $order_data[1] );
+			$order->set_billing_city( $order_data[2] );
+			$order->set_order_key( $order_data[3] );
+			$order->set_total( $order_data[4] );
+
+			$order_ids[] = $order->save();
+		}
+
+		// Relatively simple field_query.
+		$field_query = array(
+			'relation' => 'OR',
+			array(
+				'field' => 'order_key',
+				'value' => 'werner_heisenberg_1',
+			),
+			array(
+				'field' => 'order_key',
+				'value' => 'planck_1',
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[1] ), $query->orders );
+
+		// A more complex field_query.
+		$field_query = array(
+			array(
+				'field'   => 'billing_first_name',
+				'value'   => array( 'Werner', 'Max', 'Édouard' ),
+				'compare' => 'IN',
+			),
+			array(
+				'relation' => 'OR',
+				array(
+					'field'   => 'billing_last_name',
+					'value'   => 'Heisen',
+					'compare' => 'LIKE',
+				),
+				array(
+					'field'   => 'billing_city',
+					'value'   => 'Tid',
+					'compare' => 'LIKE',
+				),
+			),
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[2] ), $query->orders );
+
+		// Find orders with order_key not ending in a number (i.e. all).
+		$field_query = array(
+			array(
+				'field'   => 'order_key',
+				'value'   => '[0-9]$',
+				'compare' => 'RLIKE'
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertEqualsCanonicalizing( $order_ids, $query->orders );
+
+		// Find orders with order_key not ending in a number (i.e. none).
+		$field_query = array(
+			array(
+				'field'   => 'order_key',
+				'value'   => '[^0-9]$',
+				'compare' => 'NOT RLIKE'
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertCount( 0, $query->posts );
+
+		// Use full column name in a query.
+		$field_query = array(
+			array(
+				'field'   => $GLOBALS['wpdb']->prefix . 'wc_orders.total_amount',
+				'value'   => '10.0',
+				'compare' => '<=',
+				'type'    => 'NUMERIC',
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertEqualsCanonicalizing( array( $order_ids[2] ), $query->orders );
+	}
+
+	/**
 	 * Test that props set by datastores can be set and get by using any of metadata, object props or from data store setters.
 	 * Ideally, this should be possible only from getters and setters for objects, but for backward compatibility, earlier ways are also supported.
 	 */
@@ -1267,4 +1366,5 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			$this->assertEquals( $value, $order->{"get_$prop_name"}(), "Prop $prop_name was not set correctly." );
 		}
 	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1092,22 +1092,27 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 */
 	public function test_cot_query_field_query(): void {
 		$orders_test_data = array(
-			array( 'Werner', 'Heisenberg', 'Unknown', 'werner_heisenberg_1', '15.0' ),
-			array( 'Max', 'Planck', 'Quanta', 'planck_1', '16.0' ),
-			array( 'Édouard', 'Roche', 'Tidal', 'roche_3', '9.99' ),
+			array( 'Werner', 'Heisenberg', 'Unknown', 'werner_heisenberg_1', '15.0', '1901-12-05', '1976-02-01' ),
+			array( 'Max', 'Planck', 'Quanta', 'planck_1', '16.0', '1858-04-23', '1947-10-04' ),
+			array( 'Édouard', 'Roche', 'Tidal', 'roche_3', '9.99', '1820-10-17', '1883-04-27' ),
 		);
 		$order_ids       = array();
 
 		// Create some test orders.
-		foreach ( $orders_test_data as $order_data ) {
+		foreach ( $orders_test_data as $i => $order_data ) {
 			$order = new \WC_Order();
 			$this->switch_data_store( $order, $this->sut );
 			$order->set_status( 'wc-completed' );
+			$order->set_shipping_city( 'The Universe' );
 			$order->set_billing_first_name( $order_data[0] );
 			$order->set_billing_last_name( $order_data[1] );
 			$order->set_billing_city( $order_data[2] );
 			$order->set_order_key( $order_data[3] );
 			$order->set_total( $order_data[4] );
+
+			$order->add_meta_data( 'customer_birthdate', $order_data[5] );
+			$order->add_meta_data( 'customer_last_seen', $order_data[6] );
+			$order->add_meta_data( 'customer_age', absint( ( strtotime( $order_data[6] ) - strtotime( $order_data[5] ) ) / YEAR_IN_SECONDS ) );
 
 			$order_ids[] = $order->save();
 		}
@@ -1151,7 +1156,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[2] ), $query->orders );
 
-		// Find orders with order_key not ending in a number (i.e. all).
+		// Find orders with order_key ending in a number (i.e. all).
 		$field_query = array(
 			array(
 				'field'   => 'order_key',
@@ -1184,6 +1189,116 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		);
 		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertEqualsCanonicalizing( array( $order_ids[2] ), $query->orders );
+
+		// Pass an invalid column name.
+		$field_query = array(
+			array(
+				'field'   => 'non_existing_field',
+				'value'   => 'any-value',
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertCount( 0, $query->posts );
+
+		// Pass an apparently incorrect value to an 'IN' compare.
+		$field_query = array(
+			array(
+				'field'   => 'wc_orders.total_amount',
+				'value'   => 5.5,
+				'compare' => 'IN',
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertCount( 0, $query->posts );
+
+		// Pass an invalid 'compare'.
+		$field_query = array(
+			array(
+				'field'   => 'wc_orders.total_amount',
+				'value'   => 10.0,
+				'compare' => 'EXOSTS',
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertCount( 0, $query->posts );
+
+		// Pass an incomplete array for BETWEEN (treated as =).
+		$field_query = array(
+			array(
+				'field'   => 'total',
+				'compare' => 'BETWEEN',
+				'value'   => 10.0,
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertCount( 0, $query->posts );
+
+		// Pass an incomplete array for NOT BETWEEN (treated as !=).
+		$field_query = array(
+			array(
+				'field'   => 'total',
+				'compare' => 'NOT BETWEEN',
+				'value'   => array( 1.0 ),
+			)
+		);
+		$query = new OrdersTableQuery( array( 'field_query' => $field_query ) );
+		$this->assertCount( 0, $query->posts );
+
+		// Test combinations of field_query with regular query args:
+		$args = array(
+			'id' => array( $order_ids[0], $order_ids[1] ),
+		);
+		$query = new OrdersTableQuery( $args );
+
+		// At this point 2 orders would be returned...
+		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[1] ), $query->orders );
+
+		// ... and now just one
+		$args['field_query'] = array(
+			'relation' => 'AND',
+			array(
+				'field' => 'id',
+				'value' => $order_ids[1],
+			)
+		);
+		$query = new OrdersTableQuery( $args );
+		$this->assertEqualsCanonicalizing( array( $order_ids[1] ), $query->orders );
+
+		// ... and now none (no orders below < 5.0)
+		$args['field_query'][] = array(
+			'field'   => 'total',
+			'value'   => '5.0',
+			'compare' => '<',
+		);
+		$query = new OrdersTableQuery( $args );
+		$this->assertCount( 0, $query->orders );
+
+		// Now a more complex query with meta_query and date_query:
+		$args = array(
+			'shipping_address' => 'The Universe',
+			'field_query' => array(
+				array(
+					'field'   => 'total',
+					'value'   => array( 1.0, 11.0 ),
+					'compare' => 'NOT BETWEEN',
+				),
+			),
+		);
+
+		// this should fetch the orders from Heisenberg and Planck...
+		$query = new OrdersTableQuery( $args );
+		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[1] ), $query->orders );
+
+		// ... but only Planck is more than 80 years old.
+		$args['meta_query'] = array(
+				array(
+					'key'     => 'customer_age',
+					'value'   => 80,
+					'compare' => '>='
+				)
+		);
+		$query = new OrdersTableQuery( $args );
+		$this->assertEqualsCanonicalizing( array( $order_ids[1] ), $query->orders );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds support for a `field_query` arg to `OrdersTableQuery`, which can be used via `wc_get_orders()` when COT is active.
This came to be as a result of an internal discussion (p1660893943441389-slack-C9QDV4TL4) where we wanted to add a way to easily query orders matching various fields and value combinations without the need to write custom SQL queries. This wasn't really possible before, but thanks to most of our fields being metadata, `WP_Query`'s `meta_query` could be used for that purpose. As such, `field_query` supports most (or all?) of `meta_query`'s (metavalue) functionality but operates on core order fields instead of metadata.

With the new `field_query` you can perform complex queries: matching various fields and with AND/OR relations. For example, to obtain all pending/on-hold orders where the amount > 10.0 and the purchaser's first name or last name contains "michel" you could do this:

```php
$orders = wc_get_orders(
	[
		'field_query' => [
			[
				'field'   => 'total',
				'value'   => '10.0',
				'compare' => '>',
				'type'    => NUMERIC,
			],
			[
				'relation' => 'OR',
				[
					'field'   => 'billing_first_name',
					'value'   => 'michel',
					'compare' => 'LIKE',
				],
				[
					'field'   => 'billing_last_name',
					'value'   => 'michel',
					'compare' => 'LIKE',
				]
			]
		],
		'status' => [ 'wc-pending', 'wc-on-hold' ]
	]
);
```

The syntax for `field_query` clauses is analogous to that of WP's [meta query](https://developer.wordpress.org/reference/classes/wp_meta_query/) but with `field` standing for `key`.

Also, `field_query` can be combined with other types of queries already supported by `OrdersTableQuery` such as direct access to certain fields, `meta_query` and `date_query`.

### How to test the changes in this Pull Request:

#### Option 1
1. Check added unit tests.

#### Option 2
1. Activate and make COT authoritative.
2. Populate the db with some orders and data.
3. Run your own queries using `wc_get_orders()`. Join the fun.

### Next Steps
With `field_query` we can rewrite some of the code in `OrdersTableQuery`, dealing with basic columns in the core tables, in a more concise manner. My plan is to do that in a subsequent PR, as well adding an abstract class for this kind of "recursive" query to share code between `OrdersTableMetaQuery` and `OrdersTableFieldQuery`. We've also discussed the possibility of supporting these queries in the CPT implementation to make things simpler for devs.

Once this PR is reviewed/merged I'll submit PRs for the above.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
