### PR TITLE
Fix fatal error produced by the init_theorder_object method

### DIFF
--- a/plugins/woocommerce/changelog/fix-34722
+++ b/plugins/woocommerce/changelog/fix-34722
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error thrown by init_theorder_object due to the return type declaration

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -105,9 +105,9 @@ class COTMigrationUtil {
 	 *
 	 * @param WC_Order|WP_Post $post_or_order_object Post or order object.
 	 *
-	 * @return WC_Order WC_Order object.
+	 * @return bool|WC_Order|WC_Order_Refund WC_Order object.
 	 */
-	public function init_theorder_object( $post_or_order_object ) : WC_Order {
+	public function init_theorder_object( $post_or_order_object ) {
 		global $theorder;
 		if ( $theorder instanceof WC_Order ) {
 			return $theorder;

--- a/plugins/woocommerce/src/Utilities/OrderUtil.php
+++ b/plugins/woocommerce/src/Utilities/OrderUtil.php
@@ -64,9 +64,9 @@ final class OrderUtil {
 	 *
 	 * @param WC_Order|WP_Post $post_or_order_object Post or order object.
 	 *
-	 * @return WC_Order WC_Order object.
+	 * @return bool|WC_Order|WC_Order_Refund WC_Order object.
 	 */
-	public static function init_theorder_object( $post_or_order_object ) : WC_Order {
+	public static function init_theorder_object( $post_or_order_object ) {
 		return wc_get_container()->get( COTMigrationUtil::class )->init_theorder_object( $post_or_order_object );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes the error thrown by `COTMigrationUtil::init_theorder_object` when the current order doesn't exist or is not of type `WC_Order`, this was caused by the method having a fixed return type of `WC_Order`.

Closes #34722.

### How to test the changes in this Pull Request:

Follow the repro steps of https://github.com/woocommerce/woocommerce/issues/34722 and verify that the error is gone.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
