### PR TITLE
Fix initially selected items in SelectControl component

### DIFF
--- a/packages/js/components/changelog/fix-select-control-selection
+++ b/packages/js/components/changelog/fix-select-control-selection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix initially selected items in SelectControl component

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { createElement } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { useState } from '@wordpress/element';
+import { createElement, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,7 +28,6 @@ type SelectControlProps< ItemType > = {
 	children?: ChildrenType< ItemType >;
 	items: ItemType[];
 	label: string;
-	initialSelectedItems?: ItemType[];
 	getItemLabel?: getItemLabelType< ItemType >;
 	getItemValue?: getItemValueType< ItemType >;
 	getFilteredItems?: (
@@ -84,6 +82,18 @@ function SelectControl< ItemType = DefaultItemType >( {
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
+	let selectedItems = selected === null ? [] : selected;
+	selectedItems = Array.isArray( selectedItems )
+		? selectedItems
+		: [ selectedItems ].filter( Boolean );
+	const singleSelectedItem =
+		! multiple && selectedItems.length ? selectedItems[ 0 ] : null;
+	const filteredItems = getFilteredItems(
+		items,
+		inputValue,
+		selectedItems,
+		getItemLabel
+	);
 	const {
 		addSelectedItem,
 		getSelectedItemProps,
@@ -91,17 +101,15 @@ function SelectControl< ItemType = DefaultItemType >( {
 		removeSelectedItem,
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-	} = useMultipleSelection( { itemToString: getItemLabel } );
-	let selectedItems = selected === null ? [] : selected;
-	selectedItems = Array.isArray( selectedItems )
-		? selectedItems
-		: [ selectedItems ].filter( Boolean );
-	const filteredItems = getFilteredItems(
-		items,
-		inputValue,
-		selectedItems,
-		getItemLabel
-	);
+	} = useMultipleSelection( { itemToString: getItemLabel, selectedItems } );
+
+	useEffect( () => {
+		if ( multiple ) {
+			return;
+		}
+
+		setInputValue( getItemLabel( singleSelectedItem ) );
+	}, [ singleSelectedItem ] );
 
 	const {
 		isOpen,
@@ -112,8 +120,9 @@ function SelectControl< ItemType = DefaultItemType >( {
 		highlightedIndex,
 		getItemProps,
 		selectItem,
-		selectedItem: singleSelectedItem,
+		selectedItem: selectedItemSingle,
 	} = useCombobox< ItemType | null >( {
+		initialSelectedItem: singleSelectedItem,
 		inputValue,
 		items: filteredItems,
 		itemToString: getItemLabel,
@@ -142,7 +151,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 					}
 
 					if ( ! selectedItem && ! multiple ) {
-						setInputValue( getItemLabel( singleSelectedItem ) );
+						setInputValue( getItemLabel( selectedItemSingle ) );
 					}
 
 					break;

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -120,7 +120,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 		highlightedIndex,
 		getItemProps,
 		selectItem,
-		selectedItem: selectedItemSingle,
+		selectedItem: comboboxSingleSelectedItem,
 	} = useCombobox< ItemType | null >( {
 		initialSelectedItem: singleSelectedItem,
 		inputValue,
@@ -151,7 +151,9 @@ function SelectControl< ItemType = DefaultItemType >( {
 					}
 
 					if ( ! selectedItem && ! multiple ) {
-						setInputValue( getItemLabel( selectedItemSingle ) );
+						setInputValue(
+							getItemLabel( comboboxSingleSelectedItem )
+						);
 					}
 
 					break;

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -22,8 +22,9 @@ const sampleItems = [
 ];
 
 export const Single: React.FC = () => {
-	const [ selected, setSelected ] =
-		useState< SelectedType< DefaultItemType > >( null );
+	const [ selected, setSelected ] = useState<
+		SelectedType< DefaultItemType >
+	>( sampleItems[ 1 ] );
 
 	return (
 		<>
@@ -40,7 +41,10 @@ export const Single: React.FC = () => {
 };
 
 export const Multiple: React.FC = () => {
-	const [ selected, setSelected ] = useState< DefaultItemType[] >( [] );
+	const [ selected, setSelected ] = useState< DefaultItemType[] >( [
+		sampleItems[ 0 ],
+		sampleItems[ 2 ],
+	] );
 
 	return (
 		<>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Allows selection of single select items and shows the value in the input
* Syncs downshift's internal state of selected items
* Adds stories with selected items

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/storybook storybook`
2. Navigate to `experimental / SelectControl`
3. View the multiple and single examples to check default selected values

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
