### PR TITLE
Optimize query usage in the Onboarding tasks

### DIFF
--- a/plugins/woocommerce/changelog/fix-34833-slow-onboarding-task-list-query
+++ b/plugins/woocommerce/changelog/fix-34833-slow-onboarding-task-list-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Optimize query usage in the Onboarding tasks

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php
@@ -239,15 +239,13 @@ class TaskList {
 	 * @return bool
 	 */
 	public function is_complete() {
-		$viewable_tasks = $this->get_viewable_tasks();
+		foreach ( $this->get_viewable_tasks() as $viewable_task ) {
+			if ( $viewable_task->is_complete() === false ) {
+				return false;
+			}
+		}
 
-		return array_reduce(
-			$viewable_tasks,
-			function( $is_complete, $task ) {
-				return ! $task->is_complete() ? false : $is_complete;
-			},
-			true
-		);
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -13,6 +13,13 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayme
 class AdditionalPayments extends Payments {
 
 	/**
+	 * Used to cache is_complete() method result.
+	 * @var null
+	 */
+	private $is_complete_result = null;
+
+
+	/**
 	 * ID.
 	 *
 	 * @return string
@@ -60,7 +67,11 @@ class AdditionalPayments extends Payments {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return self::has_gateways();
+		if ( $this->is_complete_result === null ) {
+			$this->is_complete_result = self::has_gateways();
+		}
+
+		return $this->is_complete_result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Payments.php
@@ -10,6 +10,13 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
  * Payments Task
  */
 class Payments extends Task {
+
+	/**
+	 * Used to cache is_complete() method result.
+	 * @var null
+	 */
+	private $is_complete_result = null;
+
 	/**
 	 * ID.
 	 *
@@ -67,7 +74,11 @@ class Payments extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return self::has_gateways();
+		if ( $this->is_complete_result === null ) {
+			$this->is_complete_result = self::has_gateways();
+		}
+
+		return $this->is_complete_result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Products.php
@@ -167,15 +167,7 @@ class Products extends Task {
 	 * @return bool
 	 */
 	public static function has_products() {
-		$product_query = new \WC_Product_Query(
-			array(
-				'limit'  => 1,
-				'return' => 'ids',
-				'status' => array( 'publish' ),
-			)
-		);
-		$products      = $product_query->get_products();
-
-		return count( $products ) !== 0;
+		$counts = wp_count_posts('product');
+		return isset( $counts->publish ) && $counts->publish > 0;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -14,6 +14,12 @@ use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 class Tax extends Task {
 
 	/**
+	 * Used to cache is_complete() method result.
+	 * @var null
+	 */
+	private $is_complete_result = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param TaskList $task_list Parent task list.
@@ -114,9 +120,13 @@ class Tax extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return get_option( 'wc_connect_taxes_enabled' ) ||
-			count( TaxDataStore::get_taxes( array() ) ) > 0 ||
-			get_option( 'woocommerce_no_sales_tax' ) !== false;
+		if ( $this->is_complete_result === null ) {
+			$this->is_complete_result = get_option( 'wc_connect_taxes_enabled' ) ||
+				count( TaxDataStore::get_taxes( array() ) ) > 0 ||
+				get_option( 'woocommerce_no_sales_tax' ) !== false;
+		}
+
+		return $this->is_complete_result;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR optimizes query usage in the Onboarding tasks. Thanks @sun  for the findings in https://github.com/woocommerce/woocommerce/issues/33988#issuecomment-1219915956

Closes #34833 

https://github.com/woocommerce/woocommerce/commit/78d05406679c4447c2319ae7801b7b778e24122a

`WC_Product_Query` generates the following query.

```
SELECT wp_posts.ID
FROM wp_posts
LEFT JOIN wp_term_relationships
ON (wp_posts.ID = wp_term_relationships.object_id)
WHERE 1=1
AND ( wp_term_relationships.term_taxonomy_id IN (2,3,4,5,16,17) )
AND wp_posts.post_type = 'product'
AND ((wp_posts.post_status = 'publish'))
GROUP BY wp_posts.ID
ORDER BY wp_posts.post_date DESC
LIMIT 0, 1
```

If you run `EXPLAIN` on the query, you will see that it uses `Using temporary; and Using filesort` due to GROUP BY and order by. This type of query gets slower as # of rows (in this case, products) grows.

`wp_count_posts` can be used instead. The query generated by `wp_count_posts` is simpler without any potential slowdown regardless of # of products.

```
SELECT post_status, COUNT( * ) AS num_posts
FROM wp_posts
WHERE post_type = 'product'
GROUP BY post_status
```

https://github.com/woocommerce/woocommerce/commit/3d0c0f7ca7f2633a77cf7c2c7e5d5cb438e652d0

Since we're trying to see if any of the tasks are incomplete, we can return early if we find an incomplete task.

https://github.com/woocommerce/woocommerce/commit/6e54edffb907ec3c15e4fd07bb0da947ef909789

`is_complete` is called multiple times in a single request. Since some tasks have DB calls in `is_complete`, it's a good idea to cache `is_complete`.

[Usage 1](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php#L434)

[Usage 2](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskList.php#L241)

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
