### PR TITLE
fix-marketing-slider-image-size

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/components/knowledge-base/style.scss
+++ b/plugins/woocommerce-admin/client/marketing/components/knowledge-base/style.scss
@@ -64,8 +64,8 @@
 					position: absolute;
 					top: 0;
 					right: 0;
-					height: 100%;
-					width: auto;
+					height: auto;
+					width: 100%;
 				}
 			}
 		}

--- a/plugins/woocommerce/changelog/fix-marketing-slider-image-size
+++ b/plugins/woocommerce/changelog/fix-marketing-slider-image-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed the image size issue in the marketing slider.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We have fixed the image size issue in the marketing slider.

![CleanShot 2022-09-06 at 17 32 24](https://user-images.githubusercontent.com/72435501/188630271-ec56d358-ed93-44b2-a0ca-b3b90c0acf39.jpeg)


Closes #34580  .

### How to test the changes in this Pull Request:

1. Go to the backend of the site
2. Go to "Marketing" page
3. Then you will see that the images are **NOT** getting cut in the "WooCommerce Knowledge base" slider.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
