### PR TITLE
Remove PHP 7.2 and set 7.4 as default

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: ""
   php-version:
     description: The version of PHP that the action should set up.
-    default: "7.2"
+    default: "7.4"
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0' ]
+        php: [ '7.4', '8.0' ]
         wp: [ 'latest' ]
         include:
           - wp: nightly
             php: '7.4'
           - wp: '5.9'
-            php: 7.2
+            php: 7.4
           - wp: '5.8'
-            php: 7.2
+            php: 7.4
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup WooCommerce Monorepo
         uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          php-version: 7.4
 
       - name: Tool versions
         run: |

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -21,7 +21,6 @@ jobs:
         uses: ./.github/actions/setup-woocommerce-monorepo
         with:
           build: false
-          php-version: '7.4'
 
       - name: Check change files are touched for touched projects
         env:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -17,15 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0' ]
+        php: [ '7.4', '8.0' ]
         wp: [ "latest" ]
         include:
           - wp: nightly
             php: '7.4'
           - wp: '5.9'
-            php: 7.2
+            php: 7.4
           - wp: '5.8'
-            php: 7.2
+            php: 7.4
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -28,8 +28,6 @@ jobs:
         uses: ./.github/actions/setup-woocommerce-monorepo
         with:
           build: false
-          php-version: '7.4'
-          
 
       - name: "Git fetch the release branch"
         run: git fetch origin ${{ inputs.releaseBranch }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/34940

This PR mainly is to replace 7.2 with 7.4 of PHP as the default. Note that I choice to remove 7.3 as well as I don't think this is relevant anymore.

### How to test the changes in this Pull Request:

1. Make sure the CI tests are running successfully.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
