### PR TITLE
Support `wc_customer_bought_product` for hpos.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34775
+++ b/plugins/woocommerce/changelog/fix-34775
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Support `wc_customer_bought_product` function in HPOS.

--- a/plugins/woocommerce/tests/php/helpers/HPOSToggleTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/HPOSToggleTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Automattic\WooCommerce\RestApi\UnitTests;
+
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use WC_Data_Store;
+
+/**
+ * Trait HPOSToggleTrait.
+ *
+ * Provides methods to toggle the HPOS feature on and off.
+ */
+trait HPOSToggleTrait {
+
+	/**
+	 * Call in setUp to enable COT/HPOS.
+	 *
+	 * @return void
+	 */
+	public function setup_cot() {
+		// Remove the Test Suite’s use of temporary tables https://wordpress.stackexchange.com/a/220308.
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+		OrderHelper::delete_order_custom_tables();
+		OrderHelper::create_order_custom_table_if_not_exist();
+
+		$this->toggle_cot( true );
+	}
+
+	/**
+	 * Call in teardown to disable COT/HPOS.
+	 */
+	public function clean_up_cot_setup(): void {
+		$this->toggle_cot( false );
+
+		// Add back removed filter.
+		add_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+	}
+
+	/**
+	 * Enables or disables the custom orders table across WP temporarily.
+	 *
+	 * @param boolean $enabled TRUE to enable COT or FALSE to disable.
+	 * @return void
+	 */
+	private function toggle_cot( bool $enabled ): void {
+		$features_controller = wc_get_container()->get( Featurescontroller::class );
+		$features_controller->change_feature_enable( 'custom_order_tables', true );
+
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, wc_bool_to_string( $enabled ) );
+
+		// Confirm things are really correct.
+		$wc_data_store = WC_Data_Store::load( 'order' );
+		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -8,17 +8,26 @@ use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 	use HPOSToggleTrait;
 
+	/**
+	 * Setup COT.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 		$this->setup_cot();
 		$this->toggle_cot( false );
 	}
 
+	/**
+	 * Clean COT specific things.
+	 */
 	public function tearDown(): void {
 		parent::tearDown();
 		$this->clean_up_cot_setup();
 	}
 
+	/**
+	 * Test wc_get_customer_order_count. Borrowed from `WC_Tests_Customer_Functions` class for COT.
+	 */
 	public function test_hpos_wc_customer_bought_product() {
 		$this->toggle_cot( true );
 		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -1,0 +1,52 @@
+<?php
+
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+
+/**
+ * Tests for the WC_User class.
+ */
+class WC_User_Functions_Tests extends WC_Unit_Test_Case {
+	use HPOSToggleTrait;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->setup_cot();
+		$this->toggle_cot( false );
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		$this->clean_up_cot_setup();
+	}
+
+	public function test_hpos_wc_customer_bought_product() {
+		$this->toggle_cot( true );
+		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
+		$customer_id_2 = wc_create_new_customer( 'test2@example.com', 'testuser2', 'testpassword2' );
+		$product_1     = new WC_Product_Simple();
+		$product_1->save();
+		$product_id_1 = $product_1->get_id();
+		$product_2    = new WC_Product_Simple();
+		$product_2->save();
+		$product_id_2 = $product_2->get_id();
+
+		$order_1 = WC_Helper_Order::create_order( $customer_id_1, $product_1 );
+		$order_1->set_billing_email( 'test@example.com' );
+		$order_1->set_status( 'completed' );
+		$order_1->save();
+		$order_2 = WC_Helper_Order::create_order( $customer_id_2, $product_2 );
+		$order_2->set_billing_email( 'test2@example.com' );
+		$order_2->set_status( 'completed' );
+		$order_2->save();
+		$order_3 = WC_Helper_Order::create_order( $customer_id_1, $product_2 );
+		$order_3->set_billing_email( 'test@example.com' );
+		$order_3->set_status( 'pending' );
+		$order_3->save();
+
+		$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
+		$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );
+		$this->assertTrue( wc_customer_bought_product( 'test@example.com', 0, $product_id_1 ) );
+		$this->assertFalse( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_2 ) );
+		$this->assertFalse( wc_customer_bought_product( 'test2@example.com', $customer_id_2, $product_id_1 ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds support for HPOS to the `wc_customer_bought_product` function in wc-user-functions.php.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34775 

### How to test the changes in this Pull Request:

See the unit test, since it's a self contained function, it should be enough.

Alternatively, on a shell, try calling `wc_customer_bought_product` with different parameters for production that you have bough in a testing environment.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
