### PR TITLE
Add FormContext().setValues() support

### DIFF
--- a/packages/js/components/changelog/add-product_schedule_sale
+++ b/packages/js/components/changelog/add-product_schedule_sale
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Adds setValues support to FormContext

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -18,6 +18,7 @@ export type FormContext< Values extends Record< string, any > > = {
 	>;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	setValue: ( name: string, value: any ) => void;
+	setValues: ( valuesToSet: Values ) => void;
 	handleSubmit: () => Promise< Values >;
 	getInputProps< Value extends Values[ keyof Values ] >(
 		name: string

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -57,7 +57,7 @@ type FormProps< Values > = {
 		isValid: boolean
 	) => void;
 	/**
-	 * Function to call when multiple values change in the form.
+	 * Function to call when one or more values change in the form.
 	 */
 	onChanges?: (
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -57,6 +57,14 @@ type FormProps< Values > = {
 		isValid: boolean
 	) => void;
 	/**
+	 * Function to call when multiple values change in the form.
+	 */
+	onChanges?: (
+		changedValues: Values,
+		values: Values,
+		hasErrors: boolean
+	) => void;
+	/**
 	 * A function that is passed a list of all values and
 	 * should return an `errors` object with error response.
 	 */
@@ -81,6 +89,7 @@ function FormComponent< Values extends Record< string, any > >(
 	{
 		onSubmit = () => {},
 		onChange = () => {},
+		onChanges = () => {},
 		initialValues = {} as Values,
 		...props
 	}: PropsWithChildren< FormProps< Values > >,
@@ -163,7 +172,7 @@ function FormComponent< Values extends Record< string, any > >(
 				const { onChangeCallback } = props;
 
 				// Note that onChange is a no-op by default so this will never be null
-				const callback = onChangeCallback || onChange;
+				const singleValueChangeCallback = onChangeCallback || onChange;
 
 				if ( onChangeCallback ) {
 					deprecated( 'onChangeCallback', {
@@ -172,17 +181,25 @@ function FormComponent< Values extends Record< string, any > >(
 						plugin: '@woocommerce/components',
 					} );
 				}
-				// onChange keeps track of validity, so needs to
+				// onChange and onChanges keep track of validity, so needs to
 				// happen after setting the error state.
-				if ( callback ) {
+				if ( singleValueChangeCallback ) {
 					// we should change the callback to pass all changed fields in a single callback
 					for ( const key in valuesToSet ) {
-						callback(
+						singleValueChangeCallback(
 							{ name: key, value: valuesToSet[ key ] },
 							newValues,
 							! Object.keys( newErrors || {} ).length
 						);
 					}
+				}
+
+				if ( onChanges ) {
+					onChanges(
+						valuesToSet,
+						values,
+						! Object.keys( errors || {} ).length
+					);
 				}
 			} );
 		},

--- a/packages/js/components/src/form/test/index.tsx
+++ b/packages/js/components/src/form/test/index.tsx
@@ -234,6 +234,179 @@ describe( 'Form', () => {
 		}
 	} );
 
+	it( 'should call onChanges with latest changed values with one change', () => {
+		const mockOnChanges = jest.fn();
+
+		const { queryByLabelText } = render(
+			<Form onChanges={ mockOnChanges } validate={ () => ( {} ) }>
+				{ ( {
+					setValue,
+					getInputProps,
+				}: FormContext< Record< string, string > > ) => {
+					return (
+						<TextControl
+							label={ 'First Name' }
+							{ ...getInputProps( 'firstName' ) }
+						/>
+					);
+				} }
+			</Form>
+		);
+
+		const firstNameInput = queryByLabelText( 'First Name' );
+		if ( firstNameInput ) {
+			fireEvent.change( firstNameInput, { target: { value: 'F' } } );
+			expect( mockOnChanges ).toHaveBeenCalledWith(
+				[ { name: 'firstName', value: 'F' } ],
+				{ firstName: 'F' },
+				true
+			);
+
+			fireEvent.change( firstNameInput, { target: { value: 'Fi' } } );
+			expect( mockOnChanges ).toHaveBeenCalledWith(
+				[ { name: 'firstName', value: 'Fi' } ],
+				{ firstName: 'Fi' },
+				true
+			);
+		}
+	} );
+
+	it( 'should call onChanges with latest hasErrors with one change', () => {
+		const mockOnChanges = jest.fn();
+
+		type TestData = {
+			firstName: string;
+		};
+
+		const validate = ( data: TestData ): Record< string, string > => {
+			if ( data.firstName && data.firstName.length < 2 ) {
+				return {
+					firstName: 'Must be greater then 1',
+				};
+			}
+			return {};
+		};
+
+		const { queryByLabelText } = render(
+			<Form< TestData > onChanges={ mockOnChanges } validate={ validate }>
+				{ ( {
+					setValue,
+					getInputProps,
+				}: FormContext< Record< string, string > > ) => {
+					return (
+						<TextControl
+							label={ 'First Name' }
+							{ ...getInputProps( 'firstName' ) }
+						/>
+					);
+				} }
+			</Form>
+		);
+
+		const firstNameInput = queryByLabelText( 'First Name' );
+		if ( firstNameInput ) {
+			fireEvent.change( firstNameInput, { target: { value: 'F' } } );
+			expect( mockOnChanges ).toHaveBeenCalledWith(
+				[ { name: 'firstName', value: 'F' } ],
+				{ firstName: 'F' },
+				false
+			);
+
+			fireEvent.change( firstNameInput, { target: { value: 'Fi' } } );
+			expect( mockOnChanges ).toHaveBeenCalledWith(
+				[ { name: 'firstName', value: 'Fi' } ],
+				{ firstName: 'Fi' },
+				true
+			);
+		}
+	} );
+
+	it( 'should call onChanges with latest changed values with multiple changes', () => {
+		const mockOnChanges = jest.fn();
+
+		const { queryByText } = render(
+			<Form onChanges={ mockOnChanges } validate={ () => ( {} ) }>
+				{ ( {
+					setValues,
+				}: FormContext< Record< string, string > > ) => {
+					return (
+						<button
+							onClick={ () => {
+								setValues( { foo: 'bar', foo2: 'bar2' } );
+							} }
+						>
+							Submit
+						</button>
+					);
+				} }
+			</Form>
+		);
+
+		const submitButton = queryByText( 'Submit' );
+		if ( submitButton ) {
+			userEvent.click( submitButton );
+		}
+
+		expect( mockOnChanges ).toHaveBeenCalledWith(
+			[
+				{ name: 'foo', value: 'bar' },
+				{ name: 'foo2', value: 'bar2' },
+			],
+			{ foo: 'bar', foo2: 'bar2' },
+			true
+		);
+	} );
+
+	it( 'should call onChanges with latest hasErrors with multiple changes', () => {
+		const mockOnChanges = jest.fn();
+
+		type TestData = {
+			foo: string;
+			foo2: string;
+		};
+
+		const validate = ( data: TestData ): Record< string, string > => {
+			if ( data.foo && data.foo.length < 2 ) {
+				return {
+					foo: 'Must be greater then 1',
+				};
+			}
+			return {};
+		};
+
+		const { queryByText } = render(
+			<Form onChanges={ mockOnChanges } validate={ validate }>
+				{ ( {
+					setValues,
+				}: FormContext< Record< string, string > > ) => {
+					return (
+						<button
+							onClick={ () => {
+								setValues( { foo: 'b', foo2: 'bar2' } );
+							} }
+						>
+							Submit
+						</button>
+					);
+				} }
+			</Form>
+		);
+
+		const submitButton = queryByText( 'Submit' );
+		if ( submitButton ) {
+			userEvent.click( submitButton );
+		}
+
+		expect( mockOnChanges ).toHaveBeenCalledWith(
+			[
+				{ name: 'foo', value: 'b' },
+				{ name: 'foo2', value: 'bar2' },
+			],
+			{ foo: 'b', foo2: 'bar2' },
+			false
+		);
+	} );
+
 	describe( 'FormContext', () => {
 		it( 'should allow nested field to use useFormContext to set field value', async () => {
 			const mockOnChange = jest.fn();


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the ability for a consumer of the `Form`/`FormContext` components to set multiple values in a single call. It is important to be able to do this for certain scenarios, such as when initializing the scheduled sale from and to fields at once when enabling a scheduled sale (will be used in https://github.com/woocommerce/woocommerce/pull/34538).

In the future, we may want to consider deprecating (and then removing) `setValue()` and `onChange` to simplify the API and only have `setValues()` and `onChanges`, since those handle all possible usages.

### How to test the changes in this Pull Request:

1. Review unit tests and verify that they make sense.
2. Run unit tests and verify they pass: `pnpm --filter=@woocommerce/components run test -- src/form`
3. Smoke test the new product experience MVP and make sure that you can still add a new product without issue.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
