### PR TITLE
add/a2p api-core-tests order notes tests

### DIFF
--- a/plugins/woocommerce/changelog/add-api-core-tests-order-notes-crud-tests
+++ b/plugins/woocommerce/changelog/add-api-core-tests-order-notes-crud-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add playwright api-core-tests for order notes crud operations

--- a/plugins/woocommerce/tests/api-core-tests/tests/orders/orders-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/orders/orders-crud.test.js
@@ -1,5 +1,10 @@
-const { test, expect } = require( '@playwright/test' );
-const { order } = require( '../../data' );
+const {
+	test,
+	expect
+} = require('@playwright/test');
+const {
+	order
+} = require('../../data');
 
 /**
  * Billing properties to update.
@@ -62,13 +67,13 @@ const simpleProduct = {
  * @group orders
  *
  */
-test.describe( 'Orders API tests: CRUD', () => {
+test.describe('Orders API tests: CRUD', () => {
 	let orderId;
 
-	test.describe( 'Create an order', () => {
-		test( 'can create a pending order by default', async ( {
+	test.describe('Create an order', () => {
+		test('can create a pending order by default', async ({
 			request,
-		} ) => {
+		}) => {
 			// Create an order that has a null status
 			const requestPayload = {
 				...order,
@@ -76,196 +81,299 @@ test.describe( 'Orders API tests: CRUD', () => {
 			};
 
 			// call API to create an order
-			const response = await request.post( '/wp-json/wc/v3/orders', {
+			const response = await request.post('/wp-json/wc/v3/orders', {
 				data: requestPayload,
-			} );
+			});
 			const responseJSON = await response.json();
 
 			// Save the order ID. It will be used by the retrieve, update, and delete tests.
 			orderId = responseJSON.id;
 
 			// Verify that the order status is 'pending'
-			expect( response.status() ).toEqual( 201 );
-			expect( typeof responseJSON.id ).toEqual( 'number' );
-			expect( responseJSON.status ).toEqual( 'pending' );
-		} );
+			expect(response.status()).toEqual(201);
+			expect(typeof responseJSON.id).toEqual('number');
+			expect(responseJSON.status).toEqual('pending');
+		});
 
-		for ( const expectedStatus of statusesDataTable ) {
-			test( `can create an order with status ${ expectedStatus }`, async ( {
+		for (const expectedStatus of statusesDataTable) {
+			test(`can create an order with status ${ expectedStatus }`, async ({
 				request,
-			} ) => {
+			}) => {
 				const requestPayload = {
 					...order,
 					status: expectedStatus,
 				};
 				//create order with status
-				const response = await request.post( '/wp-json/wc/v3/orders', {
+				const response = await request.post('/wp-json/wc/v3/orders', {
 					data: requestPayload,
-				} );
+				});
 				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 201 );
-				expect( typeof responseJSON.id ).toEqual( 'number' );
-				expect( responseJSON.status ).toEqual( expectedStatus );
+				expect(response.status()).toEqual(201);
+				expect(typeof responseJSON.id).toEqual('number');
+				expect(responseJSON.status).toEqual(expectedStatus);
 
 				// Cleanup: Delete this order
 				await request.delete(
-					`/wp-json/wc/v3/orders/${ responseJSON.id }`,
-					{
+					`/wp-json/wc/v3/orders/${ responseJSON.id }`, {
 						data: {
 							force: true,
 						},
 					}
 				);
-			} );
+			});
 		}
-	} );
 
-	test.describe( 'Retrieve an order', () => {
-		test( 'can retrieve an order', async ( { request } ) => {
+		test.describe('Order Notes tests', () => {
+			let orderNoteId;
+			test('can create a order note', async ({
+				request,
+			}) => {
+				// call API to create an order note on the previously created order
+				const response = await request.post(`/wp-json/wc/v3/orders/${orderId}/notes`, {
+					data: {
+						note: "Order ok!!!"
+					}
+				});
+				const responseJSON = await response.json();
+
+				// Save the order note ID. It will be used by the retrieve, update and delete tests.
+				orderNoteId = responseJSON.id;
+
+				// Verify that the order status is 'pending'
+				expect(response.status()).toEqual(201);
+				expect(typeof responseJSON.id).toEqual('number');
+				expect(responseJSON.note).toEqual('Order ok!!!');
+				expect(responseJSON.customer_note).toEqual(false);
+			});
+
+
+			test('can retrieve an order note', async ({
+				request
+			}) => {
+				// call API to retrieve the previously saved order note
+				const response = await request.get(
+					`/wp-json/wc/v3/orders/${orderId}/notes/${orderNoteId}`
+				);
+				const responseJSON = await response.json();
+				expect(response.status()).toEqual(200);
+				expect(typeof responseJSON.id).toEqual('number');
+				expect(responseJSON.note).toEqual('Order ok!!!');
+				expect(responseJSON.customer_note).toEqual(false);
+				expect(responseJSON._links).toEqual(expect.objectContaining({
+					up: expect.arrayContaining([
+						expect.objectContaining({
+							href: expect.stringContaining(`/wp-json/wc/v3/orders/${orderId}`)
+						})
+					])
+				}));
+			});
+
+			test('can retrieve all order notes', async ({
+				request
+			}) => {
+				// call API to retrieve all order notes
+				const response = await request.get(`/wp-json/wc/v3/orders/${orderId}/notes`);
+				const responseJSON = await response.json();
+				expect(response.status()).toEqual(200);
+				expect(Array.isArray(responseJSON));
+				expect(responseJSON.length).toBeGreaterThan(0);
+			});
+
+			test(`cannot update an order note`, async ({
+				request,
+			}) => {
+				// attempt to update order note should fail
+				const response = await request.put(
+					`/wp-json/wc/v3/orders/${orderId}/notes/${orderNoteId}`, {
+						data: {
+							name: "Not able to update order note"
+						}
+					}
+				);
+				const responseJSON = await response.json();
+				expect(response.status()).toEqual(404);
+				expect(responseJSON.code).toEqual("rest_no_route");
+				expect(responseJSON.message).toEqual("No route was found matching the URL and request method.");
+			});
+
+			test('can permanently delete an order note', async ({
+				request
+			}) => {
+				// Delete the order note.
+				const response = await request.delete(
+					`/wp-json/wc/v3/orders/${orderId}/notes/${orderNoteId}`, {
+						data: {
+							force: true,
+						},
+					}
+				);
+				expect(response.status()).toEqual(200);
+
+				// Verify that the order note can no longer be retrieved
+				const getDeletedOrderNoteResponse = await request.get(
+					`/wp-json/wc/v3/orders/${orderId}/notes/${orderNoteId}`
+				);
+				expect(getDeletedOrderNoteResponse.status()).toEqual(404);
+			});
+		})
+	});
+
+	test.describe('Retrieve an order', () => {
+		test('can retrieve an order', async ({
+			request
+		}) => {
 			// call API to retrieve the previously saved order
 			const response = await request.get(
 				`/wp-json/wc/v3/orders/${ orderId }`
 			);
 			const responseJSON = await response.json();
-			expect( response.status() ).toEqual( 200 );
-			expect( responseJSON.id ).toEqual( orderId );
-		} );
-	} );
+			expect(response.status()).toEqual(200);
+			expect(responseJSON.id).toEqual(orderId);
+		});
+	});
 
-	test.describe( 'Update an order', () => {
-		test.beforeAll( async ( { request } ) => {
+	test.describe('Update an order', () => {
+		test.beforeAll(async ({
+			request
+		}) => {
 			// Create the product and save its id
-			const response = await request.post( '/wp-json/wc/v3/products', {
+			const response = await request.post('/wp-json/wc/v3/products', {
 				data: simpleProduct,
-			} );
+			});
 			const responseJSON = await response.json();
 			simpleProduct.id = responseJSON.id;
-		} );
+		});
 
-		test.afterAll( async ( { request } ) => {
+		test.afterAll(async ({
+			request
+		}) => {
 			// Delete the created product
 			await request.delete(
-				`/wp-json/wc/v3/products/${ simpleProduct.id }`,
-				{
+				`/wp-json/wc/v3/products/${ simpleProduct.id }`, {
 					data: {
 						force: true,
 					},
 				}
 			);
-		} );
+		});
 
-		for ( const expectedOrderStatus of statusesDataTable ) {
-			test( `can update status of an order to ${ expectedOrderStatus }`, async ( {
+		for (const expectedOrderStatus of statusesDataTable) {
+			test(`can update status of an order to ${ expectedOrderStatus }`, async ({
 				request,
-			} ) => {
+			}) => {
 				const requestPayload = {
 					status: expectedOrderStatus,
 				};
 
 				const response = await request.put(
-					`/wp-json/wc/v3/orders/${ orderId }`,
-					{
+					`/wp-json/wc/v3/orders/${ orderId }`, {
 						data: requestPayload,
 					}
 				);
 				const responseJSON = await response.json();
-				expect( response.status() ).toEqual( 200 );
-				expect( responseJSON.id ).toEqual( orderId );
-				expect( responseJSON.status ).toEqual( expectedOrderStatus );
-			} );
+				expect(response.status()).toEqual(200);
+				expect(responseJSON.id).toEqual(orderId);
+				expect(responseJSON.status).toEqual(expectedOrderStatus);
+			});
 		}
 
-		test( 'can add shipping and billing contacts to an order', async ( {
+		test('can add shipping and billing contacts to an order', async ({
 			request,
-		} ) => {
+		}) => {
 			// Update the billing and shipping fields on the order
 			order.billing = updatedCustomerBilling;
 			order.shipping = updatedCustomerShipping;
 
 			const response = await request.put(
-				`/wp-json/wc/v3/orders/${ orderId }`,
-				{
+				`/wp-json/wc/v3/orders/${ orderId }`, {
 					data: order,
 				}
 			);
 			const responseJSON = await response.json();
-			expect( response.status() ).toEqual( 200 );
-			expect( responseJSON.billing ).toEqual( updatedCustomerBilling );
-			expect( responseJSON.shipping ).toEqual( updatedCustomerShipping );
-		} );
+			expect(response.status()).toEqual(200);
+			expect(responseJSON.billing).toEqual(updatedCustomerBilling);
+			expect(responseJSON.shipping).toEqual(updatedCustomerShipping);
+		});
 
-		test( 'can add a product to an order', async ( { request } ) => {
+		test('can add a product to an order', async ({
+			request
+		}) => {
 			// Add the product to the order
 			const requestPayload = {
-				line_items: [ { product_id: simpleProduct.id } ],
+				line_items: [{
+					product_id: simpleProduct.id
+				}],
 			};
 			const response = await request.put(
-				`/wp-json/wc/v3/orders/${ orderId }`,
-				{
+				`/wp-json/wc/v3/orders/${ orderId }`, {
 					data: requestPayload,
 				}
 			);
 			const responseJSON = await response.json();
 
 			// Verify that the added product has the correct values
-			expect( response.status() ).toEqual( 200 );
-			expect( responseJSON.line_items ).toHaveLength( 1 );
-			expect( responseJSON.line_items[ 0 ].product_id ).toEqual(
+			expect(response.status()).toEqual(200);
+			expect(responseJSON.line_items).toHaveLength(1);
+			expect(responseJSON.line_items[0].product_id).toEqual(
 				simpleProduct.id
 			);
-			expect( responseJSON.line_items[ 0 ].name ).toEqual(
+			expect(responseJSON.line_items[0].name).toEqual(
 				simpleProduct.name
 			);
-		} );
+		});
 
-		test( 'can pay for an order', async ( { request } ) => {
+		test('can pay for an order', async ({
+			request
+		}) => {
 			// Setup: Set order status to 'pending'
-			await request.put( `/wp-json/wc/v3/orders/${ orderId }`, {
-				data: { status: 'pending' },
-			} );
+			await request.put(`/wp-json/wc/v3/orders/${ orderId }`, {
+				data: {
+					status: 'pending'
+				},
+			});
 
 			// Pay for the order by setting `set_paid` to true
 			const updateRequestPayload = {
 				set_paid: true,
 			};
 			const response = await request.put(
-				`/wp-json/wc/v3/orders/${ orderId }`,
-				{
+				`/wp-json/wc/v3/orders/${ orderId }`, {
 					data: updateRequestPayload,
 				}
 			);
 			const responseJSON = await response.json();
 
-			expect( response.status() ).toEqual( 200 );
-			expect( responseJSON.id ).toEqual( orderId );
+			expect(response.status()).toEqual(200);
+			expect(responseJSON.id).toEqual(orderId);
 
 			// Validate that the status of the order was automatically set to 'processing'
-			expect( responseJSON.status ).toEqual( 'processing' );
+			expect(responseJSON.status).toEqual('processing');
 
 			// Validate that the date_paid and date_paid_gmt properties are no longer null
-			expect( responseJSON.date_paid ).not.toBeNull();
-			expect( responseJSON.date_paid_gmt ).not.toBeNull();
-		} );
-	} );
+			expect(responseJSON.date_paid).not.toBeNull();
+			expect(responseJSON.date_paid_gmt).not.toBeNull();
+		});
+	});
 
-	test.describe( 'Delete an order', () => {
-		test( 'can permanently delete an order', async ( { request } ) => {
+	test.describe('Delete an order', () => {
+		test('can permanently delete an order', async ({
+			request
+		}) => {
 			// Delete the order.
 			const response = await request.delete(
-				`/wp-json/wc/v3/orders/${ orderId }`,
-				{
+				`/wp-json/wc/v3/orders/${ orderId }`, {
 					data: {
 						force: true,
 					},
 				}
 			);
-			expect( response.status() ).toEqual( 200 );
+			expect(response.status()).toEqual(200);
 
 			// Verify that the order can no longer be retrieved.
 			const getOrderResponse = await request.get(
 				`/wp-json/wc/v3/orders/${ orderId }`
 			);
-			expect( getOrderResponse.status() ).toEqual( 404 );
-		} );
-	} );
-} );
+			expect(getOrderResponse.status()).toEqual(404);
+		});
+	});
+});


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add order notes CRUD tests to increase test coverage

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 361-gh-woocommerce/woocommerce-quality .

### How to test the changes in this Pull Request:

1. Pull down code
2. Navigate to `woocommerce/plugins/woocommerce`
3. Execute tests with `USE_WP_ENV=1 pnpm playwright test --config=tests/api-core-tests/playwright.config.js tests/api-core-tests/tests/orders/orders-crud.test.js`
4. Tests should pass including new order notes tests

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.