### PR TITLE
Fix Tour Kit stories loading error

### DIFF
--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -5,8 +5,8 @@ const { get } = require( 'lodash' );
 const path = require( 'path' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-webpack-plugin' );
-const BundleAnalyzerPlugin = require( 'webpack-bundle-analyzer' )
-	.BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin =
+	require( 'webpack-bundle-analyzer' ).BundleAnalyzerPlugin;
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
 const ForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 
@@ -104,8 +104,8 @@ const webpackConfig = {
 					amd: false,
 				},
 				exclude: [
-					// Exclude node_modules/.pnpm but not node_modules/.pnpm/debug*
-					/node_modules(\/|\\)\.pnpm(\/|\\)(?!(debug))/,
+					// Exclude node_modules/.pnpm
+					/node_modules(\/|\\)\.pnpm(\/|\\)/,
 				],
 				use: {
 					loader: 'babel-loader',

--- a/plugins/woocommerce/changelog/dev-34753-tour-kit-stories-error
+++ b/plugins/woocommerce/changelog/dev-34753-tour-kit-stories-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Exclude "debug" module from babel compile to fix the tour kit stories loading error


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34753.

This PR fixes the Tour Kit stories error that was caused by [this PR](https://github.com/woocommerce/woocommerce/pull/33452). 

```
error: "Unexpected error while loading ./tour-kit/stories/index.tsx: exports is not defined
 ReferenceError: exports is not defined
    at ../../node_modules/.pnpm/debug@4.3.4/node_modules/debug/src/browser.js (http://localhost:6007/vendors-node_modules_pnpm_automattic_interpolate-components_1_2_1_adlholpkqbiq5amp2fy4vkqcli_-6aa8df.iframe.bundle.js:86363:1)
    at __webpack_require__ (http://localhost:6007/runtime~main.iframe.bundle.js:28:33)
    at fn (http://localhost:6007/runtime~main.iframe.bundle.js:347:21)
    at ../../node_modules/.pnpm/@automattic+tour-kit@1.1.1_ewcciyhsqon3yluv5ntlvxyvvm/node_modules/@automattic/tour-kit/dist/esm/utils/index.js
```

The Tour Kit stories do not load because `@automattic/tour-kit@1.1.1` [contains the "debug" module](https://github.com/Automattic/wp-calypso/pull/64647/files#diff-7601d2309668b89fd9ed1669c069fd42002ed0dd23a7cf49abd9f4e163381b23R46) and Webpack doesn't transpile it properly. Normally, Webpack should load the module with `exports` in the second argument. However, you can see below it somehow uses the `__unused_webpack___webpack_exports__`.

![Screen Shot 2022-09-26 at 14 36 29](https://user-images.githubusercontent.com/4344253/192209020-0906fac2-2bdf-4e9c-b38c-f30093788eb7.png)

I found out it's because we transpile the debug module using babel, though I'm not sure why it only throws the error in the storybook. (Maybe also due to the storybook's additional Webpack config? 🤔. ) 

We originally excluded the debug module from the "exclude" rule in [this PR](https://github.com/woocommerce/woocommerce-admin/pull/5987) to fix an IE 11 issue, but since we have dropped the IE11 support, I think we can safely remove it now to fix the error.

### How to test the changes in this Pull Request:

**Test Storybook**

1. Run Storybook: `pnpm --filter=@woocommerce/storybook storybook`
2. Go to any story
3. Should not see any errors in the web browser dev console
4. Go to tour kit stories
5. Should load tour kit stories properly

**Test "debug" work as expected**

1. Enable debugging in browser dev console:`window.localStorage.setItem( 'debug', 'wc-admin:*' )`
2. Go to woocommerce > Home
3. Observe that some tracks logs are displayed in the web dev console.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
