### PR TITLE
Fix COT testing GitHub Actions workflows due to the upgrade to pnpm 7.11.0

### DIFF
--- a/.github/workflows/cot-build-and-e2e-tests-daily.yml
+++ b/.github/workflows/cot-build-and-e2e-tests-daily.yml
@@ -24,7 +24,7 @@ jobs:
 
             - name: Download and install Chromium browser.
               working-directory: plugins/woocommerce
-              run: pnpx playwright install chromium
+              run: pnpm exec playwright install chromium
 
             - name: Run Playwright E2E tests.
               timeout-minutes: 60
@@ -32,7 +32,7 @@ jobs:
               env:
                 USE_WP_ENV: 1
               working-directory: plugins/woocommerce
-              run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
+              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
 
             - name: Generate Playwright E2E Test report.
               id: generate_e2e_report
@@ -43,7 +43,7 @@ jobs:
                     steps.run_playwright_e2e_tests.conclusion != 'skipped' 
                   )
               working-directory: plugins/woocommerce
-              run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
+              run: pnpm exec allure generate --clean e2e/allure-results --output e2e/allure-report
 
             - name: Archive Playwright E2E test report
               if: |

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
             - name: Download and install Chromium browser.
               working-directory: plugins/woocommerce
-              run: pnpx playwright install chromium
+              run: pnpm exec playwright install chromium
 
             - name: Run Playwright E2E tests.
               timeout-minutes: 60
@@ -33,7 +33,7 @@ jobs:
               env:
                 USE_WP_ENV: 1
               working-directory: plugins/woocommerce
-              run: pnpx playwright test --config=tests/e2e-pw/playwright.config.js
+              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
 
             - name: Generate Playwright E2E Test report.
               id: generate_e2e_report
@@ -44,7 +44,7 @@ jobs:
                     steps.run_playwright_e2e_tests.conclusion != 'skipped' 
                   )
               working-directory: plugins/woocommerce
-              run: pnpx allure generate --clean e2e/allure-results --output e2e/allure-report
+              run: pnpm exec allure generate --clean e2e/allure-results --output e2e/allure-report
 
             - name: Archive Playwright E2E test report
               if: |


### PR DESCRIPTION
### All Submissions:

-   [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Recently we merged [a PR](https://github.com/woocommerce/woocommerce/pull/34615) that added 2 new workflows to run tests against an environment in our pipelines. Due to the recent upgrade to pnpm 7.11.0, these workflows are broken when attempting to download the browsers for Playwright. This PR attempts to solve that problem. 

### How to test the changes in this Pull Request:

Perform the same tests that were defined for [the PR mentioned above](https://github.com/woocommerce/woocommerce/pull/34615):

**Scenario: New workflow is triggered when creating a PR labeled as 'focus: custom order tables'**
1. Add any change to the repository.
2. Create a Pull Request and label it as `focus: custom order tables`.
4. Check that the new GitHub Actions workflow `Run tests against PR in an environment with COT enabled` is triggered.

**Scenario: New workflow is not triggered when creating a PR without the 'focus: custom order tables' label**
1. Add any change to the repository.
2. Create a Pull Request and make sure to not add the `focus: custom order tables` label.
3. Check that none of the new GitHub Actions workflows - `Run tests against PR in an environment with COT enabled` and `Run daily tests in an environment with COT enabled` - is triggered.

**Scenario: New workflow is triggered every day around 2:30 AM UTC**
1. Go to the [GitHub Actions page](https://github.com/woocommerce/woocommerce/actions)
2. Check the `Run daily tests in an environment with COT enabled` was triggered every day around 2:30 AM UTC. Note: there might be a slight offset in the execution time, so the workflow might not be triggered exactly at 2:30 AM UTC, but it should be close.
### Other information:

-   [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ N/A ] Have you written new tests for your changes, as applicable?
-   [ x ] Have you successfully run tests with your changes locally?
-   [ N/A ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
