### PR TITLE
Fix JS errors when the OBW business step is accessed directly via URL

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -819,7 +819,7 @@ export const BusinessFeaturesList = compose(
 			? getInstallableExtensions( {
 					freeExtensionBundleByCategory: freeExtensions,
 					country,
-					productTypes: profileItems.product_types,
+					productTypes: profileItems.product_types || [],
 			  } )
 			: [];
 		const hasInstallableExtensions = installableExtensions.some(

--- a/plugins/woocommerce/changelog/fix-34974-obw-steps-break-via-url
+++ b/plugins/woocommerce/changelog/fix-34974-obw-steps-break-via-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix JS error when the business step is accessed directly via URL without completing the previous steps


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixed JS errors on the business step page by setting a default value for the product type var.

Other pages worked without any JS error when accessed directly via URL.

Closes #34974 

### How to test the changes in this Pull Request:

1. Start with a fresh site.
2. Access the business directly via `http://your-site/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details`
3. Confirm the page renders without any JS errors.

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
