### PR TITLE
Some improvements to plugin feature incompatibility UI

### DIFF
--- a/plugins/woocommerce/changelog/features-ui-plugins-warning
+++ b/plugins/woocommerce/changelog/features-ui-plugins-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Improve on feature incompatibility plugin screens.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -89,7 +89,7 @@ class FeaturesController {
 	 */
 	public function __construct() {
 		$features = array(
-			'analytics'              => array(
+			'analytics'           => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
 				'description'        => __( 'Enables WooCommerce Analytics', 'woocommerce' ),
 				'is_experimental'    => false,

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -784,7 +784,7 @@ class FeaturesController {
 		$message = str_replace(
 			'<a>',
 			'<a href="' . esc_url( add_query_arg( array( 'plugin_status' => 'incompatible_with_feature' ), admin_url( 'plugins.php' ) ) ) . '">',
-			__( 'WooCommerce has detected that some of your active plugins are incompatible with currently-enabled WooCommerce features. Please <a>review the details</a>.', 'woocommerce' )
+			__( 'WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features. Please <a>review the details</a>.', 'woocommerce' )
 		);
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -823,7 +823,7 @@ class FeaturesController {
 
 		$message =
 			'all' === $feature_id
-			? __( 'You are viewing plugins that are incompatible with currently-enabled WooCommerce features.', 'woocommerce' )
+			? __( 'You are viewing plugins that are incompatible with currently enabled WooCommerce features.', 'woocommerce' )
 			: sprintf(
 				/* translators: %s is a feature name. */
 				__( "You are viewing the plugins that are incompatible with the '%s' feature.", 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -812,7 +812,7 @@ class FeaturesController {
 			return;
 		}
 
-		if ( 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) {
+		if ( 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR builds upon #34879, mainly to add a couple of features:
- A warning on the Plugins screen that indicates when there's at least one incompatibility between active plugins and enabled features.
- The ability for the `plugins.php?plugin_status=incompatible_with_feature` to work without passing a `feature_id`. In that case, it'd list all plugins with known feature incompatibilities.

### How to test the changes in this Pull Request:

See https://github.com/woocommerce/woocommerce/pull/34879 for basic testing instructions, "The plugins page" section in particular.

#### Specific to this PR:

1. Given basically all WC plugins are now incompatible with all features, for testing purposes it is useful to "fake" a compatibility declaration for a WC plugin on your site. For example, if `woocommerce-accommodation-bookings` is installed, the following snippet will mark it as compatible with COT:

   ```php
   add_action('before_woocommerce_init', function() {
	   if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
		   \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-accommodation-bookings/woocommerce-accommodation-bookings.php', true);
	   }
   });
   ```

   Apply the above to other various WC extensions on your site, making sure to change the plugin path.
2. Disable all WC extension plugins.
3. Enable the HPOS feature and a few WC extensions (including the one in step 1).
4. You should now see a warning on the Plugins screen that there are incompatibilities:
   <img width="1039" alt="Screen Shot 2022-10-12 at 18 20 54" src="https://user-images.githubusercontent.com/184724/195450266-cc8632cd-f8d7-4674-aca1-aa80fa26ab1d.png">
3. Click the link to go a view of all plugins with incompatibilities (`plugins.php?plugin_status=incompatible_with_feature`). You should see _all_ extensions enabled in step 3.
4. Visit  `plugins.php?plugin_status=incompatible_with_feature&feature_id=custom_order_tables` to confirm that the filtering is working. You should see all extensions except the one in step 1 (which was marked as compatible with COT).


### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
