### PR TITLE
Delete cherry picked changelogs and some irrelevant entries

### DIFF
--- a/plugins/woocommerce/changelog/fix-34725
+++ b/plugins/woocommerce/changelog/fix-34725
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Remove typecasting to prevent fatal when $screen_id is null.

--- a/plugins/woocommerce/changelog/fix-build-zip
+++ b/plugins/woocommerce/changelog/fix-build-zip
@@ -1,3 +1,0 @@
-Significance: patch
-Type: update
-Comment: Updates the command to makepot after pnpm 7

--- a/plugins/woocommerce/changelog/fix-multiple-product-image-upload-tips
+++ b/plugins/woocommerce/changelog/fix-multiple-product-image-upload-tips
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Only show the product image upload tip once, and on all product edit pages.

--- a/plugins/woocommerce/changelog/fix-pnpm-7-script-dashes
+++ b/plugins/woocommerce/changelog/fix-pnpm-7-script-dashes
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Fix a pnpm script execution error
-
-

--- a/plugins/woocommerce/changelog/upgrade-to-pnpm-7
+++ b/plugins/woocommerce/changelog/upgrade-to-pnpm-7
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Remove version fixing to pnpm 6 now we use pnpm 7.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR deletes the changelog entries that have already been cherry picked into the `release/7.0` branch. Note that I've also elected to delete some entries that will not be cherry picked. In this instance, they're related to the the PNPM 7 upgrade and we don't want to cherry pick those as it may cause breakages in an already cut release branch.

### How to test the changes in this Pull Request:

1. N/A
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
