### PR TITLE
Revert a condition change on third param in onChange prop

### DIFF
--- a/packages/js/components/changelog/fix-revert_on_change_third_param_update
+++ b/packages/js/components/changelog/fix-revert_on_change_third_param_update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Reverted change of last PR as part of #34614
+
+

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -54,7 +54,7 @@ type FormProps< Values > = {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		value: { name: string; value: any },
 		values: Values,
-		hasErrors: boolean
+		isValid: boolean
 	) => void;
 	/**
 	 * A function that is passed a list of all values and
@@ -174,7 +174,7 @@ function FormComponent< Values extends Record< string, any > >(
 					callback(
 						{ name, value },
 						newValues,
-						!! Object.keys( newErrors || {} ).length
+						! Object.keys( newErrors || {} ).length
 					);
 				}
 			} );

--- a/packages/js/components/src/form/test/index.tsx
+++ b/packages/js/components/src/form/test/index.tsx
@@ -172,14 +172,14 @@ describe( 'Form', () => {
 			expect( mockOnChange ).toHaveBeenCalledWith(
 				{ name: 'firstName', value: 'F' },
 				{ firstName: 'F' },
-				false
+				true
 			);
 
 			fireEvent.change( firstNameInput, { target: { value: 'Fi' } } );
 			expect( mockOnChange ).toHaveBeenCalledWith(
 				{ name: 'firstName', value: 'Fi' },
 				{ firstName: 'Fi' },
-				false
+				true
 			);
 		}
 	} );
@@ -222,14 +222,14 @@ describe( 'Form', () => {
 			expect( mockOnChange ).toHaveBeenCalledWith(
 				{ name: 'firstName', value: 'F' },
 				{ firstName: 'F' },
-				true
+				false
 			);
 
 			fireEvent.change( firstNameInput, { target: { value: 'Fi' } } );
 			expect( mockOnChange ).toHaveBeenCalledWith(
 				{ name: 'firstName', value: 'Fi' },
 				{ firstName: 'Fi' },
-				false
+				true
 			);
 		}
 	} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reverts minor change merged as part of: #34614

### How to test the changes in this Pull Request:

1.  Load this branch
2. Run through the onboarding wizard and make sure all the forms run fine (especially the Business details step).
3. Load the form component in storybook and check if the onChange values match the form values above it as you update the fields (see screenshot).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
