### PR TITLE
Add new shipping class modal to a shipping class section in product page

### DIFF
--- a/packages/js/components/changelog/add-34657-add-new-shipping-class
+++ b/packages/js/components/changelog/add-34657-add-new-shipping-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add new shippping class modal to a shipping class section in product page

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -262,7 +262,7 @@ function FormComponent< Values extends Record< string, any > >(
 			}
 
 			if ( callback ) {
-				callback( values );
+				return callback( values );
 			}
 		}
 	};

--- a/packages/js/data/changelog/add-34657-add-new-shipping-class
+++ b/packages/js/data/changelog/add-34657-add-new-shipping-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add new shippping class modal to a shipping class section in product page

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -36,7 +36,7 @@ export type ProductAttribute = {
 
 export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	Schema.Post,
-	'status'
+	'status' | 'categories'
 > & {
 	id: number;
 	name: string;
@@ -88,6 +88,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	attributes: ProductAttribute[];
 	dimensions: ProductDimensions;
 	weight: string;
+	categories: ProductCategory[];
 };
 
 export const productReadOnlyProperties = [
@@ -151,4 +152,10 @@ export type ProductDimensions = {
 	width: string;
 	height: string;
 	length: string;
+};
+
+export type ProductCategory = {
+	id: number;
+	name: string;
+	slug: string;
 };

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -127,7 +127,7 @@ const EditProductPage: React.FC = () => {
 						<ProductFormLayout>
 							<ProductDetailsSection />
 							<PricingSection />
-							<ProductShippingSection />
+							<ProductShippingSection product={ product } />
 							<AttributesSection />
 							<ProductFormActions />
 						</ProductFormLayout>

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.scss
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.scss
@@ -1,0 +1,18 @@
+.woocommerce-add-new-shipping-class-modal {
+	min-width: 650px;
+	&__optional-input {
+		color: $gray-700;
+	}
+	&__buttons {
+		margin-top: $gap-larger;
+		display: flex;
+		flex-direction: row;
+		gap: 8px;
+		justify-content: flex-end;
+	}
+	.has-error {
+		.components-base-control__help {
+			color: $studio-red-50;
+		}
+	}
+}

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import interpolateComponents from '@automattic/interpolate-components';
+import { Button, Modal, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Form, FormErrors, useFormContext } from '@woocommerce/components';
+import { ProductShippingClass } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { getTextControlProps } from '../../sections/utils';
+import './add-new-shipping-class-modal.scss';
+
+export type ShippingClassFormProps = {
+	onAdd: () => Promise< ProductShippingClass >;
+	onCancel: () => void;
+};
+
+function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
+	const { getInputProps, isValidForm } =
+		useFormContext< ProductShippingClass >();
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	const inputNameProps = getTextControlProps( getInputProps( 'name' ) );
+	const inputSlugProps = getTextControlProps( getInputProps( 'slug' ) );
+	const inputDescriptionProps = getTextControlProps(
+		getInputProps( 'description' )
+	);
+
+	function handleAdd() {
+		setIsLoading( true );
+		onAdd()
+			.then( () => {
+				setIsLoading( false );
+				onCancel();
+			} )
+			.catch( () => {
+				setIsLoading( false );
+			} );
+	}
+
+	return (
+		<div className="woocommerce-add-new-shipping-class-modal__wrapper">
+			<TextControl
+				{ ...inputNameProps }
+				label={ __( 'Name', 'woocommerce' ) }
+			/>
+			<TextControl
+				{ ...inputSlugProps }
+				label={ interpolateComponents( {
+					mixedString: __(
+						'Slug {{span}}(optional){{/span}}',
+						'woocommerce'
+					),
+					components: {
+						span: (
+							<span className="woocommerce-add-new-shipping-class-modal__optional-input" />
+						),
+					},
+				} ) }
+			/>
+			<TextControl
+				{ ...inputDescriptionProps }
+				label={ interpolateComponents( {
+					mixedString: __(
+						'Description {{span}}(optional){{/span}}',
+						'woocommerce'
+					),
+					components: {
+						span: (
+							<span className="woocommerce-add-new-shipping-class-modal__optional-input" />
+						),
+					},
+				} ) }
+				help={
+					inputDescriptionProps?.help ??
+					__(
+						'Describe how you and other store administrators can use this shipping class.',
+						'woocommerce'
+					)
+				}
+			/>
+			<div className="woocommerce-add-new-shipping-class-modal__buttons">
+				<Button isSecondary onClick={ onCancel }>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</Button>
+				<Button
+					isPrimary
+					isBusy={ isLoading }
+					disabled={ ! isValidForm || isLoading }
+					onClick={ handleAdd }
+				>
+					{ __( 'Add', 'woocommerce' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function validateForm(
+	values: Partial< ProductShippingClass >
+): FormErrors< ProductShippingClass > {
+	const errors: FormErrors< ProductShippingClass > = {};
+
+	if ( ! values.name?.length ) {
+		errors.name = __(
+			'The shipping class name is required.',
+			'woocommerce'
+		);
+	}
+
+	return errors;
+}
+
+export type AddNewShippingClassModalProps = {
+	shippingClass?: Partial< ProductShippingClass >;
+	onAdd: (
+		shippingClass: Partial< ProductShippingClass >
+	) => Promise< ProductShippingClass >;
+	onCancel: () => void;
+};
+
+const INITIAL_VALUES = {
+	name: __( 'New shipping class', 'woocommerce' ),
+	slug: __( 'new-shipping-class', 'woocommerce' ),
+};
+
+export function AddNewShippingClassModal( {
+	shippingClass,
+	onAdd,
+	onCancel,
+}: AddNewShippingClassModalProps ) {
+	return (
+		<Modal
+			title={ __( 'New shipping class', 'woocommerce' ) }
+			className="woocommerce-add-new-shipping-class-modal"
+			onRequestClose={ onCancel }
+		>
+			<Form< Partial< ProductShippingClass > >
+				initialValues={ shippingClass ?? INITIAL_VALUES }
+				validate={ validateForm }
+				errors={ {} }
+				onSubmit={ onAdd }
+			>
+				{ ( childrenProps: {
+					handleSubmit: () => Promise< ProductShippingClass >;
+				} ) => (
+					<ShippingClassForm
+						onAdd={ childrenProps.handleSubmit }
+						onCancel={ onCancel }
+					/>
+				) }
+			</Form>
+		</Modal>
+	);
+}

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/index.ts
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './add-new-shipping-class-modal';

--- a/plugins/woocommerce/changelog/add-34657-add-new-shipping-class
+++ b/plugins/woocommerce/changelog/add-34657-add-new-shipping-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add new shippping class modal to a shipping class section in product page


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/34657.

### How to test the changes in this Pull Request:

1. Go to Add new product page.
2. Under Shipping Class section click on the Shipping class dropdown, an `Add new shipping class` option should be shown as the second option of the list.
3. When click `Add new shipping class` option a modal to add a new shipping class should be shown.
4. If the product does not have a category then the fields `Name` and `Slug` on the modal should be filled with `New shipping class` and `new-shipping-class` values respectively. 

<video src="https://user-images.githubusercontent.com/13334210/193664226-e1a83c33-8129-4d20-b2c7-2f7e06fd2bf0.mov"></video>
5. If the product contains a valid category different than `Uncategorized` then that value should be used to fill the fields `Name` and `Slug` on the modal. 

<video src="https://user-images.githubusercontent.com/13334210/193664590-cfc4f1ed-453a-499a-9f98-fdc3e2783d2e.mov"></video>
6. After adding the new shipping class the dropdown behind the modal should be updated with the new option added.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
