### PR TITLE
(HPOS/COT) Orders Admin List > Prevent user from paging out-of-bounds

### DIFF
--- a/plugins/woocommerce/changelog/fix-cot-hpos-list-table-max-num-pages
+++ b/plugins/woocommerce/changelog/fix-cot-hpos-list-table-max-num-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Admin list table for orders (in HPOS mode) should check in case the user pages beyond the available range.


### PR DESCRIPTION
With the 'legacy' admin list table for orders, or in fact any of the default CPT admin list tables, users are prevented from paging beyond the range of available pages. For example, suppose:

- 10 pages of results are available.
- The user tries to access page 20 (or follows an old link).
- They will be redirected back to page 10.

Due to an oversight, that same behavior does not currently happen with respect to the COT/HPOS admin list table. This change addresses that.

### How to test the changes in this Pull Request:

Enable COT/HPOS.

1. Visit the admin list table for orders.
2. Note the maximum page number.
3. Try to access a page *beyond* that.
    - With this change, you should be redirected to whatever the highest available page number is.
    - Without this change, you will see a helper screen explaining that no orders exist just yet.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
