### PR TITLE
Fix attribute taxonomy sort order meta key

### DIFF
--- a/plugins/woocommerce/changelog/fix-34213
+++ b/plugins/woocommerce/changelog/fix-34213
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Increase consistency in relation to the way taxonomy term ordering is persisted.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-taxonomies.php
@@ -103,9 +103,7 @@ class WC_Admin_Taxonomies {
 			return;
 		}
 
-		$meta_name = taxonomy_is_product_attribute( $taxonomy ) ? 'order_' . esc_attr( $taxonomy ) : 'order';
-
-		update_term_meta( $term_id, $meta_name, 0 );
+		update_term_meta( $term_id, 'order', 0 );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -569,7 +569,7 @@ function wc_create_attribute( $args ) {
 			// Update taxonomy ordering term meta.
 			$wpdb->update(
 				$wpdb->termmeta,
-				array( 'meta_key' => 'order', // WPCS: slow query ok.
+				array( 'meta_key' => 'order' ), // WPCS: slow query ok.
 				array( 'meta_key' => 'order_pa_' . sanitize_title( $old_slug ) ) // WPCS: slow query ok.
 			);
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -569,7 +569,7 @@ function wc_create_attribute( $args ) {
 			// Update taxonomy ordering term meta.
 			$wpdb->update(
 				$wpdb->termmeta,
-				array( 'meta_key' => 'order_pa_' . sanitize_title( $data['attribute_name'] ) ), // WPCS: slow query ok.
+				array( 'meta_key' => 'order', // WPCS: slow query ok.
 				array( 'meta_key' => 'order_pa_' . sanitize_title( $old_slug ) ) // WPCS: slow query ok.
 			);
 

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -569,7 +569,7 @@ function wc_create_attribute( $args ) {
 			// Update taxonomy ordering term meta.
 			$wpdb->update(
 				$wpdb->termmeta,
-				array( 'meta_key' => 'order' ), // WPCS: slow query ok.
+				array( 'meta_key' => 'order' ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				array( 'meta_key' => 'order_pa_' . sanitize_title( $old_slug ) ) // WPCS: slow query ok.
 			);
 


### PR DESCRIPTION
### All Submissions:

-   [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

Start with trunk/start without this change:

1. Via **Products ▸ Attributes**, create some product attributes and terms. 
    - For at least two different attributes, apply custom ordering.
    - Via the **Configure Terms** screen, go ahead and re-order the terms.
2. Apply a range of those same terms (for at least two different attributes) to one of your products.
    - If you visit the single product page and open the **Additional Information** tab, you should see these terms.
    - The custom ordering you applied in the admin screen should be respected here (if you have applied the terms `a` and `b`, but `b` has been custom ordered to display before `a`, that should also apply on the frontend).

Now switch to this branch:

1. Create a new attribute and terms, apply some custom ordering, then apply this new attribute and some of those terms to the same product.
2. Edit **one** of the existing attributes (that you worked on at the start), re-order some of its terms.
3. Visit the single product page: ordering should be respected for the new attribute terms, the existing terms that you re-ordered, and the existing term where you did not change the order.

Some screenshots etc, in case helpful when trying to find some of the locations referenced above:

| Asset | Notes|
| --- | --- |
| ![Additional info tab (single product page)](https://user-images.githubusercontent.com/3594411/203642892-73543e1a-aa0f-4922-9e0e-d4039e85e4a4.png) | Single product page: additional info tab |
| ![Configure terms](https://user-images.githubusercontent.com/3594411/203642895-5c94c466-2920-4b48-add4-56ba462c2c0a.png) | Admin screen: configure terms link| 
| ![🎥  Reordering terms](https://user-images.githubusercontent.com/3594411/203642898-69ca8432-3d0f-41cb-b05d-11b277a5514d.mov) | Screencast (how re-ordering terms works) |


### Other information:

-   [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.

### Developer notes

https://github.com/woocommerce/woocommerce/issues/34213#issuecomment-1210770318

It appears this issue was partially addressed in version 3.6.0. However, we updated from version 3.4 to version 6.1.0.  This caused us to miss the DB update `wc_update_360_term_meta`.  This PR will address the `order` meta key name for newly created attribute taxonomy terms. In addition, this will address the same issue when an attribute taxonomy term is updated.


