### PR TITLE
Enhance getInputProps to allow passing of non-overridden props

### DIFF
--- a/packages/js/components/changelog/update-34996
+++ b/packages/js/components/changelog/update-34996
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow passing of additional props to form inputs

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { ChangeEvent } from 'react';
 import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CheckboxProps, ConsumerInputProps, InputProps } from './form';
 
 export type FormErrors< Values > = {
 	[ P in keyof Values ]?: FormErrors< Values[ P ] > | string;
@@ -31,25 +35,14 @@ export type FormContext< Values extends Record< string, any > > = {
 	setValue: ( name: string, value: any ) => void;
 	setValues: ( valuesToSet: Values ) => void;
 	handleSubmit: () => Promise< Values >;
+	getCheckboxProps< Value extends Values[ keyof Values ] >(
+		name: string,
+		inputProps?: ConsumerInputProps< Values >
+	): CheckboxProps< Values, Value >;
 	getInputProps< Value extends Values[ keyof Values ] >(
 		name: string,
-		inputProps?: {
-			className?: string;
-			onChange?: (
-				value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
-			) => void;
-			onBlur?: () => void;
-			[ key: string ]: unknown;
-		}
-	): {
-		value: Value;
-		checked: boolean;
-		selected?: boolean;
-		onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) => void;
-		onBlur: () => void;
-		className: string | undefined;
-		help: string | null | undefined;
-	};
+		inputProps?: ConsumerInputProps< Values >
+	): InputProps< Values, Value >;
 	isValidForm: boolean;
 	resetForm: (
 		initialValues: Values,

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -32,8 +32,24 @@ export type FormContext< Values extends Record< string, any > > = {
 	setValues: ( valuesToSet: Values ) => void;
 	handleSubmit: () => Promise< Values >;
 	getInputProps< Value extends Values[ keyof Values ] >(
-		name: string
-	): InputProps< Value >;
+		name: string,
+		inputProps?: {
+			className?: string;
+			onChange?: (
+				value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
+			) => void;
+			onBlur?: () => void;
+			[ key: string ]: unknown;
+		}
+	): {
+		value: Value;
+		checked: boolean;
+		selected?: boolean;
+		onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) => void;
+		onBlur: () => void;
+		className: string | undefined;
+		help: string | null | undefined;
+	};
 	isValidForm: boolean;
 	resetForm: (
 		initialValues: Values,

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -12,16 +12,6 @@ export type FormErrors< Values > = {
 	[ P in keyof Values ]?: FormErrors< Values[ P ] > | string;
 };
 
-export type InputProps< Value > = {
-	value: Value;
-	checked: boolean;
-	selected?: boolean;
-	onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) => void;
-	onBlur: () => void;
-	className: string | undefined;
-	help: string | null | undefined;
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormContext< Values extends Record< string, any > > = {
 	values: Values;

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -6,7 +6,12 @@ import { createContext, useContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { CheckboxProps, ConsumerInputProps, InputProps } from './form';
+import {
+	CheckboxProps,
+	ConsumerInputProps,
+	InputProps,
+	SelectControlProps,
+} from './form';
 
 export type FormErrors< Values > = {
 	[ P in keyof Values ]?: FormErrors< Values[ P ] > | string;
@@ -29,6 +34,10 @@ export type FormContext< Values extends Record< string, any > > = {
 		name: string,
 		inputProps?: ConsumerInputProps< Values >
 	): CheckboxProps< Values, Value >;
+	getSelectControlProps< Value extends Values[ keyof Values ] >(
+		name: string,
+		inputProps?: ConsumerInputProps< Values >
+	): SelectControlProps< Values, Value >;
 	getInputProps< Value extends Values[ keyof Values ] >(
 		name: string,
 		inputProps?: ConsumerInputProps< Values >

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -25,7 +25,7 @@ export type FormContext< Values extends Record< string, any > > = {
 	setValue: ( name: string, value: any ) => void;
 	setValues: ( valuesToSet: Values ) => void;
 	handleSubmit: () => Promise< Values >;
-	getCheckboxProps< Value extends Values[ keyof Values ] >(
+	getCheckboxControlProps< Value extends Values[ keyof Values ] >(
 		name: string,
 		inputProps?: ConsumerInputProps< Values >
 	): CheckboxProps< Values, Value >;

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import {
 	cloneElement,
 	useState,
@@ -268,21 +269,59 @@ function FormComponent< Values extends Record< string, any > >(
 	};
 
 	function getInputProps< Value = Values[ keyof Values ] >(
-		name: string
-	): InputProps< Value > {
+		name: string,
+		inputProps: {
+			className?: string;
+			onChange?: (
+				value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
+			) => void;
+			onBlur?: () => void;
+			[ key: string ]: unknown;
+		} = {}
+	): {
+		value: Value;
+		checked: boolean;
+		selected?: boolean;
+		onChange: (
+			value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
+		) => void;
+		onBlur: () => void;
+		className: string | undefined;
+		help: string | null | undefined;
+	} {
 		const inputValue = _get( values, name );
 		const isTouched = touched[ name ];
 		const inputError = _get( errors, name );
+		const {
+			className: classNameProp,
+			onBlur: onBlurProp,
+			onChange: onChangeProp,
+			...additionalProps
+		} = inputProps;
 
 		return {
 			value: inputValue,
 			checked: Boolean( inputValue ),
 			selected: inputValue,
-			onChange: ( value: ChangeEvent< HTMLInputElement > | Value ) =>
-				handleChange( name, value as Values[ keyof Values ] ),
-			onBlur: () => handleBlur( name ),
-			className: isTouched && inputError ? 'has-error' : undefined,
+			onChange: (
+				value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
+			) => {
+				handleChange( name, value );
+				if ( onChangeProp ) {
+					onChangeProp( value );
+				}
+			},
+			onBlur: () => {
+				handleBlur( name );
+				if ( onBlurProp ) {
+					onBlurProp();
+				}
+			},
+			className: classnames( classNameProp, {
+				'has-error': isTouched && inputError,
+			} ),
 			help: isTouched ? ( inputError as string ) : null,
+			...additionalProps,
 		};
 	}
 

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -340,7 +340,7 @@ function FormComponent< Values extends Record< string, any > >(
 		};
 	}
 
-	function getCheckboxProps< Value = Values[ keyof Values ] >(
+	function getCheckboxControlProps< Value = Values[ keyof Values ] >(
 		name: string,
 		inputProps: ConsumerInputProps< Values > = {}
 	): CheckboxProps< Values, Value > {
@@ -365,7 +365,7 @@ function FormComponent< Values extends Record< string, any > >(
 			setValue,
 			setValues,
 			handleSubmit,
-			getCheckboxProps,
+			getCheckboxControlProps,
 			getInputProps,
 			isValidForm: ! Object.keys( errors ).length,
 			resetForm,

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -106,6 +106,13 @@ export type CheckboxProps< Values, Value > = Omit<
 	'value' | 'selected'
 >;
 
+export type SelectControlProps< Values, Value > = Omit<
+	InputProps< Values, Value >,
+	'value'
+> & {
+	value: string | undefined;
+};
+
 export type ConsumerInputProps< Values > = {
 	className?: string;
 	onChange?: (
@@ -350,6 +357,20 @@ function FormComponent< Values extends Record< string, any > >(
 		] );
 	}
 
+	function getSelectControlProps< Value = Values[ keyof Values ] >(
+		name: string,
+		inputProps: ConsumerInputProps< Values > = {}
+	): SelectControlProps< Values, Value > {
+		const selectControlProps = getInputProps( name, inputProps );
+		return {
+			...selectControlProps,
+			value:
+				selectControlProps.value === undefined
+					? undefined
+					: String( selectControlProps.value ),
+		};
+	}
+
 	const isDirty = useMemo(
 		() => ! _isEqual( initialValues.current, values ),
 		[ initialValues.current, values ]
@@ -367,6 +388,7 @@ function FormComponent< Values extends Record< string, any > >(
 			handleSubmit,
 			getCheckboxControlProps,
 			getInputProps,
+			getSelectControlProps,
 			isValidForm: ! Object.keys( errors ).length,
 			resetForm,
 		};

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -23,7 +23,7 @@ import _omit from 'lodash/omit';
 /**
  * Internal dependencies
  */
-import { FormContext, FormErrors, InputProps } from './form-context';
+import { FormContext, FormErrors } from './form-context';
 
 type FormProps< Values > = {
 	/**

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -111,8 +111,9 @@ export type ConsumerInputProps< Values > = {
 	onChange?: (
 		value: ChangeEvent< HTMLInputElement > | Values[ keyof Values ]
 	) => void;
-	onBlur?: ( value: Values[ keyof Values ] ) => void;
+	onBlur?: () => void;
 	[ key: string ]: unknown;
+	sanitize?: ( value: Values[ keyof Values ] ) => Values[ keyof Values ];
 };
 
 /**
@@ -306,6 +307,7 @@ function FormComponent< Values extends Record< string, any > >(
 			className: classNameProp,
 			onBlur: onBlurProp,
 			onChange: onChangeProp,
+			sanitize,
 			...additionalProps
 		} = inputProps;
 
@@ -322,9 +324,12 @@ function FormComponent< Values extends Record< string, any > >(
 				}
 			},
 			onBlur: () => {
+				if ( sanitize ) {
+					handleChange( name, sanitize( inputValue ) );
+				}
 				handleBlur( name );
 				if ( onBlurProp ) {
-					onBlurProp( inputValue );
+					onBlurProp();
 				}
 			},
 			className: classnames( classNameProp, {

--- a/packages/js/data/changelog/update-34996
+++ b/packages/js/data/changelog/update-34996
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add missing shipping class property

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -86,6 +86,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	backordered: boolean;
 	shipping_required: boolean;
 	shipping_taxable: boolean;
+	shipping_class: string;
 	shipping_class_id: number;
 	average_rating: string;
 	rating_count: number;

--- a/plugins/woocommerce-admin/client/products/add-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/add-product-page.tsx
@@ -28,7 +28,11 @@ const AddProductPage: React.FC = () => {
 	return (
 		<div className="woocommerce-add-product">
 			<Form< Partial< Product > >
-				initialValues={ { stock_quantity: 0, stock_status: 'instock' } }
+				initialValues={ {
+					name: '',
+					stock_quantity: 0,
+					stock_status: 'instock',
+				} }
 				errors={ {} }
 				validate={ validate }
 			>

--- a/plugins/woocommerce-admin/client/products/add-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/add-product-page.tsx
@@ -30,6 +30,7 @@ const AddProductPage: React.FC = () => {
 			<Form< Partial< Product > >
 				initialValues={ {
 					name: '',
+					sku: '',
 					stock_quantity: 0,
 					stock_status: 'instock',
 				} }

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -17,8 +17,19 @@
 			margin-right: $gap-smaller;
 		}
 	}
-	.components-checkbox-control__label {
-		align-items: center;
+	.components-checkbox-control {
+		&__label {
+			display: flex;
+			align-items: center;
+		}
+
+		&__input-container {
+			align-self: center;
+		}
+
+		.components-base-control__field {
+			display: flex;
+		}
 	}
 	.woocommerce-tooltip {
 		margin-left: $gap-smaller;

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -3,7 +3,7 @@
 	.woocommerce-product-form-actions {
 		margin-top: $gap-largest + $gap-smaller;
 	}
-	.woocommerce-product__checkbox,
+	.components-checkbox-control,
 	.components-toggle-control {
 		& > * {
 			margin-bottom: 0;

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -90,7 +90,10 @@ export const PricingSection: React.FC = () => {
 	} );
 
 	const currencyInputProps = getCurrencyInputProps( currencyConfig );
-	const regularPriceProps = getInputProps( 'regular_price', currencyInputProps );
+	const regularPriceProps = getInputProps(
+		'regular_price',
+		currencyInputProps
+	);
 	const salePriceProps = getInputProps( 'sale_price', currencyInputProps );
 
 	return (
@@ -132,8 +135,19 @@ export const PricingSection: React.FC = () => {
 							{ ...regularPriceProps }
 							label={ __( 'List price', 'woocommerce' ) }
 							placeholder={ __( '10.59', 'woocommerce' ) }
-							value={ formatCurrencyDisplayValue( regularPriceProps?.value, currencyConfig, formatAmount ) }
-							onBlur={ () => setValue( 'regular_price', sanitizePrice( regularPriceProps.value ) ) }
+							value={ formatCurrencyDisplayValue(
+								String( regularPriceProps?.value ),
+								currencyConfig,
+								formatAmount
+							) }
+							onBlur={ () =>
+								setValue(
+									'regular_price',
+									sanitizePrice(
+										String( regularPriceProps.value )
+									)
+								)
+							}
 						/>
 					</BaseControl>
 					{ ! isTaxSettingsResolving && (
@@ -151,8 +165,19 @@ export const PricingSection: React.FC = () => {
 							{ ...salePriceProps }
 							label={ salePriceTitle }
 							placeholder={ __( '8.59', 'woocommerce' ) }
-							value={ formatCurrencyDisplayValue( salePriceProps?.value, currencyConfig, formatAmount ) }
-							onBlur={ () => setValue( 'sales_price', sanitizePrice( salePriceProps.value ) ) }
+							value={ formatCurrencyDisplayValue(
+								String( salePriceProps?.value ),
+								currencyConfig,
+								formatAmount
+							) }
+							onBlur={ () =>
+								setValue(
+									'sales_price',
+									sanitizePrice(
+										String( salePriceProps.value )
+									)
+								)
+							}
 						/>
 					</BaseControl>
 				</CardBody>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -20,14 +20,14 @@ import {
  * Internal dependencies
  */
 import './pricing-section.scss';
-import { formatCurrencyDisplayValue, getCurrencyInputProps } from './utils';
+import { formatCurrencyDisplayValue, getCurrencySymbolProps } from './utils';
 import { ProductSectionLayout } from '../layout/product-section-layout';
 import { ADMIN_URL } from '../../utils/admin-settings';
 import { CurrencyContext } from '../../lib/currency-context';
 import { useProductHelper } from '../use-product-helper';
 
 export const PricingSection: React.FC = () => {
-	const { getInputProps, setValue } = useFormContext< Product >();
+	const { getInputProps } = useFormContext< Product >();
 	const { sanitizePrice } = useProductHelper();
 	const { isResolving: isTaxSettingsResolving, taxSettings } = useSelect(
 		( select ) => {
@@ -89,7 +89,12 @@ export const PricingSection: React.FC = () => {
 		},
 	} );
 
-	const currencyInputProps = getCurrencyInputProps( currencyConfig );
+	const currencyInputProps = {
+		...getCurrencySymbolProps( currencyConfig ),
+		sanitize: ( value: Product[ keyof Product ] ) => {
+			return sanitizePrice( String( value ) );
+		},
+	};
 	const regularPriceProps = getInputProps(
 		'regular_price',
 		currencyInputProps
@@ -140,14 +145,6 @@ export const PricingSection: React.FC = () => {
 								currencyConfig,
 								formatAmount
 							) }
-							onBlur={ () =>
-								setValue(
-									'regular_price',
-									sanitizePrice(
-										String( regularPriceProps.value )
-									)
-								)
-							}
 						/>
 					</BaseControl>
 					{ ! isTaxSettingsResolving && (
@@ -170,14 +167,6 @@ export const PricingSection: React.FC = () => {
 								currencyConfig,
 								formatAmount
 							) }
-							onBlur={ () =>
-								setValue(
-									'sales_price',
-									sanitizePrice(
-										String( salePriceProps.value )
-									)
-								)
-							}
 						/>
 					</BaseControl>
 				</CardBody>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -27,7 +27,7 @@ import { CurrencyContext } from '../../lib/currency-context';
 import { useProductHelper } from '../use-product-helper';
 
 export const PricingSection: React.FC = () => {
-	const { getInputProps } = useFormContext< Product >();
+	const { getInputProps, setValue } = useFormContext< Product >();
 	const { sanitizePrice } = useProductHelper();
 	const { isResolving: isTaxSettingsResolving, taxSettings } = useSelect(
 		( select ) => {
@@ -133,10 +133,7 @@ export const PricingSection: React.FC = () => {
 							label={ __( 'List price', 'woocommerce' ) }
 							placeholder={ __( '10.59', 'woocommerce' ) }
 							value={ formatCurrencyDisplayValue( regularPriceProps?.value, currencyConfig, formatAmount ) }
-							onChange={ ( value: string ) => {
-								const sanitizedValue = sanitizePrice( value );
-								regularPriceProps?.onChange( sanitizedValue );
-							} }
+							onBlur={ () => setValue( 'regular_price', sanitizePrice( regularPriceProps.value ) ) }
 						/>
 					</BaseControl>
 					{ ! isTaxSettingsResolving && (
@@ -155,10 +152,7 @@ export const PricingSection: React.FC = () => {
 							label={ salePriceTitle }
 							placeholder={ __( '8.59', 'woocommerce' ) }
 							value={ formatCurrencyDisplayValue( salePriceProps?.value, currencyConfig, formatAmount ) }
-							onChange={ ( value: string ) => {
-								const sanitizedValue = sanitizePrice( value );
-								salePriceProps?.onChange( sanitizedValue );
-							} }
+							onBlur={ () => setValue( 'sales_price', sanitizePrice( salePriceProps.value ) ) }
 						/>
 					</BaseControl>
 				</CardBody>

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -20,8 +20,8 @@ import {
  * Internal dependencies
  */
 import './pricing-section.scss';
+import { formatCurrencyDisplayValue, getCurrencyInputProps } from './utils';
 import { ProductSectionLayout } from '../layout/product-section-layout';
-import { getInputControlProps } from './utils';
 import { ADMIN_URL } from '../../utils/admin-settings';
 import { CurrencyContext } from '../../lib/currency-context';
 import { useProductHelper } from '../use-product-helper';
@@ -44,6 +44,8 @@ export const PricingSection: React.FC = () => {
 	const pricesIncludeTax =
 		taxSettings.woocommerce_prices_include_tax === 'yes';
 	const context = useContext( CurrencyContext );
+	const { getCurrencyConfig, formatAmount } = context;
+	const currencyConfig = getCurrencyConfig();
 
 	const taxIncludedInPriceText = __(
 		'Per your {{link}}store settings{{/link}}, tax is {{strong}}included{{/strong}} in the price.',
@@ -87,14 +89,9 @@ export const PricingSection: React.FC = () => {
 		},
 	} );
 
-	const regularPriceProps = getInputControlProps( {
-		...getInputProps( 'regular_price' ),
-		context,
-	} );
-	const salePriceProps = getInputControlProps( {
-		...getInputProps( 'sale_price' ),
-		context,
-	} );
+	const currencyInputProps = getCurrencyInputProps( currencyConfig );
+	const regularPriceProps = getInputProps( 'regular_price', currencyInputProps );
+	const salePriceProps = getInputProps( 'sale_price', currencyInputProps );
 
 	return (
 		<ProductSectionLayout
@@ -135,6 +132,7 @@ export const PricingSection: React.FC = () => {
 							{ ...regularPriceProps }
 							label={ __( 'List price', 'woocommerce' ) }
 							placeholder={ __( '10.59', 'woocommerce' ) }
+							value={ formatCurrencyDisplayValue( regularPriceProps?.value, currencyConfig, formatAmount ) }
 							onChange={ ( value: string ) => {
 								const sanitizedValue = sanitizePrice( value );
 								regularPriceProps?.onChange( sanitizedValue );
@@ -156,6 +154,7 @@ export const PricingSection: React.FC = () => {
 							{ ...salePriceProps }
 							label={ salePriceTitle }
 							placeholder={ __( '8.59', 'woocommerce' ) }
+							value={ formatCurrencyDisplayValue( salePriceProps?.value, currencyConfig, formatAmount ) }
 							onChange={ ( value: string ) => {
 								const sanitizedValue = sanitizePrice( value );
 								salePriceProps?.onChange( sanitizedValue );

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.scss
@@ -12,19 +12,4 @@
 			margin-left: $gap-smaller;
 		}
 	}
-
-	&__feature-checkbox {
-		.components-base-control__field {
-			display: flex;
-			.components-checkbox-control {
-				&__label {
-					display: flex;
-				}
-
-				&__input-container {
-					align-self: center;
-				}
-			}
-		}
-	}
 }

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -41,7 +41,7 @@ const PRODUCT_DETAILS_SLUG = 'product-details';
 
 export const ProductDetailsSection: React.FC = () => {
 	const {
-		getCheckboxProps,
+		getCheckboxControlProps,
 		getInputProps,
 		values,
 		touched,
@@ -172,7 +172,7 @@ export const ProductDetailsSection: React.FC = () => {
 								/>
 							</>
 						}
-						{ ...getCheckboxProps(
+						{ ...getCheckboxControlProps(
 							'featured',
 							getCheckboxTracks( 'featured' )
 						) }

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -72,7 +72,7 @@ export const ProductDetailsSection: React.FC = () => {
 	};
 
 	const setSkuIfEmpty = () => {
-		if ( values.sku || ! values.name.length ) {
+		if ( values.sku || ! values.name?.length ) {
 			return;
 		}
 		setValue( 'sku', cleanForSlug( values.name ) );

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -34,7 +34,7 @@ import { BlockInstance, serialize, parse } from '@wordpress/blocks';
 import './product-details-section.scss';
 import { CategoryField } from '../fields/category-field';
 import { EditProductLinkModal } from '../shared/edit-product-link-modal';
-import { getCheckboxProps, getTextControlProps } from './utils';
+import { getCheckboxProps } from './utils';
 import { ProductSectionLayout } from '../layout/product-section-layout';
 
 const PRODUCT_DETAILS_SLUG = 'product-details';
@@ -90,9 +90,7 @@ export const ProductDetailsSection: React.FC = () => {
 								'e.g. 12 oz Coffee Mug',
 								'woocommerce'
 							) }
-							{ ...getTextControlProps(
-								getInputProps( 'name' )
-							) }
+							{ ...getInputProps( 'name' ) }
 							onBlur={ () => {
 								setSkuIfEmpty();
 								getInputProps( 'name' ).onBlur();

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -34,14 +34,20 @@ import { BlockInstance, serialize, parse } from '@wordpress/blocks';
 import './product-details-section.scss';
 import { CategoryField } from '../fields/category-field';
 import { EditProductLinkModal } from '../shared/edit-product-link-modal';
-import { getCheckboxProps } from './utils';
+import { getCheckboxTracks } from './utils';
 import { ProductSectionLayout } from '../layout/product-section-layout';
 
 const PRODUCT_DETAILS_SLUG = 'product-details';
 
 export const ProductDetailsSection: React.FC = () => {
-	const { getInputProps, values, setValue, touched, errors } =
-		useFormContext< Product >();
+	const {
+		getCheckboxProps,
+		getInputProps,
+		values,
+		touched,
+		errors,
+		setValue,
+	} = useFormContext< Product >();
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
 		useState( false );
 	const [ descriptionBlocks, setDescriptionBlocks ] = useState<
@@ -168,7 +174,10 @@ export const ProductDetailsSection: React.FC = () => {
 								/>
 							</>
 						}
-						{ ...getInputProps( 'featured', getCheckboxProps( 'featured' ) ) }
+						{ ...getCheckboxProps(
+							'featured',
+							getCheckboxTracks( 'featured' )
+						) }
 					/>
 					{ showProductLinkEditModal && (
 						<EditProductLinkModal

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -168,12 +168,7 @@ export const ProductDetailsSection: React.FC = () => {
 								/>
 							</>
 						}
-						{ ...getCheckboxProps( {
-							...getInputProps( 'featured' ),
-							name: 'featured',
-							className:
-								'product-details-section__feature-checkbox',
-						} ) }
+						{ ...getInputProps( 'featured', getCheckboxProps( 'featured' ) ) }
 					/>
 					{ showProductLinkEditModal && (
 						<EditProductLinkModal

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -96,11 +96,9 @@ export const ProductDetailsSection: React.FC = () => {
 								'e.g. 12 oz Coffee Mug',
 								'woocommerce'
 							) }
-							{ ...getInputProps( 'name' ) }
-							onBlur={ () => {
-								setSkuIfEmpty();
-								getInputProps( 'name' ).onBlur();
-							} }
+							{ ...getInputProps( 'name', {
+								onBlur: setSkuIfEmpty,
+							} ) }
 						/>
 						{ values.id && ! hasNameError() && permalinkPrefix && (
 							<span className="woocommerce-product-form__secondary-text product-details-section__product-link">

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manage-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manage-stock-section.tsx
@@ -13,7 +13,6 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { getAdminSetting } from '~/utils/admin-settings';
-import { getTextControlProps } from '../utils';
 
 export const ManageStockSection: React.FC = () => {
 	const { getInputProps } = useFormContext< Product >();
@@ -25,9 +24,7 @@ export const ManageStockSection: React.FC = () => {
 			<TextControl
 				type="number"
 				label={ __( 'Current quantity', 'woocommerce' ) }
-				{ ...getTextControlProps( {
-					...getInputProps( 'stock_quantity' ),
-				} ) }
+				{ ...getInputProps( 'stock_quantity' ) }
 				min={ 0 }
 			/>
 			<TextControl
@@ -38,9 +35,7 @@ export const ManageStockSection: React.FC = () => {
 					__( '%d (store default)', 'woocommerce' ),
 					notifyLowStockAmount
 				) }
-				{ ...getTextControlProps( {
-					...getInputProps( 'low_stock_amount' ),
-				} ) }
+				{ ...getInputProps( 'low_stock_amount' ) }
 				min={ 0 }
 			/>
 			<span className="woocommerce-product-form__secondary-text">

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
@@ -23,7 +23,7 @@ import { ManageStockSection } from './manage-stock-section';
 import { ManualStockSection } from './manual-stock-section';
 
 export const ProductInventorySection: React.FC = () => {
-	const { getCheckboxProps, getInputProps, values } =
+	const { getCheckboxControlProps, getInputProps, values } =
 		useFormContext< Product >();
 	const canManageStock = getAdminSetting( 'manageStock', 'yes' ) === 'yes';
 
@@ -77,7 +77,7 @@ export const ProductInventorySection: React.FC = () => {
 									'Track quantity for this product',
 									'woocommerce'
 								) }
-								{ ...getCheckboxProps(
+								{ ...getCheckboxControlProps(
 									'manage_stock',
 									getCheckboxTracks( 'manage_stock' )
 								) }

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
@@ -16,14 +16,15 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { getCheckboxProps, getTextControlProps } from '../utils';
+import { getCheckboxTracks } from '../utils';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { ProductSectionLayout } from '../../layout/product-section-layout';
 import { ManageStockSection } from './manage-stock-section';
 import { ManualStockSection } from './manual-stock-section';
 
 export const ProductInventorySection: React.FC = () => {
-	const { getInputProps, values } = useFormContext< Product >();
+	const { getCheckboxProps, getInputProps, values } =
+		useFormContext< Product >();
 	const canManageStock = getAdminSetting( 'manageStock', 'yes' ) === 'yes';
 
 	return (
@@ -67,7 +68,7 @@ export const ProductInventorySection: React.FC = () => {
 							'washed-oxford-button-down-shirt',
 							'woocommerce'
 						) }
-						{ ...getTextControlProps( getInputProps( 'sku' ) ) }
+						{ ...getInputProps( 'sku' ) }
 					/>
 					{ canManageStock && (
 						<>
@@ -77,7 +78,8 @@ export const ProductInventorySection: React.FC = () => {
 									'woocommerce'
 								) }
 								{ ...getCheckboxProps(
-									getInputProps( 'manage_stock' )
+									'manage_stock',
+									getCheckboxTracks( 'manage_stock' )
 								) }
 							/>
 							{ values.manage_stock && <ManageStockSection /> }

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -135,10 +135,11 @@ export function ProductShippingSection( {
 		[]
 	);
 
-	const inputWidthProps = getInputProps( 'dimensions.width' );
-	const inputLengthProps = getInputProps( 'dimensions.length' );
-	const inputHeightProps = getInputProps( 'dimensions.height' );
-	const inputWeightProps = getInputProps( 'weight' );
+	const dimensionProps = { onBlur: () => setHighlightSide( undefined ), suffix: dimensionUnit };
+	const inputWidthProps = getInputProps( 'dimensions.width', dimensionProps );
+	const inputLengthProps = getInputProps( 'dimensions.length', dimensionProps );
+	const inputHeightProps = getInputProps( 'dimensions.height', dimensionProps );
+	const inputWeightProps = getInputProps( 'weight', dimensionProps );
 
 	return (
 		<ProductSectionLayout
@@ -237,11 +238,6 @@ export function ProductShippingSection( {
 											onFocus={ () => {
 												setHighlightSide( 'A' );
 											} }
-											onBlur={ () => {
-												setHighlightSide( undefined );
-												inputWidthProps?.onBlur();
-											} }
-											suffix={ dimensionUnit }
 										/>
 									</BaseControl>
 
@@ -269,11 +265,6 @@ export function ProductShippingSection( {
 											onFocus={ () => {
 												setHighlightSide( 'B' );
 											} }
-											onBlur={ () => {
-												setHighlightSide( undefined );
-												inputLengthProps?.onBlur();
-											} }
-											suffix={ dimensionUnit }
 										/>
 									</BaseControl>
 
@@ -301,11 +292,6 @@ export function ProductShippingSection( {
 											onFocus={ () => {
 												setHighlightSide( 'C' );
 											} }
-											onBlur={ () => {
-												setHighlightSide( undefined );
-												inputHeightProps?.onBlur();
-											} }
-											suffix={ dimensionUnit }
 										/>
 									</BaseControl>
 

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -93,7 +93,7 @@ function extractDefaultShippingClassFromProduct(
 export function ProductShippingSection( {
 	product,
 }: ProductShippingSectionProps ) {
-	const { getInputProps, setValue, values } =
+	const { getInputProps, getSelectControlProps, setValue } =
 		useFormContext< PartialProduct >();
 	const { formatNumber, parseNumber } = useProductHelper();
 	const [ highlightSide, setHighlightSide ] =
@@ -162,6 +162,7 @@ export function ProductShippingSection( {
 		sanitize: ( value: PartialProduct[ keyof PartialProduct ] ) =>
 			parseNumber( String( value ) ),
 	} );
+	const shippingClassProps = getInputProps( 'shipping_class' );
 
 	return (
 		<ProductSectionLayout
@@ -177,17 +178,17 @@ export function ProductShippingSection( {
 						<>
 							<SelectControl
 								label={ __( 'Shipping class', 'woocommerce' ) }
-								{ ...( getInputProps( 'shipping_class' ),
-								{
-									onChange: ( value: string ) => {
-										if (
-											value ===
-											ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
-										) {
-											setShowShippingClassModal( true );
-										}
-									},
-								} ) }
+								{ ...getSelectControlProps( 'shipping_class' ) }
+								onChange={ ( value: string ) => {
+									if (
+										value ===
+										ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
+									) {
+										setShowShippingClassModal( true );
+										return;
+									}
+									shippingClassProps.onChange( value );
+								} }
 								options={ [
 									...DEFAULT_SHIPPING_CLASS_OPTIONS,
 									...mapShippingClassToSelectOption(

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Link, Spinner, useFormContext } from '@woocommerce/components';
 import {
@@ -17,6 +17,7 @@ import {
 	Card,
 	CardBody,
 	SelectControl,
+	TextControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
@@ -31,8 +32,6 @@ import {
 	ShippingDimensionsImageProps,
 } from '../fields/shipping-dimensions-image';
 import { useProductHelper } from '../use-product-helper';
-import { AddNewShippingClassModal } from '../shared/add-new-shipping-class-modal';
-import { getTextControlProps } from './utils';
 import './product-shipping-section.scss';
 import {
 	ADD_NEW_SHIPPING_CLASS_OPTION_VALUE,
@@ -74,7 +73,7 @@ function getInterpolatedSizeLabel( mixedString: string ) {
  * the first category different to `Uncategorized`.
  *
  * @see https://github.com/woocommerce/woocommerce/issues/34657
- * @param product The product
+ * @param  product The product
  * @return The default shipping class
  */
 function extractDefaultShippingClassFromProduct(
@@ -136,23 +135,10 @@ export function ProductShippingSection( {
 		[]
 	);
 
-	const { createProductShippingClass, invalidateResolution } = useDispatch(
-		EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
-	);
-
-	const selectShippingClassProps = getTextControlProps(
-		getInputProps( 'shipping_class' )
-	);
-	const inputWidthProps = getTextControlProps(
-		getInputProps( 'dimensions.width' )
-	);
-	const inputLengthProps = getTextControlProps(
-		getInputProps( 'dimensions.length' )
-	);
-	const inputHeightProps = getTextControlProps(
-		getInputProps( 'dimensions.height' )
-	);
-	const inputWeightProps = getTextControlProps( getInputProps( 'weight' ) );
+	const inputWidthProps = getInputProps( 'dimensions.width' );
+	const inputLengthProps = getInputProps( 'dimensions.length' );
+	const inputHeightProps = getInputProps( 'dimensions.height' );
+	const inputWeightProps = getInputProps( 'weight' );
 
 	return (
 		<ProductSectionLayout
@@ -167,24 +153,24 @@ export function ProductShippingSection( {
 					{ hasResolvedShippingClasses ? (
 						<>
 							<SelectControl
-								{ ...selectShippingClassProps }
 								label={ __( 'Shipping class', 'woocommerce' ) }
+								{ ...( getInputProps( 'shipping_class' ),
+								{
+									onChange: ( value: string ) => {
+										if (
+											value ===
+											ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
+										) {
+											setShowShippingClassModal( true );
+										}
+									},
+								} ) }
 								options={ [
 									...DEFAULT_SHIPPING_CLASS_OPTIONS,
 									...mapShippingClassToSelectOption(
 										shippingClasses ?? []
 									),
 								] }
-								onChange={ ( value: string ) => {
-									if (
-										value ===
-										ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
-									) {
-										setShowShippingClassModal( true );
-										return;
-									}
-									selectShippingClassProps?.onChange( value );
-								} }
 							/>
 							<span className="woocommerce-product-form__secondary-text">
 								{ interpolateComponents( {

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -342,10 +342,10 @@ export function ProductShippingSection( {
 						product &&
 						extractDefaultShippingClassFromProduct( product )
 					}
-					onAdd={ ( shippClassValues ) =>
+					onAdd={ ( shippingClassValues ) =>
 						createProductShippingClass<
 							Promise< ProductShippingClass >
-						>( shippClassValues ).then( ( value ) => {
+						>( shippingClassValues ).then( ( value ) => {
 							invalidateResolution( 'getProductShippingClasses' );
 							setValue( 'shipping_class', value.slug );
 							return value;

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -140,26 +140,28 @@ export function ProductShippingSection( {
 		EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
 	);
 
-	const getDimensionProps = ( name: string ) => {
-		const dimensionProps = {
-			onBlur: () => {
-				setHighlightSide( undefined );
-				setValue(
-					name,
-					parseNumber(
-						String( values[ name as keyof PartialProduct ] )
-					)
-				);
-			},
-			suffix: dimensionUnit,
-		};
-		return getInputProps( 'dimensions.width', dimensionProps );
+	const dimensionProps = {
+		onBlur: () => {
+			setHighlightSide( undefined );
+		},
+		sanitize: ( value: PartialProduct[ keyof PartialProduct ] ) =>
+			parseNumber( String( value ) ),
+		suffix: dimensionUnit,
 	};
 
-	const inputWidthProps = getDimensionProps( 'dimensions.width' );
-	const inputLengthProps = getDimensionProps( 'dimensions.length' );
-	const inputHeightProps = getDimensionProps( 'dimensions.height' );
-	const inputWeightProps = getInputProps( 'weight' );
+	const inputWidthProps = getInputProps( 'dimensions.width', dimensionProps );
+	const inputLengthProps = getInputProps(
+		'dimensions.length',
+		dimensionProps
+	);
+	const inputHeightProps = getInputProps(
+		'dimensions.height',
+		dimensionProps
+	);
+	const inputWeightProps = getInputProps( 'weight', {
+		sanitize: ( value: PartialProduct[ keyof PartialProduct ] ) =>
+			parseNumber( String( value ) ),
+	} );
 
 	return (
 		<ProductSectionLayout
@@ -272,16 +274,6 @@ export function ProductShippingSection( {
 													'woocommerce'
 												)
 											) }
-											onBlur={ () =>
-												setValue(
-													'dimensions.length',
-													parseNumber(
-														String(
-															inputLengthProps?.value
-														)
-													)
-												)
-											}
 											onFocus={ () => {
 												setHighlightSide( 'B' );
 											} }
@@ -325,14 +317,6 @@ export function ProductShippingSection( {
 												'woocommerce'
 											) }
 											suffix={ weightUnit }
-											onBlur={ () => {
-												setValue(
-													'weight',
-													parseNumber(
-														values.weight || ''
-													)
-												);
-											} }
 										/>
 									</BaseControl>
 								</div>

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -46,7 +46,7 @@ export const getCheckboxTracks = ( name: string ) => {
  * @param {Object} currencyConfig - Currency context
  * @return {Object} Props.
  */
-export const getCurrencyInputProps = ( currencyConfig: CurrencyConfig ) => {
+export const getCurrencySymbolProps = ( currencyConfig: CurrencyConfig ) => {
 	const { symbol, symbolPosition } = currencyConfig;
 	const currencyPosition = symbolPosition.includes( 'left' )
 		? 'prefix'

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -33,23 +33,18 @@ type gettersProps = {
 	help: string | null | undefined;
 };
 
-export const getCheckboxProps = ( {
-	checked = false,
-	className,
-	name,
-	onBlur,
-	onChange,
-}: gettersProps ) => {
+/**
+ * Get additional props to be passed to all checkbox inputs.
+ * @param name Name of the checkbox
+ * @returns object Props.
+ */
+export const getCheckboxProps = ( name: string ) => {
 	return {
-		checked,
-		className: classnames( 'woocommerce-product__checkbox', className ),
 		onChange: ( isChecked: boolean ) => {
 			recordEvent( `product_checkbox_${ name }`, {
 				checked: isChecked,
 			} );
-			return onChange( isChecked );
 		},
-		onBlur,
 	};
 };
 

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -9,34 +8,21 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { NUMBERS_AND_ALLOWED_CHARS } from '../constants';
 
-type gettersProps = {
-	context?: {
-		formatAmount: ( number: number | string ) => string;
-		getCurrencyConfig: () => {
-			code: string;
-			symbol: string;
-			symbolPosition: string;
-			decimalSeparator: string;
-			priceFormat: string;
-			thousandSeparator: string;
-			precision: number;
-		};
-	};
-	value: string;
-	name?: string;
-	checked: boolean;
-	selected?: boolean;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	onChange: ( value: any ) => void;
-	onBlur: () => void;
-	className: string | undefined;
-	help: string | null | undefined;
+type CurrencyConfig = {
+	code: string;
+	symbol: string;
+	symbolPosition: string;
+	decimalSeparator: string;
+	priceFormat: string;
+	thousandSeparator: string;
+	precision: number;
 };
 
 /**
  * Get additional props to be passed to all checkbox inputs.
- * @param name Name of the checkbox
- * @returns object Props.
+ *
+ * @param {string} name Name of the checkbox
+ * @return {object} Props.
  */
 export const getCheckboxProps = ( name: string ) => {
 	return {
@@ -48,25 +34,37 @@ export const getCheckboxProps = ( name: string ) => {
 	};
 };
 
-export const getInputControlProps = ( {
-	className,
-	context,
-	onBlur,
-	onChange,
-	value = '',
-	help,
-}: gettersProps ) => {
-	if ( ! context ) {
-		return;
-	}
-	const { formatAmount, getCurrencyConfig } = context;
-	const { decimalSeparator, symbol, symbolPosition, thousandSeparator } =
-		getCurrencyConfig();
+/**
+ * Get input props for currency related values and symbol positions.
+ *
+ * @param {object}  context - Currency context
+ * @return {object} Props.
+ */
+export const getCurrencyInputProps = ( currencyConfig: CurrencyConfig ) => {
+	const { symbol, symbolPosition } = currencyConfig;
 	const currencyPosition = symbolPosition.includes( 'left' )
 		? 'prefix'
 		: 'suffix';
 
-	// Cleans the value to show.
+	return {
+		[ currencyPosition ]: symbol,
+	};
+};
+
+/**
+ * Cleans and formats the currency value shown to the user.
+ *
+ * @param {string} value Form value.
+ * @param {object} context Currency context.
+ * @return {string} Display value.
+ */
+export const formatCurrencyDisplayValue = (
+	value: string,
+	currencyConfig: CurrencyConfig,
+	format: ( number: number | string ) => string
+) => {
+	const { decimalSeparator, thousandSeparator } = currencyConfig;
+
 	const regex = new RegExp(
 		NUMBERS_AND_ALLOWED_CHARS.replace( '%s1', decimalSeparator ).replace(
 			'%s2',
@@ -74,16 +72,8 @@ export const getInputControlProps = ( {
 		),
 		'g'
 	);
-	const currencyString =
-		value === undefined
-			? value
-			: formatAmount( value ).replace( regex, '' );
-	return {
-		value: currencyString,
-		[ currencyPosition ]: symbol,
-		className: classnames( 'woocommerce-product__input', className ),
-		onChange,
-		onBlur,
-		help,
-	};
-};
+
+	return value === undefined
+		? value
+		: format( value ).replace( regex, '' );
+}

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { ChangeEvent } from 'react';
+import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -22,11 +24,15 @@ type CurrencyConfig = {
  * Get additional props to be passed to all checkbox inputs.
  *
  * @param {string} name Name of the checkbox
- * @return {object} Props.
+ * @return {Object} Props.
  */
-export const getCheckboxProps = ( name: string ) => {
+export const getCheckboxTracks = ( name: string ) => {
 	return {
-		onChange: ( isChecked: boolean ) => {
+		onChange: (
+			isChecked:
+				| ChangeEvent< HTMLInputElement >
+				| Product[ keyof Product ]
+		) => {
 			recordEvent( `product_checkbox_${ name }`, {
 				checked: isChecked,
 			} );
@@ -37,8 +43,8 @@ export const getCheckboxProps = ( name: string ) => {
 /**
  * Get input props for currency related values and symbol positions.
  *
- * @param {object}  context - Currency context
- * @return {object} Props.
+ * @param {Object} currencyConfig - Currency context
+ * @return {Object} Props.
  */
 export const getCurrencyInputProps = ( currencyConfig: CurrencyConfig ) => {
 	const { symbol, symbolPosition } = currencyConfig;
@@ -54,8 +60,8 @@ export const getCurrencyInputProps = ( currencyConfig: CurrencyConfig ) => {
 /**
  * Cleans and formats the currency value shown to the user.
  *
- * @param {string} value Form value.
- * @param {object} context Currency context.
+ * @param {string} value          Form value.
+ * @param {Object} currencyConfig Currency context.
  * @return {string} Display value.
  */
 export const formatCurrencyDisplayValue = (
@@ -73,7 +79,5 @@ export const formatCurrencyDisplayValue = (
 		'g'
 	);
 
-	return value === undefined
-		? value
-		: format( value ).replace( regex, '' );
-}
+	return value === undefined ? value : format( value ).replace( regex, '' );
+};

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -53,22 +53,6 @@ export const getCheckboxProps = ( {
 	};
 };
 
-export const getTextControlProps = ( {
-	className,
-	onBlur,
-	onChange,
-	value = '',
-	help,
-}: gettersProps ) => {
-	return {
-		value,
-		className: classnames( 'woocommerce-product__text', className ),
-		onChange,
-		onBlur,
-		help,
-	};
-};
-
 export const getInputControlProps = ( {
 	className,
 	context,

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -11,7 +11,6 @@ import { ProductShippingClass } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import { getTextControlProps } from '../../sections/utils';
 import './add-new-shipping-class-modal.scss';
 
 export type ShippingClassFormProps = {
@@ -20,15 +19,9 @@ export type ShippingClassFormProps = {
 };
 
 function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
-	const { getInputProps, isValidForm } =
+	const { errors, getInputProps, isValidForm } =
 		useFormContext< ProductShippingClass >();
 	const [ isLoading, setIsLoading ] = useState( false );
-
-	const inputNameProps = getTextControlProps( getInputProps( 'name' ) );
-	const inputSlugProps = getTextControlProps( getInputProps( 'slug' ) );
-	const inputDescriptionProps = getTextControlProps(
-		getInputProps( 'description' )
-	);
 
 	function handleAdd() {
 		setIsLoading( true );
@@ -45,11 +38,11 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 	return (
 		<div className="woocommerce-add-new-shipping-class-modal__wrapper">
 			<TextControl
-				{ ...inputNameProps }
+				{ ...getInputProps( 'name' ) }
 				label={ __( 'Name', 'woocommerce' ) }
 			/>
 			<TextControl
-				{ ...inputSlugProps }
+				{ ...getInputProps( 'slug' ) }
 				label={ interpolateComponents( {
 					mixedString: __(
 						'Slug {{span}}(optional){{/span}}',
@@ -63,7 +56,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 				} ) }
 			/>
 			<TextControl
-				{ ...inputDescriptionProps }
+				{ ...getInputProps( 'description' ) }
 				label={ interpolateComponents( {
 					mixedString: __(
 						'Description {{span}}(optional){{/span}}',
@@ -76,7 +69,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 					},
 				} ) }
 				help={
-					inputDescriptionProps?.help ??
+					errors?.description ??
 					__(
 						'Describe how you and other store administrators can use this shipping class.',
 						'woocommerce'

--- a/plugins/woocommerce/changelog/update-34996
+++ b/plugins/woocommerce/changelog/update-34996
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Unwrap product page input props and pass via getInputProps


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, adding an `onChange` handler or anything else that collided with `getInputProps` would require recalling `getInputProps.someFunction` inside the new handler.  This PR introduces a second argument to `getInputProps` which passes props to the control without overriding the original handlers where possible.

Some props will not override the original handler (e.g., if you pass on `onChange` it will be combined with the `Form` component's `onChange`) and some will override (e.g., `value` can not be combined and the consumer prop will override the original value).

This PR also uncovered numerous TS issues, so a `getCheckboxProps` was introduced into the `Form` component to omit invalid props (e.g., `value` for checkboxes).  More specific prop getters are probably in order (`getSelectProps`), but I think we can iterate on these as we go.

Finally, a `sanitize` method was added as part of the optional consumer input props.  This is a shortcut to sanitizing the input value and handling changes on blur.

**TL;DR:**

* `getInputProps` now takes a second argument to combine/override props where necessary
* `sanitize` method can be added to an input to handle sanitization on blur
* `getCheckboxProps` was introduced for props specific to checkboxes

Closes #34996 .

### How to test the changes in this Pull Request:

1. Navigate to the new product page `Products -> Add new (MVP)`
2. Check that styling for checkboxes is still correct
3. Add values to the price and dimension fields, using thousand commas and decimal separators (depending your locale)
4. Make sure they are sanitized on blur and persist correctly on save

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
