### PR TITLE
DateTimePickerControl updates

### DIFF
--- a/packages/js/components/changelog/update-date-time-picker-control
+++ b/packages/js/components/changelog/update-date-time-picker-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add label, placeholder, and help props to DateTimePickerControl.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
@@ -1,0 +1,5 @@
+.woocommerce-date-time-picker-control {
+	.woocommerce-date-time-picker-control__input-control__suffix {
+		padding-right: 8px;
+	}
+}

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
@@ -1,4 +1,6 @@
 .woocommerce-date-time-picker-control {
+	display: block;
+
 	.woocommerce-date-time-picker-control__input-control__suffix {
 		padding-right: 8px;
 	}

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -47,6 +47,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	className = '',
 	onChangeDebounceWait = 500,
 }: DateTimePickerControlProps ) => {
+	const inputControl = useRef< InputControl >();
+
 	const [ inputString, setInputString ] = useState( '' );
 	const [ lastValidDate, setLastValidDate ] = useState< Moment | null >(
 		null
@@ -114,6 +116,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		}
 	}
 
+	function focusInputControl() {
+		if ( inputControl.current ) {
+			inputControl.current.focus();
+		}
+	}
+
 	const isInitialUpdate = useRef( true );
 	useEffect( () => {
 		// Don't trigger the change handling on the initial update of the component
@@ -148,6 +156,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<>
 					<InputControl
+						ref={ inputControl }
 						disabled={ disabled }
 						value={ inputString }
 						onChange={ change }
@@ -160,7 +169,11 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						} }
 						label={ label }
 						suffix={
-							<Icon icon={ calendar } className="calendar-icon" />
+							<Icon
+								icon={ calendar }
+								className="calendar-icon"
+								onClick={ focusInputControl }
+							/>
 						}
 						placeholder={ placeholder }
 						describedBy={ sprintf(

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -96,7 +96,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				onChange( dateTime, isValid );
 			}
 		}, onChangeDebounceWait ),
-		[ onChangeDebounceWait ]
+		[ onChange, onChangeDebounceWait ]
 	);
 
 	function change( newInputString: string ) {

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -25,7 +25,7 @@ export type DateTimePickerControlProps = {
 	dateTimeFormat?: string;
 	disabled?: boolean;
 	is12Hour?: boolean;
-	onChange?: ( date: string ) => void;
+	onChange?: ( date: string, isValid: boolean ) => void;
 	onBlur?: () => void;
 	label?: string;
 	placeholder?: string;
@@ -86,16 +86,16 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			setInputString( newInputString );
 
 			const newDateTime = parseMoment( newInputString );
+			const isValid = newDateTime.isValid();
 
-			if ( newDateTime.isValid() ) {
+			if ( isValid ) {
 				setLastValidDate( newDateTime );
 			}
 
 			if ( onChange ) {
 				onChange(
-					newDateTime.isValid()
-						? formatMomentIso( newDateTime )
-						: newInputString
+					isValid ? formatMomentIso( newDateTime ) : newInputString,
+					isValid
 				);
 			}
 		}, 500 ),

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -128,6 +128,11 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		debouncedOnChange( newInputString );
 	}
 
+	function changeImmediate( newInputString: string ) {
+		setInputString( newInputString );
+		onChangeCallback( newInputString );
+	}
+
 	function blur() {
 		if ( onBlur ) {
 			onBlur();
@@ -225,7 +230,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						const formattedDate = formatMoment(
 							parseMomentIso( date )
 						);
-						setInputString( formattedDate );
+						changeImmediate( formattedDate );
 					} }
 					is12Hour={ is12Hour }
 				/>

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Fragment } from 'react';
 import { createElement, useState, useEffect } from '@wordpress/element';
 import { Icon, calendar } from '@wordpress/icons';
 import moment from 'moment';
