### PR TITLE
fix/#34200-need-to-add-space-between-author-image-and-meta

### DIFF
--- a/plugins/woocommerce/changelog/fix-#34200-need-to-add-space-between-author-image-and-meta
+++ b/plugins/woocommerce/changelog/fix-#34200-need-to-add-space-between-author-image-and-meta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: As the just the predefined css is deleted.
+
+

--- a/plugins/woocommerce/changelog/fix-#34200-need-to-add-space-between-author-image-and-meta
+++ b/plugins/woocommerce/changelog/fix-#34200-need-to-add-space-between-author-image-and-meta
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
-Comment: As the just the predefined css is deleted.
+Comment: Make Reviews table CSS match other list tables.
 
 

--- a/plugins/woocommerce/changelog/fix-34200-need-to-add-space-between-author-image-and-meta
+++ b/plugins/woocommerce/changelog/fix-34200-need-to-add-space-between-author-image-and-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+patch

--- a/plugins/woocommerce/changelog/fix-34200-need-to-add-space-between-author-image-and-meta
+++ b/plugins/woocommerce/changelog/fix-34200-need-to-add-space-between-author-image-and-meta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-patch

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7819,7 +7819,7 @@ table.bar_chart {
 /**
   * Product Reviews
   */
-  .wp-list-table.product-reviews {
+.wp-list-table.product-reviews {
 
 	.column-author {
 		width: 20%;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3216,10 +3216,6 @@ table.wp-list-table {
 		display: none;
 	}
 
-	img {
-		margin: 1px 2px;
-	}
-
 	.row-actions {
 		color: #999;
 	}
@@ -7820,43 +7816,6 @@ table.bar_chart {
 	}
 }
 
-/**
-  * Product Reviews
-  */
-.wp-list-table.product-reviews {
-
-	tbody#the-comment-list {
-		tr.review {
-			td.column-author {
-				strong {
-					display:block;
-					img{
-						margin-right:5px;
-					}
-				}
-			}
-		}
-	}
-
-	th.column-type {
-		width: 10%;
-	}
-	
-	@media screen and ( max-width: 782px ) {
-		th.column-type,
-		td.column-type,
-		th.column-author,
-		td.column-author,
-		th.column-rating,
-		td.column-rating {
-			display: none !important;
-		}
-
-		.toggle-row {
-			top: 10px;
-		}
-	}
-}
 
 #wp-content-media-buttons {
 	display: flex;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7816,6 +7816,34 @@ table.bar_chart {
 	}
 }
 
+/**
+  * Product Reviews
+  */
+  .wp-list-table.product-reviews {
+
+	.column-author {
+		width: 20%;
+	}
+
+	th.column-type {
+		width: 10%;
+	}
+
+	@media screen and ( max-width: 782px ) {
+		th.column-type,
+		td.column-type,
+		th.column-author,
+		td.column-author,
+		th.column-rating,
+		td.column-rating {
+			display: none !important;
+		}
+
+		.toggle-row {
+			top: 10px;
+		}
+	}
+}
 
 #wp-content-media-buttons {
 	display: flex;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7824,10 +7824,33 @@ table.bar_chart {
   * Product Reviews
   */
 .wp-list-table.product-reviews {
+
+	tbody#the-comment-list {
+		tr.review {
+			td.column-author {
+				strong {
+					display:block;
+				}
+			}
+		}
+	}
+	tbody#the-comment-list {
+		tr.review {
+			td.column-author {
+				strong {
+					display:block;
+					img{
+						margin-right:5px;
+					}
+				}
+			}
+		}
+	}
+
 	th.column-type {
 		width: 10%;
 	}
-
+	
 	@media screen and ( max-width: 782px ) {
 		th.column-type,
 		td.column-type,

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7830,15 +7830,6 @@ table.bar_chart {
 			td.column-author {
 				strong {
 					display:block;
-				}
-			}
-		}
-	}
-	tbody#the-comment-list {
-		tr.review {
-			td.column-author {
-				strong {
-					display:block;
 					img{
 						margin-right:5px;
 					}

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsListTable.php
@@ -1043,7 +1043,7 @@ class ReviewsListTable extends WP_List_Table {
 			if ( ! empty( $item->comment_author_email ) && is_email( $item->comment_author_email ) ) :
 
 				?>
-				<a href="mailto:<?php echo esc_attr( $item->comment_author_email ); ?>"><?php echo esc_html( $item->comment_author_email ); ?></a>
+				<a href="mailto:<?php echo esc_attr( $item->comment_author_email ); ?>"><?php echo esc_html( $item->comment_author_email ); ?></a><br>
 				<?php
 
 			endif;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added the scss to fix #34200 "Need to add space between author image and meta" issue.


### How to test the changes in this Pull Request:

1. Install the woocommerce in the site.
2. Add the SASS in the pull request to the admin.scss in the client > legacy > src > admin.scss
3. If you check the review tab under the products tabs.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
