### PR TITLE
Validate that tinymce exists before using it.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34221-error-on-save-product
+++ b/plugins/woocommerce/changelog/fix-34221-error-on-save-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow customer to save a product when tinymce is not the default text editor

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -152,7 +152,11 @@ class WC_Products_Tracking {
 
 					if ( ! isBlockEditor ) {
 						tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
-						description_value  = $( '#content' ).is( ':visible' ) ? $( '#content' ).val() : tinymce.get( 'content' ).getContent();
+						if ( $( '#content' ).is( ':visible' ) ) {
+							description_value = $( '#content' ).val();	
+						} else if ( typeof tinymce === 'object' ) {
+							description_value = tinymce.get( 'content' ).getContent();
+						}
 					} else {
 						description_value  = $( '.block-editor-rich-text__editable' ).text();
 					}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -154,7 +154,7 @@ class WC_Products_Tracking {
 						tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
 						if ( $( '#content' ).is( ':visible' ) ) {
 							description_value = $( '#content' ).val();	
-						} else if ( typeof tinymce === 'object' ) {
+						} else if ( typeof tinymce === 'object' && tinymce.get( 'content' ) ) {
 							description_value = tinymce.get( 'content' ).getContent();
 						}
 					} else {


### PR DESCRIPTION
If wp is not configured to use blocks and the tinymce was changed by a different editor then the error happends because tinymce is required. Applying a validation that makes sure tinymce exists before using it solves the problem. But this introduces a new problem, the description property will be send with value 'No' when event 'product_update' will be fired.
What do you thing about this @pmcpinto? We can implement a more specific code to consider tracking some kind of error messega or flag that tell us the customer is not using tinymce or blocks. Or it's no necesary to spend more time on this considering this page is gonna be replaced by the new experience.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34221 .

### How to test the changes in this Pull Request:

1. Go to All Products
2. Click on edit link of any product
3. In Edit product page, change the description of the product.
4. Open the DevTools Console in your borwser and type `delete tinymce`
5. Then click Update button
6. The product description should be saved succesfully without any error
7. The `product_update` event should be sent with `desciption: 'No'`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
