### PR TITLE
Remove failing jobs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,31 +27,3 @@ jobs:
           asset_path: plugins/woocommerce/woocommerce.zip
           asset_name: woocommerce.zip
           asset_content_type: application/zip
-  update-code-reference:
-    if: github.event.release.prerelease == false && github.event.release.draft == false && github.repository_owner == 'woocommerce'
-    name: Update Code Reference
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Invoke Code Reference build and deploy workflow
-        uses: aurelien-baudet/workflow-dispatch@v2
-        with:
-          workflow: GitHub Pages deploy
-          repo: woocommerce/code-reference
-          token: ${{ secrets.CUSTOM_GH_TOKEN }}
-          ref: refs/heads/trunk
-          inputs: '{ "version": "${{ github.event.release.tag_name }}" }'
-  run-release-smoke-tests:
-    name: Execute Smoke test release
-    needs: build
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Invoke release smoke testing workflow
-        uses: aurelien-baudet/workflow-dispatch@v2
-        with:
-          workflow: Smoke test release
-          repo: ${{ github.repository }}
-          token: ${{ secrets.E2E_WORKFLOW_GH_TOKEN }}
-          ref: refs/heads/trunk
-          inputs: '{ "release_id": "${{ github.event.release.id }}" }'
-


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/34662

Currently this workflow is disabled because of some failing jobs. But we want it to run at least the `Build release asset` job. This I believe is working. The other two I've removed as I think they are not relevant at this point. The `Code reference` site has not been updated for a long time and the `smoke test` has been failing for a long time which tells me it obviously is not that important. In addition we have smoke test running in other places already.

### How to test the changes in this Pull Request:

1. Create a temporary pre-release. Use something that is not already created or published. Try 1.0.99 for release and tag.
2. Ensure the zip package asset is created for that release. 
3. Delete the pre-release and the tag afterwards.
4.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
