### PR TITLE
Fix/json order > line_items > image schema

### DIFF
--- a/plugins/woocommerce/changelog/fix-json-product-image
+++ b/plugins/woocommerce/changelog/fix-json-product-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix JSON schema for product's image properties.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1512,7 +1512,6 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'properties'  => array(
-									'type'       => 'object',
 									'properties' => array(
 										'id'  => array(
 											'description' => __( 'Image ID.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1512,18 +1512,16 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 								'properties'  => array(
-									'properties' => array(
-										'id'  => array(
-											'description' => __( 'Image ID.', 'woocommerce' ),
-											'type'        => 'integer',
-											'context'     => array( 'view', 'edit' ),
-										),
-										'src' => array(
-											'description' => __( 'Image URL.', 'woocommerce' ),
-											'type'        => 'string',
-											'format'      => 'uri',
-											'context'     => array( 'view', 'edit' ),
-										),
+									'id'  => array(
+										'description' => __( 'Image ID.', 'woocommerce' ),
+										'type'        => 'integer',
+										'context'     => array( 'view', 'edit' ),
+									),
+									'src' => array(
+										'description' => __( 'Image URL.', 'woocommerce' ),
+										'type'        => 'string',
+										'format'      => 'uri',
+										'context'     => array( 'view', 'edit' ),
 									),
 								),
 							),


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes JSON schema: properties is not an object, it just lists values that are included in the image object itself. Reported by 3rd party extension dev.

### How to test the changes in this Pull Request:

1. Get the JSON schema for the endpoint, e.g. via OPTIONS request to `.../wp-json/wc/v3/orders`
2. See the properties under image no longer have nested properties with type object, but it's just a plain list of properties for the image object.
![Screenshot 2022-09-27 at 15 17 41](https://user-images.githubusercontent.com/2207451/192537108-a349643b-6073-4c5e-bef3-80e00fcf9fd8.png)
4. Check the GET response for an order with a product that has an image and confirm it's unchanged/still valid.
![Screenshot 2022-09-27 at 15 20 05](https://user-images.githubusercontent.com/2207451/192537591-d4726380-a87b-45e4-9318-86ff026f5762.png)
(In case of no image, both properties are empty strings)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
