### PR TITLE
Fix for #34962 - On CSV import, product variations are not visible if parent is draft

### DIFF
--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -657,7 +657,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 *
 	 * @param string $value Field value.
 	 *
-	 * @return float|string
+	 * @return int|string
 	 */
 	public function parse_published_field( $value ) {
 		if ( '' === $value ) {
@@ -671,7 +671,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return wc_string_to_bool( $value ) ? 1 : -1;
 		}
 
-		return floatval( $value );
+		return intval( $value );
 	}
 
 	/**


### PR DESCRIPTION
Fix for #34962 - `WC_Product_CSV_Importer::parse_published_field()` now returns `int|string` as expected.