### PR TITLE
fixed the inbox image issue

### DIFF
--- a/packages/js/experimental/src/inbox-note/style.scss
+++ b/packages/js/experimental/src/inbox-note/style.scss
@@ -19,7 +19,7 @@
 		flex-direction: row-reverse;
 		img {
 			width: 128px;
-			height: 100%;
+			height: auto;
 		}
 	}
 	&:hover {

--- a/plugins/woocommerce/changelog/fixed-woocommerce-inbox-image-issue
+++ b/plugins/woocommerce/changelog/fixed-woocommerce-inbox-image-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the WooCommerce Inbox Image Issue


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
I have fixed the WooCommerce inbox image in this pull request.

![CleanShot 2022-09-15 at 17 31 19@2x](https://user-images.githubusercontent.com/72435501/190398534-5e3c449c-b7a2-44ff-bc4e-b00616a485e2.png)


Closes #34674  .

### How to test the changes in this Pull Request:

1. Go to the backend of the site
2. After that go to home page of the WooCommerce
3. Then go to the display and select the **two column** layout.
4. Then in the inbox section, you will see the image getting stretched.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
