### PR TITLE
Fix enable guided mode button not trigger when its text is translated

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/add-product-tour/utils.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-tour/utils.ts
@@ -23,13 +23,9 @@ export const waitUntilElementTopNotChange = (
 export const bindEnableGuideModeClickEvent = (
 	onClick: EventListenerOrEventListenerObject
 ) => {
-	const enableGuideModeBtn = Array.from(
-		window.document.querySelectorAll( '.page-title-action' )
-	).find( ( el ) => el.textContent === 'Enable guided mode' );
-
-	if ( enableGuideModeBtn ) {
-		enableGuideModeBtn.addEventListener( 'click', onClick );
-	}
+	window.document
+		.querySelector( '.wp-heading-inline + .page-title-action' )
+		?.addEventListener( 'click', onClick );
 };
 
 // Add listener to product "Publish" button.

--- a/plugins/woocommerce/changelog/fix-34760-enable-guided-mode-button
+++ b/plugins/woocommerce/changelog/fix-34760-enable-guided-mode-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix enable guided mode button not trigger when its text is translated


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34760.

> Enable guided mode button will not trigger when its text is translated

This PR fixes it by using a class selector directly.

### How to test the changes in this Pull Request:

1. Navigate to `Tools > WCA Test Helper > Experiments`
2. Set`woocommerce_products_task_layout_card_v3` and `woocommerce_products_task_layout_stacked_v3` to **control**
3. Set `woocommerce_products_tour` to **treatment**
4. Change your site language to `Español` on Setting page
5. Go to `Escritorio > Actualizaciones` (/wp-admin/update-core.php)
6. Click on `Actualizar las traducciones` button to download woocommerce transalation
7. Go to WooCommerce > Home > "Añadir products" (Add products) task
8. Select `Empieza con una plantilla` > `Producto físico` (Physical product) and click "go"
9. Dismiss product spotlight tour
10. Click on `Activar el modo guiado`  button
11. Observe that the product spotlight tour is shown again.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
