### PR TITLE
Price section - Small refactor and style fix

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -42,12 +42,23 @@ export const ProductFormActions: React.FC = () => {
 		};
 	};
 
+	const maybeSetRegularPrice = ( product: Product ) => {
+		if (
+			product.regular_price === undefined &&
+			product.sale_price !== ''
+		) {
+			product.regular_price = product.sale_price;
+		}
+		return product;
+	};
+
 	const onSaveDraft = async () => {
 		recordEvent( 'product_edit', {
 			new_product_page: true,
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
+			maybeSetRegularPrice( values );
 			createProductWithStatus( values, 'draft' );
 		} else {
 			const product = await updateProductWithStatus(
@@ -67,6 +78,7 @@ export const ProductFormActions: React.FC = () => {
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
+			maybeSetRegularPrice( values );
 			createProductWithStatus( values, 'publish' );
 		} else {
 			const product = await updateProductWithStatus(
@@ -88,6 +100,7 @@ export const ProductFormActions: React.FC = () => {
 		if ( values.id ) {
 			await updateProductWithStatus( values.id, values, 'publish' );
 		} else {
+			maybeSetRegularPrice( values );
 			await createProductWithStatus( values, 'publish', false, true );
 		}
 		await copyProductWithStatus( values );
@@ -105,6 +118,7 @@ export const ProductFormActions: React.FC = () => {
 				values.status || 'draft'
 			);
 		}
+		maybeSetRegularPrice( values );
 		await copyProductWithStatus( values );
 	};
 

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -42,24 +42,12 @@ export const ProductFormActions: React.FC = () => {
 		};
 	};
 
-	const maybeSetRegularPrice = ( product: Product ) => {
-		if (
-			( product.regular_price === undefined ||
-				product.regular_price === '' ) &&
-			product.sale_price !== ''
-		) {
-			product.regular_price = product.sale_price;
-		}
-		return product;
-	};
-
 	const onSaveDraft = async () => {
 		recordEvent( 'product_edit', {
 			new_product_page: true,
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
-			maybeSetRegularPrice( values );
 			createProductWithStatus( values, 'draft' );
 		} else {
 			const product = await updateProductWithStatus(
@@ -79,7 +67,6 @@ export const ProductFormActions: React.FC = () => {
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
-			maybeSetRegularPrice( values );
 			createProductWithStatus( values, 'publish' );
 		} else {
 			const product = await updateProductWithStatus(
@@ -101,7 +88,6 @@ export const ProductFormActions: React.FC = () => {
 		if ( values.id ) {
 			await updateProductWithStatus( values.id, values, 'publish' );
 		} else {
-			maybeSetRegularPrice( values );
 			await createProductWithStatus( values, 'publish', false, true );
 		}
 		await copyProductWithStatus( values );
@@ -119,7 +105,6 @@ export const ProductFormActions: React.FC = () => {
 				values.status || 'draft'
 			);
 		}
-		maybeSetRegularPrice( values );
 		await copyProductWithStatus( values );
 	};
 

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -44,7 +44,8 @@ export const ProductFormActions: React.FC = () => {
 
 	const maybeSetRegularPrice = ( product: Product ) => {
 		if (
-			product.regular_price === undefined &&
+			( product.regular_price === undefined ||
+				product.regular_price === '' ) &&
 			product.sale_price !== ''
 		) {
 			product.regular_price = product.sale_price;

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -42,6 +42,11 @@
 			margin-bottom: 0;
 		}
 	}
+	.woocommerce-enriched-label__help-wrapper {
+		.components-popover {
+			margin-top: 0;
+		}
+	}
 }
 
 .woocommerce-edit-product {

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -38,11 +38,11 @@ export const validate = (
 	if (
 		values.sale_price &&
 		( ! values.regular_price ||
-			parseFloat( values.sale_price ) >
+			parseFloat( values.sale_price ) >=
 				parseFloat( values?.regular_price ) )
 	) {
 		errors.sale_price = __(
-			'Sale price cannot be higher than list price.',
+			'Sale price cannot be equal to or higher than list price.',
 			'woocommerce'
 		);
 	}

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -37,11 +37,12 @@ export const validate = (
 
 	if (
 		values.sale_price &&
-		values.regular_price &&
-		parseFloat( values.sale_price ) > parseFloat( values.regular_price )
+		( ! values.regular_price ||
+			parseFloat( values.sale_price ) >
+				parseFloat( values?.regular_price ) )
 	) {
 		errors.sale_price = __(
-			'Please enter a price with one monetary decimal point without thousand separators and currency symbols.',
+			'Sale price cannot be higher than list price.',
 			'woocommerce'
 		);
 	}

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -34,5 +34,17 @@ export const validate = (
 			'woocommerce'
 		);
 	}
+
+	if (
+		values.sale_price &&
+		values.regular_price &&
+		parseFloat( values.sale_price ) > parseFloat( values.regular_price )
+	) {
+		errors.sale_price = __(
+			'Please enter a price with one monetary decimal point without thousand separators and currency symbols.',
+			'woocommerce'
+		);
+	}
+
 	return errors;
 };

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -86,11 +86,6 @@ export const PricingSection: React.FC = () => {
 		},
 	} );
 
-	const regularPriceProps = getInputControlProps( {
-		...getInputProps( 'regular_price' ),
-		context,
-	} );
-
 	const salePriceProps = getInputControlProps( {
 		...getInputProps( 'sale_price' ),
 		context,
@@ -121,18 +116,14 @@ export const PricingSection: React.FC = () => {
 				</>
 			}
 		>
-			<div
-				className={ classnames(
-					'woocommerce-product-form__custom-label-input',
-					{
-						'has-error': regularPriceProps?.help !== '',
-					}
-				) }
-			>
+			<div className="woocommerce-product-form__custom-label-input">
 				<InputControl
 					label={ __( 'List price', 'woocommerce' ) }
 					placeholder={ __( '10.59', 'woocommerce' ) }
-					{ ...regularPriceProps }
+					{ ...getInputControlProps( {
+						...getInputProps( 'regular_price' ),
+						context,
+					} ) }
 					onChange={ ( value: string ) => {
 						const sanitizedValue = sanitizePrice( value );
 						setValue( 'regular_price', sanitizedValue );
@@ -149,7 +140,7 @@ export const PricingSection: React.FC = () => {
 				className={ classnames(
 					'woocommerce-product-form__custom-label-input',
 					{
-						'has-error': regularPriceProps?.help !== '',
+						'has-error': salePriceProps?.help !== '',
 					}
 				) }
 			>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -21,13 +21,11 @@ import { ProductSectionLayout } from '../layout/product-section-layout';
 import { getInputControlProps } from './utils';
 import { ADMIN_URL } from '../../utils/admin-settings';
 import { CurrencyContext } from '../../lib/currency-context';
-import {
-	NUMBERS_AND_DECIMAL_SEPARATOR,
-	ONLY_ONE_DECIMAL_SEPARATOR,
-} from '../constants';
+import { useProductHelper } from '../use-product-helper';
 
 export const PricingSection: React.FC = () => {
 	const { getInputProps, setValue } = useFormContext< Product >();
+	const { sanitizePrice } = useProductHelper();
 	const { isResolving: isTaxSettingsResolving, taxSettings } = useSelect(
 		( select ) => {
 			const { getSettings, hasFinishedResolution } =
@@ -43,25 +41,6 @@ export const PricingSection: React.FC = () => {
 	const pricesIncludeTax =
 		taxSettings.woocommerce_prices_include_tax === 'yes';
 	const context = useContext( CurrencyContext );
-	const { getCurrencyConfig } = context;
-	const { decimalSeparator } = getCurrencyConfig();
-	const sanitizeAndSetPrice = ( name: string, value: string ) => {
-		// Build regex to strip out everything except digits, decimal point and minus sign.
-		const regex = new RegExp(
-			NUMBERS_AND_DECIMAL_SEPARATOR.replace( '%s', decimalSeparator ),
-			'g'
-		);
-		const decimalRegex = new RegExp(
-			ONLY_ONE_DECIMAL_SEPARATOR.replaceAll( '%s', decimalSeparator ),
-			'g'
-		);
-		const cleanValue = value
-			.replace( regex, '' )
-			.replace( decimalRegex, '' )
-			.replace( decimalSeparator, '.' );
-		setValue( name, cleanValue );
-		return cleanValue;
-	};
 
 	const taxIncludedInPriceText = __(
 		'Per your {{link}}store settings{{/link}}, tax is {{strong}}included{{/strong}} in the price.',
@@ -138,9 +117,10 @@ export const PricingSection: React.FC = () => {
 						...getInputProps( 'regular_price' ),
 						context,
 					} ) }
-					onChange={ ( value: string ) =>
-						sanitizeAndSetPrice( 'regular_price', value )
-					}
+					onChange={ ( value: string ) => {
+						const sanitizedValue = sanitizePrice( value );
+						setValue( 'regular_price', sanitizedValue );
+					} }
 				/>
 				{ ! isTaxSettingsResolving && (
 					<span className="woocommerce-product-form__secondary-text">
@@ -158,9 +138,10 @@ export const PricingSection: React.FC = () => {
 						...getInputProps( 'sale_price' ),
 						context,
 					} ) }
-					onChange={ ( value: string ) =>
-						sanitizeAndSetPrice( 'sale_price', value )
-					}
+					onChange={ ( value: string ) => {
+						const sanitizedValue = sanitizePrice( value );
+						setValue( 'sale_price', sanitizedValue );
+					} }
 				/>
 			</div>
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -8,9 +8,11 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useContext } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
+import classnames from 'classnames';
 import {
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
+	BaseControl,
 } from '@wordpress/components';
 
 /**
@@ -84,6 +86,16 @@ export const PricingSection: React.FC = () => {
 		},
 	} );
 
+	const regularPriceProps = getInputControlProps( {
+		...getInputProps( 'regular_price' ),
+		context,
+	} );
+
+	const salePriceProps = getInputControlProps( {
+		...getInputProps( 'sale_price' ),
+		context,
+	} );
+
 	return (
 		<ProductSectionLayout
 			title={ __( 'Pricing', 'woocommerce' ) }
@@ -109,14 +121,18 @@ export const PricingSection: React.FC = () => {
 				</>
 			}
 		>
-			<div className="woocommerce-product-form__custom-label-input">
+			<div
+				className={ classnames(
+					'woocommerce-product-form__custom-label-input',
+					{
+						'has-error': regularPriceProps?.help !== '',
+					}
+				) }
+			>
 				<InputControl
 					label={ __( 'List price', 'woocommerce' ) }
 					placeholder={ __( '10.59', 'woocommerce' ) }
-					{ ...getInputControlProps( {
-						...getInputProps( 'regular_price' ),
-						context,
-					} ) }
+					{ ...regularPriceProps }
 					onChange={ ( value: string ) => {
 						const sanitizedValue = sanitizePrice( value );
 						setValue( 'regular_price', sanitizedValue );
@@ -129,20 +145,32 @@ export const PricingSection: React.FC = () => {
 				) }
 			</div>
 
-			<div className="woocommerce-product-form__custom-label-input">
-				<InputControl
-					label={ salePriceTitle }
+			<div
+				className={ classnames(
+					'woocommerce-product-form__custom-label-input',
+					{
+						'has-error': regularPriceProps?.help !== '',
+					}
+				) }
+			>
+				<BaseControl
 					id="sale_price"
-					placeholder={ __( '8.59', 'woocommerce' ) }
-					{ ...getInputControlProps( {
-						...getInputProps( 'sale_price' ),
-						context,
-					} ) }
-					onChange={ ( value: string ) => {
-						const sanitizedValue = sanitizePrice( value );
-						setValue( 'sale_price', sanitizedValue );
-					} }
-				/>
+					help={
+						salePriceProps && salePriceProps.help
+							? salePriceProps.help
+							: ''
+					}
+				>
+					<InputControl
+						label={ salePriceTitle }
+						placeholder={ __( '8.59', 'woocommerce' ) }
+						{ ...salePriceProps }
+						onChange={ ( value: string ) => {
+							const sanitizedValue = sanitizePrice( value );
+							setValue( 'sale_price', sanitizedValue );
+						} }
+					/>
+				</BaseControl>
 			</div>
 		</ProductSectionLayout>
 	);

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -426,6 +426,8 @@ describe( 'Validations', () => {
 			'Please enter a price with one monetary decimal point without thousand separators and currency symbols.';
 		const salePriceErrorMessage =
 			'Please enter a price with one monetary decimal point without thousand separators and currency symbols.';
+		const highSalePriceErrorMessage =
+			'Sale price cannot be higher than list price.';
 		const productWithoutName: Partial< Product > = {
 			name: '',
 		};
@@ -443,15 +445,23 @@ describe( 'Validations', () => {
 		};
 		const productSalePriceWithText: Partial< Product > = {
 			name: 'My Product',
+			regular_price: '201',
 			sale_price: 'text',
 		};
 		const productSalePriceWithNotAllowedCharacters: Partial< Product > = {
 			name: 'My Product',
+			regular_price: '201',
 			sale_price: '%&@#¢∞¬÷200',
 		};
 		const productSalePriceWithSpaces: Partial< Product > = {
 			name: 'My Product',
+			regular_price: '201',
 			sale_price: '2 0 0',
+		};
+		const productSalePriceHigherThanRegular: Partial< Product > = {
+			name: 'My Product',
+			regular_price: '201',
+			sale_price: '202',
 		};
 		const validProduct: Partial< Product > = {
 			name: 'My Product',
@@ -481,6 +491,9 @@ describe( 'Validations', () => {
 		);
 		expect( validate( productSalePriceWithSpaces ) ).toEqual( {
 			sale_price: salePriceErrorMessage,
+		} );
+		expect( validate( productSalePriceHigherThanRegular ) ).toEqual( {
+			sale_price: highSalePriceErrorMessage,
 		} );
 		expect( validate( validProduct ) ).toEqual( {} );
 	} );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -427,7 +427,7 @@ describe( 'Validations', () => {
 		const salePriceErrorMessage =
 			'Please enter a price with one monetary decimal point without thousand separators and currency symbols.';
 		const highSalePriceErrorMessage =
-			'Sale price cannot be higher than list price.';
+			'Sale price cannot be equal to or higher than list price.';
 		const productWithoutName: Partial< Product > = {
 			name: '',
 		};

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useContext, useState } from '@wordpress/element';
 import {
 	Product,
 	ProductsStoreActions,
@@ -14,6 +14,15 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { navigateTo } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { CurrencyContext } from '../lib/currency-context';
+import {
+	NUMBERS_AND_DECIMAL_SEPARATOR,
+	ONLY_ONE_DECIMAL_SEPARATOR,
+} from './constants';
 
 function removeReadonlyProperties(
 	product: Product
@@ -48,6 +57,9 @@ export function useProductHelper() {
 		draft: false,
 		publish: false,
 	} );
+	const context = useContext( CurrencyContext );
+	const { getCurrencyConfig } = context;
+	const { decimalSeparator } = getCurrencyConfig();
 
 	/**
 	 * Create product with status.
@@ -248,11 +260,38 @@ export function useProductHelper() {
 		[]
 	);
 
+	/**
+	 * Sanitizes a price.
+	 *
+	 * @param {string} price the price that will be sanitized.
+	 * @return {string} sanitized price.
+	 */
+	const sanitizePrice = useCallback(
+		( price: string ) => {
+			// Build regex to strip out everything except digits, decimal point and minus sign.
+			const regex = new RegExp(
+				NUMBERS_AND_DECIMAL_SEPARATOR.replace( '%s', decimalSeparator ),
+				'g'
+			);
+			const decimalRegex = new RegExp(
+				ONLY_ONE_DECIMAL_SEPARATOR.replaceAll( '%s', decimalSeparator ),
+				'g'
+			);
+			const cleanValue = price
+				.replace( regex, '' )
+				.replace( decimalRegex, '' )
+				.replace( decimalSeparator, '.' );
+			return cleanValue;
+		},
+		[ decimalSeparator ]
+	);
+
 	return {
 		createProductWithStatus,
 		updateProductWithStatus,
 		copyProductWithStatus,
 		deleteProductAndRedirect,
+		sanitizePrice,
 		isUpdatingDraft: updating.draft,
 		isUpdatingPublished: updating.publish,
 		isDeleting,

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -58,8 +58,6 @@ export function useProductHelper() {
 		publish: false,
 	} );
 	const context = useContext( CurrencyContext );
-	const { getCurrencyConfig } = context;
-	const { decimalSeparator } = getCurrencyConfig();
 
 	/**
 	 * Create product with status.
@@ -268,6 +266,8 @@ export function useProductHelper() {
 	 */
 	const sanitizePrice = useCallback(
 		( price: string ) => {
+			const { getCurrencyConfig } = context;
+			const { decimalSeparator } = getCurrencyConfig();
 			// Build regex to strip out everything except digits, decimal point and minus sign.
 			const regex = new RegExp(
 				NUMBERS_AND_DECIMAL_SEPARATOR.replace( '%s', decimalSeparator ),
@@ -283,7 +283,7 @@ export function useProductHelper() {
 				.replace( decimalSeparator, '.' );
 			return cleanValue;
 		},
-		[ decimalSeparator ]
+		[ context ]
 	);
 
 	return {

--- a/plugins/woocommerce/changelog/update-30_list_price_field_follow_up
+++ b/plugins/woocommerce/changelog/update-30_list_price_field_follow_up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Price section - Small refactor and style fix


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes a few things related to the prices section and addresses a couple of suggestions made for [this PR](https://github.com/woocommerce/woocommerce/pull/34382).

It adds:
- a small visual bugfix (the help tooltip popped up too high)
- a refactor of the method to sanitize the price.
- a change in the Sale price validation (now the Sale price has to be equal to or higher than the List price).
- an error message when the `Sale price` has an error.

Closes # 38-gh-woocommerce/mothra-private.

### How to test the changes in this Pull Request:

1. Verify that the `Feature this product` tooltip looks and works correctly.

![Screen Shot 2022-09-07 at 12 26 57](https://user-images.githubusercontent.com/1314156/189352458-020bfbdd-a2a0-49bd-ba40-fe2aa79e3dd9.png)

2. Verify that the prices look correct. Check the testing [instructions here](https://github.com/woocommerce/woocommerce/pull/34382) too.
3. Create a new product without `List price` but with a `Sale price` and verify that the error message `Sale price cannot be equal to or higher than list price.` is being shown after the `Sale price` loses the focus.
4. Set a `Sale price` equal to or higher than the `List price` and verify that the warning `Sale price cannot be equal to or higher than list price.` is visible under the `Sale price`.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.