### PR TITLE
REST API: Ensure meta_data prop contains an array

### DIFF
--- a/plugins/woocommerce/changelog/patch-rest-metadata-filtering
+++ b/plugins/woocommerce/changelog/patch-rest-metadata-filtering
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This fixes a bug introduced in https://github.com/woocommerce/woocommerce/pull/34478, which is also included in the 7.0 release
+
+

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -618,7 +618,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		$exclude = (array) $request['exclude_meta'];
 
 		if ( ! empty( $include ) ) {
-			return array_filter(
+			$meta_data = array_filter(
 				$meta_data,
 				function( WC_Meta_Data $item ) use ( $include ) {
 					$data = $item->get_data();
@@ -626,7 +626,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 				}
 			);
 		} elseif ( ! empty( $exclude ) ) {
-			return array_filter(
+			$meta_data = array_filter(
 				$meta_data,
 				function( WC_Meta_Data $item ) use ( $exclude ) {
 					$data = $item->get_data();
@@ -635,6 +635,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 			);
 		}
 
-		return $meta_data;
+		// Ensure the array indexes are reset so it doesn't get converted to an object in JSON.
+		return array_values( $meta_data );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -254,4 +254,25 @@ class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
 			$this->assertContains( 'test1', $meta_keys );
 		}
 	}
+
+	/**
+	 * Test that the meta_data property contains an array, and not an object, after being filtered.
+	 */
+	public function test_collection_param_include_meta_returns_array() {
+		$order = new \WC_Order();
+		$order->add_meta_data( 'test1', 'test1', true );
+		$order->add_meta_data( 'test2', 'test2', true );
+		$order->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', 'test2' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data       = $this->server->response_to_data( $response, false );
+		$encoded_data_string = wp_json_encode( $response_data );
+		$decoded_data_object = json_decode( $encoded_data_string, false ); // Ensure object instead of associative array.
+
+		$this->assertIsArray( $decoded_data_object[0]->meta_data );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-products-controller-tests.php
@@ -277,4 +277,20 @@ class WC_REST_Products_V2_Controller_Test extends WC_REST_Unit_Test_Case {
 			$this->assertContains( 'test1', $meta_keys );
 		}
 	}
+
+	/**
+	 * Test that the meta_data property contains an array, and not an object, after being filtered.
+	 */
+	public function test_collection_param_include_meta_returns_array() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'include_meta', 'test2' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data       = $this->server->response_to_data( $response, false );
+		$encoded_data_string = wp_json_encode( $response_data );
+		$decoded_data_object = json_decode( $encoded_data_string, false ); // Ensure object instead of associative array.
+
+		$this->assertIsArray( $decoded_data_object[0]->meta_data );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller-tests.php
@@ -381,4 +381,25 @@ class WC_REST_Orders_Controller_Tests extends WC_REST_Unit_Test_Case {
 			$this->assertContains( 'test1', $meta_keys );
 		}
 	}
+
+	/**
+	 * Test that the meta_data property contains an array, and not an object, after being filtered.
+	 */
+	public function test_collection_param_include_meta_returns_array() {
+		$order = new \WC_Order();
+		$order->add_meta_data( 'test1', 'test1', true );
+		$order->add_meta_data( 'test2', 'test2', true );
+		$order->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
+		$request->set_param( 'include_meta', 'test2' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data       = $this->server->response_to_data( $response, false );
+		$encoded_data_string = wp_json_encode( $response_data );
+		$decoded_data_object = json_decode( $encoded_data_string, false ); // Ensure object instead of associative array.
+
+		$this->assertIsArray( $decoded_data_object[0]->meta_data );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -408,4 +408,20 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 			$this->assertContains( 'test1', $meta_keys );
 		}
 	}
+
+	/**
+	 * Test that the meta_data property contains an array, and not an object, after being filtered.
+	 */
+	public function test_collection_param_include_meta_returns_array() {
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
+		$request->set_param( 'include_meta', 'test2' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_data       = $this->server->response_to_data( $response, false );
+		$encoded_data_string = wp_json_encode( $response_data );
+		$decoded_data_object = json_decode( $encoded_data_string, false ); // Ensure object instead of associative array.
+
+		$this->assertIsArray( $decoded_data_object[0]->meta_data );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

When filtering the meta_data array of a response with include_meta or
exclude_meta, the array indexes were getting preserved so that it was
possible for the array to not contain a 0 index, but still have some
subsequent numbers. When such an array was converted to JSON, it was
interpreted as an object rather than an array.

Example
<img width="548" alt="3-include-key_2-object" src="https://user-images.githubusercontent.com/916023/194145200-fcacb03f-06e9-4b8d-8be2-b14030927ae9.png">

This ensures the meta_data array indexes are reset after filtering, and
adds unit tests to check that meta_data always contains an array, and
not an object.

### How to test the changes in this Pull Request:

1. Use the same test directions as #34478
2. When testing `include_meta`, use a value like `test2` or some other key that was not the first meta key you added.
3. In the JSON response, the `meta_data` prop should still contain an array, and not an object.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
