### PR TITLE
Fix/test env setup set customer registered datetime

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-env-setup-set-customer-registered-datetime
+++ b/plugins/woocommerce/changelog/fix-test-env-setup-set-customer-registered-datetime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes test environment setup setting datetime for customer user creation

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -15,7 +15,8 @@ wp-env run tests-cli "wp user create customer customer@woocommercecoree2etestsui
 	--role=subscriber \
 	--first_name='Jane' \
 	--last_name='Smith' \
-	--path=/var/www/html
+	--path=/var/www/html \
+	--user_registered='2022-01-01 12:23:45'
 "
 
 echo -e 'Update Blog Name \n'


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change adds a `user_registered` property when adding the `customer` user during test environment creation.  Before the value was getting set to `0000-00-00 00:00:00` which was throwing an error when accessing the customer via the REST API

### How to test the changes in this Pull Request:

1. Pull branch
2. Spin up a test environment using `pnpm run env:test --filter=woocommerce`
3. Once complete, sign in to the admin and verify that the `customer` user exists
4. Access the database (you can use the phpMyAdmin plugin) and confirm that there is a valid datetime for the customer user in the `wp_users` table.
5. Add a REST API token under WooCommerce > Settings > REST API and try making a `GET` request to http://localhost:8086/wp-json/wc/v3/customers/2 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