@@ -59,61 +60,64 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			position="bottom center"
 			focusOnMount={ false }
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<InputControl
-					disabled={ disabled }
-					value={ inputString }
-					onChange={ ( value: string ) => setInputString( value ) }
-					onBlur={ (
-						event: React.FocusEvent< HTMLInputElement >
-					) => {
-						if ( ! isOpen ) {
-							return;
+				<>
+					<InputControl
+						disabled={ disabled }
+						value={ inputString }
+						onChange={ ( value: string ) =>
+							setInputString( value )
 						}
+						onBlur={ (
+							event: React.FocusEvent< HTMLInputElement >
+						) => {
+							if ( ! isOpen ) {
+								return;
+							}
 
-						setDateTime(
-							moment( event.target.value, dateTimeFormat )
-						);
-
-						const relatedTargetParent =
-							event.relatedTarget?.closest(
-								'.components-dropdown'
-							);
-						const currentTargetParent =
-							event.currentTarget?.closest(
-								'.components-dropdown'
+							setDateTime(
+								moment( event.target.value, dateTimeFormat )
 							);
 
-						if (
-							! relatedTargetParent ||
-							relatedTargetParent !== currentTargetParent
-						) {
+							const relatedTargetParent =
+								event.relatedTarget?.closest(
+									'.components-dropdown'
+								);
+							const currentTargetParent =
+								event.currentTarget?.closest(
+									'.components-dropdown'
+								);
+
+							if (
+								! relatedTargetParent ||
+								relatedTargetParent !== currentTargetParent
+							) {
+								onToggle();
+							}
+						} }
+						label={ label }
+						suffix={
+							<Icon icon={ calendar } className="calendar-icon" />
+						}
+						placeholder={ placeholder }
+						describedBy={ sprintf(
+							/* translators: A datetime format */
+							__(
+								'Date input describing a selected date in format %s',
+								'woocommerce'
+							),
+							dateTimeFormat
+						) }
+						onFocus={ () => {
+							if ( isOpen ) {
+								return;
+							}
+
 							onToggle();
-						}
-					} }
-					label={ label }
-					suffix={
-						<Icon icon={ calendar } className="calendar-icon" />
-					}
-					placeholder={ placeholder }
-					error={ inputError }
-					describedBy={ sprintf(
-						/* translators: A datetime format */
-						__(
-							'Date input describing a selected date in format %s',
-							'woocommerce'
-						),
-						dateTimeFormat
-					) }
-					onFocus={ () => {
-						if ( isOpen ) {
-							return;
-						}
-
-						onToggle();
-					} }
-					aria-expanded={ isOpen }
-					errorPosition="top center"
-				/>
+						} }
+						aria-expanded={ isOpen }
+					/>
+					{ inputError && <p>{ inputError }</p> }
+				</>
 			) }
 			renderContent={ () => (
 				<WpDateTimePicker

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -20,6 +20,7 @@ export type DateTimePickerControlProps = {
 	disabled?: boolean;
 	is12Hour?: boolean;
 	onChange: ( date: string ) => void;
+	placeholder?: string;
 } & Omit< React.HTMLAttributes< HTMLDivElement >, 'onChange' >;
 
 export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
@@ -28,6 +29,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	dateTimeFormat = is12Hour ? 'MM/DD/YYYY h:mm a' : 'MM/DD/YYYY H:MM',
 	disabled = false,
 	onChange,
+	placeholder,
 }: DateTimePickerControlProps ) => {
 	const [ dateTime, setDateTime ] = useState(
 		moment( currentDate || new Date().toISOString() )
@@ -94,6 +96,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 					} }
 					dateFormat={ dateTimeFormat }
 					label={ __( 'Choose a date', 'woocommerce' ) }
