### PR TITLE
Update WCPay promo requirements and ensure dismiss

### DIFF
--- a/plugins/woocommerce-admin/client/payments-welcome/exit-survey-modal.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/exit-survey-modal.tsx
@@ -37,13 +37,8 @@ function ExitSurveyModal( {
 
 	const closeModal = () => {
 		setOpen( false );
-		setExitSurveyModalOpen( false );
-	};
 
-	const removeWCPayMenu = () => {
-		recordEvent( 'wcpay_exit_survey', {
-			just_remove: true /* eslint-disable-line camelcase */,
-		} );
+		// Dismiss WCPay menu
 		apiFetch( {
 			path: 'wc-admin/options',
 			method: 'POST',
@@ -53,8 +48,14 @@ function ExitSurveyModal( {
 		} ).then( () => {
 			window.location.href = 'admin.php?page=wc-admin';
 		} );
+	};
 
-		setOpen( false );
+	const exitSurvey = () => {
+		recordEvent( 'wcpay_exit_survey', {
+			just_remove: true /* eslint-disable-line camelcase */,
+		} );
+
+		closeModal();
 	};
 
 	const sendFeedback = () => {
@@ -69,7 +70,7 @@ function ExitSurveyModal( {
 			/* eslint-enable camelcase */
 		} );
 
-		removeWCPayMenu();
+		closeModal();
 	};
 
 	if ( ! isOpen ) {
@@ -132,7 +133,7 @@ function ExitSurveyModal( {
 				<Button
 					isTertiary
 					isDestructive
-					onClick={ removeWCPayMenu }
+					onClick={ exitSurvey }
 					name="cancel"
 				>
 					{ strings.surveyCancelButton }

--- a/plugins/woocommerce/changelog/fix-4834-update-wcpay-promo-req-and-ensure-dismiss
+++ b/plugins/woocommerce/changelog/fix-4834-update-wcpay-promo-req-and-ensure-dismiss
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WCPay promo requirements and ensure it's dismissed on every scenario

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -168,7 +168,7 @@ class WcPayWelcomePage {
 		);
 
 		foreach ( $gateway_specs as $spec ) {
-			if ( ! empty( $spec->plugins ) && in_array( $spec->plugins[0], $plugin_slugs ) ) {
+			if ( ! empty( $spec->plugins ) && in_array( $spec->plugins[0], $plugin_slugs, true ) ) {
 				return true;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -3,7 +3,6 @@
 namespace Automattic\WooCommerce\Internal\Admin;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
-use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as PaymentGatewaySuggestions;
 use Automattic\WooCommerce\Admin\WCAdminHelper;
 
 /**
@@ -14,6 +13,39 @@ use Automattic\WooCommerce\Admin\WCAdminHelper;
 class WcPayWelcomePage {
 
 	const EXPERIMENT_NAME = 'woocommerce_payments_menu_promo_us_2022';
+	const OTHER_GATEWAYS  = [
+		'affirm',
+		'afterpay',
+		'amazon_payments_advanced_express',
+		'amazon_payments_advanced',
+		'authorize_net_cim_credit_card',
+		'authorize_net_cim_echeck',
+		'bacs',
+		'bambora_credit_card',
+		'braintree_credit_card',
+		'braintree_paypal',
+		'chase_paymentech',
+		'cybersource_credit_card',
+		'elavon_converge_credit_card',
+		'elavon_converge_echeck',
+		'gocardless',
+		'intuit_payments_credit_card',
+		'intuit_payments_echeck',
+		'kco',
+		'klarna_payments',
+		'payfast',
+		'paypal',
+		'paytrace',
+		'ppcp-gateway',
+		'psigate',
+		'sagepaymentsusaapi',
+		'square_credit_card',
+		'stripe_alipay',
+		'stripe_multibanco',
+		'stripe',
+		'trustcommerce',
+		'usa_epay_credit_card',
+	];
 
 	/**
 	 * WCPayWelcomePage constructor.
@@ -153,22 +185,15 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Checks if there is another payment gateway installed using PaymentGatewaySuggestions.
+	 * Checks if there is another payment gateway installed using a static list of US gateways from WC Store.
 	 *
 	 * @return bool Whether there is another payment gateway installed.
 	 */
 	private function is_another_payment_gateway_installed() {
-		$gateway_specs     = PaymentGatewaySuggestions::get_specs();
-		$installed_plugins = array_keys( get_plugins() );
-		$plugin_slugs      = array_map(
-			function( $plugin ) {
-				return explode( '/', $plugin )[0] ?? null;
-			},
-			$installed_plugins
-		);
+		$available_gateways = wp_list_pluck( WC()->payment_gateways()->get_available_payment_gateways(), 'id' );
 
-		foreach ( $gateway_specs as $spec ) {
-			if ( ! empty( $spec->plugins ) && in_array( $spec->plugins[0], $plugin_slugs, true ) ) {
+		foreach ( $available_gateways as $gateway ) {
+			if ( in_array( $gateway, self::OTHER_GATEWAYS, true ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:
Closes https://github.com/Automattic/woocommerce-payments/issues/4834

- Update the promotion requirements to only show it for merchants with an additional payment gateway installed, using as source a static list of US gateways IDs from WC store.
- Ensure the promotion is dismissed after clicking on **No thanks**, even on modal close.

### How to test the changes in this Pull Request:
It's easier to disable the unneeded conditions on [`WcPayWelcomePage.php`](https://github.com/woocommerce/woocommerce/blob/6b80bbd1aca1e3031bd1f8693eb00b3ca4e707cf/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php) to meet the requirements.

#### New requirement
1. The promo menu should be hidden without any of [the payment gateways](https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/?categoryIds=1023&collections=product&page=1&country=United+States) enabled.
2. Enabling any of them on **WooCommerce → Settings → Payments** should display the promo menu.

ℹ️  You can use `Direct bank transfer` gateway, included in WC, as an example to meet the requirement.

#### Promotion dismiss
1. Having the promo **Payments** menu visible, click on it.
2. Click on **No thanks** and test that the following actions hide the promotion menu.
   - Click on the modal **x** button.
   - Click on the first button.
   - Click on the second button.

ℹ️ To restore the promotion you'll need to remove or update `wc_calypso_bridge_payments_dismissed` option.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
