### PR TITLE
Fix wrong payment tasks display logic

### DIFF
--- a/plugins/woocommerce/changelog/fix-payment-task-display-problem
+++ b/plugins/woocommerce/changelog/fix-payment-task-display-problem
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the wc pay view logic so that we don't display it even when payment task is completed

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -87,9 +87,9 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		$has_task_list_previously_completed = ( new TaskList( array( 'id' => 'setup' ) ) )->has_previously_completed();
+		$payments = $this->task_list->get_task( 'payments' );
 
-		return ! $has_task_list_previously_completed && // Do not re-display the task if the task list has already been completed.
+		return ! $payments->is_complete() && // Do not re-display the task if the "add payments" task has already been completed.
 			self::is_installed() &&
 			self::is_supported() &&
 			( $this->get_parent_id() !== 'setup_two_column' || ! self::is_connected() );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34893 .

This PR fixes the wrong payment task display logic.

- `Set up payments` should not be displayed when WC pay task is completed and vice versa.

Test zip: https://github.com/woocommerce/woocommerce/actions/runs/3156126725

### How to test the changes in this Pull Request:

1. Go to OBW
2. Choose US as store country in the step 1
3. Complete OBW with WCPay installed.
4. Go to `WooCommerce > Home`
5. Complete `Set up WooCommerce Payments` task
6. Complete the remaining tasks on task list
7. When task list is completed, please enable the task list again
8. Observe that `Set up WooCommerce Payments` task is still displayed and marked as completed while `Set up payments` task is not shown.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
