### PR TITLE
Remove path restriction from Lint and Test JS job

### DIFF
--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -1,41 +1,36 @@
 name: Lint and tests for JS packages and woocommerce-admin/client
 
-on:
-  pull_request:
-    paths:
-      - 'packages/js/**/**'
-      - 'plugins/woocommerce-admin/client/**'
-      - '!**.md'
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: pull_request
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  lint-test-js:
-    name: Lint and Test JS
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-      
-      - uses: ./.github/actions/cache-deps
-        with:
-          workflow_name: pr-lint-test-js
-          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+    lint-test-js:
+        name: Lint and Test JS
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: '16'
 
-      - name: Install and Build
-        uses: ./.github/actions/install-build
+            - uses: ./.github/actions/cache-deps
+              with:
+                  workflow_name: pr-lint-test-js
+                  workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
 
-      - name: Lint
-        run: pnpm run lint --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
 
-      - name: Test
-        run: pnpm run test --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color
+            - name: Install and Build
+              uses: ./.github/actions/install-build
+
+            - name: Lint
+              run: pnpm run lint --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color
+
+            - name: Test
+              run: pnpm run test --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `Lint and Test JS` check runs unit testing and linting on wc-admin and all of its dependencies. This seems like a crucial test we should run before merging PRs. Unfortunately, the `path` delimiter means that the check will always be `pending` if no code touches anything in the `path` parameter when the check is marked as `required`. This leaves us the only option to remove the `path` parameter so this check can be required to merge a PR.

### How to test the changes in this Pull Request:

1. Confirm the `Lint and Test JS` check runs

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
