### PR TITLE
Products pricing section code cleanup

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -45,7 +45,7 @@ export const PricingSection: React.FC = () => {
 	const context = useContext( CurrencyContext );
 	const { getCurrencyConfig } = context;
 	const { decimalSeparator } = getCurrencyConfig();
-	const sanitizeAndSetPrice = ( value: string, name: string ) => {
+	const sanitizeAndSetPrice = ( name: string, value: string ) => {
 		// Build regex to strip out everything except digits, decimal point and minus sign.
 		const regex = new RegExp(
 			NUMBERS_AND_DECIMAL_SEPARATOR.replace( '%s', decimalSeparator ),
@@ -134,7 +134,7 @@ export const PricingSection: React.FC = () => {
 						context,
 					} ) }
 					onChange={ ( value: string ) =>
-						sanitizeAndSetPrice( value, 'regular_price' )
+						sanitizeAndSetPrice( 'regular_price', value )
 					}
 				/>
 				{ ! isTaxSettingsResolving && (
@@ -154,7 +154,7 @@ export const PricingSection: React.FC = () => {
 						context,
 					} ) }
 					onChange={ ( value: string ) =>
-						sanitizeAndSetPrice( value, 'sale_price' )
+						sanitizeAndSetPrice( 'sale_price', value )
 					}
 				/>
 			</div>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -45,7 +45,7 @@ export const PricingSection: React.FC = () => {
 	const context = useContext( CurrencyContext );
 	const { getCurrencyConfig } = context;
 	const { decimalSeparator } = getCurrencyConfig();
-	const priceValidation = ( value: string, name: string ) => {
+	const sanitizeAndSetPrice = ( value: string, name: string ) => {
 		// Build regex to strip out everything except digits, decimal point and minus sign.
 		const regex = new RegExp(
 			NUMBERS_AND_DECIMAL_SEPARATOR.replace( '%s', decimalSeparator ),
@@ -134,7 +134,7 @@ export const PricingSection: React.FC = () => {
 						context,
 					} ) }
 					onChange={ ( value: string ) =>
-						priceValidation( value, 'regular_price' )
+						sanitizeAndSetPrice( value, 'regular_price' )
 					}
 				/>
 				{ ! isTaxSettingsResolving && (
@@ -154,7 +154,7 @@ export const PricingSection: React.FC = () => {
 						context,
 					} ) }
 					onChange={ ( value: string ) =>
-						priceValidation( value, 'sale_price' )
+						sanitizeAndSetPrice( value, 'sale_price' )
 					}
 				/>
 			</div>

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -11,7 +11,7 @@ import { NUMBERS_AND_ALLOWED_CHARS } from '../constants';
 
 type gettersProps = {
 	context?: {
-		formatCurrency: ( number: number | string ) => string;
+		formatAmount: ( number: number | string ) => string;
 		getCurrencyConfig: () => {
 			code: string;
 			symbol: string;
@@ -80,7 +80,7 @@ export const getInputControlProps = ( {
 	if ( ! context ) {
 		return;
 	}
-	const { formatCurrency, getCurrencyConfig } = context;
+	const { formatAmount, getCurrencyConfig } = context;
 	const { decimalSeparator, symbol, symbolPosition, thousandSeparator } =
 		getCurrencyConfig();
 	const currencyPosition = symbolPosition.includes( 'left' )
@@ -98,7 +98,7 @@ export const getInputControlProps = ( {
 	const currencyString =
 		value === undefined
 			? value
-			: formatCurrency( value ).replace( regex, '' );
+			: formatAmount( value ).replace( regex, '' );
 	return {
 		value: currencyString,
 		[ currencyPosition ]: symbol,


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses a few code issues in the products pricing section:

* ~Removes a bit of unused code~
* Switches from `Currency().formatCurrency`, which is deprecated, to `Currency().formatAmount`
* Renames `priceValidation` to `sanitizeAndSetPrice`, which is more accurate (it was not validating the price, but rather sanitizing it and then setting it) and swaps the order of the `name` and `value`, which is more natural (name, value vs value, name)

This is a follow up to #34382

### How to test the changes in this Pull Request:

1. Go to `Products`> `Add New (MVP` and create a product.
2. Verify that settings the regular and sale price works properly still, including sanitizing of any input value (no regression; functionality should be identical).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
