### PR TITLE
Add/source param to get subscriptions call

### DIFF
--- a/plugins/woocommerce/changelog/add-source-param-to-get-subscriptions-call
+++ b/plugins/woocommerce/changelog/add-source-param-to-get-subscriptions-call
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add source parameter for calls to the subscriptions endpoint on WooCommerce.com

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
@@ -42,10 +42,10 @@ class WC_Helper_API {
 	 * @return array|WP_Error The response from wp_safe_remote_request()
 	 */
 	public static function request( $endpoint, $args = array() ) {
-		if ( ! isset( $args[ 'source' ] ) ) {
-			$args[ 'source' ] = '';
+		if ( ! isset( $args['query_string'] ) ) {
+			$args['query_string'] = '';
 		}
-		$url = self::url( $endpoint, $args['source'] );
+		$url = self::url( $endpoint, $args['query_string'] );
 
 		if ( ! empty( $args['authenticated'] ) ) {
 			if ( ! self::_authenticate( $url, $args ) ) {
@@ -166,10 +166,11 @@ class WC_Helper_API {
 	 *
 	 * @return string The absolute endpoint URL.
 	 */
-	public static function url( $endpoint, $source = '' ) {
+	public static function url( $endpoint, $query_string = '' ) {
 		$endpoint = ltrim( $endpoint, '/' );
-		$endpoint = sprintf( '%s/%s/%s', self::$api_base, $endpoint, $source );
+		$endpoint = sprintf( '%s/%s/%s', self::$api_base, $endpoint, $query_string );
 		$endpoint = esc_url_raw( $endpoint );
+		$endpoint = rtrim( $endpoint, '/' );
 		return $endpoint;
 	}
 }

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
@@ -163,6 +163,7 @@ class WC_Helper_API {
 	 * Using the API base, form a request URL from a given endpoint.
 	 *
 	 * @param string $endpoint The endpoint to request.
+	 * @param string $query_string Optional query string to append to the URL.
 	 *
 	 * @return string The absolute endpoint URL.
 	 */

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-api.php
@@ -42,7 +42,10 @@ class WC_Helper_API {
 	 * @return array|WP_Error The response from wp_safe_remote_request()
 	 */
 	public static function request( $endpoint, $args = array() ) {
-		$url = self::url( $endpoint );
+		if ( ! isset( $args[ 'source' ] ) ) {
+			$args[ 'source' ] = '';
+		}
+		$url = self::url( $endpoint, $args['source'] );
 
 		if ( ! empty( $args['authenticated'] ) ) {
 			if ( ! self::_authenticate( $url, $args ) ) {
@@ -163,9 +166,9 @@ class WC_Helper_API {
 	 *
 	 * @return string The absolute endpoint URL.
 	 */
-	public static function url( $endpoint ) {
+	public static function url( $endpoint, $source = '' ) {
 		$endpoint = ltrim( $endpoint, '/' );
-		$endpoint = sprintf( '%s/%s', self::$api_base, $endpoint );
+		$endpoint = sprintf( '%s/%s/%s', self::$api_base, $endpoint, $source );
 		$endpoint = esc_url_raw( $endpoint );
 		return $endpoint;
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1270,11 +1270,24 @@ class WC_Helper {
 			return $data;
 		}
 
+		$source = $_SERVER['REQUEST_URI'];
+		if ( preg_match( '/\S+wc-addons?\S+/', $source ) ):
+			$source = 'my-subscriptions';
+		elseif ( preg_match( '/\S+plugins.php?\S+/', $source ) ):
+			$source = 'plugins';
+		elseif ( preg_match( '/\S+wc-admin?\S+/', $source ) ):
+			$source = 'inbox-notes';
+		elseif ( preg_match( '/\Sadmin-ajax.php/', $source ) ):
+			$source = 'heartbeat-api';
+		endif;
+
 		// Obtain the connected user info.
 		$request = WC_Helper_API::get(
 			'subscriptions',
 			array(
 				'authenticated' => true,
+				'source'        => '?source=' . $source,
+
 			)
 		);
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1270,14 +1270,15 @@ class WC_Helper {
 			return $data;
 		}
 
-		$source = $_SERVER['REQUEST_URI'];
-		if ( preg_match( '/\S+wc-addons?\S+/', $source ) ):
+		$request_uri = $_SERVER['REQUEST_URI'];
+		$source = '';
+		if ( stripos( $request_uri, 'wc-addons' ) ):
 			$source = 'my-subscriptions';
-		elseif ( preg_match( '/\S+plugins.php?\S+/', $source ) ):
+		elseif ( stripos( $request_uri, 'plugins.php' ) ):
 			$source = 'plugins';
-		elseif ( preg_match( '/\S+wc-admin?\S+/', $source ) ):
+		elseif ( stripos( $request_uri, 'wc-admin' ) ):
 			$source = 'inbox-notes';
-		elseif ( preg_match( '/\Sadmin-ajax.php/', $source ) ):
+		elseif ( stripos( $request_uri, 'admin-ajax.php' ) ):
 			$source = 'heartbeat-api';
 		endif;
 
@@ -1286,7 +1287,7 @@ class WC_Helper {
 			'subscriptions',
 			array(
 				'authenticated' => true,
-				'source'        => '?source=' . $source,
+				'query_string'  => esc_url( '?source=' . $source ),
 
 			)
 		);

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1270,15 +1270,15 @@ class WC_Helper {
 			return $data;
 		}
 
-		$request_uri = $_SERVER['REQUEST_URI'];
-		$source = '';
-		if ( stripos( $request_uri, 'wc-addons' ) ):
+		$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$source      = '';
+		if ( stripos( $request_uri, 'wc-addons' ) ) :
 			$source = 'my-subscriptions';
-		elseif ( stripos( $request_uri, 'plugins.php' ) ):
+		elseif ( stripos( $request_uri, 'plugins.php' ) ) :
 			$source = 'plugins';
-		elseif ( stripos( $request_uri, 'wc-admin' ) ):
+		elseif ( stripos( $request_uri, 'wc-admin' ) ) :
 			$source = 'inbox-notes';
-		elseif ( stripos( $request_uri, 'admin-ajax.php' ) ):
+		elseif ( stripos( $request_uri, 'admin-ajax.php' ) ) :
 			$source = 'heartbeat-api';
 		endif;
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1288,7 +1288,6 @@ class WC_Helper {
 			array(
 				'authenticated' => true,
 				'query_string'  => esc_url( '?source=' . $source ),
-
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We want to add a source parameter to WooCommerce.com API requests to the subscriptions endpoint

Related issue on WooCommerce.com: 13928-gh-Automattic/woocommerce.com

### How to test the changes in this Pull Request:

Test My subscriptions

1. Open WooCommerce > Extensions
2. Open the _My Subscriptions_ tab
3. Connect to WooCommerce.com
4. Update your list of subscriptions
5. Confirm that your subscriptions are loaded
6. Confirm that other Helper functions that use the WC_Helper_API::get() and url() methods still works normally, e.g. visit the Plugins page and ensure you can activate, deactivate, and view the View Details modal for plugins hosted on WooCommerce.com

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
