### PR TITLE
Fix EnrichedLabel Storybook styles

### DIFF
--- a/packages/js/components/changelog/fix-enriched-label-storybook
+++ b/packages/js/components/changelog/fix-enriched-label-storybook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix EnrichedLabel Storybook story styles so they don't affect other stories.

--- a/packages/js/components/src/enriched-label/stories/index.js
+++ b/packages/js/components/src/enriched-label/stories/index.js
@@ -1,32 +1,44 @@
 /**
  * External dependencies
  */
-import { EnrichedLabel } from '@woocommerce/components';
 import { CheckboxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import { EnrichedLabel } from '../';
 import './style.scss';
-
-export const Basic = () => (
-	<CheckboxControl
-		label={
-			<EnrichedLabel
-				label="My label"
-				helpDescription="My description."
-				moreUrl="https://woocommerce.com"
-				tooltipLinkCallback={ () => {
-					// eslint-disable-next-line no-alert
-					window.alert( 'Learn More clicked' );
-				} }
-			/>
-		}
-		onChange={ () => {} }
-	/>
-);
 
 export default {
 	title: 'WooCommerce Admin/components/EnrichedLabel',
 	component: EnrichedLabel,
+	argTypes: {
+		tooltipLinkCallback: { action: 'tooltipLinkCallback' },
+	},
 };
+
+const Template = ( args ) => (
+	<EnrichedLabel
+		label="My label"
+		helpDescription="My description."
+		moreUrl="https://woocommerce.com"
+		tooltipLinkCallback={ () => {
+			// eslint-disable-next-line no-alert
+			window.alert( 'Learn More clicked' );
+		} }
+		{ ...args }
+	/>
+);
+
+export const Basic = Template.bind( {} );
+Basic.decorators = [
+	( story, props ) => {
+		return (
+			<CheckboxControl
+				className="woocommerce-enriched-label-story__checkbox-control"
+				label={ story( { args: { ...props.args } } ) }
+				onChange={ () => {} }
+			/>
+		);
+	},
+];

--- a/packages/js/components/src/enriched-label/stories/style.scss
+++ b/packages/js/components/src/enriched-label/stories/style.scss
@@ -1,21 +1,23 @@
-.woocommerce-enriched-label__help-wrapper {
-	.components-popover {
-		margin: 0;
+.woocommerce-enriched-label-story__checkbox-control {
+	.woocommerce-enriched-label__help-wrapper {
+		.components-popover {
+			margin: 0;
+		}
 	}
-}
-.components-base-control__field {
-	display: flex;
-	.components-checkbox-control {
-		&__label {
-			display: flex;
-		}
+	.components-base-control__field {
+		display: flex;
+		.components-checkbox-control {
+			&__label {
+				display: flex;
+			}
 
-		&__input-container {
-			align-self: center;
-		}
+			&__input-container {
+				align-self: center;
+			}
 
-		.woocommerce-enriched-label__text {
-			align-self: center;
+			.woocommerce-enriched-label__text {
+				align-self: center;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The EnrichedLabel Storybook story was incorrectly scoping it's style changes so that they would match all `.components-base-control__field`. Storybook stories all get loaded in the browser at the same time when Storybook runs, so this messed up styles in other component's stories, such as TextControlWithAffixes.

This PR fixes that.

In addition, it updates the EnrichedLabel story to support Storybook Controls and Actions, allowing for a richer experience when using Storybook.

#### Before screenshots

`EnrichedLabel / Basic`:

<img width="1048" alt="Screen Shot 2022-09-19 at 11 15 00" src="https://user-images.githubusercontent.com/2098816/191064476-c2904c75-5767-4880-a27f-b06ce987799c.png">

`TextControlWithAffixes / Basic`:

Note that the labels are incorrectly aligned to the left of the controls.

<img width="1048" alt="Screen Shot 2022-09-19 at 11 14 44" src="https://user-images.githubusercontent.com/2098816/191064563-eb1a853d-2c91-4067-bc06-1bf16c9c26ba.png">

#### After screenshots

`EnrichedLabel > Basic` (no change/regression):

<img width="1048" alt="Screen Shot 2022-09-19 at 11 15 00" src="https://user-images.githubusercontent.com/2098816/191064476-c2904c75-5767-4880-a27f-b06ce987799c.png">

`TextControlWithAffixes / Basic`:

Note that the labels are correctly aligned above the controls.

<img width="1048" alt="Screen Shot 2022-09-19 at 11 26 27" src="https://user-images.githubusercontent.com/2098816/191064540-f9705a08-cf88-483c-8fc6-6b0dacef46d0.png">


### How to test the changes in this Pull Request:

1. Run Storybook: `pnpm --filter=@woocommerce/storybook storybook`
2. Verify that `EnrichedLabel / Basic` story appears correctly.
3. Verify that the Storybook Controls can be set in for `EnrichedLabel / Basic` (in the panel at the bottom of Storybook).
4. Verify that when the "Learn more" link in the help popover is clicked, that a Storybook Action is logged (in the panel at the bottom of Storybook).
5. Verify that `TextControlWithAffixes / Basic` story appears correctly (labels above the text controls, help below the text controls).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
