### PR TITLE
Add: get mobile app task in additional tasks

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
@@ -5,6 +5,8 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { Guide } from '@wordpress/components';
 import { useSearchParams } from 'react-router-dom';
 import { updateQueryString } from '@woocommerce/navigation';
+import { useDispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -26,6 +28,7 @@ export const MobileAppModal = () => {
 	const [ guideIsOpen, setGuideIsOpen ] = useState( true );
 
 	const { state, jetpackConnectionData } = useJetpackPluginState();
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
 	const [ pageContent, setPageContent ] = useState< React.ReactNode >();
 	const [ searchParams ] = useSearchParams();
@@ -99,6 +102,9 @@ export const MobileAppModal = () => {
 			{ guideIsOpen && (
 				<Guide
 					onFinish={ () => {
+						updateOptions( {
+							woocommerce_admin_dismissed_mobile_app_modal: 'yes',
+						} );
 						// clear the search params that we use so that the URL is clean
 						updateQueryString(
 							{

--- a/plugins/woocommerce/changelog/add-get-mobile-app-task
+++ b/plugins/woocommerce/changelog/add-get-mobile-app-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added the get mobile app task to the additional tasklist

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -51,6 +51,7 @@ class TaskLists {
 		'Appearance',
 		'AdditionalPayments',
 		'ReviewShippingOptions',
+		'GetMobileApp',
 	);
 
 	/**
@@ -145,6 +146,7 @@ class TaskLists {
 				),
 				'tasks'   => array(
 					'AdditionalPayments',
+					'GetMobileApp',
 				),
 			)
 		);
@@ -182,6 +184,7 @@ class TaskLists {
 				),
 				'tasks'        => array(
 					'AdditionalPayments',
+					'GetMobileApp',
 				),
 				'event_prefix' => 'extended_tasklist_',
 			)

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
@@ -23,7 +23,7 @@ class GetMobileApp extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Get the free WooCommmerce mobile app', 'woocommerce' );
+		return __( 'Get the free WooCommerce mobile app', 'woocommerce' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
+/**
+ * Get Mobile App Task
+ */
+class GetMobileApp extends Task {
+	/**
+	 * ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'get-mobile-app';
+	}
+
+	/**
+	 * Title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return __( 'Get the free WooCommmerce mobile app', 'woocommerce' );
+	}
+
+	/**
+	 * Content.
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+		return '';
+	}
+
+	/**
+	 * Time.
+	 *
+	 * @return string
+	 */
+	public function get_time() {
+		return '';
+	}
+
+	/**
+	 * Task completion.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return get_option( 'woocommerce_admin_dismissed_mobile_app_modal' ) === 'yes';
+	}
+
+	/**
+	 * Task visibility.
+	 *
+	 * @return bool
+	 */
+	public function can_view() {
+		return current_user_can( 'manage_woocommerce' ) && current_user_can( 'install_plugins' );
+	}
+
+	/**
+	 * Action URL.
+	 *
+	 * @return string
+	 */
+	public function get_action_url() {
+		return admin_url( 'admin.php?page=wc-admin&mobileAppModal=true' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added the get mobile app task in additional tasks

### How to test the changes in this Pull Request:

1. Start with a WooCommerce installation
2. Should see the "Get WooCommerce mobile app" task in the next things tasklist
3. On next refresh of the home screen, task should be marked as completed after the modal is dismissed 

![image](https://user-images.githubusercontent.com/27843274/189815898-65761532-b49f-4154-826a-f38f6703d3f4.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
