### PR TITLE
Coupons Controller → Import `Exception` class.

### DIFF
--- a/plugins/woocommerce/changelog/spotfix-coupons-controller
+++ b/plugins/woocommerce/changelog/spotfix-coupons-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error when throwing exceptions in relation to coupon usage.

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Internal\Orders;
 
+use Exception;
+
 /**
  * Class with methods for handling order coupons.
  */


### PR DESCRIPTION
Within `Automattic\WooCommerce\Internal\Orders\CouponsController` we reference the `Exception` type, but it is not fully qualified and there is no matching import statement. So, it is consequently expanded to:

`Automattic\WooCommerce\Internal\Orders\Exception`

That doesn't actually exist, so we likely intended to use a generic `Exception`. This change resolves that issue.

### STEPS TO REPLICATE

1. Manually create or edit an order.
2. Try to apply a non-existent coupon code.
3. You should see an error informing you the coupon code does not exist:

![discount-does-not-exist](https://user-images.githubusercontent.com/3594411/188220887-aa48eb44-1679-4807-98d0-765e8c0ece24.png)

4. Whereas, with current `trunk` code checked out, you will experience:
    - The above message will not appear: you will just see a spinner icon that keeps spinning indefinitely.
    - If you monitor the dev console, you will see the corresponding ajax request resulted in a 500 Internal Server Error.
    - In your error log, you may see an entry looking something like `Uncaught Error: Class "Automattic\WooCommerce\Internal\Orders\Exception" not found in /.../src/Internal/Orders/CouponsController.php:80`

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
