### PR TITLE
Update php version used by changelog workflow

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -28,6 +28,8 @@ jobs:
         uses: ./.github/actions/setup-woocommerce-monorepo
         with:
           build: false
+          php-version: '7.4'
+          
 
       - name: "Git fetch the release branch"
         run: git fetch origin ${{ inputs.releaseBranch }}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the changelog generation workflow to use PHP 7.4. It had previously used PHP 7.4 prior to the change introduced in #34607. This fixes an issue with warnings appearing for usage of `JSON_THROW_ON_ERROR`, which wasn't introduced until 7.4.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Spot-check the change, and run the action to verify that there aren't any other warnings
2.
3.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
