### PR TITLE
Improve the "Dismiss" button visibility

### DIFF
--- a/packages/js/experimental/changelog/dev-34928_improve_dismiss_button_visibility
+++ b/packages/js/experimental/changelog/dev-34928_improve_dismiss_button_visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Improve the "Dismiss" button visibility

--- a/packages/js/experimental/src/inbox-note/style.scss
+++ b/packages/js/experimental/src/inbox-note/style.scss
@@ -24,9 +24,6 @@
 	}
 	&:hover {
 		background: $gray-100;
-		.woocommerce-inbox-message__actions button.woocommerce-admin-dismiss-notification {
-			visibility: visible;
-		}
 	}
 
 	&:not(.message-is-unread) {
@@ -160,9 +157,9 @@
 	button.woocommerce-admin-dismiss-notification {
 		color: $gray-700;
 		&:hover {
-			box-shadow: none !important;
+			box-shadow: inset 0 0 0 1px $gray-700;
 		}
-		visibility: hidden;
+		visibility: visible;
 	}
 
 	.components-dropdown {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to make the Dismiss button in the inbox notifications always visible. It used to be hidden until hovering over the notification.

![Screen Capture on 2022-10-12 at 13-37-17](https://user-images.githubusercontent.com/1314156/195399975-dc325a54-6f86-4bbf-98d1-4342f2d61d6c.gif)

Closes #34928.

### How to test the changes in this Pull Request:

1. Checkout this branch and build the project.
2. Go to the `Home` screen and verify the Dismiss button in the inbox notifications is always visible.
3. Try the buttons and verify that they work correctly.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
