### PR TITLE
Add dimensions to shipping section

### DIFF
--- a/packages/js/components/changelog/add-form_input_name_dot_notation
+++ b/packages/js/components/changelog/add-form_input_name_dot_notation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add form input name dot notation name="product.dimensions.width"

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -12,7 +12,6 @@ export type FormContext< Values extends Record< string, any > > = {
 	};
 	isDirty: boolean;
 	touched: { [ P in keyof Values ]?: boolean | undefined };
-	changedFields: { [ P in keyof Values ]?: boolean | undefined };
 	setTouched: React.Dispatch<
 		React.SetStateAction< { [ P in keyof Values ]?: boolean | undefined } >
 	>;
@@ -34,7 +33,6 @@ export type FormContext< Values extends Record< string, any > > = {
 	isValidForm: boolean;
 	resetForm: (
 		initialValues: Values,
-		changedFields?: { [ P in keyof Values ]?: boolean | undefined },
 		touchedFields?: { [ P in keyof Values ]?: boolean | undefined },
 		errors?: { [ P in keyof Values ]?: string }
 	) => void;

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -4,12 +4,14 @@
 import { ChangeEvent } from 'react';
 import { createContext, useContext } from '@wordpress/element';
 
+export type FormErrors< Values > = {
+	[ P in keyof Values ]?: FormErrors< Values[ P ] > | string;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormContext< Values extends Record< string, any > > = {
 	values: Values;
-	errors: {
-		[ P in keyof Values ]?: string;
-	};
+	errors: FormErrors< Values >;
 	isDirty: boolean;
 	touched: { [ P in keyof Values ]?: boolean | undefined };
 	setTouched: React.Dispatch<
@@ -34,7 +36,7 @@ export type FormContext< Values extends Record< string, any > > = {
 	resetForm: (
 		initialValues: Values,
 		touchedFields?: { [ P in keyof Values ]?: boolean | undefined },
-		errors?: { [ P in keyof Values ]?: string }
+		errors?: FormErrors< Values >
 	) => void;
 };
 

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -135,7 +135,9 @@ function FormComponent< Values extends Record< string, any > >(
 		newTouchedFields = {},
 		newErrors = {}
 	) => {
-		setValuesInternal( newInitialValues ?? initialValues.current ?? {} );
+		const newValues = newInitialValues ?? initialValues.current ?? {};
+		initialValues.current = newValues;
+		setValuesInternal( newValues );
 		setTouched( newTouchedFields );
 		setErrors( newErrors );
 	};

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -21,13 +21,13 @@ import _isEqual from 'lodash/isEqual';
 /**
  * Internal dependencies
  */
-import { FormContext } from './form-context';
+import { FormContext, FormErrors } from './form-context';
 
 type FormProps< Values > = {
 	/**
 	 * Object of all initial errors to store in state.
 	 */
-	errors?: { [ P in keyof Values ]?: string };
+	errors?: FormErrors< Values >;
 	/**
 	 * Object key:value pair list of all initial field values.
 	 */
@@ -74,7 +74,7 @@ type FormProps< Values > = {
 	 * A function that is passed a list of all values and
 	 * should return an `errors` object with error response.
 	 */
-	validate?: ( values: Values ) => Record< string, string >;
+	validate?: ( values: Values ) => FormErrors< Values >;
 };
 
 function isChangeEvent< T >(
@@ -105,9 +105,9 @@ function FormComponent< Values extends Record< string, any > >(
 	const [ values, setValuesInternal ] = useState< Values >(
 		props.initialValues ?? ( {} as Values )
 	);
-	const [ errors, setErrors ] = useState< {
-		[ P in keyof Values ]?: string;
-	} >( props.errors || {} );
+	const [ errors, setErrors ] = useState< FormErrors< Values > >(
+		props.errors || {}
+	);
 	const [ touched, setTouched ] = useState< {
 		[ P in keyof Values ]?: boolean;
 	} >( props.touched || {} );
@@ -291,7 +291,7 @@ function FormComponent< Values extends Record< string, any > >(
 			) => handleChange( name, value ),
 			onBlur: () => handleBlur( name ),
 			className: isTouched && inputError ? 'has-error' : undefined,
-			help: isTouched ? inputError : null,
+			help: isTouched ? ( inputError as string ) : null,
 		};
 	}
 

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -7,11 +7,16 @@ import {
 	createElement,
 	useCallback,
 	useEffect,
+	useMemo,
 	forwardRef,
 	useImperativeHandle,
 } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
-import { ChangeEvent, PropsWithChildren } from 'react';
+import { ChangeEvent, PropsWithChildren, useRef } from 'react';
+import _setWith from 'lodash/setWith';
+import _get from 'lodash/get';
+import _clone from 'lodash/clone';
+import _isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
@@ -88,21 +93,21 @@ export type FormRef< Values > = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function FormComponent< Values extends Record< string, any > >(
 	{
+		children,
 		onSubmit = () => {},
 		onChange = () => {},
 		onChanges = () => {},
-		initialValues = {} as Values,
 		...props
 	}: PropsWithChildren< FormProps< Values > >,
 	ref: React.Ref< FormRef< Values > >
 ): React.ReactElement | null {
-	const [ values, setValuesInternal ] = useState< Values >( initialValues );
+	const initialValues = useRef( props.initialValues ?? ( {} as Values ) );
+	const [ values, setValuesInternal ] = useState< Values >(
+		props.initialValues ?? ( {} as Values )
+	);
 	const [ errors, setErrors ] = useState< {
 		[ P in keyof Values ]?: string;
 	} >( props.errors || {} );
-	const [ changedFields, setChangedFields ] = useState< {
-		[ P in keyof Values ]?: boolean;
-	} >( {} );
 	const [ touched, setTouched ] = useState< {
 		[ P in keyof Values ]?: boolean;
 	} >( props.touched || {} );
@@ -126,13 +131,11 @@ function FormComponent< Values extends Record< string, any > >(
 	}, [] );
 
 	const resetForm = (
-		newInitialValues: Values,
-		newChangedFields = {},
+		newInitialValues = {} as Values,
 		newTouchedFields = {},
 		newErrors = {}
 	) => {
-		setValuesInternal( newInitialValues || {} );
-		setChangedFields( newChangedFields );
+		setValuesInternal( newInitialValues ?? initialValues.current ?? {} );
 		setTouched( newTouchedFields );
 		setErrors( newErrors );
 	};
@@ -150,24 +153,6 @@ function FormComponent< Values extends Record< string, any > >(
 		( valuesToSet: Values ) => {
 			const newValues = { ...values, ...valuesToSet };
 			setValuesInternal( newValues );
-
-			const changedFieldsToSet: { [ P in keyof Values ]?: boolean } = {};
-
-			for ( const key in valuesToSet ) {
-				if (
-					initialValues[ key ] !== valuesToSet[ key ] &&
-					! changedFields[ key ]
-				) {
-					changedFieldsToSet[ key ] = true;
-				} else if (
-					initialValues[ key ] === valuesToSet[ key ] &&
-					changedFields[ key ]
-				) {
-					changedFieldsToSet[ key ] = false;
-				}
-			}
-
-			setChangedFields( { ...changedFields, ...changedFieldsToSet } );
 
 			validate( newValues, ( newErrors ) => {
 				const { onChangeCallback } = props;
@@ -220,9 +205,7 @@ function FormComponent< Values extends Record< string, any > >(
 	const setValue = useCallback(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( name: string, value: any ) => {
-			const valuesToSet: Values = {} as Values;
-			valuesToSet[ name as keyof Values ] = value;
-			setValues( valuesToSet );
+			setValues( _setWith( { ...values }, name, value, _clone ) );
 		},
 		[ values, validate, onChange, props.onChangeCallback ]
 	);
@@ -235,7 +218,7 @@ function FormComponent< Values extends Record< string, any > >(
 			// Handle native events.
 			if ( isChangeEvent( value ) && value.target ) {
 				if ( value.target.type === 'checkbox' ) {
-					setValue( name, ! values[ name ] );
+					setValue( name, ! _get( values, name ) );
 				} else {
 					setValue( name, value.target.value );
 				}
@@ -295,77 +278,55 @@ function FormComponent< Values extends Record< string, any > >(
 		className: string | undefined;
 		help: string | null | undefined;
 	} {
+		const inputValue = _get( values, name );
+		const isTouched = touched[ name ];
+		const inputError = _get( errors, name );
+
 		return {
-			value: values[ name ],
-			checked: Boolean( values[ name ] ),
-			selected: values[ name ],
+			value: inputValue,
+			checked: Boolean( inputValue ),
+			selected: inputValue,
 			onChange: (
 				value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
 			) => handleChange( name, value ),
 			onBlur: () => handleBlur( name ),
-			className:
-				touched[ name ] && errors[ name ] ? 'has-error' : undefined,
-			help: touched[ name ] ? errors[ name ] : null,
+			className: isTouched && inputError ? 'has-error' : undefined,
+			help: isTouched ? inputError : null,
 		};
 	}
+
+	const isDirty = useMemo(
+		() => ! _isEqual( initialValues.current, values ),
+		[ initialValues.current, values ]
+	);
 
 	const getStateAndHelpers = () => {
 		return {
 			values,
 			errors,
 			touched,
+			isDirty,
 			setTouched,
 			setValue,
 			setValues,
 			handleSubmit,
 			getInputProps,
 			isValidForm: ! Object.keys( errors ).length,
+			resetForm,
 		};
 	};
 
-	const isDirty = Object.values( changedFields ).some( Boolean );
-
-	if ( props.children && typeof props.children === 'function' ) {
-		const element = props.children( getStateAndHelpers() );
-		return (
-			<FormContext.Provider
-				value={ {
-					values,
-					errors,
-					touched,
-					isDirty,
-					changedFields,
-					setTouched,
-					setValue,
-					setValues,
-					handleSubmit,
-					getInputProps,
-					isValidForm: ! Object.keys( errors ).length,
-					resetForm,
-				} }
-			>
-				{ cloneElement( element ) }
-			</FormContext.Provider>
-		);
+	function getChildren() {
+		if ( typeof children === 'function' ) {
+			const element = children( getStateAndHelpers() );
+			return cloneElement( element );
+		}
+		return children;
 	}
+
 	return (
-		<FormContext.Provider
-			value={ {
-				values,
-				errors,
-				touched,
-				isDirty,
-				changedFields,
-				setTouched,
-				setValue,
-				setValues,
-				handleSubmit,
-				getInputProps,
-				isValidForm: ! Object.keys( errors ).length,
-				resetForm,
-			} }
-		>
-			{ props.children }
+		<FormContext.Provider value={ getStateAndHelpers() }>
+			{ getChildren() }
 		</FormContext.Provider>
 	);
 }

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -15,7 +15,7 @@ export { default as EmptyContent } from './empty-content';
 export { default as Flag } from './flag';
 export { Form, useFormContext } from './form';
 export { FormSection } from './form-section';
-export type { FormContext, FormRef } from './form';
+export type { FormContext, FormRef, FormErrors } from './form';
 export { default as FilterPicker } from './filter-picker';
 export { H, Section } from './section';
 export { ImageGallery } from './image-gallery';

--- a/packages/js/data/changelog/add-34329-shipping-dimensions
+++ b/packages/js/data/changelog/add-34329-shipping-dimensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add size properties to product type #34329

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -86,6 +86,8 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	related_ids: number[];
 	variations: number[];
 	attributes: ProductAttribute[];
+	dimensions: ProductDimensions;
+	weight: string;
 };
 
 export const productReadOnlyProperties = [
@@ -143,4 +145,10 @@ export type ProductQuery<
 	min_price: string;
 	max_price: string;
 	stock_status: 'instock' | 'outofstock' | 'onbackorder';
+};
+
+export type ProductDimensions = {
+	width: string;
+	height: string;
+	length: string;
 };

--- a/packages/js/number/changelog/add-parse-number
+++ b/packages/js/number/changelog/add-parse-number
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add parse number function to convert a formatted string into fixed number

--- a/packages/js/number/src/index.ts
+++ b/packages/js/number/src/index.ts
@@ -110,3 +110,35 @@ export function calculateDelta( primaryValue: number, secondaryValue: number ) {
 		( ( primaryValue - secondaryValue ) / secondaryValue ) * 100
 	);
 }
+
+/**
+ * Parse a string into a number using site's current config
+ *
+ * @param {NumberConfig} numberConfig Number formatting configuration object.
+ * @param {string}       value        value to parse
+ * @return {string} A parsed number.
+ */
+export function parseNumber(
+	{
+		precision = null,
+		decimalSeparator = '.',
+		thousandSeparator = ',',
+	}: Partial< NumberConfig >,
+	value: string
+): string {
+	if ( typeof value !== 'string' || value === '' ) {
+		return '';
+	}
+
+	let parsedPrecision = precision === null ? NaN : Number( precision );
+	if ( isNaN( parsedPrecision ) ) {
+		const [ , decimals ] = value.split( decimalSeparator );
+		parsedPrecision = decimals ? decimals.length : 0;
+	}
+
+	return Number.parseFloat(
+		value
+			.replace( new RegExp( `\\${ thousandSeparator }`, 'g' ), '' )
+			.replace( new RegExp( `\\${ decimalSeparator }`, 'g' ), '.' )
+	).toFixed( parsedPrecision );
+}

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -127,8 +127,8 @@ const EditProductPage: React.FC = () => {
 						<ProductFormLayout>
 							<ProductDetailsSection />
 							<PricingSection />
-							<AttributesSection />
 							<ProductShippingSection />
+							<AttributesSection />
 							<ProductFormActions />
 						</ProductFormLayout>
 					</Form>

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
@@ -4,16 +4,10 @@
 	}
 
 	&__content {
-		padding: $gap-large;
-		background: $white;
-		border: 1px solid $gray-400;
-		border-radius: 2px;
-
-		> * {
-			&:not(:first-of-type) {
-				padding-top: $gap-large - $gap-smaller;
+		.components-base-control {
+			&:not(:first-child) {
+				margin-top: $gap-large - $gap-smaller;
 			}
-			width: 100%;
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -51,5 +51,31 @@ export const validate = (
 		);
 	}
 
+	if ( values.dimensions?.width && +values.dimensions.width <= 0 ) {
+		errors.dimensions = {
+			width: __( 'Width must be higher than zero.', 'woocommerce' ),
+		};
+	}
+
+	if ( values.dimensions?.length && +values.dimensions.length <= 0 ) {
+		errors.dimensions = {
+			...( ( errors.dimensions as FormErrors< ProductDimensions > ) ??
+				{} ),
+			length: __( 'Length must be higher than zero.', 'woocommerce' ),
+		};
+	}
+
+	if ( values.dimensions?.height && +values.dimensions.height <= 0 ) {
+		errors.dimensions = {
+			...( ( errors.dimensions as FormErrors< ProductDimensions > ) ??
+				{} ),
+			height: __( 'Height must be higher than zero.', 'woocommerce' ),
+		};
+	}
+
+	if ( values.weight && +values.weight <= 0 ) {
+		errors.weight = __( 'Weight must be higher than zero.', 'woocommerce' );
+	}
+
 	return errors;
 };

--- a/plugins/woocommerce-admin/client/products/product-validation.ts
+++ b/plugins/woocommerce-admin/client/products/product-validation.ts
@@ -2,14 +2,18 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ProductStatus, ProductType, Product } from '@woocommerce/data';
+import {
+	ProductStatus,
+	ProductType,
+	Product,
+	ProductDimensions,
+} from '@woocommerce/data';
+import type { FormErrors } from '@woocommerce/components';
 
 export const validate = (
 	values: Partial< Product< ProductStatus, ProductType > >
 ) => {
-	const errors: {
-		[ key: string ]: string;
-	} = {};
+	const errors: FormErrors< typeof values > = {};
 	if ( ! values.name?.length ) {
 		errors.name = __( 'This field is required.', 'woocommerce' );
 	}

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Card, CardBody } from '@wordpress/components';
 import { Link, useFormContext } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -45,7 +46,11 @@ export const AttributesSection: React.FC = () => {
 				</>
 			}
 		>
-			<AttributeField { ...getInputProps( 'attributes' ) } />
+			<Card>
+				<CardBody>
+					<AttributeField { ...getInputProps( 'attributes' ) } />
+				</CardBody>
+			</Card>
 		</ProductSectionLayout>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -28,7 +28,7 @@ import { useProductHelper } from '../use-product-helper';
 
 export const PricingSection: React.FC = () => {
 	const { getInputProps } = useFormContext< Product >();
-	const { sanitizeNumber } = useProductHelper();
+	const { sanitizePrice } = useProductHelper();
 	const { isResolving: isTaxSettingsResolving, taxSettings } = useSelect(
 		( select ) => {
 			const { getSettings, hasFinishedResolution } =
@@ -135,7 +135,7 @@ export const PricingSection: React.FC = () => {
 							label={ __( 'List price', 'woocommerce' ) }
 							placeholder={ __( '10.59', 'woocommerce' ) }
 							onChange={ ( value: string ) => {
-								const sanitizedValue = sanitizeNumber( value );
+								const sanitizedValue = sanitizePrice( value );
 								regularPriceProps?.onChange( sanitizedValue );
 							} }
 						/>
@@ -155,7 +155,7 @@ export const PricingSection: React.FC = () => {
 							label={ salePriceTitle }
 							placeholder={ __( '8.59', 'woocommerce' ) }
 							onChange={ ( value: string ) => {
-								const sanitizedValue = sanitizeNumber( value );
+								const sanitizedValue = sanitizePrice( value );
 								salePriceProps?.onChange( sanitizedValue );
 							} }
 						/>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -8,11 +8,12 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useContext } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import interpolateComponents from '@automattic/interpolate-components';
-import classnames from 'classnames';
 import {
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 	BaseControl,
+	Card,
+	CardBody,
 } from '@wordpress/components';
 
 /**
@@ -26,8 +27,8 @@ import { CurrencyContext } from '../../lib/currency-context';
 import { useProductHelper } from '../use-product-helper';
 
 export const PricingSection: React.FC = () => {
-	const { getInputProps, setValue } = useFormContext< Product >();
-	const { sanitizePrice } = useProductHelper();
+	const { getInputProps } = useFormContext< Product >();
+	const { sanitizeNumber } = useProductHelper();
 	const { isResolving: isTaxSettingsResolving, taxSettings } = useSelect(
 		( select ) => {
 			const { getSettings, hasFinishedResolution } =
@@ -86,6 +87,10 @@ export const PricingSection: React.FC = () => {
 		},
 	} );
 
+	const regularPriceProps = getInputControlProps( {
+		...getInputProps( 'regular_price' ),
+		context,
+	} );
 	const salePriceProps = getInputControlProps( {
 		...getInputProps( 'sale_price' ),
 		context,
@@ -119,53 +124,44 @@ export const PricingSection: React.FC = () => {
 				</>
 			}
 		>
-			<div className="woocommerce-product-form__custom-label-input">
-				<InputControl
-					label={ __( 'List price', 'woocommerce' ) }
-					placeholder={ __( '10.59', 'woocommerce' ) }
-					{ ...getInputControlProps( {
-						...getInputProps( 'regular_price' ),
-						context,
-					} ) }
-					onChange={ ( value: string ) => {
-						const sanitizedValue = sanitizePrice( value );
-						setValue( 'regular_price', sanitizedValue );
-					} }
-				/>
-				{ ! isTaxSettingsResolving && (
-					<span className="woocommerce-product-form__secondary-text">
-						{ taxSettingsElement }
-					</span>
-				) }
-			</div>
+			<Card>
+				<CardBody>
+					<BaseControl
+						{ ...regularPriceProps }
+						id="product_pricing_regular_price"
+					>
+						<InputControl
+							{ ...regularPriceProps }
+							label={ __( 'List price', 'woocommerce' ) }
+							placeholder={ __( '10.59', 'woocommerce' ) }
+							onChange={ ( value: string ) => {
+								const sanitizedValue = sanitizeNumber( value );
+								regularPriceProps?.onChange( sanitizedValue );
+							} }
+						/>
+					</BaseControl>
+					{ ! isTaxSettingsResolving && (
+						<span className="woocommerce-product-form__secondary-text">
+							{ taxSettingsElement }
+						</span>
+					) }
 
-			<div
-				className={ classnames(
-					'woocommerce-product-form__custom-label-input',
-					{
-						'has-error': salePriceProps?.help !== '',
-					}
-				) }
-			>
-				<BaseControl
-					id="sale_price"
-					help={
-						salePriceProps && salePriceProps.help
-							? salePriceProps.help
-							: ''
-					}
-				>
-					<InputControl
-						label={ salePriceTitle }
-						placeholder={ __( '8.59', 'woocommerce' ) }
+					<BaseControl
 						{ ...salePriceProps }
-						onChange={ ( value: string ) => {
-							const sanitizedValue = sanitizePrice( value );
-							setValue( 'sale_price', sanitizedValue );
-						} }
-					/>
-				</BaseControl>
-			</div>
+						id="product_pricing_sale_price"
+					>
+						<InputControl
+							{ ...salePriceProps }
+							label={ salePriceTitle }
+							placeholder={ __( '8.59', 'woocommerce' ) }
+							onChange={ ( value: string ) => {
+								const sanitizedValue = sanitizeNumber( value );
+								salePriceProps?.onChange( sanitizedValue );
+							} }
+						/>
+					</BaseControl>
+				</CardBody>
+			</Card>
 		</ProductSectionLayout>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.scss
@@ -1,8 +1,5 @@
 .product-details-section {
 	&__product-link {
-		color: $gray-700;
-		font-size: 12px;
-
 		> a {
 			color: inherit;
 			text-decoration: none;
@@ -27,7 +24,6 @@
 				&__input-container {
 					align-self: center;
 				}
-
 			}
 			.woocommerce-enriched-label__text {
 				align-self: center;

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { CheckboxControl, Button, TextControl } from '@wordpress/components';
+import {
+	CheckboxControl,
+	Button,
+	TextControl,
+	Card,
+	CardBody,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -55,67 +61,88 @@ export const ProductDetailsSection: React.FC = () => {
 				'woocommerce'
 			) }
 		>
-			<div>
-				<TextControl
-					label={ __( 'Name', 'woocommerce' ) }
-					name={ `${ PRODUCT_DETAILS_SLUG }-name` }
-					placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
-					{ ...getTextControlProps( getInputProps( 'name' ) ) }
-				/>
-				{ values.id && ! doesNameHaveError() && permalinkPrefix && (
-					<div className="product-details-section__product-link">
-						{ __( 'Product link', 'woocommerce' ) }:&nbsp;
-						<a
-							href={ values.permalink }
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ permalinkPrefix }
-							{ values.slug || cleanForSlug( values.name ) }
-							{ permalinkSuffix }
-						</a>
-						<Button
-							variant="link"
-							onClick={ () =>
-								setShowProductLinkEditModal( true )
-							}
-						>
-							{ __( 'Edit', 'woocommerce' ) }
-						</Button>
+			<Card>
+				<CardBody>
+					<div>
+						<TextControl
+							label={ __( 'Name', 'woocommerce' ) }
+							name={ `${ PRODUCT_DETAILS_SLUG }-name` }
+							placeholder={ __(
+								'e.g. 12 oz Coffee Mug',
+								'woocommerce'
+							) }
+							{ ...getTextControlProps(
+								getInputProps( 'name' )
+							) }
+						/>
+						{ values.id &&
+							! doesNameHaveError() &&
+							permalinkPrefix && (
+								<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
+									{ __( 'Product link', 'woocommerce' ) }
+									:&nbsp;
+									<a
+										href={ values.permalink }
+										target="_blank"
+										rel="noreferrer"
+									>
+										{ permalinkPrefix }
+										{ values.slug ||
+											cleanForSlug( values.name ) }
+										{ permalinkSuffix }
+									</a>
+									<Button
+										variant="link"
+										onClick={ () =>
+											setShowProductLinkEditModal( true )
+										}
+									>
+										{ __( 'Edit', 'woocommerce' ) }
+									</Button>
+								</span>
+							) }
 					</div>
-				) }
-			</div>
-			<CheckboxControl
-				label={
-					<EnrichedLabel
-						label={ __( 'Feature this product', 'woocommerce' ) }
-						helpDescription={ __(
-							'Include this product in a featured section on your website with a widget or shortcode.',
-							'woocommerce'
-						) }
-						moreUrl="https://woocommerce.com/document/woocommerce-shortcodes/#products"
-						tooltipLinkCallback={ () =>
-							recordEvent( 'add_product_learn_more', {
-								category: PRODUCT_DETAILS_SLUG,
-							} )
+					<CheckboxControl
+						label={
+							<EnrichedLabel
+								label={ __(
+									'Feature this product',
+									'woocommerce'
+								) }
+								helpDescription={ __(
+									'Include this product in a featured section on your website with a widget or shortcode.',
+									'woocommerce'
+								) }
+								moreUrl="https://woocommerce.com/document/woocommerce-shortcodes/#products"
+								tooltipLinkCallback={ () =>
+									recordEvent( 'add_product_learn_more', {
+										category: PRODUCT_DETAILS_SLUG,
+									} )
+								}
+							/>
 						}
+						{ ...getCheckboxProps( {
+							...getInputProps( 'featured' ),
+							name: 'featured',
+							className:
+								'product-details-section__feature-checkbox',
+						} ) }
 					/>
-				}
-				{ ...getCheckboxProps( {
-					...getInputProps( 'featured' ),
-					name: 'featured',
-					className: 'product-details-section__feature-checkbox',
-				} ) }
-			/>
-			{ showProductLinkEditModal && (
-				<EditProductLinkModal
-					permalinkPrefix={ permalinkPrefix || '' }
-					permalinkSuffix={ permalinkSuffix || '' }
-					product={ values }
-					onCancel={ () => setShowProductLinkEditModal( false ) }
-					onSaved={ () => setShowProductLinkEditModal( false ) }
-				/>
-			) }
+					{ showProductLinkEditModal && (
+						<EditProductLinkModal
+							permalinkPrefix={ permalinkPrefix || '' }
+							permalinkSuffix={ permalinkSuffix || '' }
+							product={ values }
+							onCancel={ () =>
+								setShowProductLinkEditModal( false )
+							}
+							onSaved={ () =>
+								setShowProductLinkEditModal( false )
+							}
+						/>
+					) }
+				</CardBody>
+			</Card>
 		</ProductSectionLayout>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.scss
@@ -5,4 +5,14 @@
 		justify-content: center;
 		height: 100%;
 	}
+	&__subtitle {
+		margin: 0;
+	}
+	&__container {
+		.components-base-control {
+			&__field {
+				margin-bottom: 8px;
+			}
+		}
+	}
 }

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.scss
@@ -8,11 +8,4 @@
 	&__subtitle {
 		margin: 0;
 	}
-	&__container {
-		.components-base-control {
-			&__field {
-				margin-bottom: 8px;
-			}
-		}
-	}
 }

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -52,7 +52,7 @@ function getInterpolatedSizeLabel( mixedString: string ) {
 
 export const ProductShippingSection: React.FC = () => {
 	const { getInputProps } = useFormContext< Product >();
-	const { sanitizeNumber } = useProductHelper();
+	const { formatNumber, parseNumber } = useProductHelper();
 
 	const { shippingClasses, hasResolvedShippingClasses } = useSelect(
 		( select ) => {
@@ -156,6 +156,9 @@ export const ProductShippingSection: React.FC = () => {
 								>
 									<InputControl
 										{ ...inputWidthProps }
+										value={ formatNumber(
+											inputWidthProps.value
+										) }
 										label={ getInterpolatedSizeLabel(
 											__(
 												'Width {{span}}A{{/span}}',
@@ -164,7 +167,7 @@ export const ProductShippingSection: React.FC = () => {
 										) }
 										onChange={ ( value: string ) =>
 											inputWidthProps?.onChange(
-												sanitizeNumber( value )
+												parseNumber( value )
 											)
 										}
 										suffix="cm"
@@ -177,6 +180,9 @@ export const ProductShippingSection: React.FC = () => {
 								>
 									<InputControl
 										{ ...inputLengthProps }
+										value={ formatNumber(
+											inputLengthProps.value
+										) }
 										label={ getInterpolatedSizeLabel(
 											__(
 												'Length {{span}}B{{/span}}',
@@ -185,7 +191,7 @@ export const ProductShippingSection: React.FC = () => {
 										) }
 										onChange={ ( value: string ) =>
 											inputLengthProps?.onChange(
-												sanitizeNumber( value )
+												parseNumber( value )
 											)
 										}
 										suffix="cm"
@@ -198,6 +204,9 @@ export const ProductShippingSection: React.FC = () => {
 								>
 									<InputControl
 										{ ...inputHeightProps }
+										value={ formatNumber(
+											inputHeightProps.value
+										) }
 										label={ getInterpolatedSizeLabel(
 											__(
 												'Height {{span}}C{{/span}}',
@@ -206,7 +215,7 @@ export const ProductShippingSection: React.FC = () => {
 										) }
 										onChange={ ( value: string ) =>
 											inputHeightProps?.onChange(
-												sanitizeNumber( value )
+												parseNumber( value )
 											)
 										}
 										suffix="cm"
@@ -219,10 +228,13 @@ export const ProductShippingSection: React.FC = () => {
 								>
 									<InputControl
 										{ ...inputWeightProps }
+										value={ formatNumber(
+											inputWeightProps.value
+										) }
 										label={ __( 'Weight', 'woocommerce' ) }
 										onChange={ ( value: string ) =>
 											inputWeightProps?.onChange(
-												sanitizeNumber( value )
+												parseNumber( value )
 											)
 										}
 										suffix="kg"

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Link, Spinner, useFormContext } from '@woocommerce/components';
@@ -11,6 +10,11 @@ import {
 	ProductShippingClass,
 } from '@woocommerce/data';
 import interpolateComponents from '@automattic/interpolate-components';
+import {
+	SelectControl,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -33,6 +37,15 @@ function mapShippingClassToSelectOption(
 	} ) );
 }
 
+function getInterpolatedSizeLabel( mixedString: string ) {
+	return interpolateComponents( {
+		mixedString,
+		components: {
+			span: <span className="woocommerce-product-form__secondary-text" />,
+		},
+	} );
+}
+
 export const ProductShippingSection: React.FC = () => {
 	const { getInputProps } = useFormContext< Product >();
 
@@ -53,52 +66,137 @@ export const ProductShippingSection: React.FC = () => {
 	);
 
 	return (
-		<ProductSectionLayout
-			title={ __( 'Shipping', 'woocommerce' ) }
-			description={ __(
-				'Set up shipping costs and enter dimensions used for accurate rate calculations.',
-				'woocommerce'
-			) }
-		>
-			{ hasResolvedShippingClasses ? (
-				<div>
-					<SelectControl
-						label={ __( 'Shipping class', 'woocommerce' ) }
-						{ ...getTextControlProps(
-							getInputProps( 'shipping_class' )
-						) }
-						options={ [
-							...DEFAULT_SHIPPING_CLASS_OPTIONS,
-							...mapShippingClassToSelectOption(
-								shippingClasses ?? []
-							),
-						] }
-					/>
-					<span className="woocommerce-product-form__secondary-text">
-						{ interpolateComponents( {
-							mixedString: __(
-								'Manage shipping classes and rates in {{link}}global settings{{/link}}.',
-								'woocommerce'
-							),
-							components: {
-								link: (
-									<Link
-										href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping&section=classes` }
-										target="_blank"
-										type="external"
-									>
-										<></>
-									</Link>
+		<>
+			<ProductSectionLayout
+				title={ __( 'Shipping', 'woocommerce' ) }
+				description={ __(
+					'Set up shipping costs and enter dimensions used for accurate rate calculations.',
+					'woocommerce'
+				) }
+			>
+				{ hasResolvedShippingClasses ? (
+					<div>
+						<SelectControl
+							label={ __( 'Shipping class', 'woocommerce' ) }
+							{ ...getTextControlProps(
+								getInputProps( 'shipping_class' )
+							) }
+							options={ [
+								...DEFAULT_SHIPPING_CLASS_OPTIONS,
+								...mapShippingClassToSelectOption(
+									shippingClasses ?? []
 								),
-							},
-						} ) }
-					</span>
+							] }
+						/>
+						<span className="woocommerce-product-form__secondary-text">
+							{ interpolateComponents( {
+								mixedString: __(
+									'Manage shipping classes and rates in {{link}}global settings{{/link}}.',
+									'woocommerce'
+								),
+								components: {
+									link: (
+										<Link
+											href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping&section=classes` }
+											target="_blank"
+											type="external"
+										>
+											<></>
+										</Link>
+									),
+								},
+							} ) }
+						</span>
+					</div>
+				) : (
+					<div className="product-shipping-section__spinner-wrapper">
+						<Spinner />
+					</div>
+				) }
+			</ProductSectionLayout>
+
+			<ProductSectionLayout title={ '' } description={ '' }>
+				<h4 className="product-shipping-section__subtitle">
+					{ __( 'Dimensions', 'woocommerce' ) }
+				</h4>
+				<p className="woocommerce-product-form__secondary-text">
+					{ __(
+						'Enter the size of the product as you’d put it in a shipping box, including packaging like bubble wrap.',
+						'woocommerce'
+					) }
+				</p>
+				<div className="product-shipping-section__container">
+					<div>
+						<div className="components-base-control">
+							<div className="components-base-control__field">
+								<InputControl
+									label={ getInterpolatedSizeLabel(
+										__(
+											'Width {{span}}A{{/span}}',
+											'woocommerce'
+										)
+									) }
+									type="number"
+									{ ...getTextControlProps(
+										getInputProps( 'dimensions.width' )
+									) }
+									suffix="cm"
+								/>
+							</div>
+						</div>
+
+						<div className="components-base-control">
+							<div className="components-base-control__field">
+								<InputControl
+									label={ getInterpolatedSizeLabel(
+										__(
+											'Length {{span}}B{{/span}}',
+											'woocommerce'
+										)
+									) }
+									type="number"
+									{ ...getTextControlProps(
+										getInputProps( 'dimensions.length' )
+									) }
+									suffix="cm"
+								/>
+							</div>
+						</div>
+
+						<div className="components-base-control">
+							<div className="components-base-control__field">
+								<InputControl
+									label={ getInterpolatedSizeLabel(
+										__(
+											'Height {{span}}C{{/span}}',
+											'woocommerce'
+										)
+									) }
+									type="number"
+									{ ...getTextControlProps(
+										getInputProps( 'dimensions.height' )
+									) }
+									suffix="cm"
+								/>
+							</div>
+						</div>
+
+						<div className="components-base-control">
+							<div className="components-base-control__field">
+								<InputControl
+									label={ __( 'Weight', 'woocommerce' ) }
+									type="number"
+									{ ...getTextControlProps(
+										getInputProps( 'weight' )
+									) }
+									suffix="kg"
+								/>
+							</div>
+						</div>
+					</div>
+					<div></div>
 				</div>
-			) : (
-				<div className="product-shipping-section__spinner-wrapper">
-					<Spinner />
-				</div>
-			) }
-		</ProductSectionLayout>
+			</ProductSectionLayout>
+		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -11,6 +11,9 @@ import {
 } from '@woocommerce/data';
 import interpolateComponents from '@automattic/interpolate-components';
 import {
+	BaseControl,
+	Card,
+	CardBody,
 	SelectControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
@@ -19,9 +22,10 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductSectionLayout } from '../layout/product-section-layout';
-import { getTextControlProps } from './utils';
 import { ADMIN_URL } from '../../utils/admin-settings';
+import { ProductSectionLayout } from '../layout/product-section-layout';
+import { useProductHelper } from '../use-product-helper';
+import { getTextControlProps } from './utils';
 import './product-shipping-section.scss';
 
 const DEFAULT_SHIPPING_CLASS_OPTIONS: SelectControl.Option[] = [
@@ -48,6 +52,7 @@ function getInterpolatedSizeLabel( mixedString: string ) {
 
 export const ProductShippingSection: React.FC = () => {
 	const { getInputProps } = useFormContext< Product >();
+	const { sanitizeNumber } = useProductHelper();
 
 	const { shippingClasses, hasResolvedShippingClasses } = useSelect(
 		( select ) => {
@@ -65,6 +70,17 @@ export const ProductShippingSection: React.FC = () => {
 		[]
 	);
 
+	const inputWidthProps = getTextControlProps(
+		getInputProps( 'dimensions.width' )
+	);
+	const inputLengthProps = getTextControlProps(
+		getInputProps( 'dimensions.length' )
+	);
+	const inputHeightProps = getTextControlProps(
+		getInputProps( 'dimensions.height' )
+	);
+	const inputWeightProps = getTextControlProps( getInputProps( 'weight' ) );
+
 	return (
 		<>
 			<ProductSectionLayout
@@ -74,128 +90,149 @@ export const ProductShippingSection: React.FC = () => {
 					'woocommerce'
 				) }
 			>
-				{ hasResolvedShippingClasses ? (
-					<div>
-						<SelectControl
-							label={ __( 'Shipping class', 'woocommerce' ) }
-							{ ...getTextControlProps(
-								getInputProps( 'shipping_class' )
+				<Card>
+					<CardBody>
+						{ hasResolvedShippingClasses ? (
+							<>
+								<SelectControl
+									label={ __(
+										'Shipping class',
+										'woocommerce'
+									) }
+									{ ...getTextControlProps(
+										getInputProps( 'shipping_class' )
+									) }
+									options={ [
+										...DEFAULT_SHIPPING_CLASS_OPTIONS,
+										...mapShippingClassToSelectOption(
+											shippingClasses ?? []
+										),
+									] }
+								/>
+								<span className="woocommerce-product-form__secondary-text">
+									{ interpolateComponents( {
+										mixedString: __(
+											'Manage shipping classes and rates in {{link}}global settings{{/link}}.',
+											'woocommerce'
+										),
+										components: {
+											link: (
+												<Link
+													href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping&section=classes` }
+													target="_blank"
+													type="external"
+												>
+													<></>
+												</Link>
+											),
+										},
+									} ) }
+								</span>
+							</>
+						) : (
+							<div className="product-shipping-section__spinner-wrapper">
+								<Spinner />
+							</div>
+						) }
+					</CardBody>
+				</Card>
+
+				<Card>
+					<CardBody>
+						<h4 className="product-shipping-section__subtitle">
+							{ __( 'Dimensions', 'woocommerce' ) }
+						</h4>
+						<p className="woocommerce-product-form__secondary-text">
+							{ __(
+								'Enter the size of the product as you’d put it in a shipping box, including packaging like bubble wrap.',
+								'woocommerce'
 							) }
-							options={ [
-								...DEFAULT_SHIPPING_CLASS_OPTIONS,
-								...mapShippingClassToSelectOption(
-									shippingClasses ?? []
-								),
-							] }
-						/>
-						<span className="woocommerce-product-form__secondary-text">
-							{ interpolateComponents( {
-								mixedString: __(
-									'Manage shipping classes and rates in {{link}}global settings{{/link}}.',
-									'woocommerce'
-								),
-								components: {
-									link: (
-										<Link
-											href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping&section=classes` }
-											target="_blank"
-											type="external"
-										>
-											<></>
-										</Link>
-									),
-								},
-							} ) }
-						</span>
-					</div>
-				) : (
-					<div className="product-shipping-section__spinner-wrapper">
-						<Spinner />
-					</div>
-				) }
-			</ProductSectionLayout>
+						</p>
+						<div className="product-shipping-section__container">
+							<div>
+								<BaseControl
+									{ ...inputWidthProps }
+									id="product_shipping_dimensions_width"
+								>
+									<InputControl
+										{ ...inputWidthProps }
+										label={ getInterpolatedSizeLabel(
+											__(
+												'Width {{span}}A{{/span}}',
+												'woocommerce'
+											)
+										) }
+										onChange={ ( value: string ) =>
+											inputWidthProps?.onChange(
+												sanitizeNumber( value )
+											)
+										}
+										suffix="cm"
+									/>
+								</BaseControl>
 
-			<ProductSectionLayout title={ '' } description={ '' }>
-				<h4 className="product-shipping-section__subtitle">
-					{ __( 'Dimensions', 'woocommerce' ) }
-				</h4>
-				<p className="woocommerce-product-form__secondary-text">
-					{ __(
-						'Enter the size of the product as you’d put it in a shipping box, including packaging like bubble wrap.',
-						'woocommerce'
-					) }
-				</p>
-				<div className="product-shipping-section__container">
-					<div>
-						<div className="components-base-control">
-							<div className="components-base-control__field">
-								<InputControl
-									label={ getInterpolatedSizeLabel(
-										__(
-											'Width {{span}}A{{/span}}',
-											'woocommerce'
-										)
-									) }
-									type="number"
-									{ ...getTextControlProps(
-										getInputProps( 'dimensions.width' )
-									) }
-									suffix="cm"
-								/>
-							</div>
-						</div>
+								<BaseControl
+									{ ...inputLengthProps }
+									id="product_shipping_dimensions_length"
+								>
+									<InputControl
+										{ ...inputLengthProps }
+										label={ getInterpolatedSizeLabel(
+											__(
+												'Length {{span}}B{{/span}}',
+												'woocommerce'
+											)
+										) }
+										onChange={ ( value: string ) =>
+											inputLengthProps?.onChange(
+												sanitizeNumber( value )
+											)
+										}
+										suffix="cm"
+									/>
+								</BaseControl>
 
-						<div className="components-base-control">
-							<div className="components-base-control__field">
-								<InputControl
-									label={ getInterpolatedSizeLabel(
-										__(
-											'Length {{span}}B{{/span}}',
-											'woocommerce'
-										)
-									) }
-									type="number"
-									{ ...getTextControlProps(
-										getInputProps( 'dimensions.length' )
-									) }
-									suffix="cm"
-								/>
-							</div>
-						</div>
+								<BaseControl
+									{ ...inputHeightProps }
+									id="product_shipping_dimensions_height"
+								>
+									<InputControl
+										{ ...inputHeightProps }
+										label={ getInterpolatedSizeLabel(
+											__(
+												'Height {{span}}C{{/span}}',
+												'woocommerce'
+											)
+										) }
+										onChange={ ( value: string ) =>
+											inputHeightProps?.onChange(
+												sanitizeNumber( value )
+											)
+										}
+										suffix="cm"
+									/>
+								</BaseControl>
 
-						<div className="components-base-control">
-							<div className="components-base-control__field">
-								<InputControl
-									label={ getInterpolatedSizeLabel(
-										__(
-											'Height {{span}}C{{/span}}',
-											'woocommerce'
-										)
-									) }
-									type="number"
-									{ ...getTextControlProps(
-										getInputProps( 'dimensions.height' )
-									) }
-									suffix="cm"
-								/>
+								<BaseControl
+									{ ...inputWeightProps }
+									id="product_shipping_weight"
+								>
+									<InputControl
+										{ ...inputWeightProps }
+										label={ __( 'Weight', 'woocommerce' ) }
+										onChange={ ( value: string ) =>
+											inputWeightProps?.onChange(
+												sanitizeNumber( value )
+											)
+										}
+										suffix="kg"
+									/>
+								</BaseControl>
 							</div>
+							<div></div>
 						</div>
-
-						<div className="components-base-control">
-							<div className="components-base-control__field">
-								<InputControl
-									label={ __( 'Weight', 'woocommerce' ) }
-									type="number"
-									{ ...getTextControlProps(
-										getInputProps( 'weight' )
-									) }
-									suffix="kg"
-								/>
-							</div>
-						</div>
-					</div>
-					<div></div>
-				</div>
+					</CardBody>
+				</Card>
 			</ProductSectionLayout>
 		</>
 	);

--- a/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
@@ -38,8 +38,7 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 	const [ slug, setSlug ] = useState(
 		product.slug || cleanForSlug( product.name )
 	);
-	const { resetForm, changedFields, touched, errors } =
-		useFormContext< Product >();
+	const { resetForm, touched, errors } = useFormContext< Product >();
 
 	const onSave = async () => {
 		recordEvent( 'product_update_slug', {
@@ -63,7 +62,6 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 					slug: updatedProduct.slug,
 					permalink: updatedProduct.permalink,
 				},
-				changedFields,
 				touched,
 				errors
 			);

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -259,13 +259,13 @@ export function useProductHelper() {
 	);
 
 	/**
-	 * Sanitizes a price.
+	 * Sanitizes a value using the Woo General Currency Settings.
 	 *
-	 * @param {string} price the price that will be sanitized.
-	 * @return {string} sanitized price.
+	 * @param {string} value the value that will be sanitized.
+	 * @return {string} sanitized value.
 	 */
-	const sanitizePrice = useCallback(
-		( price: string ) => {
+	const sanitizeNumber = useCallback(
+		( value: string ) => {
 			const { getCurrencyConfig } = context;
 			const { decimalSeparator } = getCurrencyConfig();
 			// Build regex to strip out everything except digits, decimal point and minus sign.
@@ -277,7 +277,7 @@ export function useProductHelper() {
 				ONLY_ONE_DECIMAL_SEPARATOR.replaceAll( '%s', decimalSeparator ),
 				'g'
 			);
-			const cleanValue = price
+			const cleanValue = value
 				.replace( regex, '' )
 				.replace( decimalRegex, '' )
 				.replace( decimalSeparator, '.' );
@@ -291,7 +291,7 @@ export function useProductHelper() {
 		updateProductWithStatus,
 		copyProductWithStatus,
 		deleteProductAndRedirect,
-		sanitizePrice,
+		sanitizeNumber,
 		isUpdatingDraft: updating.draft,
 		isUpdatingPublished: updating.publish,
 		isDeleting,

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useContext, useState } from '@wordpress/element';
+import * as WooNumber from '@woocommerce/number';
 import {
 	Product,
 	ProductsStoreActions,
@@ -259,13 +260,13 @@ export function useProductHelper() {
 	);
 
 	/**
-	 * Sanitizes a value using the Woo General Currency Settings.
+	 * Sanitizes a price.
 	 *
-	 * @param {string} value the value that will be sanitized.
-	 * @return {string} sanitized value.
+	 * @param {string} price the price that will be sanitized.
+	 * @return {string} sanitized price.
 	 */
-	const sanitizeNumber = useCallback(
-		( value: string ) => {
+	const sanitizePrice = useCallback(
+		( price: string ) => {
 			const { getCurrencyConfig } = context;
 			const { decimalSeparator } = getCurrencyConfig();
 			// Build regex to strip out everything except digits, decimal point and minus sign.
@@ -277,11 +278,49 @@ export function useProductHelper() {
 				ONLY_ONE_DECIMAL_SEPARATOR.replaceAll( '%s', decimalSeparator ),
 				'g'
 			);
-			const cleanValue = value
+			const cleanValue = price
 				.replace( regex, '' )
 				.replace( decimalRegex, '' )
 				.replace( decimalSeparator, '.' );
 			return cleanValue;
+		},
+		[ context ]
+	);
+
+	/**
+	 * Format a value using the Woo General Currency Settings.
+	 *
+	 * @param {string} value the value that will be formatted.
+	 * @return {string} the formatted number.
+	 */
+	const formatNumber = useCallback(
+		( value: string ): string => {
+			const { getCurrencyConfig } = context;
+			const { decimalSeparator, thousandSeparator } = getCurrencyConfig();
+
+			return WooNumber.numberFormat(
+				{ decimalSeparator, thousandSeparator },
+				value
+			);
+		},
+		[ context ]
+	);
+
+	/**
+	 * Parse a value using the Woo General Currency Settings.
+	 *
+	 * @param {string} value the value that will be parsed.
+	 * @return {string} the parsed number.
+	 */
+	const parseNumber = useCallback(
+		( value: string ): string => {
+			const { getCurrencyConfig } = context;
+			const { decimalSeparator, thousandSeparator } = getCurrencyConfig();
+
+			return WooNumber.parseNumber(
+				{ decimalSeparator, thousandSeparator },
+				value
+			);
 		},
 		[ context ]
 	);
@@ -291,7 +330,9 @@ export function useProductHelper() {
 		updateProductWithStatus,
 		copyProductWithStatus,
 		deleteProductAndRedirect,
-		sanitizeNumber,
+		sanitizePrice,
+		formatNumber,
+		parseNumber,
 		isUpdatingDraft: updating.draft,
 		isUpdatingPublished: updating.publish,
 		isDeleting,

--- a/plugins/woocommerce/changelog/add-34329-shipping-dimensions
+++ b/plugins/woocommerce/changelog/add-34329-shipping-dimensions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add shipping dimensions section to product page #34329


### PR DESCRIPTION
Change the FormComponent to support input name with dot notation like dimensions.width Add the dimension controls to the product form

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- The form now support dot notation in input names. It uses `get` and `setWith` function from lodash.
- The @woocommerce/number now implements parseNumber function which is helpful to parse a given formatted string using the separators configured in settings into a fixed number
- An entire Dimensions Section is added to a new Product page. 
- Add validations to the size fields.
- Add number format to the fields.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partialy closes https://github.com/woocommerce/woocommerce/issues/34329.

### How to test the changes in this Pull Request:

1. Visit the New Product page
2. A dimensions section should be shown with Width, Length, Height and Weight fields.
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/13334210/192602530-d81aa7f5-0763-479f-b088-302a5233f630.png">
3. If you type a number in any of the fields, that number should be formated acording the Currency Options configured in WooCommerce > Settings > General section.
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/13334210/192602717-118a7541-42f8-44c3-a910-c6302c84f3b1.png">
4. If any values is less or equals to zero an error message should be shown below the input field.
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/13334210/192602792-43e3763a-9090-4e6a-93d1-eaf1c86db923.png">
5. If the product is saved successfuly with dimensions set then in the edition page the dimensions fields should show the values formatted acording the Currency Options configured in WooCommerce > Settings > General section.
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/13334210/192602939-8a40f939-ad6b-4f34-acd4-93787544fa3a.png">

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
