### PR TITLE
update/a2p update workflows to use the playwright api-core-tests instead of the …

### DIFF
--- a/.github/workflows/cot-build-and-e2e-tests-daily.yml
+++ b/.github/workflows/cot-build-and-e2e-tests-daily.yml
@@ -73,22 +73,35 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpm env:test:cot --filter=woocommerce
 
-            - name: Run tests command.
+            - name: Run Playwright API tests.
+              id: run_playwright_api_tests
               working-directory: plugins/woocommerce
               env:
                   BASE_URL: http://localhost:8086
                   USER_KEY: admin
                   USER_SECRET: password
-              run: pnpm exec wc-api-tests test api
-
-            - name: Archive API test report
-              if: always()
+              run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js
+            - name: Generate Playwright API Test report.
+              id: generate_api_report
+              if: |
+                  always() &&
+                  (
+                    steps.run_playwright_api_tests.conclusion != 'cancelled' ||
+                    steps.run_playwright_api_tests.conclusion != 'skipped' 
+                  )
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean api-test-report/allure-results --output api-test-report/allure-report
+            - name: Archive Playwright API test report
+              if: |
+                  always() &&
+                  steps.generate_api_report.conclusion == 'success'
               uses: actions/upload-artifact@v3
               with:
                   name: api-test-report---pr-${{ github.event.number }}
                   path: |
-                      ${{ env.API_TEST_REPORT_DIR }}/allure-results
-                      ${{ env.API_TEST_REPORT_DIR }}/allure-report
+                      plugins/woocommerce/api-test-report/allure-results
+                      plugins/woocommerce/api-test-report/allure-report
+                  if-no-files-found: ignore
                   retention-days: 5
 
     test-summary:

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -75,22 +75,37 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpm env:test:cot --filter=woocommerce
 
-            - name: Run tests command.
+            - name: Run Playwright API tests.
+              id: run_playwright_api_tests
               working-directory: plugins/woocommerce
               env:
                   BASE_URL: http://localhost:8086
                   USER_KEY: admin
                   USER_SECRET: password
-              run: pnpm exec wc-api-tests test api
+              run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js
 
-            - name: Archive API test report
-              if: always()
+            - name: Generate Playwright API Test report.
+              id: generate_api_report
+              if: |
+                  always() &&
+                  (
+                    steps.run_playwright_api_tests.conclusion != 'cancelled' ||
+                    steps.run_playwright_api_tests.conclusion != 'skipped' 
+                  )
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean api-test-report/allure-results --output api-test-report/allure-report
+              
+            - name: Archive Playwright API test report
+              if: |
+                  always() &&
+                  steps.generate_api_report.conclusion == 'success'
               uses: actions/upload-artifact@v3
               with:
                   name: api-test-report---pr-${{ github.event.number }}
                   path: |
-                      ${{ env.API_TEST_REPORT_DIR }}/allure-results
-                      ${{ env.API_TEST_REPORT_DIR }}/allure-report
+                      plugins/woocommerce/api-test-report/allure-results
+                      plugins/woocommerce/api-test-report/allure-report
+                  if-no-files-found: ignore
                   retention-days: 5
 
     test-summary:

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -72,22 +72,36 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpm env:test --filter=woocommerce
 
-            - name: Run tests command.
+            - name: Run Playwright API tests.
+              id: run_playwright_api_tests
               working-directory: plugins/woocommerce
               env:
                   BASE_URL: http://localhost:8086
                   USER_KEY: admin
                   USER_SECRET: password
-              run: pnpm exec wc-api-tests test api
-
-            - name: Archive API test report
-              if: always()
+              run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js
+              
+            - name: Generate Playwright API Test report.
+              id: generate_api_report
+              if: |
+                  always() &&
+                  (
+                    steps.run_playwright_api_tests.conclusion != 'cancelled' ||
+                    steps.run_playwright_api_tests.conclusion != 'skipped' 
+                  )
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean api-test-report/allure-results --output api-test-report/allure-report
+            - name: Archive Playwright API test report
+              if: |
+                  always() &&
+                  steps.generate_api_report.conclusion == 'success'
               uses: actions/upload-artifact@v3
               with:
                   name: api-test-report---pr-${{ github.event.number }}
                   path: |
-                      ${{ env.API_TEST_REPORT_DIR }}/allure-results
-                      ${{ env.API_TEST_REPORT_DIR }}/allure-report
+                      plugins/woocommerce/api-test-report/allure-results
+                      plugins/woocommerce/api-test-report/allure-report
+                  if-no-files-found: ignore
                   retention-days: 5
 
     k6-tests-run:

--- a/plugins/woocommerce/changelog/enhancement-A2P-update-workflows-to-use-playwright-api-core-tests
+++ b/plugins/woocommerce/changelog/enhancement-A2P-update-workflows-to-use-playwright-api-core-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+The updates will mean that the github workflows use the playwright versions of the api-core-tests rather than the supertest versions of the tests.


### PR DESCRIPTION
…equivalent supertest versions

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR updates the 3 x github workflows that currently execute the api-core-tests. The updates will mean that the workflows use the playwright versions of the tests rather than the supertest versions of the tests.

Closes 371-gh-woocommerce/woocommerce-quality .

### How to test the changes in this Pull Request:

There are 3 workflows updated in this PR and therefore 3 workflows to validate:

1. Create a PR 
2. Commit and push the changes
3. The following Workflow will execute:
- pr-build-and-e2e-tests.yml

Then (or alternatively as the below steps will kick off 2 workflows):
1. Create a PR with label "focus: custom order tables"
2. Commit and push the changes
3. The following Workflows will execute:
- cot-pr-build-and-e2e-tests.yml
- pr-build-and-e2e-tests.yml

Playwright versions of the api-core-tests will execute for each of these workflows (rather than the original supertest versions)

The tests will also kick off automatically at 230am for the  "cot-build-and-e2e-tests-daily.yml" workflow based on cron: "30 2 * * *" and this workflow should also use the playwright versions of the tests rather than the supertest versions.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.