### PR TITLE
Added the filter in class-wc-emails.php

### DIFF
--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -1021,7 +1021,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			case self::E_WC_COUPON_USAGE_LIMIT_COUPON_STUCK:
 				if ( is_user_logged_in() && wc_get_page_id( 'myaccount' ) > 0 ) {
 					/* translators: %s: myaccount page link. */
-					$err = sprintf( __( 'Coupon usage limit has been reached. If you were using this coupon just now but order was not complete, you can retry or cancel the order by going to the <a href="%s">my account page</a>.', 'woocommerce' ), wc_get_endpoint_url( 'orders', '', wc_get_page_permalink( 'myaccount' ) ) );
+					$err = sprintf( __( 'Coupon usage limit has been reached. If you were using this coupon just now but your order was not complete, you can retry or cancel the order by going to the <a href="%s">my account page</a>.', 'woocommerce' ), wc_get_endpoint_url( 'orders', '', wc_get_page_permalink( 'myaccount' ) ) );
 				} else {
 					$err = $this->get_coupon_error( self::E_WC_COUPON_USAGE_LIMIT_REACHED );
 				}

--- a/plugins/woocommerce/includes/class-wc-emails.php
+++ b/plugins/woocommerce/includes/class-wc-emails.php
@@ -24,6 +24,14 @@ class WC_Emails {
 	 */
 	public $emails = array();
 
+
+	/**
+	 * Array of email notification classes and paths
+	 *
+	 * @var WC_Email[]
+	 */
+	public $default_emails_paths = array();
+
 	/**
 	 * The single instance of the class
 	 *
@@ -217,20 +225,36 @@ class WC_Emails {
 	public function init() {
 		// Include email classes.
 		include_once dirname( __FILE__ ) . '/emails/class-wc-email.php';
+		$this->default_emails_paths = $this->default_emails_paths();
+       	$emails_data = apply_filters( 'woocommerce_before_email_classes', $this->default_emails_paths );
+    	foreach ( $emails_data as $class_name => $email_file_path ) {
 
-		$this->emails['WC_Email_New_Order']                 = include __DIR__ . '/emails/class-wc-email-new-order.php';
-		$this->emails['WC_Email_Cancelled_Order']           = include __DIR__ . '/emails/class-wc-email-cancelled-order.php';
-		$this->emails['WC_Email_Failed_Order']              = include __DIR__ . '/emails/class-wc-email-failed-order.php';
-		$this->emails['WC_Email_Customer_On_Hold_Order']    = include __DIR__ . '/emails/class-wc-email-customer-on-hold-order.php';
-		$this->emails['WC_Email_Customer_Processing_Order'] = include __DIR__ . '/emails/class-wc-email-customer-processing-order.php';
-		$this->emails['WC_Email_Customer_Completed_Order']  = include __DIR__ . '/emails/class-wc-email-customer-completed-order.php';
-		$this->emails['WC_Email_Customer_Refunded_Order']   = include __DIR__ . '/emails/class-wc-email-customer-refunded-order.php';
-		$this->emails['WC_Email_Customer_Invoice']          = include __DIR__ . '/emails/class-wc-email-customer-invoice.php';
-		$this->emails['WC_Email_Customer_Note']             = include __DIR__ . '/emails/class-wc-email-customer-note.php';
-		$this->emails['WC_Email_Customer_Reset_Password']   = include __DIR__ . '/emails/class-wc-email-customer-reset-password.php';
-		$this->emails['WC_Email_Customer_New_Account']      = include __DIR__ . '/emails/class-wc-email-customer-new-account.php';
+        		if ( ! empty( $email_file_path ) && ! empty( $class_name ) && file_exists( dirname( __FILE__ ) . $email_file_path ) ) {
+            		$this->emails[ $class_name ] = include dirname( __FILE__ ) . $email_file_path;
+       		}
+    	}
+		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );	
+	}
 
-		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );
+	/**
+	 * Get the default email classes.
+	 *
+	 * @return Array of default email classes and their paths.
+	 */
+	public function default_emails_paths() {
+		return array(
+			'WC_Email_New_Order' => '/emails/class-wc-email-new-order.php',
+			'WC_Email_Cancelled_Order' => '/emails/class-wc-email-cancelled-order.php',
+			'WC_Email_Failed_Order' => '/emails/class-wc-email-failed-order.php',
+			'WC_Email_Customer_On_Hold_Order' => '/emails/class-wc-email-customer-on-hold-order.php',
+			'WC_Email_Customer_Processing_Order' => '/emails/class-wc-email-customer-processing-order.php',
+			'WC_Email_Customer_Completed_Order' => '/emails/class-wc-email-customer-completed-order.php',
+			'WC_Email_Customer_Refunded_Order' => '/emails/class-wc-email-customer-refunded-order.php',
+			'WC_Email_Customer_Invoice' => '/emails/class-wc-email-customer-invoice.php',
+			'WC_Email_Customer_Note' => '/emails/class-wc-email-customer-note.php',
+			'WC_Email_Customer_Reset_Password' => '/emails/class-wc-email-customer-reset-password.php',
+			'WC_Email_Customer_New_Account' => '/emails/class-wc-email-customer-new-account.php',
+		);
 	}
 
 	/**


### PR DESCRIPTION
Changed the way it was loading the files from init function. 

 - Created a new function, `default_emails_paths`, and added all the path and class information inside an array.
 - Applied filter on that array called `woocommerce_before_email_classes`

Fixes #33825

### All Submissions:

-   [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33825.

### How to test the changes in this Pull Request:

1. Changed the way it was loading the files for email classes.
2. New filter added with name "woocommerce_before_email_classes"


<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
