### PR TITLE
Add initial attributes section for empty state

### DIFF
--- a/packages/js/data/changelog/add-34330_attributes_section
+++ b/packages/js/data/changelog/add-34330_attributes_section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add product attribute types to the Product type.

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -25,6 +25,15 @@ export type ProductDownload = {
 	file: string;
 };
 
+export type ProductAttribute = {
+	id: number;
+	name: string;
+	position: number;
+	visible: boolean;
+	variation: boolean;
+	options: string[];
+};
+
 export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	Schema.Post,
 	'status'
@@ -76,6 +85,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	rating_count: number;
 	related_ids: number[];
 	variations: number[];
+	attributes: ProductAttribute[];
 };
 
 export const productReadOnlyProperties = [

--- a/plugins/woocommerce-admin/client/products/add-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/add-product-page.tsx
@@ -16,6 +16,7 @@ import { PricingSection } from './sections/pricing-section';
 import { ProductShippingSection } from './sections/product-shipping-section';
 import './product-page.scss';
 import { validate } from './product-validation';
+import { AttributesSection } from './sections/attributes-section';
 
 const AddProductPage: React.FC = () => {
 	useEffect( () => {
@@ -33,6 +34,7 @@ const AddProductPage: React.FC = () => {
 					<ProductDetailsSection />
 					<PricingSection />
 					<ProductShippingSection />
+					<AttributesSection />
 					<ProductFormActions />
 				</ProductFormLayout>
 			</Form>

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -24,6 +24,7 @@ import { PricingSection } from './sections/pricing-section';
 import { ProductShippingSection } from './sections/product-shipping-section';
 import './product-page.scss';
 import { validate } from './product-validation';
+import { AttributesSection } from './sections/attributes-section';
 
 const EditProductPage: React.FC = () => {
 	const { productId } = useParams();
@@ -126,6 +127,7 @@ const EditProductPage: React.FC = () => {
 						<ProductFormLayout>
 							<ProductDetailsSection />
 							<PricingSection />
+							<AttributesSection />
 							<ProductShippingSection />
 							<ProductFormActions />
 						</ProductFormLayout>

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-empty-state-logo.svg
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-empty-state-logo.svg
@@ -1,0 +1,19 @@
+<svg width="151" height="72" viewBox="0 0 151 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="45.8291" y="25.2363" width="78.4945" height="45.2637" rx="3.7381" fill="#F6F7F7" stroke="#DDDDDD" stroke-width="3" stroke-dasharray="4 3"/>
+<rect x="2.3125" y="1.5" width="78.4945" height="69" rx="3.7381" fill="white" stroke="#DDDDDD" stroke-width="3"/>
+<line x1="11.3516" y1="9.94922" x2="33.6702" y2="9.94922" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<line x1="11.0156" y1="55.4668" x2="33.3343" y2="55.4668" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<line x1="11.0156" y1="61.0054" x2="26.2134" y2="61.0054" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<rect x="11.0156" y="41.0605" width="27.0659" height="8.07692" rx="1.5" stroke="#DDDDDD" stroke-width="3"/>
+<line x1="45.0361" y1="55.4673" x2="67.3548" y2="55.4673" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<line x1="45.0361" y1="61.0054" x2="60.2339" y2="61.0054" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<rect x="45.0361" y="41.0605" width="27.0659" height="8.07692" rx="1.5" stroke="#DDDDDD" stroke-width="3"/>
+<rect x="11.0156" y="18.1152" width="61.0879" height="14.4066" rx="1.5" stroke="#DDDDDD" stroke-width="3"/>
+<path d="M58.5703 23.7363L61.4236 26.5897C61.8142 26.9802 62.4473 26.9802 62.8379 26.5897L65.6912 23.7363" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<line x1="17.5" y1="25" x2="39.8187" y2="25" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round"/>
+<path d="M149.188 42.6308L134.977 30.1968" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<circle r="18.0392" transform="matrix(-1 0 0 1 122.541 19.5392)" fill="white" stroke="#DDDDDD" stroke-width="3" stroke-linejoin="round"/>
+<path d="M121.297 15.834H131.667M121.297 24.0007H131.667" stroke="#DDDDDD" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<ellipse cx="114.333" cy="23.9993" rx="2.33333" ry="2.33333" fill="#DDDDDD"/>
+<ellipse cx="114.333" cy="15.8333" rx="2.33333" ry="2.33333" fill="#DDDDDD"/>
+</svg>

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
@@ -1,0 +1,17 @@
+.woocommerce-attribute-field {
+	width: 100%;
+
+	&__empty-container {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+	&__empty-logo {
+		max-width: 150px;
+		margin: $gap-larger 0 $gap-large;
+	}
+	&__add-new {
+		margin: $gap-large 0 $gap-larger;
+	}
+}

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { ProductAttribute } from '@woocommerce/data';
+import { Text } from '@woocommerce/experimental';
+
+/**
+ * Internal dependencies
+ */
+import './attribute-field.scss';
+import AttributeEmptyStateLogo from './attribute-empty-state-logo.svg';
+
+type AttributeFieldProps = {
+	value: ProductAttribute[];
+	onChange: ( value: ProductAttribute[] ) => void;
+};
+
+export const AttributeField: React.FC< AttributeFieldProps > = ( {
+	value,
+	onChange,
+} ) => {
+	if ( ! value || value.length === 0 ) {
+		return (
+			<div className="woocommerce-attribute-field">
+				<div className="woocommerce-attribute-field__empty-container">
+					<img
+						src={ AttributeEmptyStateLogo }
+						alt="Completed"
+						className="woocommerce-attribute-field__empty-logo"
+					/>
+					<Text
+						variant="subtitle.small"
+						weight="600"
+						size="14"
+						lineHeight="20px"
+						className="woocommerce-attribute-field__empty-subtitle"
+					>
+						{ __( 'No attributes yet', 'woocommerce' ) }
+					</Text>
+					<Button
+						variant="secondary"
+						className="woocommerce-attribute-field__add-new"
+						disabled={ true }
+					>
+						{ __( 'Add first attribute', 'woocommerce' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	}
+	return <div className="woocommerce-attribute-field"></div>;
+};

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/index.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/index.ts
@@ -1,0 +1,1 @@
+export * from './attribute-field';

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
@@ -14,7 +14,7 @@ describe( 'AttributeField', () => {
 	} );
 
 	describe( 'empty state', () => {
-		it( 'should show subittle and "Add first attribute" button', () => {
+		it( 'should show subtitle and "Add first attribute" button', () => {
 			const { queryByText } = render(
 				<AttributeField value={ [] } onChange={ () => {} } />
 			);

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { AttributeField } from '../attribute-field';
+
+describe( 'AttributeField', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'empty state', () => {
+		it( 'should show subittle and "Add first attribute" button', () => {
+			const { queryByText } = render(
+				<AttributeField value={ [] } onChange={ () => {} } />
+			);
+			expect( queryByText( 'No attributes yet' ) ).toBeInTheDocument();
+			expect( queryByText( 'Add first attribute' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
@@ -13,7 +13,12 @@ import { ProductSectionLayout } from '../layout/product-section-layout';
 import { AttributeField } from '../fields/attribute-field';
 
 export const AttributesSection: React.FC = () => {
-	const { getInputProps, setValue } = useFormContext< Product >();
+	const { getInputProps, values } = useFormContext< Product >();
+
+	// TODO: remove https://github.com/woocommerce/woocommerce/issues/34333 is done.
+	if ( values.attributes && values.attributes.length > 0 ) {
+		return null;
+	}
 
 	return (
 		<ProductSectionLayout

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Link, useFormContext } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { ProductSectionLayout } from '../layout/product-section-layout';
+import { AttributeField } from '../fields/attribute-field';
+
+export const AttributesSection: React.FC = () => {
+	const { getInputProps, setValue } = useFormContext< Product >();
+
+	return (
+		<ProductSectionLayout
+			title={ __( 'Attributes', 'woocommerce' ) }
+			description={
+				<>
+					<span>
+						{ __(
+							'Add descriptive pieces of information that customers can use to filter and search for this product.',
+							'woocommerce'
+						) }
+					</span>
+					<Link
+						className="woocommerce-form-section__header-link"
+						href="https://woocommerce.com/document/managing-product-taxonomies/#product-attributes"
+						target="_blank"
+						type="external"
+						onClick={ () => {
+							recordEvent( 'learn_more_about_attributes_help' );
+						} }
+					>
+						{ __( 'Learn more about attributes', 'woocommerce' ) }
+					</Link>
+				</>
+			}
+		>
+			<AttributeField { ...getInputProps( 'attributes' ) } />
+		</ProductSectionLayout>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -111,7 +111,10 @@ export const PricingSection: React.FC = () => {
 							recordEvent( 'add_product_pricing_help' );
 						} }
 					>
-						How to price your product: expert tips
+						{ __(
+							'How to price your product: expert tips',
+							'woocommerce'
+						) }
 					</Link>
 				</>
 			}

--- a/plugins/woocommerce/changelog/add-34330_attributes_section
+++ b/plugins/woocommerce/changelog/add-34330_attributes_section
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new attributes section and field for the new Product Management Experience.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the initial attributes section for product with no attributes yet. This should follow the design, the **Add first attribute** button currently disabled as this would be done as part of: https://github.com/woocommerce/woocommerce/issues/34331

<img width="1258" alt="Screen Shot 2022-09-20 at 3 39 22 PM" src="https://user-images.githubusercontent.com/2240960/191339875-a7df3a0d-8080-44ae-8dde-509fb76ee328.png">

Closes #34330  .

### How to test the changes in this Pull Request:

1. Load this branch and enable the `new-product-management-experience` feature flag by using the WCA Test Helper (Tools > WCA Test Helper > Features) and refresh the page.
2. Click the **Products > Add New (MVP)** button and notice the new attributes section
3. It should look the same as the design here: 5sAIeTRd9Yp7nSCT33BAWz-fi-6823%3A312388 the only difference is that the add new button is disabled.
4. Check that the link in the Section description links to [this documentation page](https://woocommerce.com/document/managing-product-taxonomies/#product-attributes) in a new tab.
5. Save this Product and add some attributes using the old UI
6. Refresh the page, the attributes empty state section should now be gone ( as this will be done as part of https://github.com/woocommerce/woocommerce/issues/34333 )

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.