### PR TITLE
Allow features to declare a default 'enabled' state

### DIFF
--- a/plugins/woocommerce/changelog/fix-34866
+++ b/plugins/woocommerce/changelog/fix-34866
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow features to declare their initial enabled state.

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -8,7 +8,6 @@ namespace Automattic\WooCommerce\Admin\Features;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Internal\Admin\Loader;
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 
 /**
  * Features Class.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -57,10 +57,11 @@ class FeaturesController {
 	 */
 	public function __construct() {
 		$features = array(
-			'analytics'           => array(
-				'name'            => __( 'Analytics', 'woocommerce' ),
-				'description'     => __( 'Enables WooCommerce Analytics', 'woocommerce' ),
-				'is_experimental' => false,
+			'analytics'              => array(
+				'name'               => __( 'Analytics', 'woocommerce' ),
+				'description'        => __( 'Enables WooCommerce Analytics', 'woocommerce' ),
+				'is_experimental'    => false,
+				'enabled_by_default' => true,
 			),
 			'new_navigation'      => array(
 				'name'            => __( 'Navigation', 'woocommerce' ),
@@ -163,7 +164,22 @@ class FeaturesController {
 	 * @return bool True if the feature is enabled, false if not or if the feature doesn't exist.
 	 */
 	public function feature_is_enabled( string $feature_id ): bool {
-		return $this->feature_exists( $feature_id ) && 'yes' === get_option( $this->feature_enable_option_name( $feature_id ) );
+		if ( ! $this->feature_exists( $feature_id ) ) {
+			return false;
+		}
+
+		$default_value = $this->feature_is_enabled_by_default( $feature_id ) ? 'yes' : 'no';
+		return 'yes' === get_option( $this->feature_enable_option_name( $feature_id ), $default_value );
+	}
+
+	/**
+	 * Check if a given feature is enabled by default.
+	 *
+	 * @param string $feature_id Unique feature id.
+	 * @return boolean TRUE if the feature is enabled by default, FALSE otherwise.
+	 */
+	private function feature_is_enabled_by_default( string $feature_id ): bool {
+		return ! empty( $this->features[ $feature_id ]['enabled_by_default'] );
 	}
 
 	/**
@@ -502,6 +518,7 @@ class FeaturesController {
 			'id'       => $this->feature_enable_option_name( $feature_id ),
 			'class'    => $disabled ? 'disabled' : '',
 			'desc_tip' => $desc_tip,
+			'default'  => $this->feature_is_enabled_by_default( $feature_id ) ? 'yes' : 'no',
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Features in the new `FeaturesController` can't declare their default state (i.e. enabled or disabled), which means the checkboxes on WC > Settings > Advanced > Features do not work for certain features, for example, _Analytics_ which is enabled by default.

Closes #34866.

### How to test the changes in this Pull Request:

1. Delete the `woocommerce_analytics_enabled` option from the database (if it exists).
2. You should see the "Analytics" menu item, meaning it's actually enabled.
3. Go to WC > Settings > Advanced > Features.
4.
   - On WC < 7.x (say, 6.9.4), you should see that the checkbox is correctly checked off.
   - On `trunk` you'll see the checkbox is not checked off, despite the "Analytics" menu showing.
   - On this branch (fix/34866) the checkbox should be checked off.
5. On any branch, clicking "Save Changes" should persist the choice (either on or off).

The API should also reflect the correct enabled/disabled states:

```php
use Automattic\WooCommerce\Utilities\FeaturesUtil;

delete_option( 'woocommerce_analytics_enabled' );
var_dump( FeaturesUtil::feature_is_enabled( 'analytics' ) ); // true (default)

update_option( 'woocommerce_analytics_enabled', 'no' );
var_dump( FeaturesUtil::feature_is_enabled( 'analytics' ) ); // false

update_option( 'woocommerce_analytics_enabled', 'yes' );
var_dump( FeaturesUtil::feature_is_enabled( 'analytics' ) ); // true
```

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
