### PR TITLE
Add/34333 attribute list

### DIFF
--- a/packages/js/components/changelog/add-34333_attribute_list
+++ b/packages/js/components/changelog/add-34333_attribute_list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove default selected sortable item.

--- a/packages/js/components/src/form-section/form-section.tsx
+++ b/packages/js/components/src/form-section/form-section.tsx
@@ -2,19 +2,22 @@
  * External dependencies
  */
 import { createElement } from '@wordpress/element';
+import classnames from 'classnames';
 
 type FormSectionProps = {
 	title: JSX.Element | string;
 	description: JSX.Element | string;
+	className?: string;
 };
 
 export const FormSection: React.FC< FormSectionProps > = ( {
 	title,
 	description,
+	className,
 	children,
 } ) => {
 	return (
-		<div className="woocommerce-form-section">
+		<div className={ classnames( 'woocommerce-form-section', className ) }>
 			<div className="woocommerce-form-section__header">
 				<h3 className="woocommerce-form-section__title">{ title }</h3>
 				<div className="woocommerce-form-section__description">

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -44,6 +44,7 @@ export { SelectControl as __experimentalSelectControl } from './experimental-sel
 export { MenuItem as __experimentalSelectControlMenuItem } from './experimental-select-control/menu-item';
 export { default as ScrollTo } from './scroll-to';
 export { Sortable } from './sortable';
+export { ListItem } from './list-item';
 export { default as Spinner } from './spinner';
 export { default as Stepper, StepperProps } from './stepper';
 export { default as SummaryList } from './summary';

--- a/packages/js/components/src/sortable/sortable.tsx
+++ b/packages/js/components/src/sortable/sortable.tsx
@@ -51,7 +51,7 @@ export const Sortable = ( {
 }: SortableProps ) => {
 	const ref = useRef< HTMLOListElement >( null );
 	const [ items, setItems ] = useState< SortableChild[] >( [] );
-	const [ selectedIndex, setSelectedIndex ] = useState< number >( 0 );
+	const [ selectedIndex, setSelectedIndex ] = useState< number >( -1 );
 	const [ dragIndex, setDragIndex ] = useState< number | null >( null );
 	const [ dropIndex, setDropIndex ] = useState< number | null >( null );
 

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
@@ -14,4 +14,47 @@
 	&__add-new {
 		margin: $gap-large 0 $gap-larger;
 	}
+	&__attribute-option-chip {
+		padding: 4px 8px;
+		gap: 2px;
+
+		background: $gray-100;
+		border-radius: 2px;
+	}
+
+	&__attribute-options {
+		display: flex;
+		flex-direction: row;
+		gap: 4px;
+	}
+
+	&__attribute-actions {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		justify-content: end;
+		gap: 8px;
+	}
+
+	.woocommerce-list-item {
+		height: 82px;
+		padding: 0px $gap-large;
+
+		&:last-child {
+			margin: -1px;
+		}
+	}
+
+	.woocommerce-sortable {
+		margin: 0;
+
+		.woocommerce-list-item {
+			display: grid;
+			grid-template-columns: 24px 26% auto 90px;
+		}
+	}
+
+	.woocommerce-sortable__item:not( :first-child ) {
+		margin-top: -1px;
+	}
 }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
@@ -15,7 +15,7 @@
 		margin: $gap-large 0 $gap-larger;
 	}
 	&__attribute-option-chip {
-		padding: 4px 8px;
+		padding: $gap-smallest $gap-smaller;
 		gap: 2px;
 
 		background: $gray-100;
@@ -25,7 +25,7 @@
 	&__attribute-options {
 		display: flex;
 		flex-direction: row;
-		gap: 4px;
+		gap: $gap-smallest;
 	}
 
 	&__attribute-actions {
@@ -33,11 +33,11 @@
 		flex-direction: row;
 		align-items: center;
 		justify-content: end;
-		gap: 8px;
+		gap: $gap-smaller;
 	}
 
 	.woocommerce-list-item {
-		height: 82px;
+		min-height: 82px;
 		padding: 0 $gap-large;
 
 		&:last-child {
@@ -54,11 +54,12 @@
 		}
 	}
 
-	.woocommerce-sortable__item:not(:first-child) {
+	.woocommerce-sortable__item:not( :first-child ) {
 		margin-top: -1px;
 	}
-	.woocommerce-sortable__item:focus-visible:not(:active) + .woocommerce-sortable__item
-	.woocommerce-list-item {
+	.woocommerce-sortable__item:focus-visible:not( :active )
+		+ .woocommerce-sortable__item
+		.woocommerce-list-item {
 		background: none;
 		border-top: 0;
 	}

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
@@ -54,12 +54,10 @@
 		}
 	}
 
-	.woocommerce-sortable__item:not( :first-child ) {
+	.woocommerce-sortable__item:not(:first-child) {
 		margin-top: -1px;
 	}
-	.woocommerce-sortable__item:focus-visible:not( :active )
-		+ .woocommerce-sortable__item
-		.woocommerce-list-item {
+	.woocommerce-sortable__item:focus-visible:not(:active) + .woocommerce-sortable__item .woocommerce-list-item {
 		background: none;
 		border-top: 0;
 	}

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.scss
@@ -38,7 +38,7 @@
 
 	.woocommerce-list-item {
 		height: 82px;
-		padding: 0px $gap-large;
+		padding: 0 $gap-large;
 
 		&:last-child {
 			margin: -1px;
@@ -54,7 +54,12 @@
 		}
 	}
 
-	.woocommerce-sortable__item:not( :first-child ) {
+	.woocommerce-sortable__item:not(:first-child) {
 		margin-top: -1px;
+	}
+	.woocommerce-sortable__item:focus-visible:not(:active) + .woocommerce-sortable__item
+	.woocommerce-list-item {
+		background: none;
+		border-top: 0;
 	}
 }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { ProductAttribute } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
+import { Sortable, ListItem } from '@woocommerce/components';
+import { trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -21,6 +23,13 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	value,
 	onChange,
 } ) => {
+	const onRemove = ( attribute: ProductAttribute ) => {
+		// eslint-disable-next-line no-alert
+		if ( window.confirm( __( 'Remove this attribute', 'woocommerce' ) ) ) {
+			onChange( value.filter( ( attr ) => attr.id !== attribute.id ) );
+		}
+	};
+
 	if ( ! value || value.length === 0 ) {
 		return (
 			<div className="woocommerce-attribute-field">
@@ -50,5 +59,88 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 			</div>
 		);
 	}
-	return <div className="woocommerce-attribute-field"></div>;
+
+	const sortedAttributes = value.sort( ( a, b ) => a.position - b.position );
+	const attributeKeyValues = value.reduce(
+		(
+			keyValue: Record< number, ProductAttribute >,
+			attribute: ProductAttribute
+		) => {
+			keyValue[ attribute.id ] = attribute;
+			return keyValue;
+		},
+		{} as Record< number, ProductAttribute >
+	);
+	return (
+		<div className="woocommerce-attribute-field">
+			<Sortable
+				onOrderChange={ ( items ) => {
+					const newAttributes: ProductAttribute[] = items
+						.map( ( item, index ): ProductAttribute | undefined => {
+							const key = item.key
+								? parseInt( item.key as string, 10 )
+								: NaN;
+							if ( key !== NaN ) {
+								return {
+									...attributeKeyValues[ key ],
+									position: index,
+								};
+							}
+							return undefined;
+						} )
+						.filter(
+							( attr ): attr is ProductAttribute =>
+								attr !== undefined
+						);
+					onChange( newAttributes );
+				} }
+			>
+				{ sortedAttributes.map( ( attribute ) => (
+					<ListItem key={ attribute.id }>
+						<div>{ attribute.name }</div>
+						<div className="woocommerce-attribute-field__attribute-options">
+							{ attribute.options
+								.slice( 0, 2 )
+								.map( ( option, index ) => (
+									<div
+										className="woocommerce-attribute-field__attribute-option-chip"
+										key={ index }
+									>
+										{ option }
+									</div>
+								) ) }
+							{ attribute.options.length > 2 && (
+								<div className="woocommerce-attribute-field__attribute-option-chip">
+									+ { attribute.options.length - 2 }&nbsp;
+									{ __( 'more', 'woocommerce' ) }
+								</div>
+							) }
+						</div>
+						<div className="woocommerce-attribute-field__attribute-actions">
+							<Button variant="tertiary" disabled>
+								{ __( 'edit', 'woocommerce' ) }
+							</Button>
+							<Button
+								icon={ trash }
+								label={ __(
+									'Remove attribute',
+									'woocommerce'
+								) }
+								onClick={ () => onRemove( attribute ) }
+							></Button>
+						</div>
+					</ListItem>
+				) ) }
+			</Sortable>
+			<ListItem>
+				<Button
+					variant="secondary"
+					className="woocommerce-attribute-field__add"
+					disabled={ true }
+				>
+					{ __( 'Add attribute', 'woocommerce' ) }
+				</Button>
+			</ListItem>
+		</div>
+	);
 };

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -25,7 +25,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 } ) => {
 	const onRemove = ( attribute: ProductAttribute ) => {
 		// eslint-disable-next-line no-alert
-		if ( window.confirm( __( 'Remove this attribute', 'woocommerce' ) ) ) {
+		if ( window.confirm( __( 'Remove this attribute?', 'woocommerce' ) ) ) {
 			onChange( value.filter( ( attr ) => attr.id !== attribute.id ) );
 		}
 	};

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { ProductAttribute } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
@@ -13,6 +13,7 @@ import { trash } from '@wordpress/icons';
  */
 import './attribute-field.scss';
 import AttributeEmptyStateLogo from './attribute-empty-state-logo.svg';
+import { reorderSortableProductAttributePositions } from './utils';
 
 type AttributeFieldProps = {
 	value: ProductAttribute[];
@@ -75,24 +76,12 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 		<div className="woocommerce-attribute-field">
 			<Sortable
 				onOrderChange={ ( items ) => {
-					const newAttributes: ProductAttribute[] = items
-						.map( ( item, index ): ProductAttribute | undefined => {
-							const key = item.key
-								? parseInt( item.key as string, 10 )
-								: NaN;
-							if ( key !== NaN ) {
-								return {
-									...attributeKeyValues[ key ],
-									position: index,
-								};
-							}
-							return undefined;
-						} )
-						.filter(
-							( attr ): attr is ProductAttribute =>
-								attr !== undefined
-						);
-					onChange( newAttributes );
+					onChange(
+						reorderSortableProductAttributePositions(
+							items,
+							attributeKeyValues
+						)
+					);
 				} }
 			>
 				{ sortedAttributes.map( ( attribute ) => (
@@ -111,8 +100,10 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 								) ) }
 							{ attribute.options.length > 2 && (
 								<div className="woocommerce-attribute-field__attribute-option-chip">
-									+ { attribute.options.length - 2 }&nbsp;
-									{ __( 'more', 'woocommerce' ) }
+									{ sprintf(
+										__( '+ %i more', 'woocommerce' ),
+										attribute.options.length - 2
+									) }
 								</div>
 							) }
 						</div>
@@ -135,7 +126,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 			<ListItem>
 				<Button
 					variant="secondary"
-					className="woocommerce-attribute-field__add"
+					className="woocommerce-attribute-field__add-attribute"
 					disabled={ true }
 				>
 					{ __( 'Add attribute', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
@@ -2,11 +2,78 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { useState, useEffect } from '@wordpress/element';
+import { ProductAttribute } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { AttributeField } from '../attribute-field';
+
+let triggerDrag: ( items: Array< { key: string } > ) => void;
+
+jest.mock( '@woocommerce/components', () => ( {
+	__esModule: true,
+	ListItem: ( { children }: { children: JSX.Element } ) => children,
+	Sortable: ( {
+		onOrderChange,
+		children,
+	}: {
+		onOrderChange: ( items: Array< { key: string } > ) => void;
+		children: JSX.Element[];
+	} ) => {
+		const [ items, setItems ] = useState< JSX.Element[] >( [] );
+		useEffect( () => {
+			if ( ! children ) {
+				return;
+			}
+			setItems( Array.isArray( children ) ? children : [ children ] );
+		}, [ children ] );
+
+		triggerDrag = ( newItems: Array< { key: string } > ) => {
+			onOrderChange( newItems );
+		};
+		return (
+			<>
+				{ items.map( ( child, index ) => (
+					<div key={ index }>{ child }</div>
+				) ) }
+			</>
+		);
+	},
+} ) );
+
+const attributeList: ProductAttribute[] = [
+	{
+		id: 15,
+		name: 'Automotive',
+		position: 0,
+		visible: true,
+		variation: false,
+		options: [ 'test' ],
+	},
+	{
+		id: 1,
+		name: 'Color',
+		position: 2,
+		visible: true,
+		variation: true,
+		options: [
+			'Beige',
+			'black',
+			'Blue',
+			'brown',
+			'Gray',
+			'Green',
+			'mint',
+			'orange',
+			'pink',
+			'Red',
+			'white',
+			'Yellow',
+		],
+	},
+];
 
 describe( 'AttributeField', () => {
 	beforeEach( () => {
@@ -20,6 +87,110 @@ describe( 'AttributeField', () => {
 			);
 			expect( queryByText( 'No attributes yet' ) ).toBeInTheDocument();
 			expect( queryByText( 'Add first attribute' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'should render the list of existing attributes', () => {
+		const { queryByText } = render(
+			<AttributeField
+				value={ [ ...attributeList ] }
+				onChange={ () => {} }
+			/>
+		);
+		expect( queryByText( 'No attributes yet' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'Add first attribute' ) ).not.toBeInTheDocument();
+		expect( queryByText( attributeList[ 0 ].name ) ).toBeInTheDocument();
+		expect( queryByText( attributeList[ 1 ].name ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the first two terms of each attribute, and show "+ n more" for the rest', () => {
+		const { queryByText } = render(
+			<AttributeField
+				value={ [ ...attributeList ] }
+				onChange={ () => {} }
+			/>
+		);
+		expect(
+			queryByText( attributeList[ 0 ].options[ 0 ] )
+		).toBeInTheDocument();
+		expect(
+			queryByText( attributeList[ 1 ].options[ 0 ] )
+		).toBeInTheDocument();
+		expect(
+			queryByText( attributeList[ 1 ].options[ 1 ] )
+		).toBeInTheDocument();
+		expect(
+			queryByText( attributeList[ 1 ].options[ 2 ] )
+		).not.toBeInTheDocument();
+		expect(
+			queryByText(
+				`+ ${ attributeList[ 1 ].options.length - 2 }&nbsp;more`
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	describe( 'deleting', () => {
+		it( 'should show a window confirm when trash icon is clicked', () => {
+			jest.spyOn( global, 'confirm' ).mockReturnValueOnce( false );
+			const { queryAllByLabelText } = render(
+				<AttributeField
+					value={ [ ...attributeList ] }
+					onChange={ () => {} }
+				/>
+			);
+			queryAllByLabelText( 'Remove attribute' )[ 0 ].click();
+			expect( global.confirm ).toHaveBeenCalled();
+		} );
+
+		it( 'should trigger onChange with removed item when user clicks ok on alert', () => {
+			jest.spyOn( global, 'confirm' ).mockReturnValueOnce( true );
+			const onChange = jest.fn();
+			const { queryAllByLabelText } = render(
+				<AttributeField
+					value={ [ ...attributeList ] }
+					onChange={ onChange }
+				/>
+			);
+			queryAllByLabelText( 'Remove attribute' )[ 0 ].click();
+			expect( global.confirm ).toHaveBeenCalled();
+			expect( onChange ).toHaveBeenCalledWith( [ attributeList[ 1 ] ] );
+		} );
+
+		it( 'should not trigger onChange with removed item when user cancel', () => {
+			jest.spyOn( global, 'confirm' ).mockReturnValueOnce( false );
+			const onChange = jest.fn();
+			const { queryAllByLabelText } = render(
+				<AttributeField
+					value={ [ ...attributeList ] }
+					onChange={ onChange }
+				/>
+			);
+			queryAllByLabelText( 'Remove attribute' )[ 0 ].click();
+			expect( global.confirm ).toHaveBeenCalled();
+			expect( onChange ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'dragging', () => {
+		it( 'should trigger onChange with new order when onOrderChange triggered', () => {
+			const onChange = jest.fn();
+			const { queryAllByLabelText } = render(
+				<AttributeField
+					value={ [ ...attributeList ] }
+					onChange={ onChange }
+				/>
+			);
+			if ( triggerDrag ) {
+				triggerDrag( [
+					{ key: attributeList[ 1 ].id.toString() },
+					{ key: attributeList[ 0 ].id.toString() },
+				] );
+			}
+			queryAllByLabelText( 'Remove attribute' )[ 0 ].click();
+			expect( onChange ).toHaveBeenCalledWith( [
+				{ ...attributeList[ 1 ], position: 0 },
+				{ ...attributeList[ 0 ], position: 1 },
+			] );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/utils.spec.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/utils.spec.ts
@@ -53,4 +53,19 @@ describe( 'reorderSortableProductAttributePositions', () => {
 		expect( newList[ 2 ].position ).toEqual( 2 );
 		expect( newList[ 2 ].id ).toEqual( 1 );
 	} );
+
+	it( 'should filter out elements that do not contain a key', () => {
+		const elements = [
+			{ key: '3' },
+			{},
+			{ key: '15' },
+			{},
+			{ key: '1' },
+		] as JSX.Element[];
+		const newList = reorderSortableProductAttributePositions(
+			elements,
+			attributeList
+		);
+		expect( newList.length ).toEqual( 3 );
+	} );
 } );

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/utils.spec.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/utils.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { ProductAttribute } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { reorderSortableProductAttributePositions } from '../utils';
+
+const attributeList: Record< number, ProductAttribute > = {
+	15: {
+		id: 15,
+		name: 'Automotive',
+		position: 0,
+		visible: true,
+		variation: false,
+		options: [ 'test' ],
+	},
+	1: {
+		id: 1,
+		name: 'Color',
+		position: 1,
+		visible: true,
+		variation: true,
+		options: [ 'Beige', 'black', 'Blue' ],
+	},
+	3: {
+		id: 3,
+		name: 'Random',
+		position: 2,
+		visible: true,
+		variation: true,
+		options: [ 'Beige', 'black', 'Blue' ],
+	},
+};
+
+describe( 'reorderSortableProductAttributePositions', () => {
+	it( 'should update product attribute positions depending on JSX.Element order', () => {
+		const elements = [
+			{ key: '3' },
+			{ key: '15' },
+			{ key: '1' },
+		] as JSX.Element[];
+		const newList = reorderSortableProductAttributePositions(
+			elements,
+			attributeList
+		);
+		expect( newList[ 0 ].position ).toEqual( 0 );
+		expect( newList[ 0 ].id ).toEqual( 3 );
+		expect( newList[ 1 ].position ).toEqual( 1 );
+		expect( newList[ 1 ].id ).toEqual( 15 );
+		expect( newList[ 2 ].position ).toEqual( 2 );
+		expect( newList[ 2 ].id ).toEqual( 1 );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
@@ -7,7 +7,7 @@ import { ProductAttribute } from '@woocommerce/data';
  * Updates the position of a product attribute from the new items JSX.Element list.
  *
  * @param { JSX.Element[] } items list of JSX elements coming back from sortable container.
- * @param { object } attributeKeyValues key value pair of product attributes.
+ * @param { Object } attributeKeyValues key value pair of product attributes.
  */
 export function reorderSortableProductAttributePositions(
 	items: JSX.Element[],
@@ -16,7 +16,7 @@ export function reorderSortableProductAttributePositions(
 	return items
 		.map( ( item, index ): ProductAttribute | undefined => {
 			const key = item.key ? parseInt( item.key as string, 10 ) : NaN;
-			if ( key !== NaN ) {
+			if ( key !== NaN && attributeKeyValues[ key ] ) {
 				return {
 					...attributeKeyValues[ key ],
 					position: index,

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { ProductAttribute } from '@woocommerce/data';
+
+/**
+ * Updates the position of a product attribute from the new items JSX.Element list.
+ *
+ * @param { JSX.Element[] } items list of JSX elements coming back from sortable container.
+ * @param { object } attributeKeyValues key value pair of product attributes.
+ */
+export function reorderSortableProductAttributePositions(
+	items: JSX.Element[],
+	attributeKeyValues: Record< number, ProductAttribute >
+): ProductAttribute[] {
+	return items
+		.map( ( item, index ): ProductAttribute | undefined => {
+			const key = item.key ? parseInt( item.key as string, 10 ) : NaN;
+			if ( key !== NaN ) {
+				return {
+					...attributeKeyValues[ key ],
+					position: index,
+				};
+			}
+			return undefined;
+		} )
+		.filter( ( attr ): attr is ProductAttribute => attr !== undefined );
+}

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.tsx
@@ -13,15 +13,21 @@ import { ProductFieldLayout } from './product-field-layout';
 type ProductSectionLayoutProps = {
 	title: string;
 	description: string | JSX.Element;
+	className?: string;
 };
 
 export const ProductSectionLayout: React.FC< ProductSectionLayoutProps > = ( {
 	title,
 	description,
+	className,
 	children,
 } ) => {
 	return (
-		<FormSection title={ title } description={ description }>
+		<FormSection
+			title={ title }
+			description={ description }
+			className={ className }
+		>
 			{ Children.map( children, ( child ) => {
 				if ( isValidElement( child ) && child.props.onChange ) {
 					return (

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.scss
@@ -1,6 +1,6 @@
 .woocommerce-product-attributes-section.woocommerce-form-section {
 	.woocommerce-form-section__content {
-		padding: 0px;
-		border: 0px;
+		padding: 0;
+		border: 0;
 	}
 }

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.scss
@@ -1,0 +1,6 @@
+.woocommerce-product-attributes-section.woocommerce-form-section {
+	.woocommerce-form-section__content {
+		padding: 0px;
+		border: 0px;
+	}
+}

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
@@ -10,20 +10,17 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import './attributes-section.scss';
 import { ProductSectionLayout } from '../layout/product-section-layout';
 import { AttributeField } from '../fields/attribute-field';
 
 export const AttributesSection: React.FC = () => {
-	const { getInputProps, values } = useFormContext< Product >();
-
-	// TODO: remove https://github.com/woocommerce/woocommerce/issues/34333 is done.
-	if ( values.attributes && values.attributes.length > 0 ) {
-		return null;
-	}
+	const { getInputProps } = useFormContext< Product >();
 
 	return (
 		<ProductSectionLayout
 			title={ __( 'Attributes', 'woocommerce' ) }
+			className="woocommerce-product-attributes-section"
 			description={
 				<>
 					<span>

--- a/plugins/woocommerce/changelog/add-34333_attribute_list
+++ b/plugins/woocommerce/changelog/add-34333_attribute_list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Expand attributes list to display attributes list and allow removal and re-ordering.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Expands the attributes field to support existing attributes, allows the re-ordering and removal of attributes.

Closes #34333  .

https://user-images.githubusercontent.com/2240960/192361050-6b666941-0e68-43ee-a857-3546620150d2.mp4

### How to test the changes in this Pull Request:

1. 1. Load this branch and enable the `new-product-management-experience` feature flag by using the WCA Test Helper (Tools > WCA Test Helper > Features) and refresh the page.
2. Create a product with several attributes in the old Product screen and keep track of the product id
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fproduct%2F1020`, replacing the `1020` at the end with your product id.
4. Make sure the attributes show up and match the design: [5sAIeTRd9Yp7nSCT33BAWz-fi-5180%3A129070](https://href.li/?https://www.figma.com/file/5sAIeTRd9Yp7nSCT33BAWz/?node-id=5180%3A129070), it should show the first 2 terms and after that a tag with `+ n more`
Note that the `edit` button is currently disabled as that functionality is part of another issue: https://github.com/woocommerce/woocommerce/issues/34332
5. Try re-ordering by dragging and dropping or by keyboard (using up and down arrows and space) and saving it, the order should persist on save and refresh
6. Try removing a attribute, it should show a browser alert with `Remove this attribute?`, this should remove if you click `ok` and not if you click `cancel`.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
