### PR TITLE
fix: add tracks for shipping default settings tour

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-default-settings-tour-tracks-events
+++ b/plugins/woocommerce/changelog/fix-shipping-default-settings-tour-tracks-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added in the missing tracks events for the shipping default settings tour


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds tracks events for the shipping smart defaults settings tour.

The tracks that were added are:

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_walkthrough_settings_shipping_view`   |
| What does the track measure      | View count for shipping settings walkthrough. |
| When does the track fire      | When a user views the shipping settings walkthrough. |
| Event properties      | - |

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_walkthrough_settings_shipping_dismissed`   |
| What does the track measure      | Dismissal count for shipping settings walkthrough. |
| When does the track fire      | When a user dismisses or closes shipping settings walkthrough before the last step. |
| Event properties      | step_name: The name of the particular step when the dismissal occurs, i.e: `shipping-zones`, `shipping-methods`, `woocommerce-shipping` |


| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_walkthrough_settings_shipping_completed`   |
| What does the track measure      | Completion count for shipping settings walkthrough.  |
| When does the track fire      | When a user completes shipping settings walkthrough. |
| Event properties      | - |


| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_walkthrough_settings_shipping_next_click`   |
| What does the track measure      | Click count for next buttons in shipping settings walkthrough.  |
| When does the track fire      | When a user clicks the next button in shipping settings walkthrough. |
| Event properties      | step_name: The name of the particular step, i.e: `shipping-zones`, `shipping-methods`, `woocommerce-shipping`  |

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_walkthrough_settings_shipping_back_click`   |
| What does the track measure      | Click count for back buttons in shipping settings walkthrough.  |
| When does the track fire      | When a user clicks the back button in shipping settings walkthrough. |
| Event properties      | step_name: The name of the particular step, i.e: `shipping-zones`, `shipping-methods`, `woocommerce-shipping`  |


### How to test the changes in this Pull Request:

1. Start with a fresh install of WooCommerce, and enable tracks debug logging by entering `localStorage.debug="*"
2. Start OBW and choose `United States` as store country
3. Choose "Physical products" 
4. Complete the OBW without installing anything from the `Business Details` tab.
5. Navigate to WooCommerce -> Settings -> Shipping
6. "United States (US)" zone should be created with `Free shipping` method
7. There should be a partial tour kit spotlight over the two leftmost columns for step 1 of the tour
8. Check that proceeding through the tour works as expected, and that the tracks events are correctly logged for any permutation of sequences

![image](https://user-images.githubusercontent.com/27843274/188845158-7906b6aa-904f-4e15-8a09-3d8eb1e83404.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
