### PR TITLE
Add changelog.txt update workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,68 @@
+name: Run post release processes
+on: 
+  release:
+    types: [released]
+
+env:
+    GIT_COMMITTER_NAME: 'WooCommerce Bot'
+    GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
+    GIT_AUTHOR_NAME: 'WooCommerce Bot'
+    GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
+
+jobs:
+  update-changelog-in-trunk:
+    name: Update changelog in trunk
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get tag name
+        id: tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const tag = ${{ toJSON( github.event.release.tag_name ) }}
+
+            console.log( `::set-output name=tag::release/${ tag.substring( 0, 3 ) }` )
+
+      - name: Git fetch trunk branch
+        run: git fetch origin trunk
+
+      - name: Copy changelog.txt to vm root
+        run: cp changelog.txt ../../changelog.txt
+
+      - name: Switch to trunk branch
+        run: git checkout trunk
+      
+      - name: Create a new branch based on trunk
+        run: git checkout -b update/changelog-from-release-${{ github.event.release.tag_name }}
+
+      - name: Copy saved changelog.txt to monorepo
+        run: cp ../../changelog.txt ./changelog.txt
+
+      - name: Commit changes
+        run: git commit -am "Update changelog.txt from release ${{ github.event.release.tag_name }}"
+
+      - name: Push branch up
+        run: git push origin update/changelog-from-release-${{ github.event.release.tag_name }}
+
+      - name: Create the PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const body = "This PR updates the changelog.txt based on the latest release: ${{ github.event.release.tag_name }}"
+
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Update changelog.txt from release ${{ github.event.release.tag_name }}",
+              head: "update/changelog-from-release-${{ github.event.release.tag_name }}",
+              base: "trunk",
+              body: body
+            })
+
+            const prCreated = await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.data.number,
+              reviewers: ["${{ github.event.release.author.login }}"]
+            })


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/34366

This PR automates the process where we need to update the `changelog.txt` file in trunk whenever we do a final release.

### How to test the changes in this Pull Request:

1. Fork this repo. All steps following will be in your fork.
2. Merge this branch into trunk.
3. Create a release branch named `release/7.0`.
4. In the `release/7.0` branch, add new changelog version block (`= 7.0.0 2022-09-15 =`) with some dummy entries to `changelog.txt` file so that it is different from trunk. ![wrC5Gp.png](https://user-images.githubusercontent.com/2132595/188161877-8087465d-37fc-4507-9533-33ec82c79a3f.png)
5. Create a new release - select to create a new tag `7.0.0`,  target the `release/7.0` branch and click on `Publish release` button. ![i9HQrc.png](https://user-images.githubusercontent.com/2132595/188160537-a0a967c2-356f-4f70-9b19-2c34ee2a503d.png)
6. At this point the event should trigger the workflow. After it is done, you should see a new PR created.
7. Check that the PR contains changes to the `changelog.txt` with the new entries you've added in step 4 and that it is targeting trunk. It should also have the PR reviewer assigned. It assigns the person who created the release. In this case it usually is the release lead.
8. Check that this event should NOT run if it is a prerelease or if it is a draft release.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.