### PR TITLE
Fix form onchange callback

### DIFF
--- a/packages/js/components/changelog/fix-34584_form_onchange_callback
+++ b/packages/js/components/changelog/fix-34584_form_onchange_callback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue with form onChange handler, passing outdated values.

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -97,11 +97,16 @@ function FormComponent< Values extends Record< string, any > >(
 		[ P in keyof Values ]?: boolean;
 	} >( props.touched || {} );
 
-	const validate = useCallback(
+	const validate: (
+		newValues: Values,
+		onValidate?: ( newErrors: {
+			[ P in keyof Values ]?: string;
+		} ) => void
+	) => void = useCallback(
 		( newValues: Values, onValidate = () => {} ) => {
 			const newErrors = props.validate ? props.validate( newValues ) : {};
 			setErrors( newErrors || {} );
-			onValidate();
+			onValidate( newErrors );
 		},
 		[ props.validate ]
 	);
@@ -150,7 +155,7 @@ function FormComponent< Values extends Record< string, any > >(
 					[ name ]: false,
 				} );
 			}
-			validate( newValues, () => {
+			validate( newValues, ( newErrors ) => {
 				const { onChangeCallback } = props;
 
 				// Note that onChange is a no-op by default so this will never be null
@@ -169,7 +174,7 @@ function FormComponent< Values extends Record< string, any > >(
 					callback(
 						{ name, value },
 						newValues,
-						! Object.keys( errors || {} ).length
+						!! Object.keys( newErrors || {} ).length
 					);
 				}
 			} );

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -134,7 +134,8 @@ function FormComponent< Values extends Record< string, any > >(
 	const setValue = useCallback(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( name: string, value: any ) => {
-			setValues( { ...values, [ name ]: value } );
+			const newValues = { ...values, [ name ]: value };
+			setValues( newValues );
 			if ( initialValues[ name ] !== value && ! changedFields[ name ] ) {
 				setChangedFields( {
 					...changedFields,
@@ -149,7 +150,7 @@ function FormComponent< Values extends Record< string, any > >(
 					[ name ]: false,
 				} );
 			}
-			validate( { ...values, [ name ]: value }, () => {
+			validate( newValues, () => {
 				const { onChangeCallback } = props;
 
 				// Note that onChange is a no-op by default so this will never be null
@@ -167,7 +168,7 @@ function FormComponent< Values extends Record< string, any > >(
 				if ( callback ) {
 					callback(
 						{ name, value },
-						values,
+						newValues,
 						! Object.keys( errors || {} ).length
 					);
 				}

--- a/packages/js/components/src/form/stories/index.js
+++ b/packages/js/components/src/form/stories/index.js
@@ -29,7 +29,7 @@ const initialValues = {
 	lastName: '',
 	select: '3',
 	checkbox: true,
-	radio: '2',
+	radio: 'one',
 };
 
 export const Basic = () => {
@@ -47,55 +47,59 @@ export const Basic = () => {
 				onChange={ handleChange }
 				initialValues={ initialValues }
 			>
-				{ ( { getInputProps, values, errors, handleSubmit } ) => (
-					<div>
-						<TextControl
-							label={ 'First Name' }
-							{ ...getInputProps( 'firstName' ) }
-						/>
-						<TextControl
-							label={ 'Last Name' }
-							{ ...getInputProps( 'lastName' ) }
-						/>
-						<SelectControl
-							label="Select"
-							options={ [
-								{ label: 'Option 1', value: '1' },
-								{ label: 'Option 2', value: '2' },
-								{ label: 'Option 3', value: '3' },
-							] }
-							{ ...getInputProps( 'select' ) }
-						/>
-						<CheckboxControl
-							label="Checkbox"
-							{ ...getInputProps( 'checkbox' ) }
-						/>
-						<RadioControl
-							label="Radio"
-							options={ [
-								{ label: 'Option 1', value: '1' },
-								{ label: 'Option 2', value: '2' },
-								{ label: 'Option 3', value: '3' },
-							] }
-							{ ...getInputProps( 'radio' ) }
-						/>
-						<Button
-							isPrimary
-							onClick={ handleSubmit }
-							disabled={ Object.keys( errors ).length }
-						>
-							Submit
-						</Button>
-						<br />
-						<br />
-						<h3>Return data:</h3>
-						<pre>
-							Values: { JSON.stringify( values ) }
+				{ ( { getInputProps, values, errors, handleSubmit } ) => {
+					const radioInputProps = getInputProps( 'radio' );
+					return (
+						<div>
+							<TextControl
+								label={ 'First Name' }
+								{ ...getInputProps( 'firstName' ) }
+							/>
+							<TextControl
+								label={ 'Last Name' }
+								{ ...getInputProps( 'lastName' ) }
+							/>
+							<SelectControl
+								label="Select"
+								options={ [
+									{ label: 'Option 1', value: '1' },
+									{ label: 'Option 2', value: '2' },
+									{ label: 'Option 3', value: '3' },
+								] }
+								{ ...getInputProps( 'select' ) }
+							/>
+							<CheckboxControl
+								label="Checkbox"
+								{ ...getInputProps( 'checkbox' ) }
+							/>
+							<RadioControl
+								label="Radio"
+								onChange={ radioInputProps.onChange }
+								selected={ radioInputProps.value }
+								options={ [
+									{ label: 'Option 1', value: 'one' },
+									{ label: 'Option 2', value: 'two' },
+									{ label: 'Option 3', value: 'three' },
+								] }
+							/>
+							<Button
+								isPrimary
+								onClick={ handleSubmit }
+								disabled={ Object.keys( errors ).length }
+							>
+								Submit
+							</Button>
 							<br />
-							Errors: { JSON.stringify( errors ) }
-						</pre>
-					</div>
-				) }
+							<br />
+							<h3>Return data:</h3>
+							<pre>
+								Values: { JSON.stringify( values ) }
+								<br />
+								Errors: { JSON.stringify( errors ) }
+							</pre>
+						</div>
+					);
+				} }
 			</Form>
 			<div>
 				<pre>onChange values: { JSON.stringify( onChangeValues ) }</pre>

--- a/packages/js/components/src/form/stories/index.js
+++ b/packages/js/components/src/form/stories/index.js
@@ -8,6 +8,7 @@ import {
 	SelectControl,
 	TextControl,
 } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { Form } from '@woocommerce/components';
 
 const validate = ( values ) => {
@@ -31,63 +32,77 @@ const initialValues = {
 	radio: '2',
 };
 
-export const Basic = () => (
-	<Form
-		validate={ validate }
-		onSubmit={ onSubmit }
-		initialValues={ initialValues }
-	>
-		{ ( { getInputProps, values, errors, handleSubmit } ) => (
+export const Basic = () => {
+	const [ onChangeValues, setOnChangeValues ] = useState( {} );
+
+	const handleChange = ( change, newValues ) => {
+		setOnChangeValues( newValues );
+	};
+
+	return (
+		<div>
+			<Form
+				validate={ validate }
+				onSubmit={ onSubmit }
+				onChange={ handleChange }
+				initialValues={ initialValues }
+			>
+				{ ( { getInputProps, values, errors, handleSubmit } ) => (
+					<div>
+						<TextControl
+							label={ 'First Name' }
+							{ ...getInputProps( 'firstName' ) }
+						/>
+						<TextControl
+							label={ 'Last Name' }
+							{ ...getInputProps( 'lastName' ) }
+						/>
+						<SelectControl
+							label="Select"
+							options={ [
+								{ label: 'Option 1', value: '1' },
+								{ label: 'Option 2', value: '2' },
+								{ label: 'Option 3', value: '3' },
+							] }
+							{ ...getInputProps( 'select' ) }
+						/>
+						<CheckboxControl
+							label="Checkbox"
+							{ ...getInputProps( 'checkbox' ) }
+						/>
+						<RadioControl
+							label="Radio"
+							options={ [
+								{ label: 'Option 1', value: '1' },
+								{ label: 'Option 2', value: '2' },
+								{ label: 'Option 3', value: '3' },
+							] }
+							{ ...getInputProps( 'radio' ) }
+						/>
+						<Button
+							isPrimary
+							onClick={ handleSubmit }
+							disabled={ Object.keys( errors ).length }
+						>
+							Submit
+						</Button>
+						<br />
+						<br />
+						<h3>Return data:</h3>
+						<pre>
+							Values: { JSON.stringify( values ) }
+							<br />
+							Errors: { JSON.stringify( errors ) }
+						</pre>
+					</div>
+				) }
+			</Form>
 			<div>
-				<TextControl
-					label={ 'First Name' }
-					{ ...getInputProps( 'firstName' ) }
-				/>
-				<TextControl
-					label={ 'Last Name' }
-					{ ...getInputProps( 'lastName' ) }
-				/>
-				<SelectControl
-					label="Select"
-					options={ [
-						{ label: 'Option 1', value: '1' },
-						{ label: 'Option 2', value: '2' },
-						{ label: 'Option 3', value: '3' },
-					] }
-					{ ...getInputProps( 'select' ) }
-				/>
-				<CheckboxControl
-					label="Checkbox"
-					{ ...getInputProps( 'checkbox' ) }
-				/>
-				<RadioControl
-					label="Radio"
-					options={ [
-						{ label: 'Option 1', value: '1' },
-						{ label: 'Option 2', value: '2' },
-						{ label: 'Option 3', value: '3' },
-					] }
-					{ ...getInputProps( 'radio' ) }
-				/>
-				<Button
-					isPrimary
-					onClick={ handleSubmit }
-					disabled={ Object.keys( errors ).length }
-				>
-					Submit
-				</Button>
-				<br />
-				<br />
-				<h3>Return data:</h3>
-				<pre>
-					Values: { JSON.stringify( values ) }
-					<br />
-					Errors: { JSON.stringify( errors ) }
-				</pre>
+				<pre>onChange values: { JSON.stringify( onChangeValues ) }</pre>
 			</div>
-		) }
-	</Form>
-);
+		</div>
+	);
+};
 
 export default {
 	title: 'WooCommerce Admin/components/Form',

--- a/packages/js/components/src/form/test/index.tsx
+++ b/packages/js/components/src/form/test/index.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { createElement, Fragment } from '@wordpress/element';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -144,6 +145,93 @@ describe( 'Form', () => {
 		await waitFor( () =>
 			expect( mockOnChange ).toHaveBeenCalledTimes( 1 )
 		);
+	} );
+
+	it( 'should call onChange with latest changed values', () => {
+		const mockOnChange = jest.fn();
+
+		const { queryByLabelText } = render(
+			<Form onChange={ mockOnChange } validate={ () => ( {} ) }>
+				{ ( {
+					setValue,
+					getInputProps,
+				}: FormContext< Record< string, string > > ) => {
+					return (
+						<TextControl
+							label={ 'First Name' }
+							{ ...getInputProps( 'firstName' ) }
+						/>
+					);
+				} }
+			</Form>
+		);
+
+		const firstNameInput = queryByLabelText( 'First Name' );
+		if ( firstNameInput ) {
+			fireEvent.change( firstNameInput, { target: { value: 'F' } } );
+			expect( mockOnChange ).toHaveBeenCalledWith(
+				{ name: 'firstName', value: 'F' },
+				{ firstName: 'F' },
+				false
+			);
+
+			fireEvent.change( firstNameInput, { target: { value: 'Fi' } } );
+			expect( mockOnChange ).toHaveBeenCalledWith(
+				{ name: 'firstName', value: 'Fi' },
+				{ firstName: 'Fi' },
+				false
+			);
+		}
+	} );
+
+	it( 'should call onChange with latest hasErrors', () => {
+		const mockOnChange = jest.fn();
+
+		type TestData = {
+			firstName: string;
+		};
+
+		const validate = ( data: TestData ): Record< string, string > => {
+			if ( data.firstName && data.firstName.length < 2 ) {
+				return {
+					firstName: 'Must be greater then 1',
+				};
+			}
+			return {};
+		};
+
+		const { queryByLabelText } = render(
+			<Form< TestData > onChange={ mockOnChange } validate={ validate }>
+				{ ( {
+					setValue,
+					getInputProps,
+				}: FormContext< Record< string, string > > ) => {
+					return (
+						<TextControl
+							label={ 'First Name' }
+							{ ...getInputProps( 'firstName' ) }
+						/>
+					);
+				} }
+			</Form>
+		);
+
+		const firstNameInput = queryByLabelText( 'First Name' );
+		if ( firstNameInput ) {
+			fireEvent.change( firstNameInput, { target: { value: 'F' } } );
+			expect( mockOnChange ).toHaveBeenCalledWith(
+				{ name: 'firstName', value: 'F' },
+				{ firstName: 'F' },
+				true
+			);
+
+			fireEvent.change( firstNameInput, { target: { value: 'Fi' } } );
+			expect( mockOnChange ).toHaveBeenCalledWith(
+				{ name: 'firstName', value: 'Fi' },
+				{ firstName: 'Fi' },
+				false
+			);
+		}
 	} );
 
 	describe( 'FormContext', () => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes issue were we are not passing the latest changed value into the `onChange` method. This bug was introduced as part of #34082

Closes #34584 .

<img width="771" alt="Screen Shot 2022-09-08 at 11 06 46 AM" src="https://user-images.githubusercontent.com/2240960/189143405-0576ebaf-d44c-41e0-8546-15ec57e715a9.png">

### How to test the changes in this Pull Request:

Forms within WooCommerce still seem to work correctly, so the easiest way to test is with the example used in the issue:
1.  Load this branch
2. Build & Run storybook `pnpm run build && pnpm run storybook`
3. Load the form component in storybook and check if the onChange values match the form values above it as you update the fields (see screenshot).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
