### PR TITLE
Add "aria-disabled" prop to truly disable OBW continue buttons

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -627,6 +627,7 @@ class BusinessDetails extends Component {
 											this.persistProfileItems();
 										} }
 										disabled={ ! isValidForm }
+										aria-disabled={ ! isValidForm }
 										isBusy={ isInstallingActivating }
 									>
 										{ ! hasInstallActivateError

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -291,6 +291,9 @@ class Industry extends Component {
 							disabled={
 								! selected.length || isProfileItemsRequesting
 							}
+							aria-disabled={
+								! selected.length || isProfileItemsRequesting
+							}
 						>
 							{ __( 'Continue', 'woocommerce' ) }
 						</Button>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
@@ -286,6 +286,11 @@ export class ProductTypes extends Component {
 								isProfileItemsRequesting ||
 								isInstallingActivating
 							}
+							aria-disabled={
+								! selected.length ||
+								isProfileItemsRequesting ||
+								isInstallingActivating
+							}
 						>
 							{ __( 'Continue', 'woocommerce' ) }
 						</Button>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/test/__snapshots__/index.js.snap
@@ -128,6 +128,7 @@ you can purchase and install it later.
           data-wp-component="CardFooter"
         >
           <button
+            aria-disabled="true"
             class="components-button is-primary"
             disabled=""
             type="button"
@@ -323,6 +324,7 @@ you can purchase and install it later.
           data-wp-component="CardFooter"
         >
           <button
+            aria-disabled="true"
             class="components-button is-primary"
             disabled=""
             type="button"

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/index.js
@@ -376,6 +376,7 @@ export class StoreDetails extends Component {
 									onClick={ handleSubmit }
 									isBusy={ isBusy }
 									disabled={ ! isValidForm || isBusy }
+									aria-disabled={ ! isValidForm || isBusy }
 								>
 									{ __( 'Continue', 'woocommerce' ) }
 								</Button>

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/store-details/test/__snapshots__/index.js.snap
@@ -288,6 +288,7 @@ Object {
               data-wp-component="CardFooter"
             >
               <button
+                aria-disabled="true"
                 class="components-button is-primary"
                 disabled=""
                 type="button"
@@ -601,6 +602,7 @@ Object {
             data-wp-component="CardFooter"
           >
             <button
+              aria-disabled="true"
               class="components-button is-primary"
               disabled=""
               type="button"

--- a/plugins/woocommerce/changelog/fix-33986-obw-validation-issue
+++ b/plugins/woocommerce/changelog/fix-33986-obw-validation-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix obw validation issue to truly disable the continue buttons


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33986.

This PR fixes the confusing UI when clicking the disabled "Continue" button during OBW.

Before:

https://user-images.githubusercontent.com/94531721/181192036-a3074b29-82c5-439c-a6c1-0f0d8e1f1f58.mp4

After:

https://user-images.githubusercontent.com/4344253/192672052-be097f80-1746-486b-9cf1-7a3eb685aba0.mov

### How to test the changes in this Pull Request:

1. Go to OBW
2. Click "Continue" and confirm that it's disabled completely.
3. Select a Country and go to the next step
4. Click "Continue" and confirm that it's disabled completely.
5. Select an industry and go to the next step
6. Uncheck `Physical products` option
7. Click "Continue" and confirm that it's disabled completely.
8. Select a products type and go to the next step
9. Click "Continue" and confirm that it's disabled completely.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
