### PR TITLE
Update/experimental select control

### DIFF
--- a/packages/js/components/changelog/update-experimental_select_control
+++ b/packages/js/components/changelog/update-experimental_select_control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update experimental SelectControl compoment to expose combobox functions from Downshift and provide additional options.

--- a/packages/js/components/src/experimental-select-control/menu.scss
+++ b/packages/js/components/src/experimental-select-control/menu.scss
@@ -1,16 +1,17 @@
 .woocommerce-experimental-select-control__menu {
-    position: absolute;
-    width: 100%;
-    top: 100%;
-    left: 0;
-    margin-top: $gap-smaller;
-    box-sizing: border-box;
-    display: none;
-    background: $studio-white;
-    border: 1px solid $studio-gray-5;
-    border-radius: 3px;
+	position: absolute;
+	width: 100%;
+	top: 100%;
+	left: 0;
+	margin-top: $gap-smaller;
+	box-sizing: border-box;
+	display: none;
+	background: $studio-white;
+	border: 1px solid $studio-gray-5;
+	border-radius: 3px;
+	z-index: 10;
 
-    &.is-open.has-results {
-        display: block;
-    }
+	&.is-open.has-results {
+		display: block;
+	}
 }

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -3,12 +3,18 @@
  */
 import classnames from 'classnames';
 import {
+	useCombobox,
+	UseComboboxState,
+	UseComboboxStateChange,
+	UseComboboxStateChangeOptions,
+	useMultipleSelection,
+} from 'downshift';
+import {
+	useState,
+	useEffect,
 	createElement,
 	Fragment,
-	useEffect,
-	useState,
 } from '@wordpress/element';
