### PR TITLE
Remove the pre-commit husky hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-pnpm exec lint-staged


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This removes the pre-commit husky hook, which for many people causes a lot of friction in development. Sometimes you want to make a commit before you're ready to run lint or tests, and sometimes it just feels too slow to wait on a check you already confirmed during development. It can also get in the way so much when you're trying to do git history manipulation. Additionally CI does all these checks for you anyway when creating a PR.

### How to test the changes in this Pull Request:

1. Checkout this branch
2. Add a random change.
3. Peform a commit and see no precommit hook happens


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
