### PR TITLE
Get the first array item for the alt_text.

### DIFF
--- a/plugins/woocommerce/changelog/34071-alt-text-handling
+++ b/plugins/woocommerce/changelog/34071-alt-text-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve the way we retrieve the alt text property for product attachments.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -819,7 +819,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		}
 
 		$alt_text     = array_filter( $alt_text );
-		$props['alt'] = isset( $alt_text[0] ) ? $alt_text[0] : '';
+		$props['alt'] = $alt_text ? reset( $alt_text ) : '';
 
 		// Large version.
 		$full_size           = apply_filters( 'woocommerce_gallery_full_size', apply_filters( 'woocommerce_product_thumbnails_large_size', 'full' ) );


### PR DESCRIPTION
Get the first array item for the alt_text.
Props galbaras

Minimal testing performed, example testing:
```
wp> $alt_text = array_filter( [ false, 'should be alt text' ] );
=> array(1) {
  [1] =>
  string(18) "should be alt text"
}

wp> isset( $alt_text[0] ) ? $alt_text[0] : ''; // Current
=> string(0) ""

wp> $alt_text ? reset( $alt_text ) : ''; // proposed
=> string(18) "should be alt text"
```

(Maintainers: If you could add any additional things needed to this PR for commit, please do so, I probably won't get back to this as quick as you will)


### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34071 .

### How to test the changes in this Pull Request:

See #34071

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
