### PR TITLE
Add scheduled sale fields

### DIFF
--- a/packages/js/components/changelog/fix-date-time-picker-blur-close
+++ b/packages/js/components/changelog/fix-date-time-picker-blur-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Close DateTimePickerControl's dropdown when blurring from input.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -216,8 +216,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			parseAsISODateTime( currentDate, false )
 		);
 
+		if ( ! newDateTime.isValid() ) {
+			// keep the invalid string, so the user can correct it
+			return currentDate;
+		}
+
 		if (
-			! newDateTime.isValid() ||
 			newDateTime.isSame(
 				maybeForceTime( parseAsLocalDateTime( inputString ) )
 			)

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -212,6 +212,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	const getUserInputOrUpdatedCurrentDate = useCallback( () => {
+		if ( currentDate === undefined ) {
+			// the component is uncontrolled (not using currentDate),
+			// so just return the input string
+			return inputString;
+		}
+
 		const newDateTime = maybeForceTime(
 			parseAsISODateTime( currentDate, false )
 		);
@@ -314,13 +320,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			} }
 			renderContent={ () => {
 				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;
-				const pickerCurrentDateTime = parseAsISODateTime( currentDate );
 
 				return (
 					<Picker
 						currentDate={
-							currentDate && pickerCurrentDateTime.isValid()
-								? currentDate
+							inputStringDateTime.isValid()
+								? formatDateTimeAsISO( inputStringDateTime )
 								: undefined
 						}
 						onChange={ ( newDateTimeISOString: string ) =>

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -310,12 +310,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			} }
 			renderContent={ () => {
 				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;
-				const currentDateTime = parseAsISODateTime( currentDate );
+				const pickerCurrentDateTime = parseAsISODateTime( currentDate );
 
 				return (
 					<Picker
 						currentDate={
-							currentDate && currentDateTime.isValid()
+							currentDate && pickerCurrentDateTime.isValid()
 								? currentDate
 								: undefined
 						}

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -297,13 +297,13 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			} }
 			renderContent={ () => {
 				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;
-				const inputDateTime = parseAsLocalDateTime( inputString );
+				const currentDateTime = parseAsISODateTime( currentDate );
 
 				return (
 					<Picker
 						currentDate={
-							inputDateTime.isValid()
-								? formatDateTimeAsISO( inputDateTime )
+							currentDate && currentDateTime.isValid()
+								? currentDate
 								: undefined
 						}
 						onChange={ ( newDateTimeISOString: string ) =>

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -37,42 +37,6 @@ CustomDateTimeFormat.args = {
 	dateTimeFormat: customFormat,
 };
 
-function ControlledContainer( { children, ...props } ) {
-	function nowWithZeroedSeconds() {
-		const now = new Date();
-		now.setSeconds( 0 );
-		now.setMilliseconds( 0 );
-		return now;
-	}
-
-	const [ controlledDate, setControlledDate ] = useState(
-		nowWithZeroedSeconds().toISOString()
-	);
-
-	return (
-		<div { ...props }>
-			<div>{ children( controlledDate, setControlledDate ) }</div>
-			<div>
-				<Button
-					onClick={ () =>
-						setControlledDate(
-							nowWithZeroedSeconds().toISOString()
-						)
-					}
-				>
-					Reset to now
-				</Button>
-				<div>
-					<div>
-						Controlled date:
-						<br /> <span>{ controlledDate }</span>
-					</div>
-				</div>
-			</div>
-		</div>
-	);
-}
-
 export const ReallyLongHelp = Template.bind( {} );
 ReallyLongHelp.args = {
 	...Basic.args,

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { Button, Popover, SlotFillProvider } from '@wordpress/components';
-import { createElement, useState } from '@wordpress/element';
+import { createElement, useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -61,13 +61,19 @@ function ControlledDecorator( Story, props ) {
 		nowWithZeroedSeconds().toISOString()
 	);
 
+	const onChange = useCallback( ( newDateTimeISOString ) => {
+		setControlledDate( newDateTimeISOString );
+		// eslint-disable-next-line no-console
+		console.log( 'onChange', newDateTimeISOString );
+	}, [] );
+
 	return (
 		<div>
 			<Story
 				args={ {
 					...props.args,
 					currentDate: controlledDate,
-					onChange: setControlledDate,
+					onChange,
 				} }
 			/>
 			<div>

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
@@ -14,7 +14,7 @@
 				> .components-base-control,
 				> .components-dropdown,
 				> .woocommerce-rich-text-editor {
-					&:not( :first-child ):not( .components-radio-control ) {
+					&:not(:first-child):not(.components-radio-control) {
 						margin-top: $gap-large - $gap-smaller;
 						margin-bottom: 0;
 					}
@@ -46,7 +46,7 @@
 		}
 	}
 
-	&:not( :first-child ) {
+	&:not(:first-child) {
 		margin-top: $gap-largest;
 	}
 }

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
@@ -14,8 +14,9 @@
 		}
 
 		.components-base-control,
+		.components-dropdown,
 		.woocommerce-rich-text-editor {
-			&:not(:first-child):not(.components-radio-control) {
+			&:not( :first-child ):not( .components-radio-control ) {
 				margin-top: $gap-large - $gap-smaller;
 				margin-bottom: 0;
 			}
@@ -45,7 +46,7 @@
 		}
 	}
 
-	&:not(:first-child) {
+	&:not( :first-child ) {
 		margin-top: $gap-largest;
 	}
 }

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
@@ -10,15 +10,15 @@
 			box-shadow: none;
 			&__body {
 				padding: $gap-large;
-			}
-		}
 
-		.components-base-control,
-		.components-dropdown,
-		.woocommerce-rich-text-editor {
-			&:not( :first-child ):not( .components-radio-control ) {
-				margin-top: $gap-large - $gap-smaller;
-				margin-bottom: 0;
+				> .components-base-control,
+				> .components-dropdown,
+				> .woocommerce-rich-text-editor {
+					&:not( :first-child ):not( .components-radio-control ) {
+						margin-top: $gap-large - $gap-smaller;
+						margin-bottom: 0;
+					}
+				}
 			}
 		}
 

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -32,8 +32,8 @@
 		}
 	}
 	.components-toggle-control
-		.components-base-control__field
-		.components-toggle-control__label {
+	.components-base-control__field
+	.components-toggle-control__label {
 		display: flex;
 		align-items: center;
 	}

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -31,6 +31,12 @@
 			display: flex;
 		}
 	}
+	.components-toggle-control
+		.components-base-control__field
+		.components-toggle-control__label {
+		display: flex;
+		align-items: center;
+	}
 	.woocommerce-tooltip {
 		margin-left: $gap-smaller;
 	}
@@ -104,4 +110,3 @@
 		height: 100%;
 	}
 }
-

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -9,6 +9,7 @@ import {
 	ProductDimensions,
 } from '@woocommerce/data';
 import type { FormErrors } from '@woocommerce/components';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -54,6 +55,45 @@ export const validate = (
 	) {
 		errors.sale_price = __(
 			'Sale price cannot be equal to or higher than list price.',
+			'woocommerce'
+		);
+	}
+
+	const dateOnSaleFrom = moment(
+		values.date_on_sale_from_gmt,
+		moment.ISO_8601,
+		true
+	);
+	const dateOnSaleTo = moment(
+		values.date_on_sale_to_gmt,
+		moment.ISO_8601,
+		true
+	);
+
+	if ( values.date_on_sale_from_gmt && ! dateOnSaleFrom.isValid() ) {
+		errors.date_on_sale_from_gmt = __(
+			'Please enter a valid date.',
+			'woocommerce'
+		);
+	}
+
+	if ( values.date_on_sale_to_gmt && ! dateOnSaleTo.isValid() ) {
+		errors.date_on_sale_to_gmt = __(
+			'Please enter a valid date.',
+			'woocommerce'
+		);
+	}
+
+	if ( dateOnSaleFrom.isAfter( dateOnSaleTo ) ) {
+		errors.date_on_sale_from_gmt = __(
+			'The start date of the sale must be before the end date.',
+			'woocommerce'
+		);
+	}
+
+	if ( dateOnSaleTo.isBefore( dateOnSaleFrom ) ) {
+		errors.date_on_sale_to_gmt = __(
+			'The end date of the sale must be after the start date.',
 			'woocommerce'
 		);
 	}

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -16,6 +16,53 @@ import moment from 'moment';
  */
 import { validate as validateInventory } from './sections/product-inventory-section';
 
+function validateScheduledSaleFields(
+	values: Partial< Product< ProductStatus, ProductType > >
+): FormErrors< typeof values > {
+	const errors: FormErrors< typeof values > = {};
+
+	const dateOnSaleFrom = moment(
+		values.date_on_sale_from_gmt,
+		moment.ISO_8601,
+		true
+	);
+	const dateOnSaleTo = moment(
+		values.date_on_sale_to_gmt,
+		moment.ISO_8601,
+		true
+	);
+
+	if ( values.date_on_sale_from_gmt && ! dateOnSaleFrom.isValid() ) {
+		errors.date_on_sale_from_gmt = __(
+			'Please enter a valid date.',
+			'woocommerce'
+		);
+	}
+
+	if ( values.date_on_sale_to_gmt && ! dateOnSaleTo.isValid() ) {
+		errors.date_on_sale_to_gmt = __(
+			'Please enter a valid date.',
+			'woocommerce'
+		);
+	}
+
+	if ( dateOnSaleFrom.isAfter( dateOnSaleTo ) ) {
+		errors.date_on_sale_from_gmt = __(
+			'The start date of the sale must be before the end date.',
+			'woocommerce'
+		);
+	}
+
+	if ( dateOnSaleTo.isBefore( dateOnSaleFrom ) ) {
+		errors.date_on_sale_to_gmt = __(
+			'The end date of the sale must be after the start date.',
+			'woocommerce'
+		);
+	}
+
+	return errors;
+}
+
 export const validate = (
 	values: Partial< Product< ProductStatus, ProductType > >
 ) => {
@@ -59,44 +106,10 @@ export const validate = (
 		);
 	}
 
-	const dateOnSaleFrom = moment(
-		values.date_on_sale_from_gmt,
-		moment.ISO_8601,
-		true
-	);
-	const dateOnSaleTo = moment(
-		values.date_on_sale_to_gmt,
-		moment.ISO_8601,
-		true
-	);
-
-	if ( values.date_on_sale_from_gmt && ! dateOnSaleFrom.isValid() ) {
-		errors.date_on_sale_from_gmt = __(
-			'Please enter a valid date.',
-			'woocommerce'
-		);
-	}
-
-	if ( values.date_on_sale_to_gmt && ! dateOnSaleTo.isValid() ) {
-		errors.date_on_sale_to_gmt = __(
-			'Please enter a valid date.',
-			'woocommerce'
-		);
-	}
-
-	if ( dateOnSaleFrom.isAfter( dateOnSaleTo ) ) {
-		errors.date_on_sale_from_gmt = __(
-			'The start date of the sale must be before the end date.',
-			'woocommerce'
-		);
-	}
-
-	if ( dateOnSaleTo.isBefore( dateOnSaleFrom ) ) {
-		errors.date_on_sale_to_gmt = __(
-			'The end date of the sale must be after the start date.',
-			'woocommerce'
-		);
-	}
+	errors = {
+		...errors,
+		...validateScheduledSaleFields( values ),
+	};
 
 	if ( values.dimensions?.width && +values.dimensions.width <= 0 ) {
 		errors.dimensions = {

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.scss
@@ -4,3 +4,14 @@
 		margin-top: $gap-small;
 	}
 }
+
+.product-pricing-section {
+	&__scheduled-sale {
+		&__spinner-wrapper {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			min-height: 150px;
+		}
+	}
+}

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -286,12 +286,7 @@ export const PricingSection: React.FC = () => {
 						checked={ showSaleSchedule }
 						onChange={ onSaleScheduleToggleChange }
 						// @ts-ignore disabled prop exists
-						disabled={
-							! (
-								values.sale_price &&
-								values.sale_price.length > 0
-							)
-						}
+						disabled={ ! ( values.sale_price?.length > 0 ) }
 					/>
 
 					{ showSaleSchedule && (

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -89,7 +89,7 @@ export const PricingSection: React.FC = () => {
 
 		if ( value ) {
 			setValues( {
-				date_on_sale_from_gmt: moment().add( 1, 'hours' ).toISOString(),
+				date_on_sale_from_gmt: moment().startOf( 'day' ).toISOString(),
 				date_on_sale_to_gmt: null,
 			} as Product );
 		} else {
@@ -246,6 +246,7 @@ export const PricingSection: React.FC = () => {
 								<DateTimePickerControl
 									label={ __( 'From', 'woocommerce' ) }
 									placeholder={ __( 'Now', 'woocommerce' ) }
+									timeForDateOnly={ 'start-of-day' }
 									currentDate={ values.date_on_sale_from_gmt }
 									{ ...getInputProps(
 										'date_on_sale_from_gmt',
@@ -261,6 +262,7 @@ export const PricingSection: React.FC = () => {
 										'No end date',
 										'woocommerce'
 									) }
+									timeForDateOnly={ 'end-of-day' }
 									currentDate={ values.date_on_sale_to_gmt }
 									{ ...getInputProps( 'date_on_sale_to_gmt', {
 										...dateTimePickerProps,

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	DateTimePickerControl,
 	Link,
-	Spinner,
 	useFormContext,
 	__experimentalTooltip as Tooltip,
 } from '@woocommerce/components';
@@ -76,19 +75,13 @@ export const PricingSection: React.FC = () => {
 		'woocommerce'
 	);
 
-	const { dateFormat, timeFormat, hasResolvedDateFormat } = useSelect(
-		( select ) => {
-			const { getOption, hasFinishedResolution } =
-				select( OPTIONS_STORE_NAME );
-			return {
-				dateFormat: getOption( 'date_format' ) as string,
-				timeFormat: ( getOption( 'time_format' ) as string ) || 'H:i',
-				hasResolvedDateFormat: hasFinishedResolution( 'getOption', [
-					'date_format',
-				] ),
-			};
-		}
-	);
+	const { dateFormat, timeFormat } = useSelect( ( select ) => {
+		const { getOption } = select( OPTIONS_STORE_NAME );
+		return {
+			dateFormat: ( getOption( 'date_format' ) as string ) || 'F j, Y',
+			timeFormat: ( getOption( 'time_format' ) as string ) || 'H:i',
+		};
+	} );
 
 	const onSaleScheduleToggleChange = ( value: boolean ) => {
 		setUserToggledSaleSchedule( true );
@@ -165,6 +158,7 @@ export const PricingSection: React.FC = () => {
 	const dateTimePickerProps = {
 		className: 'woocommerce-product__date-time-picker',
 		isDateOnlyPicker: true,
+		dateTimeFormat: dateFormat,
 	};
 
 	return (
@@ -300,40 +294,32 @@ export const PricingSection: React.FC = () => {
 						}
 					/>
 
-					{ showSaleSchedule &&
-						( hasResolvedDateFormat ? (
-							<>
-								<DateTimePickerControl
-									label={ __( 'From', 'woocommerce' ) }
-									placeholder={ __( 'Now', 'woocommerce' ) }
-									timeForDateOnly={ 'start-of-day' }
-									currentDate={ values.date_on_sale_from_gmt }
-									{ ...getInputProps(
-										'date_on_sale_from_gmt',
-										{
-											...dateTimePickerProps,
-										}
-									) }
-								/>
+					{ showSaleSchedule && (
+						<>
+							<DateTimePickerControl
+								label={ __( 'From', 'woocommerce' ) }
+								placeholder={ __( 'Now', 'woocommerce' ) }
+								timeForDateOnly={ 'start-of-day' }
+								currentDate={ values.date_on_sale_from_gmt }
+								{ ...getInputProps( 'date_on_sale_from_gmt', {
+									...dateTimePickerProps,
+								} ) }
+							/>
 
-								<DateTimePickerControl
-									label={ __( 'To', 'woocommerce' ) }
-									placeholder={ __(
-										'No end date',
-										'woocommerce'
-									) }
-									timeForDateOnly={ 'end-of-day' }
-									currentDate={ values.date_on_sale_to_gmt }
-									{ ...getInputProps( 'date_on_sale_to_gmt', {
-										...dateTimePickerProps,
-									} ) }
-								/>
-							</>
-						) : (
-							<div className="product-pricing-section__scheduled-sale__spinner-wrapper">
-								<Spinner />
-							</div>
-						) ) }
+							<DateTimePickerControl
+								label={ __( 'To', 'woocommerce' ) }
+								placeholder={ __(
+									'No end date',
+									'woocommerce'
+								) }
+								timeForDateOnly={ 'end-of-day' }
+								currentDate={ values.date_on_sale_to_gmt }
+								{ ...getInputProps( 'date_on_sale_to_gmt', {
+									...dateTimePickerProps,
+								} ) }
+							/>
+						</>
+					) }
 				</CardBody>
 			</Card>
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -285,6 +285,7 @@ export const PricingSection: React.FC = () => {
 						}
 						checked={ showSaleSchedule }
 						onChange={ onSaleScheduleToggleChange }
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore disabled prop exists
 						disabled={ ! ( values.sale_price?.length > 0 ) }
 					/>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -84,6 +84,10 @@ export const PricingSection: React.FC = () => {
 	} );
 
 	const onSaleScheduleToggleChange = ( value: boolean ) => {
+		recordEvent( 'product_pricing_schedule_sale_toggle_click', {
+			enabled: value,
+		} );
+
 		setUserToggledSaleSchedule( true );
 		setShowSaleSchedule( value );
 

--- a/plugins/woocommerce/changelog/add-product_schedule_sale
+++ b/plugins/woocommerce/changelog/add-product_schedule_sale
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add scheduled sale support to new product edit page.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds scheduled sale support to the new product editing experience.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 43-gh-woocommerce/mothra-private

### How to test the changes in this Pull Request:

1. Install the [WC-Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper) and enable the `new-product-management-experience`.
2. Go to `Products > Add New (MVP)`.
3. Go to the Pricing section.
4. Verify that acceptance criteria from 43-gh-woocommerce/mothra-private is met.

#### Known issues

- ~After saving a product with a scheduled sale, the product will be marked as dirty immediately (causing the "Update" button to be enabled). This was fixed by https://github.com/woocommerce/woocommerce/pull/35397~
- ~If you change the input of the scheduled to or from fields to the same date by typing, two onChange events get fired. This baffles me (none should be fired in this case). I will create an issue for follow-up at some later point (it's pretty edge-case).~ This was fixed in 8229b6f28d6856f5d81089cd240d7dc93d3014d8
- If the input of a DateTimePickerControl field is blank, the picker shows the current date as selected (this appears to be a Gutenberg regression) -- this should be followed up separately with Gutenberg
- If the site's timezone is not the same as the browser's timezone, the date selected in the picker is incorrect -- this should be addressed in a followup issue/PR

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
