### PR TITLE
Added woocommerce_reduce_order_item_stock action hook to let other plugin hook functionalities without looping through the order items again and again.

### DIFF
--- a/plugins/woocommerce/changelog/woocommerce-reduce-order-item-stock
+++ b/plugins/woocommerce/changelog/woocommerce-reduce-order-item-stock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added woocommerce_reduce_order_item_stock action hook

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -197,21 +197,22 @@ function wc_reduce_stock_levels( $order_id ) {
 		$item->add_meta_data( '_reduced_stock', $qty, true );
 		$item->save();
 
-		$changes[] = array(
+		$change = array(
 			'product' => $product,
 			'from'    => $new_stock + $qty,
 			'to'      => $new_stock,
 		);
+		$changes[] = $change;
 
 		/**
 		 * Fires when stock reduced to a specific line item
 		 *
 		 * @param WC_Order_Item_Product $item Order item data.
-		 * @param WC_Product $product  Line item product.
+		 * @param array $change  Change Details.
 		 * @param WC_Order $order  Order data.
-		 * @since 7.0.0
+		 * @since 7.4.0
 		 */
-		do_action( 'woocommerce_reduce_order_item_stock', $item, $product, $order );
+		do_action( 'woocommerce_reduce_order_item_stock', $item, $change, $order );
 	}
 
 	wc_trigger_stock_change_notifications( $order, $changes );

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -197,7 +197,7 @@ function wc_reduce_stock_levels( $order_id ) {
 		$item->add_meta_data( '_reduced_stock', $qty, true );
 		$item->save();
 
-		$change = array(
+		$change    = array(
 			'product' => $product,
 			'from'    => $new_stock + $qty,
 			'to'      => $new_stock,
@@ -210,7 +210,7 @@ function wc_reduce_stock_levels( $order_id ) {
 		 * @param WC_Order_Item_Product $item Order item data.
 		 * @param array $change  Change Details.
 		 * @param WC_Order $order  Order data.
-		 * @since 7.4.0
+		 * @since 7.6.0
 		 */
 		do_action( 'woocommerce_reduce_order_item_stock', $item, $change, $order );
 	}

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -202,6 +202,16 @@ function wc_reduce_stock_levels( $order_id ) {
 			'from'    => $new_stock + $qty,
 			'to'      => $new_stock,
 		);
+
+		/**
+		 * Fires when stock reduced to a specific line item
+		 *
+		 * @param WC_Order_Item_Product $item Order item data.
+		 * @param WC_Product $product  Line item product.
+		 * @param WC_Order $order  Order data.
+		 * @since 7.0.0
+		 */
+		do_action( 'woocommerce_reduce_order_item_stock', $item, $product, $order );
 	}
 
 	wc_trigger_stock_change_notifications( $order, $changes );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Assume, you have to do something when the WooCommerce reduce order item stock by iterating through the line items. How can you do that?

The answer will, by using the ```woocommerce_reduce_order_stock``` hook which send order data to pass to callback function. But, you have to call ```$order->get_items()``` again and iterate again. And per iteration, you have to check 4-3 more conditions and call more queries again and again. But if we add a new hook at the end of the iteration block then we can reduce a lot of query call and complexities. Is't it good? I also have a real world example from my current project but can't disclose it before the plugin release, because of some company policies.

Into this PR, I have added a new ```woocommerce_reduce_order_item_stock``` hook which will pass line item, product and order data to the callback functions to do necessary things into the loop WooCommerce called to reduce stock. This will help the developers to reduce extra complexities.

### How to test the changes in this Pull Request:

1. By running pnpm test command

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->
