### PR TITLE
Fix DateTimePickerControl initial setting of input field

### DIFF
--- a/packages/js/components/changelog/fix-date-time-picker-control-initial-setting
+++ b/packages/js/components/changelog/fix-date-time-picker-control-initial-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the initial setting of DateTimePickerControl's input field.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -89,7 +89,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	const onChangeCallback = useCallback(
-		( newInputString: string ) => {
+		( newInputString: string, fireOnChange: boolean ) => {
 			if ( ! isMounted.current ) return;
 
 			const newDateTime = parseMoment( newInputString );
@@ -99,7 +99,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				setLastValidDate( newDateTime );
 			}
 
-			if ( onChange ) {
+			if ( fireOnChange && typeof onChange === 'function' ) {
 				onChange(
 					isValid ? formatMomentIso( newDateTime ) : newInputString,
 					isValid
@@ -116,12 +116,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 
 	function change( newInputString: string ) {
 		setInputString( newInputString );
-		debouncedOnChange( newInputString );
+		debouncedOnChange( newInputString, true );
 	}
 
-	function changeImmediate( newInputString: string ) {
+	function changeImmediate( newInputString: string, fireOnChange: boolean ) {
 		setInputString( newInputString );
-		onChangeCallback( newInputString );
+		onChangeCallback( newInputString, fireOnChange );
 	}
 
 	function blur() {
@@ -138,18 +138,17 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 
 	const isInitialUpdate = useRef( true );
 	useEffect( () => {
-		// Don't trigger the change handling on the initial update of the component
+		const fireOnChange = ! isInitialUpdate.current;
 		if ( isInitialUpdate.current ) {
 			isInitialUpdate.current = false;
-			return;
 		}
 
 		const newDate = parseMomentIso( currentDate );
 
 		if ( newDate.isValid() ) {
-			change( formatMoment( newDate ) );
+			changeImmediate( formatMoment( newDate ), fireOnChange );
 		} else {
-			change( currentDate || '' );
+			changeImmediate( currentDate || '', fireOnChange );
 		}
 	}, [ currentDate, dateTimeFormat ] );
 
@@ -223,7 +222,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						const formattedDate = formatMoment(
 							parseMomentIso( date )
 						);
-						changeImmediate( formattedDate );
+						changeImmediate( formattedDate, true );
 					} }
 					is12Hour={ is12Hour }
 				/>

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -37,7 +37,7 @@ export type DateTimePickerControlProps = {
 export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	currentDate,
 	is12Hour = true,
-	dateTimeFormat = is12Hour ? 'MM/DD/YYYY h:mm a' : 'MM/DD/YYYY H:MM',
+	dateTimeFormat = is12Hour ? 'MM/DD/YYYY h:mm a' : 'MM/DD/YYYY H:mm',
 	disabled = false,
 	onChange,
 	onBlur,

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -21,6 +21,9 @@ import {
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 
+export const default12HourDateTimeFormat = 'MM/DD/YYYY h:mm a';
+export const default24HourDateTimeFormat = 'MM/DD/YYYY H:mm';
+
 export type DateTimePickerControlProps = {
 	currentDate?: string | null;
 	dateTimeFormat?: string;
@@ -37,7 +40,9 @@ export type DateTimePickerControlProps = {
 export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	currentDate,
 	is12Hour = true,
-	dateTimeFormat = is12Hour ? 'MM/DD/YYYY h:mm a' : 'MM/DD/YYYY H:mm',
+	dateTimeFormat = is12Hour
+		? default12HourDateTimeFormat
+		: default24HourDateTimeFormat,
 	disabled = false,
 	onChange,
 	onBlur,

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -110,7 +110,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '09/15/2022 02:30 am' );
+		expect( input?.value ).toBe( '09/15/2022 2:30 am' );
 	} );
 
 	it( 'should use the date time format if set', () => {
@@ -124,7 +124,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '02:30, 09-15-2022' );
+		expect( input?.value ).toBe( '2:30, 09-15-2022' );
 	} );
 
 	it( 'should update the input when currentDate is changed', () => {

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -125,6 +125,28 @@ describe( 'DateTimePickerControl', () => {
 		expect( input?.value ).toBe( '02:30, 09-15-2022' );
 	} );
 
+	it( 'should update the input when currentDate is changed', () => {
+		const originalDateTime = moment( '2022-09-15 02:30:40' );
+		const updatedDateTime = moment( '2022-10-06 10:25:00' );
+
+		const { container, rerender } = render(
+			<DateTimePickerControl
+				currentDate={ originalDateTime.toISOString() }
+				is12Hour={ false }
+			/>
+		);
+
+		rerender(
+			<DateTimePickerControl
+				currentDate={ updatedDateTime.toISOString() }
+				is12Hour={ false }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		expect( input?.value ).toBe( '10/06/2022 10:25' );
+	} );
+
 	it( 'should show the date time picker popup when focused', async () => {
 		const { container, queryByText } = render( <DateTimePickerControl /> );
 

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -74,7 +74,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.placeholder === 'This is the placeholder' );
+		expect( input?.placeholder ).toBe( 'This is the placeholder' );
 	} );
 
 	it( 'should disable the input if set', () => {
@@ -94,7 +94,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value === '09/15/2022 02:30' );
+		expect( input?.value ).toBe( '09/15/2022 02:30' );
 	} );
 
 	it( 'should use the default 12 hour date time format', () => {
@@ -108,7 +108,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value === '09/15/2022 02:30 AM' );
+		expect( input?.value ).toBe( '09/15/2022 02:30 AM' );
 	} );
 
 	it( 'should use the date time format if set', () => {
@@ -122,7 +122,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value === '02:30, 09-15-2022' );
+		expect( input?.value ).toBe( '02:30, 09-15-2022' );
 	} );
 
 	it( 'should show the date time picker popup when focused', async () => {

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -4,7 +4,6 @@
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createElement } from '@wordpress/element';
-import { isRTL } from '@wordpress/i18n/build-types';
 import moment from 'moment';
 
 /**
@@ -87,14 +86,17 @@ describe( 'DateTimePickerControl', () => {
 	} );
 
 	it( 'should use the default 24 hour date time format', () => {
-		const dateTime = moment( '2022-09-15 02:30:40' );
+		const dateTime = moment( '2022-09-15 22:30:40' );
 
 		const { container } = render(
-			<DateTimePickerControl currentDate={ dateTime.toISOString() } />
+			<DateTimePickerControl
+				currentDate={ dateTime.toISOString() }
+				is12Hour={ false }
+			/>
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '09/15/2022 02:30' );
+		expect( input?.value ).toBe( '09/15/2022 22:30' );
 	} );
 
 	it( 'should use the default 12 hour date time format', () => {
@@ -108,7 +110,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '09/15/2022 02:30 AM' );
+		expect( input?.value ).toBe( '09/15/2022 02:30 am' );
 	} );
 
 	it( 'should use the date time format if set', () => {

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -9,7 +9,11 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { DateTimePickerControl } from '../';
+import {
+	DateTimePickerControl,
+	default12HourDateTimeFormat,
+	default24HourDateTimeFormat,
+} from '../';
 
 describe( 'DateTimePickerControl', () => {
 	// The end user of the component doesn't care about how it is rendered in the DOM.
@@ -96,7 +100,9 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '09/15/2022 22:30' );
+		expect( input?.value ).toBe(
+			dateTime.format( default24HourDateTimeFormat )
+		);
 	} );
 
 	it( 'should use the default 12 hour date time format', () => {
@@ -110,21 +116,24 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '09/15/2022 2:30 am' );
+		expect( input?.value ).toBe(
+			dateTime.format( default12HourDateTimeFormat )
+		);
 	} );
 
 	it( 'should use the date time format if set', () => {
 		const dateTime = moment( '2022-09-15 02:30:40' );
+		const dateTimeFormat = 'H:mm, MM-DD-YYYY';
 
 		const { container } = render(
 			<DateTimePickerControl
 				currentDate={ dateTime.toISOString() }
-				dateTimeFormat="H:mm, MM-DD-YYYY"
+				dateTimeFormat={ dateTimeFormat }
 			/>
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '2:30, 09-15-2022' );
+		expect( input?.value ).toBe( dateTime.format( dateTimeFormat ) );
 	} );
 
 	it( 'should update the input when currentDate is changed', () => {
@@ -146,7 +155,9 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( '10/06/2022 10:25' );
+		expect( input?.value ).toBe(
+			updatedDateTime.format( default24HourDateTimeFormat )
+		);
 	} );
 
 	it( 'should show the date time picker popup when focused', async () => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The main focus of this PR is to fix the initial setting of the input field's text when the `currentDate` is initially set.

This problem has existed for a while. However, it was masked in the unit tests because the tests were buggy and were not properly making assertions. So, this PR fixes up those tests as well.

### How to test the changes in this Pull Request:

0. Review unit tests to make sure that assertions are now correct. 🙀
1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook stories and make sure input field is set by default on DateTimePickerControl / Controlled story: `pnpm --filter=@woocommerce/storybook storybook`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
