### PR TITLE
Update tracking parameters for mobile messaging

### DIFF
--- a/plugins/woocommerce/changelog/update-mobile-messaging-tracking-parameters
+++ b/plugins/woocommerce/changelog/update-mobile-messaging-tracking-parameters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Updates tracking parameters for marketing messages of mobile apps in New order mail.

--- a/plugins/woocommerce/changelog/update-mobile-messaging-tracking-parameters
+++ b/plugins/woocommerce/changelog/update-mobile-messaging-tracking-parameters
@@ -1,4 +1,4 @@
-Significance: minor
-Type: add
+Significance: patch
+Type: update
 
 Updates tracking parameters for marketing messages of mobile apps in New order mail.

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -230,12 +230,14 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 */
 		public function mobile_messaging() {
 			if ( null !== $this->object ) {
+				$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 				wc_get_template(
 					'emails/email-mobile-messaging.php',
 					array(
 						'order'   => $this->object,
 						'blog_id' => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 						'now'     => new DateTime(),
+						'domain'  => is_string( $domain ) ? $domain : '',
 					)
 				);
 			}

--- a/plugins/woocommerce/templates/emails/email-mobile-messaging.php
+++ b/plugins/woocommerce/templates/emails/email-mobile-messaging.php
@@ -17,4 +17,4 @@
 
 use Automattic\WooCommerce\Internal\Orders\MobileMessagingHandler;
 
-echo wp_kses_post( MobileMessagingHandler::prepare_mobile_message( $order, $blog_id, $now ) );
+echo wp_kses_post( MobileMessagingHandler::prepare_mobile_message( $order, $blog_id, $now, $domain ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Orders/MobileMessagingHandlerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Orders/MobileMessagingHandlerTest.php
@@ -9,6 +9,7 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 
 	const BLOG_ID  = 2;
 	const ORDER_ID = 5;
+	const DOMAIN   = 'sample-domain.com';
 
 	/**
 	 * @var string $initial_country that is set on site which is a platform for unit tests, before running tests in this test suite.
@@ -42,7 +43,7 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 	public function test_tracker_reports_only_android_usage() {
 		$now = $this->prepare_timeline_with_valid_last_mobile_app_usage();
 
-		$mobile_message = MobileMessagingHandler::prepare_mobile_message( new WC_Order(), self::BLOG_ID, $now );
+		$mobile_message = MobileMessagingHandler::prepare_mobile_message( new WC_Order(), self::BLOG_ID, $now, self::DOMAIN );
 
 		$this->assertNotNull( $mobile_message );
 	}
@@ -57,10 +58,10 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 			array()
 		);
 
-		$mobile_message = MobileMessagingHandler::prepare_mobile_message( new WC_Order(), self::BLOG_ID, $now );
+		$mobile_message = MobileMessagingHandler::prepare_mobile_message( new WC_Order(), self::BLOG_ID, $now, self::DOMAIN );
 
 		$this->assertContains(
-			'href="https://woocommerce.com/mobile?blog_id=' . self::BLOG_ID . '&#038;utm_source=mobile_deeplink_no_app&#038;utm_content=' . self::BLOG_ID,
+			'href="https://woocommerce.com/mobile?blog_id=' . self::BLOG_ID . '&#038;utm_campaign=deeplinks_promote_app&#038;utm_medium=email&#038;utm_source=' . self::DOMAIN . '&#038;utm_term=' . self::BLOG_ID,
 			$mobile_message
 		);
 	}
@@ -73,10 +74,10 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 		$this->make_store_not_ipp_eligible();
 		$ipp_eligible_order = $this->generate_ipp_eligible_order();
 
-		$mobile_message = MobileMessagingHandler::prepare_mobile_message( $ipp_eligible_order, self::BLOG_ID, $now );
+		$mobile_message = MobileMessagingHandler::prepare_mobile_message( $ipp_eligible_order, self::BLOG_ID, $now, self::DOMAIN );
 
 		$this->assertContains(
-			'href="https://woocommerce.com/mobile/orders/details?blog_id=' . self::BLOG_ID . '&#038;order_id=' . self::ORDER_ID . '&#038;utm_source=mobile_deeplink_orders_details&#038;utm_content=' . self::BLOG_ID,
+			'href="https://woocommerce.com/mobile/orders/details?blog_id=' . self::BLOG_ID . '&#038;order_id=' . self::ORDER_ID . '&#038;utm_campaign=deeplinks_orders_details&#038;utm_medium=email&#038;utm_source=' . self::DOMAIN . '&#038;utm_term=' . self::BLOG_ID,
 			$mobile_message
 		);
 	}
@@ -89,10 +90,10 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 		$this->make_store_ipp_eligible();
 		$ipp_eligible_order = $this->generate_ipp_eligible_order();
 
-		$mobile_message = MobileMessagingHandler::prepare_mobile_message( $ipp_eligible_order, self::BLOG_ID, $now );
+		$mobile_message = MobileMessagingHandler::prepare_mobile_message( $ipp_eligible_order, self::BLOG_ID, $now, self::DOMAIN );
 
 		$this->assertContains(
-			'href="https://woocommerce.com/mobile/payments?blog_id=' . self::BLOG_ID . '&#038;utm_source=mobile_deeplink_payments&#038;utm_content=' . self::BLOG_ID,
+			'href="https://woocommerce.com/mobile/payments?blog_id=' . self::BLOG_ID . '&#038;utm_campaign=deeplinks_payments&#038;utm_medium=email&#038;utm_source=' . self::DOMAIN . '&#038;utm_term=' . self::BLOG_ID,
 			$mobile_message
 		);
 	}
@@ -109,10 +110,10 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 		$this->make_store_ipp_eligible();
 		$ipp_eligible_order = $this->generate_ipp_eligible_order();
 
-		$mobile_message = MobileMessagingHandler::prepare_mobile_message( $ipp_eligible_order, null, $now );
+		$mobile_message = MobileMessagingHandler::prepare_mobile_message( $ipp_eligible_order, null, $now, self::DOMAIN );
 
 		$this->assertContains(
-			'href="https://woocommerce.com/mobile/payments?blog_id=0&#038;utm_source=mobile_deeplink_payments&#038;utm_content=0',
+			'href="https://woocommerce.com/mobile/payments?blog_id=0&#038;utm_campaign=deeplinks_payments&#038;utm_medium=email&#038;utm_source=' . self::DOMAIN . '&#038;utm_term=0',
 			$mobile_message
 		);
 	}
@@ -148,6 +149,7 @@ class MobileMessagingHandlerTest extends \WC_Unit_Test_Case {
 				),
 			)
 		);
+
 		return $now;
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34716.

This PR adds required tracking parameters to mobile messaging deep links. We do this to make tracking deep links on the WooCommerce.com site easier.

For details, please see the attached issue.

### How to test the changes in this Pull Request:

I think that unit tests are sufficient. Otherwise, to test this PR please prepare 3 orders to meet 3 different copies (as described here) and assert that each link, that is part of new order footer, contains those 3 params:
1. `utm_campaign`
2. `utm_medium`
3. `utm_source`
4. `utm_term`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
