### PR TITLE
Skip changelog deletion if none is provided closes #34604

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -258,9 +258,11 @@ jobs:
             console.log( `::set-output name=changelogsToBeDeleted::${ changelogsToBeDeleted }` )
 
       - name: Delete changelog files from cherry pick branch
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git rm ${{ steps.changelog.outputs.changelogsToBeDeleted }}
 
       - name: Commit changes for cherry pick
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git commit --no-verify -am "Prep for cherry pick ${{ needs.prep.outputs.pr }}"
 
       - name: Push cherry pick branch up
@@ -286,22 +288,28 @@ jobs:
 
             console.log( `::set-output name=cherry-pick-pr::${ pr.data.html_url }` )
       - name: Checkout trunk branch
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git checkout trunk
 
       - name: Create a branch based on trunk branch
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git checkout -b delete-changelogs/${{ needs.prep.outputs.pr }}
 
       - name: Delete changelogs from trunk
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git rm ${{ steps.changelog.outputs.changelogsToBeDeleted }}
 
       - name: Commit changes for deletion
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git commit --no-verify -am "Delete changelog files for ${{ needs.prep.outputs.pr }}"
 
       - name: Push deletion branch up
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         run: git push origin delete-changelogs/${{ needs.prep.outputs.pr }}
 
       - name: Create the PR for deletion branch
         id: deletion-pr
+        if: steps.changelog.outputs.changelogsToBeDeleted != '' && steps.changelog.outputs.changelogsToBeDeleted != null
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout release branch
         uses: actions/checkout@v3
         with:
-          fetch-depth: 100
+          fetch-depth: 0
 
       - name: Git fetch the release branch
         run: git fetch origin ${{ needs.prep.outputs.release }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34604

This PR prevents failing cherry picks if there are no changelogs present. This is useful for example if there are changes such as with readme.txt which does not require a changelog but still needs to go into the release branch.

### How to test the changes in this Pull Request:

1. Fork this repo. All the steps here on out will be done in your fork ONLY!
2. Enable Actions ( by default it is disabled ). `settings/actions`.
3. Enable Issues `settings`.
4. Ensure the repo is setup as squash and merge only.
5. Create a milestone named `7.1`.
6. In trunk, merge this branch (dev/cherry-pick-tool-rm)
7. In trunk update `plugins/woocommerce/readme.txt` so that it contains changelog entries. You can copy from https://github.com/woocommerce/woocommerce/blob/release/7.0/plugins/woocommerce/readme.txt and then commit and push it up to trunk.
8. Create a branch named `release/7.1` based on trunk on your Forked GitHub repo.
9. Create a private Slack channel. Right click on the channel and click on "Channel Details". Note the channel ID at the bottom. Save that information.
10. Create an action secrets token named `CODE_FREEZE_BOT_TOKEN`. You can get the bot token from the Slack APP you were invited to from your email.
11. Create an action secrets token named `WOO_RELEASE_SLACK_CHANNEL`. Add the channel ID you saved from step 9.
12.  Create a branch from trunk name `testing-cherry`.
13. Make some changes to `plugins/woocommerce/woocommerce.php` and add a changelog file in `plugins/woocommerce/changelog`.
14. Commit the changes and push this branch up to your repo and create PRs for it. BECAREFUL, make sure you select your own fork when creating the PR on GitHub because sometimes it defaults to the upstream origin.
15. Squash and Merge the PR without doing anything else. Witness that the cherry pick automation fires but it stops as far as the verification step. This is expected because no milestone was added.
16. Repeat steps 12 - 14. This time tag it with 7.1 milestone. Squash and merge it.
17. Witness the cherry pick tool automation runs and this time it should have created two PRs. One that targets the release branch (`release/7.1`). Another PR targets the trunk branch with the deleted changelog file. Also check your Slack channel that you created from step 9. You should see a message from the code freeze notification bot with the listed PRs for the release lead to review.
18. Close both of these auto generated PRs and delete the branches it created.
19. Test again from step 12 BUT this time don't create a changelog file. You should see the cherry picking process still goes through and ONE PR is created this time.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
