### PR TITLE
Fix the match pattern for the version bump tool

### DIFF
--- a/tools/version-bump/README.md
+++ b/tools/version-bump/README.md
@@ -9,7 +9,7 @@
 Bump WooCommerce to version 7.1.0:
 
 ```
-pnpm run version --filter version-bump -- bump woocommerce -v 7.1.0
+pnpm --filter version-bump run version bump woocommerce -v 7.1.0
 ```
 
 **Arguments**:

--- a/tools/version-bump/lib/update.ts
+++ b/tools/version-bump/lib/update.ts
@@ -25,7 +25,7 @@ export const updateReadmeStableTag = async (
 		const readmeContents = await readFile( filePath, 'utf8' );
 
 		const updatedReadmeContents = readmeContents.replace(
-			/Stable tag: \d.\d.\d\n/m,
+			/Stable tag: \d+\.\d+\.\d+\n/m,
 			`Stable tag: ${ nextVersion }\n`
 		);
 
@@ -50,7 +50,7 @@ export const updateReadmeChangelog = async (
 		const readmeContents = await readFile( filePath, 'utf8' );
 
 		const updatedReadmeContents = readmeContents.replace(
-			/= \d.\d.\d \d\d\d\d-XX-XX =\n/m,
+			/= \d+\.\d+\.\d+ \d\d\d\d-XX-XX =\n/m,
 			`= ${ nextVersion } ${ new Date().getFullYear() }-XX-XX =\n`
 		);
 
@@ -86,7 +86,7 @@ export const updateClassPluginFile = async (
 		const classPluginFileContents = await readFile( filePath, 'utf8' );
 
 		const updatedClassPluginFileContents = classPluginFileContents.replace(
-			/public \$version = '\d.\d.\d';\n/m,
+			/public \$version = '\d+\.\d+\.\d+';\n/m,
 			`public $version = '${ nextVersion }';\n`
 		);
 
@@ -142,7 +142,7 @@ export const updatePluginFile = async (
 		const pluginFileContents = await readFile( filePath, 'utf8' );
 
 		const updatedPluginFileContents = pluginFileContents.replace(
-			/Version: \d.\d.\d.*\n/m,
+			/Version: \d+\.\d+\.\d+.*\n/m,
 			`Version: ${ nextVersion }\n`
 		);
 		await writeFile( filePath, updatedPluginFileContents );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the matching pattern introduced in #34555 to be able to match multi-digit version numbers. Prior to this change, a version of "6.11.0", for example, would not be matched. It also updates the decimal placed to be matched as a literal character (as opposed to its normal meaning of "any character").

I also updated the README to account for the change in parameter order from pnpm7.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->



### How to test the changes in this Pull Request:

1. Before this change, run `pnpm --filter version-bump run version bump woocommerce -v 7.10.0`. Everything should update as intended. Then run `pnpm --filter version-bump run version bump woocommerce -v 7.11.0`. Notice that not all updates occurred.
2. Checkout this PR and repeat the previous commands. Both should update as intended.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
