### PR TITLE
Enable backfill for orders from custom tables to wp_posts via CLI

### DIFF
--- a/plugins/woocommerce/changelog/implement-wp-cli-backfill
+++ b/plugins/woocommerce/changelog/implement-wp-cli-backfill
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Support sync instead of migrate for orders COT.
+Deprecate existing `wp wc cot migrate` command and replace with `wp wc cot sync`.

--- a/plugins/woocommerce/changelog/implement-wp-cli-backfill
+++ b/plugins/woocommerce/changelog/implement-wp-cli-backfill
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support sync instead of migrate for orders COT.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -138,7 +138,7 @@ class CLIRunner {
 	}
 
 	/**
-	 * Sync order data between the custom orders table and wp_posts table.
+	 * Sync order data between the custom order tables and the core WordPress post tables.
 	 *
 	 * ## OPTIONS
 	 *

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -138,7 +138,7 @@ class CLIRunner {
 	}
 
 	/**
-	 * Migrate order data to the custom orders table.
+	 * Sync order data between the custom orders table and wp_posts table.
 	 *
 	 * ## OPTIONS
 	 *
@@ -150,7 +150,7 @@ class CLIRunner {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp wc cot migrate --batch-size=500
+	 *     wp wc cot sync --batch-size=500
 	 *
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -58,6 +58,7 @@ class CLIRunner {
 	public function register_commands() {
 		WP_CLI::add_command( 'wc cot count_unmigrated', array( $this, 'count_unmigrated' ) );
 		WP_CLI::add_command( 'wc cot migrate', array( $this, 'migrate' ) );
+		WP_CLI::add_command( 'wc cot sync', array( $this, 'sync' ) );
 		WP_CLI::add_command( 'wc cot verify_cot_data', array( $this, 'verify_cot_data' ) );
 	}
 
@@ -121,10 +122,10 @@ class CLIRunner {
 		if ( isset( $assoc_args['log'] ) && $assoc_args['log'] ) {
 			WP_CLI::log(
 				sprintf(
-					/* Translators: %1$d is the number of orders to be migrated. */
+					/* Translators: %1$d is the number of orders to be synced. */
 					_n(
-						'There is %1$d order to be migrated.',
-						'There are %1$d orders to be migrated.',
+						'There is %1$d order to be synced.',
+						'There are %1$d orders to be synced.',
 						$order_count,
 						'woocommerce'
 					),
@@ -154,21 +155,17 @@ class CLIRunner {
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function migrate( $args = array(), $assoc_args = array() ) {
+	public function sync( $args = array(), $assoc_args = array() ) {
 		$this->log_production_warning();
 		if ( ! $this->is_enabled() ) {
 			return;
-		}
-
-		if ( $this->synchronizer->custom_orders_table_is_authoritative() ) {
-			return WP_CLI::error( __( 'Migration is not yet supported when custom tables are authoritative. Switch to post tables as authoritative source if you are testing.', 'woocommerce' ) );
 		}
 
 		$order_count = $this->count_unmigrated();
 
 		// Abort if there are no orders to migrate.
 		if ( ! $order_count ) {
-			return WP_CLI::warning( __( 'There are no orders to migrate, aborting.', 'woocommerce' ) );
+			return WP_CLI::warning( __( 'There are no orders to sync, aborting.', 'woocommerce' ) );
 		}
 
 		$assoc_args  = wp_parse_args(
@@ -178,7 +175,7 @@ class CLIRunner {
 			)
 		);
 		$batch_size  = ( (int) $assoc_args['batch-size'] ) === 0 ? 500 : (int) $assoc_args['batch-size'];
-		$progress    = WP_CLI\Utils\make_progress_bar( 'Order Data Migration', $order_count / $batch_size );
+		$progress    = WP_CLI\Utils\make_progress_bar( 'Order Data Sync', $order_count / $batch_size );
 		$processed   = 0;
 		$batch_count = 1;
 		$total_time  = 0;
@@ -194,9 +191,9 @@ class CLIRunner {
 				)
 			);
 			$batch_start_time = microtime( true );
-			$order_ids        = $this->synchronizer->get_ids_of_orders_pending_sync( $this->synchronizer::ID_TYPE_MISSING_IN_ORDERS_TABLE, $batch_size );
+			$order_ids        = $this->synchronizer->get_next_batch_to_process( $batch_size );
 			if ( count( $order_ids ) ) {
-				$this->post_to_cot_migrator->migrate_orders( $order_ids );
+				$this->synchronizer->process_batch( $order_ids );
 			}
 			$processed       += count( $order_ids );
 			$batch_total_time = microtime( true ) - $batch_start_time;
@@ -227,17 +224,17 @@ class CLIRunner {
 
 		// Issue a warning if no orders were migrated.
 		if ( ! $processed ) {
-			return WP_CLI::warning( __( 'No orders were migrated.', 'woocommerce' ) );
+			return WP_CLI::warning( __( 'No orders were synced.', 'woocommerce' ) );
 		}
 
-		WP_CLI::log( __( 'Migration completed.', 'woocommerce' ) );
+		WP_CLI::log( __( 'Sync completed.', 'woocommerce' ) );
 
 		return WP_CLI::success(
 			sprintf(
 				/* Translators: %1$d is the number of migrated orders and %2$d is the execution time in seconds. */
 				_n(
-					'%1$d order was migrated in %2$d seconds.',
-					'%1$d orders were migrated in %2$d seconds.',
+					'%1$d order was synced in %2$d seconds.',
+					'%1$d orders were synced in %2$d seconds.',
 					$processed,
 					'woocommerce'
 				),
@@ -269,8 +266,9 @@ class CLIRunner {
 	 * @param array $args Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function backfill( $args = array(), $assoc_args = array() ) {
-		return WP_CLI::error( __( 'Error: Backfill is not implemented yet.', 'woocommerce' ) );
+	public function migrate( $args = array(), $assoc_args = array() ) {
+		$this->log_production_warning();
+		WP_CLI::log( __( 'Migrate command is deprecated. Please use `sync` instead.', 'woocommerce' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds `sync` functionality which replaces earlier `migrate` command. 

### How to test the changes in this Pull Request:

1. Disable the sync and add/update few orders.
2. Run the command `wp wc cot sync`. It should sync all the pending sync orders.
3. Toggle the authoritative storage (but keep the sync disabled).
4. Add a few more orders, and run the command again `wp wc cot sync`. It should sync again, in reverse direction automatically.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
