### PR TITLE
fix: handle mobile app wrong user connection

### DIFF
--- a/packages/js/data/changelog/fix-jetpack-connection-data-type
+++ b/packages/js/data/changelog/fix-jetpack-connection-data-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Enhanced jetpack connection data

--- a/packages/js/data/src/plugins/types.ts
+++ b/packages/js/data/src/plugins/types.ts
@@ -84,23 +84,26 @@ export type ActivatePluginsResponse = PluginsResponse< {
 } >;
 
 export type JetpackConnectionDataResponse = {
+	/** The user on this site who is connected to Jetpack with their WordPress.com account */
+	connectionOwner: string | null;
+	/** Details about the currently logged in user on this site */
 	currentUser: {
 		isConnected: boolean;
 		isMaster: boolean;
 		username: string;
 		id: number;
-		wpcomUser: {
-			ID: number;
-			login: string;
-			email: string;
-			display_name: string;
-			text_direction: string;
-			site_count: number;
-			jetpack_connect: string;
-			color_scheme: string;
-			sidebar_collapsed: boolean;
-			user_locale: string;
-			avatar: string;
+		wpcomUser?: {
+			ID?: number;
+			login?: string;
+			email?: string;
+			display_name?: string;
+			text_direction?: string;
+			site_count?: number;
+			jetpack_connect?: string;
+			color_scheme?: string;
+			sidebar_collapsed?: boolean;
+			user_locale?: string;
+			avatar?: string;
 		};
 		gravatar: string;
 		permissions: {

--- a/plugins/woocommerce-admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/help.js
@@ -16,7 +16,6 @@ import {
 } from '@woocommerce/data';
 import { compose } from 'redux';
 import { recordEvent } from '@woocommerce/tracks';
-import { getAdminLink } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -36,13 +35,6 @@ function getHomeItems() {
 		{
 			title: __( 'Home Screen', 'woocommerce' ),
 			link: 'https://woocommerce.com/document/home-screen/?utm_medium=product',
-		},
-		{
-			title: __( 'Get the WooCommerce app', 'woocommerce' ),
-			link: getAdminLink(
-				'./admin.php?page=wc-admin&mobileAppModal=true'
-			),
-			linkType: 'wc-admin',
 		},
 		{
 			title: __( 'Inbox', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
@@ -86,7 +86,7 @@ export const JetpackInstallationStepper = ( {
 		} else if ( step === 'second' ) {
 			// this step is shown on the return callback from the WordPress.com user connection
 			const wordpressAccountEmailAddress =
-				jetpackConnectionData?.currentUser.wpcomUser.email;
+				jetpackConnectionData?.currentUser?.wpcomUser?.email;
 			setStepsToDisplay( [
 				{
 					key: 'first',
@@ -122,7 +122,7 @@ export const JetpackInstallationStepper = ( {
 		installHandler,
 		state,
 		isWaitingForRedirect,
-		jetpackConnectionData?.currentUser.wpcomUser.email,
+		jetpackConnectionData?.currentUser?.wpcomUser?.email,
 		sendMagicLinkHandler,
 	] );
 

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
@@ -68,38 +68,42 @@ export const useJetpackPluginState = () => {
 	}, [ installJetpackAndConnect ] );
 
 	useEffect( () => {
-		if ( jetpackInstallState === 'activated' ) {
-			if (
-				// Jetpack can be installed and activated but not connected to a WordPress.com user account, this handles that
-				jetpackConnectionData &&
-				! jetpackConnectionData?.connectionOwner
-			) {
-				setPluginState( JetpackPluginStates.USERLESS_CONNECTION );
-			} else if (
-				jetpackConnectionData &&
-				jetpackConnectionData?.currentUser?.username !==
-					jetpackConnectionData?.connectionOwner
-			) {
-				setPluginState( JetpackPluginStates.NOT_OWNER_OF_CONNECTION );
-			} else if (
-				jetpackConnectionData &&
-				jetpackConnectionData?.currentUser?.isConnected &&
-				jetpackConnectionData?.currentUser?.isMaster
-			) {
-				setPluginState( JetpackPluginStates.FULL_CONNECTION );
-			}
-		}
-
 		if ( ! canUserInstallPlugins ) {
 			setPluginState( JetpackPluginStates.USER_CANNOT_INSTALL );
-		}
-
-		if ( jetpackInstallState === 'installed' ) {
-			setPluginState( JetpackPluginStates.NOT_ACTIVATED );
-		}
-
-		if ( jetpackInstallState === 'unavailable' ) {
-			setPluginState( JetpackPluginStates.NOT_INSTALLED );
+		} else {
+			switch ( jetpackInstallState ) {
+				case 'installed':
+					setPluginState( JetpackPluginStates.NOT_ACTIVATED );
+					break;
+				case 'unavailable':
+					setPluginState( JetpackPluginStates.NOT_INSTALLED );
+					break;
+				case 'activated':
+					if (
+						// Jetpack can be installed and activated but not connected to a WordPress.com user account, this handles that
+						jetpackConnectionData &&
+						! jetpackConnectionData?.connectionOwner
+					) {
+						setPluginState(
+							JetpackPluginStates.USERLESS_CONNECTION
+						);
+					} else if (
+						jetpackConnectionData &&
+						jetpackConnectionData?.currentUser?.username !==
+							jetpackConnectionData?.connectionOwner
+					) {
+						setPluginState(
+							JetpackPluginStates.NOT_OWNER_OF_CONNECTION
+						);
+					} else if (
+						jetpackConnectionData &&
+						jetpackConnectionData?.currentUser?.isConnected &&
+						jetpackConnectionData?.currentUser?.isMaster
+					) {
+						setPluginState( JetpackPluginStates.FULL_CONNECTION );
+					}
+					break;
+			}
 		}
 	}, [ canUserInstallPlugins, jetpackInstallState, jetpackConnectionData ] );
 

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
@@ -17,6 +17,8 @@ export const JetpackPluginStates = {
 	NOT_ACTIVATED: 'not-activated',
 	/** Jetpack plugin is installed but not connected to a WordPress.com user */
 	USERLESS_CONNECTION: 'userless-connection',
+	/** Jetpack on this site is connected to a user but not the currently logged in user */
+	NOT_OWNER_OF_CONNECTION: 'not-owner-of-connection',
 	/** Jetpack Plugin installed and WordPress.com user connected */
 	FULL_CONNECTION: 'full-connection',
 	/** Still retrieving Jetpack state from Wordpress Installation */
@@ -66,31 +68,38 @@ export const useJetpackPluginState = () => {
 	}, [ installJetpackAndConnect ] );
 
 	useEffect( () => {
-		if ( ! canUserInstallPlugins ) {
-			setPluginState( JetpackPluginStates.USER_CANNOT_INSTALL );
+		if ( jetpackInstallState === 'activated' ) {
+			if (
+				// Jetpack can be installed and activated but not connected to a WordPress.com user account, this handles that
+				jetpackConnectionData &&
+				! jetpackConnectionData?.connectionOwner
+			) {
+				setPluginState( JetpackPluginStates.USERLESS_CONNECTION );
+			} else if (
+				jetpackConnectionData &&
+				jetpackConnectionData?.currentUser?.username !==
+					jetpackConnectionData?.connectionOwner
+			) {
+				setPluginState( JetpackPluginStates.NOT_OWNER_OF_CONNECTION );
+			} else if (
+				jetpackConnectionData &&
+				jetpackConnectionData?.currentUser?.isConnected &&
+				jetpackConnectionData?.currentUser?.isMaster
+			) {
+				setPluginState( JetpackPluginStates.FULL_CONNECTION );
+			}
 		}
 
-		if ( jetpackInstallState === 'unavailable' ) {
-			setPluginState( JetpackPluginStates.NOT_INSTALLED );
+		if ( ! canUserInstallPlugins ) {
+			setPluginState( JetpackPluginStates.USER_CANNOT_INSTALL );
 		}
 
 		if ( jetpackInstallState === 'installed' ) {
 			setPluginState( JetpackPluginStates.NOT_ACTIVATED );
 		}
 
-		if ( jetpackInstallState === 'activated' ) {
-			if (
-				// Jetpack can be installed and activated but not connected to a WordPress.com user account, this handles that
-				jetpackConnectionData &&
-				! jetpackConnectionData.currentUser.isConnected
-			) {
-				setPluginState( JetpackPluginStates.USERLESS_CONNECTION );
-			} else if (
-				jetpackConnectionData &&
-				jetpackConnectionData.currentUser.isConnected
-			) {
-				setPluginState( JetpackPluginStates.FULL_CONNECTION );
-			}
+		if ( jetpackInstallState === 'unavailable' ) {
+			setPluginState( JetpackPluginStates.NOT_INSTALLED );
 		}
 	}, [ canUserInstallPlugins, jetpackInstallState, jetpackConnectionData ] );
 

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/WrongUserConnectedPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/WrongUserConnectedPage.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+interface WrongUserConnectedPageProps {
+	wordpressAccountEmailAddress?: string | undefined;
+}
+
+export const WrongUserConnectedPage: React.FC<
+	WrongUserConnectedPageProps
+> = () => {
+	// The user shouldn't see this screen at all unless he's messing with the page URL manually to get here when he's not allowed to
+	return (
+		<div className="wrong-user-connected-modal-body">
+			<div className="wrong-user-connected-title">
+				<h1>{ __( 'Oops!', 'woocommerce' ) }</h1>
+			</div>
+			<div className="wrong-user-connected-subheader-spacer">
+				<div className="wrong-user-connected-subheader">
+					{ __(
+						'It looks like this site is connected to another WordPress.com account.',
+						'woocommerce'
+					) }
+				</div>
+				<br />
+				<div className="wrong-user-connected-subheader">
+					{ __(
+						'WooCommerce Mobile App can currently only be registered to a single WordPress.com account.',
+						'woocommerce'
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/style.scss
@@ -224,3 +224,29 @@ button.components-button.send-magic-link-button {
 		}
 	}
 }
+.wrong-user-connected-modal-body {
+	padding-block: 40px;
+	padding-inline: 56px;
+	margin: auto; // center the content both vertically and horizontally
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	height: 495px;
+	animation: fadeIn 0.7s ease-in-out; // fade in the modal content for consistency because the previous content fades in
+
+	.wrong-user-connected-title {
+		padding-top: 111px;
+	}
+	.wrong-user-connected-subheader-spacer {
+		flex-grow: 1;
+		padding-inline: 32px;
+		margin-top: 16px;
+		.wrong-user-connected-subheader {
+			font-weight: 400;
+			font-size: 16px;
+			line-height: 1.5rem;
+			color: #757575;
+			text-align: center;
+		}
+	}
+}

--- a/plugins/woocommerce/changelog/fix-handle-mobile-app-wrong-user-connection
+++ b/plugins/woocommerce/changelog/fix-handle-mobile-app-wrong-user-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+handle mobile app wrong user connection


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

For the mobile app feature, there are some cases where the user is simply not eligible to use the mobile app connection such as:
1. The user does not have permissions to install plugins, so they cannot install Jetpack which is a requirement for the mobile app
2. There is already a wordpress.com user registered as master of the site, and it is not the currently logged in user.

In order to handle these cases, the help entry should not show up for them so that they cannot access the modal. 
A filter callback has been added that appends the help entry depending on the user's eligibility.

If the user manages to access the modal somehow, there is also a rudimentary error page.

### How to test the changes in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/34637

But take the opportunity to also check that the entry does not show up for non-admin users and admin users who is not the admin user who has connected to the wordpress.com account

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
