### PR TITLE
Update to WC Blocks 8.5.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.5.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.5.1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 8.5.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.5.0"
+		"woocommerce/woocommerce-blocks": "8.5.1"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c169511cbe86d97becc23fe987debd2a",
+    "content-hash": "a5b89843fb6a65d3db7cfdafaccd2c16",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.5.0",
+            "version": "v8.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "b38ab30a27f42e76d0e96df01a74817e440e29d1"
+                "reference": "b14d64b63cf1edb5871f638e6250dd633504fb38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/b38ab30a27f42e76d0e96df01a74817e440e29d1",
-                "reference": "b38ab30a27f42e76d0e96df01a74817e440e29d1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/b14d64b63cf1edb5871f638e6250dd633504fb38",
+                "reference": "b14d64b63cf1edb5871f638e6250dd633504fb38",
                 "shasum": ""
             },
             "require": {
@@ -681,9 +681,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.5.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.5.1"
             },
-            "time": "2022-09-13T12:22:25+00:00"
+            "time": "2022-09-23T12:24:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.5.1. The Cart & Checkout Blocks functionality was broken for people with subfolder installs. This PR fixes this issue.

## Blocks 8.5.1

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7212)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/07d7c9dd2a4d33ee87091f456c4bee2973416f30/docs/internal-developers/testing/releases/851.md)


### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Ensure that scripts are loaded using absolute URLs to prevent loading issues with subfolder installs. ([7211](https://github.com/woocommerce/woocommerce-blocks/pull/7211))

### Changelog entry

> Dev - Update WooCommerce Blocks version to 8.5.1




