### PR TITLE
Serialize value before sending to meta display form.

### DIFF
--- a/plugins/woocommerce/changelog/fix-meta_render_array
+++ b/plugins/woocommerce/changelog/fix-meta_render_array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Serialize meta value before rendering so that it's rendered properly.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -40,7 +40,7 @@ class CustomMetaBox {
 			$metadata_to_list[] = array(
 				'meta_id'    => $data['id'],
 				'meta_key'   => $data['key'], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- False positive, not a meta query.
-				'meta_value' => $data['value'], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive, not a meta query.
+				'meta_value' => maybe_serialize( $data['value'] ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- False positive, not a meta query.
 			);
 		}
 		return $metadata_to_list;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We use WP's `list_meta` meta function to render custom metadata entries in the order edit screen. However, this function expects all meta value to be strings, in we were sending arrays too if the meta_value is an array.

This PR serializes array meta values before passing to WP's list_meta function, similar to the behavior in the WP core.

Fixes #34913 

### How to test the changes in this Pull Request:

1. For an order, save a meta data for a custom key as an array. For example `$order->update_meta_data('custom_key', array('foo'=>'bar')); ` and save the order.
3. Try to edit the order, you will see an error (or a notice depending upon PHP version) for string expected but passed array.
4. Checkout this branch, the error will go away (although the meta_key will not displayed also, which is the expected behavior).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
