### PR TITLE
Disable action buttons when product form is invalid

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -226,7 +226,7 @@ export const ProductFormActions: React.FC = () => {
 								<MenuItem
 									onClick={ onTrash }
 									isDestructive
-									disabled={ ! isValidForm || ! values.id }
+									disabled={ ! values.id }
 								>
 									{ __( 'Move to trash', 'woocommerce' ) }
 								</MenuItem>

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -30,7 +30,8 @@ export const ProductFormActions: React.FC = () => {
 		isUpdatingPublished,
 		isDeleting,
 	} = useProductHelper();
-	const { isDirty, values, resetForm } = useFormContext< Product >();
+	const { isDirty, isValidForm, values, resetForm } =
+		useFormContext< Product >();
 
 	const getProductDataForTracks = () => {
 		return {
@@ -125,6 +126,7 @@ export const ProductFormActions: React.FC = () => {
 			<Button
 				onClick={ onSaveDraft }
 				disabled={
+					! isValidForm ||
 					( ! isDirty &&
 						!! values.id &&
 						values.status !== 'publish' ) ||
@@ -160,7 +162,7 @@ export const ProductFormActions: React.FC = () => {
 					} )
 				}
 				href={ values.permalink + '?preview=true' }
-				disabled={ ! values.permalink }
+				disabled={ ! isValidForm || ! values.permalink }
 				target="_blank"
 			>
 				{ __( 'Preview', 'woocommerce' ) }
@@ -171,6 +173,7 @@ export const ProductFormActions: React.FC = () => {
 					variant="primary"
 					isBusy={ isUpdatingPublished }
 					disabled={
+						! isValidForm ||
 						( ! isDirty && !! isPublished ) ||
 						isUpdatingDraft ||
 						isUpdatingPublished ||
@@ -197,7 +200,10 @@ export const ProductFormActions: React.FC = () => {
 					{ () => (
 						<>
 							<MenuGroup>
-								<MenuItem onClick={ onPublishAndDuplicate }>
+								<MenuItem
+									onClick={ onPublishAndDuplicate }
+									disabled={ ! isValidForm }
+								>
 									{ isPublished
 										? __(
 												'Update & duplicate',
@@ -208,7 +214,10 @@ export const ProductFormActions: React.FC = () => {
 												'woocommerce'
 										  ) }
 								</MenuItem>
-								<MenuItem onClick={ onCopyToNewDraft }>
+								<MenuItem
+									onClick={ onCopyToNewDraft }
+									disabled={ ! isValidForm }
+								>
 									{ __(
 										'Copy to a new draft',
 										'woocommerce'
@@ -217,7 +226,7 @@ export const ProductFormActions: React.FC = () => {
 								<MenuItem
 									onClick={ onTrash }
 									isDestructive
-									disabled={ ! values.id }
+									disabled={ ! isValidForm || ! values.id }
 								>
 									{ __( 'Move to trash', 'woocommerce' ) }
 								</MenuItem>

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -223,13 +223,11 @@ export const ProductFormActions: React.FC = () => {
 										'woocommerce'
 									) }
 								</MenuItem>
-								<MenuItem
-									onClick={ onTrash }
-									isDestructive
-									disabled={ ! values.id }
-								>
-									{ __( 'Move to trash', 'woocommerce' ) }
-								</MenuItem>
+								{ values.id && (
+									<MenuItem onClick={ onTrash } isDestructive>
+										{ __( 'Move to trash', 'woocommerce' ) }
+									</MenuItem>
+								) }
 							</MenuGroup>
 						</>
 					) }

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -195,7 +195,10 @@ export const ProductFormActions: React.FC = () => {
 					label={ __( 'Publish options', 'woocommerce' ) }
 					icon={ chevronDown }
 					popoverProps={ { position: 'bottom left' } }
-					toggleProps={ { variant: 'primary' } }
+					toggleProps={ {
+						variant: 'primary',
+						disabled: ! values.id && ! isValidForm,
+					} }
 				>
 					{ () => (
 						<>

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -25,7 +25,8 @@ import { getCheckboxProps, getTextControlProps } from './utils';
 const PRODUCT_DETAILS_SLUG = 'product-details';
 
 export const ProductDetailsSection: React.FC = () => {
-	const { getInputProps, values } = useFormContext< Product >();
+	const { getInputProps, values, touched, errors } =
+		useFormContext< Product >();
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
 		useState( false );
 	const { permalinkPrefix, permalinkSuffix } = useSelect(
@@ -42,6 +43,10 @@ export const ProductDetailsSection: React.FC = () => {
 		}
 	);
 
+	function doesNameHaveError(): boolean {
+		return Boolean( touched.name ) && Boolean( errors.name );
+	}
+
 	return (
 		<ProductSectionLayout
 			title={ __( 'Product info', 'woocommerce' ) }
@@ -57,7 +62,7 @@ export const ProductDetailsSection: React.FC = () => {
 					placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
 					{ ...getTextControlProps( getInputProps( 'name' ) ) }
 				/>
-				{ values.id && permalinkPrefix && (
+				{ values.id && ! doesNameHaveError() && permalinkPrefix && (
 					<div className="product-details-section__product-link">
 						{ __( 'Product link', 'woocommerce' ) }:&nbsp;
 						<a

--- a/plugins/woocommerce-admin/client/products/sections/test/product-details-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/test/product-details-section.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelect } from '@wordpress/data';
+import { Form } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { ProductDetailsSection } from '../product-details-section';
+import { validate } from '../../product-validation';
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+
+describe( 'ProductDetailsSection', () => {
+	const useSelectMock = useSelect as jest.Mock;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'when editing a product', () => {
+		const product: Partial< Product > = {
+			id: 1,
+			name: 'Lorem',
+			slug: 'lorem',
+		};
+		const permalinkPrefix = 'http://localhost/';
+		const linkUrl = permalinkPrefix + product.slug;
+
+		beforeEach( () => {
+			useSelectMock.mockReturnValue( {
+				permalinkPrefix,
+			} );
+		} );
+
+		it( 'should render the product link', () => {
+			render(
+				<Form initialValues={ product } validate={ validate }>
+					<ProductDetailsSection />
+				</Form>
+			);
+
+			expect( screen.queryByText( linkUrl ) ).toBeInTheDocument();
+		} );
+
+		it( 'should hide the product link if field name has errors', () => {
+			render(
+				<Form initialValues={ product } validate={ validate }>
+					<ProductDetailsSection />
+				</Form>
+			);
+			userEvent.clear( screen.getByLabelText( 'Name' ) );
+			userEvent.tab();
+
+			expect( screen.queryByText( linkUrl ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -441,8 +441,11 @@ describe( 'ProductFormActions', () => {
 
 			const optionsMenu = screen.getByRole( 'menu' );
 			const menuItems = within( optionsMenu ).getAllByRole( 'menuitem' );
+			// Verify only the first two items (Publish & duplicate|Update & duplicate
+			// and Copy to a new draft) from the action menu.
+			const firstTwoItems = menuItems.slice( 0, 2 );
 
-			menuItems.forEach( ( menuItem ) => {
+			firstTwoItems.forEach( ( menuItem ) => {
 				expect( menuItem ).toBeDisabled();
 			} );
 		} );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -435,24 +435,37 @@ describe( 'ProductFormActions', () => {
 	} );
 
 	describe( 'when the form is invalid', () => {
-		beforeEach( () => {
-			render(
-				<Form initialValues={ {} } validate={ validate }>
-					<ProductFormActions />
-				</Form>
-			);
-		} );
-
 		[ 'Save draft', 'Preview', 'Publish' ].forEach( ( buttonText ) => {
 			it( `should have the ${ buttonText } button disabled`, () => {
+				render(
+					<Form initialValues={ {} } validate={ validate }>
+						<ProductFormActions />
+					</Form>
+				);
 				const actionButton = screen.getByText( buttonText );
 				expect( actionButton ).toBeDisabled();
 			} );
 		} );
 
+		it( 'should have the Publish options menu button disabled', () => {
+			render(
+				<Form initialValues={ {} } validate={ validate }>
+					<ProductFormActions />
+				</Form>
+			);
+			expect( screen.getByLabelText( 'Publish options' ) ).toBeDisabled();
+		} );
+
 		it( 'should have the Publish options menu items disabled', () => {
+			render(
+				<Form initialValues={ { id: 1 } } validate={ validate }>
+					<ProductFormActions />
+				</Form>
+			);
+
 			const publishOptionsButton =
 				screen.getByLabelText( 'Publish options' );
+
 			userEvent.click( publishOptionsButton );
 
 			const optionsMenu = screen.getByRole( 'menu' );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -458,7 +458,11 @@ describe( 'ProductFormActions', () => {
 
 		it( 'should have the Publish options menu items disabled', () => {
 			render(
-				<Form initialValues={ { id: 1 } } validate={ validate }>
+				// This consider a product created and published
+				<Form
+					initialValues={ { id: 1, status: 'publish' } }
+					validate={ validate }
+				>
 					<ProductFormActions />
 				</Form>
 			);
@@ -469,14 +473,14 @@ describe( 'ProductFormActions', () => {
 			userEvent.click( publishOptionsButton );
 
 			const optionsMenu = screen.getByRole( 'menu' );
-			const menuItems = within( optionsMenu ).getAllByRole( 'menuitem' );
-			// Verify only the first two items (Publish & duplicate|Update & duplicate
-			// and Copy to a new draft) from the action menu.
-			const firstTwoItems = menuItems.slice( 0, 2 );
-
-			firstTwoItems.forEach( ( menuItem ) => {
-				expect( menuItem ).toBeDisabled();
-			} );
+			[ 'Update & duplicate', 'Copy to a new draft' ].forEach(
+				( itemText ) => {
+					const menuItem = within( optionsMenu )
+						.getByText( itemText )
+						.closest( 'button' );
+					expect( menuItem ).toBeDisabled();
+				}
+			);
 		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen, within } from '@testing-library/react';
 import { Form, FormContext } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -415,6 +415,36 @@ describe( 'ProductFormActions', () => {
 			await waitFor( () =>
 				expect( copyProductWithStatus ).toHaveBeenCalledWith( product )
 			);
+		} );
+	} );
+
+	describe( 'when the form is invalid', () => {
+		beforeEach( () => {
+			render(
+				<Form initialValues={ {} } validate={ validate }>
+					<ProductFormActions />
+				</Form>
+			);
+		} );
+
+		[ 'Save draft', 'Preview', 'Publish' ].forEach( ( buttonText ) => {
+			it( `should have the ${ buttonText } button disabled`, () => {
+				const actionButton = screen.getByText( buttonText );
+				expect( actionButton ).toBeDisabled();
+			} );
+		} );
+
+		it( 'should have the Publish options menu items disabled', () => {
+			const publishOptionsButton =
+				screen.getByLabelText( 'Publish options' );
+			userEvent.click( publishOptionsButton );
+
+			const optionsMenu = screen.getByRole( 'menu' );
+			const menuItems = within( optionsMenu ).getAllByRole( 'menuitem' );
+
+			menuItems.forEach( ( menuItem ) => {
+				expect( menuItem ).toBeDisabled();
+			} );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -46,19 +46,35 @@ describe( 'ProductFormActions', () => {
 		expect( queryByText( 'Publish' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should have a publish dropdown button with three other actions', () => {
-		const { queryByText, queryByLabelText, debug } = render(
+	it( 'should have a publish dropdown button with two other actions', () => {
+		render(
 			<Form initialValues={ {} }>
 				<ProductFormActions />
 			</Form>
 		);
-		queryByLabelText( 'Publish options' )?.click();
-		expect( queryByText( 'Publish & duplicate' ) ).toBeInTheDocument();
-		expect( queryByText( 'Copy to a new draft' ) ).toBeInTheDocument();
-		expect( queryByText( 'Move to trash' ) ).toBeInTheDocument();
+		screen.getByLabelText( 'Publish options' ).click();
+		expect(
+			screen.queryByText( 'Publish & duplicate' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Copy to a new draft' )
+		).toBeInTheDocument();
 	} );
 
 	describe( 'with new product', () => {
+		it( 'should not have the Move to trash button present', () => {
+			render(
+				<Form initialValues={ {} }>
+					<ProductFormActions />
+				</Form>
+			);
+
+			screen.getByLabelText( 'Publish options' ).click();
+			expect(
+				screen.queryByText( 'Move to trash' )
+			).not.toBeInTheDocument();
+		} );
+
 		it( 'should trigger createProductWithStatus and the product_edit track when Save draft is clicked', () => {
 			const product = { name: 'Name' };
 			const { queryByText } = render(
@@ -115,24 +131,24 @@ describe( 'ProductFormActions', () => {
 				true
 			);
 		} );
+	} );
 
-		it( 'should have the Move to trash button disabled', () => {
-			const product = { name: 'Name' };
-			const { queryByText, queryByLabelText } = render(
+	describe( 'with existing product', () => {
+		it( 'should have the Move to trash button present', () => {
+			const product: Partial< Product > = {
+				id: 5,
+				name: 'Name',
+			};
+			render(
 				<Form initialValues={ product }>
 					<ProductFormActions />
 				</Form>
 			);
-			queryByLabelText( 'Publish options' )?.click();
-			const moveToTrashButton = queryByText( 'Move to trash' );
-			expect(
-				( moveToTrashButton?.parentElement as HTMLButtonElement )
-					.disabled
-			).toEqual( true );
-		} );
-	} );
 
-	describe( 'with existing product', () => {
+			screen.getByLabelText( 'Publish options' ).click();
+			expect( screen.queryByText( 'Move to trash' ) ).toBeInTheDocument();
+		} );
+
 		it( 'The publish button should be renamed to Update when product is published', () => {
 			const { queryByText } = render(
 				<Form< Partial< Product > >

--- a/plugins/woocommerce/changelog/add-33537-disable-action-buttons
+++ b/plugins/woocommerce/changelog/add-33537-disable-action-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Disable action buttons when product form is invalid


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 38-gh-woocommerce/mothra-private.

### How to test the changes in this Pull Request:

1. Visit the Add product (MVP) page
2. All action buttons should be disabled
<img width="962" alt="image" src="https://user-images.githubusercontent.com/13334210/190423340-f7b23bdc-2f7f-4a01-911a-adc958541028.png">
3. If at least one field is invalid all action buttons should become disabled
<img width="962" alt="image" src="https://user-images.githubusercontent.com/13334210/190423340-f7b23bdc-2f7f-4a01-911a-adc958541028.png">
4. When form fields are valid, action buttons disable behavior should remain in accordance with other requirements
<img width="962" alt="image" src="https://user-images.githubusercontent.com/13334210/190424645-14402aa6-1197-4843-ba44-d019afc45be2.png">
5. When editing a product if the form is invalid then Move to trash action button should be enabled
<img width="970" alt="image" src="https://user-images.githubusercontent.com/13334210/190191033-984c853e-c100-4ba1-b7e1-f1d968436b6d.png">
6. When adding a new product `Move to trash` action button should not be shown
<img width="962" alt="image" src="https://user-images.githubusercontent.com/13334210/190423340-f7b23bdc-2f7f-4a01-911a-adc958541028.png">
7. `Move to trash` is only visible when editing the product
<img width="962" alt="image" src="https://user-images.githubusercontent.com/13334210/190423764-c085cfb4-9934-42cb-a382-a31be7c82fe3.png">
8. When editing a product if the name field has any error then the product link is not shown but the error message does. See #issuecomment-1248104111 down below.
<img width="962" alt="image" src="https://user-images.githubusercontent.com/13334210/190447322-e0dec050-1fb9-4bda-82a7-d697156a02fd.png">
9. Publish options menu should be disabled if all menu items are disabled
<img width="887" alt="image" src="https://user-images.githubusercontent.com/13334210/191781512-7b79c55c-8fb6-4a64-8688-f02b36f0946f.png">

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.