### PR TITLE
Correct the textarea name in the Product Short Description template.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34925-product-short-description
+++ b/plugins/woocommerce/changelog/fix-34925-product-short-description
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This was broken in the 7.0.0 betas, but the bug had not entered production. For that reason, a changelog entry is not required.
+
+

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
@@ -23,7 +23,7 @@ class WC_Meta_Box_Product_Short_Description {
 	public static function output( $post ) {
 
 		$settings = array(
-			'textarea_name' => 'customer_note',
+			'textarea_name' => 'excerpt',
 			'quicktags'     => array( 'buttons' => 'em,strong,link' ),
 			'tinymce'       => array(
 				'theme_advanced_buttons1' => 'bold,italic,strikethrough,separator,bullist,numlist,separator,blockquote,separator,justifyleft,justifycenter,justifyright,separator,link,unlink,separator,undo,redo,separator',


### PR DESCRIPTION
Corrects an error introduced in https://github.com/woocommerce/woocommerce/pull/34477, in which an admin template used in the product editor was modified, stopping product short descriptions from being saved.

Closes #34925. 

### How to test the changes in this Pull Request:

1. Please confirm everything still works as per the testing instructions in https://github.com/woocommerce/woocommerce/pull/34477 (noting that the `wp wc cot migrate` command is now `wp wc cot sync`).
2. Then, edit a product and modify the short description. Save. The change should persist.

<img width="769" alt="product-short-desc-field" src="https://user-images.githubusercontent.com/3594411/193648241-33a70a04-59d4-4e81-bdef-d9cdbb7db555.png">

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
