### PR TITLE
Replace expired token with generic GH token

### DIFF
--- a/.github/workflows/triage-replies.yml
+++ b/.github/workflows/triage-replies.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Add developer feedback comment
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -33,7 +33,7 @@ jobs:
       - name: Add needs reproduction comment
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -52,7 +52,7 @@ jobs:
       - name: Add support request comment
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -75,7 +75,7 @@ jobs:
       - name: Close support request issue
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.update({
                   owner: context.repo.owner,
@@ -92,7 +92,7 @@ jobs:
       - name: Add votes needed comment
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -110,7 +110,7 @@ jobs:
       - name: Close votes needed issue
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.update({
                   owner: context.repo.owner,
@@ -127,7 +127,7 @@ jobs:
       - name: Add reply to fill template
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -157,10 +157,10 @@ jobs:
       - name: remove-needs-template-label
         uses: actions-ecosystem/action-remove-labels@v1
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'needs: template'
       - name: add-needs-author-feedback-label
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          github-token: ${{ secrets.WC_BOT_TRIAGE_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'needs: author feedback'


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We currently have failing triage replies workflows due to expired tokens. Instead, we could use generic GH token to do the job and not have to worry about them expiring in the future.

### How to test the changes in this Pull Request:

1. Merge, Wait and see :)
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
