### PR TITLE
[7.0] Disable mobile messaging

### DIFF
--- a/plugins/woocommerce/changelog/patch-disable-mobile-messaging
+++ b/plugins/woocommerce/changelog/patch-disable-mobile-messaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: This disables feature introduced in https://github.com/woocommerce/woocommerce/pull/34467 because of bug described in https://github.com/woocommerce/woocommerce/issues/35016
+

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -47,7 +47,6 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 			add_action( 'woocommerce_order_status_cancelled_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
 			add_action( 'woocommerce_order_status_cancelled_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
 			add_action( 'woocommerce_order_status_cancelled_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
-			add_action( 'woocommerce_email_footer', array( $this, 'mobile_messaging' ), 9 ); // Run before the default email footer.
 
 			// Call parent constructor.
 			parent::__construct();
@@ -222,25 +221,6 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 					'desc_tip'    => true,
 				),
 			);
-		}
-
-
-		/**
-		 * Add mobile messaging.
-		 */
-		public function mobile_messaging() {
-			if ( null !== $this->object ) {
-				$domain = wp_parse_url( home_url(), PHP_URL_HOST );
-				wc_get_template(
-					'emails/email-mobile-messaging.php',
-					array(
-						'order'   => $this->object,
-						'blog_id' => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
-						'now'     => new DateTime(),
-						'domain'  => is_string( $domain ) ? $domain : '',
-					)
-				);
-			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR disables the feature of adding mobile messaging in the footers of emails. This change is motivated because of an issue found in #35016. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35016.

### How to test the changes in this Pull Request:

(copied and updated from the issue)

1. Place an order with 7.0, see rules for Email links/Order types in https://github.com/woocommerce/woocommerce/pull/34467
2. Check footer links in Merchant New Order Emails. Assert it does not contain any mobile messages
3. Check Customer "Your order has been received!" Email. Assert it does not contain any mobile messages

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
