### PR TITLE
first pass at applying button styling to generic button elements with…

### DIFF
--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -164,6 +164,7 @@ $tt2-gray: #f7f7f7;
 	}
 
 	a.button,
+	button.button,
 	button[name="add-to-cart"],
 	input[name="submit"],
 	button.single_add_to_cart_button,
@@ -189,14 +190,14 @@ $tt2-gray: #f7f7f7;
 
 	#respond input#submit.alt,
 	a.button.alt,
-	button.button.alt,
+	button.button.alt:not(.single_add_to_cart_button),
 	input.button.alt {
-		background-color: var(--wp--preset--color--primary);
-		color: #fff;
+		background-color: var(--wp--preset--color--foreground,#a46497);
+		color: var(--wp--preset--color--background,#fff);
 
 		&:hover {
-			background-color: var(--wp--preset--color--primary);
-			color: #fff;
+			background-color: var(--wp--preset--color--foreground,#a46497);
+			color: var(--wp--preset--color--background,#fff);
 			opacity: 1;
 		}
 


### PR DESCRIPTION
… button class.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

style for `button.button` elements. question, should this apply to straight up `<button>` with no class?

Closes #35042  .

### How to test the changes in this Pull Request:

```
function kia_test_button_on_single_product() {
	echo '<button class="button">Send Tacos</button>';
	echo '<button class="button alt">Send pizza</button>';
}
add_action( 'woocommerce_before_single_product_summary', 'kia_test_button_on_single_product' );
```

view on single product page

![image](https://user-images.githubusercontent.com/507025/195373545-e2b8cd0f-8e57-4027-8d84-7a75bbd96b3b.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
