### PR TITLE
[HPOS/COT] Ensure date_creation_gmt is correctly populated with a GMT datetime

### DIFF
--- a/plugins/woocommerce/changelog/fix-34874-cot-order-creation-gmt
+++ b/plugins/woocommerce/changelog/fix-34874-cot-order-creation-gmt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+(HPOS) Ensure we use GMT when populating the `date_created_gmt` column for orders.

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -5,6 +5,9 @@
 
 namespace Automattic\WooCommerce\Internal\Utilities;
 
+use DateTime;
+use DateTimeZone;
+
 /**
  * A class of utilities for dealing with the database.
  */
@@ -157,10 +160,12 @@ AND index_name='$index_name'"
 				$value = strval( $value );
 				break;
 			case 'date':
-				$value = $value ? ( new \DateTime( $value ) )->format( 'Y-m-d H:i:s' ) : null;
+				// Date properties are converted to the WP timezone (see WC_Data::set_date_prop() method), however
+				// for our own tables we persist dates in GMT.
+				$value = $value ? ( new DateTime( $value ) )->setTimezone( new DateTimeZone( '+00:00' ) )->format( 'Y-m-d H:i:s' ) : null;
 				break;
 			case 'date_epoch':
-				$value = $value ? ( new \DateTime( "@{$value}" ) )->format( 'Y-m-d H:i:s' ) : null;
+				$value = $value ? ( new DateTime( "@{$value}" ) )->format( 'Y-m-d H:i:s' ) : null;
 				break;
 			default:
 				throw new \Exception( 'Invalid type received: ' . $type );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -6,7 +6,6 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
-use DateTime;
 
 /**
  * Class OrdersTableDataStoreTests.
@@ -329,16 +328,28 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * Confirm we store the order creation date in GMT.
 	 */
 	public function test_order_dates_are_gmt(): void {
+		global $wpdb;
+
 		// Switch to the COT datastore, set WordPress to use a non-UTC timezone, and create a new order.
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
 		update_option( 'timezone_string', 'America/Los_Angeles' );
-		$order = OrderHelper::create_order();
 
-		// We tolerate a 20 second difference to account for pauses during test execution.
-		$this->assertLessThan(
-			20,
-			$order->get_date_created()->getTimestamp() - $order->get_date_created()->getOffsetTimestamp(),
-			'Date created field is set to GMT, therefore the timestamp and offset timestamp are identical.'
+		$order            = OrderHelper::create_order();
+		$date_created_gmt = $wpdb->get_var(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			'SELECT date_created_gmt FROM ' . OrdersTableDataStore::get_orders_table_name() . ' WHERE id = ' . $order->get_id()
+		);
+
+		$this->assertNotEquals(
+			$date_created_gmt,
+			$order->get_date_created()->format( 'Y-m-d H:i:s' ),
+			'The creation date in the database should be in GMT, but the retrieved datetime should be in the local WP timezone.'
+		);
+
+		$this->assertEquals(
+			$date_created_gmt,
+			$order->get_date_created()->setTimezone( new DateTimeZone( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
+			'The order creation datetime, when cast to UTC/GMT, should match the same value stored in the database.'
 		);
 	}
 


### PR DESCRIPTION
When the HPOS data-store is in use, a newly created order may be stored with the wrong creation date: this should be GMT, but it seems possible for it to be stored in whatever the WP timezone is.

### Steps to replicate

1. Enable COT/HPOS.
2. Via **Settings ▸ General** set your WP timezone to `America/Vancouver` or some other non-GMT timezone.
3. As a customer, create a new order.
4. As an admin user, promptly visit **WooCommerce ▸ Orders** and look at the new entry in the list table. In the date column, we could reasonably expect to see something like *"Created 10 seconds ago"* but in fact we will see a displacement such as *"Created 7 hours ago"* (if you were to select `America/Vancouver`, at least):

<img width="650" alt="hpos-cot-order-date-created" src="https://user-images.githubusercontent.com/3594411/192921571-db7bf5ac-0fea-47d9-9921-8fb6458f2c52.png">

6. Similarly, if you inspect the corresponding row of the `wp_wc_orders` table, you will see the entry in the `date_created_gmt` column is close to the current time as per the WP timezone setting.
With this branch checked out, however, the problem should not occur.

Closes #34874.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
