### PR TITLE
Allow external tags in SelectControl component

### DIFF
--- a/packages/js/components/changelog/update-select-control-tag-location
+++ b/packages/js/components/changelog/update-select-control-tag-location
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow external tags in SelectControl component

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -1,13 +1,17 @@
 .woocommerce-experimental-select-control__combo-box-wrapper {
     cursor: text;
+
     border: 1px solid $studio-gray-20;
     border-radius: 3px;
     background: $studio-white;
     position: relative;
     display: flex;
     flex-wrap: wrap;
+    flex-wrap: wrap;
     align-items: center;
+    padding: $gap-smallest $gap-smaller;
     padding: $gap-smallest 36px $gap-smallest $gap-smaller;
+    margin-bottom: 4px;
 
     > * {
         display: inline-flex;
@@ -18,6 +22,7 @@
     flex-grow: 1;
     align-items: center;
     flex-basis: 120px;
+    display: inline-flex;
 
     input {
         width: 100%;

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -1,15 +1,12 @@
 .woocommerce-experimental-select-control__combo-box-wrapper {
     cursor: text;
-
     border: 1px solid $studio-gray-20;
     border-radius: 3px;
     background: $studio-white;
     position: relative;
     display: flex;
     flex-wrap: wrap;
-    flex-wrap: wrap;
     align-items: center;
-    padding: $gap-smallest $gap-smaller;
     padding: $gap-smallest 36px $gap-smallest $gap-smaller;
     margin-bottom: 4px;
 

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -13,7 +13,6 @@ type ComboBoxProps = {
 	children?: JSX.Element | JSX.Element[] | null;
 	comboBoxProps: Props;
 	inputProps: Props;
-	inputRef?: React.RefObject< HTMLInputElement > | null;
 };
 
 export const ComboBox = ( {

--- a/packages/js/components/src/experimental-select-control/menu.scss
+++ b/packages/js/components/src/experimental-select-control/menu.scss
@@ -2,6 +2,8 @@
     position: absolute;
     width: 100%;
     top: 100%;
+    left: 0;
+    margin-top: $gap-smaller;
     box-sizing: border-box;
     display: none;
     background: $studio-white;

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { createElement, Fragment, useState } from '@wordpress/element';
+import {
+	createElement,
+	Fragment,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { useCombobox, useMultipleSelection } from 'downshift';
 
 /**

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { createElement, Fragment, useState } from '@wordpress/element';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { createElement, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -36,6 +36,7 @@ type SelectControlProps< ItemType > = {
 		selectedItems: ItemType[],
 		getItemLabel: getItemLabelType< ItemType >
 	) => ItemType[];
+	hasExternalTags?: boolean;
 	multiple?: boolean;
 	onInputChange?: ( value: string | undefined ) => void;
 	onRemove?: ( item: ItemType ) => void;
@@ -47,6 +48,7 @@ type SelectControlProps< ItemType > = {
 function SelectControl< ItemType = DefaultItemType >( {
 	getItemLabel = defaultGetItemLabel,
 	getItemValue = defaultGetItemValue,
+	hasExternalTags = false,
 	children = ( {
 		items: renderItems,
 		highlightedIndex,
@@ -170,6 +172,16 @@ function SelectControl< ItemType = DefaultItemType >( {
 		onRemove( item );
 	};
 
+	const selectedItemTags = multiple ? (
+		<SelectedItems
+			items={ selectedItems }
+			getItemLabel={ getItemLabel }
+			getItemValue={ getItemValue }
+			getSelectedItemProps={ getSelectedItemProps }
+			onRemove={ onRemoveItem }
+		/>
+	) : null;
+
 	return (
 		<div
 			className={ classnames( 'woocommerce-experimental-select-control', {
@@ -192,26 +204,21 @@ function SelectControl< ItemType = DefaultItemType >( {
 					placeholder,
 				} ) }
 			>
-				{ multiple ? (
-					<SelectedItems
-						items={ selectedItems }
-						getItemLabel={ getItemLabel }
-						getItemValue={ getItemValue }
-						getSelectedItemProps={ getSelectedItemProps }
-						onRemove={ onRemoveItem }
-					/>
-				) : null }
+				<>
+					{ children( {
+						items: filteredItems,
+						highlightedIndex,
+						getItemProps,
+						getMenuProps,
+						isOpen,
+						getItemLabel,
+						getItemValue,
+					} ) }
+					{ ! hasExternalTags && selectedItemTags }
+				</>
 			</ComboBox>
 
-			{ children( {
-				items: filteredItems,
-				highlightedIndex,
-				getItemProps,
-				getMenuProps,
-				isOpen,
-				getItemLabel,
-				getItemValue,
-			} ) }
+			{ hasExternalTags && selectedItemTags }
 		</div>
 	);
 }

--- a/packages/js/components/src/experimental-select-control/selected-items.scss
+++ b/packages/js/components/src/experimental-select-control/selected-items.scss
@@ -3,6 +3,7 @@
     margin-top: 2px;
     margin-bottom: 2px;
     cursor: default;
+    display: inline-flex;
 
     .woocommerce-tag {
         margin: 0;

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -297,8 +297,9 @@ const customItems: CustomItemType[] = [
 ];
 
 export const CustomItemType: React.FC = () => {
-	const [ selected, setSelected ] =
-		useState< SelectedType< Array< CustomItemType > > >( null );
+	const [ selected, setSelected ] = useState<
+		SelectedType< Array< CustomItemType > >
+	>( [] );
 
 	return (
 		<>
@@ -315,7 +316,9 @@ export const CustomItemType: React.FC = () => {
 							: [ item ]
 					)
 				}
-				onRemove={ () => setSelected( null ) }
+				onRemove={ ( item ) =>
+					setSelected( selected?.filter( ( i ) => i !== item ) || [] )
+				}
 				getItemLabel={ ( item ) => item?.user.name || '' }
 				getItemValue={ ( item ) => String( item?.itemId ) }
 			/>

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { CheckboxControl, Spinner } from '@wordpress/components';
-import React, { createElement } from 'react';
-import { useState } from '@wordpress/element';
+import React from 'react';
+import { createElement, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -52,6 +52,29 @@ export const Multiple: React.FC = () => {
 				multiple
 				items={ sampleItems }
 				label="Multiple values"
+				selected={ selected }
+				onSelect={ ( item ) =>
+					Array.isArray( selected ) &&
+					setSelected( [ ...selected, item ] )
+				}
+				onRemove={ ( item ) =>
+					setSelected( selected.filter( ( i ) => i !== item ) )
+				}
+			/>
+		</>
+	);
+};
+
+export const ExternalTags: React.FC = () => {
+	const [ selected, setSelected ] = useState< DefaultItemType[] >( [] );
+
+	return (
+		<>
+			<SelectControl
+				multiple
+				hasExternalTags
+				items={ sampleItems }
+				label="External tags"
 				selected={ selected }
 				onSelect={ ( item ) =>
 					Array.isArray( selected ) &&
@@ -292,10 +315,8 @@ export const CustomItemType: React.FC = () => {
 							: [ item ]
 					)
 				}
-				onRemove={ ( item ) =>
-					setSelected( selected.filter( ( i ) => i !== item ) )
-				}
-				getItemLabel={ ( item ) => item?.user.name }
+				onRemove={ () => setSelected( null ) }
+				getItemLabel={ ( item ) => item?.user.name || '' }
 				getItemValue={ ( item ) => String( item?.itemId ) }
 			/>
 		</>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a prop to move tags below the combobox.  cc @jarekmorawski Just want to double check the interaction here since when the menu is open, it will cover the tags (seen below).  I think we discussed this as an inevitable downside to external tags, but let me know if you'd like to adjust.

<img width="550" alt="Screen Shot 2022-09-23 at 3 58 25 PM" src="https://user-images.githubusercontent.com/10561050/192067200-058d884c-1caa-408d-af7d-1db8cd87d6ed.png">


<img width="637" alt="Screen Shot 2022-09-23 at 3 52 14 PM" src="https://user-images.githubusercontent.com/10561050/192067163-dcc98d83-03d3-4127-bbda-d238a4237d0a.png">


Closes #34700 .

### How to test the changes in this Pull Request:

1. Run `pnpm --filter=@woocommerce/storybook storybook`
2. Navigate to `experimental/SelectControl`
3. Check the "External tags" story
4. Add some tags and verify that they work are displayed as expected

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
