### PR TITLE
Only show five inbox messages and add "Show more" button

### DIFF
--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -373,6 +373,9 @@ const InboxPanel = ( { showHeader = true } ) => {
 					{ Boolean( allNotes.length ) &&
 						renderNotes( {
 							loadMoreNotes: () => {
+								recordEvent( 'inbox_action_load_more', {
+									quantity_shown: allNotes.length,
+								} );
 								setNoteDisplayQty(
 									noteDisplayQty + ADD_NOTES_AMOUNT
 								);

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -199,7 +199,9 @@ const renderNotes = ( {
 };
 
 const InboxPanel = ( { showHeader = true } ) => {
-	const [ pageSize, setPageSize ] = useState( DEFAULT_INBOX_QUERY.per_page );
+	const [ noteDisplayQty, setNoteDisplayQty ] = useState(
+		DEFAULT_INBOX_QUERY.per_page
+	);
 	const [ allNotesFetched, setAllNotesFetched ] = useState( false );
 	const [ allNotes, setAllNotes ] = useState( [] );
 	const { createNotice } = useDispatch( 'core/notices' );
@@ -231,7 +233,10 @@ const InboxPanel = ( { showHeader = true } ) => {
 				'en_ZA',
 			];
 
-			const inboxQuery = { ...DEFAULT_INBOX_QUERY, per_page: pageSize };
+			const inboxQuery = {
+				...DEFAULT_INBOX_QUERY,
+				per_page: noteDisplayQty,
+			};
 			const notes = getNotes( inboxQuery );
 
 			return {
@@ -270,7 +275,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 	);
 
 	useEffect( () => {
-		if ( notesHaveResolved && notes.length < pageSize ) {
+		if ( notesHaveResolved && notes.length < noteDisplayQty ) {
 			setAllNotesFetched( true );
 		}
 
@@ -368,7 +373,9 @@ const InboxPanel = ( { showHeader = true } ) => {
 					{ Boolean( allNotes.length ) &&
 						renderNotes( {
 							loadMoreNotes: () => {
-								setPageSize( pageSize + ADD_NOTES_AMOUNT );
+								setNoteDisplayQty(
+									noteDisplayQty + ADD_NOTES_AMOUNT
+								);
 							},
 							hasNotes,
 							isBatchUpdating,

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -122,7 +122,6 @@ const renderNotes = ( {
 		} );
 	};
 
-	// TODO: What does this line do?
 	const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
 	return (
@@ -275,7 +274,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 			setAllNotesFetched( true );
 		}
 
-		if ( notes.length && notesHash !== allNotesHash ) {
+		if ( notesHaveResolved && notesHash !== allNotesHash ) {
 			setAllNotes( notes );
 		}
 	}, [ notes ] );
@@ -346,6 +345,10 @@ const InboxPanel = ( { showHeader = true } ) => {
 
 	const hasNotes = hasValidNotes( allNotes );
 
+	if ( notesHaveResolved && ! allNotes.length ) {
+		return null;
+	}
+
 	return (
 		<>
 			{ showDismissAllModal && (
@@ -356,13 +359,13 @@ const InboxPanel = ( { showHeader = true } ) => {
 				/>
 			) }
 			<div className="woocommerce-homepage-notes-wrapper">
-				{ ! allNotes.length && (
+				{ ! notesHaveResolved && ! allNotes.length && (
 					<Section>
 						<InboxNotePlaceholder className="banner message-is-unread" />
 					</Section>
 				) }
 				<Section>
-					{ allNotes.length &&
+					{ Boolean( allNotes.length ) &&
 						renderNotes( {
 							loadMoreNotes: () => {
 								setPageSize( pageSize + ADD_NOTES_AMOUNT );

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -87,6 +87,8 @@ const onBodyLinkClick = ( note, innerLink ) => {
 
 let hasFiredPanelViewTrack = false;
 
+console.debug( 'updated' );
+
 const renderNotes = ( {
 	hasNotes,
 	isBatchUpdating,
@@ -113,6 +115,8 @@ const renderNotes = ( {
 		} );
 		hasFiredPanelViewTrack = true;
 	}
+
+	console.debug( 'allNotesFetched', allNotesFetched );
 
 	const screen = getScreenName();
 	const onNoteVisible = ( note ) => {
@@ -178,25 +182,34 @@ const renderNotes = ( {
 					);
 				} ) }
 			</TransitionGroup>
-			{ allNotesFetched ? null : notesHaveResolved ? (
-				<CardFooter
-					className="wooocommerce-inbox-card__footer"
-					size="medium"
-				>
-					<Button
-						isPrimary={ true }
-						onClick={ () => {
-							loadMoreNotes();
-						} }
-					>
-						{ notesArray.length > DEFAULT_INBOX_QUERY.per_page
-							? __( 'Show more', 'woocommerce' )
-							: __( 'Show older', 'woocommerce' ) }
-					</Button>
-				</CardFooter>
-			) : (
-				<InboxNotePlaceholder className="banner message-is-unread" />
-			) }
+			{ allNotesFetched
+				? null
+				: ( () => {
+						if ( ! notesHaveResolved ) {
+							return (
+								<InboxNotePlaceholder className="banner message-is-unread" />
+							);
+						}
+
+						return (
+							<CardFooter
+								className="wooocommerce-inbox-card__footer"
+								size="medium"
+							>
+								<Button
+									isPrimary={ true }
+									onClick={ () => {
+										loadMoreNotes();
+									} }
+								>
+									{ notesArray.length >
+									DEFAULT_INBOX_QUERY.per_page
+										? __( 'Show more', 'woocommerce' )
+										: __( 'Show older', 'woocommerce' ) }
+								</Button>
+							</CardFooter>
+						);
+				  } )() }
 		</Card>
 	);
 };

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -87,8 +87,6 @@ const onBodyLinkClick = ( note, innerLink ) => {
 
 let hasFiredPanelViewTrack = false;
 
-console.debug( 'updated' );
-
 const renderNotes = ( {
 	hasNotes,
 	isBatchUpdating,
@@ -115,8 +113,6 @@ const renderNotes = ( {
 		} );
 		hasFiredPanelViewTrack = true;
 	}
-
-	console.debug( 'allNotesFetched', allNotesFetched );
 
 	const screen = getScreenName();
 	const onNoteVisible = ( note ) => {

--- a/plugins/woocommerce-admin/client/inbox-panel/index.scss
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.scss
@@ -76,3 +76,10 @@
 		}
 	}
 }
+
+.wooocommerce-inbox-card__footer {
+	background-color: #f6f7f7;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}

--- a/plugins/woocommerce-admin/client/inbox-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/test/index.js
@@ -111,7 +111,7 @@ describe( 'inbox_panel_view_event', () => {
 		useSelect.mockImplementation( () => ( {
 			notes,
 			isError: false,
-			isResolvingNotes: false,
+			notesHaveResolved: true,
 			isBatchUpdating: false,
 		} ) );
 		render( <InboxPanel /> );

--- a/plugins/woocommerce-admin/client/inbox-panel/utils.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/utils.js
@@ -120,14 +120,3 @@ export const truncateRenderableHTML = ( originalHTML, limit ) => {
 	}
 	return originalHTML;
 };
-
-/**
- * Generates string form IDs in current set to represent content.
- *
- * @param {array} notes Array of note objects.
- */
-export const generateNotesHash = ( notes ) =>
-	notes.reduce( ( acc, note ) => {
-		acc += String( note.id );
-		return acc;
-	}, '' );

--- a/plugins/woocommerce-admin/client/inbox-panel/utils.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/utils.js
@@ -120,3 +120,14 @@ export const truncateRenderableHTML = ( originalHTML, limit ) => {
 	}
 	return originalHTML;
 };
+
+/**
+ * Generates string form IDs in current set to represent content.
+ *
+ * @param {array} notes Array of note objects.
+ */
+export const generateNotesHash = ( notes ) =>
+	notes.reduce( ( acc, note ) => {
+		acc += String( note.id );
+		return acc;
+	}, '' );

--- a/plugins/woocommerce/changelog/update-34927-inbox-expansion
+++ b/plugins/woocommerce/changelog/update-34927-inbox-expansion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Changing inbox display to only 5 notes with the ability to load more.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reducing initial inbox messages to only display 5 messages, and adding the "show more" button to load another 10 messages at a time. 

Closes #34927 .

### How to test the changes in this Pull Request:

1. Checkout branch
2. Ensure you have more than 15 inbox notes in your store (use WCA Test Helper to create more if need be)
3. Go to Homescreen.
4. You should only see 5 notes, with the "Show older" button at the bottom.
5. Click the button, and it should load 10 more.
6. The button should still remain at the bottom (if you have enough notes) and it should now read "Show more."
7. Dismiss any note, and it should disappear, loading one more at the end of the list.
8. Hit the "undo" button after dismissing a note, and it should reappear.
9. The button and Footer section should disappear after all notes have been loaded.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
