### PR TITLE
Add async select control

### DIFF
--- a/packages/js/components/changelog/add-34331_add_async_select_control
+++ b/packages/js/components/changelog/add-34331_add_async_select_control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add AsyncSelectControl component for async dropdowns, this is a wrapper around the experimental AsyncControl.

--- a/packages/js/components/src/experimental-select-control/async-select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/async-select-control.tsx
@@ -93,8 +93,7 @@ export function AsyncSelectControl< ItemType >( {
 		(
 			allItems: ItemType[],
 			inputValue: string,
-			selectedItems: ItemType[],
-			getItemLabel: getItemLabelType< ItemType >
+			selectedItems: ItemType[]
 		) => {
 			if ( filterClientSide ) {
 				const getFilteredItemsFunc =

--- a/packages/js/components/src/experimental-select-control/async-select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/async-select-control.tsx
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import { Spinner } from '@wordpress/components';
+import {
+	createElement,
+	useState,
+	useMemo,
+	useCallback,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
+import { debounce } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { SelectControlProps, SelectControl } from './select-control';
+import { Menu } from './menu';
+import { MenuItem } from './menu-item';
+import {
+	defaultGetFilteredItems,
+	defaultGetItemLabel,
+	defaultGetItemValue,
+} from './utils';
+import { getItemLabelType } from './types';
+
+type AsyncSelectControlProps< ItemType > = Omit<
+	SelectControlProps< ItemType >,
+	'onInputChange' | 'items'
+> & {
+	onSearch: ( value: string | undefined ) => Promise< ItemType[] >;
+	items?: ItemType[];
+	triggerInitialFetch?: boolean;
+	pageSize?: number;
+	total?: number;
+};
+
+export function AsyncSelectControl< ItemType >( {
+	onSearch,
+	getItemLabel = defaultGetItemLabel,
+	getItemValue = defaultGetItemValue,
+	items = [],
+	triggerInitialFetch = true,
+	pageSize,
+	total,
+	...remainingSelectControlProps
+}: AsyncSelectControlProps< ItemType > ) {
+	const [ fetchedItems, setFetchedItems ] = useState< ItemType[] >( items );
+	const [ isFetching, setIsFetching ] = useState( false );
+
+	const fetchItems = useCallback(
+		( value: string | undefined ) => {
+			setIsFetching( true );
+			onSearch( value ).then(
+				( results ) => {
+					setFetchedItems( results );
+					setIsFetching( false );
+				},
+				() => {
+					setIsFetching( false );
+				}
+			);
+		},
+		[ setFetchedItems, setIsFetching ]
+	);
+
+	useEffect( () => {
+		if ( triggerInitialFetch && items.length === 0 ) {
+			fetchItems( '' );
+		}
+	}, [] );
+
+	const searchDebounced = useMemo(
+		() => debounce( fetchItems, 150 ),
+		[ fetchItems ]
+	);
+
+	const filterClientSide =
+		pageSize && total && pageSize > 0 && total < pageSize;
+
+	const onInputChange = useCallback(
+		( value?: string ) => {
+			if ( filterClientSide ) {
+				return;
+			}
+			searchDebounced( value );
+		},
+		[ filterClientSide ]
+	);
+
+	const getFilteredItems = useCallback(
+		(
+			allItems: ItemType[],
+			inputValue: string,
+			selectedItems: ItemType[],
+			getItemLabel: getItemLabelType< ItemType >
+		) => {
+			if ( filterClientSide ) {
+				const getFilteredItemsFunc =
+					remainingSelectControlProps.getFilteredItems ??
+					defaultGetFilteredItems;
+				return getFilteredItemsFunc(
+					allItems,
+					inputValue,
+					selectedItems,
+					getItemLabel
+				);
+			}
+			return allItems;
+		},
+		[ filterClientSide ]
+	);
+
+	return (
+		<SelectControl< ItemType >
+			{ ...remainingSelectControlProps }
+			getFilteredItems={ getFilteredItems }
+			items={ fetchedItems }
+			onInputChange={ onInputChange }
+			getItemLabel={ getItemLabel }
+			getItemValue={ getItemValue }
+		>
+			{ ( {
+				items: selectControlItems,
+				isOpen,
+				highlightedIndex,
+				getItemProps,
+				getMenuProps,
+			} ) => {
+				return (
+					<Menu isOpen={ isOpen } getMenuProps={ getMenuProps }>
+						{ isFetching ? (
+							<Spinner />
+						) : (
+							selectControlItems.map( ( item, index: number ) => (
+								<MenuItem
+									key={ `${ getItemValue( item ) }` }
+									index={ index }
+									isActive={ highlightedIndex === index }
+									item={ item }
+									getItemProps={ getItemProps }
+								>
+									{ getItemLabel( item ) }
+								</MenuItem>
+							) )
+						) }
+					</Menu>
+				);
+			} }
+		</SelectControl>
+	);
+}

--- a/packages/js/components/src/experimental-select-control/index.ts
+++ b/packages/js/components/src/experimental-select-control/index.ts
@@ -1,1 +1,2 @@
 export * from './select-control';
+export * from './async-select-control';

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -34,7 +34,7 @@ import {
 	defaultGetFilteredItems,
 } from './utils';
 
-type SelectControlProps< ItemType > = {
+export type SelectControlProps< ItemType > = {
 	children?: ChildrenType< ItemType >;
 	items: ItemType[];
 	label: string;
@@ -58,6 +58,7 @@ type SelectControlProps< ItemType > = {
 	) => Partial< UseComboboxState< ItemType | null > >;
 	placeholder?: string;
 	selected: ItemType | ItemType[] | null;
+	disabled?: boolean;
 };
 
 export const selectControlStateChangeTypes = useCombobox.stateChangeTypes;
@@ -100,6 +101,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 	stateReducer = ( state, actionAndChanges ) => actionAndChanges.changes,
 	placeholder,
 	selected,
+	disabled,
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -234,6 +236,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 					},
 					onBlur: () => setIsFocused( false ),
 					placeholder,
+					disabled,
 				} ) }
 			>
 				<>

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -48,7 +48,10 @@ export type SelectControlProps< ItemType > = {
 	) => ItemType[];
 	hasExternalTags?: boolean;
 	multiple?: boolean;
-	onInputChange?: ( value: string | undefined ) => void;
+	onInputChange?: (
+		value: string | undefined,
+		changes: Partial< Omit< UseComboboxState< ItemType >, 'inputValue' > >
+	) => void;
 	onRemove?: ( item: ItemType ) => void;
 	onSelect?: ( selected: ItemType ) => void;
 	onFocus?: ( data: { inputValue: string } ) => void;
@@ -154,12 +157,10 @@ function SelectControl< ItemType = DefaultItemType >( {
 		itemToString: getItemLabel,
 		onSelectedItemChange: ( { selectedItem } ) =>
 			selectedItem && onSelect( selectedItem ),
-		onInputValueChange: ( changes ) => {
-			if ( changes.inputValue !== undefined ) {
-				setInputValue( changes.inputValue );
-				if ( changes.isOpen ) {
-					onInputChange( changes.inputValue );
-				}
+		onInputValueChange: ( { inputValue: value, ...changes } ) => {
+			if ( value !== undefined ) {
+				setInputValue( value );
+				onInputChange( value, changes );
 			}
 		},
 		stateReducer: ( state, actionAndChanges ) => {

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -42,6 +42,7 @@ export { default as SegmentedSelection } from './segmented-selection';
 export { default as SelectControl } from './select-control';
 export {
 	SelectControl as __experimentalSelectControl,
+	AsyncSelectControl as __experimentalAsyncSelectControl,
 	selectControlStateChangeTypes,
 } from './experimental-select-control';
 export { MenuItem as __experimentalSelectControlMenuItem } from './experimental-select-control/menu-item';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds an `AsyncSelectControl` component that is a wrapper around the `SelectControl` component.
It adds a `onSearch` prop that expects a promise with the search results.

If a user decides to pass in the `pageSize` and `total`, if the `total` is less then the `pageSize` it will do the filtering on the client side and not hit `onSearch` for every key stroke.

Partially addresses #34331

### How to test the changes in this Pull Request:

1. Load this branch and run `pnpm --filter=@woocommerce/storybook storybook`
2. Check out the `Async` and `Async with client side filtering` under the experimental select control.
3. The latter should not show the spinner after the initial items have been retrieved.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
