### PR TITLE
Update text input placement in SelectControl

### DIFF
--- a/packages/js/components/changelog/update-select-control-input-placement
+++ b/packages/js/components/changelog/update-select-control-input-placement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update text input placement in SelectControl

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -1,5 +1,17 @@
 .woocommerce-experimental-select-control__combo-box-wrapper {
     cursor: text;
+    border: 1px solid $studio-gray-20;
+    border-radius: 3px;
+    background: $studio-white;
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: $gap-smallest 36px $gap-smallest $gap-smaller;
+
+    > * {
+        display: inline-flex;
+    }
 }
 
 .woocommerce-experimental-select-control__combox-box {
@@ -15,6 +27,8 @@
 }
 
 .woocommerce-experimental-select-control__combox-box-icon {
-    padding-left: 10px;
-    margin-right: -2px;
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
 }

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -1,11 +1,12 @@
 .woocommerce-experimental-select-control__combox-box {
     flex-grow: 1;
-    display: flex;
     align-items: center;
+    flex-basis: 120px;
 
     input {
         width: 100%;
-        padding: $gap-smaller 0;
+        margin-top: 2px;
+        margin-bottom: 2px;
     }
 }
 

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -1,3 +1,7 @@
+.woocommerce-experimental-select-control__combo-box-wrapper {
+    cursor: text;
+}
+
 .woocommerce-experimental-select-control__combox-box {
     flex-grow: 1;
     align-items: center;

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -60,11 +60,11 @@ export const ComboBox = ( {
 						 )( node );
 					} }
 				/>
-				<Icon
-					className="woocommerce-experimental-select-control__combox-box-icon"
-					icon={ search }
-				/>
 			</div>
+			<Icon
+				className="woocommerce-experimental-select-control__combox-box-icon"
+				icon={ search }
+			/>
 		</div>
 	);
 };

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -3,7 +3,6 @@
  */
 import { createElement, MouseEvent, useRef } from 'react';
 import { Icon, search } from '@wordpress/icons';
-// import { MouseEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -21,8 +20,9 @@ export const ComboBox = ( {
 	children,
 	comboBoxProps,
 	inputProps,
