### PR TITLE
Product creation experience: shortcut to add variation price

### DIFF
--- a/plugins/woocommerce/changelog/add-33554_variation-price
+++ b/plugins/woocommerce/changelog/add-33554_variation-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add variation price shortcut

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5126,7 +5126,6 @@ img.help_tip {
 		font-size: 15px;
 		font-weight: 400;
 		margin-right: 0.5em;
-		visibility: hidden;
 		text-align: center;
 		vertical-align: middle;
 
@@ -5146,11 +5145,22 @@ img.help_tip {
 			color: #777;
 		}
 	}
+	.edit_variation {
+		margin-left: 0.5em;
+	}
 
 	h3:hover,
 	&.ui-sortable-helper {
 		.sort {
 			visibility: visible;
+		}
+	}
+}
+
+.woocommerce_attribute {
+	h3 {
+		.sort, a.delete {
+			visibility: hidden;
 		}
 	}
 }
@@ -5478,7 +5488,8 @@ img.help_tip {
 			cursor: move;
 
 			button,
-			a.delete {
+			a.delete,
+			a.edit {
 				float: right;
 			}
 
@@ -5488,7 +5499,13 @@ img.help_tip {
 				line-height: 26px;
 				text-decoration: none;
 				position: relative;
-				visibility: hidden;
+			}
+
+			a.edit {
+				font-weight: normal;
+				line-height: 26px;
+				text-decoration: none;
+				position: relative;
 			}
 
 			strong {
@@ -5520,6 +5537,7 @@ img.help_tip {
 			padding: 0.5em 0.75em 0.5em 1em !important;
 
 			a.delete,
+			a.edit,
 			.handlediv,
 			.sort {
 				margin-top: 0.25em;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -952,7 +952,43 @@
 
 #variable_product_options #message,
 #variable_product_options .notice {
+	display: flex;
 	margin: 10px;
+	background-color: #FCFAE8;
+	> p {
+		width: 85%;
+	}
+	.woocommerce-add-variation-price-container {
+		width: 15%;
+		display: flex;
+		justify-content: center;
+		> button {
+			align-self: center;
+		}
+	}
+}
+
+.woocommerce-set-price-variations {
+	.woocommerce-usage-modal__wrapper{
+		.woocommerce-usage-modal__message {
+			height: 60px;
+			flex-wrap: wrap;
+			display: flex;
+			> span {
+				padding-bottom: 16px;
+			}
+		}
+		.woocommerce-usage-modal__actions {
+			display: flex;
+			justify-content: flex-end;
+			margin-top: 20px;
+			> button{
+				margin-left: 16px;
+				width: 88px;
+				display: unset;
+			}
+		}
+	}
 }
 
 #variable_product_options {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5508,6 +5508,10 @@ img.help_tip {
 				position: relative;
 			}
 
+			a.remove_variation {
+				margin: 0 0.5em;
+			}
+
 			strong {
 				font-weight: normal;
 				line-height: 26px;
@@ -5541,6 +5545,13 @@ img.help_tip {
 			.handlediv,
 			.sort {
 				margin-top: 0.25em;
+			}
+		}
+		&.woocommerce_variation h3 {
+			a.delete,
+			a.edit,
+			.sort {
+				margin-top: 0.45em;
 			}
 		}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -961,7 +961,7 @@
 	.woocommerce-add-variation-price-container {
 		width: 15%;
 		display: flex;
-		justify-content: center;
+		justify-content: flex-end;
 		> button {
 			align-self: center;
 		}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -285,6 +285,7 @@ jQuery( function ( $ ) {
 					$( el ).val( variation_price ).trigger( 'change' );
 				}
 			} );
+			wc_meta_boxes_product_variations_ajax.save_variations();
 		},
 
 		/**

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -278,7 +278,6 @@ jQuery( function ( $ ) {
 					? 'variable_subscription_sign_up_fee'
 					: 'variable_regular_price';
 			var input = $( `.wc_input_price[name^=${ input_type }]` );
-			console.log( 'input', input );
 
 			// We don't want to override prices already set
 			input.each( function ( index, el ) {
@@ -595,7 +594,6 @@ jQuery( function ( $ ) {
 		 * @return {Bool}
 		 */
 		check_for_changes: function () {
-			console.log( 'check_for_changes' );
 			var need_update = $( '#variable_product_options' ).find(
 				'.woocommerce_variations .variation-needs-update'
 			);
@@ -707,7 +705,6 @@ jQuery( function ( $ ) {
 		get_variations_fields: function ( fields ) {
 			var data = $( ':input', fields ).serializeJSON();
 
-			console.log( 'get_variations_fields', data );
 			$( '.variations-defaults select' ).each( function (
 				index,
 				element
@@ -1224,7 +1221,6 @@ jQuery( function ( $ ) {
 			}
 
 			wc_meta_boxes_product_variations_ajax.block();
-			console.log( 'data', data );
 
 			$.ajax( {
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1,27 +1,51 @@
 /* global wp, woocommerce_admin_meta_boxes_variations, woocommerce_admin, accounting */
-jQuery( function( $ ) {
-    'use strict';
+jQuery( function ( $ ) {
+	'use strict';
 
 	/**
 	 * Variations actions
 	 */
 	var wc_meta_boxes_product_variations_actions = {
-
 		/**
 		 * Initialize variations actions
 		 */
-		init: function() {
+		init: function () {
 			$( '#variable_product_options' )
-				.on( 'change', 'input.variable_is_downloadable', this.variable_is_downloadable )
-				.on( 'change', 'input.variable_is_virtual', this.variable_is_virtual )
-				.on( 'change', 'input.variable_manage_stock', this.variable_manage_stock )
+				.on(
+					'change',
+					'input.variable_is_downloadable',
+					this.variable_is_downloadable
+				)
+				.on(
+					'change',
+					'input.variable_is_virtual',
+					this.variable_is_virtual
+				)
+				.on(
+					'change',
+					'input.variable_manage_stock',
+					this.variable_manage_stock
+				)
 				.on( 'click', 'button.notice-dismiss', this.notice_dismiss )
 				.on( 'click', 'h3 .sort', this.set_menu_order )
+				.on(
+					'click',
+					'button.add_price_for_variations',
+					this.open_modal_to_set_variations_price
+				)
 				.on( 'reload', this.reload );
 
-			$( 'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock' ).trigger( 'change' );
-			$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded', this.variations_loaded );
-			$( document.body ).on( 'woocommerce_variations_added', this.variation_added );
+			$(
+				'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock'
+			).trigger( 'change' );
+			$( '#woocommerce-product-data' ).on(
+				'woocommerce_variations_loaded',
+				this.variations_loaded
+			);
+			$( document.body ).on(
+				'woocommerce_variations_added',
+				this.variation_added
+			);
 		},
 
 		/**
@@ -30,7 +54,7 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		reload: function() {
+		reload: function () {
 			wc_meta_boxes_product_variations_ajax.load_variations( 1 );
 			wc_meta_boxes_product_variations_pagenav.set_paginav( 0 );
 		},
@@ -38,47 +62,74 @@ jQuery( function( $ ) {
 		/**
 		 * Check if variation is downloadable and show/hide elements
 		 */
-		variable_is_downloadable: function() {
-			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_downloadable' ).hide();
+		variable_is_downloadable: function () {
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.show_if_variation_downloadable' )
+				.hide();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_downloadable' ).show();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.show_if_variation_downloadable' )
+					.show();
 			}
 		},
 
 		/**
 		 * Check if variation is virtual and show/hide elements
 		 */
-		variable_is_virtual: function() {
-			$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_virtual' ).show();
+		variable_is_virtual: function () {
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.hide_if_variation_virtual' )
+				.show();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_virtual' ).hide();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.hide_if_variation_virtual' )
+					.hide();
 			}
 		},
 
 		/**
 		 * Check if variation manage stock and show/hide elements
 		 */
-		variable_manage_stock: function() {
-			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).hide();
-			$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).show();
+		variable_manage_stock: function () {
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.show_if_variation_manage_stock' )
+				.hide();
+			$( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.variable_stock_status' )
+				.show();
 
 			if ( $( this ).is( ':checked' ) ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).show();
-				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.show_if_variation_manage_stock' )
+					.show();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.variable_stock_status' )
+					.hide();
 			}
 
 			// Parent level.
 			if ( $( 'input#_manage_stock:checked' ).length ) {
-				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.find( '.variable_stock_status' )
+					.hide();
 			}
 		},
 
 		/**
 		 * Notice dismiss
 		 */
-		notice_dismiss: function() {
+		notice_dismiss: function () {
 			$( this ).closest( 'div.notice' ).remove();
 		},
 
@@ -88,31 +139,43 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} needsUpdate
 		 */
-		variations_loaded: function( event, needsUpdate ) {
+		variations_loaded: function ( event, needsUpdate ) {
 			needsUpdate = needsUpdate || false;
 
 			var wrapper = $( '#woocommerce-product-data' );
 
 			if ( ! needsUpdate ) {
 				// Show/hide downloadable, virtual and stock fields
-				$( 'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock', wrapper ).trigger( 'change' );
+				$(
+					'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock',
+					wrapper
+				).trigger( 'change' );
 
 				// Open sale schedule fields when have some sale price date
-				$( '.woocommerce_variation', wrapper ).each( function( index, el ) {
-					var $el       = $( el ),
+				$( '.woocommerce_variation', wrapper ).each( function (
+					index,
+					el
+				) {
+					var $el = $( el ),
 						date_from = $( '.sale_price_dates_from', $el ).val(),
-						date_to   = $( '.sale_price_dates_to', $el ).val();
+						date_to = $( '.sale_price_dates_to', $el ).val();
 
 					if ( '' !== date_from || '' !== date_to ) {
 						$( 'a.sale_schedule', $el ).trigger( 'click' );
 					}
-				});
+				} );
 
 				// Remove variation-needs-update classes
-				$( '.woocommerce_variations .variation-needs-update', wrapper ).removeClass( 'variation-needs-update' );
+				$(
+					'.woocommerce_variations .variation-needs-update',
+					wrapper
+				).removeClass( 'variation-needs-update' );
 
 				// Disable cancel and save buttons
-				$( 'button.cancel-variation-changes, button.save-variation-changes', wrapper ).attr( 'disabled', 'disabled' );
+				$(
+					'button.cancel-variation-changes, button.save-variation-changes',
+					wrapper
+				).attr( 'disabled', 'disabled' );
 			}
 
 			// Init TipTip
@@ -120,48 +183,53 @@ jQuery( function( $ ) {
 			$( '#tiptip_arrow' ).removeAttr( 'style' );
 			$(
 				'.woocommerce_variations .tips, ' +
-				'.woocommerce_variations .help_tip, ' +
-				'.woocommerce_variations .woocommerce-help-tip, ' +
-				'.toolbar-variations-defaults .woocommerce-help-tip',
+					'.woocommerce_variations .help_tip, ' +
+					'.woocommerce_variations .woocommerce-help-tip, ' +
+					'.toolbar-variations-defaults .woocommerce-help-tip',
 				wrapper
-			)
-				.tipTip({
-					'attribute': 'data-tip',
-					'fadeIn':    50,
-					'fadeOut':   50,
-					'delay':     200
-			});
+			).tipTip( {
+				attribute: 'data-tip',
+				fadeIn: 50,
+				fadeOut: 50,
+				delay: 200,
+			} );
 
 			// Datepicker fields
-			$( '.sale_price_dates_fields', wrapper ).find( 'input' ).datepicker({
-				defaultDate:     '',
-				dateFormat:      'yy-mm-dd',
-				numberOfMonths:  1,
-				showButtonPanel: true,
-				onSelect:        function() {
-					var option = $( this ).is( '.sale_price_dates_from' ) ? 'minDate' : 'maxDate',
-						dates  = $( this ).closest( '.sale_price_dates_fields' ).find( 'input' ),
-						date   = $( this ).datepicker( 'getDate' );
+			$( '.sale_price_dates_fields', wrapper )
+				.find( 'input' )
+				.datepicker( {
+					defaultDate: '',
+					dateFormat: 'yy-mm-dd',
+					numberOfMonths: 1,
+					showButtonPanel: true,
+					onSelect: function () {
+						var option = $( this ).is( '.sale_price_dates_from' )
+								? 'minDate'
+								: 'maxDate',
+							dates = $( this )
+								.closest( '.sale_price_dates_fields' )
+								.find( 'input' ),
+							date = $( this ).datepicker( 'getDate' );
 
-					dates.not( this ).datepicker( 'option', option, date );
-					$( this ).trigger( 'change' );
-				}
-			});
+						dates.not( this ).datepicker( 'option', option, date );
+						$( this ).trigger( 'change' );
+					},
+				} );
 
 			// Allow sorting
-			$( '.woocommerce_variations', wrapper ).sortable({
-				items:                '.woocommerce_variation',
-				cursor:               'move',
-				axis:                 'y',
-				handle:               '.sort',
-				scrollSensitivity:    40,
+			$( '.woocommerce_variations', wrapper ).sortable( {
+				items: '.woocommerce_variation',
+				cursor: 'move',
+				axis: 'y',
+				handle: '.sort',
+				scrollSensitivity: 40,
 				forcePlaceholderSize: true,
-				helper:               'clone',
-				opacity:              0.65,
-				stop:                 function() {
-				    wc_meta_boxes_product_variations_actions.variation_row_indexes();
-				}
-			});
+				helper: 'clone',
+				opacity: 0.65,
+				stop: function () {
+					wc_meta_boxes_product_variations_actions.variation_row_indexes();
+				},
+			} );
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 		},
@@ -172,32 +240,60 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		variation_added: function( event, qty ) {
+		variation_added: function ( event, qty ) {
 			if ( 1 === qty ) {
-				wc_meta_boxes_product_variations_actions.variations_loaded( null, true );
+				wc_meta_boxes_product_variations_actions.variations_loaded(
+					null,
+					true
+				);
 			}
+		},
+
+		/**
+		 * Opens the modal to set a price for every variation
+		 */
+		open_modal_to_set_variations_price: function ( event ) {
+			$( this ).WCBackboneModal( {
+				template: 'wc-modal-set-price-variations',
+			} );
 		},
 
 		/**
 		 * Lets the user manually input menu order to move items around pages
 		 */
-		set_menu_order: function( event ) {
+		set_menu_order: function ( event ) {
 			event.preventDefault();
-			var $menu_order  = $( this ).closest( '.woocommerce_variation' ).find( '.variation_menu_order' );
-			var variation_id = $( this ).closest( '.woocommerce_variation' ).find( '.variable_post_id' ).val();
-			var value        = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order, $menu_order.val() );
+			var $menu_order = $( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.variation_menu_order' );
+			var variation_id = $( this )
+				.closest( '.woocommerce_variation' )
+				.find( '.variable_post_id' )
+				.val();
+			var value = window.prompt(
+				woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order,
+				$menu_order.val()
+			);
 
 			if ( value != null ) {
 				// Set value, save changes and reload view
 				$menu_order.val( parseInt( value, 10 ) ).trigger( 'change' );
 
-				$( this ).closest( '.woocommerce_variation' )
-					.append( '<input type="hidden" name="new_variation_menu_order_id" value="'
-						+ encodeURIComponent( variation_id ) + '" />' );
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.append(
+						'<input type="hidden" name="new_variation_menu_order_id" value="' +
+							encodeURIComponent( variation_id ) +
+							'" />'
+					);
 
-				$( this ).closest( '.woocommerce_variation' )
-					.append( '<input type="hidden" name="new_variation_menu_order_value" value="'
-						+ encodeURIComponent( parseInt( value, 10 ) ) + '" />' );
+				$( this )
+					.closest( '.woocommerce_variation' )
+					.append(
+						'<input type="hidden" name="new_variation_menu_order_value" value="' +
+							encodeURIComponent( parseInt( value, 10 ) ) +
+							'" />'
+					);
 
 				wc_meta_boxes_product_variations_ajax.save_variations();
 			}
@@ -206,25 +302,40 @@ jQuery( function( $ ) {
 		/**
 		 * Set menu order
 		 */
-		variation_row_indexes: function() {
-			var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+		variation_row_indexes: function () {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
 				current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
-				offset       = parseInt( ( current_page - 1 ) * woocommerce_admin_meta_boxes_variations.variations_per_page, 10 );
+				offset = parseInt(
+					( current_page - 1 ) *
+						woocommerce_admin_meta_boxes_variations.variations_per_page,
+					10
+				);
 
-			$( '.woocommerce_variations .woocommerce_variation' ).each( function ( index, el ) {
-				$( '.variation_menu_order', el )
-					.val( parseInt( $( el )
-					.index( '.woocommerce_variations .woocommerce_variation' ), 10 ) + 1 + offset )
-					.trigger( 'change' );
-			});
-		}
+			$( '.woocommerce_variations .woocommerce_variation' ).each(
+				function ( index, el ) {
+					$( '.variation_menu_order', el )
+						.val(
+							parseInt(
+								$( el ).index(
+									'.woocommerce_variations .woocommerce_variation'
+								),
+								10
+							) +
+								1 +
+								offset
+						)
+						.trigger( 'change' );
+				}
+			);
+		},
 	};
 
 	/**
 	 * Variations media actions
 	 */
 	var wc_meta_boxes_product_variations_media = {
-
 		/**
 		 * wp.media frame object
 		 *
@@ -256,8 +367,12 @@ jQuery( function( $ ) {
 		/**
 		 * Initialize media actions
 		 */
-		init: function() {
-			$( '#variable_product_options' ).on( 'click', '.upload_image_button', this.add_image );
+		init: function () {
+			$( '#variable_product_options' ).on(
+				'click',
+				'.upload_image_button',
+				this.add_image
+			);
 			$( 'a.add_media' ).on( 'click', this.restore_wp_media_post_id );
 		},
 
@@ -266,64 +381,101 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Object} event
 		 */
-		add_image: function( event ) {
+		add_image: function ( event ) {
 			var $button = $( this ),
 				post_id = $button.attr( 'rel' ),
 				$parent = $button.closest( '.upload_image' );
 
-			wc_meta_boxes_product_variations_media.setting_variation_image    = $parent;
+			wc_meta_boxes_product_variations_media.setting_variation_image = $parent;
 			wc_meta_boxes_product_variations_media.setting_variation_image_id = post_id;
 
 			event.preventDefault();
 
 			if ( $button.is( '.remove' ) ) {
-
-				$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( '' ).trigger( 'change' );
-				wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 )
-					.attr( 'src', woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src );
-				wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).removeClass( 'remove' );
-
+				$(
+					'.upload_image_id',
+					wc_meta_boxes_product_variations_media.setting_variation_image
+				)
+					.val( '' )
+					.trigger( 'change' );
+				wc_meta_boxes_product_variations_media.setting_variation_image
+					.find( 'img' )
+					.eq( 0 )
+					.attr(
+						'src',
+						woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src
+					);
+				wc_meta_boxes_product_variations_media.setting_variation_image
+					.find( '.upload_image_button' )
+					.removeClass( 'remove' );
 			} else {
-
 				// If the media frame already exists, reopen it.
-				if ( wc_meta_boxes_product_variations_media.variable_image_frame ) {
-					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader
-						.param( 'post_id', wc_meta_boxes_product_variations_media.setting_variation_image_id );
+				if (
+					wc_meta_boxes_product_variations_media.variable_image_frame
+				) {
+					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader.param(
+						'post_id',
+						wc_meta_boxes_product_variations_media.setting_variation_image_id
+					);
 					wc_meta_boxes_product_variations_media.variable_image_frame.open();
 					return;
 				} else {
-					wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.setting_variation_image_id;
+					wp.media.model.settings.post.id =
+						wc_meta_boxes_product_variations_media.setting_variation_image_id;
 				}
 
 				// Create the media frame.
-				wc_meta_boxes_product_variations_media.variable_image_frame = wp.media.frames.variable_image = wp.media({
-					// Set the title of the modal.
-					title: woocommerce_admin_meta_boxes_variations.i18n_choose_image,
-					button: {
-						text: woocommerce_admin_meta_boxes_variations.i18n_set_image
-					},
-					states: [
-						new wp.media.controller.Library({
-							title: woocommerce_admin_meta_boxes_variations.i18n_choose_image,
-							filterable: 'all'
-						})
-					]
-				});
+				wc_meta_boxes_product_variations_media.variable_image_frame = wp.media.frames.variable_image = wp.media(
+					{
+						// Set the title of the modal.
+						title:
+							woocommerce_admin_meta_boxes_variations.i18n_choose_image,
+						button: {
+							text:
+								woocommerce_admin_meta_boxes_variations.i18n_set_image,
+						},
+						states: [
+							new wp.media.controller.Library( {
+								title:
+									woocommerce_admin_meta_boxes_variations.i18n_choose_image,
+								filterable: 'all',
+							} ),
+						],
+					}
+				);
 
 				// When an image is selected, run a callback.
-				wc_meta_boxes_product_variations_media.variable_image_frame.on( 'select', function () {
+				wc_meta_boxes_product_variations_media.variable_image_frame.on(
+					'select',
+					function () {
+						var attachment = wc_meta_boxes_product_variations_media.variable_image_frame
+								.state()
+								.get( 'selection' )
+								.first()
+								.toJSON(),
+							url =
+								attachment.sizes && attachment.sizes.thumbnail
+									? attachment.sizes.thumbnail.url
+									: attachment.url;
 
-					var attachment = wc_meta_boxes_product_variations_media.variable_image_frame.state()
-						.get( 'selection' ).first().toJSON(),
-						url = attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url;
+						$(
+							'.upload_image_id',
+							wc_meta_boxes_product_variations_media.setting_variation_image
+						)
+							.val( attachment.id )
+							.trigger( 'change' );
+						wc_meta_boxes_product_variations_media.setting_variation_image
+							.find( '.upload_image_button' )
+							.addClass( 'remove' );
+						wc_meta_boxes_product_variations_media.setting_variation_image
+							.find( 'img' )
+							.eq( 0 )
+							.attr( 'src', url );
 
-					$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( attachment.id )
-						.trigger( 'change' );
-					wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).addClass( 'remove' );
-					wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 ).attr( 'src', url );
-
-					wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.wp_media_post_id;
-				});
+						wp.media.model.settings.post.id =
+							wc_meta_boxes_product_variations_media.wp_media_post_id;
+					}
+				);
 
 				// Finally, open the modal.
 				wc_meta_boxes_product_variations_media.variable_image_frame.open();
@@ -333,41 +485,65 @@ jQuery( function( $ ) {
 		/**
 		 * Restore wp.media post ID.
 		 */
-		restore_wp_media_post_id: function() {
-			wp.media.model.settings.post.id = wc_meta_boxes_product_variations_media.wp_media_post_id;
-		}
+		restore_wp_media_post_id: function () {
+			wp.media.model.settings.post.id =
+				wc_meta_boxes_product_variations_media.wp_media_post_id;
+		},
 	};
 
 	/**
 	 * Product variations metabox ajax methods
 	 */
 	var wc_meta_boxes_product_variations_ajax = {
-
 		/**
 		 * Initialize variations ajax methods
 		 */
-		init: function() {
+		init: function () {
 			$( 'li.variations_tab a' ).on( 'click', this.initial_load );
 
 			$( '#variable_product_options' )
-				.on( 'click', 'button.save-variation-changes', this.save_variations )
-				.on( 'click', 'button.cancel-variation-changes', this.cancel_variations )
+				.on(
+					'click',
+					'button.save-variation-changes',
+					this.save_variations
+				)
+				.on(
+					'click',
+					'button.cancel-variation-changes',
+					this.cancel_variations
+				)
 				.on( 'click', '.remove_variation', this.remove_variation )
-				.on( 'click','.downloadable_files a.delete', this.input_changed );
+				.on(
+					'click',
+					'.downloadable_files a.delete',
+					this.input_changed
+				);
 
 			$( document.body )
-				.on( 'change input', '#variable_product_options .woocommerce_variations :input', this.input_changed )
-				.on( 'change', '.variations-defaults select', this.defaults_changed );
+				.on(
+					'change input',
+					'#variable_product_options .woocommerce_variations :input',
+					this.input_changed
+				)
+				.on(
+					'change',
+					'.variations-defaults select',
+					this.defaults_changed
+				);
 
 			var postForm = $( 'form#post' );
 
 			postForm.on( 'submit', this.save_on_submit );
 
-			$( 'input:submit', postForm ).on( 'click keypress', function() {
+			$( 'input:submit', postForm ).on( 'click keypress', function () {
 				postForm.data( 'callerid', this.id );
-			});
+			} );
 
-			$( '.wc-metaboxes-wrapper' ).on( 'click', 'a.do_variation_action', this.do_variation_action );
+			$( '.wc-metaboxes-wrapper' ).on(
+				'click',
+				'a.do_variation_action',
+				this.do_variation_action
+			);
 		},
 
 		/**
@@ -375,11 +551,17 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		check_for_changes: function() {
-			var need_update = $( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' );
+		check_for_changes: function () {
+			var need_update = $( '#variable_product_options' ).find(
+				'.woocommerce_variations .variation-needs-update'
+			);
 
 			if ( 0 < need_update.length ) {
-				if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_edited_variations ) ) {
+				if (
+					window.confirm(
+						woocommerce_admin_meta_boxes_variations.i18n_edited_variations
+					)
+				) {
 					wc_meta_boxes_product_variations_ajax.save_changes();
 				} else {
 					need_update.removeClass( 'variation-needs-update' );
@@ -393,20 +575,20 @@ jQuery( function( $ ) {
 		/**
 		 * Block edit screen
 		 */
-		block: function() {
-			$( '#woocommerce-product-data' ).block({
+		block: function () {
+			$( '#woocommerce-product-data' ).block( {
 				message: null,
 				overlayCSS: {
 					background: '#fff',
-					opacity: 0.6
-				}
-			});
+					opacity: 0.6,
+				},
+			} );
 		},
 
 		/**
 		 * Unblock edit screen
 		 */
-		unblock: function() {
+		unblock: function () {
 			$( '#woocommerce-product-data' ).unblock();
 		},
 
@@ -415,8 +597,13 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		initial_load: function() {
-			if ( 0 === $( '#variable_product_options' ).find( '.woocommerce_variations .woocommerce_variation' ).length ) {
+		initial_load: function () {
+			if (
+				0 ===
+				$( '#variable_product_options' ).find(
+					'.woocommerce_variations .woocommerce_variation'
+				).length
+			) {
 				wc_meta_boxes_product_variations_pagenav.go_to_page();
 			}
 		},
@@ -427,33 +614,43 @@ jQuery( function( $ ) {
 		 * @param {Int} page (default: 1)
 		 * @param {Int} per_page (default: 10)
 		 */
-		load_variations: function( page, per_page ) {
-			page     = page || 1;
-			per_page = per_page || woocommerce_admin_meta_boxes_variations.variations_per_page;
+		load_variations: function ( page, per_page ) {
+			page = page || 1;
+			per_page =
+				per_page ||
+				woocommerce_admin_meta_boxes_variations.variations_per_page;
 
-			var wrapper = $( '#variable_product_options' ).find( '.woocommerce_variations' );
+			var wrapper = $( '#variable_product_options' ).find(
+				'.woocommerce_variations'
+			);
 
 			wc_meta_boxes_product_variations_ajax.block();
 
-			$.ajax({
+			$.ajax( {
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,
 				data: {
-					action:     'woocommerce_load_variations',
-					security:   woocommerce_admin_meta_boxes_variations.load_variations_nonce,
+					action: 'woocommerce_load_variations',
+					security:
+						woocommerce_admin_meta_boxes_variations.load_variations_nonce,
 					product_id: woocommerce_admin_meta_boxes_variations.post_id,
 					attributes: wrapper.data( 'attributes' ),
-					page:       page,
-					per_page:   per_page
+					page: page,
+					per_page: per_page,
 				},
 				type: 'POST',
-				success: function( response ) {
-					wrapper.empty().append( response ).attr( 'data-page', page );
+				success: function ( response ) {
+					wrapper
+						.empty()
+						.append( response )
+						.attr( 'data-page', page );
 
-					$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_loaded' );
+					$( '#woocommerce-product-data' ).trigger(
+						'woocommerce_variations_loaded'
+					);
 
 					wc_meta_boxes_product_variations_ajax.unblock();
-				}
-			});
+				},
+			} );
 		},
 
 		/**
@@ -463,13 +660,16 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Object}
 		 */
-		get_variations_fields: function( fields ) {
+		get_variations_fields: function ( fields ) {
 			var data = $( ':input', fields ).serializeJSON();
 
-			$( '.variations-defaults select' ).each( function( index, element ) {
+			$( '.variations-defaults select' ).each( function (
+				index,
+				element
+			) {
 				var select = $( element );
 				data[ select.attr( 'name' ) ] = select.val();
-			});
+			} );
 
 			return data;
 		},
@@ -479,39 +679,49 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Function} callback Called once saving is complete
 		 */
-		save_changes: function( callback ) {
-			var wrapper     = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+		save_changes: function ( callback ) {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
 				need_update = $( '.variation-needs-update', wrapper ),
-				data        = {};
+				data = {};
 
 			// Save only with products need update.
 			if ( 0 < need_update.length ) {
 				wc_meta_boxes_product_variations_ajax.block();
 
-				data                 = wc_meta_boxes_product_variations_ajax.get_variations_fields( need_update );
-				data.action          = 'woocommerce_save_variations';
-				data.security        = woocommerce_admin_meta_boxes_variations.save_variations_nonce;
-				data.product_id      = woocommerce_admin_meta_boxes_variations.post_id;
-				data['product-type'] = $( '#product-type' ).val();
+				data = wc_meta_boxes_product_variations_ajax.get_variations_fields(
+					need_update
+				);
+				data.action = 'woocommerce_save_variations';
+				data.security =
+					woocommerce_admin_meta_boxes_variations.save_variations_nonce;
+				data.product_id =
+					woocommerce_admin_meta_boxes_variations.post_id;
+				data[ 'product-type' ] = $( '#product-type' ).val();
 
-				$.ajax({
+				$.ajax( {
 					url: woocommerce_admin_meta_boxes_variations.ajax_url,
 					data: data,
 					type: 'POST',
-					success: function( response ) {
+					success: function ( response ) {
 						// Allow change page, delete and add new variations
 						need_update.removeClass( 'variation-needs-update' );
-						$( 'button.cancel-variation-changes, button.save-variation-changes' ).attr( 'disabled', 'disabled' );
+						$(
+							'button.cancel-variation-changes, button.save-variation-changes'
+						).attr( 'disabled', 'disabled' );
 
-						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_saved' );
+						$( '#woocommerce-product-data' ).trigger(
+							'woocommerce_variations_saved'
+						);
 
 						if ( typeof callback === 'function' ) {
 							callback( response );
 						}
 
 						wc_meta_boxes_product_variations_ajax.unblock();
-					}
-				});
+					},
+				} );
 			}
 		},
 
@@ -520,25 +730,33 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		save_variations: function() {
-			$( '#variable_product_options' ).trigger( 'woocommerce_variations_save_variations_button' );
+		save_variations: function () {
+			$( '#variable_product_options' ).trigger(
+				'woocommerce_variations_save_variations_button'
+			);
 
-			wc_meta_boxes_product_variations_ajax.save_changes( function( error ) {
-				var wrapper = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+			wc_meta_boxes_product_variations_ajax.save_changes( function (
+				error
+			) {
+				var wrapper = $( '#variable_product_options' ).find(
+						'.woocommerce_variations'
+					),
 					current = wrapper.attr( 'data-page' );
 
-				$( '#variable_product_options' ).find( '#woocommerce_errors' ).remove();
+				$( '#variable_product_options' )
+					.find( '#woocommerce_errors' )
+					.remove();
 
 				if ( error ) {
 					wrapper.before( error );
 				}
 
-				$( '.variations-defaults select' ).each( function() {
+				$( '.variations-defaults select' ).each( function () {
 					$( this ).attr( 'data-current', $( this ).val() );
-				});
+				} );
 
 				wc_meta_boxes_product_variations_pagenav.go_to_page( current );
-			});
+			} );
 
 			return false;
 		},
@@ -546,27 +764,41 @@ jQuery( function( $ ) {
 		/**
 		 * Save on post form submit
 		 */
-		save_on_submit: function( e ) {
-			var need_update = $( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' );
+		save_on_submit: function ( e ) {
+			var need_update = $( '#variable_product_options' ).find(
+				'.woocommerce_variations .variation-needs-update'
+			);
 
 			if ( 0 < need_update.length ) {
 				e.preventDefault();
-				$( '#variable_product_options' ).trigger( 'woocommerce_variations_save_variations_on_submit' );
-				wc_meta_boxes_product_variations_ajax.save_changes( wc_meta_boxes_product_variations_ajax.save_on_submit_done );
+				$( '#variable_product_options' ).trigger(
+					'woocommerce_variations_save_variations_on_submit'
+				);
+				wc_meta_boxes_product_variations_ajax.save_changes(
+					wc_meta_boxes_product_variations_ajax.save_on_submit_done
+				);
 			}
 		},
 
 		/**
 		 * After saved, continue with form submission
 		 */
-		save_on_submit_done: function() {
+		save_on_submit_done: function () {
 			var postForm = $( 'form#post' ),
 				callerid = postForm.data( 'callerid' );
 
 			if ( 'publish' === callerid ) {
-				postForm.append('<input type="hidden" name="publish" value="1" />').trigger( 'submit' );
+				postForm
+					.append(
+						'<input type="hidden" name="publish" value="1" />'
+					)
+					.trigger( 'submit' );
 			} else {
-				postForm.append('<input type="hidden" name="save-post" value="1" />').trigger( 'submit' );
+				postForm
+					.append(
+						'<input type="hidden" name="save-post" value="1" />'
+					)
+					.trigger( 'submit' );
 			}
 		},
 
@@ -575,14 +807,20 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		cancel_variations: function() {
-			var current = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-page' ), 10 );
+		cancel_variations: function () {
+			var current = parseInt(
+				$( '#variable_product_options' )
+					.find( '.woocommerce_variations' )
+					.attr( 'data-page' ),
+				10
+			);
 
-			$( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' )
+			$( '#variable_product_options' )
+				.find( '.woocommerce_variations .variation-needs-update' )
 				.removeClass( 'variation-needs-update' );
-			$( '.variations-defaults select' ).each( function() {
+			$( '.variations-defaults select' ).each( function () {
 				$( this ).val( $( this ).attr( 'data-current' ) );
-			});
+			} );
 
 			wc_meta_boxes_product_variations_pagenav.go_to_page( current );
 
@@ -594,26 +832,38 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		add_variation: function() {
+		add_variation: function () {
 			wc_meta_boxes_product_variations_ajax.block();
 
 			var data = {
 				action: 'woocommerce_add_variation',
 				post_id: woocommerce_admin_meta_boxes_variations.post_id,
 				loop: $( '.woocommerce_variation' ).length,
-				security: woocommerce_admin_meta_boxes_variations.add_variation_nonce
+				security:
+					woocommerce_admin_meta_boxes_variations.add_variation_nonce,
 			};
 
-			$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function( response ) {
-				var variation = $( response );
-				variation.addClass( 'variation-needs-update' );
+			$.post(
+				woocommerce_admin_meta_boxes_variations.ajax_url,
+				data,
+				function ( response ) {
+					var variation = $( response );
+					variation.addClass( 'variation-needs-update' );
 
-				$( '.woocommerce-notice-invalid-variation' ).remove();
-				$( '#variable_product_options' ).find( '.woocommerce_variations' ).prepend( variation );
-				$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
-				$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', 1 );
-				wc_meta_boxes_product_variations_ajax.unblock();
-			});
+					$( '.woocommerce-notice-invalid-variation' ).remove();
+					$( '#variable_product_options' )
+						.find( '.woocommerce_variations' )
+						.prepend( variation );
+					$(
+						'button.cancel-variation-changes, button.save-variation-changes'
+					).prop( 'disabled', false );
+					$( '#variable_product_options' ).trigger(
+						'woocommerce_variations_added',
+						1
+					);
+					wc_meta_boxes_product_variations_ajax.unblock();
+				}
+			);
 
 			return false;
 		},
@@ -623,14 +873,18 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		remove_variation: function() {
+		remove_variation: function () {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_remove_variation ) ) {
-				var variation     = $( this ).attr( 'rel' ),
+			if (
+				window.confirm(
+					woocommerce_admin_meta_boxes_variations.i18n_remove_variation
+				)
+			) {
+				var variation = $( this ).attr( 'rel' ),
 					variation_ids = [],
-					data          = {
-						action: 'woocommerce_remove_variations'
+					data = {
+						action: 'woocommerce_remove_variations',
 					};
 
 				wc_meta_boxes_product_variations_ajax.block();
@@ -639,27 +893,52 @@ jQuery( function( $ ) {
 					variation_ids.push( variation );
 
 					data.variation_ids = variation_ids;
-					data.security      = woocommerce_admin_meta_boxes_variations.delete_variations_nonce;
+					data.security =
+						woocommerce_admin_meta_boxes_variations.delete_variations_nonce;
 
-					$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function() {
-						var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-							current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
-							total_pages  = Math.ceil( (
-								parseInt( wrapper.attr( 'data-total' ), 10 ) - 1
-							) / woocommerce_admin_meta_boxes_variations.variations_per_page ),
-							page         = 1;
+					$.post(
+						woocommerce_admin_meta_boxes_variations.ajax_url,
+						data,
+						function () {
+							var wrapper = $( '#variable_product_options' ).find(
+									'.woocommerce_variations'
+								),
+								current_page = parseInt(
+									wrapper.attr( 'data-page' ),
+									10
+								),
+								total_pages = Math.ceil(
+									( parseInt(
+										wrapper.attr( 'data-total' ),
+										10
+									) -
+										1 ) /
+										woocommerce_admin_meta_boxes_variations.variations_per_page
+								),
+								page = 1;
 
-						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_removed' );
+							$( '#woocommerce-product-data' ).trigger(
+								'woocommerce_variations_removed'
+							);
 
-						if ( current_page === total_pages || current_page <= total_pages ) {
-							page = current_page;
-						} else if ( current_page > total_pages && 0 !== total_pages ) {
-							page = total_pages;
+							if (
+								current_page === total_pages ||
+								current_page <= total_pages
+							) {
+								page = current_page;
+							} else if (
+								current_page > total_pages &&
+								0 !== total_pages
+							) {
+								page = total_pages;
+							}
+
+							wc_meta_boxes_product_variations_pagenav.go_to_page(
+								page,
+								-1
+							);
 						}
-
-						wc_meta_boxes_product_variations_pagenav.go_to_page( page, -1 );
-					});
-
+					);
 				} else {
 					wc_meta_boxes_product_variations_ajax.unblock();
 				}
@@ -673,36 +952,61 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		link_all_variations: function() {
+		link_all_variations: function () {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_link_all_variations ) ) {
+			if (
+				window.confirm(
+					woocommerce_admin_meta_boxes_variations.i18n_link_all_variations
+				)
+			) {
 				wc_meta_boxes_product_variations_ajax.block();
 
 				var data = {
 					action: 'woocommerce_link_all_variations',
 					post_id: woocommerce_admin_meta_boxes_variations.post_id,
-					security: woocommerce_admin_meta_boxes_variations.link_variation_nonce
+					security:
+						woocommerce_admin_meta_boxes_variations.link_variation_nonce,
 				};
 
-				$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function( response ) {
-					var count = parseInt( response, 10 );
+				$.post(
+					woocommerce_admin_meta_boxes_variations.ajax_url,
+					data,
+					function ( response ) {
+						var count = parseInt( response, 10 );
 
-					if ( 1 === count ) {
-						window.alert( count + ' ' + woocommerce_admin_meta_boxes_variations.i18n_variation_added );
-					} else if ( 0 === count || count > 1 ) {
-						window.alert( count + ' ' + woocommerce_admin_meta_boxes_variations.i18n_variations_added );
-					} else {
-						window.alert( woocommerce_admin_meta_boxes_variations.i18n_no_variations_added );
-					}
+						if ( 1 === count ) {
+							window.alert(
+								count +
+									' ' +
+									woocommerce_admin_meta_boxes_variations.i18n_variation_added
+							);
+						} else if ( 0 === count || count > 1 ) {
+							window.alert(
+								count +
+									' ' +
+									woocommerce_admin_meta_boxes_variations.i18n_variations_added
+							);
+						} else {
+							window.alert(
+								woocommerce_admin_meta_boxes_variations.i18n_no_variations_added
+							);
+						}
 
-					if ( count > 0 ) {
-						wc_meta_boxes_product_variations_pagenav.go_to_page( 1, count );
-						$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', count );
-					} else {
-						wc_meta_boxes_product_variations_ajax.unblock();
+						if ( count > 0 ) {
+							wc_meta_boxes_product_variations_pagenav.go_to_page(
+								1,
+								count
+							);
+							$( '#variable_product_options' ).trigger(
+								'woocommerce_variations_added',
+								count
+							);
+						} else {
+							wc_meta_boxes_product_variations_ajax.unblock();
+						}
 					}
-				});
+				);
 			}
 
 			return false;
@@ -711,87 +1015,119 @@ jQuery( function( $ ) {
 		/**
 		 * Add new class when have changes in some input
 		 */
-		input_changed: function( event ) {
+		input_changed: function ( event ) {
 			$( this )
 				.closest( '.woocommerce_variation' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
+			$(
+				'button.cancel-variation-changes, button.save-variation-changes'
+			).prop( 'disabled', false );
 
 			// Do not trigger 'woocommerce_variations_input_changed' for 'input' events for backwards compat.
 			if ( 'input' === event.type && $( this ).is( ':text' ) ) {
 				return;
 			}
 
-			$( '#variable_product_options' ).trigger( 'woocommerce_variations_input_changed' );
+			$( '#variable_product_options' ).trigger(
+				'woocommerce_variations_input_changed'
+			);
 		},
 
 		/**
 		 * Added new .variation-needs-update class when defaults is changed
 		 */
-		defaults_changed: function() {
+		defaults_changed: function () {
 			$( this )
 				.closest( '#variable_product_options' )
 				.find( '.woocommerce_variation:first' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
+			$(
+				'button.cancel-variation-changes, button.save-variation-changes'
+			).prop( 'disabled', false );
 
-			$( '#variable_product_options' ).trigger( 'woocommerce_variations_defaults_changed' );
+			$( '#variable_product_options' ).trigger(
+				'woocommerce_variations_defaults_changed'
+			);
 		},
 
 		/**
 		 * Actions
 		 */
-		do_variation_action: function() {
+		do_variation_action: function () {
 			var do_variation_action = $( 'select.variation_actions' ).val(),
-				data       = {},
-				changes    = 0,
+				data = {},
+				changes = 0,
 				value;
 
 			switch ( do_variation_action ) {
-				case 'add_variation' :
+				case 'add_variation':
 					wc_meta_boxes_product_variations_ajax.add_variation();
 					return;
-				case 'link_all_variations' :
+				case 'link_all_variations':
 					wc_meta_boxes_product_variations_ajax.link_all_variations();
 					return;
-				case 'delete_all' :
-					if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations ) ) {
-						if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_last_warning ) ) {
+				case 'delete_all':
+					if (
+						window.confirm(
+							woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations
+						)
+					) {
+						if (
+							window.confirm(
+								woocommerce_admin_meta_boxes_variations.i18n_last_warning
+							)
+						) {
 							data.allowed = true;
-							changes      = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' )
-								.attr( 'data-total' ), 10 ) * -1;
+							changes =
+								parseInt(
+									$( '#variable_product_options' )
+										.find( '.woocommerce_variations' )
+										.attr( 'data-total' ),
+									10
+								) * -1;
 						}
 					}
 					break;
-				case 'variable_regular_price_increase' :
-				case 'variable_regular_price_decrease' :
-				case 'variable_sale_price_increase' :
-				case 'variable_sale_price_decrease' :
-					value = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent );
+				case 'variable_regular_price_increase':
+				case 'variable_regular_price_decrease':
+				case 'variable_sale_price_increase':
+				case 'variable_sale_price_decrease':
+					value = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value_fixed_or_percent
+					);
 
 					if ( value != null ) {
 						if ( value.indexOf( '%' ) >= 0 ) {
-							data.value = accounting.unformat( value.replace( /\%/, '' ), woocommerce_admin.mon_decimal_point ) + '%';
+							data.value =
+								accounting.unformat(
+									value.replace( /\%/, '' ),
+									woocommerce_admin.mon_decimal_point
+								) + '%';
 						} else {
-							data.value = accounting.unformat( value, woocommerce_admin.mon_decimal_point );
+							data.value = accounting.unformat(
+								value,
+								woocommerce_admin.mon_decimal_point
+							);
 						}
 					} else {
 						return;
 					}
 					break;
-				case 'variable_regular_price' :
-				case 'variable_sale_price' :
-				case 'variable_stock' :
-				case 'variable_low_stock_amount' :
-				case 'variable_weight' :
-				case 'variable_length' :
-				case 'variable_width' :
-				case 'variable_height' :
-				case 'variable_download_limit' :
-				case 'variable_download_expiry' :
-					value = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_a_value );
+				case 'variable_regular_price':
+				case 'variable_sale_price':
+				case 'variable_stock':
+				case 'variable_low_stock_amount':
+				case 'variable_weight':
+				case 'variable_length':
+				case 'variable_width':
+				case 'variable_height':
+				case 'variable_download_limit':
+				case 'variable_download_expiry':
+					value = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_enter_a_value
+					);
 
 					if ( value != null ) {
 						data.value = value;
@@ -799,9 +1135,13 @@ jQuery( function( $ ) {
 						return;
 					}
 					break;
-				case 'variable_sale_schedule' :
-					data.date_from = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_start );
-					data.date_to   = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_end );
+				case 'variable_sale_schedule':
+					data.date_from = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_start
+					);
+					data.date_to = window.prompt(
+						woocommerce_admin_meta_boxes_variations.i18n_scheduled_sale_end
+					);
 
 					if ( null === data.date_from ) {
 						data.date_from = false;
@@ -815,9 +1155,14 @@ jQuery( function( $ ) {
 						return;
 					}
 					break;
-				default :
-					$( 'select.variation_actions' ).trigger( do_variation_action );
-					data = $( 'select.variation_actions' ).triggerHandler( do_variation_action + '_ajax_data', data );
+				default:
+					$( 'select.variation_actions' ).trigger(
+						do_variation_action
+					);
+					data = $( 'select.variation_actions' ).triggerHandler(
+						do_variation_action + '_ajax_data',
+						data
+					);
 
 					if ( null === data ) {
 						return;
@@ -826,47 +1171,67 @@ jQuery( function( $ ) {
 			}
 
 			if ( 'delete_all' === do_variation_action && data.allowed ) {
-				$( '#variable_product_options' ).find( '.variation-needs-update' ).removeClass( 'variation-needs-update' );
+				$( '#variable_product_options' )
+					.find( '.variation-needs-update' )
+					.removeClass( 'variation-needs-update' );
 			} else {
 				wc_meta_boxes_product_variations_ajax.check_for_changes();
 			}
 
 			wc_meta_boxes_product_variations_ajax.block();
 
-			$.ajax({
+			$.ajax( {
 				url: woocommerce_admin_meta_boxes_variations.ajax_url,
 				data: {
-					action:       'woocommerce_bulk_edit_variations',
-					security:     woocommerce_admin_meta_boxes_variations.bulk_edit_variations_nonce,
-					product_id:   woocommerce_admin_meta_boxes_variations.post_id,
+					action: 'woocommerce_bulk_edit_variations',
+					security:
+						woocommerce_admin_meta_boxes_variations.bulk_edit_variations_nonce,
+					product_id: woocommerce_admin_meta_boxes_variations.post_id,
 					product_type: $( '#product-type' ).val(),
-					bulk_action:  do_variation_action,
-					data:         data
+					bulk_action: do_variation_action,
+					data: data,
 				},
 				type: 'POST',
-				success: function() {
-					wc_meta_boxes_product_variations_pagenav.go_to_page( 1, changes );
-				}
-			});
-		}
+				success: function () {
+					wc_meta_boxes_product_variations_pagenav.go_to_page(
+						1,
+						changes
+					);
+				},
+			} );
+		},
 	};
 
 	/**
 	 * Product variations pagenav
 	 */
 	var wc_meta_boxes_product_variations_pagenav = {
-
 		/**
 		 * Initialize products variations meta box
 		 */
-		init: function() {
+		init: function () {
 			$( document.body )
-				.on( 'woocommerce_variations_added', this.update_single_quantity )
-				.on( 'change', '.variations-pagenav .page-selector', this.page_selector )
-				.on( 'click', '.variations-pagenav .first-page', this.first_page )
+				.on(
+					'woocommerce_variations_added',
+					this.update_single_quantity
+				)
+				.on(
+					'change',
+					'.variations-pagenav .page-selector',
+					this.page_selector
+				)
+				.on(
+					'click',
+					'.variations-pagenav .first-page',
+					this.first_page
+				)
 				.on( 'click', '.variations-pagenav .prev-page', this.prev_page )
 				.on( 'click', '.variations-pagenav .next-page', this.next_page )
-				.on( 'click', '.variations-pagenav .last-page', this.last_page );
+				.on(
+					'click',
+					'.variations-pagenav .last-page',
+					this.last_page
+				);
 		},
 
 		/**
@@ -876,18 +1241,30 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Int}
 		 */
-		update_variations_count: function( qty ) {
-			var wrapper        = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-				total          = parseInt( wrapper.attr( 'data-total' ), 10 ) + qty,
+		update_variations_count: function ( qty ) {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
+				total = parseInt( wrapper.attr( 'data-total' ), 10 ) + qty,
 				displaying_num = $( '.variations-pagenav .displaying-num' );
 
 			// Set the new total of variations
 			wrapper.attr( 'data-total', total );
 
 			if ( 1 === total ) {
-				displaying_num.text( woocommerce_admin_meta_boxes_variations.i18n_variation_count_single.replace( '%qty%', total ) );
+				displaying_num.text(
+					woocommerce_admin_meta_boxes_variations.i18n_variation_count_single.replace(
+						'%qty%',
+						total
+					)
+				);
 			} else {
-				displaying_num.text( woocommerce_admin_meta_boxes_variations.i18n_variation_count_plural.replace( '%qty%', total ) );
+				displaying_num.text(
+					woocommerce_admin_meta_boxes_variations.i18n_variation_count_plural.replace(
+						'%qty%',
+						total
+					)
+				);
 			}
 
 			return total;
@@ -899,11 +1276,13 @@ jQuery( function( $ ) {
 		 * @param {Object} event
 		 * @param {Int} qty
 		 */
-		update_single_quantity: function( event, qty ) {
+		update_single_quantity: function ( event, qty ) {
 			if ( 1 === qty ) {
 				var page_nav = $( '.variations-pagenav' );
 
-				wc_meta_boxes_product_variations_pagenav.update_variations_count( qty );
+				wc_meta_boxes_product_variations_pagenav.update_variations_count(
+					qty
+				);
 
 				if ( page_nav.is( ':hidden' ) ) {
 					$( 'option, optgroup', '.variation_actions' ).show();
@@ -920,15 +1299,22 @@ jQuery( function( $ ) {
 		 *
 		 * @param {Int} qty
 		 */
-		set_paginav: function( qty ) {
-			var wrapper          = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-				new_qty          = wc_meta_boxes_product_variations_pagenav.update_variations_count( qty ),
-				toolbar          = $( '#variable_product_options' ).find( '.toolbar' ),
+		set_paginav: function ( qty ) {
+			var wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				),
+				new_qty = wc_meta_boxes_product_variations_pagenav.update_variations_count(
+					qty
+				),
+				toolbar = $( '#variable_product_options' ).find( '.toolbar' ),
 				variation_action = $( '.variation_actions' ),
-				page_nav         = $( '.variations-pagenav' ),
+				page_nav = $( '.variations-pagenav' ),
 				displaying_links = $( '.pagination-links', page_nav ),
-				total_pages      = Math.ceil( new_qty / woocommerce_admin_meta_boxes_variations.variations_per_page ),
-				options          = '';
+				total_pages = Math.ceil(
+					new_qty /
+						woocommerce_admin_meta_boxes_variations.variations_per_page
+				),
+				options = '';
 
 			// Set the new total of pages
 			wrapper.attr( 'data-total_pages', total_pages );
@@ -949,7 +1335,6 @@ jQuery( function( $ ) {
 				$( 'option, optgroup', variation_action ).hide();
 				$( '.variation_actions' ).val( 'add_variation' );
 				$( 'option[data-global="true"]', variation_action ).show();
-
 			} else {
 				toolbar.show();
 				page_nav.show();
@@ -970,18 +1355,18 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		check_is_enabled: function( current ) {
+		check_is_enabled: function ( current ) {
 			return ! $( current ).hasClass( 'disabled' );
 		},
 
 		/**
 		 * Change "disabled" class on pagenav
 		 */
-		change_classes: function( selected, total ) {
+		change_classes: function ( selected, total ) {
 			var first_page = $( '.variations-pagenav .first-page' ),
-				prev_page  = $( '.variations-pagenav .prev-page' ),
-				next_page  = $( '.variations-pagenav .next-page' ),
-				last_page  = $( '.variations-pagenav .last-page' );
+				prev_page = $( '.variations-pagenav .prev-page' ),
+				next_page = $( '.variations-pagenav .next-page' ),
+				last_page = $( '.variations-pagenav .last-page' );
 
 			if ( 1 === selected ) {
 				first_page.addClass( 'disabled' );
@@ -1003,8 +1388,11 @@ jQuery( function( $ ) {
 		/**
 		 * Set page
 		 */
-		set_page: function( page ) {
-			$( '.variations-pagenav .page-selector' ).val( page ).first().trigger( 'change' );
+		set_page: function ( page ) {
+			$( '.variations-pagenav .page-selector' )
+				.val( page )
+				.first()
+				.trigger( 'change' );
 		},
 
 		/**
@@ -1013,9 +1401,9 @@ jQuery( function( $ ) {
 		 * @param {Int} page
 		 * @param {Int} qty
 		 */
-		go_to_page: function( page, qty ) {
+		go_to_page: function ( page, qty ) {
 			page = page || 1;
-			qty  = qty || 0;
+			qty = qty || 0;
 
 			wc_meta_boxes_product_variations_pagenav.set_paginav( qty );
 			wc_meta_boxes_product_variations_pagenav.set_page( page );
@@ -1024,14 +1412,19 @@ jQuery( function( $ ) {
 		/**
 		 * Paginav pagination selector
 		 */
-		page_selector: function() {
+		page_selector: function () {
 			var selected = parseInt( $( this ).val(), 10 ),
-				wrapper  = $( '#variable_product_options' ).find( '.woocommerce_variations' );
+				wrapper = $( '#variable_product_options' ).find(
+					'.woocommerce_variations'
+				);
 
 			$( '.variations-pagenav .page-selector' ).val( selected );
 
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
-			wc_meta_boxes_product_variations_pagenav.change_classes( selected, parseInt( wrapper.attr( 'data-total_pages' ), 10 ) );
+			wc_meta_boxes_product_variations_pagenav.change_classes(
+				selected,
+				parseInt( wrapper.attr( 'data-total_pages' ), 10 )
+			);
 			wc_meta_boxes_product_variations_ajax.load_variations( selected );
 		},
 
@@ -1040,8 +1433,12 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		first_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
+		first_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
 				wc_meta_boxes_product_variations_pagenav.set_page( 1 );
 			}
 
@@ -1053,11 +1450,17 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		prev_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
-				var wrapper   = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
+		prev_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
+				var wrapper = $( '#variable_product_options' ).find(
+						'.woocommerce_variations'
+					),
 					prev_page = parseInt( wrapper.attr( 'data-page' ), 10 ) - 1,
-					new_page  = ( 0 < prev_page ) ? prev_page : 1;
+					new_page = 0 < prev_page ? prev_page : 1;
 
 				wc_meta_boxes_product_variations_pagenav.set_page( new_page );
 			}
@@ -1070,12 +1473,22 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		next_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
-				var wrapper     = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
-					total_pages = parseInt( wrapper.attr( 'data-total_pages' ), 10 ),
-					next_page   = parseInt( wrapper.attr( 'data-page' ), 10 ) + 1,
-					new_page    = ( total_pages >= next_page ) ? next_page : total_pages;
+		next_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
+				var wrapper = $( '#variable_product_options' ).find(
+						'.woocommerce_variations'
+					),
+					total_pages = parseInt(
+						wrapper.attr( 'data-total_pages' ),
+						10
+					),
+					next_page = parseInt( wrapper.attr( 'data-page' ), 10 ) + 1,
+					new_page =
+						total_pages >= next_page ? next_page : total_pages;
 
 				wc_meta_boxes_product_variations_pagenav.set_page( new_page );
 			}
@@ -1088,20 +1501,25 @@ jQuery( function( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		last_page: function() {
-			if ( wc_meta_boxes_product_variations_pagenav.check_is_enabled( this ) ) {
-				var last_page = $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-total_pages' );
+		last_page: function () {
+			if (
+				wc_meta_boxes_product_variations_pagenav.check_is_enabled(
+					this
+				)
+			) {
+				var last_page = $( '#variable_product_options' )
+					.find( '.woocommerce_variations' )
+					.attr( 'data-total_pages' );
 
 				wc_meta_boxes_product_variations_pagenav.set_page( last_page );
 			}
 
 			return false;
-		}
+		},
 	};
 
 	wc_meta_boxes_product_variations_actions.init();
 	wc_meta_boxes_product_variations_media.init();
 	wc_meta_boxes_product_variations_ajax.init();
 	wc_meta_boxes_product_variations_pagenav.init();
-
-});
+} );

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -1,32 +1,32 @@
 /* global woocommerce_admin */
-( function( $, woocommerce_admin ) {
-	$( function() {
+( function ( $, woocommerce_admin ) {
+	$( function () {
 		if ( 'undefined' === typeof woocommerce_admin ) {
 			return;
 		}
 
 		// Add buttons to product screen.
 		var $product_screen = $( '.edit-php.post-type-product' ),
-			$title_action   = $product_screen.find( '.page-title-action:first' ),
-			$blankslate     = $product_screen.find( '.woocommerce-BlankState' );
+			$title_action = $product_screen.find( '.page-title-action:first' ),
+			$blankslate = $product_screen.find( '.woocommerce-BlankState' );
 
 		if ( 0 === $blankslate.length ) {
 			if ( woocommerce_admin.urls.export_products ) {
 				$title_action.after(
 					'<a href="' +
-					woocommerce_admin.urls.export_products +
-					'" class="page-title-action">' +
-					woocommerce_admin.strings.export_products +
-					'</a>'
+						woocommerce_admin.urls.export_products +
+						'" class="page-title-action">' +
+						woocommerce_admin.strings.export_products +
+						'</a>'
 				);
 			}
 			if ( woocommerce_admin.urls.import_products ) {
 				$title_action.after(
 					'<a href="' +
-					woocommerce_admin.urls.import_products +
-					'" class="page-title-action">' +
-					woocommerce_admin.strings.import_products +
-					'</a>'
+						woocommerce_admin.urls.import_products +
+						'" class="page-title-action">' +
+						woocommerce_admin.strings.import_products +
+						'</a>'
 				);
 			}
 		} else {
@@ -34,60 +34,103 @@
 		}
 
 		// Progress indicators when showing steps.
-		$( '.woocommerce-progress-form-wrapper .button-next' ).on( 'click', function() {
-			$('.wc-progress-form-content').block({
-				message: null,
-				overlayCSS: {
-					background: '#fff',
-					opacity: 0.6
-				}
-			});
-			return true;
-		} );
+		$( '.woocommerce-progress-form-wrapper .button-next' ).on(
+			'click',
+			function () {
+				$( '.wc-progress-form-content' ).block( {
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6,
+					},
+				} );
+				return true;
+			}
+		);
 
 		// Field validation error tips
 		$( document.body )
-
-			.on( 'wc_add_error_tip', function( e, element, error_type ) {
+			.on( 'wc_add_error_tip', function ( e, element, error_type ) {
 				var offset = element.position();
 
 				if ( element.parent().find( '.wc_error_tip' ).length === 0 ) {
-					element.after( '<div class="wc_error_tip ' + error_type + '">' + woocommerce_admin[error_type] + '</div>' );
-					element.parent().find( '.wc_error_tip' )
-						.css( 'left', offset.left + element.width() - ( element.width() / 2 ) - ( $( '.wc_error_tip' ).width() / 2 ) )
+					element.after(
+						'<div class="wc_error_tip ' +
+							error_type +
+							'">' +
+							woocommerce_admin[ error_type ] +
+							'</div>'
+					);
+					element
+						.parent()
+						.find( '.wc_error_tip' )
+						.css(
+							'left',
+							offset.left +
+								element.width() -
+								element.width() / 2 -
+								$( '.wc_error_tip' ).width() / 2
+						)
 						.css( 'top', offset.top + element.height() )
 						.fadeIn( '100' );
 				}
-			})
+			} )
 
-			.on( 'wc_remove_error_tip', function( e, element, error_type ) {
-				element.parent().find( '.wc_error_tip.' + error_type ).fadeOut( '100', function() { $( this ).remove(); } );
-			})
+			.on( 'wc_remove_error_tip', function ( e, element, error_type ) {
+				element
+					.parent()
+					.find( '.wc_error_tip.' + error_type )
+					.fadeOut( '100', function () {
+						$( this ).remove();
+					} );
+			} )
 
-			.on( 'click', function() {
-				$( '.wc_error_tip' ).fadeOut( '100', function() { $( this ).remove(); } );
-			})
+			.on( 'click', function () {
+				$( '.wc_error_tip' ).fadeOut( '100', function () {
+					$( this ).remove();
+				} );
+			} )
 
-			.on( 'blur', '.wc_input_decimal[type=text], .wc_input_price[type=text], .wc_input_country_iso[type=text]', function() {
-				$( '.wc_error_tip' ).fadeOut( '100', function() { $( this ).remove(); } );
-			})
+			.on(
+				'blur',
+				'.wc_input_decimal[type=text], .wc_input_price[type=text], .wc_input_country_iso[type=text]',
+				function () {
+					$( '.wc_error_tip' ).fadeOut( '100', function () {
+						$( this ).remove();
+					} );
+				}
+			)
 
 			.on(
 				'change',
-				'.wc_input_price[type=text], .wc_input_decimal[type=text], .wc-order-totals #refund_amount[type=text]',
-				function() {
-					var regex, decimalRegex,
+				'.wc_input_price[type=text], .wc_input_decimal[type=text], .wc-order-totals #refund_amount[type=text], ' +
+					'.wc_input_variations_price[type=text]',
+				function () {
+					var regex,
+						decimalRegex,
 						decimailPoint = woocommerce_admin.decimal_point;
 
-					if ( $( this ).is( '.wc_input_price' ) || $( this ).is( '#refund_amount' ) ) {
+					if (
+						$( this ).is( '.wc_input_price' ) ||
+						$( this ).is( '.wc_input_variations_price' ) ||
+						$( this ).is( '#refund_amount' )
+					) {
 						decimailPoint = woocommerce_admin.mon_decimal_point;
 					}
 
-					regex        = new RegExp( '[^\-0-9\%\\' + decimailPoint + ']+', 'gi' );
-					decimalRegex = new RegExp( '\\' + decimailPoint + '+', 'gi' );
+					regex = new RegExp(
+						'[^-0-9%\\' + decimailPoint + ']+',
+						'gi'
+					);
+					decimalRegex = new RegExp(
+						'\\' + decimailPoint + '+',
+						'gi'
+					);
 
-					var value    = $( this ).val();
-					var newvalue = value.replace( regex, '' ).replace( decimalRegex, decimailPoint );
+					var value = $( this ).val();
+					var newvalue = value
+						.replace( regex, '' )
+						.replace( decimalRegex, decimailPoint );
 
 					if ( value !== newvalue ) {
 						$( this ).val( newvalue );
@@ -98,120 +141,198 @@
 			.on(
 				'keyup',
 				// eslint-disable-next-line max-len
-				'.wc_input_price[type=text], .wc_input_decimal[type=text], .wc_input_country_iso[type=text], .wc-order-totals #refund_amount[type=text]',
-				function() {
+				'.wc_input_price[type=text], .wc_input_decimal[type=text], .wc_input_country_iso[type=text], .wc-order-totals #refund_amount[type=text], .wc_input_variations_price[type=text]',
+				function () {
 					var regex, error, decimalRegex;
 					var checkDecimalNumbers = false;
-
-					if ( $( this ).is( '.wc_input_price' ) || $( this ).is( '#refund_amount' ) ) {
+					console.log( 'entro' );
+					if (
+						$( this ).is( '.wc_input_price' ) ||
+						$( this ).is( '.wc_input_variations_price' ) ||
+						$( this ).is( '#refund_amount' )
+					) {
 						checkDecimalNumbers = true;
-						regex = new RegExp( '[^\-0-9\%\\' + woocommerce_admin.mon_decimal_point + ']+', 'gi' );
-						decimalRegex = new RegExp( '[^\\' + woocommerce_admin.mon_decimal_point + ']', 'gi' );
+						regex = new RegExp(
+							'[^-0-9%\\' +
+								woocommerce_admin.mon_decimal_point +
+								']+',
+							'gi'
+						);
+						decimalRegex = new RegExp(
+							'[^\\' + woocommerce_admin.mon_decimal_point + ']',
+							'gi'
+						);
 						error = 'i18n_mon_decimal_error';
 					} else if ( $( this ).is( '.wc_input_country_iso' ) ) {
 						regex = new RegExp( '([^A-Z])+|(.){3,}', 'im' );
 						error = 'i18n_country_iso_error';
 					} else {
 						checkDecimalNumbers = true;
-						regex = new RegExp( '[^\-0-9\%\\' + woocommerce_admin.decimal_point + ']+', 'gi' );
-						decimalRegex = new RegExp( '[^\\' + woocommerce_admin.decimal_point + ']', 'gi' );
+						regex = new RegExp(
+							'[^-0-9%\\' +
+								woocommerce_admin.decimal_point +
+								']+',
+							'gi'
+						);
+						decimalRegex = new RegExp(
+							'[^\\' + woocommerce_admin.decimal_point + ']',
+							'gi'
+						);
 						error = 'i18n_decimal_error';
 					}
 
-					var value    = $( this ).val();
+					var value = $( this ).val();
 					var newvalue = value.replace( regex, '' );
 
 					// Check if newvalue have more than one decimal point.
-					if ( checkDecimalNumbers && 1 < newvalue.replace( decimalRegex, '' ).length ) {
+					if (
+						checkDecimalNumbers &&
+						1 < newvalue.replace( decimalRegex, '' ).length
+					) {
 						newvalue = newvalue.replace( decimalRegex, '' );
 					}
 
 					if ( value !== newvalue ) {
-						$( document.body ).triggerHandler( 'wc_add_error_tip', [ $( this ), error ] );
+						$( document.body ).triggerHandler( 'wc_add_error_tip', [
+							$( this ),
+							error,
+						] );
 					} else {
-						$( document.body ).triggerHandler( 'wc_remove_error_tip', [ $( this ), error ] );
+						$(
+							document.body
+						).triggerHandler( 'wc_remove_error_tip', [
+							$( this ),
+							error,
+						] );
 					}
 				}
 			)
 
-			.on( 'change', '#_sale_price.wc_input_price[type=text], .wc_input_price[name^=variable_sale_price]', function() {
-				var sale_price_field = $( this ), regular_price_field;
+			.on(
+				'change',
+				'#_sale_price.wc_input_price[type=text], .wc_input_price[name^=variable_sale_price]',
+				function () {
+					var sale_price_field = $( this ),
+						regular_price_field;
 
-				if ( sale_price_field.attr( 'name' ).indexOf( 'variable' ) !== -1 ) {
-					regular_price_field = sale_price_field
-						.parents( '.variable_pricing' )
-						.find( '.wc_input_price[name^=variable_regular_price]' );
-				} else {
-					regular_price_field = $( '#_regular_price' );
+					if (
+						sale_price_field
+							.attr( 'name' )
+							.indexOf( 'variable' ) !== -1
+					) {
+						regular_price_field = sale_price_field
+							.parents( '.variable_pricing' )
+							.find(
+								'.wc_input_price[name^=variable_regular_price]'
+							);
+					} else {
+						regular_price_field = $( '#_regular_price' );
+					}
+
+					var sale_price = parseFloat(
+						window.accounting.unformat(
+							sale_price_field.val(),
+							woocommerce_admin.mon_decimal_point
+						)
+					);
+					var regular_price = parseFloat(
+						window.accounting.unformat(
+							regular_price_field.val(),
+							woocommerce_admin.mon_decimal_point
+						)
+					);
+
+					if ( sale_price >= regular_price ) {
+						$( this ).val( '' );
+					}
 				}
+			)
 
-				var sale_price    = parseFloat(
-					window.accounting.unformat( sale_price_field.val(), woocommerce_admin.mon_decimal_point )
-				);
-				var regular_price = parseFloat(
-					window.accounting.unformat( regular_price_field.val(), woocommerce_admin.mon_decimal_point )
-				);
+			.on(
+				'keyup',
+				'#_sale_price.wc_input_price[type=text], .wc_input_price[name^=variable_sale_price]',
+				function () {
+					var sale_price_field = $( this ),
+						regular_price_field;
 
-				if ( sale_price >= regular_price ) {
-					$( this ).val( '' );
+					if (
+						sale_price_field
+							.attr( 'name' )
+							.indexOf( 'variable' ) !== -1
+					) {
+						regular_price_field = sale_price_field
+							.parents( '.variable_pricing' )
+							.find(
+								'.wc_input_price[name^=variable_regular_price]'
+							);
+					} else {
+						regular_price_field = $( '#_regular_price' );
+					}
+
+					var sale_price = parseFloat(
+						window.accounting.unformat(
+							sale_price_field.val(),
+							woocommerce_admin.mon_decimal_point
+						)
+					);
+					var regular_price = parseFloat(
+						window.accounting.unformat(
+							regular_price_field.val(),
+							woocommerce_admin.mon_decimal_point
+						)
+					);
+
+					if ( sale_price >= regular_price ) {
+						$( document.body ).triggerHandler( 'wc_add_error_tip', [
+							$( this ),
+							'i18n_sale_less_than_regular_error',
+						] );
+					} else {
+						$(
+							document.body
+						).triggerHandler( 'wc_remove_error_tip', [
+							$( this ),
+							'i18n_sale_less_than_regular_error',
+						] );
+					}
 				}
-			})
+			)
 
-			.on( 'keyup', '#_sale_price.wc_input_price[type=text], .wc_input_price[name^=variable_sale_price]', function() {
-				var sale_price_field = $( this ), regular_price_field;
-
-				if ( sale_price_field.attr( 'name' ).indexOf( 'variable' ) !== -1 ) {
-					regular_price_field = sale_price_field
-						.parents( '.variable_pricing' )
-						.find( '.wc_input_price[name^=variable_regular_price]' );
-				} else {
-					regular_price_field = $( '#_regular_price' );
-				}
-
-				var sale_price    = parseFloat(
-					window.accounting.unformat( sale_price_field.val(), woocommerce_admin.mon_decimal_point )
-				);
-				var regular_price = parseFloat(
-					window.accounting.unformat( regular_price_field.val(), woocommerce_admin.mon_decimal_point )
-				);
-
-				if ( sale_price >= regular_price ) {
-					$( document.body ).triggerHandler( 'wc_add_error_tip', [ $(this), 'i18n_sale_less_than_regular_error' ] );
-				} else {
-					$( document.body ).triggerHandler( 'wc_remove_error_tip', [ $(this), 'i18n_sale_less_than_regular_error' ] );
-				}
-			})
-
-			.on( 'init_tooltips', function() {
-
+			.on( 'init_tooltips', function () {
 				$( '.tips, .help_tip, .woocommerce-help-tip' ).tipTip( {
-					'attribute': 'data-tip',
-					'fadeIn': 50,
-					'fadeOut': 50,
-					'delay': 200,
-					'keepAlive': true
+					attribute: 'data-tip',
+					fadeIn: 50,
+					fadeOut: 50,
+					delay: 200,
+					keepAlive: true,
 				} );
 
 				$( '.column-wc_actions .wc-action-button' ).tipTip( {
-					'fadeIn': 50,
-					'fadeOut': 50,
-					'delay': 200
+					fadeIn: 50,
+					fadeOut: 50,
+					delay: 200,
 				} );
 
 				// Add tiptip to parent element for widefat tables
-				$( '.parent-tips' ).each( function() {
-					$( this ).closest( 'a, th' ).attr( 'data-tip', $( this ).data( 'tip' ) ).tipTip( {
-						'attribute': 'data-tip',
-						'fadeIn': 50,
-						'fadeOut': 50,
-						'delay': 200,
-						'keepAlive': true
-					} ).css( 'cursor', 'help' );
-				});
-			})
+				$( '.parent-tips' ).each( function () {
+					$( this )
+						.closest( 'a, th' )
+						.attr( 'data-tip', $( this ).data( 'tip' ) )
+						.tipTip( {
+							attribute: 'data-tip',
+							fadeIn: 50,
+							fadeOut: 50,
+							delay: 200,
+							keepAlive: true,
+						} )
+						.css( 'cursor', 'help' );
+				} );
+			} )
 
-			.on( 'click', '.wc-confirm-delete', function( event ) {
-				if ( ! window.confirm( woocommerce_admin.i18n_confirm_delete ) ) {
+			.on( 'click', '.wc-confirm-delete', function ( event ) {
+				if (
+					! window.confirm( woocommerce_admin.i18n_confirm_delete )
+				) {
 					event.stopPropagation();
 				}
 			} );
@@ -220,7 +341,7 @@
 		$( document.body ).trigger( 'init_tooltips' );
 
 		// wc_input_table tables
-		$( '.wc_input_table.sortable tbody' ).sortable({
+		$( '.wc_input_table.sortable tbody' ).sortable( {
 			items: 'tr',
 			cursor: 'move',
 			axis: 'y',
@@ -229,205 +350,290 @@
 			helper: 'clone',
 			opacity: 0.65,
 			placeholder: 'wc-metabox-sortable-placeholder',
-			start: function( event, ui ) {
+			start: function ( event, ui ) {
 				ui.item.css( 'background-color', '#f6f6f6' );
 			},
-			stop: function( event, ui ) {
+			stop: function ( event, ui ) {
 				ui.item.removeAttr( 'style' );
-			}
-		});
+			},
+		} );
 		// Focus on inputs within the table if clicked instead of trying to sort.
-		$( '.wc_input_table.sortable tbody input' ).on( 'click', function() {
+		$( '.wc_input_table.sortable tbody input' ).on( 'click', function () {
 			$( this ).trigger( 'focus' );
 		} );
 
-		$( '.wc_input_table .remove_rows' ).on( 'click', function() {
+		$( '.wc_input_table .remove_rows' ).on( 'click', function () {
 			var $tbody = $( this ).closest( '.wc_input_table' ).find( 'tbody' );
 			if ( $tbody.find( 'tr.current' ).length > 0 ) {
 				var $current = $tbody.find( 'tr.current' );
-				$current.each( function() {
+				$current.each( function () {
 					$( this ).remove();
-				});
+				} );
 			}
 			return false;
-		});
+		} );
 
 		var controlled = false;
-		var shifted    = false;
-		var hasFocus   = false;
+		var shifted = false;
+		var hasFocus = false;
 
-		$( document.body ).on( 'keyup keydown', function( e ) {
-			shifted    = e.shiftKey;
+		$( document.body ).on( 'keyup keydown', function ( e ) {
+			shifted = e.shiftKey;
 			controlled = e.ctrlKey || e.metaKey;
-		});
+		} );
 
-		$( '.wc_input_table' ).on( 'focus click', 'input', function( e ) {
-			var $this_table = $( this ).closest( 'table, tbody' );
-			var $this_row   = $( this ).closest( 'tr' );
+		$( '.wc_input_table' )
+			.on( 'focus click', 'input', function ( e ) {
+				var $this_table = $( this ).closest( 'table, tbody' );
+				var $this_row = $( this ).closest( 'tr' );
 
-			if ( ( e.type === 'focus' && hasFocus !== $this_row.index() ) || ( e.type === 'click' && $( this ).is( ':focus' ) ) ) {
-				hasFocus = $this_row.index();
+				if (
+					( e.type === 'focus' && hasFocus !== $this_row.index() ) ||
+					( e.type === 'click' && $( this ).is( ':focus' ) )
+				) {
+					hasFocus = $this_row.index();
 
-				if ( ! shifted && ! controlled ) {
-					$( 'tr', $this_table ).removeClass( 'current' ).removeClass( 'last_selected' );
-					$this_row.addClass( 'current' ).addClass( 'last_selected' );
-				} else if ( shifted ) {
-					$( 'tr', $this_table ).removeClass( 'current' );
-					$this_row.addClass( 'selected_now' ).addClass( 'current' );
+					if ( ! shifted && ! controlled ) {
+						$( 'tr', $this_table )
+							.removeClass( 'current' )
+							.removeClass( 'last_selected' );
+						$this_row
+							.addClass( 'current' )
+							.addClass( 'last_selected' );
+					} else if ( shifted ) {
+						$( 'tr', $this_table ).removeClass( 'current' );
+						$this_row
+							.addClass( 'selected_now' )
+							.addClass( 'current' );
 
-					if ( $( 'tr.last_selected', $this_table ).length > 0 ) {
-						if ( $this_row.index() > $( 'tr.last_selected', $this_table ).index() ) {
-							$( 'tr', $this_table )
-								.slice( $( 'tr.last_selected', $this_table ).index(), $this_row.index() )
-								.addClass( 'current' );
+						if ( $( 'tr.last_selected', $this_table ).length > 0 ) {
+							if (
+								$this_row.index() >
+								$( 'tr.last_selected', $this_table ).index()
+							) {
+								$( 'tr', $this_table )
+									.slice(
+										$(
+											'tr.last_selected',
+											$this_table
+										).index(),
+										$this_row.index()
+									)
+									.addClass( 'current' );
+							} else {
+								$( 'tr', $this_table )
+									.slice(
+										$this_row.index(),
+										$(
+											'tr.last_selected',
+											$this_table
+										).index() + 1
+									)
+									.addClass( 'current' );
+							}
+						}
+
+						$( 'tr', $this_table ).removeClass( 'last_selected' );
+						$this_row.addClass( 'last_selected' );
+					} else {
+						$( 'tr', $this_table ).removeClass( 'last_selected' );
+						if (
+							controlled &&
+							$( this ).closest( 'tr' ).is( '.current' )
+						) {
+							$this_row.removeClass( 'current' );
 						} else {
-							$( 'tr', $this_table )
-								.slice( $this_row.index(), $( 'tr.last_selected', $this_table ).index() + 1 )
-								.addClass( 'current' );
+							$this_row
+								.addClass( 'current' )
+								.addClass( 'last_selected' );
 						}
 					}
 
-					$( 'tr', $this_table ).removeClass( 'last_selected' );
-					$this_row.addClass( 'last_selected' );
-				} else {
-					$( 'tr', $this_table ).removeClass( 'last_selected' );
-					if ( controlled && $( this ).closest( 'tr' ).is( '.current' ) ) {
-						$this_row.removeClass( 'current' );
-					} else {
-						$this_row.addClass( 'current' ).addClass( 'last_selected' );
-					}
+					$( 'tr', $this_table ).removeClass( 'selected_now' );
 				}
-
-				$( 'tr', $this_table ).removeClass( 'selected_now' );
-			}
-		}).on( 'blur', 'input', function() {
-			hasFocus = false;
-		});
-
-		// Additional cost and Attribute term tables
-		$( '.woocommerce_page_wc-settings .shippingrows tbody tr:even, table.attributes-table tbody tr:nth-child(odd)' )
-			.addClass( 'alternate' );
-
-		// Show order items on orders page
-		$( document.body ).on( 'click', '.show_order_items', function() {
-			$( this ).closest( 'td' ).find( 'table' ).toggle();
-			return false;
-		});
-
-		// Select availability
-		$( 'select.availability' ).on( 'change', function() {
-			if ( $( this ).val() === 'all' ) {
-				$( this ).closest( 'tr' ).next( 'tr' ).hide();
-			} else {
-				$( this ).closest( 'tr' ).next( 'tr' ).show();
-			}
-		}).trigger( 'change' );
-
-		// Hidden options
-		$( '.hide_options_if_checked' ).each( function() {
-			$( this ).find( 'input:eq(0)' ).on( 'change', function() {
-				if ( $( this ).is( ':checked' ) ) {
-					$( this )
-						.closest( 'fieldset, tr' )
-						.nextUntil( '.hide_options_if_checked, .show_options_if_checked', '.hidden_option' )
-						.hide();
-				} else {
-					$( this )
-						.closest( 'fieldset, tr' )
-						.nextUntil( '.hide_options_if_checked, .show_options_if_checked', '.hidden_option' )
-						.show();
-				}
-			}).trigger( 'change' );
-		});
-
-		$( '.show_options_if_checked' ).each( function() {
-			$( this ).find( 'input:eq(0)' ).on( 'change', function() {
-				if ( $( this ).is( ':checked' ) ) {
-					$( this )
-						.closest( 'fieldset, tr' )
-						.nextUntil( '.hide_options_if_checked, .show_options_if_checked', '.hidden_option' )
-						.show();
-				} else {
-					$( this )
-						.closest( 'fieldset, tr' )
-						.nextUntil( '.hide_options_if_checked, .show_options_if_checked', '.hidden_option' )
-						.hide();
-				}
-			}).trigger( 'change' );
-		});
-
-		// Reviews.
-		$( 'input#woocommerce_enable_reviews' ).on( 'change', function() {
-			if ( $( this ).is( ':checked' ) ) {
-				$( '#woocommerce_enable_review_rating' ).closest( 'tr' ).show();
-			} else {
-				$( '#woocommerce_enable_review_rating' ).closest( 'tr' ).hide();
-			}
-		}).trigger( 'change' );
-
-		// Attribute term table
-		$( 'table.attributes-table tbody tr:nth-child(odd)' ).addClass( 'alternate' );
-
-		// Toggle gateway on/off.
-		$( '.wc_gateways' ).on( 'click', '.wc-payment-gateway-method-toggle-enabled', function() {
-			var $link   = $( this ),
-				$row    = $link.closest( 'tr' ),
-				$toggle = $link.find( '.woocommerce-input-toggle' );
-
-			var data = {
-				action: 'woocommerce_toggle_gateway_enabled',
-				security: woocommerce_admin.nonces.gateway_toggle,
-				gateway_id: $row.data( 'gateway_id' )
-			};
-
-			$toggle.addClass( 'woocommerce-input-toggle--loading' );
-
-			$.ajax( {
-				url:      woocommerce_admin.ajax_url,
-				data:     data,
-				dataType : 'json',
-				type     : 'POST',
-				success:  function( response ) {
-					if ( true === response.data ) {
-						$toggle.removeClass( 'woocommerce-input-toggle--enabled, woocommerce-input-toggle--disabled' );
-						$toggle.addClass( 'woocommerce-input-toggle--enabled' );
-						$toggle.removeClass( 'woocommerce-input-toggle--loading' );
-					} else if ( false === response.data ) {
-						$toggle.removeClass( 'woocommerce-input-toggle--enabled, woocommerce-input-toggle--disabled' );
-						$toggle.addClass( 'woocommerce-input-toggle--disabled' );
-						$toggle.removeClass( 'woocommerce-input-toggle--loading' );
-					} else if ( 'needs_setup' === response.data ) {
-						window.location.href = $link.attr( 'href' );
-					}
-				}
+			} )
+			.on( 'blur', 'input', function () {
+				hasFocus = false;
 			} );
 
-			return false;
-		});
+		// Additional cost and Attribute term tables
+		$(
+			'.woocommerce_page_wc-settings .shippingrows tbody tr:even, table.attributes-table tbody tr:nth-child(odd)'
+		).addClass( 'alternate' );
 
-		$( '#wpbody' ).on( 'click', '#doaction, #doaction2', function() {
-			var action = $( this ).is( '#doaction' ) ? $( '#bulk-action-selector-top' ).val() : $( '#bulk-action-selector-bottom' ).val();
+		// Show order items on orders page
+		$( document.body ).on( 'click', '.show_order_items', function () {
+			$( this ).closest( 'td' ).find( 'table' ).toggle();
+			return false;
+		} );
+
+		// Select availability
+		$( 'select.availability' )
+			.on( 'change', function () {
+				if ( $( this ).val() === 'all' ) {
+					$( this ).closest( 'tr' ).next( 'tr' ).hide();
+				} else {
+					$( this ).closest( 'tr' ).next( 'tr' ).show();
+				}
+			} )
+			.trigger( 'change' );
+
+		// Hidden options
+		$( '.hide_options_if_checked' ).each( function () {
+			$( this )
+				.find( 'input:eq(0)' )
+				.on( 'change', function () {
+					if ( $( this ).is( ':checked' ) ) {
+						$( this )
+							.closest( 'fieldset, tr' )
+							.nextUntil(
+								'.hide_options_if_checked, .show_options_if_checked',
+								'.hidden_option'
+							)
+							.hide();
+					} else {
+						$( this )
+							.closest( 'fieldset, tr' )
+							.nextUntil(
+								'.hide_options_if_checked, .show_options_if_checked',
+								'.hidden_option'
+							)
+							.show();
+					}
+				} )
+				.trigger( 'change' );
+		} );
+
+		$( '.show_options_if_checked' ).each( function () {
+			$( this )
+				.find( 'input:eq(0)' )
+				.on( 'change', function () {
+					if ( $( this ).is( ':checked' ) ) {
+						$( this )
+							.closest( 'fieldset, tr' )
+							.nextUntil(
+								'.hide_options_if_checked, .show_options_if_checked',
+								'.hidden_option'
+							)
+							.show();
+					} else {
+						$( this )
+							.closest( 'fieldset, tr' )
+							.nextUntil(
+								'.hide_options_if_checked, .show_options_if_checked',
+								'.hidden_option'
+							)
+							.hide();
+					}
+				} )
+				.trigger( 'change' );
+		} );
+
+		// Reviews.
+		$( 'input#woocommerce_enable_reviews' )
+			.on( 'change', function () {
+				if ( $( this ).is( ':checked' ) ) {
+					$( '#woocommerce_enable_review_rating' )
+						.closest( 'tr' )
+						.show();
+				} else {
+					$( '#woocommerce_enable_review_rating' )
+						.closest( 'tr' )
+						.hide();
+				}
+			} )
+			.trigger( 'change' );
+
+		// Attribute term table
+		$( 'table.attributes-table tbody tr:nth-child(odd)' ).addClass(
+			'alternate'
+		);
+
+		// Toggle gateway on/off.
+		$( '.wc_gateways' ).on(
+			'click',
+			'.wc-payment-gateway-method-toggle-enabled',
+			function () {
+				var $link = $( this ),
+					$row = $link.closest( 'tr' ),
+					$toggle = $link.find( '.woocommerce-input-toggle' );
+
+				var data = {
+					action: 'woocommerce_toggle_gateway_enabled',
+					security: woocommerce_admin.nonces.gateway_toggle,
+					gateway_id: $row.data( 'gateway_id' ),
+				};
+
+				$toggle.addClass( 'woocommerce-input-toggle--loading' );
+
+				$.ajax( {
+					url: woocommerce_admin.ajax_url,
+					data: data,
+					dataType: 'json',
+					type: 'POST',
+					success: function ( response ) {
+						if ( true === response.data ) {
+							$toggle.removeClass(
+								'woocommerce-input-toggle--enabled, woocommerce-input-toggle--disabled'
+							);
+							$toggle.addClass(
+								'woocommerce-input-toggle--enabled'
+							);
+							$toggle.removeClass(
+								'woocommerce-input-toggle--loading'
+							);
+						} else if ( false === response.data ) {
+							$toggle.removeClass(
+								'woocommerce-input-toggle--enabled, woocommerce-input-toggle--disabled'
+							);
+							$toggle.addClass(
+								'woocommerce-input-toggle--disabled'
+							);
+							$toggle.removeClass(
+								'woocommerce-input-toggle--loading'
+							);
+						} else if ( 'needs_setup' === response.data ) {
+							window.location.href = $link.attr( 'href' );
+						}
+					},
+				} );
+
+				return false;
+			}
+		);
+
+		$( '#wpbody' ).on( 'click', '#doaction, #doaction2', function () {
+			var action = $( this ).is( '#doaction' )
+				? $( '#bulk-action-selector-top' ).val()
+				: $( '#bulk-action-selector-bottom' ).val();
 
 			if ( 'remove_personal_data' === action ) {
-				return window.confirm( woocommerce_admin.i18n_remove_personal_data_notice );
+				return window.confirm(
+					woocommerce_admin.i18n_remove_personal_data_notice
+				);
 			}
-		});
+		} );
 
-		var marketplaceSectionDropdown = $( '#marketplace-current-section-dropdown' );
+		var marketplaceSectionDropdown = $(
+			'#marketplace-current-section-dropdown'
+		);
 		var marketplaceSectionName = $( '#marketplace-current-section-name' );
 		var marketplaceMenuIsOpen = false;
 
 		// Add event listener to toggle Marketplace menu on touch devices
 		if ( marketplaceSectionDropdown.length ) {
 			if ( isTouchDevice() ) {
-				marketplaceSectionName.on( 'click', function() {
+				marketplaceSectionName.on( 'click', function () {
 					marketplaceMenuIsOpen = ! marketplaceMenuIsOpen;
 					if ( marketplaceMenuIsOpen ) {
 						marketplaceSectionDropdown.addClass( 'is-open' );
 						$( document ).on( 'click', maybeToggleMarketplaceMenu );
 					} else {
 						marketplaceSectionDropdown.removeClass( 'is-open' );
-						$( document ).off( 'click', maybeToggleMarketplaceMenu );
+						$( document ).off(
+							'click',
+							maybeToggleMarketplaceMenu
+						);
 					}
 				} );
 			} else {
@@ -438,8 +644,8 @@
 		// Close menu if the user clicks outside it
 		function maybeToggleMarketplaceMenu( e ) {
 			if (
-				! marketplaceSectionDropdown.is( e.target )
-				&& marketplaceSectionDropdown.has( e.target ).length === 0
+				! marketplaceSectionDropdown.is( e.target ) &&
+				marketplaceSectionDropdown.has( e.target ).length === 0
 			) {
 				marketplaceSectionDropdown.removeClass( 'is-open' );
 				marketplaceMenuIsOpen = false;
@@ -448,11 +654,11 @@
 		}
 
 		function isTouchDevice() {
-			return ( ( 'ontouchstart' in window ) ||
-				( navigator.maxTouchPoints > 0 ) ||
-				( navigator.msMaxTouchPoints > 0 ) );
+			return (
+				'ontouchstart' in window ||
+				navigator.maxTouchPoints > 0 ||
+				navigator.msMaxTouchPoints > 0
+			);
 		}
-
-	});
-
-})( jQuery, woocommerce_admin );
+	} );
+} )( jQuery, woocommerce_admin );

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -145,7 +145,6 @@
 				function () {
 					var regex, error, decimalRegex;
 					var checkDecimalNumbers = false;
-					console.log( 'entro' );
 					if (
 						$( this ).is( '.wc_input_price' ) ||
 						$( this ).is( '.wc_input_variations_price' ) ||

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -188,9 +188,9 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				$params = array(
 					/* translators: %s: decimal */
-					'i18n_decimal_error'                => sprintf( __( 'Please enter with one decimal point (%s) without thousand separators.', 'woocommerce' ), $decimal ),
+					'i18n_decimal_error'                => sprintf( __( 'Please enter a value with one decimal point (%s) without thousand separators.', 'woocommerce' ), $decimal ),
 					/* translators: %s: price decimal separator */
-					'i18n_mon_decimal_error'            => sprintf( __( 'Please enter with one monetary decimal point (%s) without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
+					'i18n_mon_decimal_error'            => sprintf( __( 'Please enter a value with one monetary decimal point (%s) without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
 					'i18n_country_iso_error'            => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
 					'i18n_sale_less_than_regular_error' => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
 					'i18n_delete_product_notice'        => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			// @deprecated 2.3.
 			if ( has_action( 'woocommerce_admin_css' ) ) {
-				/* phpcs:disable */
+				/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 				do_action( 'woocommerce_admin_css' );
 				/* phpcs: enable */
 				wc_deprecated_function( 'The woocommerce_admin_css action', '2.3', 'admin_enqueue_scripts' );
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Meta boxes.
-			/* phpcs:disable */
+			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
 				wp_enqueue_media();
 				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), $version );
@@ -310,7 +310,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					)
 				);
 			}
-			/* phpcs:disable */
+			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 			if ( in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ) ) ) {
 				wp_enqueue_script( 'wc-admin-coupon-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-coupon' . $suffix . '.js', array( 'wc-admin-meta-boxes' ), $version );
 				wp_localize_script(
@@ -415,7 +415,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Term ordering - only when sorting by term_order.
-			/* phpcs:disable */
+			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 			if ( ( strstr( $screen_id, 'edit-pa_' ) || ( ! empty( $_GET['taxonomy'] ) && in_array( wp_unslash( $_GET['taxonomy'] ), apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) ) ) ) ) && ! isset( $_GET['orderby'] ) ) {
 
 				wp_register_script( 'woocommerce_term_ordering', WC()->plugin_url() . '/assets/js/admin/term-ordering' . $suffix . '.js', array( 'jquery-ui-sortable' ), $version );
@@ -438,7 +438,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Reports Pages.
-			/* phpcs:disable */
+			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
 				wp_register_script( 'wc-reports', WC()->plugin_url() . '/assets/js/admin/reports' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker' ), $version );
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -184,9 +184,9 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'jquery-ui-sortable' );
 				wp_enqueue_script( 'jquery-ui-autocomplete' );
 
-				$locale  = localeconv();
+				$locale        = localeconv();
 				$decimal_point = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
-				$decimal = ( ! empty( wc_get_price_decimal_separator() ) ) ? wc_get_price_decimal_separator() : $decimal_point;
+				$decimal       = ( ! empty( wc_get_price_decimal_separator() ) ) ? wc_get_price_decimal_separator() : $decimal_point;
 
 				$params = array(
 					/* translators: %s: decimal */
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Meta boxes.
-			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
+			/* phpcs:disable */
 			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
 				wp_enqueue_media();
 				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), $version );
@@ -320,8 +320,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'generate_button_text' => esc_html__( 'Generate coupon code', 'woocommerce' ),
 						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ23456789' ),
 						'char_length'          => apply_filters( 'woocommerce_coupon_code_generator_character_length', 8 ),
-						'prefix'                => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
-						'suffix'                => apply_filters( 'woocommerce_coupon_code_generator_suffix', '' ),
+						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
+						'suffix'               => apply_filters( 'woocommerce_coupon_code_generator_suffix', '' ),
 					)
 				);
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -84,7 +84,9 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			// @deprecated 2.3.
 			if ( has_action( 'woocommerce_admin_css' ) ) {
+				/* phpcs:disable */
 				do_action( 'woocommerce_admin_css' );
+				/* phpcs: enable */
 				wc_deprecated_function( 'The woocommerce_admin_css action', '2.3', 'admin_enqueue_scripts' );
 			}
 
@@ -247,6 +249,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Meta boxes.
+			/* phpcs:disable */
 			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
 				wp_enqueue_media();
 				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), $version );
@@ -289,6 +292,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				wp_localize_script( 'wc-admin-variation-meta-boxes', 'woocommerce_admin_meta_boxes_variations', $params );
 			}
+			/* phpcs: enable */
 			if ( $this->is_order_meta_box_screen( $screen_id ) ) {
 				$default_location = wc_get_customer_default_location();
 
@@ -306,6 +310,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					)
 				);
 			}
+			/* phpcs:disable */
 			if ( in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ) ) ) {
 				wp_enqueue_script( 'wc-admin-coupon-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-coupon' . $suffix . '.js', array( 'wc-admin-meta-boxes' ), $version );
 				wp_localize_script(
@@ -315,11 +320,12 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'generate_button_text' => esc_html__( 'Generate coupon code', 'woocommerce' ),
 						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ23456789' ),
 						'char_length'          => apply_filters( 'woocommerce_coupon_code_generator_character_length', 8 ),
-						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
-						'suffix'               => apply_filters( 'woocommerce_coupon_code_generator_suffix', '' ),
+						'prefix'                => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
+						'suffix'                => apply_filters( 'woocommerce_coupon_code_generator_suffix', '' ),
 					)
 				);
 			}
+			/* phpcs: enable */
 			if ( in_array( str_replace( 'edit-', '', $screen_id ), array( 'shop_coupon', 'product' ), true ) || $this->is_order_meta_box_screen( $screen_id ) ) {
 				$post_id                = isset( $post->ID ) ? $post->ID : '';
 				$currency               = '';
@@ -409,6 +415,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Term ordering - only when sorting by term_order.
+			/* phpcs:disable */
 			if ( ( strstr( $screen_id, 'edit-pa_' ) || ( ! empty( $_GET['taxonomy'] ) && in_array( wp_unslash( $_GET['taxonomy'] ), apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) ) ) ) ) && ! isset( $_GET['orderby'] ) ) {
 
 				wp_register_script( 'woocommerce_term_ordering', WC()->plugin_url() . '/assets/js/admin/term-ordering' . $suffix . '.js', array( 'jquery-ui-sortable' ), $version );
@@ -422,6 +429,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				wp_localize_script( 'woocommerce_term_ordering', 'woocommerce_term_ordering_params', $woocommerce_term_order_params );
 			}
+			/* phpcs: enable */
 
 			// Product sorting - only when sorting by menu order on the products page.
 			if ( current_user_can( 'edit_others_pages' ) && 'edit-product' === $screen_id && isset( $wp_query->query['orderby'] ) && 'menu_order title' === $wp_query->query['orderby'] ) {
@@ -430,6 +438,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 
 			// Reports Pages.
+			/* phpcs:disable */
 			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
 				wp_register_script( 'wc-reports', WC()->plugin_url() . '/assets/js/admin/reports' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker' ), $version );
 
@@ -440,6 +449,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'flot-pie' );
 				wp_enqueue_script( 'flot-stack' );
 			}
+			/* phpcs: enable */
 
 			// API settings.
 			if ( $wc_screen_id . '_page_wc-settings' === $screen_id && isset( $_GET['section'] ) && 'keys' == $_GET['section'] ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -250,7 +250,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
 				wp_enqueue_media();
 				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), $version );
-				wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'serializejson', 'media-models' ), $version );
+				wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'serializejson', 'media-models', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), $version );
 
 				wp_enqueue_script( 'wc-admin-product-meta-boxes' );
 				wp_enqueue_script( 'wc-admin-variation-meta-boxes' );

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -176,6 +176,7 @@ class WC_Meta_Box_Product_Data {
 		$variations_count       = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
+		$modal_title            = get_bloginfo( 'name' ) . __( ' says', 'woocommerce' );
 
 		include __DIR__ . '/views/html-product-data-variations.php';
 	}

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -53,7 +53,7 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function get_product_type_options() {
-		/* phpcs:disable */
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		return apply_filters(
 			'product_type_options',
 			array(
@@ -82,7 +82,7 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function get_product_data_tabs() {
-		/* phpcs:disable */
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$tabs = apply_filters(
 			'woocommerce_product_data_tabs',
 			array(
@@ -177,7 +177,7 @@ class WC_Meta_Box_Product_Data {
 
 		$variation_attributes   = array_filter( $product_object->get_attributes(), array( __CLASS__, 'filter_variation_attributes' ) );
 		$default_attributes     = $product_object->get_default_attributes();
-		/* phpcs:disable */
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$variations_count       = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
 		/* phpcs: enable */
@@ -279,7 +279,7 @@ class WC_Meta_Box_Product_Data {
 				$attribute->set_position( $attribute_position[ $i ] );
 				$attribute->set_visible( isset( $attribute_visibility[ $i ] ) );
 				$attribute->set_variation( isset( $attribute_variation[ $i ] ) );
-				/* phpcs:disable */
+				/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 				$attributes[] = apply_filters( 'woocommerce_admin_meta_boxes_prepare_attribute', $attribute, $data, $i );
 				/* phpcs: enable */
 			}
@@ -434,7 +434,7 @@ class WC_Meta_Box_Product_Data {
 
 			$product->get_data_store()->sync_variation_names( $product, $original_post_title, $post_title );
 		}
-		/* phpcs:disable */
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
 		/* phpcs: enable */
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
@@ -570,7 +570,7 @@ class WC_Meta_Box_Product_Data {
 				do_action( 'woocommerce_admin_process_variation_object', $variation, $i );
 
 				$variation->save();
-				/* phpcs:disable */
+				/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );
 				/* phpcs: enable */
 			}

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -53,6 +53,7 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function get_product_type_options() {
+		/* phpcs:disable */
 		return apply_filters(
 			'product_type_options',
 			array(
@@ -72,6 +73,7 @@ class WC_Meta_Box_Product_Data {
 				),
 			)
 		);
+		/* phpcs: enable */
 	}
 
 	/**
@@ -80,6 +82,7 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function get_product_data_tabs() {
+		/* phpcs:disable */
 		$tabs = apply_filters(
 			'woocommerce_product_data_tabs',
 			array(
@@ -127,6 +130,7 @@ class WC_Meta_Box_Product_Data {
 				),
 			)
 		);
+		/* phpcs: enable */
 
 		// Sort tabs based on priority.
 		uasort( $tabs, array( __CLASS__, 'product_data_tabs_sort' ) );
@@ -173,8 +177,10 @@ class WC_Meta_Box_Product_Data {
 
 		$variation_attributes   = array_filter( $product_object->get_attributes(), array( __CLASS__, 'filter_variation_attributes' ) );
 		$default_attributes     = $product_object->get_default_attributes();
+		/* phpcs:disable */
 		$variations_count       = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
+		/* phpcs: enable */
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
 		$modal_title            = get_bloginfo( 'name' ) . __( ' says', 'woocommerce' );
 
@@ -273,7 +279,9 @@ class WC_Meta_Box_Product_Data {
 				$attribute->set_position( $attribute_position[ $i ] );
 				$attribute->set_visible( isset( $attribute_visibility[ $i ] ) );
 				$attribute->set_variation( isset( $attribute_variation[ $i ] ) );
+				/* phpcs:disable */
 				$attributes[] = apply_filters( 'woocommerce_admin_meta_boxes_prepare_attribute', $attribute, $data, $i );
+				/* phpcs: enable */
 			}
 		}
 		return $attributes;
@@ -426,8 +434,9 @@ class WC_Meta_Box_Product_Data {
 
 			$product->get_data_store()->sync_variation_names( $product, $original_post_title, $post_title );
 		}
-
+		/* phpcs:disable */
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
+		/* phpcs: enable */
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 
@@ -449,7 +458,7 @@ class WC_Meta_Box_Product_Data {
 			$max_loop   = max( array_keys( wp_unslash( $_POST['variable_post_id'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$data_store = $parent->get_data_store();
 			$data_store->sort_all_product_variations( $parent->get_id() );
-			$new_variation_menu_order_id = ! empty( $_POST['new_variation_menu_order_id'] ) ? wc_clean( wp_unslash( $_POST['new_variation_menu_order_id'] ) ) : false;
+			$new_variation_menu_order_id    = ! empty( $_POST['new_variation_menu_order_id'] ) ? wc_clean( wp_unslash( $_POST['new_variation_menu_order_id'] ) ) : false;
 			$new_variation_menu_order_value = ! empty( $_POST['new_variation_menu_order_value'] ) ? wc_clean( wp_unslash( $_POST['new_variation_menu_order_value'] ) ) : false;
 
 			// Only perform this operation if setting menu order via the prompt.
@@ -561,7 +570,9 @@ class WC_Meta_Box_Product_Data {
 				do_action( 'woocommerce_admin_process_variation_object', $variation, $i );
 
 				$variation->save();
+				/* phpcs:disable */
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );
+				/* phpcs: enable */
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -436,8 +436,7 @@ class WC_Meta_Box_Product_Data {
 		}
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
-		/* phpcs: enable */
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		/* phpcs:enable WordPress.Security.NonceVerification.Missing and WooCommerce.Commenting.CommentHooks.MissingHookComment */
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -175,14 +175,14 @@ class WC_Meta_Box_Product_Data {
 	public static function output_variations() {
 		global $post, $wpdb, $product_object;
 
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$variation_attributes   = array_filter( $product_object->get_attributes(), array( __CLASS__, 'filter_variation_attributes' ) );
 		$default_attributes     = $product_object->get_default_attributes();
-		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$variations_count       = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
-		/* phpcs: enable */
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
 		$modal_title            = get_bloginfo( 'name' ) . __( ' says', 'woocommerce' );
+		/* phpcs: enable */
 
 		include __DIR__ . '/views/html-product-data-variations.php';
 	}

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -164,7 +164,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</div>
 					<div class="woocommerce-usage-modal__actions">
 						<button class="modal-close components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-						<button class="modal-close button components-button add_variations_price_button is-primary" disabled><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
+						<button class="modal-close button components-button add_variations_price_button is-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -163,8 +163,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<input type="text" class="components-text-control__input wc_input_variations_price"/>
 					</div>
 					<div class="woocommerce-usage-modal__actions">
-						<button id="btn-cancel" class="modal-close components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-						<button id="btn-ok" class="button components-button is-primary"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
+						<button class="modal-close components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+						<button class="modal-close button components-button add_variations_price_button is-primary" disabled><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -159,7 +159,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<div class="woocommerce-usage-modal__wrapper">
 					<div class="woocommerce-usage-modal__message">
-						<span>Add price to all variations (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
+						<span>Add price to all variations that don't have a price (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
 						<input type="text" class="components-text-control__input wc_input_variations_price"/>
 					</div>
 					<div class="woocommerce-usage-modal__actions">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -150,3 +150,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endif; ?>
 	</div>
 </div>
+<script type="text/template" id="tmpl-wc-modal-set-price-variations">
+	<div class="wc-backbone-modal">
+		<div class="wc-backbone-modal-content">
+			<div class="components-modal__content woocommerce-set-price-variations" role="document">
+				<div class="components-modal__header">
+					<h2><?php echo esc_attr( $modal_title ); ?></h2>
+				</div>
+				<div class="woocommerce-usage-modal__wrapper">
+					<div class="woocommerce-usage-modal__message">
+						<span>Add price to all variations (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
+						<input type="text" class="components-text-control__input wc_input_variations_price"/>
+					</div>
+					<div class="woocommerce-usage-modal__actions">
+						<button id="btn-cancel" class="modal-close components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
+						<button id="btn-ok" class="button components-button is-primary"><?php esc_html_e( 'OK', 'woocommerce' ); ?></button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="wc-backbone-modal-backdrop modal-close"></div>
+</script>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -16,7 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div id="message" class="inline notice woocommerce-message">
 				<p><?php echo wp_kses_post( __( 'Before you can add a variation you need to add some variation attributes on the <strong>Attributes</strong> tab.', 'woocommerce' ) ); ?></p>
+				<?php /* phpcs:disable */ ?>
 				<p><a class="button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'https://docs.woocommerce.com/document/variable-product/', 'product-variations' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'woocommerce' ); ?></a></p>
+				<?php /* phpcs:enable */ ?>
 			</div>
 
 		<?php else : ?>
@@ -33,11 +35,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<option value=""><?php echo esc_html( sprintf( __( 'No default %s&hellip;', 'woocommerce' ), wc_attribute_label( $attribute->get_name() ) ) ); ?></option>
 							<?php if ( $attribute->is_taxonomy() ) : ?>
 								<?php foreach ( $attribute->get_terms() as $option ) : ?>
+									<?php /* phpcs:disable */ ?>
 									<option <?php selected( $selected_value, $option->slug ); ?> value="<?php echo esc_attr( $option->slug ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option->name, $option, $attribute->get_name(), $product_object ) ); ?></option>
+									<?php /* phpcs:enable */ ?>
 								<?php endforeach; ?>
 							<?php else : ?>
 								<?php foreach ( $attribute->get_options() as $option ) : ?>
+									<?php /* phpcs:disable */ ?>
 									<option <?php selected( $selected_value, $option ); ?> value="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option, null, $attribute->get_name(), $product_object ) ); ?></option>
+									<?php /* phpcs:enable */ ?>
 								<?php endforeach; ?>
 							<?php endif; ?>
 						</select>
@@ -48,7 +54,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div class="clear"></div>
 			</div>
 
+			<?php /* phpcs:disable */ ?>
 			<?php do_action( 'woocommerce_variable_product_before_variations' ); ?>
+			<?php /* phpcs:enable */ ?>
 
 			<div class="toolbar toolbar-top">
 				<select id="field_to_edit" class="variation_actions">
@@ -87,7 +95,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<option value="variable_download_limit"><?php esc_html_e( 'Download limit', 'woocommerce' ); ?></option>
 						<option value="variable_download_expiry"><?php esc_html_e( 'Download expiry', 'woocommerce' ); ?></option>
 					</optgroup>
+					<?php /* phpcs:disable */ ?>
 					<?php do_action( 'woocommerce_variable_product_bulk_edit_actions' ); ?>
+					<?php /* phpcs:enable */ ?>
 				</select>
 				<a class="button bulk_edit do_variation_action"><?php esc_html_e( 'Go', 'woocommerce' ); ?></a>
 
@@ -104,7 +114,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<label for="current-page-selector-1" class="screen-reader-text"><?php esc_html_e( 'Select Page', 'woocommerce' ); ?></label>
 							<select class="page-selector" id="current-page-selector-1" title="<?php esc_attr_e( 'Current page', 'woocommerce' ); ?>">
 								<?php for ( $i = 1; $i <= $variations_total_pages; $i++ ) : ?>
+									<?php /* phpcs:disable */ ?>
 									<option value="<?php echo $i; // WPCS: XSS ok. ?>"><?php echo $i; // WPCS: XSS ok. ?></option>
+									<?php /* phpcs:enable */ ?>
 								<?php endfor; ?>
 							</select>
 							<?php echo esc_html_x( 'of', 'number of pages', 'woocommerce' ); ?> <span class="total-pages"><?php echo esc_html( $variations_total_pages ); ?></span>
@@ -116,7 +128,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div class="clear"></div>
 			</div>
 
+			<?php /* phpcs:disable */ ?>
 			<div class="woocommerce_variations wc-metaboxes" data-attributes="<?php echo wc_esc_json( wp_json_encode( wc_list_pluck( $variation_attributes, 'get_data' ) ) ); // WPCS: XSS ok. ?>" data-total="<?php echo esc_attr( $variations_count ); ?>" data-total_pages="<?php echo esc_attr( $variations_total_pages ); ?>" data-page="1" data-edited="false"></div>
+			<?php /* phpcs:enable */ ?>
 
 			<div class="toolbar">
 				<button type="button" class="button-primary save-variation-changes" disabled="disabled"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
@@ -135,7 +149,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<label for="current-page-selector-1" class="screen-reader-text"><?php esc_html_e( 'Select Page', 'woocommerce' ); ?></label>
 							<select class="page-selector" id="current-page-selector-1" title="<?php esc_attr_e( 'Current page', 'woocommerce' ); ?>">
 								<?php for ( $i = 1; $i <= $variations_total_pages; $i++ ) : ?>
+									<?php /* phpcs:disable */ ?>
 									<option value="<?php echo $i; // WPCS: XSS ok. ?>"><?php echo $i; // WPCS: XSS ok. ?></option>
+									<?php /* phpcs:enable */ ?>
 								<?php endfor; ?>
 							</select>
 							<?php echo esc_html_x( 'of', 'number of pages', 'woocommerce' ); ?> <span class="total-pages"><?php echo esc_html( $variations_total_pages ); ?></span>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -159,7 +159,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<div class="woocommerce-usage-modal__wrapper">
 					<div class="woocommerce-usage-modal__message">
-						<span>Add price to all variations that don't have a price (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
+						<span><?php esc_html_e( 'Add prices to all variations that don\'t have a price', 'woocommerce' ); ?> (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
 						<input type="text" class="components-text-control__input wc_input_variations_price"/>
 					</div>
 					<div class="woocommerce-usage-modal__actions">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -159,7 +159,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</div>
 				<div class="woocommerce-usage-modal__wrapper">
 					<div class="woocommerce-usage-modal__message">
-						<span><?php esc_html_e( 'Add prices to all variations that don\'t have a price', 'woocommerce' ); ?> (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
+						<span><?php esc_html_e( 'Add price to all variations that don\'t have a price', 'woocommerce' ); ?> (<?php echo esc_attr( get_woocommerce_currency_symbol() ); ?> <?php echo esc_textarea( get_woocommerce_currency() ); ?>)</span>
 						<input type="text" class="components-text-control__input wc_input_variations_price"/>
 					</div>
 					<div class="woocommerce-usage-modal__actions">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div id="message" class="inline notice woocommerce-message">
 				<p><?php echo wp_kses_post( __( 'Before you can add a variation you need to add some variation attributes on the <strong>Attributes</strong> tab.', 'woocommerce' ) ); ?></p>
-				<?php /* phpcs:disable */ ?>
+				<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 				<p><a class="button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'https://docs.woocommerce.com/document/variable-product/', 'product-variations' ) ); ?>" target="_blank"><?php esc_html_e( 'Learn more', 'woocommerce' ); ?></a></p>
 				<?php /* phpcs:enable */ ?>
 			</div>
@@ -35,13 +35,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<option value=""><?php echo esc_html( sprintf( __( 'No default %s&hellip;', 'woocommerce' ), wc_attribute_label( $attribute->get_name() ) ) ); ?></option>
 							<?php if ( $attribute->is_taxonomy() ) : ?>
 								<?php foreach ( $attribute->get_terms() as $option ) : ?>
-									<?php /* phpcs:disable */ ?>
+									<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 									<option <?php selected( $selected_value, $option->slug ); ?> value="<?php echo esc_attr( $option->slug ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option->name, $option, $attribute->get_name(), $product_object ) ); ?></option>
 									<?php /* phpcs:enable */ ?>
 								<?php endforeach; ?>
 							<?php else : ?>
 								<?php foreach ( $attribute->get_options() as $option ) : ?>
-									<?php /* phpcs:disable */ ?>
+									<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 									<option <?php selected( $selected_value, $option ); ?> value="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option, null, $attribute->get_name(), $product_object ) ); ?></option>
 									<?php /* phpcs:enable */ ?>
 								<?php endforeach; ?>
@@ -54,7 +54,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div class="clear"></div>
 			</div>
 
-			<?php /* phpcs:disable */ ?>
+			<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 			<?php do_action( 'woocommerce_variable_product_before_variations' ); ?>
 			<?php /* phpcs:enable */ ?>
 
@@ -95,7 +95,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<option value="variable_download_limit"><?php esc_html_e( 'Download limit', 'woocommerce' ); ?></option>
 						<option value="variable_download_expiry"><?php esc_html_e( 'Download expiry', 'woocommerce' ); ?></option>
 					</optgroup>
-					<?php /* phpcs:disable */ ?>
+					<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 					<?php do_action( 'woocommerce_variable_product_bulk_edit_actions' ); ?>
 					<?php /* phpcs:enable */ ?>
 				</select>
@@ -114,7 +114,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<label for="current-page-selector-1" class="screen-reader-text"><?php esc_html_e( 'Select Page', 'woocommerce' ); ?></label>
 							<select class="page-selector" id="current-page-selector-1" title="<?php esc_attr_e( 'Current page', 'woocommerce' ); ?>">
 								<?php for ( $i = 1; $i <= $variations_total_pages; $i++ ) : ?>
-									<?php /* phpcs:disable */ ?>
+									<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 									<option value="<?php echo $i; // WPCS: XSS ok. ?>"><?php echo $i; // WPCS: XSS ok. ?></option>
 									<?php /* phpcs:enable */ ?>
 								<?php endfor; ?>
@@ -128,7 +128,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<div class="clear"></div>
 			</div>
 
-			<?php /* phpcs:disable */ ?>
+			<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 			<div class="woocommerce_variations wc-metaboxes" data-attributes="<?php echo wc_esc_json( wp_json_encode( wc_list_pluck( $variation_attributes, 'get_data' ) ) ); // WPCS: XSS ok. ?>" data-total="<?php echo esc_attr( $variations_count ); ?>" data-total_pages="<?php echo esc_attr( $variations_total_pages ); ?>" data-page="1" data-edited="false"></div>
 			<?php /* phpcs:enable */ ?>
 
@@ -149,7 +149,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<label for="current-page-selector-1" class="screen-reader-text"><?php esc_html_e( 'Select Page', 'woocommerce' ); ?></label>
 							<select class="page-selector" id="current-page-selector-1" title="<?php esc_attr_e( 'Current page', 'woocommerce' ); ?>">
 								<?php for ( $i = 1; $i <= $variations_total_pages; $i++ ) : ?>
-									<?php /* phpcs:disable */ ?>
+									<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 									<option value="<?php echo $i; // WPCS: XSS ok. ?>"><?php echo $i; // WPCS: XSS ok. ?></option>
 									<?php /* phpcs:enable */ ?>
 								<?php endfor; ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -164,7 +164,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</div>
 					<div class="woocommerce-usage-modal__actions">
 						<button class="modal-close components-button is-secondary"><?php esc_html_e( 'Cancel', 'woocommerce' ); ?></button>
-						<button class="modal-close button components-button add_variations_price_button is-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
+						<button class="modal-close button components-button add_variations_price_button button-primary" disabled><?php esc_html_e( 'Add prices', 'woocommerce' ); ?></button>
 					</div>
 				</div>
 			</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -14,8 +14,8 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div class="woocommerce_variation wc-metabox closed">
 	<h3>
+		<a href="javascript:void(0)" class="edit_variation edit"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a>
 		<a href="#" class="remove_variation delete" rel="<?php echo esc_attr( $variation_id ); ?>"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
-		<div class="handlediv" aria-label="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop, or click to set admin variation order', 'woocommerce' ); ?>"></div>
 		<strong>#<?php echo esc_html( $variation_id ); ?> </strong>
 		<?php

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -36,13 +36,13 @@ defined( 'ABSPATH' ) || exit;
 				</option>
 				<?php if ( $attribute->is_taxonomy() ) : ?>
 					<?php foreach ( $attribute->get_terms() as $option ) : ?>
-						<?php /* phpcs:disable */ ?>
+						<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 						<option <?php selected( $selected_value, $option->slug ); ?> value="<?php echo esc_attr( $option->slug ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option->name, $option, $attribute->get_name(), $product_object ) ); ?></option>
 						<?php /* phpcs:enable */ ?>
 					<?php endforeach; ?>
 				<?php else : ?>
 					<?php foreach ( $attribute->get_options() as $option ) : ?>
-						<?php /* phpcs:disable */ ?>
+						<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 						<option <?php selected( $selected_value, $option ); ?> value="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option, null, $attribute->get_name(), $product_object ) ); ?></option>
 						<?php /* phpcs:enable */ ?>
 					<?php endforeach; ?>
@@ -110,7 +110,7 @@ defined( 'ABSPATH' ) || exit;
 					</label>
 				<?php endif; ?>
 
-				<?php /* phpcs:disable */ ?>
+				<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 				<?php do_action( 'woocommerce_variation_options', $loop, $variation_data, $variation ); ?>
 				<?php /* phpcs:enable */ ?>
 			</p>
@@ -158,7 +158,7 @@ defined( 'ABSPATH' ) || exit;
 				$sale_price_dates_from = $sale_price_dates_from_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_from_timestamp ) : '';
 				$sale_price_dates_to   = $sale_price_dates_to_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_to_timestamp ) : '';
 
-				/* phpcs:disable */
+				/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 				echo '<div class="form-field sale_price_dates_fields hidden">
 					<p class="form-row form-row-first">
 						<label>' . esc_html__( 'Sale start date', 'woocommerce' ) . '</label>
@@ -509,7 +509,7 @@ defined( 'ABSPATH' ) || exit;
 				do_action( 'woocommerce_variation_options_download', $loop, $variation_data, $variation );
 				?>
 			</div>
-			<?php /* phpcs:disable */ ?>
+			<?php /* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */ ?>
 			<?php do_action( 'woocommerce_product_after_variable_attributes', $loop, $variation_data, $variation ); ?>
 			<?php /* phpcs:enable */ ?>
 		</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -36,11 +36,15 @@ defined( 'ABSPATH' ) || exit;
 				</option>
 				<?php if ( $attribute->is_taxonomy() ) : ?>
 					<?php foreach ( $attribute->get_terms() as $option ) : ?>
+						<?php /* phpcs:disable */ ?>
 						<option <?php selected( $selected_value, $option->slug ); ?> value="<?php echo esc_attr( $option->slug ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option->name, $option, $attribute->get_name(), $product_object ) ); ?></option>
+						<?php /* phpcs:enable */ ?>
 					<?php endforeach; ?>
 				<?php else : ?>
 					<?php foreach ( $attribute->get_options() as $option ) : ?>
+						<?php /* phpcs:disable */ ?>
 						<option <?php selected( $selected_value, $option ); ?> value="<?php echo esc_attr( $option ); ?>"><?php echo esc_html( apply_filters( 'woocommerce_variation_option_name', $option, null, $attribute->get_name(), $product_object ) ); ?></option>
+						<?php /* phpcs:enable */ ?>
 					<?php endforeach; ?>
 				<?php endif; ?>
 			</select>
@@ -106,7 +110,9 @@ defined( 'ABSPATH' ) || exit;
 					</label>
 				<?php endif; ?>
 
+				<?php /* phpcs:disable */ ?>
 				<?php do_action( 'woocommerce_variation_options', $loop, $variation_data, $variation ); ?>
+				<?php /* phpcs:enable */ ?>
 			</p>
 
 			<div class="variable_pricing">
@@ -152,6 +158,7 @@ defined( 'ABSPATH' ) || exit;
 				$sale_price_dates_from = $sale_price_dates_from_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_from_timestamp ) : '';
 				$sale_price_dates_to   = $sale_price_dates_to_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_to_timestamp ) : '';
 
+				/* phpcs:disable */
 				echo '<div class="form-field sale_price_dates_fields hidden">
 					<p class="form-row form-row-first">
 						<label>' . esc_html__( 'Sale start date', 'woocommerce' ) . '</label>
@@ -162,6 +169,7 @@ defined( 'ABSPATH' ) || exit;
 						<input type="text" class="sale_price_dates_to" name="variable_sale_price_dates_to[' . esc_attr( $loop ) . ']" value="' . esc_attr( $sale_price_dates_to ) . '" placeholder="' . esc_attr_x( 'To&hellip;', 'placeholder', 'woocommerce' ) . '  YYYY-MM-DD" maxlength="10" pattern="' . esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ) . '" />
 					</p>
 				</div>';
+				/* phpcs: enable */
 
 				/**
 				 * Variation options pricing action.
@@ -236,7 +244,7 @@ defined( 'ABSPATH' ) || exit;
 							'custom_attributes' => array(
 								'step' => 'any',
 							),
-							'wrapper_class' => 'form-row',
+							'wrapper_class'     => 'form-row',
 						)
 					);
 
@@ -409,7 +417,7 @@ defined( 'ABSPATH' ) || exit;
 
 							if ( $downloadable_files ) {
 								foreach ( $downloadable_files as $key => $file ) {
-									$disabled_download = isset( $file['enabled'] ) && false === $file['enabled'];
+									$disabled_download         = isset( $file['enabled'] ) && false === $file['enabled'];
 									$disabled_downloads_count += (int) $disabled_download;
 									include __DIR__ . '/html-product-variation-download.php';
 								}
@@ -421,8 +429,8 @@ defined( 'ABSPATH' ) || exit;
 								<th colspan="1">
 									<a href="#" class="button insert" data-row="
 									<?php
-									$key  = '';
-									$file = array(
+									$key               = '';
+									$file              = array(
 										'file' => '',
 										'name' => '',
 									);
@@ -501,7 +509,9 @@ defined( 'ABSPATH' ) || exit;
 				do_action( 'woocommerce_variation_options_download', $loop, $variation_data, $variation );
 				?>
 			</div>
+			<?php /* phpcs:disable */ ?>
 			<?php do_action( 'woocommerce_product_after_variable_attributes', $loop, $variation_data, $variation ); ?>
+			<?php /* phpcs:enable */ ?>
 		</div>
 	</div>
 </div>

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -499,7 +499,7 @@ function wc_render_invalid_variation_notice( $product_object ) {
 
 	if ( 0 < ( $variation_count - $invalid_variation_count ) ) {
 		?>
-		<div id="message" class="inline notice woocommerce-message woocommerce-notice-invalid-variation">
+		<div id="message" class="inline notice notice-warning woocommerce-message woocommerce-notice-invalid-variation">
 			<p>
 			<?php
 			echo wp_kses_post(
@@ -512,6 +512,9 @@ function wc_render_invalid_variation_notice( $product_object ) {
 			);
 			?>
 			</p>
+			<div class="woocommerce-add-variation-price-container">
+				<button type="button" class="button add_price_for_variations"><?php esc_html_e( 'Add price', 'woocommerce' ); ?></button>
+			</div>
 		</div>
 		<?php
 	}

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -490,8 +490,8 @@ function wc_render_invalid_variation_notice( $product_object ) {
 		"
 		SELECT count(post_id) FROM {$wpdb->postmeta}
 		WHERE post_id in (" . implode( ',', array_map( 'absint', $variation_ids ) ) . ")
-		AND meta_key='_price'
-		AND meta_value >= 0
+		AND ( meta_key='_subscription_sign_up_fee' OR meta_key='_price' )
+		AND meta_value > 0
 		AND meta_value != ''
 		"
 	);

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -55,7 +55,7 @@ function wc_get_screen_ids() {
 		}
 	}
 
-	/* phpcs:disable */
+	/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 	return apply_filters( 'woocommerce_screen_ids', $screen_ids );
 	/* phpcs: enable */
 }
@@ -109,7 +109,7 @@ function wc_create_page( $slug, $option = '', $page_title = '', $page_content = 
 		$valid_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status NOT IN ( 'pending', 'trash', 'future', 'auto-draft' )  AND post_name = %s LIMIT 1;", $slug ) );
 	}
 
-	/* phpcs:disable */
+	/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 	$valid_page_found = apply_filters( 'woocommerce_create_page_id', $valid_page_found, $slug, $page_content );
 	/* phpcs: enable */
 
@@ -149,7 +149,7 @@ function wc_create_page( $slug, $option = '', $page_title = '', $page_content = 
 		);
 		$page_id   = wp_insert_post( $page_data );
 
-		/* phpcs:disable */
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		do_action( 'woocommerce_page_created', $page_id, $page_data );
 		/* phpcs: enable */
 	}
@@ -293,7 +293,7 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
  */
 function wc_save_order_items( $order_id, $items ) {
 	// Allow other plugins to check change in order items before they are saved.
-	/* phpcs:disable */
+	/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 	do_action( 'woocommerce_before_save_order_items', $order_id, $items );
 	/* phpcs: enable */
 
@@ -369,7 +369,7 @@ function wc_save_order_items( $order_id, $items ) {
 			}
 
 			// Allow other plugins to change item object before it is saved.
-			/* phpcs:disable */
+			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 			do_action( 'woocommerce_before_save_order_item', $item );
 			/* phpcs: enable */
 
@@ -448,7 +448,7 @@ function wc_save_order_items( $order_id, $items ) {
 	$order->calculate_totals( false );
 
 	// Inform other plugins that the items have been saved.
-	/* phpcs:disable */
+	/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 	do_action( 'woocommerce_saved_order_items', $order_id, $items );
 	/* phpcs: enable */
 }
@@ -484,7 +484,7 @@ function wc_render_invalid_variation_notice( $product_object ) {
 	global $wpdb;
 
 	// Give ability for extensions to hide this notice.
-	/* phpcs:disable */
+	/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 	if ( ! apply_filters( 'woocommerce_show_invalid_variations_notice', true, $product_object ) ) {
 		return;
 	}

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -55,7 +55,9 @@ function wc_get_screen_ids() {
 		}
 	}
 
+	/* phpcs:disable */
 	return apply_filters( 'woocommerce_screen_ids', $screen_ids );
+	/* phpcs: enable */
 }
 
 /**
@@ -107,7 +109,9 @@ function wc_create_page( $slug, $option = '', $page_title = '', $page_content = 
 		$valid_page_found = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type='page' AND post_status NOT IN ( 'pending', 'trash', 'future', 'auto-draft' )  AND post_name = %s LIMIT 1;", $slug ) );
 	}
 
+	/* phpcs:disable */
 	$valid_page_found = apply_filters( 'woocommerce_create_page_id', $valid_page_found, $slug, $page_content );
+	/* phpcs: enable */
 
 	if ( $valid_page_found ) {
 		if ( $option ) {
@@ -145,7 +149,9 @@ function wc_create_page( $slug, $option = '', $page_title = '', $page_content = 
 		);
 		$page_id   = wp_insert_post( $page_data );
 
+		/* phpcs:disable */
 		do_action( 'woocommerce_page_created', $page_id, $page_data );
+		/* phpcs: enable */
 	}
 
 	if ( $option ) {
@@ -287,7 +293,9 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
  */
 function wc_save_order_items( $order_id, $items ) {
 	// Allow other plugins to check change in order items before they are saved.
+	/* phpcs:disable */
 	do_action( 'woocommerce_before_save_order_items', $order_id, $items );
+	/* phpcs: enable */
 
 	$qty_change_order_notes = array();
 	$order                  = wc_get_order( $order_id );
@@ -361,7 +369,9 @@ function wc_save_order_items( $order_id, $items ) {
 			}
 
 			// Allow other plugins to change item object before it is saved.
+			/* phpcs:disable */
 			do_action( 'woocommerce_before_save_order_item', $item );
+			/* phpcs: enable */
 
 			$item->save();
 
@@ -438,7 +448,9 @@ function wc_save_order_items( $order_id, $items ) {
 	$order->calculate_totals( false );
 
 	// Inform other plugins that the items have been saved.
+	/* phpcs:disable */
 	do_action( 'woocommerce_saved_order_items', $order_id, $items );
+	/* phpcs: enable */
 }
 
 /**
@@ -472,9 +484,11 @@ function wc_render_invalid_variation_notice( $product_object ) {
 	global $wpdb;
 
 	// Give ability for extensions to hide this notice.
+	/* phpcs:disable */
 	if ( ! apply_filters( 'woocommerce_show_invalid_variations_notice', true, $product_object ) ) {
 		return;
 	}
+	/* phpcs: enable */
 
 	$variation_ids = $product_object ? $product_object->get_children() : array();
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR aims to introduce an easy way for users to add the variation price. It also modifies a few styles to show the action buttons for the variations without hovering over the rows.

Closes #33554.

### How to test the changes in this Pull Request:

1. Go to `Products` > `Add New`.
2. Add a product name and a description.
3. In the `Product data` section select `Variable product`.
4. Go to `Attributes` and create (or select) a product attribute to use for variations.
5. Go to `Variations` and add a few variations (don't modify them).
6. Press `Save changes`.
7. Verify that a warning is shown with the number of variations without price.

![Screen Shot 2022-10-19 at 17 13 28](https://user-images.githubusercontent.com/1314156/196794456-07a33a32-d808-47e8-8dcd-2b76b5a0f107.png)

9. Press `Add price`. A modal like the one below will be visible.
![Screen Shot 2022-10-19 at 16 03 45](https://user-images.githubusercontent.com/1314156/196781258-65f90590-5ba0-416e-b62b-d7ab79ab1478.png)

10. Verify the currency matches the currency used on the site.
11. Add a text (not numbers) and verify that the validation fails. Add a number with multiple decimal points and verify that the error text says: `Please enter a value with one decimal point (%s) without thousand separators`.
12. After adding a valid number the button `OK` should be enabled.
13. Add a valid number and press `Add prices`.
14. Verify that the `Regular price` for every variation is set with the number added in the modal.
15. Verify that the accordion expands after pressing `Edit`.
16. Press `Save changes`. The warning should disappear.
17. Publish the product.
18. Add another variation. Press `Save changes`. The warning should be shown again.
19. Now add another value and verify that the new value has been added to the new variation without modifying the other variations' values.

Now create a new product but select `Variable subscription` instead of `Variable product` in step 3, and continue with the other steps.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
