### PR TITLE
Render columns via action so that they can be hooked into

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-add_column_filter
+++ b/plugins/woocommerce/changelog/enhancement-add_column_filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Render columns via action so that they can be hooked into.

--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -173,49 +173,49 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * Render column: order_number.
 	 */
 	protected function render_order_number_column() {
-		$this->orders_list_table->column_order_number( $this->object );
+		$this->orders_list_table->render_order_number_column( $this->object );
 	}
 
 	/**
 	 * Render column: order_status.
 	 */
 	protected function render_order_status_column() {
-		$this->orders_list_table->column_order_status( $this->object );
+		$this->orders_list_table->render_order_status_column( $this->object );
 	}
 
 	/**
 	 * Render column: order_date.
 	 */
 	protected function render_order_date_column() {
-		$this->orders_list_table->column_order_date( $this->object );
+		$this->orders_list_table->render_order_date_column( $this->object );
 	}
 
 	/**
 	 * Render column: order_total.
 	 */
 	protected function render_order_total_column() {
-		$this->orders_list_table->column_order_total( $this->object );
+		$this->orders_list_table->render_order_total_column( $this->object );
 	}
 
 	/**
 	 * Render column: wc_actions.
 	 */
 	protected function render_wc_actions_column() {
-		$this->orders_list_table->column_wc_actions( $this->object );
+		$this->orders_list_table->render_wc_actions_column( $this->object );
 	}
 
 	/**
 	 * Render column: billing_address.
 	 */
 	protected function render_billing_address_column() {
-		$this->orders_list_table->column_billing_address( $this->object );
+		$this->orders_list_table->render_billing_address_column( $this->object );
 	}
 
 	/**
 	 * Render column: shipping_address.
 	 */
 	protected function render_shipping_address_column() {
-		$this->orders_list_table->column_shipping_address( $this->object );
+		$this->orders_list_table->render_shipping_address_column( $this->object );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -72,6 +72,23 @@ class ListTable extends WP_List_Table {
 
 		$this->items_per_page();
 		set_screen_options();
+		add_action( 'manage_' . wc_get_page_screen_id( 'shop-order' ) . '_custom_column', array( $this, 'render_column' ), 10, 2 );
+	}
+
+	/**
+	 * Render individual column.
+	 *
+	 * @param string   $column_id Column ID to render.
+	 * @param WC_Order $order Order object.
+	 */
+	public function render_column( $column_id, $order ) {
+		if ( ! $order ) {
+			return;
+		}
+
+		if ( is_callable( array( $this, 'render_' . $column_id . '_column' ) ) ) {
+			call_user_func( array( $this, 'render_' . $column_id . '_column' ), $order );
+		}
 	}
 
 	/**
@@ -604,7 +621,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_number( WC_Order $order ): void {
+	public function render_order_number_column( WC_Order $order ): void {
 		$buyer = '';
 
 		if ( $order->get_billing_first_name() || $order->get_billing_last_name() ) {
@@ -653,7 +670,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_date( WC_Order $order ): void {
+	public function render_order_date_column( WC_Order $order ): void {
 		$order_timestamp = $order->get_date_created() ? $order->get_date_created()->getTimestamp() : '';
 
 		if ( ! $order_timestamp ) {
@@ -686,7 +703,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_status( WC_Order $order ): void {
+	public function render_order_status_column( WC_Order $order ): void {
 		$tooltip                 = '';
 		$comment_count           = get_comment_count( $order->get_id() );
 		$approved_comments_count = absint( $comment_count['approved'] );
@@ -734,7 +751,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_billing_address( WC_Order $order ): void {
+	public function render_billing_address_column( WC_Order $order ): void {
 		$address = $order->get_formatted_billing_address();
 
 		if ( $address ) {
@@ -756,7 +773,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_shipping_address( WC_Order $order ): void {
+	public function render_shipping_address_column( WC_Order $order ): void {
 		$address = $order->get_formatted_shipping_address();
 
 		if ( $address ) {
@@ -777,7 +794,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_order_total( WC_Order $order ): void {
+	public function render_order_total_column( WC_Order $order ): void {
 		if ( $order->get_payment_method_title() ) {
 			/* translators: %s: method */
 			echo '<span class="tips" data-tip="' . esc_attr( sprintf( __( 'via %s', 'woocommerce' ), $order->get_payment_method_title() ) ) . '">' . wp_kses_post( $order->get_formatted_order_total() ) . '</span>';
@@ -793,7 +810,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function column_wc_actions( WC_Order $order ): void {
+	public function render_wc_actions_column( WC_Order $order ): void {
 		echo '<p>';
 
 		/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

n the post-table implementation, all the column rendering methods are called via hooks, which is not the case anymore with HPOS. In HPOS, they are called directly. Therefore there is no option to modify the values in the columns (Or insert values before/after).

This PR changes how the render column function is called to provide the same extensibility as before.

Closes #34899.

### How to test the changes in this Pull Request:

For posts and HPOS, check that order list table is rendered as expected one by one.

Then to test that action works, add this code somewhere:
```php

add_action( 'manage_woocommerce_page_wc-orders_custom_column', function( $column_name ) {

	if ( $column_name === 'order_number' ) {
		echo 'It works.';
	}

 } );
```

After adding above code snippet, then if HPOS is active, you should see `It works` string in the order number column, where in when posts is active then you won't see this string.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
