### PR TITLE
Fix rounding difference on refunds with per-line taxes. Closes #30263

### DIFF
--- a/plugins/woocommerce/changelog/fix-refund-rounding-difference
+++ b/plugins/woocommerce/changelog/fix-refund-rounding-difference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fix rounding difference on refunds with per-line taxes

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1043,15 +1043,19 @@ jQuery( function ( $ ) {
 			},
 
 			input_changed: function() {
-				var refund_amount = 0;
-				var $items        = $( '.woocommerce_order_items' ).find( 'tr.item, tr.fee, tr.shipping' );
+				var refund_amount     = 0;
+				var $items            = $( '.woocommerce_order_items' ).find( 'tr.item, tr.fee, tr.shipping' );
+				var round_at_subtotal = 'yes' === woocommerce_admin_meta_boxes.round_at_subtotal;
 
 				$items.each(function() {
 					var $row               = $( this );
 					var refund_cost_fields = $row.find( '.refund input:not(.refund_order_item_qty)' );
 
 					refund_cost_fields.each(function( index, el ) {
-						refund_amount += parseFloat( accounting.unformat( $( el ).val() || 0, woocommerce_admin.mon_decimal_point ) );
+						var field_amount = accounting.unformat( $( el ).val() || 0, woocommerce_admin.mon_decimal_point );
+						refund_amount += parseFloat( round_at_subtotal ?
+							field_amount :
+							accounting.formatNumber( field_amount, woocommerce_admin_meta_boxes.currency_format_num_decimals, '' ) );
 					});
 				});
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -3,7 +3,7 @@
  * Shows an order item
  *
  * @package WooCommerce\Admin
- * @var object $item The item being displayed
+ * @var WC_Order_Item $item The item being displayed
  * @var int $item_id The id of the item being displayed
  */
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Rounds each refund line individually when using per-line tax rounding setting.
In this way _refund amount_ cannot surpass _total available to refund_ when recalculating refund amount based on refund quantities, because when the tax portion is rounded up, the non-tax portion is rounded down and vice-versa. 

_Refund amount_ shound always equal _total available to refund_ when all order lines are refunded.

This is a minimalistic fix due to the admin refund logic needing to be rewritten completely imo.

Also fixes a type hint in an associated template.

Closes #30263

### How to test the changes in this Pull Request:

1. Set tax rate to 24%
2. In Settings -> Tax, select: Yes, I will enter prices inclusive of tax
3. Leave Rounding unchecked, so it calculates per line.
4. Create two products priced at 2.10 each and add each to the cart.
5. Complete checkout and then mark order complete
6. Go to refund the order and you'll see that the refund amount is 4.20 where it previously would have been 4.21.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
