### PR TITLE
Honor query args when redirecting from posts to HPOS list table

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -73,6 +73,7 @@ class PostsRedirectionController {
 		}
 
 		$new_url = $this->page_controller->get_orders_url();
+		$new_url = add_query_arg( $query_args, $new_url );
 
 		// Handle bulk actions.
 		if ( $action && in_array( $action, array( 'trash', 'untrash', 'delete', 'mark_processing', 'mark_on-hold', 'mark_completed', 'mark_cancelled' ), true ) ) {


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes an issue detecting by internal testing: pb22l9-1xy-p2#comment-1556, where query args weren't being preserved when redirecting from the posts table to the HPOS list table.

### How to test the changes in this Pull Request:
Same instructions as #34644, with emphasis on these two tests:

-  `/wp-admin/edit.php?post_status=wc-pending&post_type=shop_order` should take you to the main order screen with `status=wc-pending`.
- `/wp-admin/edit.php?s&post_status=all&post_type=shop_order&action=-1&m=202208&_customer_user&filter_action=Filter&paged=1&action2=-1` should take you to the main order screen with all query args still present (and thus, with the date filter active to Aug 2022).

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
