### PR TITLE
Disable product management experience in dev env

### DIFF
--- a/plugins/woocommerce/changelog/patch-disable_product_management_experience_in_dev_env
+++ b/plugins/woocommerce/changelog/patch-disable_product_management_experience_in_dev_env
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Disable new-product-management-experience feature flag in development.

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -16,7 +16,7 @@
 		"minified-js": true,
 		"mobile-app-banner": true,
 		"navigation": true,
-		"new-product-management-experience": true,
+		"new-product-management-experience": false,
 		"onboarding": true,
 		"onboarding-tasks": true,
 		"payment-gateway-suggestions": true,


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Disable product management experience in dev env

### How to test the changes in this Pull Request:

1. Make sure you have the **WooCommerce Beta tester** disabled
2. Run ```pnpm run build && pnpm --filter=woocommerce/client/admin run start```
3. The **Add New (MVP)** under **Products** should not show up
4. Now enable the **WooCommerce Beta tester** (the latest within the monorepo) and enable the product management experience feature flag under **Tools > WCA Test Helper > Features**
5. The **Add New (MVP)** under **Products** should show up now

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
