### PR TITLE
Fix product list price help label to properly reflect tax settings

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -63,16 +63,19 @@ export const PricingSection: React.FC = () => {
 		return cleanValue;
 	};
 
-	const taxSettingsText =
-		'Per your {{link}}store settings{{/link}}, tax is {{strong}}%sincluded{{/strong}} in the price.';
-	const addNot = pricesIncludeTax ? '' : 'not ';
-	taxSettingsText.replace( taxSettingsText, addNot );
+	const taxIncludedInPriceText = __(
+		'Per your {{link}}store settings{{/link}}, tax is {{strong}}included{{/strong}} in the price.',
+		'woocommerce'
+	);
+	const taxNotIncludedInPriceText = __(
+		'Per your {{link}}store settings{{/link}}, tax is {{strong}}not included{{/strong}} in the price.',
+		'woocommerce'
+	);
 
 	const taxSettingsElement = interpolateComponents( {
-		mixedString: __(
-			'Per your {{link}}store settings{{/link}}, tax is {{strong}}not included{{/strong}} in the price.',
-			'woocommerce'
-		),
+		mixedString: pricesIncludeTax
+			? taxIncludedInPriceText
+			: taxNotIncludedInPriceText,
 		components: {
 			link: (
 				<Link
@@ -80,7 +83,9 @@ export const PricingSection: React.FC = () => {
 					target="_blank"
 					type="external"
 					onClick={ () => {
-						recordEvent( 'product_pricing_list_price_help' );
+						recordEvent(
+							'product_pricing_list_price_help_tax_settings_click'
+						);
 					} }
 				>
 					<></>

--- a/plugins/woocommerce/changelog/fix-products-pricing-tax-included-label
+++ b/plugins/woocommerce/changelog/fix-products-pricing-tax-included-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix product list price help label to properly reflect tax settings.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the helper text shown below the list price field to reflect whether taxes are to be included in the price or not.

Follow up to #34382

### How to test the changes in this Pull Request:

1. Go to `Products` > `Add New (MVP)` and create a product.
2. If tax is included in the price, the helper text reads: "Per your store settings, tax is **included** in the price."
3. If tax is excluded from the price, the helper text reads: "Per your store settings, tax is **not included** in the price."
4. Verify that clicking "store settings" in the label below the list price takes you to `wp-admin/admin.php?page=wc-settings&tab=tax`
5. Verify that clicking "store settings" fires the `wcadmin_product_pricing_list_price_help_tax_settings_click` Tracks event

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
