### PR TITLE
Action: Assign community PRs a reviewer

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,0 +1,3 @@
+
+".github/*":
+  - woocommerce/atlas

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -15,20 +15,24 @@ jobs:
   verify:
     name: Verify
     runs-on: ubuntu-20.04
-    outputs:
-      issueId: ${{ steps.check.outputs.issueId }}
-      run: ${{ steps.check.outputs.run }}
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup Node.js
-        id: check
         uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
 
       - name: Install Octokit 
         run: npm --prefix .github/workflows/scripts install @octokit/action
 
       - name: Check if user is a community contributor
+        id: check
         run: node .github/workflows/scripts/is-community-contributor.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: "If community PR, assign a reviewer"
+        if: github.event.pull_request && steps.check.outputs.is-community == 'yes'
+        uses: shufo/auto-assign-reviewer-by-files@24a9fcbd5c51c4403b64c8b6e087c824b67a5c35
+        with:
+          config: ".github/project-community-pr-assigner.yml"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -39,7 +39,8 @@ const applyLabelToCommunityContributor = async () => {
 	const { number } = eventPayload?.issue || eventPayload?.pull_request;
 	
 	const isCommunityUser = await isCommunityContributor(owner, repo, username);
-
+	console.log( '::set-output name=is-community::%s', isCommunityUser ? 'yes' : 'no' );
+	
 	if (isCommunityUser) {
 		console.log('Adding community contributor label');
 		await addLabel('type: community contribution', owner, repo, number);


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the community labeler action to assign pull requests that come from community members a reviewer. The assigned reviewer is based on a configuration file / glob match.

This PR initially only assigns PRs that touch `.github/*` to `woocommerce/atlas`. I was unable to  test team reviewers in my fork, as my fork doesn't have team reviewers, but I was able to test this with assignments to myself. We should test that this works with team reviewers shortly after merging, but it can otherwise be tested in a fork.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34215.

### How to test the changes in this Pull Request:

1. Create a fork and merge these changes to `trunk` of your fork.
2. Enable issues within your fork, and create the label `type: community contributor`
3. Update `.github/project-community-pr-assigner.yml` with a configuration that assigns a review to yourself. For example, change `woocommerce/atlas` to your username.
4. Create a PR as yourself in a path matching the config. Even though the path matches the config, because you aren't a community contributor, nothing should happen
5. Create a PR as someone other than yourself in a path not matching the config. The community label should be added, but because the path was outside of the config, no reviewer should be added.
6. Create a PR as someone other than yourself in a path matching the config. Both the community label should be added, and you should be added as a reviewer to the PR.

If you don't have another user available to make the PRs, just ping me and I'll create the required PRs in your repo.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
