### PR TITLE
dev: change webpack config to use asset modules instead of custom loaders

### DIFF
--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -129,7 +129,7 @@ const webpackConfig = {
 			{ test: /\.md$/, use: 'raw-loader' },
 			{
 				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/,
-				loader: 'url-loader',
+				type: 'asset',
 			},
 			...styleConfig.rules,
 		],

--- a/plugins/woocommerce/changelog/dev-webpack-asset-modules
+++ b/plugins/woocommerce/changelog/dev-webpack-asset-modules
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+change webpack config to use asset modules instead of custom loaders


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Asset modules are a new webpack 5 feature that handles inlining or extracting resources. It replaces loader configurations such as url-loader with defaults that work.

https://medium.com/@mehran.hrajabi98/webpack-5-asset-loaders-vs-asset-modules-b08263970510

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34306.

### How to test the changes in this Pull Request:

1. Smoke test to check that resources are still loading

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
