### PR TITLE
Add manual stock management section to product management experience

### DIFF
--- a/plugins/woocommerce-admin/client/products/add-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/add-product-page.tsx
@@ -28,7 +28,7 @@ const AddProductPage: React.FC = () => {
 	return (
 		<div className="woocommerce-add-product">
 			<Form< Partial< Product > >
-				initialValues={ { stock_quantity: 0 } }
+				initialValues={ { stock_quantity: 0, stock_status: 'instock' } }
 				errors={ {} }
 				validate={ validate }
 			>

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
@@ -2,11 +2,13 @@
 	max-width: 1032px;
 	margin: 0 auto;
 
-	h4 {
+	h4,
+	.components-radio-control .components-base-control__label {
 		font-size: 14px;
 		font-weight: 600;
 		margin-bottom: 18px;
 		margin-top: 26px;
+		text-transform: none;
 	}
 
 	.components-card__body h4:first-child {

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
@@ -15,10 +15,14 @@
 
 		.components-base-control,
 		.woocommerce-rich-text-editor {
-			&:not(:first-child) {
+			&:not(:first-child):not(.components-radio-control) {
 				margin-top: $gap-large - $gap-smaller;
 				margin-bottom: 0;
 			}
+		}
+
+		.components-radio-control .components-v-stack {
+			gap: $gap-small;
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manual-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manual-stock-section.tsx
@@ -8,24 +8,34 @@ import { Product } from '@woocommerce/data';
 
 export const ManualStockSection: React.FC = () => {
 	const { getInputProps, values } = useFormContext< Product >();
-    const inputProps = getInputProps( 'stock_status' );
-    // These properties cause issues with the RadioControl component.
-    // A fix to form upstream would help if we can identify what type of input is used.
-    // @ts-ignore
-    delete inputProps.checked;
-    delete inputProps.value;
+	const inputProps = getInputProps( 'stock_status' );
+	// These properties cause issues with the RadioControl component.
+	// A fix to form upstream would help if we can identify what type of input is used.
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	delete inputProps.checked;
+	delete inputProps.value;
 
 	return (
 		<>
-            <RadioControl
-                label={ __( 'Stock status', 'woocommerce' ) }
-                options={ [
-                    { label: __( 'In stock', 'woocommerce' ), value: 'instock' },
-                    { label: __( 'Out of stock', 'woocommerce' ), value: 'outofstock' },
-                    { label: __( 'On backorder', 'woocommerce' ), value: 'onbackorder' },
-                ] }
-                { ...inputProps }
-            />
+			<RadioControl
+				label={ __( 'Stock status', 'woocommerce' ) }
+				options={ [
+					{
+						label: __( 'In stock', 'woocommerce' ),
+						value: 'instock',
+					},
+					{
+						label: __( 'Out of stock', 'woocommerce' ),
+						value: 'outofstock',
+					},
+					{
+						label: __( 'On backorder', 'woocommerce' ),
+						value: 'onbackorder',
+					},
+				] }
+				{ ...inputProps }
+			/>
 		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manual-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manual-stock-section.tsx
@@ -7,7 +7,7 @@ import { useFormContext } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 
 export const ManualStockSection: React.FC = () => {
-	const { getInputProps, values } = useFormContext< Product >();
+	const { getInputProps } = useFormContext< Product >();
 	const inputProps = getInputProps( 'stock_status' );
 	// These properties cause issues with the RadioControl component.
 	// A fix to form upstream would help if we can identify what type of input is used.
@@ -17,25 +17,23 @@ export const ManualStockSection: React.FC = () => {
 	delete inputProps.value;
 
 	return (
-		<>
-			<RadioControl
-				label={ __( 'Stock status', 'woocommerce' ) }
-				options={ [
-					{
-						label: __( 'In stock', 'woocommerce' ),
-						value: 'instock',
-					},
-					{
-						label: __( 'Out of stock', 'woocommerce' ),
-						value: 'outofstock',
-					},
-					{
-						label: __( 'On backorder', 'woocommerce' ),
-						value: 'onbackorder',
-					},
-				] }
-				{ ...inputProps }
-			/>
-		</>
+		<RadioControl
+			label={ __( 'Stock status', 'woocommerce' ) }
+			options={ [
+				{
+					label: __( 'In stock', 'woocommerce' ),
+					value: 'instock',
+				},
+				{
+					label: __( 'Out of stock', 'woocommerce' ),
+					value: 'outofstock',
+				},
+				{
+					label: __( 'On backorder', 'woocommerce' ),
+					value: 'onbackorder',
+				},
+			] }
+			{ ...inputProps }
+		/>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manual-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/manual-stock-section.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RadioControl } from '@wordpress/components';
+import { useFormContext } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+
+export const ManualStockSection: React.FC = () => {
+	const { getInputProps, values } = useFormContext< Product >();
+    const inputProps = getInputProps( 'stock_status' );
+    // These properties cause issues with the RadioControl component.
+    // A fix to form upstream would help if we can identify what type of input is used.
+    // @ts-ignore
+    delete inputProps.checked;
+    delete inputProps.value;
+
+	return (
+		<>
+            <RadioControl
+                label={ __( 'Stock status', 'woocommerce' ) }
+                options={ [
+                    { label: __( 'In stock', 'woocommerce' ), value: 'instock' },
+                    { label: __( 'Out of stock', 'woocommerce' ), value: 'outofstock' },
+                    { label: __( 'On backorder', 'woocommerce' ), value: 'onbackorder' },
+                ] }
+                { ...inputProps }
+            />
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
@@ -20,6 +20,7 @@ import { getCheckboxProps, getTextControlProps } from '../utils';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { ProductSectionLayout } from '../../layout/product-section-layout';
 import { ManageStockSection } from './manage-stock-section';
+import { ManualStockSection } from './manual-stock-section';
 
 export const ProductInventorySection: React.FC = () => {
 	const { getInputProps, values } = useFormContext< Product >();
@@ -82,6 +83,7 @@ export const ProductInventorySection: React.FC = () => {
 							{ values.manage_stock && <ManageStockSection /> }
 						</>
 					) }
+					{ ! values.manage_stock && <ManualStockSection /> }
 				</CardBody>
 			</Card>
 		</ProductSectionLayout>

--- a/plugins/woocommerce/changelog/add-34388
+++ b/plugins/woocommerce/changelog/add-34388
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add manual stock management section to product management experience


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the section to manually manage the stock status.

Closes #34388 .

### How to test the changes in this Pull Request:

1. Navigate to `Products -> Add new (MVP)`
2. Toggle off the "Track quantity for this product" setting
3. Switch between various stock statuses shown
4. Make sure that the stock statuses persist on refresh
5. Toggle on the "Track quantity for this product" setting
6. Make sure the stock statuses are not shown

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
