### PR TITLE
Add 2 new GitHub Actions workflows to include COT E2E and API automated tests in CI.

### DIFF
--- a/.github/workflows/cot-build-and-e2e-tests-daily.yml
+++ b/.github/workflows/cot-build-and-e2e-tests-daily.yml
@@ -1,0 +1,210 @@
+name: Run daily tests in an environment with COT enabled
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cot-e2e-tests-run:
+    name: Runs E2E tests against COT env.
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: cot-main
+      - uses: ./.github/actions/cache-deps
+        with:
+          workflow_name: cot-pr-build-and-e2e-tests
+          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+
+      - name: Install and Build
+        uses: ./.github/actions/install-build
+
+      - name: Load docker images and start containers with COT enabled.
+        working-directory: plugins/woocommerce
+        run: pnpm env:test:cot --filter=woocommerce
+
+      - name: Download and install Chromium browser.
+        working-directory: plugins/woocommerce
+        run: pnpx playwright install chromium
+
+      - name: Run Playwright E2E tests.
+        timeout-minutes: 60
+        id: run_playwright_e2e_tests
+        env:
+          USE_WP_ENV: 1
+        working-directory: plugins/woocommerce
+        run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
+
+      - name: Generate Playwright E2E Test report.
+        id: generate_e2e_report
+        if: |
+          always() &&
+          (
+            steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
+            steps.run_playwright_e2e_tests.conclusion != 'skipped' 
+          )
+        working-directory: plugins/woocommerce
+        run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
+
+      - name: Archive Playwright E2E test report
+        if: |
+          always() &&
+          steps.generate_e2e_report.conclusion == 'success'
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-report---pr-${{ github.event.number }}
+          path: |
+            plugins/woocommerce/e2e/allure-results
+            plugins/woocommerce/e2e/allure-report
+          if-no-files-found: ignore
+          retention-days: 5
+
+  cot-api-tests-run:
+    name: Runs API tests against COT env.
+    runs-on: ubuntu-20.04
+    env:
+      API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: cot-main
+      - uses: ./.github/actions/cache-deps
+        with:
+          workflow_name: cot-pr-build-and-e2e-tests
+          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+
+      - name: Install and Build
+        uses: ./.github/actions/install-build
+
+      - name: Load docker images and start containers with COT enabled.
+        working-directory: plugins/woocommerce
+        run: pnpm env:test:cot --filter=woocommerce
+
+      - name: Run tests command.
+        working-directory: plugins/woocommerce
+        env:
+          BASE_URL: http://localhost:8086
+          USER_KEY: admin
+          USER_SECRET: password
+        run: pnpm exec wc-api-tests test api
+
+      - name: Archive API test report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: api-test-report---pr-${{ github.event.number }}
+          path: |
+            ${{ env.API_TEST_REPORT_DIR }}/allure-results
+            ${{ env.API_TEST_REPORT_DIR }}/allure-report
+          retention-days: 5
+
+  test-summary:
+    name: Post test results
+    if: |
+      always() && 
+      ! github.event.pull_request.head.repo.fork &&
+      (
+        contains( needs.*.result, 'success' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+    runs-on: ubuntu-20.04
+    needs: [cot-api-tests-run, cot-e2e-tests-run]
+    steps:
+      - name: Create dirs
+        run: |
+          mkdir -p repo
+          mkdir -p artifacts/api 
+          mkdir -p artifacts/e2e
+          mkdir -p output
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: repo
+
+      - name: Download API test report artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: api-test-report---pr-${{ github.event.number }}
+          path: artifacts/api
+
+      - name: Download Playwright E2E test report artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: e2e-test-report---pr-${{ github.event.number }}
+          path: artifacts/e2e
+
+      - name: Prepare test summary
+        id: prepare-test-summary
+        uses: actions/github-script@v6
+        env:
+          API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
+          E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
+          E2E_PPTR_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/test-results.json
+          PR_NUMBER: ${{ github.event.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          result-encoding: string
+          script: |
+            const script = require( './repo/.github/workflows/scripts/prepare-test-summary.js' )
+            return await script( { core } )
+      - name: Find PR comment by github-actions[bot]
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Test Results Summary
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.prepare-test-summary.outputs.result }}
+          edit-mode: replace
+
+  publish-test-reports:
+    name: Publish test reports
+    if: |
+      always() && 
+      ! github.event.pull_request.head.repo.fork &&
+      (
+        contains( needs.*.result, 'success' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+    runs-on: ubuntu-20.04
+    needs: [cot-api-tests-run, cot-e2e-tests-run]
+    env:
+      GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+      PR_NUMBER: ${{ github.event.number }}
+      RUN_ID: ${{ github.run_id }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Publish test reports
+        env:
+          API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
+          E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
+        run: |
+          gh workflow run publish-test-reports-pr.yml \
+            -f run_id=$RUN_ID \
+            -f api_artifact=$API_ARTIFACT \
+            -f e2e_artifact=$E2E_ARTIFACT \
+            -f pr_number=$PR_NUMBER \
+            -f commit_sha=$COMMIT_SHA \
+            -f s3_root=public \
+            --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/cot-build-and-e2e-tests-daily.yml
+++ b/.github/workflows/cot-build-and-e2e-tests-daily.yml
@@ -9,202 +9,182 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cot-e2e-tests-run:
-    name: Runs E2E tests against COT env.
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: cot-main
-      - uses: ./.github/actions/cache-deps
-        with:
-          workflow_name: cot-pr-build-and-e2e-tests
-          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+    cot-e2e-tests-run:
+        name: Runs E2E tests with COT enabled.
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
+            
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "7.4"
+            - name: Load docker images and start containers with COT enabled.
+              working-directory: plugins/woocommerce
+              run: pnpm env:test:cot --filter=woocommerce
 
-      - name: Install and Build
-        uses: ./.github/actions/install-build
+            - name: Download and install Chromium browser.
+              working-directory: plugins/woocommerce
+              run: pnpx playwright install chromium
 
-      - name: Load docker images and start containers with COT enabled.
-        working-directory: plugins/woocommerce
-        run: pnpm env:test:cot --filter=woocommerce
+            - name: Run Playwright E2E tests.
+              timeout-minutes: 60
+              id: run_playwright_e2e_tests
+              env:
+                USE_WP_ENV: 1
+              working-directory: plugins/woocommerce
+              run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
 
-      - name: Download and install Chromium browser.
-        working-directory: plugins/woocommerce
-        run: pnpx playwright install chromium
+            - name: Generate Playwright E2E Test report.
+              id: generate_e2e_report
+              if: |
+                  always() &&
+                  (
+                    steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
+                    steps.run_playwright_e2e_tests.conclusion != 'skipped' 
+                  )
+              working-directory: plugins/woocommerce
+              run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
 
-      - name: Run Playwright E2E tests.
-        timeout-minutes: 60
-        id: run_playwright_e2e_tests
+            - name: Archive Playwright E2E test report
+              if: |
+                  always() &&
+                  steps.generate_e2e_report.conclusion == 'success'
+              uses: actions/upload-artifact@v3
+              with:
+                  name: e2e-test-report---pr-${{ github.event.number }}
+                  path: |
+                      plugins/woocommerce/e2e/allure-results
+                      plugins/woocommerce/e2e/allure-report
+                  if-no-files-found: ignore
+                  retention-days: 5
+
+    cot-api-tests-run:
+        name: Runs API tests with COT enabled.
+        runs-on: ubuntu-20.04
         env:
-          USE_WP_ENV: 1
-        working-directory: plugins/woocommerce
-        run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
+            API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report
+        steps:
+            - uses: actions/checkout@v3
+            
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-      - name: Generate Playwright E2E Test report.
-        id: generate_e2e_report
+            - name: Load docker images and start containers with COT enabled.
+              working-directory: plugins/woocommerce
+              run: pnpm env:test:cot --filter=woocommerce
+
+            - name: Run tests command.
+              working-directory: plugins/woocommerce
+              env:
+                  BASE_URL: http://localhost:8086
+                  USER_KEY: admin
+                  USER_SECRET: password
+              run: pnpm exec wc-api-tests test api
+
+            - name: Archive API test report
+              if: always()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: api-test-report---pr-${{ github.event.number }}
+                  path: |
+                      ${{ env.API_TEST_REPORT_DIR }}/allure-results
+                      ${{ env.API_TEST_REPORT_DIR }}/allure-report
+                  retention-days: 5
+
+    test-summary:
+        name: Post test results
         if: |
-          always() &&
-          (
-            steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
-            steps.run_playwright_e2e_tests.conclusion != 'skipped' 
-          )
-        working-directory: plugins/woocommerce
-        run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
+            always() && 
+            ! github.event.pull_request.head.repo.fork &&
+            (
+              contains( needs.*.result, 'success' ) ||
+              contains( needs.*.result, 'failure' )
+            )
+        runs-on: ubuntu-20.04
+        needs: [cot-api-tests-run, cot-e2e-tests-run]
+        steps:
+            - name: Create dirs
+              run: |
+                  mkdir -p repo
+                  mkdir -p artifacts/api 
+                  mkdir -p artifacts/e2e
+                  mkdir -p output
 
-      - name: Archive Playwright E2E test report
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  path: repo
+
+            - name: Download API test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: api-test-report---pr-${{ github.event.number }}
+                  path: artifacts/api
+
+            - name: Download Playwright E2E test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: e2e-test-report---pr-${{ github.event.number }}
+                  path: artifacts/e2e
+
+            - name: Prepare test summary
+              id: prepare-test-summary
+              uses: actions/github-script@v6
+              env:
+                  API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
+                  E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
+                  E2E_PPTR_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/test-results.json
+                  PR_NUMBER: ${{ github.event.number }}
+                  SHA: ${{ github.event.pull_request.head.sha }}
+              with:
+                  result-encoding: string
+                  script: |
+                      const script = require( './repo/.github/workflows/scripts/prepare-test-summary.js' )
+                      return await script( { core } )
+
+            - name: Find PR comment by github-actions[bot]
+              uses: peter-evans/find-comment@v2
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: 'github-actions[bot]'
+                  body-includes: Test Results Summary
+
+            - name: Create or update PR comment
+              uses: peter-evans/create-or-update-comment@v2
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: ${{ steps.prepare-test-summary.outputs.result }}
+                  edit-mode: replace
+
+    publish-test-reports:
+        name: Publish test reports
         if: |
-          always() &&
-          steps.generate_e2e_report.conclusion == 'success'
-        uses: actions/upload-artifact@v3
-        with:
-          name: e2e-test-report---pr-${{ github.event.number }}
-          path: |
-            plugins/woocommerce/e2e/allure-results
-            plugins/woocommerce/e2e/allure-report
-          if-no-files-found: ignore
-          retention-days: 5
-
-  cot-api-tests-run:
-    name: Runs API tests against COT env.
-    runs-on: ubuntu-20.04
-    env:
-      API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: cot-main
-      - uses: ./.github/actions/cache-deps
-        with:
-          workflow_name: cot-pr-build-and-e2e-tests
-          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "7.4"
-
-      - name: Install and Build
-        uses: ./.github/actions/install-build
-
-      - name: Load docker images and start containers with COT enabled.
-        working-directory: plugins/woocommerce
-        run: pnpm env:test:cot --filter=woocommerce
-
-      - name: Run tests command.
-        working-directory: plugins/woocommerce
+            always() && 
+            ! github.event.pull_request.head.repo.fork &&
+            (
+              contains( needs.*.result, 'success' ) ||
+              contains( needs.*.result, 'failure' )
+            )
+        runs-on: ubuntu-20.04
+        needs: [cot-api-tests-run, cot-e2e-tests-run]
         env:
-          BASE_URL: http://localhost:8086
-          USER_KEY: admin
-          USER_SECRET: password
-        run: pnpm exec wc-api-tests test api
-
-      - name: Archive API test report
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: api-test-report---pr-${{ github.event.number }}
-          path: |
-            ${{ env.API_TEST_REPORT_DIR }}/allure-results
-            ${{ env.API_TEST_REPORT_DIR }}/allure-report
-          retention-days: 5
-
-  test-summary:
-    name: Post test results
-    if: |
-      always() && 
-      ! github.event.pull_request.head.repo.fork &&
-      (
-        contains( needs.*.result, 'success' ) ||
-        contains( needs.*.result, 'failure' )
-      )
-    runs-on: ubuntu-20.04
-    needs: [cot-api-tests-run, cot-e2e-tests-run]
-    steps:
-      - name: Create dirs
-        run: |
-          mkdir -p repo
-          mkdir -p artifacts/api 
-          mkdir -p artifacts/e2e
-          mkdir -p output
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          path: repo
-
-      - name: Download API test report artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: api-test-report---pr-${{ github.event.number }}
-          path: artifacts/api
-
-      - name: Download Playwright E2E test report artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: e2e-test-report---pr-${{ github.event.number }}
-          path: artifacts/e2e
-
-      - name: Prepare test summary
-        id: prepare-test-summary
-        uses: actions/github-script@v6
-        env:
-          API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
-          E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
-          E2E_PPTR_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/test-results.json
-          PR_NUMBER: ${{ github.event.number }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-        with:
-          result-encoding: string
-          script: |
-            const script = require( './repo/.github/workflows/scripts/prepare-test-summary.js' )
-            return await script( { core } )
-      - name: Find PR comment by github-actions[bot]
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: Test Results Summary
-
-      - name: Create or update PR comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.prepare-test-summary.outputs.result }}
-          edit-mode: replace
-
-  publish-test-reports:
-    name: Publish test reports
-    if: |
-      always() && 
-      ! github.event.pull_request.head.repo.fork &&
-      (
-        contains( needs.*.result, 'success' ) ||
-        contains( needs.*.result, 'failure' )
-      )
-    runs-on: ubuntu-20.04
-    needs: [cot-api-tests-run, cot-e2e-tests-run]
-    env:
-      GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-      PR_NUMBER: ${{ github.event.number }}
-      RUN_ID: ${{ github.run_id }}
-      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-    steps:
-      - name: Publish test reports
-        env:
-          API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
-          E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
-        run: |
-          gh workflow run publish-test-reports-pr.yml \
-            -f run_id=$RUN_ID \
-            -f api_artifact=$API_ARTIFACT \
-            -f e2e_artifact=$E2E_ARTIFACT \
-            -f pr_number=$PR_NUMBER \
-            -f commit_sha=$COMMIT_SHA \
-            -f s3_root=public \
-            --repo woocommerce/woocommerce-test-reports
+            GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+            PR_NUMBER: ${{ github.event.number }}
+            RUN_ID: ${{ github.run_id }}
+            COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        steps:
+            - name: Publish test reports
+              env:
+                  API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
+                  E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
+              run: |
+                  gh workflow run publish-test-reports-pr.yml \
+                    -f run_id=$RUN_ID \
+                    -f api_artifact=$API_ARTIFACT \
+                    -f e2e_artifact=$E2E_ARTIFACT \
+                    -f pr_number=$PR_NUMBER \
+                    -f commit_sha=$COMMIT_SHA \
+                    -f s3_root=public \
+                    --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -1,0 +1,207 @@
+name: Run tests against PR in a environment with COT enabled
+on:
+  pull_request:
+    branches:
+      - cot-main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cot-e2e-tests-run:
+    name: Runs E2E tests against COT env.
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cache-deps
+        with:
+          workflow_name: cot-pr-build-and-e2e-tests
+          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+
+      - name: Install and Build
+        uses: ./.github/actions/install-build
+
+      - name: Load docker images and start containers with COT enabled.
+        working-directory: plugins/woocommerce
+        run: pnpm env:test:cot --filter=woocommerce
+
+      - name: Download and install Chromium browser.
+        working-directory: plugins/woocommerce
+        run: pnpx playwright install chromium
+
+      - name: Run Playwright E2E tests.
+        timeout-minutes: 60
+        id: run_playwright_e2e_tests
+        env:
+          USE_WP_ENV: 1
+        working-directory: plugins/woocommerce
+        run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
+
+      - name: Generate Playwright E2E Test report.
+        id: generate_e2e_report
+        if: |
+          always() &&
+          (
+            steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
+            steps.run_playwright_e2e_tests.conclusion != 'skipped' 
+          )
+        working-directory: plugins/woocommerce
+        run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
+
+      - name: Archive Playwright E2E test report
+        if: |
+          always() &&
+          steps.generate_e2e_report.conclusion == 'success'
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-report---pr-${{ github.event.number }}
+          path: |
+            plugins/woocommerce/e2e/allure-results
+            plugins/woocommerce/e2e/allure-report
+          if-no-files-found: ignore
+          retention-days: 5
+
+  cot-api-tests-run:
+    name: Runs API tests against COT env.
+    runs-on: ubuntu-20.04
+    env:
+      API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cache-deps
+        with:
+          workflow_name: cot-pr-build-and-e2e-tests
+          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "7.4"
+
+      - name: Install and Build
+        uses: ./.github/actions/install-build
+
+      - name: Load docker images and start containers with COT enabled.
+        working-directory: plugins/woocommerce
+        run: pnpm env:test:cot --filter=woocommerce
+
+      - name: Run tests command.
+        working-directory: plugins/woocommerce
+        env:
+          BASE_URL: http://localhost:8086
+          USER_KEY: admin
+          USER_SECRET: password
+        run: pnpm exec wc-api-tests test api
+
+      - name: Archive API test report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: api-test-report---pr-${{ github.event.number }}
+          path: |
+            ${{ env.API_TEST_REPORT_DIR }}/allure-results
+            ${{ env.API_TEST_REPORT_DIR }}/allure-report
+          retention-days: 5
+
+  test-summary:
+    name: Post test results
+    if: |
+      always() && 
+      ! github.event.pull_request.head.repo.fork &&
+      (
+        contains( needs.*.result, 'success' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+    runs-on: ubuntu-20.04
+    needs: [cot-api-tests-run, cot-e2e-tests-run]
+    steps:
+      - name: Create dirs
+        run: |
+          mkdir -p repo
+          mkdir -p artifacts/api 
+          mkdir -p artifacts/e2e
+          mkdir -p output
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: repo
+
+      - name: Download API test report artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: api-test-report---pr-${{ github.event.number }}
+          path: artifacts/api
+
+      - name: Download Playwright E2E test report artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: e2e-test-report---pr-${{ github.event.number }}
+          path: artifacts/e2e
+
+      - name: Prepare test summary
+        id: prepare-test-summary
+        uses: actions/github-script@v6
+        env:
+          API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
+          E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
+          E2E_PPTR_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/test-results.json
+          PR_NUMBER: ${{ github.event.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          result-encoding: string
+          script: |
+            const script = require( './repo/.github/workflows/scripts/prepare-test-summary.js' )
+            return await script( { core } )
+      - name: Find PR comment by github-actions[bot]
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Test Results Summary
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.prepare-test-summary.outputs.result }}
+          edit-mode: replace
+
+  publish-test-reports:
+    name: Publish test reports
+    if: |
+      always() && 
+      ! github.event.pull_request.head.repo.fork &&
+      (
+        contains( needs.*.result, 'success' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+    runs-on: ubuntu-20.04
+    needs: [cot-api-tests-run, cot-e2e-tests-run]
+    env:
+      GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+      PR_NUMBER: ${{ github.event.number }}
+      RUN_ID: ${{ github.run_id }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Publish test reports
+        env:
+          API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
+          E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
+        run: |
+          gh workflow run publish-test-reports-pr.yml \
+            -f run_id=$RUN_ID \
+            -f api_artifact=$API_ARTIFACT \
+            -f e2e_artifact=$E2E_ARTIFACT \
+            -f pr_number=$PR_NUMBER \
+            -f commit_sha=$COMMIT_SHA \
+            -f s3_root=public \
+            --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -1,4 +1,4 @@
-name: Run tests against PR in a environment with COT enabled
+name: Run tests against PR in an environment with COT enabled
 on:
   pull_request:
     branches:

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -1,6 +1,7 @@
 name: Run tests against PR in an environment with COT enabled
 on:
     pull_request:
+        types: [labeled]
     workflow_dispatch:
 
 concurrency:
@@ -10,6 +11,7 @@ concurrency:
 jobs:
     cot-e2e-tests-run:
         name: Runs E2E tests with COT enabled.
+        if: "${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'focus: custom order tables' }}"
         runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v3
@@ -59,6 +61,7 @@ jobs:
 
     cot-api-tests-run:
         name: Runs API tests with COT enabled.
+        if: "${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'focus: custom order tables' }}"
         runs-on: ubuntu-20.04
         env:
             API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -1,8 +1,6 @@
 name: Run tests against PR in an environment with COT enabled
 on:
   pull_request:
-    branches:
-      - cot-main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -1,205 +1,189 @@
 name: Run tests against PR in an environment with COT enabled
 on:
-  pull_request:
-  workflow_dispatch:
+    pull_request:
+    workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  cot-e2e-tests-run:
-    name: Runs E2E tests against COT env.
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cache-deps
-        with:
-          workflow_name: cot-pr-build-and-e2e-tests
-          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
+    cot-e2e-tests-run:
+        name: Runs E2E tests with COT enabled.
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
+            
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "7.4"
+            - name: Load docker images and start containers with COT enabled.
+              working-directory: plugins/woocommerce
+              run: pnpm env:test:cot --filter=woocommerce
 
-      - name: Install and Build
-        uses: ./.github/actions/install-build
+            - name: Download and install Chromium browser.
+              working-directory: plugins/woocommerce
+              run: pnpx playwright install chromium
 
-      - name: Load docker images and start containers with COT enabled.
-        working-directory: plugins/woocommerce
-        run: pnpm env:test:cot --filter=woocommerce
+            - name: Run Playwright E2E tests.
+              timeout-minutes: 60
+              id: run_playwright_e2e_tests
+              env:
+                USE_WP_ENV: 1
+              working-directory: plugins/woocommerce
+              run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
 
-      - name: Download and install Chromium browser.
-        working-directory: plugins/woocommerce
-        run: pnpx playwright install chromium
+            - name: Generate Playwright E2E Test report.
+              id: generate_e2e_report
+              if: |
+                  always() &&
+                  (
+                    steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
+                    steps.run_playwright_e2e_tests.conclusion != 'skipped' 
+                  )
+              working-directory: plugins/woocommerce
+              run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
 
-      - name: Run Playwright E2E tests.
-        timeout-minutes: 60
-        id: run_playwright_e2e_tests
+            - name: Archive Playwright E2E test report
+              if: |
+                  always() &&
+                  steps.generate_e2e_report.conclusion == 'success'
+              uses: actions/upload-artifact@v3
+              with:
+                  name: e2e-test-report---pr-${{ github.event.number }}
+                  path: |
+                      plugins/woocommerce/e2e/allure-results
+                      plugins/woocommerce/e2e/allure-report
+                  if-no-files-found: ignore
+                  retention-days: 5
+
+    cot-api-tests-run:
+        name: Runs API tests with COT enabled.
+        runs-on: ubuntu-20.04
         env:
-          USE_WP_ENV: 1
-        working-directory: plugins/woocommerce
-        run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
+            API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report
+        steps:
+            - uses: actions/checkout@v3
+            
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-      - name: Generate Playwright E2E Test report.
-        id: generate_e2e_report
+            - name: Load docker images and start containers with COT enabled.
+              working-directory: plugins/woocommerce
+              run: pnpm env:test:cot --filter=woocommerce
+
+            - name: Run tests command.
+              working-directory: plugins/woocommerce
+              env:
+                  BASE_URL: http://localhost:8086
+                  USER_KEY: admin
+                  USER_SECRET: password
+              run: pnpm exec wc-api-tests test api
+
+            - name: Archive API test report
+              if: always()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: api-test-report---pr-${{ github.event.number }}
+                  path: |
+                      ${{ env.API_TEST_REPORT_DIR }}/allure-results
+                      ${{ env.API_TEST_REPORT_DIR }}/allure-report
+                  retention-days: 5
+
+    test-summary:
+        name: Post test results
         if: |
-          always() &&
-          (
-            steps.run_playwright_e2e_tests.conclusion != 'cancelled' ||
-            steps.run_playwright_e2e_tests.conclusion != 'skipped' 
-          )
-        working-directory: plugins/woocommerce
-        run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
+            always() && 
+            ! github.event.pull_request.head.repo.fork &&
+            (
+              contains( needs.*.result, 'success' ) ||
+              contains( needs.*.result, 'failure' )
+            )
+        runs-on: ubuntu-20.04
+        needs: [cot-api-tests-run, cot-e2e-tests-run]
+        steps:
+            - name: Create dirs
+              run: |
+                  mkdir -p repo
+                  mkdir -p artifacts/api 
+                  mkdir -p artifacts/e2e
+                  mkdir -p output
 
-      - name: Archive Playwright E2E test report
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  path: repo
+
+            - name: Download API test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: api-test-report---pr-${{ github.event.number }}
+                  path: artifacts/api
+
+            - name: Download Playwright E2E test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: e2e-test-report---pr-${{ github.event.number }}
+                  path: artifacts/e2e
+
+            - name: Prepare test summary
+              id: prepare-test-summary
+              uses: actions/github-script@v6
+              env:
+                  API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
+                  E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
+                  E2E_PPTR_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/test-results.json
+                  PR_NUMBER: ${{ github.event.number }}
+                  SHA: ${{ github.event.pull_request.head.sha }}
+              with:
+                  result-encoding: string
+                  script: |
+                      const script = require( './repo/.github/workflows/scripts/prepare-test-summary.js' )
+                      return await script( { core } )
+
+            - name: Find PR comment by github-actions[bot]
+              uses: peter-evans/find-comment@v2
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: 'github-actions[bot]'
+                  body-includes: Test Results Summary
+
+            - name: Create or update PR comment
+              uses: peter-evans/create-or-update-comment@v2
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: ${{ steps.prepare-test-summary.outputs.result }}
+                  edit-mode: replace
+
+    publish-test-reports:
+        name: Publish test reports
         if: |
-          always() &&
-          steps.generate_e2e_report.conclusion == 'success'
-        uses: actions/upload-artifact@v3
-        with:
-          name: e2e-test-report---pr-${{ github.event.number }}
-          path: |
-            plugins/woocommerce/e2e/allure-results
-            plugins/woocommerce/e2e/allure-report
-          if-no-files-found: ignore
-          retention-days: 5
-
-  cot-api-tests-run:
-    name: Runs API tests against COT env.
-    runs-on: ubuntu-20.04
-    env:
-      API_TEST_REPORT_DIR: ${{ github.workspace }}/api-test-report
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cache-deps
-        with:
-          workflow_name: cot-pr-build-and-e2e-tests
-          workflow_cache: ${{ secrets.WORKFLOW_CACHE }}
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: "7.4"
-
-      - name: Install and Build
-        uses: ./.github/actions/install-build
-
-      - name: Load docker images and start containers with COT enabled.
-        working-directory: plugins/woocommerce
-        run: pnpm env:test:cot --filter=woocommerce
-
-      - name: Run tests command.
-        working-directory: plugins/woocommerce
+            always() && 
+            ! github.event.pull_request.head.repo.fork &&
+            (
+              contains( needs.*.result, 'success' ) ||
+              contains( needs.*.result, 'failure' )
+            )
+        runs-on: ubuntu-20.04
+        needs: [cot-api-tests-run, cot-e2e-tests-run]
         env:
-          BASE_URL: http://localhost:8086
-          USER_KEY: admin
-          USER_SECRET: password
-        run: pnpm exec wc-api-tests test api
-
-      - name: Archive API test report
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: api-test-report---pr-${{ github.event.number }}
-          path: |
-            ${{ env.API_TEST_REPORT_DIR }}/allure-results
-            ${{ env.API_TEST_REPORT_DIR }}/allure-report
-          retention-days: 5
-
-  test-summary:
-    name: Post test results
-    if: |
-      always() && 
-      ! github.event.pull_request.head.repo.fork &&
-      (
-        contains( needs.*.result, 'success' ) ||
-        contains( needs.*.result, 'failure' )
-      )
-    runs-on: ubuntu-20.04
-    needs: [cot-api-tests-run, cot-e2e-tests-run]
-    steps:
-      - name: Create dirs
-        run: |
-          mkdir -p repo
-          mkdir -p artifacts/api 
-          mkdir -p artifacts/e2e
-          mkdir -p output
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          path: repo
-
-      - name: Download API test report artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: api-test-report---pr-${{ github.event.number }}
-          path: artifacts/api
-
-      - name: Download Playwright E2E test report artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: e2e-test-report---pr-${{ github.event.number }}
-          path: artifacts/e2e
-
-      - name: Prepare test summary
-        id: prepare-test-summary
-        uses: actions/github-script@v6
-        env:
-          API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
-          E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
-          E2E_PPTR_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/test-results.json
-          PR_NUMBER: ${{ github.event.number }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-        with:
-          result-encoding: string
-          script: |
-            const script = require( './repo/.github/workflows/scripts/prepare-test-summary.js' )
-            return await script( { core } )
-      - name: Find PR comment by github-actions[bot]
-        uses: peter-evans/find-comment@v2
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: Test Results Summary
-
-      - name: Create or update PR comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.prepare-test-summary.outputs.result }}
-          edit-mode: replace
-
-  publish-test-reports:
-    name: Publish test reports
-    if: |
-      always() && 
-      ! github.event.pull_request.head.repo.fork &&
-      (
-        contains( needs.*.result, 'success' ) ||
-        contains( needs.*.result, 'failure' )
-      )
-    runs-on: ubuntu-20.04
-    needs: [cot-api-tests-run, cot-e2e-tests-run]
-    env:
-      GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-      PR_NUMBER: ${{ github.event.number }}
-      RUN_ID: ${{ github.run_id }}
-      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-    steps:
-      - name: Publish test reports
-        env:
-          API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
-          E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
-        run: |
-          gh workflow run publish-test-reports-pr.yml \
-            -f run_id=$RUN_ID \
-            -f api_artifact=$API_ARTIFACT \
-            -f e2e_artifact=$E2E_ARTIFACT \
-            -f pr_number=$PR_NUMBER \
-            -f commit_sha=$COMMIT_SHA \
-            -f s3_root=public \
-            --repo woocommerce/woocommerce-test-reports
+            GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+            PR_NUMBER: ${{ github.event.number }}
+            RUN_ID: ${{ github.run_id }}
+            COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        steps:
+            - name: Publish test reports
+              env:
+                  API_ARTIFACT: api-test-report---pr-${{ github.event.number }}
+                  E2E_ARTIFACT: e2e-test-report---pr-${{ github.event.number }}
+              run: |
+                  gh workflow run publish-test-reports-pr.yml \
+                    -f run_id=$RUN_ID \
+                    -f api_artifact=$API_ARTIFACT \
+                    -f e2e_artifact=$E2E_ARTIFACT \
+                    -f pr_number=$PR_NUMBER \
+                    -f commit_sha=$COMMIT_SHA \
+                    -f s3_root=public \
+                    --repo woocommerce/woocommerce-test-reports


### PR DESCRIPTION
### All Submissions:

-   [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Two GitHub Actions workflows were created to run E2E and API automated tests in an environment with COT enabled in our pipelines. In concrete, these are the workflows:
- **cot-pr-build-and-e2e-tests.yml:** Runs E2E and API tests in an environment with COT enabled every time a new PR is created with the label `focus: custom order tables`. This way we can find potential issues caused by new changes before they are merged.
- **cot-build-and-e2e-tests-daily.yml:** Runs E2E and API tests daily at 2:30 AM UTC in the `trunk` branch. This way we can continuously test the current COT integration and also find out potential intermittent issues since we would have a good set of test runs that we might use to find patterns in the test outcomes.

Note: These two workflows might be temporary until the COT project is completed. We might want to decide to remove them or refactor and leave them afterwards when the time comes.

### How to test the changes in this Pull Request:

**NOTE:** I'm afraid you won't be able to test these scenarios in this repository because:
- The scheduled workflows only run in the **default** branch (trunk, in our case), as stated in the [official documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule):
> Scheduled workflows run on the latest commit on the default or base branch.

This means that we won't be able to test the daily COT tests until they are merged into trunk.

- For some reason (I'm new to GitHub Actions, so there must be any explanation that I'm missing), seems that workflows are reused when we create 2 PRs from the same base branch to different target branches. This PR is created to be merged into `trunk`, so we might not be able to test properly what happens when we create another PR at the same time against `cot-main`.

I suggest testing the following instructions in a forked repository like this one, where there is already a [PR with the changes](https://github.com/alopezari/woocommerce/pull/6).

Three different tests can be defined for this PR:

**Scenario: New workflow is triggered when creating a PR labeled as 'focus: custom order tables'**
1. Add any change to the repository.
2. Create a Pull Request and label it as `focus: custom order tables`.
4. Check that the new GitHub Actions workflow `Run tests against PR in an environment with COT enabled` is triggered.

**Scenario: New workflow is not triggered when creating a PR without the 'focus: custom order tables' label**
1. Add any change to the repository.
2. Create a Pull Request and make sure to not add the `focus: custom order tables` label.
3. Check that none of the new GitHub Actions workflows - `Run tests against PR in an environment with COT enabled` and `Run daily tests in an environment with COT enabled` - is triggered.

**Scenario: New workflow is triggered every day around 2:30 AM UTC**
1. Go to the [GitHub Actions page](https://github.com/woocommerce/woocommerce/actions)
2. Check the `Run daily tests in an environment with COT enabled` was triggered every day around 2:30 AM UTC. Note: there might be a slight offset in the execution time, so the workflow might not be triggered exactly at 2:30 AM UTC, but it should be close.

### Other information:

-   [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ N/A ] Have you written new tests for your changes, as applicable?
-   [ x ] Have you successfully run tests with your changes locally?
-   [ N/A? ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
