### PR TITLE
Added tracks for mobile welcome modal

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
@@ -52,7 +52,7 @@ export const JetpackInstallationStepper = ( {
 								onClick={ () => {
 									setIsWaitingForRedirect( true );
 									recordEvent(
-										'wcadmin_magic_prompt_install_connect_click'
+										'magic_prompt_install_connect_click'
 									);
 									installHandler();
 								} }

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Spinner, Stepper, StepperProps } from '@woocommerce/components';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -50,6 +51,9 @@ export const JetpackInstallationStepper = ( {
 								className="install-jetpack-button"
 								onClick={ () => {
 									setIsWaitingForRedirect( true );
+									recordEvent(
+										'wcadmin_magic_prompt_install_connect_click'
+									);
 									installHandler();
 								} }
 							>

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/SendMagicLinkButton.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/SendMagicLinkButton.tsx
@@ -9,12 +9,7 @@ export const SendMagicLinkButton = ( {
 }: {
 	onClickHandler: () => void;
 } ) => (
-	<Button
-		className="send-magic-link-button"
-		onClick={ () => {
-			onClickHandler();
-		} }
-	>
+	<Button className="send-magic-link-button" onClick={ onClickHandler }>
 		{ __( '✨️ Send the sign-in link', 'woocommerce' ) }
 	</Button>
 );

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/SendMagicLinkButton.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/SendMagicLinkButton.tsx
@@ -9,7 +9,12 @@ export const SendMagicLinkButton = ( {
 }: {
 	onClickHandler: () => void;
 } ) => (
-	<Button className="send-magic-link-button" onClick={ onClickHandler }>
+	<Button
+		className="send-magic-link-button"
+		onClick={ () => {
+			onClickHandler();
+		} }
+	>
 		{ __( '✨️ Send the sign-in link', 'woocommerce' ) }
 	</Button>
 );

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
@@ -55,6 +55,8 @@ export const MobileAppModal = () => {
 	}, [ searchParams ] );
 
 	const [ hasSentEmail, setHasSentEmail ] = useState( false );
+	const [ isRetryingMagicLinkSend, setIsRetryingMagicLinkSend ] =
+		useState( false );
 
 	const { fetchMagicLinkApiCall } = useSendMagicLink();
 
@@ -68,7 +70,11 @@ export const MobileAppModal = () => {
 		if ( hasSentEmail ) {
 			setPageContent(
 				<EmailSentPage
-					hasSentEmailHandler={ () => setHasSentEmail( false ) }
+					returnToSendLinkPage={ () => {
+						setHasSentEmail( false );
+						setIsRetryingMagicLinkSend( true );
+						recordEvent( 'magic_prompt_retry_send_signin_link' );
+					} }
 				/>
 			);
 		} else if ( state === JetpackPluginStates.NOT_OWNER_OF_CONNECTION ) {
@@ -85,6 +91,7 @@ export const MobileAppModal = () => {
 					isReturningFromWordpressConnection={
 						isReturningFromWordpressConnection
 					}
+					isRetryingMagicLinkSend={ isRetryingMagicLinkSend }
 					sendMagicLinkHandler={ sendMagicLink }
 				/>
 			);
@@ -100,6 +107,7 @@ export const MobileAppModal = () => {
 					wordpressAccountEmailAddress={
 						wordpressAccountEmailAddress
 					}
+					isRetryingMagicLinkSend={ isRetryingMagicLinkSend }
 					sendMagicLinkHandler={ sendMagicLink }
 				/>
 			);
@@ -110,6 +118,7 @@ export const MobileAppModal = () => {
 		isReturningFromWordpressConnection,
 		jetpackConnectionData?.currentUser?.wpcomUser?.email,
 		state,
+		isRetryingMagicLinkSend,
 	] );
 
 	return (

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
@@ -61,7 +61,7 @@ export const MobileAppModal = () => {
 	const sendMagicLink = useCallback( () => {
 		fetchMagicLinkApiCall();
 		setHasSentEmail( true );
-		recordEvent( 'wcadmin_magic_prompt_send_signin_link_click' );
+		recordEvent( 'magic_prompt_send_signin_link_click' );
 	}, [ fetchMagicLinkApiCall ] );
 
 	useEffect( () => {

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
@@ -11,6 +11,7 @@ import { getAdminLink } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -31,7 +32,9 @@ import { WrongUserConnectedPage } from './pages/WrongUserConnectedPage';
 import { SETUP_TASK_HELP_ITEMS_FILTER } from '../../activity-panel/panels/help';
 
 export const MobileAppModal = () => {
-	const [ guideIsOpen, setGuideIsOpen ] = useState( true );
+	const [ guideIsOpen, setGuideIsOpen ] = useState( false );
+	const [ isReturningFromWordpressConnection, setIsReturning ] =
+		useState( false );
 
 	const { state, jetpackConnectionData } = useJetpackPluginState();
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
@@ -45,10 +48,11 @@ export const MobileAppModal = () => {
 		} else {
 			setGuideIsOpen( false );
 		}
-	}, [ searchParams ] );
 
-	const isReturningFromWordpressConnection =
-		searchParams.get( 'jetpackState' ) === 'returning';
+		if ( searchParams.get( 'jetpackState' ) === 'returning' ) {
+			setIsReturning( true );
+		}
+	}, [ searchParams ] );
 
 	const [ hasSentEmail, setHasSentEmail ] = useState( false );
 
@@ -57,6 +61,7 @@ export const MobileAppModal = () => {
 	const sendMagicLink = useCallback( () => {
 		fetchMagicLinkApiCall();
 		setHasSentEmail( true );
+		recordEvent( 'wcadmin_magic_prompt_send_signin_link_click' );
 	}, [ fetchMagicLinkApiCall ] );
 
 	useEffect( () => {

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/EmailSentPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/EmailSentPage.tsx
@@ -6,11 +6,11 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 interface EmailSentProps {
-	hasSentEmailHandler: () => void;
+	returnToSendLinkPage: () => void;
 }
 
 export const EmailSentPage: React.FC< EmailSentProps > = ( {
-	hasSentEmailHandler,
+	returnToSendLinkPage: returnToSendLinkPage,
 } ) => {
 	return (
 		<div className="email-sent-modal-body">
@@ -41,7 +41,7 @@ export const EmailSentPage: React.FC< EmailSentProps > = ( {
 								<Button
 									className="email-sent-send-another-link"
 									onClick={ () => {
-										hasSentEmailHandler();
+										returnToSendLinkPage();
 									} }
 								>
 									{ __( 'send another link', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
+import { useSelect } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -17,6 +21,32 @@ interface JetpackAlreadyInstalledPageProps {
 export const JetpackAlreadyInstalledPage: React.FC<
 	JetpackAlreadyInstalledPageProps
 > = ( { wordpressAccountEmailAddress, sendMagicLinkHandler } ) => {
+	const DISMISSED_MOBILE_APP_MODAL_OPTION =
+		'woocommerce_admin_dismissed_mobile_app_modal';
+
+	const { repeatUser, isLoading } = useSelect( ( select ) => {
+		const { hasFinishedResolution, getOption } =
+			select( OPTIONS_STORE_NAME );
+
+		return {
+			isLoading: ! hasFinishedResolution( 'getOption', [
+				DISMISSED_MOBILE_APP_MODAL_OPTION,
+			] ),
+			repeatUser:
+				getOption( DISMISSED_MOBILE_APP_MODAL_OPTION ) === 'yes',
+		};
+	} );
+
+	useEffect( () => {
+		if ( ! isLoading ) {
+			recordEvent( 'wcadmin_magic_prompt_view', {
+				// jetpack_state value is implied by the precondition of rendering this screen
+				jetpack_state: 'full-connection',
+				repeat_user: repeatUser,
+			} );
+		}
+	}, [ repeatUser, isLoading ] );
+
 	return (
 		<ModalContentLayoutWithTitle>
 			<>

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
@@ -15,12 +15,17 @@ import { SendMagicLinkButton } from '../components';
 
 interface JetpackAlreadyInstalledPageProps {
 	wordpressAccountEmailAddress: string | undefined;
+	isRetryingMagicLinkSend: boolean;
 	sendMagicLinkHandler: () => void;
 }
 
 export const JetpackAlreadyInstalledPage: React.FC<
 	JetpackAlreadyInstalledPageProps
-> = ( { wordpressAccountEmailAddress, sendMagicLinkHandler } ) => {
+> = ( {
+	wordpressAccountEmailAddress,
+	sendMagicLinkHandler,
+	isRetryingMagicLinkSend,
+} ) => {
 	const DISMISSED_MOBILE_APP_MODAL_OPTION =
 		'woocommerce_admin_dismissed_mobile_app_modal';
 
@@ -38,14 +43,14 @@ export const JetpackAlreadyInstalledPage: React.FC<
 	} );
 
 	useEffect( () => {
-		if ( ! isLoading ) {
+		if ( ! isLoading && ! isRetryingMagicLinkSend ) {
 			recordEvent( 'magic_prompt_view', {
 				// jetpack_state value is implied by the precondition of rendering this screen
 				jetpack_state: 'full-connection',
 				repeat_user: repeatUser,
 			} );
 		}
-	}, [ repeatUser, isLoading ] );
+	}, [ repeatUser, isLoading, isRetryingMagicLinkSend ] );
 
 	return (
 		<ModalContentLayoutWithTitle>

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
@@ -39,7 +39,7 @@ export const JetpackAlreadyInstalledPage: React.FC<
 
 	useEffect( () => {
 		if ( ! isLoading ) {
-			recordEvent( 'wcadmin_magic_prompt_view', {
+			recordEvent( 'magic_prompt_view', {
 				// jetpack_state value is implied by the precondition of rendering this screen
 				jetpack_state: 'full-connection',
 				repeat_user: repeatUser,

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackInstallStepperPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackInstallStepperPage.tsx
@@ -17,12 +17,17 @@ import {
 
 interface JetpackInstallStepperPageProps {
 	isReturningFromWordpressConnection: boolean;
+	isRetryingMagicLinkSend: boolean;
 	sendMagicLinkHandler: () => void;
 }
 
 export const JetpackInstallStepperPage: React.FC<
 	JetpackInstallStepperPageProps
-> = ( { isReturningFromWordpressConnection, sendMagicLinkHandler } ) => {
+> = ( {
+	isReturningFromWordpressConnection,
+	sendMagicLinkHandler,
+	isRetryingMagicLinkSend,
+} ) => {
 	const { state: jetpackPluginState } = useJetpackPluginState();
 	const jetpackPluginStateRef =
 		useRef< JetpackPluginStates >( jetpackPluginState );
@@ -37,13 +42,17 @@ export const JetpackInstallStepperPage: React.FC<
 			jetpackPluginStateRef.current = jetpackPluginState;
 			if ( isReturningFromWordpressConnection ) {
 				recordEvent( 'magic_prompt_return_from_wp_connection' );
-			} else {
+			} else if ( ! isRetryingMagicLinkSend ) {
 				recordEvent( 'magic_prompt_view', {
 					jetpack_state: jetpackPluginStateRef.current,
 				} );
 			}
 		}
-	}, [ isReturningFromWordpressConnection, jetpackPluginState ] );
+	}, [
+		isReturningFromWordpressConnection,
+		jetpackPluginState,
+		isRetryingMagicLinkSend,
+	] );
 
 	return (
 		<ModalContentLayoutWithTitle>

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackInstallStepperPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackInstallStepperPage.tsx
@@ -36,9 +36,9 @@ export const JetpackInstallStepperPage: React.FC<
 		) {
 			jetpackPluginStateRef.current = jetpackPluginState;
 			if ( isReturningFromWordpressConnection ) {
-				recordEvent( 'wcadmin_magic_prompt_return_from_wp_connection' );
+				recordEvent( 'magic_prompt_return_from_wp_connection' );
 			} else {
-				recordEvent( 'wcadmin_magic_prompt_view', {
+				recordEvent( 'magic_prompt_view', {
 					jetpack_state: jetpackPluginStateRef.current,
 				} );
 			}

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/WrongUserConnectedPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/WrongUserConnectedPage.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
+import { useEffect } from '@wordpress/element';
 
 interface WrongUserConnectedPageProps {
 	wordpressAccountEmailAddress?: string | undefined;
@@ -10,7 +12,11 @@ interface WrongUserConnectedPageProps {
 export const WrongUserConnectedPage: React.FC<
 	WrongUserConnectedPageProps
 > = () => {
-	// The user shouldn't see this screen at all unless he's messing with the page URL manually to get here when he's not allowed to
+	useEffect( () => {
+		recordEvent( 'wcadmin_magic_prompt_mismatched_wpcom_user_view' );
+	}, [] );
+
+	// The user may see this screen if he clicks on the additional task and there is already another wpcom user connected to this site.
 	return (
 		<div className="wrong-user-connected-modal-body">
 			<div className="wrong-user-connected-title">

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/WrongUserConnectedPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/WrongUserConnectedPage.tsx
@@ -13,7 +13,7 @@ export const WrongUserConnectedPage: React.FC<
 	WrongUserConnectedPageProps
 > = () => {
 	useEffect( () => {
-		recordEvent( 'wcadmin_magic_prompt_mismatched_wpcom_user_view' );
+		recordEvent( 'magic_prompt_mismatched_wpcom_user_view' );
 	}, [] );
 
 	// The user may see this screen if he clicks on the additional task and there is already another wpcom user connected to this site.

--- a/plugins/woocommerce/changelog/add-tracks-for-mobile-welcome
+++ b/plugins/woocommerce/changelog/add-tracks-for-mobile-welcome
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added tracks for woocommerce mobile app modal


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

76-gh-woocommerce/team-ghidorah

Tracks events for the moile app welcome modal: 

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_magic_prompt_view`   |
| What does the track measure      | View count for WooCommerce Mobile App magic link prompt. Note: this does not fire on the return of the user from wordpress.com account connection |
| When does the track fire      | When a user views magic link prompt |
| Event properties      | `jetpack_state`: Status of Jetpack plugin. Values: `full-connection` , `not-installed` , `installing` , `user-cannot-install` , `not-activated` , `userless-connection` , `not-owner-of-connection` <br><br> `repeat_user`: Whether the user has dismissed the modal before. Values: `true`, `false`

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_magic_prompt_return_from_wp_connection`   |
| What does the track measure      |  Count of users who returned from the jetpack installation flow  |
| When does the track fire      | When a user has completed the jetpack installation flow and returns to wpadmin |
| Event properties      | - |

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_magic_prompt_install_connect_click`   |
| What does the track measure      | Clicks count on Install and Connect button  |
| When does the track fire      | When a user clicks on Install and Connect button |
| Event properties      | - |

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_magic_prompt_send_signin_link_click`   |
| What does the track measure      | Clicks count on Send the sign-in link button  |
| When does the track fire      | When a user clicks on Send the sign-in link button |
| Event properties      | - |

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_magic_prompt_mismatched_wpcom_user_view`   |
| What does the track measure      |  The number of users who have mismatched wpcom accounts  |
| When does the track fire      | When a user clicks on the additional task list item to get the woocommerce mobile app |
| Event properties      | - |

| Setting      | Value |
| ----------- | ----------- |
| Name      |  `wcadmin_magic_prompt_retry_send_signin_link`   |
| What does the track measure      |  The number of users who return to the send link page  |
| When does the track fire      | When a user clicks on the 'send another link' link on the email success page |
| Event properties      | - |




### How to test the changes in this Pull Request:

Same as: https://github.com/woocommerce/woocommerce/pull/34637

To see the tracks events you need to run the command `localStorage.debug="*"` in your browser console.

To see the mismatched connection event you will also need to set up a second admin account to attempt the flow.


A run-through of the install, connect, send magic link sequence should look like this:

![image](https://user-images.githubusercontent.com/27843274/190316366-c43bf076-d00a-4d90-98df-6dc2cc3c79a5.png)

A run-through of the jetpack-already-installed sequence should look like this:

![image](https://user-images.githubusercontent.com/27843274/190316682-8af6d4df-3f3e-4ae5-a1ef-e919cc4d339d.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.