### PR TITLE
Enhance "Add store details" task onboarding experience

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
@@ -19,33 +19,31 @@ const STORE_CITY_SETTINGS_OPTION = 'woocommerce_store_city';
 const STORE_POSTCODE_SETTINGS_OPTION = 'woocommerce_store_postcode';
 
 const useShowStoreLocationTour = () => {
-	const { hasReviewedStoreLocationSettings, isLoading } = useSelect(
-		( select ) => {
-			const { hasFinishedResolution, getOption } =
-				select( OPTIONS_STORE_NAME );
+	const { hasFilledStoreAddress, isLoading } = useSelect( ( select ) => {
+		const { hasFinishedResolution, getOption } =
+			select( OPTIONS_STORE_NAME );
 
-			return {
-				isLoading:
-					! hasFinishedResolution( 'getOption', [
-						STORE_ADDRESS_SETTINGS_OPTION,
-					] ) ||
-					! hasFinishedResolution( 'getOption', [
-						STORE_CITY_SETTINGS_OPTION,
-					] ) ||
-					! hasFinishedResolution( 'getOption', [
-						STORE_POSTCODE_SETTINGS_OPTION,
-					] ),
-				hasReviewedStoreLocationSettings:
-					getOption( STORE_ADDRESS_SETTINGS_OPTION ) !== '' &&
-					getOption( STORE_CITY_SETTINGS_OPTION ) !== '' &&
-					getOption( STORE_POSTCODE_SETTINGS_OPTION ) !== '',
-			};
-		}
-	);
+		return {
+			isLoading:
+				! hasFinishedResolution( 'getOption', [
+					STORE_ADDRESS_SETTINGS_OPTION,
+				] ) ||
+				! hasFinishedResolution( 'getOption', [
+					STORE_CITY_SETTINGS_OPTION,
+				] ) ||
+				! hasFinishedResolution( 'getOption', [
+					STORE_POSTCODE_SETTINGS_OPTION,
+				] ),
+			hasFilledStoreAddress:
+				getOption( STORE_ADDRESS_SETTINGS_OPTION ) !== '' &&
+				getOption( STORE_CITY_SETTINGS_OPTION ) !== '' &&
+				getOption( STORE_POSTCODE_SETTINGS_OPTION ) !== '',
+		};
+	} );
 
 	return {
 		isLoading,
-		show: ! isLoading && ! hasReviewedStoreLocationSettings,
+		show: ! isLoading && ! hasFilledStoreAddress,
 	};
 };
 

--- a/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
@@ -67,7 +67,7 @@ const StoreAddressTourOverlay = () => {
 					heading: 'Add your store location',
 					descriptions: {
 						desktop: __(
-							'Add your store location details such as address and Country to help us configure shipping, taxes, currency and more in a fully automated way.',
+							'Add your store location details to help us configure shipping, taxes, currency and more in a fully automated way. Once done, click on the "Save" button at the end of the form.',
 							'woocommerce'
 						),
 					},

--- a/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/store-address-tour.tsx
@@ -6,7 +6,7 @@ import { TourKit, TourKitTypes } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useState } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**

--- a/plugins/woocommerce/changelog/enchancement-store-details-tour
+++ b/plugins/woocommerce/changelog/enchancement-store-details-tour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enchance tour experience for store location


### PR DESCRIPTION
Closes #34694 

This PR ensures that the user's attention is always focused on the Store Address section when they are taken to the WooCommerce Settings via the **Add store details** task.

### How to test the changes in this Pull Request:

1. Setup a new WooCommerce store.
2. Skip the Setup Wizard.
3. Click the "Add store details" task item in the setup list.
4. Click the **Got it** button in the aid modal.
5. Refresh the page without entering your store's location, or go back to the Task List and click the **Add store details** task.
6. The focusing aid should show up.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
