### PR TITLE
Update pnpm command to run makepot

### DIFF
--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -16,7 +16,7 @@ pnpm -w run build --filter=woocommerce || exit "$?"
 echo "Cleaning up PHP dependencies..."
 composer install --no-dev || exit "$?"
 echo "Run makepot..."
-pnpm makepot --filter=woocommerce || exit "$?"
+pnpm -r --filter=woocommerce run makepot || exit "$?"
 echo "Syncing files..."
 rsync -rc --exclude-from="$PROJECT_PATH/.distignore" "$PROJECT_PATH/" "$DEST_PATH/" --delete --delete-excluded
 

--- a/plugins/woocommerce/changelog/fix-build-zip
+++ b/plugins/woocommerce/changelog/fix-build-zip
@@ -1,0 +1,3 @@
+Significance: patch
+Type: update
+Comment: Updates the command to makepot after pnpm 7


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was a recent change to use [PNPM 7](https://github.com/woocommerce/woocommerce/pull/34661). With this change some commands required  a different way of being called. The issue was reported [here](https://github.com/woocommerce/woocommerce/actions/runs/3081208580/jobs/4979487566#step:4:609)

### How to test the changes in this Pull Request:

1. Make sure you're on PNPM 7.
2. CD `plugins/woocommerce`.
3. Run `bash bin/build-zip.sh`
4. Witness the command will eventually fail with the error you see in the actions workflow.
5. Checkout this branch and run the command again (`bash bin/build-zip.sh`).
6. This time the command should complete without issues and you should see `Build done!` message and check that POT file was generated and also a zip file is created.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
