### PR TITLE
Change the e2e selector for unchecking all business features

### DIFF
--- a/plugins/woocommerce/changelog/update-e2e-pw-uncheck-business-features
+++ b/plugins/woocommerce/changelog/update-e2e-pw-uncheck-business-features
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: fix e2e CI failures
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -296,6 +296,7 @@ test.describe( 'Store owner can go through setup Task List', () => {
 			await page.click( '.components-checkbox-control__input' );
 		}
 		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=Continue with my active theme' );
 		await page.waitForLoadState( 'networkidle' ); // not autowaiting for form submission
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -288,6 +288,14 @@ test.describe( 'Store owner can go through setup Task List', () => {
 		await page.check( '#inspector-checkbox-control-0' );
 		await page.click( 'button >> text=Continue' );
 		await page.click( 'button >> text=No thanks' );
+		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=Continue' );
+		// Uncheck all business features
+		if ( page.isChecked( '.components-checkbox-control__input' ) ) {
+			await page.click( '.components-checkbox-control__input' );
+		}
+		await page.click( 'button >> text=Continue' );
 		await page.waitForLoadState( 'networkidle' ); // not autowaiting for form submission
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -227,8 +227,8 @@ test.describe(
 				page.locator( 'a:has-text("WooCommerce Payments")' )
 			).toHaveCount( 0 );
 			// Uncheck all business features
-			if ( page.isChecked( '#inspector-checkbox-control-1' ) ) {
-				await page.click( '#inspector-checkbox-control-1' );
+			if ( page.isChecked( '.components-checkbox-control__input' ) ) {
+				await page.click( '.components-checkbox-control__input' );
 			}
 			await page.click( 'button >> text=Continue' );
 		} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There have been a large number of failures in CI for `can setup shipping`.

After debugging the majority of these failures appear to be because smart shipping zones haven't been setup for a `US` store.
The most likely reason for this is `Add recommended business features to my site` has not been unchecked due to test flakiness and therefore WC Shipping installed which would mean no smart shipping zones would be setup.

To try prevent this from happening this PR updates the selector used to uncheck the `Add recommended business features to my site` checkbox to [match the selector used in `admin-e2e-tests`](https://github.com/woocommerce/woocommerce/blob/a0768a086ca73747957273457fc6151be3e19b4c/packages/js/admin-e2e-tests/src/sections/onboarding/BusinessSection.ts#L91)

It also adds some additional beforeEach setup hooks for the `can setup shipping` test to uncheck the `Add recommended business features to my site` checkbox if it is checked.

### How to test the changes in this Pull Request:

1. [Run e2e tests locally](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#introduction)
2. [Check e2e CI results](https://woocommerce.github.io/woocommerce-test-reports/pr/34685/e2e/)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
