### PR TITLE
Fix: can't place orders for Saint Martin

### DIFF
--- a/plugins/woocommerce/changelog/fix-34911
+++ b/plugins/woocommerce/changelog/fix-34911
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: can't place orders for Saint Martin (French part)

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -1238,6 +1238,12 @@ class WC_Countries {
 							'hidden'   => true,
 						),
 					),
+					'MF' => array(
+						'state' => array(
+							'required' => false,
+							'hidden'   => true,
+						),
+					),
 					'MQ' => array(
 						'state' => array(
 							'required' => false,


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce/issues/34911 by completing the change implemented in https://github.com/woocommerce/woocommerce/pull/34014

Closes #34911.

### How to test the changes in this Pull Request:

In WooCommerce 7.0 RC try to place and order with _Saint Martin (French part)_ as the country in the billing of shipping address. Without the fix you'll get a "State is required" error and you're stuck. With the fix the order is placed successfully.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
