### PR TITLE
[HPOS] Add hooks that fire before an order is trashed/deleted.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34231-before-delete-hooks
+++ b/plugins/woocommerce/changelog/fix-34231-before-delete-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add hooks that fire before an HPOS order is deleted or trashed.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1236,12 +1236,32 @@ LEFT JOIN {$operational_data_clauses['join']}
 				return;
 			}
 
+			/**
+			 * Fires immediately before an order is deleted from the database.
+			 *
+			 * @since 7.1.0
+			 *
+			 * @param int      $order_id ID of the order about to be deleted.
+			 * @param WC_Order $order    Instance of the order that is about to be deleted.
+			 */
+			do_action( 'woocommerce_before_delete_order', $order_id, $order );
+
 			// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
 			// Once we stop creating posts for orders, we should do the cleanup here instead.
 			wp_delete_post( $order_id );
 
 			do_action( 'woocommerce_delete_order', $order_id ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		} else {
+			/**
+			 * Fires immediately before an order is trashed.
+			 *
+			 * @since 7.1.0
+			 *
+			 * @param int      $order_id ID of the order about to be deleted.
+			 * @param WC_Order $order    Instance of the order that is about to be deleted.
+			 */
+			do_action( 'woocommerce_before_trash_order', $order_id, $order );
+
 			$this->trash_order( $order );
 
 			do_action( 'woocommerce_trash_order', $order_id ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment


### PR DESCRIPTION
New hooks are:

1. `woocommerce_before_delete_order`
2. `woocommerce_before_trash_order`

These fire immediately before an (HPOS) order is deleted or trashed, and act as analogs to `delete_post` and `wp_trash_post` in the case of CPT objects.

Closes #34231.

### How to test the changes in this Pull Request:

It should be sufficient to review the code, there are no functional differences (since there is no code within core that uses these new actions).

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
