### PR TITLE
Remove abuse of wp_count_posts and use efficient SQL queries instead. Large WooCommerce customers are suffering because of this code.

### DIFF
--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -494,9 +494,10 @@ class WC_Install {
 	 * @return boolean
 	 */
 	public static function is_new_install() {
-		$product_count = array_sum( (array) wp_count_posts( 'product' ) );
-
-		return is_null( get_option( 'woocommerce_version', null ) ) || ( 0 === $product_count && -1 === wc_get_page_id( 'shop' ) );
+		global $wpdb;
+		// this query will give you either 0 or 1 depending on whether a product exists or not
+		$product_exists = $wpdb->get_var("select CASE WHEN EXISTS (SELECT * from $wpdb->posts where post_type = 'product') THEN 1 ELSE 0 END as product_exists;");
+		return is_null( get_option( 'woocommerce_version', null ) ) || ( !$product_exists && -1 === wc_get_page_id( 'shop' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -532,8 +532,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return string Template contents.
 	 */
 	private static function get_homepage_template( $post_id ) {
-		$products = wp_count_posts( 'product' );
-		if ( $products->publish >= 4 ) {
+		global $wpdb;
+		$first_5_products = $wpdb->get_results("SELECT ID from $wpdb->posts where post_type = 'product' and post_status = 'publish' LIMIT 5;");
+		if ($wpdb->num_rows >= 4) {
 			$images   = self::sideload_homepage_images( $post_id, 1 );
 			$image_1  = ! empty( $images[0] ) ? $images[0] : '';
 			$template = self::get_homepage_cover_block( $image_1 ) . '


### PR DESCRIPTION
### All Submissions:

-   [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
You can see a full description of this pull request in my article here:

https://www.wpintense.com/2022/10/12/tracking-down-the-origins-of-slow-sql-code-in-wordpress/

Closes # .

### How to test the changes in this Pull Request:

1. Flush the cache with wp_flush_cache
2. Load any wp-admin edit.php page
3. Confirm that wp_count_posts doesn't get called by either of the two Woo onboarding files altered in this commit


### Other information:

-   [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
