### PR TITLE
Do a checkout of compared branches to ensure prepush checks work

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -32,7 +32,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Ensure both branches are tracked or check-changelogger-use will fail.
-git checkout $PROTECTED_BRANCH
-git checkout $CURRENT_BRANCH
+git checkout $PROTECTED_BRANCH --quiet
+git checkout $CURRENT_BRANCH --quiet
 
 php tools/monorepo/check-changelogger-use.php $PROTECTED_BRANCH $CURRENT_BRANCH

--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -31,4 +31,8 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+# Ensure both branches are tracked or check-changelogger-use will fail.
+git checkout $PROTECTED_BRANCH
+git checkout $CURRENT_BRANCH
+
 php tools/monorepo/check-changelogger-use.php $PROTECTED_BRANCH $CURRENT_BRANCH


### PR DESCRIPTION


### Changes proposed in this Pull Request:
@joelclimbsthings noticed that if you haven't tracked `trunk` and your current branch by doing a checkout that prepush checks will fail.

This solves that by ensuring both have been checked out.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. Do a fresh clone of WooCommerce
2. Do not checkout trunk, checkout this branch: `dev/checkout-branches-in-prepush`
3. Add a change (maybe you could remove or add a line ending in this branch lol)
4. stage and push the change
5. The prepush should succeed and the change should be pushed.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
