### PR TITLE
Potential fix for failing cherry picks

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@v3
         with:
-          fetch-depth: 100
+          fetch-depth: 0
 
       - name: Git fetch the release branch
         run: git fetch origin ${{ needs.prep.outputs.release }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was occurrences of failing cherry pick tool automation with `bad object` on a squash commit. Ref https://github.com/woocommerce/woocommerce/actions/runs/3098012329/jobs/5015387847#step:7:10. I believe the reason is our checkout fetch depth is too shallow and aren't able to pick up commits that are too far in the history. This PR sets the fetch depth to `0` to include all commits. We'll monitor to see if this fixes the problem.

### How to test the changes in this Pull Request:

1. There is no testing step as of right now but will have to test it at a later time. But regardless this change will not break anything.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
