### PR TITLE
Only show the product image upload tip once, and on all product edit pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-multiple-product-image-upload-tips
+++ b/plugins/woocommerce/changelog/fix-multiple-product-image-upload-tips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Only show the product image upload tip once, and on all product edit pages.

--- a/plugins/woocommerce/includes/class-wc-product-simple.php
+++ b/plugins/woocommerce/includes/class-wc-product-simple.php
@@ -15,13 +15,6 @@ defined( 'ABSPATH' ) || exit;
 class WC_Product_Simple extends WC_Product {
 
 	/**
-	 * Track wehther post_upload_ui hook was run.
-	 *
-	 * @var boolean
-	 */
-	public static $post_upload_hook_done = false;
-
-	/**
 	 * Initialize simple product.
 	 *
 	 * @param WC_Product|int $product Product instance or ID.
@@ -29,23 +22,6 @@ class WC_Product_Simple extends WC_Product {
 	public function __construct( $product = 0 ) {
 		$this->supports[] = 'ajax_add_to_cart';
 		parent::__construct( $product );
-		add_filter('admin_post_thumbnail_html', array( $this, 'add_product_photo_suggestions' ) );
-	}
-
-	/**
-	 * Adding product photo suggestions in upload modal.
-	 */
-	public function add_product_photo_suggestions ( $content ) {
-
-		$suggestion  = '<div class="image-added-detail">';
-		$suggestion .= '<p>';
-		$suggestion .= '<span class="dashicons-info-outline dashicons"></span>';
-		$suggestion .= esc_html__( 'Upload JPEG files that are 1000 x 1000 pixels or larger (max. 2 GB).', 'woocommerce' );
-		$suggestion .= ' <a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '<span class="dashicons-external dashicons"></span></a>';
-		$suggestion .= '</p>';
-		$suggestion .= '</div>';
-
-		return $content . $suggestion;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -284,12 +284,10 @@ add_filter( 'post_type_link', 'wc_product_post_type_link', 10, 2 );
 /**
  * Filter to add upload tips under the product image thumbnail.
  *
- * @param  string  $content The HTML markup for the admin post thumbnail.
+ * @param  string $content The HTML markup for the admin post thumbnail.
  * @return string
  */
 function wc_product_post_thumbnail_html( $content ) {
-
-
 	$suggestion  = '<div class="image-added-detail">';
 	$suggestion .= '<p>';
 	$suggestion .= '<span class="dashicons-info-outline dashicons"></span>';

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -291,7 +291,8 @@ function wc_product_post_thumbnail_html( $content ) {
 	$suggestion  = '<div class="image-added-detail">';
 	$suggestion .= '<p>';
 	$suggestion .= '<span class="dashicons-info-outline dashicons"></span>';
-	$suggestion .= esc_html__( 'Upload JPEG files that are 1000 x 1000 pixels or larger (max. 2 GB).', 'woocommerce' );
+	/* translators: 1: formatted file size */
+	$suggestion .= esc_html( sprintf( __( 'Upload JPEG files that are 1000 x 1000 pixels or larger (max. %1$s).', 'woocommerce' ), size_format( wp_max_upload_size() ) ) );
 	$suggestion .= ' <a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '<span class="dashicons-external dashicons"></span></a>';
 	$suggestion .= '</p>';
 	$suggestion .= '</div>';

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -282,6 +282,38 @@ function wc_product_post_type_link( $permalink, $post ) {
 add_filter( 'post_type_link', 'wc_product_post_type_link', 10, 2 );
 
 /**
+ * Filter to add upload tips under the product image thumbnail.
+ *
+ * @param  string  $content The HTML markup for the admin post thumbnail.
+ * @return string
+ */
+function wc_product_post_thumbnail_html( $content ) {
+
+
+	$suggestion  = '<div class="image-added-detail">';
+	$suggestion .= '<p>';
+	$suggestion .= '<span class="dashicons-info-outline dashicons"></span>';
+	$suggestion .= esc_html__( 'Upload JPEG files that are 1000 x 1000 pixels or larger (max. 2 GB).', 'woocommerce' );
+	$suggestion .= ' <a href="https://woocommerce.com/posts/fast-high-quality-product-photos/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'How to prepare images?', 'woocommerce' ) . '<span class="dashicons-external dashicons"></span></a>';
+	$suggestion .= '</p>';
+	$suggestion .= '</div>';
+
+	return $content . $suggestion;
+}
+
+/**
+ * Action to add the filter to add upload tips under the product image thumbnail.
+ *
+ * @param WP_Screen $current_screen Current WP_Screen object.
+ */
+function wc_add_product_post_thumbnail_html_filter( $current_screen ) {
+	if ( 'product' === $current_screen->post_type && 'post' === $current_screen->base ) {
+		add_filter( 'admin_post_thumbnail_html', 'wc_product_post_thumbnail_html' );
+	}
+}
+add_action( 'current_screen', 'wc_add_product_post_thumbnail_html_filter' );
+
+/**
  * Get the placeholder image URL either from media, or use the fallback image.
  *
  * @param string $size Thumbnail size to use.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In WooCommerce 6.9, a tip was added under the product image thumbnail in the sidebar of the product edit page (see #33660).

Under certain circumstances, this tip can be rendered multiple times. 

<img width="1128" alt="Screen Shot 2022-09-19 at 19 56 17" src="https://user-images.githubusercontent.com/2098816/191139984-60151a74-04d1-43ba-b34a-1348cea4cf56.png">

This is because the `add_filter` call is incorrectly called from the constructor of the `WC_Simple_Product` class. This is not a good location to call `add_filter` because:

1. There is no guarantee that a plugin or even core functionality will not construct multiple `WC_Simple_Product` instances while rendering the product edit page, and
2. By calling it from the `WC_Simple_Product` constructor, it doesn't appear for other product types, such as variable products.

I've changed the implementation to work when editing any product type and to only render a single time.

<img width="1128" alt="Screen Shot 2022-09-19 at 19 51 16" src="https://user-images.githubusercontent.com/2098816/191139994-60f602ce-41e5-4780-9733-f1c51c31bc3b.png">

Fixes #34728.

### How to test the changes in this Pull Request:

0. Add the following code to a plugin/mu-plugin. It will trigger the issue:

```
function test_create_product_objects() {
	$product1 = new WC_Product_Simple();
	$product2 = new WC_Product_Simple();
}

add_action( 'admin_init', 'test_create_product_objects' );
```

1. Go to Products > Add New
2. Observe the tip in the bottom of the product image metabox.
3. Click the new link and ensure it works as expected.
4. Go to Posts > Add New
5. Verify that the tip does not appear in the bottom of the featured image metabox.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
