### PR TITLE
Fix: mismatching jetpack user should not see mobile app task list item

### DIFF
--- a/plugins/woocommerce/changelog/fix-mismatching-user-mobile-app
+++ b/plugins/woocommerce/changelog/fix-mismatching-user-mobile-app
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+fixed mismatching jetpack user should not see mobile app task list item

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
@@ -3,7 +3,7 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
-use Automattic\Jetpack\Connection\Manager; // https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-manager.php
+use Automattic\Jetpack\Connection\Manager; // https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-manager.php .
 
 /**
  * Get Mobile App Task
@@ -57,19 +57,24 @@ class GetMobileApp extends Task {
 	/**
 	 * Task visibility.
 	 * Can view under these conditions:
-	 *	- Jetpack is installed and connected && current site user has a wordpress.com account connected to jetpack
-	 *	- Jetpack is not connected && current user is capable of installing plugins
+	 *  - Jetpack is installed and connected && current site user has a wordpress.com account connected to jetpack
+	 *  - Jetpack is not connected && current user is capable of installing plugins
+	 *
 	 * @return bool
 	 */
 	public function can_view() {
-		$jetpack_connected = self::is_jetpack_connected();
-		$jetpack_can_be_installed = current_user_can( 'manage_woocommerce' ) && current_user_can( 'install_plugins' ) && ! $jetpack_connected;
+		$jetpack_can_be_installed                        = current_user_can( 'manage_woocommerce' ) && current_user_can( 'install_plugins' ) && ! self::is_jetpack_connected();
 		$jetpack_is_installed_and_current_user_connected = self::is_current_user_connected();
-		
+
 		return $jetpack_can_be_installed || $jetpack_is_installed_and_current_user_connected;
 	}
 
-	public static function is_jetpack_connected() {
+	/**
+	 * Determines if site has any users connected to WordPress.com via JetPack
+	 *
+	 * @return bool
+	 */
+	private static function is_jetpack_connected() {
 		if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_active' ) ) {
 			$connection = new Manager();
 			return $connection->is_active();
@@ -77,7 +82,12 @@ class GetMobileApp extends Task {
 		return false;
 	}
 
-	public static function is_current_user_connected() {
+	/**
+	 * Determines if the current user is connected to Jetpack.
+	 *
+	 * @return bool
+	 */
+	private static function is_current_user_connected() {
 		if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_user_connected' ) ) {
 			$connection = new Manager();
 			return $connection->is_user_connected();

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use Automattic\Jetpack\Connection\Manager; // https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-manager.php
 
 /**
  * Get Mobile App Task
@@ -55,11 +56,33 @@ class GetMobileApp extends Task {
 
 	/**
 	 * Task visibility.
-	 *
+	 * Can view under these conditions:
+	 *	- Jetpack is installed and connected && current site user has a wordpress.com account connected to jetpack
+	 *	- Jetpack is not connected && current user is capable of installing plugins
 	 * @return bool
 	 */
 	public function can_view() {
-		return current_user_can( 'manage_woocommerce' ) && current_user_can( 'install_plugins' );
+		$jetpack_connected = self::is_jetpack_connected();
+		$jetpack_can_be_installed = current_user_can( 'manage_woocommerce' ) && current_user_can( 'install_plugins' ) && ! $jetpack_connected;
+		$jetpack_is_installed_and_current_user_connected = self::is_current_user_connected();
+		
+		return $jetpack_can_be_installed || $jetpack_is_installed_and_current_user_connected;
+	}
+
+	public static function is_jetpack_connected() {
+		if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_active' ) ) {
+			$connection = new Manager();
+			return $connection->is_active();
+		}
+		return false;
+	}
+
+	public static function is_current_user_connected() {
+		if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_user_connected' ) ) {
+			$connection = new Manager();
+			return $connection->is_user_connected();
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Add conditions to exclude mismatching Jetpack users from seeing the additional task list item

Closes #34797 .

### How to test the changes in this Pull Request:

Same as https://github.com/woocommerce/woocommerce/pull/34653

1. Create a new WooCommerce store that can have Jetpack installed and connected
2. Skip OBW, do not install Jetpack in OBW
3. Observe that as the admin user you can see the 'Get the free WooCommerce mobile app' additional task list item
4. Click on it and go through with the entire flow
5. Create a second admin user
6. Observe that the second admin user cannot see the task 
7. Non-admins should also not be able to see the task

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