-	inputRef = null,
 }: ComboBoxProps ) => {
+	const inputRef = useRef< HTMLInputElement | null >( null );
+
 	const maybeFocusInput = ( event: MouseEvent< HTMLDivElement > ) => {
 		if ( ! inputRef || ! inputRef.current ) {
 			return;
@@ -49,7 +49,17 @@ export const ComboBox = ( {
 				{ ...comboBoxProps }
 				className="woocommerce-experimental-select-control__combox-box"
 			>
-				<input { ...inputProps } />
+				<input
+					{ ...inputProps }
+					ref={ ( node ) => {
+						inputRef.current = node;
+						(
+							inputProps.ref as unknown as (
+								node: HTMLInputElement | null
+							) => void
+						 )( node );
+					} }
+				/>
 				<Icon
 					className="woocommerce-experimental-select-control__combox-box-icon"
 					icon={ search }

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { createElement } from 'react';
+import { createElement, MouseEvent, useRef } from 'react';
 import { Icon, search } from '@wordpress/icons';
+// import { MouseEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -10,21 +11,50 @@ import { Icon, search } from '@wordpress/icons';
 import { Props } from './types';
 
 type ComboBoxProps = {
+	children?: JSX.Element | JSX.Element[] | null;
 	comboBoxProps: Props;
 	inputProps: Props;
+	inputRef?: React.RefObject< HTMLInputElement > | null;
 };
 
-export const ComboBox = ( { comboBoxProps, inputProps }: ComboBoxProps ) => {
+export const ComboBox = ( {
+	children,
+	comboBoxProps,
+	inputProps,
+	inputRef = null,
+}: ComboBoxProps ) => {
+	const maybeFocusInput = ( event: MouseEvent< HTMLDivElement > ) => {
+		if ( ! inputRef || ! inputRef.current ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		if ( document.activeElement !== inputRef.current ) {
+			inputRef.current.focus();
+			event.stopPropagation();
+		}
+	};
+
 	return (
+		// Disable reason: The click event is purely for accidental clicks around the input.
+		// Keyboard users are still able to tab to and interact with elements in the combobox.
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		<div
-			{ ...comboBoxProps }
-			className="woocommerce-experimental-select-control__combox-box"
+			className="woocommerce-experimental-select-control__combo-box-wrapper"
+			onMouseDown={ maybeFocusInput }
 		>
-			<input { ...inputProps } />
-			<Icon
-				className="woocommerce-experimental-select-control__combox-box-icon"
-				icon={ search }
-			/>
+			{ children }
+			<div
+				{ ...comboBoxProps }
+				className="woocommerce-experimental-select-control__combox-box"
+			>
+				<input { ...inputProps } />
+				<Icon
+					className="woocommerce-experimental-select-control__combox-box-icon"
+					icon={ search }
+				/>
+			</div>
 		</div>
 	);
 };

--- a/packages/js/components/src/experimental-select-control/select-control.scss
+++ b/packages/js/components/src/experimental-select-control/select-control.scss
@@ -1,6 +1,7 @@
 @import './combo-box.scss';
 @import './menu.scss';
 @import './menu-item.scss';
+@import './selected-items.scss';
 
 .woocommerce-experimental-select-control {
     position: relative;
@@ -11,9 +12,13 @@
         background: $studio-white;
         position: relative;
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
-        padding-left: $gap-small;
-        padding-right: $gap-small;
+        padding: $gap-smallest $gap-smaller;
+
+        > * {
+            display: inline-flex;
+        }
     }
 
     &.is-focused .woocommerce-experimental-select-control__combo-box-wrapper {

--- a/packages/js/components/src/experimental-select-control/select-control.scss
+++ b/packages/js/components/src/experimental-select-control/select-control.scss
@@ -6,21 +6,6 @@
 .woocommerce-experimental-select-control {
     position: relative;
 
-    .woocommerce-experimental-select-control__combo-box-wrapper {
-        border: 1px solid $studio-gray-20;
-        border-radius: 3px;
-        background: $studio-white;
-        position: relative;
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        padding: $gap-smallest $gap-smaller;
-
-        > * {
-            display: inline-flex;
-        }
-    }
-
     &.is-focused .woocommerce-experimental-select-control__combo-box-wrapper {
         box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
         border-color: var(--wp-admin-theme-color);

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -3,7 +3,7 @@
  */
 import classnames from 'classnames';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { createElement, useEffect, useRef, useState } from '@wordpress/element';
+import { createElement, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -3,7 +3,7 @@
  */
 import classnames from 'classnames';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { createElement, useEffect, useState } from '@wordpress/element';
+import { createElement, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -82,6 +82,8 @@ function SelectControl< ItemType = DefaultItemType >( {
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
+	const inputRef = useRef< HTMLInputElement >( null );
+
 	let selectedItems = selected === null ? [] : selected;
 	selectedItems = Array.isArray( selectedItems )
 		? selectedItems
@@ -179,8 +181,21 @@ function SelectControl< ItemType = DefaultItemType >( {
 			{ /* eslint-disable jsx-a11y/label-has-for */ }
 			<label { ...getLabelProps() }>{ label }</label>
 			{ /* eslint-enable jsx-a11y/label-has-for */ }
-			<div className="woocommerce-experimental-select-control__combo-box-wrapper">
-				{ multiple && (
+			<ComboBox
+				comboBoxProps={ getComboboxProps() }
+				inputProps={ getInputProps( {
+					...getDropdownProps( {
+						preventKeyAction: isOpen,
+						ref: inputRef,
+					} ),
+					className: 'woocommerce-experimental-select-control__input',
+					onFocus: () => setIsFocused( true ),
+					onBlur: () => setIsFocused( false ),
+					placeholder,
+				} ) }
+				inputRef={ inputRef }
+			>
+				{ multiple ? (
 					<SelectedItems
 						items={ selectedItems }
 						getItemLabel={ getItemLabel }
@@ -188,19 +203,8 @@ function SelectControl< ItemType = DefaultItemType >( {
 						getSelectedItemProps={ getSelectedItemProps }
 						onRemove={ onRemoveItem }
 					/>
-				) }
-				<ComboBox
-					comboBoxProps={ getComboboxProps() }
-					inputProps={ getInputProps( {
-						...getDropdownProps( { preventKeyAction: isOpen } ),
-						className:
-							'woocommerce-experimental-select-control__input',
-						onFocus: () => setIsFocused( true ),
-						onBlur: () => setIsFocused( false ),
-						placeholder,
-					} ) }
-				/>
-			</div>
+				) : null }
+			</ComboBox>
 
 			{ children( {
 				items: filteredItems,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -82,7 +82,6 @@ function SelectControl< ItemType = DefaultItemType >( {
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
-	const inputRef = useRef< HTMLInputElement >( null );
 
 	let selectedItems = selected === null ? [] : selected;
 	selectedItems = Array.isArray( selectedItems )
@@ -186,14 +185,12 @@ function SelectControl< ItemType = DefaultItemType >( {
 				inputProps={ getInputProps( {
 					...getDropdownProps( {
 						preventKeyAction: isOpen,
-						ref: inputRef,
 					} ),
 					className: 'woocommerce-experimental-select-control__input',
 					onFocus: () => setIsFocused( true ),
 					onBlur: () => setIsFocused( false ),
 					placeholder,
 				} ) }
-				inputRef={ inputRef }
 			>
 				{ multiple ? (
 					<SelectedItems

--- a/packages/js/components/src/experimental-select-control/selected-items.scss
+++ b/packages/js/components/src/experimental-select-control/selected-items.scss
@@ -2,6 +2,7 @@
     margin-right: $gap-smallest;
     margin-top: 2px;
     margin-bottom: 2px;
+    cursor: default;
 
     .woocommerce-tag {
         margin: 0;

--- a/packages/js/components/src/experimental-select-control/selected-items.scss
+++ b/packages/js/components/src/experimental-select-control/selected-items.scss
@@ -1,0 +1,9 @@
+.woocommerce-experimental-select-control__selected-item {
+    margin-right: $gap-smallest;
+    margin-top: 2px;
+    margin-bottom: 2px;
+
+    .woocommerce-tag {
+        margin: 0;
+    }
+}

--- a/packages/js/components/src/experimental-select-control/selected-items.tsx
+++ b/packages/js/components/src/experimental-select-control/selected-items.tsx
@@ -30,24 +30,32 @@ export const SelectedItems = < ItemType, >( {
 }: SelectedItemsProps< ItemType > ) => {
 	return (
 		<>
-			{ items.map( ( item, index ) => (
-				<div
-					key={ `selected-item-${ index }` }
-					className="woocommerce-experimental-select-control__selected-item"
-					{ ...getSelectedItemProps( {
-						selectedItem: item,
-						index,
-					} ) }
-				>
-					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-					{ /* @ts-ignore Additional props are not required. */ }
-					<Tag
-						id={ getItemValue( item ) }
-						remove={ () => () => onRemove( item ) }
-						label={ getItemLabel( item ) }
-					/>
-				</div>
-			) ) }
+			{ items.map( ( item, index ) => {
+				return (
+					// Disable reason: We prevent the default action to keep the input focused on click.
+					// Keyboard users are unaffected by this change.
+					/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+					<div
+						key={ `selected-item-${ index }` }
+						className="woocommerce-experimental-select-control__selected-item"
+						{ ...getSelectedItemProps( {
+							selectedItem: item,
+							index,
+						} ) }
+						onClick={ ( event ) => {
+							event.preventDefault();
+						} }
+					>
+						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+						{ /* @ts-ignore Additional props are not required. */ }
+						<Tag
+							id={ getItemValue( item ) }
+							remove={ () => () => onRemove( item ) }
+							label={ getItemLabel( item ) }
+						/>
+					</div>
+				);
+			} ) }
 		</>
 	);
 };

--- a/packages/js/components/src/experimental-select-control/selected-items.tsx
+++ b/packages/js/components/src/experimental-select-control/selected-items.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement } from 'react';
+import { createElement, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,9 +29,9 @@ export const SelectedItems = < ItemType, >( {
 	onRemove,
 }: SelectedItemsProps< ItemType > ) => {
 	return (
-		<div className="woocommerce-experimental-select-control__selected-items">
+		<>
 			{ items.map( ( item, index ) => (
-				<span
+				<div
 					key={ `selected-item-${ index }` }
 					className="woocommerce-experimental-select-control__selected-item"
 					{ ...getSelectedItemProps( {
@@ -46,8 +46,8 @@ export const SelectedItems = < ItemType, >( {
 						remove={ () => () => onRemove( item ) }
 						label={ getItemLabel( item ) }
 					/>
-				</span>
+				</div>
 			) ) }
-		</div>
+		</>
 	);
 };


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the input to the end of the tag list.  Also adds some click handling to keep the input focused on accidental clicks that are not directly above the actual input.
<img width="352" alt="Screen Shot 2022-09-21 at 3 18 36 PM" src="https://user-images.githubusercontent.com/10561050/191853153-b5b74484-e965-4220-8ee5-c6bd8a01981d.png">
<img width="347" alt="Screen Shot 2022-09-21 at 3 18 22 PM" src="https://user-images.githubusercontent.com/10561050/191853157-304ad65f-e389-401f-b942-5fedfc95cc0b.png">



Closes #34699 .

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/storybook storybook`
2. Navigate to `experimental/SelectControl`
3. Add multiple items and narrow your screen size
4. Check that the input shows at the end of the tag list each time and not vertically centered to the right like it was previously
5. Try to click on other areas within the combobox (search icon or around the tags)
6. Make sure the input stays focused and does not lose focus

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