+					placeholder={ placeholder }
 					error={ inputError }
 					describedBy={ sprintf(
 						/* translators: A datetime format */

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -2,17 +2,15 @@
  * External dependencies
  */
 import { createElement, useState, useEffect } from '@wordpress/element';
+import { Icon, calendar } from '@wordpress/icons';
+import moment from 'moment';
+import { sprintf, __ } from '@wordpress/i18n';
 import {
 	Dropdown,
 	DateTimePicker as WpDateTimePicker,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
-import moment from 'moment';
-import { sprintf, __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import { default as DateInput } from '../calendar/input';
 
 export type DateTimePickerControlProps = {
 	currentDate?: string | null;
@@ -20,6 +18,7 @@ export type DateTimePickerControlProps = {
 	disabled?: boolean;
 	is12Hour?: boolean;
 	onChange: ( date: string ) => void;
+	label?: string;
 	placeholder?: string;
 } & Omit< React.HTMLAttributes< HTMLDivElement >, 'onChange' >;
 
@@ -29,6 +28,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	dateTimeFormat = is12Hour ? 'MM/DD/YYYY h:mm a' : 'MM/DD/YYYY H:MM',
 	disabled = false,
 	onChange,
+	label,
 	placeholder,
 }: DateTimePickerControlProps ) => {
 	const [ dateTime, setDateTime ] = useState(
@@ -59,14 +59,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			position="bottom center"
 			focusOnMount={ false }
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<DateInput
+				<InputControl
 					disabled={ disabled }
 					value={ inputString }
-					onChange={ ( {
-						target,
-					}: React.ChangeEvent< HTMLInputElement > ) =>
-						setInputString( target.value )
-					}
+					onChange={ ( value: string ) => setInputString( value ) }
 					onBlur={ (
 						event: React.FocusEvent< HTMLInputElement >
 					) => {
@@ -94,8 +90,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 							onToggle();
 						}
 					} }
-					dateFormat={ dateTimeFormat }
-					label={ __( 'Choose a date', 'woocommerce' ) }
+					label={ label }
+					suffix={
+						<Icon icon={ calendar } className="calendar-icon" />
+					}
 					placeholder={ placeholder }
 					error={ inputError }
 					describedBy={ sprintf(

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -5,6 +5,7 @@ import { Fragment } from 'react';
 import { createElement, useState, useEffect } from '@wordpress/element';
 import { Icon, calendar } from '@wordpress/icons';
 import moment, { Moment } from 'moment';
+import classNames from 'classnames';
 import { sprintf, __ } from '@wordpress/i18n';
 import {
 	Dropdown,
@@ -35,6 +36,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	label,
 	placeholder,
 	help,
+	className = '',
 }: DateTimePickerControlProps ) => {
 	const [ inputString, setInputString ] = useState( '' );
 	const [ lastValidDate, setLastValidDate ] = useState< Moment | null >(
@@ -115,6 +117,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 
 	return (
 		<Dropdown
+			className={ classNames(
+				'woocommerce-date-time-picker-control',
+				className
+			) }
 			position="bottom center"
 			focusOnMount={ false }
 			// @ts-expect-error `onToggle` does exist.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -14,7 +14,9 @@ import moment, { Moment } from 'moment';
 import { debounce } from 'lodash';
 import classNames from 'classnames';
 import { sprintf, __ } from '@wordpress/i18n';
+import { useInstanceId } from '@wordpress/compose';
 import {
+	BaseControl,
 	Dropdown,
 	DateTimePicker as WpDateTimePicker,
 	// @ts-expect-error `__experimentalInputControl` does exist.
@@ -47,6 +49,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	className = '',
 	onChangeDebounceWait = 500,
 }: DateTimePickerControlProps ) => {
+	const instanceId = useInstanceId( DateTimePickerControl );
+	const id = `inspector-date-time-picker-control-${ instanceId }`;
 	const inputControl = useRef< InputControl >();
 
 	const [ inputString, setInputString ] = useState( '' );
@@ -154,8 +158,9 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				}
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<>
+				<BaseControl id={ id } label={ label } help={ help }>
 					<InputControl
+						id={ id }
 						ref={ inputControl }
 						disabled={ disabled }
 						value={ inputString }
@@ -167,7 +172,6 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 								onToggle(); // hide the dropdown
 							}
 						} }
-						label={ label }
 						suffix={
 							<Icon
 								icon={ calendar }
@@ -194,8 +198,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						} }
 						aria-expanded={ isOpen }
 					/>
-					{ help && <p>{ help }</p> }
-				</>
+				</BaseControl>
 			) }
 			renderContent={ () => (
 				<WpDateTimePicker

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -77,15 +77,22 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function change() {
-		const newDate = parseMoment( inputString );
-		setLastSentChange(
-			newDate.isValid() ? formatMomentIso( newDate ) : inputString
-		);
+		const newDateTime = parseMoment( inputString );
+
+		if ( newDateTime.isValid() ) {
+			setLastValidDate( newDateTime );
+		}
+
+		if ( onChange ) {
+			onChange(
+				newDateTime.isValid()
+					? formatMomentIso( newDateTime )
+					: inputString
+			);
+		}
 	}
 
 	function blur() {
-		change();
-
 		if ( onBlur ) {
 			onBlur();
 		}
@@ -102,18 +109,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}, [ currentDate, dateTimeFormat ] );
 
 	useEffect( () => {
-		const newDate = parseMoment( inputString );
-
-		if ( newDate.isValid() ) {
-			setLastValidDate( newDate );
-		}
+		change();
 	}, [ inputString ] );
-
-	useEffect( () => {
-		if ( onChange ) {
-			onChange( lastSentChange );
-		}
-	}, [ lastSentChange ] );
 
 	return (
 		<Dropdown

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -171,8 +171,9 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						suffix={
 							<Icon
 								icon={ calendar }
-								className="calendar-icon"
+								className="calendar-icon woocommerce-date-time-picker-control__input-control__suffix"
 								onClick={ focusInputControl }
+								size={ 16 }
 							/>
 						}
 						placeholder={ placeholder }

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -81,26 +81,29 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		);
 	}
 
-	const change = useCallback(
-		debounce( ( newInputString: string ) => {
-			setInputString( newInputString );
-
-			const newDateTime = parseMoment( newInputString );
-			const isValid = newDateTime.isValid();
-
-			if ( isValid ) {
-				setLastValidDate( newDateTime );
-			}
-
+	const debouncedOnChange = useCallback(
+		debounce( ( dateTime: string, isValid: boolean ) => {
 			if ( onChange ) {
-				onChange(
-					isValid ? formatMomentIso( newDateTime ) : newInputString,
-					isValid
-				);
+				onChange( dateTime, isValid );
 			}
 		}, 500 ),
 		[]
 	);
+
+	function change( newInputString: string ) {
+		setInputString( newInputString );
+		const newDateTime = parseMoment( newInputString );
+		const isValid = newDateTime.isValid();
+
+		if ( isValid ) {
+			setLastValidDate( newDateTime );
+		}
+
+		debouncedOnChange(
+			isValid ? formatMomentIso( newDateTime ) : newInputString,
+			isValid
+		);
+	}
 
 	function blur() {
 		if ( onBlur ) {

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -149,7 +149,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				'woocommerce-date-time-picker-control',
 				className
 			) }
-			position="bottom center"
+			position="bottom left"
 			focusOnMount={ false }
 			// @ts-expect-error `onToggle` does exist.
 			onToggle={ ( willOpen ) => {

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Fragment } from 'react';
 import {
 	createElement,
 	useState,

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -80,19 +80,11 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return momentDate.format( dateTimeFormat );
 	}
 
-	function hasFocusLeftComponent(
+	function hasFocusLeftInputAndDropdownContent(
 		event: React.FocusEvent< HTMLInputElement >
 	): boolean {
-		const dropdownParentOfTargetReceivingFocus =
-			event.relatedTarget?.closest( '.components-dropdown' );
-		const dropdownParentOfTargetLosingFocus = event.currentTarget?.closest(
-			'.components-dropdown'
-		);
-
-		return (
-			! dropdownParentOfTargetReceivingFocus ||
-			dropdownParentOfTargetReceivingFocus !==
-				dropdownParentOfTargetLosingFocus
+		return ! event.relatedTarget?.closest(
+			'.components-dropdown__content'
 		);
 	}
 
@@ -186,7 +178,9 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						onBlur={ (
 							event: React.FocusEvent< HTMLInputElement >
 						) => {
-							if ( hasFocusLeftComponent( event ) ) {
+							if (
+								hasFocusLeftInputAndDropdownContent( event )
+							) {
 								onToggle(); // hide the dropdown
 							}
 						} }

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -10,53 +10,51 @@ import { createElement, useState } from '@wordpress/element';
  */
 import { DateTimePickerControl } from '../';
 
-export const Basic: React.FC = () => {
-	return (
-		<DateTimePickerControl
-			// eslint-disable-next-line no-console
-			onChange={ ( date ) => console.log( 'selected date: ' + date ) }
-		/>
-	);
+export default {
+	title: 'WooCommerce Admin/components/DateTimePickerControl',
+	component: DateTimePickerControl,
+	argTypes: {
+		onChange: { action: 'onChange' },
+		onBlur: { action: 'onBlur' },
+	},
 };
 
-export const Disabled: React.FC = () => {
-	return <DateTimePickerControl disabled onChange={ () => null } />;
-};
+const Template = ( args ) => <DateTimePickerControl { ...args } />;
 
-export const DateFormat: React.FC = () => {
-	return (
-		<DateTimePickerControl
-			onChange={ () => null }
-			dateTimeFormat="DD.MM.YYYY"
-		/>
-	);
-};
+export const Basic = Template.bind( {} );
 
-export const ControlledDate: React.FC = () => {
-	const [ currentDate, setCurrentDate ] = useState(
+function ControlledContainer( { children, ...props } ) {
+	const [ controlledDate, setControlledDate ] = useState(
 		new Date().toISOString()
 	);
 
 	return (
-		<>
+		<div { ...props }>
+			{ children( controlledDate, setControlledDate ) }
 			<Button
-				onClick={ () => setCurrentDate( new Date().toISOString() ) }
+				onClick={ () => setControlledDate( new Date().toISOString() ) }
 			>
-				Reset to today
+				Reset to now
 			</Button>
-			<DateTimePickerControl
-				onChange={ () => null }
-				currentDate={ currentDate }
-			/>
-		</>
+		</div>
 	);
-};
+}
 
-export const TwentyFourHour: React.FC = () => {
-	return <DateTimePickerControl is12Hour={ false } onChange={ () => null } />;
-};
-
-export default {
-	title: 'WooCommerce Admin/components/DateTimePickerControl',
-	component: DateTimePickerControl,
-};
+export const Controlled = ( args ) => <DateTimePickerControl { ...args } />;
+Controlled.decorators = [
+	( story, props ) => {
+		return (
+			<ControlledContainer>
+				{ ( controlledDate, setControlledDate ) =>
+					story( {
+						args: {
+							currentDate: controlledDate,
+							onChange: setControlledDate,
+							...props.args,
+						},
+					} )
+				}
+			</ControlledContainer>
+		);
+	},
+];

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -62,6 +62,12 @@ ReallyLongHelp.args = {
 	help: 'The help for this date time field is extremely long. Longer than the control itself should probably be.',
 };
 
+export const CustomClassName = Template.bind( {} );
+CustomClassName.args = {
+	...Basic.args,
+	className: 'custom-class-name',
+};
+
 export const Controlled = Template.bind( {} );
 Controlled.args = {
 	...Basic.args,

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -28,6 +28,13 @@ Basic.args = {
 	help: 'Type a date and time or use the picker',
 };
 
+export const CustomDateTimeFormat = Template.bind( {} );
+CustomDateTimeFormat.args = {
+	...Basic.args,
+	help: 'Format: YYYY-MM-DD HH:mm',
+	dateTimeFormat: 'YYYY-MM-DD HH:mm',
+};
+
 function ControlledContainer( { children, ...props } ) {
 	const [ controlledDate, setControlledDate ] = useState(
 		new Date().toISOString()
@@ -48,6 +55,12 @@ function ControlledContainer( { children, ...props } ) {
 		</div>
 	);
 }
+
+export const ReallyLongHelp = Template.bind( {} );
+ReallyLongHelp.args = {
+	...Basic.args,
+	help: 'The help for this date time field is extremely long. Longer than the control itself should probably be.',
+};
 
 export const Controlled = Template.bind( {} );
 Controlled.args = {

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -22,6 +22,11 @@ export default {
 const Template = ( args ) => <DateTimePickerControl { ...args } />;
 
 export const Basic = Template.bind( {} );
+Basic.args = {
+	label: 'Start date and time',
+	placeholder: 'Enter the start date and time',
+	help: 'Type a date and time or use the picker',
+};
 
 function ControlledContainer( { children, ...props } ) {
 	const [ controlledDate, setControlledDate ] = useState(
@@ -40,7 +45,11 @@ function ControlledContainer( { children, ...props } ) {
 	);
 }
 
-export const Controlled = ( args ) => <DateTimePickerControl { ...args } />;
+export const Controlled = Template.bind( {} );
+Controlled.args = {
+	...Basic.args,
+	help: "I'm controlled by a container that uses React state",
+};
 Controlled.decorators = [
 	( story, props ) => {
 		return (

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -35,12 +35,16 @@ function ControlledContainer( { children, ...props } ) {
 
 	return (
 		<div { ...props }>
-			{ children( controlledDate, setControlledDate ) }
-			<Button
-				onClick={ () => setControlledDate( new Date().toISOString() ) }
-			>
-				Reset to now
-			</Button>
+			<div>{ children( controlledDate, setControlledDate ) }</div>
+			<div>
+				<Button
+					onClick={ () =>
+						setControlledDate( new Date().toISOString() )
+					}
+				>
+					Reset to now
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -1,8 +1,11 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createElement } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n/build-types';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -10,12 +13,213 @@ import { createElement } from '@wordpress/element';
 import { DateTimePickerControl } from '../';
 
 describe( 'DateTimePickerControl', () => {
-	it( 'should add the supplied class name', () => {
+	it.skip( 'should render the expected DOM elements', () => {
+		const { container } = render(
+			<DateTimePickerControl
+				label="This is the label"
+				help="This is the help"
+				placeholder="This is the placeholder"
+			/>
+		);
+
+		const control = container.querySelector(
+			'.woocommerce-date-time-picker-control'
+		);
+		expect( control ).toBeInTheDocument();
+
+		const label = control?.querySelector(
+			'.components-input-control__label'
+		);
+		expect( label ).toBeInTheDocument();
+
+		const help = control?.querySelector(
+			'.woocommerce-date-time-picker-control__help'
+		);
+		expect( help ).toBeInTheDocument();
+	} );
+
+	it( 'should add a class name if set', () => {
 		const { container } = render(
 			<DateTimePickerControl className="custom-class-name" />
 		);
 
 		const control = container.querySelector( '.custom-class-name' );
 		expect( control ).toBeInTheDocument();
+	} );
+
+	it( 'should render a label if set', () => {
+		const { getByText } = render(
+			<DateTimePickerControl label="This is the label" />
+		);
+
+		expect( getByText( 'This is the label' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render a help message if set', () => {
+		const { getByText } = render(
+			<DateTimePickerControl help="This is the help" />
+		);
+
+		expect( getByText( 'This is the help' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render a placeholder if set', () => {
+		const { container } = render(
+			<DateTimePickerControl placeholder="This is the placeholder" />
+		);
+
+		const input = container.querySelector( 'input' );
+		expect( input?.placeholder === 'This is the placeholder' );
+	} );
+
+	it( 'should disable the input if set', () => {
+		const { container } = render(
+			<DateTimePickerControl disabled={ true } />
+		);
+
+		const input = container.querySelector( 'input' );
+		expect( input ).toBeDisabled();
+	} );
+
+	it( 'should use the default 24 hour date time format', () => {
+		const dateTime = moment( '2022-09-15 02:30:40' );
+
+		const { container } = render(
+			<DateTimePickerControl currentDate={ dateTime.toISOString() } />
+		);
+
+		const input = container.querySelector( 'input' );
+		expect( input?.value === '09/15/2022 02:30' );
+	} );
+
+	it( 'should use the default 12 hour date time format', () => {
+		const dateTime = moment( '2022-09-15 02:30:40' );
+
+		const { container } = render(
+			<DateTimePickerControl
+				currentDate={ dateTime.toISOString() }
+				is12Hour={ true }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		expect( input?.value === '09/15/2022 02:30 AM' );
+	} );
+
+	it( 'should use the date time format if set', () => {
+		const dateTime = moment( '2022-09-15 02:30:40' );
+
+		const { container } = render(
+			<DateTimePickerControl
+				currentDate={ dateTime.toISOString() }
+				dateTimeFormat="H:mm, MM-DD-YYYY"
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		expect( input?.value === '02:30, 09-15-2022' );
+	} );
+
+	it( 'should show the date time picker popup when focused', async () => {
+		const { container, queryByText } = render( <DateTimePickerControl /> );
+
+		const input = container.querySelector( 'input' );
+
+		userEvent.click( input! );
+
+		await waitFor( () =>
+			expect(
+				container.querySelector( '.components-dropdown__content' )
+			).toBeInTheDocument()
+		);
+	} );
+
+	it( 'should hide the date time picker popup when no longer focused', async () => {
+		const { container } = render( <DateTimePickerControl /> );
+
+		const input = container.querySelector(
+			'.woocommerce-date-time-picker-control input'
+		);
+		userEvent.click( input! );
+		fireEvent.blur( input! );
+
+		await waitFor( () =>
+			expect(
+				container.querySelector( '.components-dropdown__content' )
+			).not.toBeInTheDocument()
+		);
+	} );
+
+	it( 'should set the date time picker popup to 12 hour mode', async () => {
+		const { container, queryByText } = render(
+			<DateTimePickerControl is12Hour={ true } />
+		);
+
+		const input = container.querySelector( 'input' );
+
+		userEvent.click( input! );
+
+		await waitFor( () =>
+			expect(
+				container.querySelector(
+					'.components-datetime__time-pm-button'
+				)
+			).toBeInTheDocument()
+		);
+	} );
+
+	it( 'should call onBlur when losing focus', async () => {
+		const onBlurHandler = jest.fn();
+
+		const { container } = render(
+			<div>
+				<input />
+				<DateTimePickerControl onBlur={ onBlurHandler } />
+			</div>
+		);
+
+		userEvent.click(
+			container.querySelector(
+				'.woocommerce-date-time-picker-control input'
+			)!
+		);
+		userEvent.click( container.querySelector( ':scope > input' )! );
+
+		await waitFor( () =>
+			expect( onBlurHandler ).toHaveBeenCalledTimes( 1 )
+		);
+	} );
+
+	it( 'should call onChange when the input is changed', async () => {
+		const originalDateTime = moment( '2022-09-15 02:30:40' );
+		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
+		const newDateTimeInputString = '02:04, 06-08-2010';
+		const newDateTime = moment( newDateTimeInputString, dateTimeFormat );
+		const onChangeHandler = jest.fn();
+
+		const { container } = render(
+			<div>
+				<input />
+				<DateTimePickerControl
+					dateTimeFormat={ dateTimeFormat }
+					currentDate={ originalDateTime.toISOString() }
+					onChange={ onChangeHandler }
+				/>
+			</div>
+		);
+
+		const input = container.querySelector(
+			'.woocommerce-date-time-picker-control input'
+		);
+		userEvent.click( input! );
+		fireEvent.change( input!, {
+			target: { value: newDateTimeInputString },
+		} );
+
+		await waitFor( () =>
+			expect( onChangeHandler ).toHaveBeenLastCalledWith(
+				newDateTime.toISOString()
+			)
+		);
 	} );
 } );

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -4,6 +4,7 @@
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createElement } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n/build-types';
 import moment from 'moment';
 
 /**
@@ -119,7 +120,7 @@ describe( 'DateTimePickerControl', () => {
 		expect( input?.value === '02:30, 09-15-2022' );
 	} );
 
-	it( 'should show the date time picker popup when focused', async () => {
+	it.skip( 'should show the date time picker popup when focused', async () => {
 		const { container, queryByText } = render( <DateTimePickerControl /> );
 
 		const input = container.querySelector( 'input' );
@@ -133,7 +134,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it( 'should hide the date time picker popup when no longer focused', async () => {
+	it.skip( 'should hide the date time picker popup when no longer focused', async () => {
 		const { container } = render( <DateTimePickerControl /> );
 
 		const input = container.querySelector( 'input' );
@@ -147,7 +148,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it( 'should set the date time picker popup to 12 hour mode', async () => {
+	it.skip( 'should set the date time picker popup to 12 hour mode', async () => {
 		const { container, queryByText } = render(
 			<DateTimePickerControl is12Hour={ true } />
 		);
@@ -165,7 +166,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it( 'should call onBlur when losing focus', async () => {
+	it.skip( 'should call onBlur when losing focus', async () => {
 		const onBlurHandler = jest.fn();
 
 		const { container } = render(
@@ -181,7 +182,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it( 'should call onChange when the input is changed', async () => {
+	it.skip( 'should call onChange when the input is changed', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
 		const newDateTimeInputString = '02:04, 06-08-2010';
@@ -213,7 +214,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it( 'should call onChange with isValid false when the input is invalid', async () => {
+	it.skip( 'should call onChange with isValid false when the input is invalid', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const onChangeHandler = jest.fn();
 		const invalidDateTime = 'I am not a valid date time';

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -212,7 +212,7 @@ describe( 'DateTimePickerControl', () => {
 				),
 			{ timeout: 100 }
 		);
-	} );
+	}, 10000 );
 
 	it.skip( 'should call onChange with isValid false when the input is invalid', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -120,7 +120,7 @@ describe( 'DateTimePickerControl', () => {
 		expect( input?.value === '02:30, 09-15-2022' );
 	} );
 
-	it.skip( 'should show the date time picker popup when focused', async () => {
+	it( 'should show the date time picker popup when focused', async () => {
 		const { container, queryByText } = render( <DateTimePickerControl /> );
 
 		const input = container.querySelector( 'input' );

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DateTimePickerControl } from '../';
+
+describe( 'DateTimePickerControl', () => {
+	it( 'should add the supplied class name', () => {
+		const { container } = render(
+			<DateTimePickerControl className="custom-class-name" />
+		);
+
+		const control = container.querySelector( '.custom-class-name' );
+		expect( control ).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -182,9 +182,13 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	// we need to bump up the timeout for this test because:
-	// 1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
-	// 2. moment.js is slow
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
 	it( 'should call onChange when the input is changed', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
@@ -217,9 +221,13 @@ describe( 'DateTimePickerControl', () => {
 		);
 	}, 10000 );
 
-	// we need to bump up the timeout for this test because:
-	// 1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
-	// 2. moment.js is slow
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
 	it( 'should call onChange with isValid false when the input is invalid', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const onChangeHandler = jest.fn();

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -182,7 +182,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it.skip( 'should call onChange when the input is changed', async () => {
+	it( 'should call onChange when the input is changed', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
 		const newDateTimeInputString = '02:04, 06-08-2010';

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -134,7 +134,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it.skip( 'should hide the date time picker popup when no longer focused', async () => {
+	it( 'should hide the date time picker popup when no longer focused', async () => {
 		const { container } = render( <DateTimePickerControl /> );
 
 		const input = container.querySelector( 'input' );

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -182,6 +182,9 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
+	// we need to bump up the timeout for this test because:
+	// 1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	// 2. moment.js is slow
 	it( 'should call onChange when the input is changed', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
@@ -214,7 +217,10 @@ describe( 'DateTimePickerControl', () => {
 		);
 	}, 10000 );
 
-	it.skip( 'should call onChange with isValid false when the input is invalid', async () => {
+	// we need to bump up the timeout for this test because:
+	// 1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	// 2. moment.js is slow
+	it( 'should call onChange with isValid false when the input is invalid', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const onChangeHandler = jest.fn();
 		const invalidDateTime = 'I am not a valid date time';
@@ -238,7 +244,7 @@ describe( 'DateTimePickerControl', () => {
 				false
 			)
 		);
-	} );
+	}, 10000 );
 
 	// Skipping this test for now because it does not work with Jest's fake timers
 	it.skip( 'should call onChange once when multiple changes are made rapidly', async () => {

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -148,7 +148,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it.skip( 'should set the date time picker popup to 12 hour mode', async () => {
+	it( 'should set the date time picker popup to 12 hour mode', async () => {
 		const { container, queryByText } = render(
 			<DateTimePickerControl is12Hour={ true } />
 		);
@@ -166,7 +166,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it.skip( 'should call onBlur when losing focus', async () => {
+	it( 'should call onBlur when losing focus', async () => {
 		const onBlurHandler = jest.fn();
 
 		const { container } = render(

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -13,7 +13,11 @@ import moment from 'moment';
 import { DateTimePickerControl } from '../';
 
 describe( 'DateTimePickerControl', () => {
-	it.skip( 'should render the expected DOM elements', () => {
+	// The end user of the component doesn't care about how it is rendered in the DOM.
+	// The consumer of the component might, however, if they are applying any custom styles to it.
+	// By having this test, we will know right away if the resulting DOM changes at some point, so that we
+	// can address that in documentation.
+	it( 'should render the expected DOM elements', () => {
 		const { container } = render(
 			<DateTimePickerControl
 				label="This is the label"
@@ -22,19 +26,20 @@ describe( 'DateTimePickerControl', () => {
 			/>
 		);
 
+		// Make sure the default classname is set on the component.
 		const control = container.querySelector(
 			'.woocommerce-date-time-picker-control'
 		);
 		expect( control ).toBeInTheDocument();
 
+		// Make sure the default classname is set on the label.
 		const label = control?.querySelector(
-			'.components-input-control__label'
+			'.components-base-control__label'
 		);
 		expect( label ).toBeInTheDocument();
 
-		const help = control?.querySelector(
-			'.woocommerce-date-time-picker-control__help'
-		);
+		// Make sure the default classname is set on the help.
+		const help = control?.querySelector( '.components-base-control__help' );
 		expect( help ).toBeInTheDocument();
 	} );
 

--- a/packages/js/components/src/style.scss
+++ b/packages/js/components/src/style.scss
@@ -17,6 +17,7 @@
 @import 'experimental-select-control/select-control.scss';
 @import 'advanced-filters/style.scss';
 @import 'date-range-filter-picker/style.scss';
+@import 'date-time-picker-control/date-time-picker-control.scss';
 @import 'filter-picker/style.scss';
 @import 'filters/style.scss';
 @import 'flag/style.scss';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR replaces the underlying implementation of `DateTimePickerControl` to be based on `__experimentalInputControl` from `@wordpress/components` instead of `DateInput` from `@woocommerce/components`'s `Calendar`. There really wasn't anything we were gaining from using `DateInput`, and that sub-component was never really designed to be reused outside of `Calendar`. The styling was off, and it didn't support the props we need for full integration in the product form. The product form is using `__experimentalInputControl` for other fields, so by using that under the hood in this component we will gain additional consistency in behavior and look-and-feel.

In addition to changing the underlying implementation, the following props were added:
- `label`
- `placeholder`
- `help`

Note: the following issues exist and will be addressed in follow-up PRs:
- The positioning of the popup picker. It should be left-aligned. However, there appears to be a bug in the underlying `Dropdown` component in the version we are using (see https://github.com/WordPress/gutenberg/pull/41361, https://github.com/WordPress/gutenberg/pull/43377). Upgrading `@wordpress/components` may address this.
- There may be minor styles tweaks needed once this component is integrated in the product form (see https://github.com/woocommerce/woocommerce/pull/34538)
- The use of `moment` makes things easy, since we are used to using `moment`. However, `moment` has performance issues (seen when running the unit tests in CI) and isn't really the way forward. We should consider replacing it with a smaller, more performant library (from `moment`'s website: https://momentjs.com/docs/#/-project-status/)
    - The poor performance of `moment` is the major reason why two of the tests have their timeout increased. The tests run extremely slow in our CI environment and timeout otherwise.
- Two of the unit tests are skipped because they do not work with Jest's fake timers. I believe it we upgrade [Jest](https://jestjs.io/), [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/), [Testing Library User Event](https://testing-library.com/docs/user-event/intro/), we will be able to re-enable these tests since there is additional support to advance the fake timers from the tests.

### How to test the changes in this Pull Request:

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook stories and make sure component functions and looks reasonable: `pnpm --filter=@woocommerce/storybook storybook`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
