### PR TITLE
Undefined array key Check

### DIFF
--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -317,6 +317,7 @@ class WC_Products_Tracking {
 
 		if (
 			'post-new.php' === $hook &&
+			isset( $_GET['post_type'] ) &&
 			'product' === wp_unslash( $_GET['post_type'] )
 		) {
 			return 'new';


### PR DESCRIPTION
There was no conditional branch when the array key 'post_type' was undefined.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Avoiding Undefined array key Warning errors.

### How to test the changes in this Pull Request:

1. Make a new post and no error appears.
