### PR TITLE
Immediately propagate changes to orders (from CPT → COT).

### DIFF
--- a/plugins/woocommerce/changelog/fix-33157-update-cot-when-cpt-authoritative
+++ b/plugins/woocommerce/changelog/fix-33157-update-cot-when-cpt-authoritative
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+When the primary order store is the posts table, and sync is enabled, propagate changes outside of dedicated migrations.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -66,6 +66,17 @@ class DataSynchronizer implements BatchProcessorInterface {
 			10,
 			2
 		);
+
+		// When posts is authoritative and sync is enabled, updating a post triggers a corresponding change in the COT table.
+		add_action(
+			'woocommerce_update_order',
+			function ( $order_id ) {
+				if ( ! $this->custom_orders_table_is_authoritative() && $this->data_sync_is_enabled() ) {
+					$this->posts_to_cot_migrator->migrate_orders( array( $order_id ) );
+				}
+			},
+			100
+		);
 	}
 
 	/**


### PR DESCRIPTION
When the post store is primary, and when sync is enabled, any changes to orders should immediately be propagated to the COT store, to avoid possible race conditions as described in the linked issue.

Closes #33157.

### How to test the changes in this Pull Request:

1. Review added test.
2. Optionally, comment out the [newly added callback](https://github.com/woocommerce/woocommerce/compare/fix/33157-update-cot-when-cpt-authoritative?expand=1#diff-1e070cc170d3b65cd6ba61b60cbd0697c8431fda674b4720926c8fbc1afecce7R71-R79) and re-run the newly added test to see it fail.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
