### PR TITLE
Add DateTimePickerControl Form stories and tests

### DIFF
--- a/packages/js/components/changelog/add-date-time-picker-control-to-form
+++ b/packages/js/components/changelog/add-date-time-picker-control-to-form
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add DateTimePickerControl support to Form.
+Add support for aliasing props returned from FormContext's getInputProps.

--- a/packages/js/components/changelog/add-date-time-picker-control-to-form
+++ b/packages/js/components/changelog/add-date-time-picker-control-to-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add DateTimePickerControl support to Form.

--- a/packages/js/components/changelog/add-date-time-picker-control-to-form
+++ b/packages/js/components/changelog/add-date-time-picker-control-to-form
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add support for aliasing props returned from FormContext's getInputProps.
+Export ImportProps type. Add DateTimePickerControl to Form stories and tests.

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -18,12 +18,6 @@ export type InputProps< Value > = {
 	help: string | null | undefined;
 };
 
-export type InputPropsOptions< Type > = {
-	alias?: {
-		[ Property in keyof Type ]?: string;
-	};
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormContext< Values extends Record< string, any > > = {
 	values: Values;

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -18,11 +18,10 @@ export type InputProps< Value > = {
 	help: string | null | undefined;
 };
 
-export type DateTimePickerControlProps< Value > = Pick<
-	InputProps< Value >,
-	'onChange' | 'onBlur' | 'className' | 'help'
-> & {
-	currentDate: Value;
+export type InputPropsOptions< Type > = {
+	alias?: {
+		[ Property in keyof Type ]?: string;
+	};
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,11 +38,9 @@ export type FormContext< Values extends Record< string, any > > = {
 	setValues: ( valuesToSet: Values ) => void;
 	handleSubmit: () => Promise< Values >;
 	getInputProps< Value extends Values[ keyof Values ] >(
-		name: string
+		name: string,
+		options?: InputPropsOptions< InputProps< Value > >
 	): InputProps< Value >;
-	getDateTimePickerControlProps< Value extends Values[ keyof Values ] >(
-		name: string
-	): DateTimePickerControlProps< Value >;
 	isValidForm: boolean;
 	resetForm: (
 		initialValues: Values,

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -32,6 +32,15 @@ export type FormContext< Values extends Record< string, any > > = {
 		className: string | undefined;
 		help: string | null | undefined;
 	};
+	getDateTimePickerControlProps< Value extends Values[ keyof Values ] >(
+		name: string
+	): {
+		currentDate: Value;
+		className?: string;
+		onChange: ( date: Values[ keyof Values ] ) => void;
+		onBlur: () => void;
+		help?: string | null;
+	};
 	isValidForm: boolean;
 	resetForm: (
 		initialValues: Values,

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -14,13 +14,13 @@ export type InputProps< Value > = {
 	selected?: boolean;
 	onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) => void;
 	onBlur: () => void;
-	className?: string;
-	help?: string | null;
+	className: string | undefined;
+	help: string | null | undefined;
 };
 
-export type DateTimePickerControlProps< Value > = Omit<
+export type DateTimePickerControlProps< Value > = Pick<
 	InputProps< Value >,
-	'value' | 'checked'
+	'onChange' | 'onBlur' | 'className' | 'help'
 > & {
 	currentDate: Value;
 };

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -8,6 +8,23 @@ export type FormErrors< Values > = {
 	[ P in keyof Values ]?: FormErrors< Values[ P ] > | string;
 };
 
+export type InputProps< Value > = {
+	value: Value;
+	checked: boolean;
+	selected?: boolean;
+	onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) => void;
+	onBlur: () => void;
+	className?: string;
+	help?: string | null;
+};
+
+export type DateTimePickerControlProps< Value > = Omit<
+	InputProps< Value >,
+	'value' | 'checked'
+> & {
+	currentDate: Value;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormContext< Values extends Record< string, any > > = {
 	values: Values;
@@ -23,24 +40,10 @@ export type FormContext< Values extends Record< string, any > > = {
 	handleSubmit: () => Promise< Values >;
 	getInputProps< Value extends Values[ keyof Values ] >(
 		name: string
-	): {
-		value: Value;
-		checked: boolean;
-		selected?: boolean;
-		onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) => void;
-		onBlur: () => void;
-		className: string | undefined;
-		help: string | null | undefined;
-	};
+	): InputProps< Value >;
 	getDateTimePickerControlProps< Value extends Values[ keyof Values ] >(
 		name: string
-	): {
-		currentDate: Value;
-		className?: string;
-		onChange: ( date: Values[ keyof Values ] ) => void;
-		onBlur: () => void;
-		help?: string | null;
-	};
+	): DateTimePickerControlProps< Value >;
 	isValidForm: boolean;
 	resetForm: (
 		initialValues: Values,

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -38,8 +38,7 @@ export type FormContext< Values extends Record< string, any > > = {
 	setValues: ( valuesToSet: Values ) => void;
 	handleSubmit: () => Promise< Values >;
 	getInputProps< Value extends Values[ keyof Values ] >(
-		name: string,
-		options?: InputPropsOptions< InputProps< Value > >
+		name: string
 	): InputProps< Value >;
 	isValidForm: boolean;
 	resetForm: (

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -273,14 +273,13 @@ function FormComponent< Values extends Record< string, any > >(
 	};
 
 	function getInputProps< Value = Values[ keyof Values ] >(
-		name: string,
-		options?: InputPropsOptions< InputProps< Value > >
+		name: string
 	): InputProps< Value > {
 		const inputValue = _get( values, name );
 		const isTouched = touched[ name ];
 		const inputError = _get( errors, name );
 
-		const inputProps = {
+		return {
 			value: inputValue,
 			checked: Boolean( inputValue ),
 			selected: inputValue,
@@ -290,20 +289,6 @@ function FormComponent< Values extends Record< string, any > >(
 			className: isTouched && inputError ? 'has-error' : undefined,
 			help: isTouched ? ( inputError as string ) : null,
 		};
-
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const aliasedProps = {} as Record< string, any >;
-		if ( options?.alias ) {
-			for ( const key in options.alias ) {
-				const alias = options.alias[ key as keyof InputProps< Value > ];
-				if ( alias ) {
-					aliasedProps[ alias ] =
-						inputProps[ key as keyof InputProps< Value > ];
-				}
-			}
-		}
-
-		return { ...inputProps, ...aliasedProps };
 	}
 
 	const isDirty = useMemo(

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -220,8 +220,7 @@ function FormComponent< Values extends Record< string, any > >(
 	const handleChange = useCallback(
 		(
 			name: string,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			value: ChangeEvent< HTMLInputElement > | any
+			value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
 		) => {
 			// Handle native events.
 			if ( isChangeEvent( value ) && value.target ) {
@@ -286,7 +285,7 @@ function FormComponent< Values extends Record< string, any > >(
 			checked: Boolean( inputValue ),
 			selected: inputValue,
 			onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) =>
-				handleChange( name, value ),
+				handleChange( name, value as Values[ keyof Values ] ),
 			onBlur: () => handleBlur( name ),
 			className: isTouched && inputError ? 'has-error' : undefined,
 			help: isTouched ? ( inputError as string ) : null,

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -302,6 +302,29 @@ function FormComponent< Values extends Record< string, any > >(
 		[ initialValues.current, values ]
 	);
 
+	function getDateTimePickerControlProps< Value = Values[ keyof Values ] >(
+		name: string
+	): {
+		currentDate: Value;
+		className?: string;
+		onChange: ( date: Values[ keyof Values ] ) => void;
+		onBlur: () => void;
+		help?: string | null;
+	} {
+		const value = _get( values, name );
+		const isTouched = touched[ name ];
+		const error = _get( errors, name );
+
+		return {
+			currentDate: value,
+			onChange: ( date: Values[ keyof Values ] ) =>
+				handleChange( name, date ),
+			onBlur: () => handleBlur( name ),
+			className: isTouched && error ? 'has-error' : undefined,
+			help: isTouched ? ( error as string ) : null,
+		};
+	}
+
 	const getStateAndHelpers = () => {
 		return {
 			values,
@@ -313,6 +336,7 @@ function FormComponent< Values extends Record< string, any > >(
 			setValues,
 			handleSubmit,
 			getInputProps,
+			getDateTimePickerControlProps,
 			isValidForm: ! Object.keys( errors ).length,
 			resetForm,
 		};

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -21,7 +21,12 @@ import _isEqual from 'lodash/isEqual';
 /**
  * Internal dependencies
  */
-import { FormContext, FormErrors } from './form-context';
+import {
+	DateTimePickerControlProps,
+	FormContext,
+	FormErrors,
+	InputProps,
+} from './form-context';
 
 type FormProps< Values > = {
 	/**
@@ -215,7 +220,8 @@ function FormComponent< Values extends Record< string, any > >(
 	const handleChange = useCallback(
 		(
 			name: string,
-			value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			value: ChangeEvent< HTMLInputElement > | any
 		) => {
 			// Handle native events.
 			if ( isChangeEvent( value ) && value.target ) {
@@ -269,17 +275,7 @@ function FormComponent< Values extends Record< string, any > >(
 
 	function getInputProps< Value = Values[ keyof Values ] >(
 		name: string
-	): {
-		value: Value;
-		checked: boolean;
-		selected?: boolean;
-		onChange: (
-			value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
-		) => void;
-		onBlur: () => void;
-		className: string | undefined;
-		help: string | null | undefined;
-	} {
+	): InputProps< Value > {
 		const inputValue = _get( values, name );
 		const isTouched = touched[ name ];
 		const inputError = _get( errors, name );
@@ -288,9 +284,8 @@ function FormComponent< Values extends Record< string, any > >(
 			value: inputValue,
 			checked: Boolean( inputValue ),
 			selected: inputValue,
-			onChange: (
-				value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
-			) => handleChange( name, value ),
+			onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) =>
+				handleChange( name, value ),
 			onBlur: () => handleBlur( name ),
 			className: isTouched && inputError ? 'has-error' : undefined,
 			help: isTouched ? ( inputError as string ) : null,
@@ -304,24 +299,12 @@ function FormComponent< Values extends Record< string, any > >(
 
 	function getDateTimePickerControlProps< Value = Values[ keyof Values ] >(
 		name: string
-	): {
-		currentDate: Value;
-		className?: string;
-		onChange: ( date: Values[ keyof Values ] ) => void;
-		onBlur: () => void;
-		help?: string | null;
-	} {
-		const value = _get( values, name );
-		const isTouched = touched[ name ];
-		const error = _get( errors, name );
+	): DateTimePickerControlProps< Value > {
+		const inputProps = getInputProps< Value >( name );
 
 		return {
-			currentDate: value,
-			onChange: ( date: Values[ keyof Values ] ) =>
-				handleChange( name, date ),
-			onBlur: () => handleBlur( name ),
-			className: isTouched && error ? 'has-error' : undefined,
-			help: isTouched ? ( error as string ) : null,
+			currentDate: inputProps.value,
+			...inputProps,
 		};
 	}
 

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -21,12 +21,7 @@ import _isEqual from 'lodash/isEqual';
 /**
  * Internal dependencies
  */
-import {
-	FormContext,
-	FormErrors,
-	InputProps,
-	InputPropsOptions,
-} from './form-context';
+import { FormContext, FormErrors, InputProps } from './form-context';
 
 type FormProps< Values > = {
 	/**

--- a/packages/js/components/src/form/stories/index.js
+++ b/packages/js/components/src/form/stories/index.js
@@ -52,13 +52,7 @@ export const Basic = () => {
 				onChange={ handleChange }
 				initialValues={ initialValues }
 			>
-				{ ( {
-					getInputProps,
-					getDateTimePickerControlProps,
-					values,
-					errors,
-					handleSubmit,
-				} ) => {
+				{ ( { getInputProps, values, errors, handleSubmit } ) => {
 					const radioInputProps = getInputProps( 'radio' );
 					return (
 						<div>
@@ -83,7 +77,9 @@ export const Basic = () => {
 								label="Date"
 								dateTimeFormat="YYYY-MM-DD HH:mm"
 								placeholder="Enter a date"
-								{ ...getDateTimePickerControlProps( 'date' ) }
+								{ ...getInputProps( 'date', {
+									alias: { value: 'currentDate' },
+								} ) }
 							/>
 							<CheckboxControl
 								label="Checkbox"

--- a/packages/js/components/src/form/stories/index.js
+++ b/packages/js/components/src/form/stories/index.js
@@ -77,9 +77,8 @@ export const Basic = () => {
 								label="Date"
 								dateTimeFormat="YYYY-MM-DD HH:mm"
 								placeholder="Enter a date"
-								{ ...getInputProps( 'date', {
-									alias: { value: 'currentDate' },
-								} ) }
+								currentDate={ values.date }
+								{ ...getInputProps( 'date' ) }
 							/>
 							<CheckboxControl
 								label="Checkbox"

--- a/packages/js/components/src/form/stories/index.js
+++ b/packages/js/components/src/form/stories/index.js
@@ -9,7 +9,8 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { Form } from '@woocommerce/components';
+import { Form, DateTimePickerControl } from '@woocommerce/components';
+import moment from 'moment';
 
 const validate = ( values ) => {
 	const errors = {};
@@ -18,6 +19,9 @@ const validate = ( values ) => {
 	}
 	if ( values.lastName.length < 3 ) {
 		errors.lastName = 'Last name must be at least 3 characters';
+	}
+	if ( ! moment( values.date, moment.ISO_8601, true ).isValid() ) {
+		errors.date = 'Invalid date';
 	}
 	return errors;
 };
@@ -28,6 +32,7 @@ const initialValues = {
 	firstName: '',
 	lastName: '',
 	select: '3',
+	date: '2014-10-24T13:02',
 	checkbox: true,
 	radio: 'one',
 };
@@ -47,7 +52,13 @@ export const Basic = () => {
 				onChange={ handleChange }
 				initialValues={ initialValues }
 			>
-				{ ( { getInputProps, values, errors, handleSubmit } ) => {
+				{ ( {
+					getInputProps,
+					getDateTimePickerControlProps,
+					values,
+					errors,
+					handleSubmit,
+				} ) => {
 					const radioInputProps = getInputProps( 'radio' );
 					return (
 						<div>
@@ -67,6 +78,12 @@ export const Basic = () => {
 									{ label: 'Option 3', value: '3' },
 								] }
 								{ ...getInputProps( 'select' ) }
+							/>
+							<DateTimePickerControl
+								label="Date"
+								dateTimeFormat="YYYY-MM-DD HH:mm"
+								placeholder="Enter a date"
+								{ ...getDateTimePickerControlProps( 'date' ) }
 							/>
 							<CheckboxControl
 								label="Checkbox"

--- a/packages/js/components/src/form/test/index.tsx
+++ b/packages/js/components/src/form/test/index.tsx
@@ -428,14 +428,13 @@ describe( 'Form', () => {
 
 		const { container, queryByText } = render(
 			<Form< TestData > onChange={ mockOnChange } validate={ validate }>
-				{ ( { getInputProps }: FormContext< TestData > ) => {
+				{ ( { getInputProps, values }: FormContext< TestData > ) => {
 					return (
 						<DateTimePickerControl
 							label={ 'Date' }
 							onChangeDebounceWait={ 10 }
-							{ ...getInputProps( 'date', {
-								alias: { value: 'currentDate' },
-							} ) }
+							currentDate={ values.date }
+							{ ...getInputProps( 'date' ) }
 						/>
 					);
 				} }

--- a/packages/js/components/src/form/test/index.tsx
+++ b/packages/js/components/src/form/test/index.tsx
@@ -428,14 +428,14 @@ describe( 'Form', () => {
 
 		const { container, queryByText } = render(
 			<Form< TestData > onChange={ mockOnChange } validate={ validate }>
-				{ ( {
-					getDateTimePickerControlProps,
-				}: FormContext< TestData > ) => {
+				{ ( { getInputProps }: FormContext< TestData > ) => {
 					return (
 						<DateTimePickerControl
 							label={ 'Date' }
 							onChangeDebounceWait={ 10 }
-							{ ...getDateTimePickerControlProps( 'date' ) }
+							{ ...getInputProps( 'date', {
+								alias: { value: 'currentDate' },
+							} ) }
 						/>
 					);
 				} }

--- a/packages/js/components/src/form/test/index.tsx
+++ b/packages/js/components/src/form/test/index.tsx
@@ -11,6 +11,7 @@ import { TextControl } from '@wordpress/components';
  */
 import { Form, useFormContext } from '../';
 import type { FormContext } from '../';
+import { DateTimePickerControl } from '../../date-time-picker-control';
 
 const TestInputWithContext = () => {
 	const formProps = useFormContext< { foo: string } >();
@@ -406,6 +407,69 @@ describe( 'Form', () => {
 			false
 		);
 	} );
+
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
+	it( 'should provide props that automatically handle DateTimePickerControl changes', async () => {
+		const newDateTimeInputString = 'invalid input';
+
+		type TestData = { date: string };
+
+		const mockOnChange = jest.fn();
+
+		function validate(): Record< string, string > {
+			return { date: 'This is a bad date' };
+		}
+
+		const { container, queryByText } = render(
+			<Form< TestData > onChange={ mockOnChange } validate={ validate }>
+				{ ( {
+					getDateTimePickerControlProps,
+				}: FormContext< TestData > ) => {
+					return (
+						<DateTimePickerControl
+							label={ 'Date' }
+							onChangeDebounceWait={ 10 }
+							{ ...getDateTimePickerControlProps( 'date' ) }
+						/>
+					);
+				} }
+			</Form>
+		);
+
+		const controlRoot = container.querySelector(
+			'.woocommerce-date-time-picker-control'
+		);
+
+		const input = controlRoot?.querySelector( 'input' );
+		userEvent.type(
+			input!,
+			'{selectall}{backspace}' + newDateTimeInputString
+		);
+		fireEvent.blur( input! );
+
+		await waitFor(
+			() => {
+				expect( mockOnChange ).toHaveBeenLastCalledWith(
+					{ name: 'date', value: newDateTimeInputString },
+					{ date: newDateTimeInputString },
+					false
+				);
+				expect( controlRoot?.classList.contains( 'has-error' ) ).toBe(
+					true
+				);
+				expect(
+					queryByText( 'This is a bad date' )
+				).toBeInTheDocument();
+			},
+			{ timeout: 100 }
+		);
+	}, 10000 );
 
 	describe( 'FormContext', () => {
 		it( 'should allow nested field to use useFormContext to set field value', async () => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds `<DateTimePickerControl>` to `<Form>` stories and tests.

It also exports an `InputProps` type.

Needed by #34538

### How to test the changes in this Pull Request:

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/form`
2. Interact with Storybook stories and make sure DateTimePickerControl functions on Form: `pnpm --filter=@woocommerce/storybook storybook`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
