### PR TITLE
[COT] Do not set order prop to NULL while reading order data

### DIFF
--- a/plugins/woocommerce/changelog/fix-34677
+++ b/plugins/woocommerce/changelog/fix-34677
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do no override order defaults with NULL values (HPOS)

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -836,6 +836,9 @@ SELECT type FROM {$this->get_orders_table_name()} WHERE id = %d;
 				}
 
 				$prop_value = $order_data->{$prop_details['name']};
+				if ( is_null( $prop_value ) ) {
+					continue;
+				}
 
 				if ( 'date' === $prop_details['type'] ) {
 					$prop_value = $this->string_to_timestamp( $prop_value );


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When reading orders, we should exclude `NULL` values from being set using the property setters. This is in line with the way [`WC_Data::set_props()` behaves](), which is how the CPT datastore [loads props into the order object](https://github.com/woocommerce/woocommerce/blob/96cdef649a14c08efedb59b735e558c94366bee4/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php#L126
).

The HPOS/COT datastore, however, [doesn't use `set_props()`](https://github.com/woocommerce/woocommerce/blob/96cdef649a14c08efedb59b735e558c94366bee4/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L831
) so we need to emulate this behavior, which is what this PR does.

Ideally, we would also use `set_props()` but for that to correctly work we need to address #34627 first, so this could be considered an interim fix (or a definitive fix if we don't move to using `set_props()` in the end).

Closes #34677.

### How to test the changes in this Pull Request:

1. Check out `trunk` and temporarily _disable_ COT (i.e. use CPT as datastore).
2. Use the following code to trigger the customer lookup write:
   ```php
   $order = new \WC_Order();
   $order->save();
   
   $order = wc_get_order( $order->get_id() );
   $report_customer_id = $order->get_report_customer_id();
   
   var_dump( $order->get_billing_first_name() );
   ```
3. Confirm both that (i) the result of the last call is an empty string (ii) no error logs are added to your log file.
4. Repeat step 2 but now with COT enabled. Confirm that (i) now the function call in step 2 returns `NULL` and (ii) an error similar to this one is now in your log files:
   ```
   [...] WordPress database error Column 'first_name' cannot be null for query INSERT INTO `wp_wc_customer_lookup` [...]
   ```
4. Check out this branch (`fix/34677`) and repeat step 2 (COT enabled). Confirm that the results are the same as in step 3 (empty string, no error).

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
