### PR TITLE
Fix industry options not populate after reloading page

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -46,6 +46,7 @@ class Industry extends Component {
 	constructor( props ) {
 		const profileItems = get( props, 'profileItems', {} );
 		let selected = profileItems.industry || [];
+
 		/**
 		 * @todo Remove block on `updateProfileItems` refactor to wp.data dataStores.
 		 *

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -9,6 +9,7 @@ import {
 	CardBody,
 	CardFooter,
 	CheckboxControl,
+	Spinner,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { filter, find, findIndex, get } from 'lodash';
@@ -26,11 +27,25 @@ import { getAdminSetting } from '~/utils/admin-settings';
 
 const onboarding = getAdminSetting( 'onboarding', {} );
 
+const Loader = ( props ) => {
+	if ( props.isLoading ) {
+		return (
+			<div
+				className="woocommerce-admin__industry__spinner"
+				style={ { textAlign: 'center' } }
+			>
+				<Spinner />
+			</div>
+		);
+	}
+
+	return <Industry { ...props } />;
+};
+
 class Industry extends Component {
 	constructor( props ) {
 		const profileItems = get( props, 'profileItems', {} );
 		let selected = profileItems.industry || [];
-
 		/**
 		 * @todo Remove block on `updateProfileItems` refactor to wp.data dataStores.
 		 *
@@ -287,9 +302,16 @@ class Industry extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getProfileItems, getOnboardingError, isOnboardingRequesting } =
-			select( ONBOARDING_STORE_NAME );
-		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const {
+			getProfileItems,
+			getOnboardingError,
+			isOnboardingRequesting,
+			hasFinishedResolution: hasOnboardingFinishedResolution,
+		} = select( ONBOARDING_STORE_NAME );
+		const {
+			getSettings,
+			hasFinishedResolution: hasSettingsFinishedResolution,
+		} = select( SETTINGS_STORE_NAME );
 		const { general: locationSettings = {} } = getSettings( 'general' );
 
 		return {
@@ -298,6 +320,9 @@ export default compose(
 			locationSettings,
 			isProfileItemsRequesting:
 				isOnboardingRequesting( 'updateProfileItems' ),
+			isLoading:
+				! hasOnboardingFinishedResolution( 'getProfileItems', [] ) ||
+				! hasSettingsFinishedResolution( 'getSettings', [ 'general' ] ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
@@ -309,4 +334,4 @@ export default compose(
 			updateProfileItems,
 		};
 	} )
-)( Industry );
+)( Loader );

--- a/plugins/woocommerce/changelog/fix-34765-industry-reloading-page
+++ b/plugins/woocommerce/changelog/fix-34765-industry-reloading-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Industry" options fails to save in the Industry step after reloading the page for OBW


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34765.

This PR adds wrap Industry in a loader component to ensure it's rendered after all required data are fetched to populate checkboxes properly.

It doesn't show selected options because the options are populated in the constructor when profile items are loading.

https://github.com/woocommerce/woocommerce/blob/0a021730dc0c12e13d4e8054d4262673b62c4b32/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js#L46-L48

### How to test the changes in this Pull Request:

1. Go to OBW
2. Fill store details and click on "continue" button.
3. On "Industry" tab select one or more option and click on "continue" button.
4. Click on previous "Industry" tab.
5. Reload the page
6. Observe that selected "Industry" options are shown in the Industry step after reloading the page for OBW.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
