### PR TITLE
 Remove typecasting to prevent fatal when $screen_id is null.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34725
+++ b/plugins/woocommerce/changelog/fix-34725
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove typecasting to prevent fatal when $screen_id is null.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -507,7 +507,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 *
 		 * @return bool Whether the current screen is an order edit screen.
 		 */
-		private function is_order_meta_box_screen( string $screen_id ) {
+		private function is_order_meta_box_screen( $screen_id ) {
 			return in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ) ) ||
 						wc_get_page_screen_id( 'shop-order' ) === $screen_id;
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -305,7 +305,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					)
 				);
 			}
-			if ( in_array( str_replace( 'edit-', '', $screen_id ), array( 'shop_coupon', 'product' ) ) || $this->is_order_meta_box_screen( $screen_id ) ) {
+			if ( in_array( str_replace( 'edit-', '', $screen_id ), array( 'shop_coupon', 'product' ), true ) || $this->is_order_meta_box_screen( $screen_id ) ) {
 				$post_id                = isset( $post->ID ) ? $post->ID : '';
 				$currency               = '';
 				$remove_item_notice     = __( 'Are you sure you want to remove the selected items?', 'woocommerce' );
@@ -508,7 +508,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * @return bool Whether the current screen is an order edit screen.
 		 */
 		private function is_order_meta_box_screen( $screen_id ) {
-			return in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ) ) ||
+			return in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ), true ) ||
 						wc_get_page_screen_id( 'shop-order' ) === $screen_id;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34725 

We added a function `is_order_meta_box_screen` which as `string` type definition as one of its param. From PHP 8.1, if null is passed as the screen_id, it's not typecasted, but instead a fatal is thrown. This PR removes the type definition to accomodate `null` screen ID.

### How to test the changes in this Pull Request:

1. Start with a WooCommerce site with PHP 8.1.
2. Install a plugin that adds a new screen in admin, such as [SEOPress](https://wordpress.org/plugins/wp-seopress/)
3. Start the configuration wizard for the plugin. Without this PR you will see a fatal like so: `Uncaught TypeError: WC_Admin_Assets::is_order_meta_box_screen(): Argum`. With this PR, it should be resolved and setup screen with load as usual.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