-import { useCombobox, useMultipleSelection } from 'downshift';
 
 /**
  * Internal dependencies
@@ -46,9 +52,16 @@ type SelectControlProps< ItemType > = {
 	onInputChange?: ( value: string | undefined ) => void;
 	onRemove?: ( item: ItemType ) => void;
 	onSelect?: ( selected: ItemType ) => void;
+	onFocus?: ( data: { inputValue: string } ) => void;
+	stateReducer?: (
+		state: UseComboboxState< ItemType | null >,
+		actionAndChanges: UseComboboxStateChangeOptions< ItemType | null >
+	) => Partial< UseComboboxState< ItemType | null > >;
 	placeholder?: string;
 	selected: ItemType | ItemType[] | null;
 };
+
+export const selectControlStateChangeTypes = useCombobox.stateChangeTypes;
 
 function SelectControl< ItemType = DefaultItemType >( {
 	getItemLabel = defaultGetItemLabel,
@@ -84,6 +97,8 @@ function SelectControl< ItemType = DefaultItemType >( {
 	onInputChange = () => null,
 	onRemove = () => null,
 	onSelect = () => null,
+	onFocus = () => null,
+	stateReducer = ( state, actionAndChanges ) => actionAndChanges.changes,
 	placeholder,
 	selected,
 }: SelectControlProps< ItemType > ) {
@@ -129,45 +144,56 @@ function SelectControl< ItemType = DefaultItemType >( {
 		getItemProps,
 		selectItem,
 		selectedItem: comboboxSingleSelectedItem,
+		openMenu,
+		closeMenu,
 	} = useCombobox< ItemType | null >( {
 		initialSelectedItem: singleSelectedItem,
 		inputValue,
 		items: filteredItems,
+		selectedItem: multiple ? null : undefined,
 		itemToString: getItemLabel,
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		onStateChange: ( { inputValue: value, type, selectedItem } ) => {
+		onSelectedItemChange: ( { selectedItem } ) =>
+			selectedItem && onSelect( selectedItem ),
+		onInputValueChange: ( changes ) => {
+			if ( changes.inputValue !== undefined ) {
+				setInputValue( changes.inputValue );
+				if ( changes.isOpen ) {
+					onInputChange( changes.inputValue );
+				}
+			}
+		},
+		stateReducer: ( state, actionAndChanges ) => {
+			const { changes, type } = actionAndChanges;
+			let newChanges;
 			switch ( type ) {
-				case useCombobox.stateChangeTypes.InputChange:
-					onInputChange( value );
-					setInputValue( value || '' );
-
+				case selectControlStateChangeTypes.InputBlur:
+					// Set input back to selected item if there is a selected item, blank otherwise.
+					newChanges = {
+						...changes,
+						inputValue:
+							changes.selectedItem === state.selectedItem &&
+							! multiple
+								? getItemLabel( comboboxSingleSelectedItem )
+								: '',
+					};
 					break;
-				case useCombobox.stateChangeTypes.InputKeyDownEnter:
-				case useCombobox.stateChangeTypes.ItemClick:
-				case useCombobox.stateChangeTypes.InputBlur:
-					if ( selectedItem ) {
-						onSelect( selectedItem );
-						if ( multiple ) {
-							addSelectedItem( selectedItem );
-							setInputValue( '' );
-							break;
-						}
-
-						selectItem( selectedItem );
-						setInputValue( getItemLabel( selectedItem ) );
+				case selectControlStateChangeTypes.InputKeyDownEnter:
+				case selectControlStateChangeTypes.FunctionSelectItem:
+				case selectControlStateChangeTypes.ItemClick:
+					if ( changes.selectedItem && multiple ) {
+						newChanges = {
+							...changes,
+							inputValue: '',
+						};
 					}
-
-					if ( ! selectedItem && ! multiple ) {
-						setInputValue(
-							getItemLabel( comboboxSingleSelectedItem )
-						);
-					}
-
 					break;
 				default:
 					break;
 			}
+			return stateReducer( state, {
+				...actionAndChanges,
+				changes: newChanges ?? changes,
+			} );
 		},
 	} );
 
@@ -204,7 +230,10 @@ function SelectControl< ItemType = DefaultItemType >( {
 						preventKeyAction: isOpen,
 					} ),
 					className: 'woocommerce-experimental-select-control__input',
-					onFocus: () => setIsFocused( true ),
+					onFocus: () => {
+						setIsFocused( true );
+						onFocus( { inputValue } );
+					},
 					onBlur: () => setIsFocused( false ),
 					placeholder,
 				} ) }
@@ -218,6 +247,10 @@ function SelectControl< ItemType = DefaultItemType >( {
 						isOpen,
 						getItemLabel,
 						getItemValue,
+						selectItem,
+						setInputValue,
+						openMenu,
+						closeMenu,
 					} ) }
 					{ ! hasExternalTags && selectedItemTags }
 				</>

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -117,7 +117,6 @@ function SelectControl< ItemType = DefaultItemType >( {
 		getItemLabel
 	);
 	const {
-		addSelectedItem,
 		getSelectedItemProps,
 		getDropdownProps,
 		removeSelectedItem,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import {
 	useCombobox,
 	UseComboboxState,
-	UseComboboxStateChange,
 	UseComboboxStateChangeOptions,
 	useMultipleSelection,
 } from 'downshift';

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -188,7 +188,9 @@ export const Async: React.FC = () => {
 };
 
 export const CustomRender: React.FC = () => {
-	const [ selected, setSelected ] = useState< DefaultItemType[] >( [] );
+	const [ selected, setSelected ] = useState< DefaultItemType[] >( [
+		sampleItems[ 0 ],
+	] );
 
 	const onRemove = ( item ) => {
 		setSelected( selected.filter( ( i ) => i !== item ) );
@@ -233,8 +235,12 @@ export const CustomRender: React.FC = () => {
 				stateReducer={ ( state, actionAndChanges ) => {
 					const { changes, type } = actionAndChanges;
 					switch ( type ) {
-						case selectControlStateChangeTypes.ItemClick:
 						case selectControlStateChangeTypes.ControlledPropUpdatedSelectedItem:
+							return {
+								...changes,
+								inputValue: state.inputValue,
+							};
+						case selectControlStateChangeTypes.ItemClick:
 							return {
 								...changes,
 								isOpen: true,

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -8,9 +8,9 @@ import { createElement, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { SelectedType, DefaultItemType } from '../types';
+import { SelectedType, DefaultItemType, getItemLabelType } from '../types';
 import { MenuItem } from '../menu-item';
-import { SelectControl } from '../';
+import { SelectControl, selectControlStateChangeTypes } from '../';
 import { Menu } from '../menu';
 
 const sampleItems = [
@@ -195,12 +195,29 @@ export const CustomRender: React.FC = () => {
 	};
 
 	const onSelect = ( item ) => {
-		const isSelected = selected.find( ( i ) => i === item );
+		const isSelected = selected.find( ( i ) => i.value === item.value );
 		if ( isSelected ) {
 			onRemove( item );
 			return;
 		}
 		setSelected( [ ...selected, item ] );
+	};
+
+	const getFilteredItems = (
+		allItems: DefaultItemType[],
+		inputValue: string,
+		selectedItems: DefaultItemType[],
+		getItemLabel: getItemLabelType< DefaultItemType >
+	) => {
+		const escapedInputValue = inputValue.replace(
+			/[.*+?^${}()|[\]\\]/g,
+			'\\$&'
+		);
+		const re = new RegExp( escapedInputValue, 'gi' );
+
+		return allItems.filter( ( item ) => {
+			return re.test( getItemLabel( item ).toLowerCase() );
+		} );
 	};
 
 	return (
@@ -209,25 +226,41 @@ export const CustomRender: React.FC = () => {
 				multiple
 				label="Custom render"
 				items={ sampleItems }
-				getFilteredItems={ ( allItems ) => allItems }
 				selected={ selected }
 				onSelect={ onSelect }
 				onRemove={ onRemove }
+				getFilteredItems={ getFilteredItems }
+				stateReducer={ ( state, actionAndChanges ) => {
+					const { changes, type } = actionAndChanges;
+					switch ( type ) {
+						case selectControlStateChangeTypes.ItemClick:
+						case selectControlStateChangeTypes.ControlledPropUpdatedSelectedItem:
+							return {
+								...changes,
+								isOpen: true,
+								inputValue: state.inputValue,
+								highlightedIndex: state.highlightedIndex,
+							};
+						default:
+							return changes;
+					}
+				} }
 			>
 				{ ( {
 					items,
 					highlightedIndex,
 					getItemProps,
 					getMenuProps,
+					isOpen,
 				} ) => {
 					return (
-						<Menu isOpen={ true } getMenuProps={ getMenuProps }>
+						<Menu isOpen={ isOpen } getMenuProps={ getMenuProps }>
 							{ items.map( ( item, index: number ) => {
 								const isSelected = selected.includes( item );
 
 								return (
 									<MenuItem
-										key={ `${ item.value }${ index }` }
+										key={ `${ item.value }` }
 										index={ index }
 										isActive={ highlightedIndex === index }
 										item={ item }

--- a/packages/js/components/src/experimental-select-control/types.ts
+++ b/packages/js/components/src/experimental-select-control/types.ts
@@ -6,6 +6,7 @@ import {
 	UseComboboxGetItemPropsOptions,
 	UseComboboxGetMenuPropsOptions,
 	GetPropsCommonOptions,
+	UseComboboxGetToggleButtonPropsOptions,
 } from 'downshift';
 
 export type DefaultItemType = {
@@ -25,6 +26,12 @@ export type getItemPropsType< ItemType > = (
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ) => any;
 
+export type getToggleButtonPropsType = (
+	options?: UseComboboxGetToggleButtonPropsOptions
+	// These are the types provided by Downshift.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => any;
+
 export type getMenuPropsType = (
 	options?: UseComboboxGetMenuPropsOptions,
 	otherOptions?: GetPropsCommonOptions
@@ -40,6 +47,10 @@ export type ChildrenProps< ItemType > = {
 	getMenuProps: getMenuPropsType;
 	getItemLabel: getItemLabelType< ItemType >;
 	getItemValue: getItemValueType< ItemType >;
+	selectItem: ( item: ItemType ) => void;
+	setInputValue: ( value: string ) => void;
+	openMenu: () => void;
+	closeMenu: () => void;
 };
 
 export type ChildrenType< ItemType > = ( {

--- a/packages/js/components/src/experimental-select-control/utils.ts
+++ b/packages/js/components/src/experimental-select-control/utils.ts
@@ -33,11 +33,16 @@ export const defaultGetFilteredItems = < ItemType >(
 	selectedItems: ItemType[],
 	getItemLabel: getItemLabelType< ItemType >
 ) => {
-	return allItems.filter(
-		( item ) =>
-			selectedItems.indexOf( item ) < 0 &&
-			getItemLabel( item )
-				.toLowerCase()
-				.startsWith( inputValue.toLowerCase() )
+	const escapedInputValue = inputValue.replace(
+		/[.*+?^${}()|[\]\\]/g,
+		'\\$&'
 	);
+	const re = new RegExp( escapedInputValue, 'gi' );
+
+	return allItems.filter( ( item ) => {
+		return (
+			selectedItems.indexOf( item ) < 0 &&
+			re.test( getItemLabel( item ).toLowerCase() )
+		);
+	} );
 };

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -40,7 +40,10 @@ export { default as SearchListItem } from './search-list-control/item';
 export { default as SectionHeader } from './section-header';
 export { default as SegmentedSelection } from './segmented-selection';
 export { default as SelectControl } from './select-control';
-export { SelectControl as __experimentalSelectControl } from './experimental-select-control';
+export {
+	SelectControl as __experimentalSelectControl,
+	selectControlStateChangeTypes,
+} from './experimental-select-control';
 export { MenuItem as __experimentalSelectControlMenuItem } from './experimental-select-control/menu-item';
 export { default as ScrollTo } from './scroll-to';
 export { Sortable } from './sortable';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Exposes some functions that are provided by the `useCombobox` hook from the `downshift` library and adds two extra properties:
`clearSearchOnSelect` - Clears the search field once the user selects an item
`keepMenuOpenOnSelect` - Keeps the dropdown open once a user selects an item.


### How to test the changes in this Pull Request:

1. Load this branch and run: `pnpm run build && pnpm run storybook`
2. Load the `Custom Render` component of the experimental select control
3. Type something in or hit the down arrow and select an item, the dropdown should stay open.
4. Load the `Custom render clear on select` component and do a search and select an item. Notice how your search cleared input cleared after selection.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
