### PR TITLE
Fix recording events without props

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracking_events_without_props
+++ b/plugins/woocommerce/changelog/fix-tracking_events_without_props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix recording events without props #34595

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -81,7 +81,7 @@ class WC_Site_Tracking {
 		<script type="text/javascript">
 			window.wcTracks = window.wcTracks || {};
 			window.wcTracks.isEnabled = <?php echo self::is_tracking_enabled() ? 'true' : 'false'; ?>;
-			window.wcTracks.validateEvent = function( eventName, props ) {
+			window.wcTracks.validateEvent = function( eventName, props = {} ) {
 				let isValid = true;
 				if ( ! <?php echo esc_js( WC_Tracks_Event::EVENT_NAME_REGEX ); ?>.test( eventName ) ) {
 					if ( <?php echo $environment_type !== 'production' ? 'true' : 'false'; ?> ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the changes to allow record events without props.
The PR [34005](https://github.com/woocommerce/woocommerce/pull/34005) added an event validation but that addition didn't allow recording events without props. With this PR that scenario is allowed again.

### How to test the changes in this Pull Request:

1. Go to the new product management experience (`Products > Add New (MVP)`)
2. Verify the event `wcadmin_view_new_product_management_experience` is being recorded.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
