### PR TITLE
Redirect new/edit/delete URLs from CPT implementation to COT

### DIFF
--- a/plugins/woocommerce/changelog/fix-34229
+++ b/plugins/woocommerce/changelog/fix-34229
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Redirect CPT-based URLs to OrdersTableDataStore ones.

--- a/plugins/woocommerce/changelog/fix-34229
+++ b/plugins/woocommerce/changelog/fix-34229
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Redirect CPT-based URLs to OrdersTableDataStore ones.
+Redirect CPT-based admin order URLs to the corresponding Custom Order Table URLs.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -9,6 +9,13 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableControlle
 class PageController {
 
 	/**
+	 * Instance of the posts redirection controller.
+	 *
+	 * @var PostsRedirectionController
+	 */
+	private $redirection_controller;
+
+	/**
 	 * Instance of the orders list table.
 	 *
 	 * @var ListTable
@@ -70,6 +77,8 @@ class PageController {
 	 * @return void
 	 */
 	public function setup(): void {
+		$this->redirection_controller = new PostsRedirectionController( $this );
+
 		// Register menu.
 		if ( 'admin_menu' === current_action() ) {
 			$this->register_menu();

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -215,6 +215,17 @@ class PageController {
 	}
 
 	/**
+	 * Helper method to generate a link to the main orders screen.
+	 *
+	 * @return string Orders screen URL.
+	 */
+	public function get_orders_url(): string {
+		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ?
+			admin_url( 'admin.php?page=wc-orders' ) :
+			admin_url( 'edit.php?post_type=shop_order' );
+	}
+
+	/**
 	 * Helper method to generate edit link for an order.
 	 *
 	 * @param int $order_id Order ID.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
 /**
  * When {@see OrdersTableDataStore} is in use, this class takes care of redirecting admins from CPT-based URLs
  * to the new ones.
@@ -21,6 +23,10 @@ class PostsRedirectionController {
 	 */
 	public function __construct( PageController $page_controller ) {
 		$this->page_controller = $page_controller;
+
+		if ( ! wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
+			return;
+		}
 
 		add_action(
 			'load-edit.php',

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -106,7 +106,7 @@ class PostsRedirectionController {
 	private function maybe_redirect_to_edit_order_page(): void {
 		$post_id = absint( $_GET['post'] ?? 0 );
 
-		if ( ! $post_id || 'shop_order' !== get_post_type( $post_id ) || ! isset( $_GET['action'] ) ) {
+		if ( ! $post_id || ! in_array( get_post_type( $post_id ), array( 'shop_order_placehold', 'shop_order' ), true )  || ! isset( $_GET['action'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a controller class that takes care of redirecting requests for certain order-related actions from their CPT version to their COT version.

Closes #34229.

### How to test the changes in this Pull Request:

1. Make posts authoritative and make sure to populate your site with some orders.
2. Go to WC > Orders and take note of the URL as well as some of the links to specific orders and/or order actions such as "trash" or "untrash".
3. Make COT authoritative and migrate orders.
4. Try to use some of the links from step 2 and confirm that you are redirected to the new URLs (i.e. those under `admin.php?page=wc-orders`). In most cases, query args are preserved verbatim, except for some specific ones that are translated to new ones or removed entirely (for example, `post_type` is no longer needed).
   Some scenarios that could be tested:
   - `/wp-admin/post-new.php?post_type=shop_order` should take you to the new order screen (/wp-admin/admin.php?page=wc-orders&action=new).
   - `/wp-admin/post.php?post=POST_ID&action=edit` should take you to the edit screen for `POST_ID`. If `POST_ID` is not an order, no redirection should take place.
   - `/wp-admin/edit.php?post_type=shop_order` should take you to the main order screen.
   - `/wp-admin/edit.php?post_status=wc-pending&post_type=shop_order` should take you to the main order screen with `status=wc-pending`.
   - `/wp-admin/edit.php?s&post_status=all&post_type=shop_order&action=-1&m=202208&_customer_user&filter_action=Filter&paged=1&action2=-1` should take you to the main order screen with all query args still present (and thus, with the date filter active to Aug 2022).
   - `wp-admin/post.php?post=POST_ID&action=trash&_wpnonce=NONCE` should trash the order using COT and take you to the orders screen. Keep in mind that `NONCE` can expire, so this kind of link should be tested quickly.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
