### PR TITLE
fix: set shipping defaults when address details not filled out

### DIFF
--- a/plugins/woocommerce/changelog/fix-shipping-defaults-when-address-not-set
+++ b/plugins/woocommerce/changelog/fix-shipping-defaults-when-address-not-set
@@ -1,0 +1,4 @@
+Significance: minor 
+Type: fix
+
+Shipping defaults is now set when the user completes onboarding profiler, even if they did not set their address details

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -97,9 +97,15 @@ class Homescreen {
 			return $settings;
 		}
 
-		$user_skipped_obw = $settings['onboarding']['profile']['skipped'] ?? false;
-		$store_address    = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
-		$product_types    = $settings['onboarding']['profile']['product_types'] ?? array();
+		$user_skipped_obw           = $settings['onboarding']['profile']['skipped'] ?? false;
+		$store_address              = $settings['preloadSettings']['general']['woocommerce_store_address'] ?? '';
+		$product_types              = $settings['onboarding']['profile']['product_types'] ?? array();
+		$user_has_set_store_country = $settings['onboarding']['profile']['is_store_country_set'] ?? false;
+
+		// Do not proceed if user has not filled out their country in the onboarding profiler.
+		if ( ! $user_has_set_store_country ) {
+			return $settings;
+		}
 
 		// If user skipped the obw or has not completed the store_details
 		// then we assume the user is going to sell physical products.
@@ -113,13 +119,6 @@ class Homescreen {
 
 		$country_code = wc_format_country_state_string( $settings['preloadSettings']['general']['woocommerce_default_country'] )['country'];
 		$country_name = WC()->countries->get_countries()[ $country_code ] ?? null;
-
-		// we also need to make sure woocommerce_store_address is not empty
-		// to make sure store country is set by an actual user
-		// since woocommerce_store_address is set to US:CA by default.
-		if ( '' === $country_code || null === $country_name || '' === $store_address ) {
-			return $settings;
-		}
 
 		$is_jetpack_installed = in_array( 'jetpack', $settings['plugins']['installedPlugins'] ?? array(), true );
 		$is_wcs_installed     = in_array( 'woocommerce-services', $settings['plugins']['installedPlugins'] ?? array(), true );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1662617142524119-slack-C01SFMVEYAK

It was noticed that if the user completes the onboarding profiler without filling in their address details (which are not mandatory anymore since https://github.com/woocommerce/woocommerce/pull/34176) then the shipping smart defaults flow would not kick in.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Go to OBW
1. Select a "Country", but NOT fill the "Address"
1. Complete the rest of OBW with "physical products" and any other required details
1. Upon completing the OBW you should notice that there is a item to "Review Shipping Details" and clicking on it should bring you to the shipping settings page which should have a free shipping default filled in.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.