### PR TITLE
Allowing generic item type in new experimental SelectControl

### DIFF
--- a/packages/js/components/src/experimental-select-control/README.md
+++ b/packages/js/components/src/experimental-select-control/README.md
@@ -5,7 +5,7 @@ A component that allows searching and selection of one or more items, providing 
 
 ## Usage
 
-`SelectControl` expects an array of item objects with `value` and `label` properties by default.  However, using the `itemToString` prop will allow you to pass a function to determine the label used and customize this object's shape.
+`SelectControl` expects an array of item objects with `value` and `label` properties by default, with the option of passing your own ItemType to the component. Using the `getItemLabel` and `getItemValue` props will allow you to pass a function to determine the respective label and value used and customize this object's shape.
 
 ```jsx
 const [ selected, setSelected ] = useState< SelectedType >( [] );
@@ -25,6 +25,37 @@ const items = [
 />
 ```
 
+And with a Custom Type to describe the item shape:
+
+```jsx
+const [ selected, setSelected ] =
+		useState< SelectedType< Array< CustomItemType > > >( null );
+
+const customItems = [
+  { id: 1, name: 'Joe', email: 'joe@notreally.com' },
+  { id: 2, name: 'Jen' },
+];
+
+<SelectControl < CustomItemType >
+  multiple
+  items={ customItems }
+  label="CustomItemType value"
+  selected={ selected }
+  onSelect={ ( item ) =>
+    setSelected(
+      Array.isArray( selected )
+        ? [ ...selected, item ]
+        : [ item ]
+    )
+  }
+  onRemove={ ( item ) =>
+    setSelected( selected.filter( ( i ) => i !== item ) )
+  }
+  getItemLabel={ ( item ) => item?.name }
+  getItemValue={ ( item ) => String( item?.id ) }
+/>
+```
+
 By default, the menu will render selectable items based on the provided items, but by passing a child function you can determine the render of those items.
 
 ```jsx
@@ -41,15 +72,17 @@ By default, the menu will render selectable items based on the provided items, b
         highlightedIndex,
         getItemProps,
         getMenuProps,
+        getItemLabel,
+        getItemValue
     } ) => {
         return (
             <ul { ...getMenuProps() }>
                 { isOpen && items.map( ( item, index: number ) => (
                     <li 
-                        key={ `${ item.value }${ index }` }
+                        key={ `${ getItemValue(item) }${ index }` }
                         { ...getItemProps() }
                     >
-                        { item.label }
+                        { getItemLabel(item) }
                     </li>
                 ) ) }
             </ul>
@@ -66,7 +99,8 @@ Name | Type | Default | Description
 `multiple` | Boolean | `false` | Whether the input should allow multiple selections or a single selection
 `items` | Array | `undefined` | The items used in the dropdown as an array of objects with `value` and `label` properties
 `label` | String | `undefined` | A string shown above the input
-`itemToString` | Function | `( item ) => item.label` | A function used to determine how a selected item should be shown
+`getItemLabel` | Function | `( item ) => item.label` | A function used to determine the label for an item
+`getItemValue` | Function | `( item ) => item.value` | A function used to determine the value for an item
 `getFilteredItems` | Function | `( allItems, inputValue, selectedItems ) => allItems.filter( ( item ) => selectedItems.indexOf( item ) < 0 && item.label.toLowerCase().startsWith( inputValue.toLowerCase() ) )` | A function to determine how items should be filtered based on user input and previously selected items
 `onInputChange` | Function | `() => null` | A callback that fires when the user input has changed
 `onRemove` | Function | `() => null` | A callback that fires when a selected item has been removed

--- a/packages/js/components/src/experimental-select-control/menu-item.tsx
+++ b/packages/js/components/src/experimental-select-control/menu-item.tsx
@@ -6,23 +6,23 @@ import { createElement, ReactElement } from 'react';
 /**
  * Internal dependencies
  */
-import { ItemType, getItemPropsType } from './types';
+import { getItemPropsType } from './types';
 
-type MenuItemProps = {
+type MenuItemProps< ItemType > = {
 	index: number;
 	isActive: boolean;
 	item: ItemType;
 	children: ReactElement | string;
-	getItemProps: getItemPropsType;
+	getItemProps: getItemPropsType< ItemType >;
 };
 
-export const MenuItem = ( {
+export const MenuItem = < ItemType, >( {
 	children,
 	getItemProps,
 	index,
 	isActive,
 	item,
-}: MenuItemProps ) => {
+}: MenuItemProps< ItemType > ) => {
 	return (
 		<li
 			style={ isActive ? { backgroundColor: '#bde4ff' } : {} }

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -4,27 +4,29 @@
 import classnames from 'classnames';
 import { createElement } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { useState, Fragment } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { ChildrenType, ItemType } from './types';
+import { ChildrenType, DefaultItemType } from './types';
 import { SelectedItems } from './selected-items';
 import { ComboBox } from './combo-box';
 import { Menu } from './menu';
 import { MenuItem } from './menu-item';
 import {
-	itemToString as defaultItemToString,
+	getItemLabel as defaultGetItemLabel,
+	getItemValue as defaultGetItemValue,
 	getFilteredItems as defaultGetFilteredItems,
 } from './utils';
 
-type SelectControlProps = {
-	children?: ChildrenType;
+type SelectControlProps< ItemType > = {
+	children?: ChildrenType< ItemType >;
 	items: ItemType[];
 	label: string;
 	initialSelectedItems?: ItemType[];
-	itemToString?: ( item: ItemType | null ) => string;
+	getItemLabel?: ( item: ItemType | null ) => string;
+	getItemValue?: ( item: ItemType | null ) => string;
 	getFilteredItems?: (
 		allItems: ItemType[],
 		inputValue: string,
@@ -38,7 +40,7 @@ type SelectControlProps = {
 	selected: ItemType | ItemType[] | null;
 };
 
-export const SelectControl = ( {
+export const SelectControl = < ItemType = DefaultItemType, >( {
 	children = ( {
 		items,
 		highlightedIndex,
@@ -50,13 +52,13 @@ export const SelectControl = ( {
 			<Menu getMenuProps={ getMenuProps } isOpen={ isOpen }>
 				{ items.map( ( item, index: number ) => (
 					<MenuItem
-						key={ `${ item.value }${ index }` }
+						key={ `${ getItemValue( item ) }${ index }` }
 						index={ index }
 						isActive={ highlightedIndex === index }
 						item={ item }
 						getItemProps={ getItemProps }
 					>
-						{ item.label }
+						{ getItemLabel( item ) }
 					</MenuItem>
 				) ) }
 			</Menu>
@@ -65,14 +67,15 @@ export const SelectControl = ( {
 	multiple = false,
 	items,
 	label,
-	itemToString = defaultItemToString,
+	getItemLabel = defaultGetItemLabel,
+	getItemValue = defaultGetItemValue,
 	getFilteredItems = defaultGetFilteredItems,
 	onInputChange = () => null,
 	onRemove = () => null,
 	onSelect = () => null,
 	placeholder,
 	selected,
-}: SelectControlProps ) => {
+}: SelectControlProps< ItemType > ) => {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
 	const { getSelectedItemProps, getDropdownProps } = useMultipleSelection();
@@ -93,7 +96,7 @@ export const SelectControl = ( {
 	} = useCombobox( {
 		inputValue,
 		items: filteredItems,
-		itemToString,
+		itemToString: getItemLabel,
 		selectedItem: null,
 		onStateChange: ( { inputValue: value, type, selectedItem } ) => {
 			switch ( type ) {
@@ -108,7 +111,7 @@ export const SelectControl = ( {
 					if ( selectedItem ) {
 						onSelect( selectedItem );
 						setInputValue(
-							multiple ? '' : itemToString( selectedItem )
+							multiple ? '' : getItemLabel( selectedItem )
 						);
 					}
 
@@ -133,7 +136,8 @@ export const SelectControl = ( {
 				{ multiple && (
 					<SelectedItems
 						items={ selectedItems }
-						itemToString={ itemToString }
+						getItemLabel={ getItemLabel }
+						getItemValue={ getItemValue }
 						getSelectedItemProps={ getSelectedItemProps }
 						onRemove={ onRemove }
 					/>

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -9,7 +9,12 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ChildrenType, DefaultItemType } from './types';
+import {
+	ChildrenType,
+	DefaultItemType,
+	getItemLabelType,
+	getItemValueType,
+} from './types';
 import { SelectedItems } from './selected-items';
 import { ComboBox } from './combo-box';
 import { Menu } from './menu';
@@ -25,8 +30,8 @@ type SelectControlProps< ItemType > = {
 	items: ItemType[];
 	label: string;
 	initialSelectedItems?: ItemType[];
-	getItemLabel?: ( item: ItemType | null ) => string;
-	getItemValue?: ( item: ItemType | null ) => string;
+	getItemLabel?: getItemLabelType< ItemType >;
+	getItemValue?: getItemValueType< ItemType >;
 	getFilteredItems?: (
 		allItems: ItemType[],
 		inputValue: string,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -20,9 +20,9 @@ import { ComboBox } from './combo-box';
 import { Menu } from './menu';
 import { MenuItem } from './menu-item';
 import {
-	getItemLabel as defaultGetItemLabel,
-	getItemValue as defaultGetItemValue,
-	getFilteredItems as defaultGetFilteredItems,
+	defaultGetItemLabel,
+	defaultGetItemValue,
+	defaultGetFilteredItems,
 } from './utils';
 
 type SelectControlProps< ItemType > = {
@@ -35,7 +35,8 @@ type SelectControlProps< ItemType > = {
 	getFilteredItems?: (
 		allItems: ItemType[],
 		inputValue: string,
-		selectedItems: ItemType[]
+		selectedItems: ItemType[],
+		getItemLabel: getItemLabelType< ItemType >
 	) => ItemType[];
 	multiple?: boolean;
 	onInputChange?: ( value: string | undefined ) => void;
@@ -88,7 +89,12 @@ export const SelectControl = < ItemType = DefaultItemType, >( {
 	selectedItems = Array.isArray( selectedItems )
 		? selectedItems
 		: [ selectedItems ].filter( Boolean );
-	const filteredItems = getFilteredItems( items, inputValue, selectedItems );
+	const filteredItems = getFilteredItems(
+		items,
+		inputValue,
+		selectedItems,
+		getItemLabel
+	);
 
 	const {
 		isOpen,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -46,9 +46,11 @@ type SelectControlProps< ItemType > = {
 	selected: ItemType | ItemType[] | null;
 };
 
-export const SelectControl = < ItemType = DefaultItemType, >( {
+function SelectControl< ItemType = DefaultItemType >( {
+	getItemLabel = defaultGetItemLabel,
+	getItemValue = defaultGetItemValue,
 	children = ( {
-		items,
+		items: renderItems,
 		highlightedIndex,
 		getItemProps,
 		getMenuProps,
@@ -56,7 +58,7 @@ export const SelectControl = < ItemType = DefaultItemType, >( {
 	} ) => {
 		return (
 			<Menu getMenuProps={ getMenuProps } isOpen={ isOpen }>
-				{ items.map( ( item, index: number ) => (
+				{ renderItems.map( ( item, index: number ) => (
 					<MenuItem
 						key={ `${ getItemValue( item ) }${ index }` }
 						index={ index }
@@ -73,15 +75,13 @@ export const SelectControl = < ItemType = DefaultItemType, >( {
 	multiple = false,
 	items,
 	label,
-	getItemLabel = defaultGetItemLabel,
-	getItemValue = defaultGetItemValue,
 	getFilteredItems = defaultGetFilteredItems,
 	onInputChange = () => null,
 	onRemove = () => null,
 	onSelect = () => null,
 	placeholder,
 	selected,
-}: SelectControlProps< ItemType > ) => {
+}: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
 	const { getSelectedItemProps, getDropdownProps } = useMultipleSelection();
@@ -177,4 +177,6 @@ export const SelectControl = < ItemType = DefaultItemType, >( {
 			} ) }
 		</div>
 	);
-};
+}
+
+export { SelectControl };

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -172,6 +172,8 @@ export const SelectControl = < ItemType = DefaultItemType, >( {
 				getItemProps,
 				getMenuProps,
 				isOpen,
+				getItemLabel,
+				getItemValue,
 			} ) }
 		</div>
 	);

--- a/packages/js/components/src/experimental-select-control/selected-items.tsx
+++ b/packages/js/components/src/experimental-select-control/selected-items.tsx
@@ -6,12 +6,12 @@ import { createElement } from 'react';
 /**
  * Internal dependencies
  */
-import { ItemType } from './types';
 import Tag from '../tag';
 
-type SelectedItemsProps = {
+type SelectedItemsProps< ItemType > = {
 	items: ItemType[];
-	itemToString: ( item: ItemType | null ) => string;
+	getItemLabel: ( item: ItemType | null ) => string;
+	getItemValue: ( item: ItemType | null ) => string;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore These are the types provided by Downshift.
 	getSelectedItemProps: ( { selectedItem: any, index: any } ) => {
@@ -20,12 +20,13 @@ type SelectedItemsProps = {
 	onRemove: ( item: ItemType ) => void;
 };
 
-export const SelectedItems = ( {
+export const SelectedItems = < ItemType, >( {
 	items,
-	itemToString,
+	getItemLabel,
+	getItemValue,
 	getSelectedItemProps,
 	onRemove,
-}: SelectedItemsProps ) => {
+}: SelectedItemsProps< ItemType > ) => {
 	return (
 		<div className="woocommerce-experimental-select-control__selected-items">
 			{ items.map( ( item, index ) => (
@@ -40,9 +41,9 @@ export const SelectedItems = ( {
 					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 					{ /* @ts-ignore Additional props are not required. */ }
 					<Tag
-						id={ item.value }
+						id={ getItemValue( item ) }
 						remove={ () => () => onRemove( item ) }
-						label={ itemToString( item ) }
+						label={ getItemLabel( item ) }
 					/>
 				</span>
 			) ) }

--- a/packages/js/components/src/experimental-select-control/selected-items.tsx
+++ b/packages/js/components/src/experimental-select-control/selected-items.tsx
@@ -7,11 +7,12 @@ import { createElement } from 'react';
  * Internal dependencies
  */
 import Tag from '../tag';
+import { getItemLabelType, getItemValueType } from './types';
 
 type SelectedItemsProps< ItemType > = {
 	items: ItemType[];
-	getItemLabel: ( item: ItemType | null ) => string;
-	getItemValue: ( item: ItemType | null ) => string;
+	getItemLabel: getItemLabelType< ItemType >;
+	getItemValue: getItemValueType< ItemType >;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore These are the types provided by Downshift.
 	getSelectedItemProps: ( { selectedItem: any, index: any } ) => {

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { CheckboxControl, Spinner } from '@wordpress/components';
-import React from 'react';
+import React, { createElement } from 'react';
 import { useState } from '@wordpress/element';
 
 /**

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { CheckboxControl, Spinner } from '@wordpress/components';
-import React, { createElement } from 'react';
+import React from 'react';
 import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { ItemType, SelectedType } from '../types';
+import { SelectedType, DefaultItemType } from '../types';
 import { MenuItem } from '../menu-item';
 import { SelectControl } from '../';
 import { Menu } from '../menu';
@@ -22,7 +22,8 @@ const sampleItems = [
 ];
 
 export const Single: React.FC = () => {
-	const [ selected, setSelected ] = useState< SelectedType >( null );
+	const [ selected, setSelected ] =
+		useState< SelectedType< DefaultItemType > >( null );
 
 	return (
 		<>
@@ -39,7 +40,7 @@ export const Single: React.FC = () => {
 };
 
 export const Multiple: React.FC = () => {
-	const [ selected, setSelected ] = useState< ItemType[] >( [] );
+	const [ selected, setSelected ] = useState< DefaultItemType[] >( [] );
 
 	return (
 		<>
@@ -61,12 +62,12 @@ export const Multiple: React.FC = () => {
 };
 
 export const FuzzyMatching: React.FC = () => {
-	const [ selected, setSelected ] = useState< ItemType[] >( [] );
+	const [ selected, setSelected ] = useState< DefaultItemType[] >( [] );
 
 	const getFilteredItems = (
-		allItems: ItemType[],
+		allItems: DefaultItemType[],
 		inputValue: string,
-		selectedItems: ItemType[]
+		selectedItems: DefaultItemType[]
 	) => {
 		const pattern =
 			'.*' + inputValue.toLowerCase().split( '' ).join( '.*' ) + '.*';
@@ -96,8 +97,11 @@ export const FuzzyMatching: React.FC = () => {
 };
 
 export const Async: React.FC = () => {
-	const [ selectedItem, setSelectedItem ] = useState< SelectedType >( null );
-	const [ fetchedItems, setFetchedItems ] = useState< ItemType[] >( [] );
+	const [ selectedItem, setSelectedItem ] =
+		useState< SelectedType< DefaultItemType > >( null );
+	const [ fetchedItems, setFetchedItems ] = useState< DefaultItemType[] >(
+		[]
+	);
 	const [ isFetching, setIsFetching ] = useState( false );
 
 	const fetchItems = ( value: string | undefined ) => {
@@ -153,7 +157,7 @@ export const Async: React.FC = () => {
 };
 
 export const CustomRender: React.FC = () => {
-	const [ selected, setSelected ] = useState< ItemType[] >( [] );
+	const [ selected, setSelected ] = useState< DefaultItemType[] >( [] );
 
 	const onRemove = ( item ) => {
 		setSelected( selected.filter( ( i ) => i !== item ) );

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -231,6 +231,69 @@ export const CustomRender: React.FC = () => {
 	);
 };
 
+type CustomItemType = {
+	itemId: number;
+	user: {
+		name: string;
+		email?: string;
+		id: number;
+	};
+};
+
+const customItems: CustomItemType[] = [
+	{
+		itemId: 1,
+		user: {
+			name: 'Joe',
+			email: 'joe@a8c.com',
+			id: 32,
+		},
+	},
+	{
+		itemId: 2,
+		user: {
+			name: 'Jen',
+			id: 16,
+		},
+	},
+	{
+		itemId: 3,
+		user: {
+			name: 'Jared',
+			id: 112,
+		},
+	},
+];
+
+export const CustomItemType: React.FC = () => {
+	const [ selected, setSelected ] =
+		useState< SelectedType< Array< CustomItemType > > >( null );
+
+	return (
+		<>
+			Selected: { JSON.stringify( selected ) }
+			<SelectControl< CustomItemType >
+				multiple
+				items={ customItems }
+				label="CustomItemType value"
+				selected={ selected }
+				onSelect={ ( item ) =>
+					setSelected(
+						Array.isArray( selected )
+							? [ ...selected, item ]
+							: [ item ]
+					)
+				}
+				onRemove={ ( item ) =>
+					setSelected( selected.filter( ( i ) => i !== item ) )
+				}
+				getItemLabel={ ( item ) => item?.user.name }
+				getItemValue={ ( item ) => String( item?.itemId ) }
+			/>
+		</>
+	);
+};
+
 export default {
 	title: 'WooCommerce Admin/experimental/SelectControl',
 	component: SelectControl,

--- a/packages/js/components/src/experimental-select-control/types.ts
+++ b/packages/js/components/src/experimental-select-control/types.ts
@@ -38,6 +38,8 @@ export type ChildrenProps< ItemType > = {
 	highlightedIndex: number;
 	getItemProps: getItemPropsType< ItemType >;
 	getMenuProps: getMenuPropsType;
+	getItemLabel: getItemLabelType< ItemType >;
+	getItemValue: getItemValueType< ItemType >;
 };
 
 export type ChildrenType< ItemType > = ( {

--- a/packages/js/components/src/experimental-select-control/types.ts
+++ b/packages/js/components/src/experimental-select-control/types.ts
@@ -45,3 +45,7 @@ export type ChildrenType< ItemType > = ( {
 	isOpen,
 	highlightedIndex,
 }: ChildrenProps< ItemType > ) => ReactElement | Component;
+
+export type getItemLabelType< ItemType > = ( item: ItemType | null ) => string;
+
+export type getItemValueType< ItemType > = ( item: ItemType | null ) => string;

--- a/packages/js/components/src/experimental-select-control/types.ts
+++ b/packages/js/components/src/experimental-select-control/types.ts
@@ -10,7 +10,7 @@ import {
 
 export type DefaultItemType = {
 	label: string;
-	value: string;
+	value: string | number;
 };
 
 export type SelectedType< ItemType > = ItemType | null;
@@ -50,4 +50,6 @@ export type ChildrenType< ItemType > = ( {
 
 export type getItemLabelType< ItemType > = ( item: ItemType | null ) => string;
 
-export type getItemValueType< ItemType > = ( item: ItemType | null ) => string;
+export type getItemValueType< ItemType > = (
+	item: ItemType | null
+) => string | number;

--- a/packages/js/components/src/experimental-select-control/types.ts
+++ b/packages/js/components/src/experimental-select-control/types.ts
@@ -9,8 +9,8 @@ import {
 } from 'downshift';
 
 export type DefaultItemType = {
-	value: string;
 	label: string;
+	value: string;
 };
 
 export type SelectedType< ItemType > = ItemType | null;

--- a/packages/js/components/src/experimental-select-control/types.ts
+++ b/packages/js/components/src/experimental-select-control/types.ts
@@ -8,18 +8,18 @@ import {
 	GetPropsCommonOptions,
 } from 'downshift';
 
-export type ItemType = {
+export type DefaultItemType = {
 	value: string;
 	label: string;
 };
 
-export type SelectedType = ItemType | null;
+export type SelectedType< ItemType > = ItemType | null;
 
 export type Props = {
 	[ key: string ]: string;
 };
 
-export type getItemPropsType = (
+export type getItemPropsType< ItemType > = (
 	options: UseComboboxGetItemPropsOptions< ItemType >
 	// These are the types provided by Downshift.
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,16 +32,16 @@ export type getMenuPropsType = (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ) => any;
 
-export type ChildrenProps = {
+export type ChildrenProps< ItemType > = {
 	items: ItemType[];
 	isOpen: boolean;
 	highlightedIndex: number;
-	getItemProps: getItemPropsType;
+	getItemProps: getItemPropsType< ItemType >;
 	getMenuProps: getMenuPropsType;
 };
 
-export type ChildrenType = ( {
+export type ChildrenType< ItemType > = ( {
 	items,
 	isOpen,
 	highlightedIndex,
-}: ChildrenProps ) => ReactElement | Component;
+}: ChildrenProps< ItemType > ) => ReactElement | Component;

--- a/packages/js/components/src/experimental-select-control/utils.ts
+++ b/packages/js/components/src/experimental-select-control/utils.ts
@@ -1,9 +1,17 @@
+/**
+ * Internal dependencies
+ */
 import { getItemLabelType } from './types';
+
 export const defaultGetItemLabel = < ItemType >( item: ItemType | null ) => {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore this default handler should only be used with the default item type
 	return item ? item.label : '';
 };
 
 export const defaultGetItemValue = < ItemType >( item: ItemType | null ) => {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore this default handler should only be used with the default item type
 	return item ? item.value : '';
 };
 

--- a/packages/js/components/src/experimental-select-control/utils.ts
+++ b/packages/js/components/src/experimental-select-control/utils.ts
@@ -1,15 +1,17 @@
-export const getItemLabel = < ItemType >( item: ItemType | null ) => {
+import { getItemLabelType } from './types';
+export const defaultGetItemLabel = < ItemType >( item: ItemType | null ) => {
 	return item ? item.label : '';
 };
 
-export const getItemValue = < ItemType >( item: ItemType | null ) => {
+export const defaultGetItemValue = < ItemType >( item: ItemType | null ) => {
 	return item ? item.value : '';
 };
 
-export const getFilteredItems = < ItemType >(
+export const defaultGetFilteredItems = < ItemType >(
 	allItems: ItemType[],
 	inputValue: string,
-	selectedItems: ItemType[]
+	selectedItems: ItemType[],
+	getItemLabel: getItemLabelType< ItemType >
 ) => {
 	return allItems.filter(
 		( item ) =>

--- a/packages/js/components/src/experimental-select-control/utils.ts
+++ b/packages/js/components/src/experimental-select-control/utils.ts
@@ -7,6 +7,7 @@ function isDefaultItemType< ItemType >(
 	item: ItemType | DefaultItemType | null
 ): item is DefaultItemType {
 	return (
+		Boolean( item ) &&
 		( item as DefaultItemType ).label !== undefined &&
 		( item as DefaultItemType ).value !== undefined
 	);

--- a/packages/js/components/src/experimental-select-control/utils.ts
+++ b/packages/js/components/src/experimental-select-control/utils.ts
@@ -1,13 +1,12 @@
-/**
- * Internal dependencies
- */
-import { ItemType, SelectedType } from './types';
-
-export const itemToString = ( item: ItemType | null ) => {
+export const getItemLabel = < ItemType >( item: ItemType | null ) => {
 	return item ? item.label : '';
 };
 
-export const getFilteredItems = (
+export const getItemValue = < ItemType >( item: ItemType | null ) => {
+	return item ? item.value : '';
+};
+
+export const getFilteredItems = < ItemType >(
 	allItems: ItemType[],
 	inputValue: string,
 	selectedItems: ItemType[]
@@ -15,6 +14,8 @@ export const getFilteredItems = (
 	return allItems.filter(
 		( item ) =>
 			selectedItems.indexOf( item ) < 0 &&
-			item.label.toLowerCase().startsWith( inputValue.toLowerCase() )
+			getItemLabel( item )
+				.toLowerCase()
+				.startsWith( inputValue.toLowerCase() )
 	);
 };

--- a/packages/js/components/src/experimental-select-control/utils.ts
+++ b/packages/js/components/src/experimental-select-control/utils.ts
@@ -1,18 +1,29 @@
 /**
  * Internal dependencies
  */
-import { getItemLabelType } from './types';
+import { getItemLabelType, DefaultItemType } from './types';
+
+function isDefaultItemType< ItemType >(
+	item: ItemType | DefaultItemType | null
+): item is DefaultItemType {
+	return (
+		( item as DefaultItemType ).label !== undefined &&
+		( item as DefaultItemType ).value !== undefined
+	);
+}
 
 export const defaultGetItemLabel = < ItemType >( item: ItemType | null ) => {
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore this default handler should only be used with the default item type
-	return item ? item.label : '';
+	if ( isDefaultItemType< ItemType >( item ) ) {
+		return item.label;
+	}
+	return '';
 };
 
 export const defaultGetItemValue = < ItemType >( item: ItemType | null ) => {
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore this default handler should only be used with the default item type
-	return item ? item.value : '';
+	if ( isDefaultItemType< ItemType >( item ) ) {
+		return item.value;
+	}
+	return '';
 };
 
 export const defaultGetFilteredItems = < ItemType >(

--- a/plugins/woocommerce/changelog/update-34399-select-control
+++ b/plugins/woocommerce/changelog/update-34399-select-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Allowing generic item type in new experimental SelectControl.


### PR DESCRIPTION
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates to the new experimental SelectControl to support passing a custom type to describe the items, as well as including `getItemValue()` and `getItemLabel()` functions as props to parse those items. 

Note: This PR was a bit adventurous for me as I wasn't entirely familiar with TS generic types, but it was a fun learning experience. The only issue I haven't been able to resolve is a couple [TS errors within the utils for the default `item` and `value` getters](https://github.com/woocommerce/woocommerce/pull/34547/files#r960866165). 

Closes #34399 .

### How to test the changes in this Pull Request:

1. Checkout branch.
2. Fire up storybook with `npm run storybook`
3. Observe and interact with the new `Experimental > SelectControl > Custom Item Type` story.
4. Optionally including the Select control with a custom type (can copy from story) live on any react screen to interact with it there.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
