### PR TITLE
Fix failing to update onboarding profile data for PHP 8

### DIFF
--- a/plugins/woocommerce/changelog/fix-34745-update-industries-error
+++ b/plugins/woocommerce/changelog/fix-34745-update-industries-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix failing to update industries after clicking "Continue" on "Industry" tab
+Fix failing to update onboarding profile data for PHP 8

--- a/plugins/woocommerce/changelog/fix-34745-update-industries-error
+++ b/plugins/woocommerce/changelog/fix-34745-update-industries-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix failing to update industries after clicking "Continue" on "Industry" tab

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -443,7 +443,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'description'       => __( 'Whether or not this store country is set via onboarding profiler.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
-				'validate_callback' => array( __CLASS__, 'rest_validate_request_arg' ),
+				'validate_callback' => 'rest_validate_request_arg',
 			),
 		);
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
@@ -67,7 +67,31 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 				'slug' => 'health-beauty',
 			),
 		);
-		$request->set_body( wp_json_encode( array( 'industry' => $industry ) ) );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'completed'            => true,
+					'skipped'              => false,
+					'industry'             => $industry,
+					'product_types'        => 'physical',
+					'product_count'        => '1-10',
+					'selling_venues'       => 'brick-mortar',
+					'number_employees'     => '<10',
+					'revenue'              => 'none',
+					'other_platform'       => 'shopify',
+					'other_platform_name'  => '',
+					'business_extensions'  => array(
+						'jetpack',
+					),
+					'theme'                => 'Test',
+					'wccom_connected'      => false,
+					'setup_client'         => false,
+					'is_agree_marketing'   => true,
+					'store_email'          => 'user@example.com',
+					'is_store_country_set' => true,
+				)
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34745, #34815, #34817.

This PR fixes an updating industries bug. This bug also causes the shipping task display issue (https://github.com/woocommerce/woocommerce/issues/34815) and saving store address issue (https://github.com/woocommerce/woocommerce/issues/34817).

It throws an error because [`rest_validate_request_arg`](https://developer.wordpress.org/reference/functions/rest_validate_request_arg/) is not a class method but a WP function.

### How to test the changes in this Pull Request:

You can use this zip https://github.com/woocommerce/woocommerce/actions/runs/3126273256

 
**Test update industries**

1. Create any test site using Atomic site (or site with PHP 8).
2. Start OBW.
3. Fill the Store address and click on Continue.
4. Select any options from Industry tab.
5. Click on Continue.
6. Observe that "There was a problem updating your industries" notification should **NOT** displayed.
 
**Test shipping task**

1. Create any test site using Atomic site (or site with PHP 8).
2. Install and activate all the required plugins.
3. Complete the Onboarding setup wizard.
4. Go to Woocommerce > Home
5. Observe that "Shipping task"  is displayed on Woocommerce > Home page after completing OBW.

**Test saving the store address**

1. Create any test site using Atomic site (or site with PHP 8).
2. Install and activate all the required plugins.
3. Complete the Onboarding setup wizard.
4. Start OBW.
5. Fill Store address and Email Address.
6. Click on Contiune.
7. Click on Store details header.
8. Observe that  "Country/ Region" and "Email address" are saved properly

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
