### PR TITLE
Remove the check for plugins: woocommerce label

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -31,7 +31,6 @@ jobs:
           php-version: '7.4'
       - name: "Run the script to assign a milestone"
         if: |
-          contains(github.event.pull_request.labels.*.name, 'plugin: woocommerce') &&
           !github.event.pull_request.milestone &&
           github.event.pull_request.base.ref == 'trunk'
         run: php assign-milestone-to-merged-pr.php
@@ -39,7 +38,6 @@ jobs:
           PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Run the script to post a comment with next steps hint"
-        if: "contains(github.event.pull_request.labels.*.name, 'plugin: woocommerce')"
         run: php add-post-merge-comment.php
         env:
           PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the check for the `plugins: woocommerce` label as a validation to add milestone to the merged PR. This is an interim solution to [this issue](https://github.com/woocommerce/woocommerce/issues/34767)

### How to test the changes in this Pull Request:

1. N/A
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
