### PR TITLE
Skip Store owner can go through setup Task List test

### DIFF
--- a/plugins/woocommerce/changelog/update-skip-flaky-task-test
+++ b/plugins/woocommerce/changelog/update-skip-flaky-task-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: skip task e2e test as flaky
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -268,7 +268,8 @@ test.describe(
 	}
 );
 
-test.describe( 'Store owner can go through setup Task List', () => {
+// Skipping this test because it's very flaky.
+test.describe.skip( 'Store owner can go through setup Task List', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeEach( async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
@@ -95,6 +95,19 @@ const errorMessage =
 test.describe( 'Import Products from a CSV file', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
+	test.beforeAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		// make sure the currency is USD
+		await api.put( 'settings/general/woocommerce_currency', {
+			value: 'USD',
+		} );
+	} );
+
 	test.afterAll( async ( { baseURL } ) => {
 		const api = new wcApi( {
 			url: baseURL,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
@@ -250,7 +250,7 @@ test.describe( 'Import Products from a CSV file', () => {
 			elements.map( ( item ) => item.innerText )
 		);
 
-		await expect( productPrices.sort() ).toEqual(
+		await expect( productPrices.sort() ).toStrictEqual(
 			productPricesOverride.sort()
 		);
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/calculate-shipping.spec.js
@@ -26,6 +26,10 @@ test.describe( 'Cart Calculate Shipping', () => {
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
 		} );
+		// make sure the currency is USD
+		await api.put( 'settings/general/woocommerce_currency', {
+			value: 'USD',
+		} );
 		// add products
 		await api
 			.post( 'products', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-coupons.spec.js
@@ -33,6 +33,10 @@ test.describe( 'Cart applying coupons', () => {
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
 		} );
+		// make sure the currency is USD
+		await api.put( 'settings/general/woocommerce_currency', {
+			value: 'USD',
+		} );
 		// add product
 		await api
 			.post( 'products', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart.spec.js
@@ -15,6 +15,10 @@ test.describe( 'Cart page', () => {
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
 		} );
+		// make sure the currency is USD
+		await api.put( 'settings/general/woocommerce_currency', {
+			value: 'USD',
+		} );
 		// add products
 		await api
 			.post( 'products', {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-coupons.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-coupons.spec.js
@@ -33,6 +33,10 @@ test.describe( 'Checkout coupons', () => {
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
 		} );
+		// make sure the currency is USD
+		await api.put( 'settings/general/woocommerce_currency', {
+			value: 'USD',
+		} );
 		// add product
 		await api
 			.post( 'products', {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There have been a large number of failures in CI for can setup shipping. An initial improvement to the flakiness of this test was made here but there test is still failing a lot. This PR skips this test until this is resolved.

### How to test the changes in this Pull Request:

1.[Run e2e tests locally](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#introduction)
2. [Check e2e CI results](https://woocommerce.github.io/woocommerce-test-reports/pr/34715/e2e/)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
