### PR TITLE
Add date-only mode to DateTimePickerControl

### DIFF
--- a/packages/js/components/changelog/add-date-time-picker-control-date-only-mode
+++ b/packages/js/components/changelog/add-date-time-picker-control-date-only-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add date-only mode to DateTimePickerControl.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
@@ -4,4 +4,8 @@
 	.woocommerce-date-time-picker-control__input-control__suffix {
 		padding-right: 8px;
 	}
+
+	.components-datetime__date {
+		border-top: 0;
+	}
 }

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -6,7 +6,7 @@ import {
 	useState,
 	useEffect,
 	useLayoutEffect,
-	useCallback,
+	useMemo,
 	useRef,
 } from '@wordpress/element';
 import { Icon, calendar } from '@wordpress/icons';
@@ -16,12 +16,14 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { useDebounce, useInstanceId } from '@wordpress/compose';
 import {
 	BaseControl,
-	Dropdown,
+	DatePicker,
 	DateTimePicker as WpDateTimePicker,
+	Dropdown,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 
+export const defaultDateFormat = 'MM/DD/YYYY';
 export const default12HourDateTimeFormat = 'MM/DD/YYYY h:mm a';
 export const default24HourDateTimeFormat = 'MM/DD/YYYY H:mm';
 
@@ -34,7 +36,8 @@ export type DateTimePickerControlProps = {
 	currentDate?: string | null;
 	dateTimeFormat?: string;
 	disabled?: boolean;
-	is12Hour?: boolean;
+	isDateOnlyPicker?: boolean;
+	is12HourPicker?: boolean;
 	onChange?: DateTimePickerControlOnChangeHandler;
 	onBlur?: () => void;
 	label?: string;
@@ -45,10 +48,9 @@ export type DateTimePickerControlProps = {
 
 export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	currentDate,
-	is12Hour = true,
-	dateTimeFormat = is12Hour
-		? default12HourDateTimeFormat
-		: default24HourDateTimeFormat,
+	isDateOnlyPicker = false,
+	is12HourPicker = true,
+	dateTimeFormat,
 	disabled = false,
 	onChange,
 	onBlur,
@@ -75,6 +77,22 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		null
 	);
 
+	const displayFormat = useMemo( () => {
+		if ( dateTimeFormat ) {
+			return dateTimeFormat;
+		}
+
+		if ( isDateOnlyPicker ) {
+			return defaultDateFormat;
+		}
+
+		if ( is12HourPicker ) {
+			return default12HourDateTimeFormat;
+		}
+
+		return default24HourDateTimeFormat;
+	}, [ dateTimeFormat, isDateOnlyPicker, is12HourPicker ] );
+
 	function parseMomentIso(
 		dateString?: string | null,
 		assumeLocalTime = false
@@ -87,8 +105,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function parseMoment( dateString?: string | null ): Moment {
-		// parse input date string as local time
-		return moment( dateString, dateTimeFormat );
+		return moment( dateString, displayFormat );
 	}
 
 	function formatMomentIso( momentDate: Moment ): string {
@@ -96,7 +113,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function formatMoment( momentDate: Moment ): string {
-		return momentDate.local().format( dateTimeFormat );
+		return momentDate.format( displayFormat );
 	}
 
 	function hasFocusLeftInputAndDropdownContent(
@@ -211,7 +228,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		} else {
 			changeImmediate( currentDate || '', fireOnChange );
 		}
-	}, [ currentDate, dateTimeFormat ] );
+	}, [ currentDate, displayFormat ] );
 
 	return (
 		<Dropdown
@@ -272,23 +289,27 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 					/>
 				</BaseControl>
 			) }
-			renderContent={ () => (
-				<WpDateTimePicker
-					currentDate={
-						lastValidDate
-							? formatMomentIso( lastValidDate )
-							: undefined
-					}
-					onChange={ ( date: string ) => {
-						// the picker returns the date in local time
-						const formattedDate = formatMoment(
-							parseMomentIso( date, true )
-						);
-						changeImmediate( formattedDate, true );
-					} }
-					is12Hour={ is12Hour }
-				/>
-			) }
+			renderContent={ () => {
+				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;
+
+				return (
+					<Picker
+						currentDate={
+							lastValidDate
+								? formatMomentIso( lastValidDate )
+								: undefined
+						}
+						onChange={ ( date: string ) => {
+							// the picker returns the date in local time
+							const formattedDate = formatMoment(
+								parseMomentIso( date, true )
+							);
+							changeImmediate( formattedDate, true );
+						} }
+						is12Hour={ is12HourPicker }
+					/>
+				);
+			} }
 		/>
 	);
 };

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -77,7 +77,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		null
 	);
 
-	const displayFormat = useMemo( () => {
+	const displayFormat = ( () => {
 		if ( dateTimeFormat ) {
 			return dateTimeFormat;
 		}
@@ -91,7 +91,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		}
 
 		return default24HourDateTimeFormat;
-	}, [ dateTimeFormat, isDateOnlyPicker, is12HourPicker ] );
+	} )();
 
 	function parseMomentIso(
 		dateString?: string | null,

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -6,7 +6,6 @@ import {
 	useState,
 	useEffect,
 	useLayoutEffect,
-	useMemo,
 	useRef,
 } from '@wordpress/element';
 import { Icon, calendar } from '@wordpress/icons';
@@ -105,6 +104,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function parseMoment( dateString?: string | null ): Moment {
+		// parse input date string as local time
 		return moment( dateString, displayFormat );
 	}
 
@@ -113,7 +113,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function formatMoment( momentDate: Moment ): string {
-		return momentDate.format( displayFormat );
+		return momentDate.local().format( displayFormat );
 	}
 
 	function hasFocusLeftInputAndDropdownContent(

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -90,3 +90,10 @@ Controlled.decorators = [
 		);
 	},
 ];
+
+export const ControlledDateOnly = Template.bind( {} );
+ControlledDateOnly.args = {
+	...Controlled.args,
+	isDateOnlyPicker: true,
+};
+ControlledDateOnly.decorators = Controlled.decorators;

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -112,7 +112,7 @@ describe( 'DateTimePickerControl', () => {
 		const { container } = render(
 			<DateTimePickerControl
 				currentDate={ ambiguousISODateTimeString }
-				is12Hour={ false }
+				is12HourPicker={ false }
 			/>
 		);
 
@@ -132,7 +132,7 @@ describe( 'DateTimePickerControl', () => {
 		const { container } = render(
 			<DateTimePickerControl
 				currentDate={ unambiguousISODateTimeString }
-				is12Hour={ false }
+				is12HourPicker={ false }
 			/>
 		);
 

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -96,7 +96,7 @@ describe( 'DateTimePickerControl', () => {
 		const { container } = render(
 			<DateTimePickerControl
 				currentDate={ dateTime.toISOString() }
-				is12Hour={ false }
+				is12HourPicker={ false }
 			/>
 		);
 
@@ -152,7 +152,7 @@ describe( 'DateTimePickerControl', () => {
 		const { container } = render(
 			<DateTimePickerControl
 				currentDate={ dateTime.toISOString() }
-				is12Hour={ true }
+				is12HourPicker={ true }
 			/>
 		);
 
@@ -184,14 +184,14 @@ describe( 'DateTimePickerControl', () => {
 		const { container, rerender } = render(
 			<DateTimePickerControl
 				currentDate={ originalDateTime.toISOString() }
-				is12Hour={ false }
+				is12HourPicker={ false }
 			/>
 		);
 
 		rerender(
 			<DateTimePickerControl
 				currentDate={ updatedDateTime.toISOString() }
-				is12Hour={ false }
+				is12HourPicker={ false }
 			/>
 		);
 
@@ -231,7 +231,7 @@ describe( 'DateTimePickerControl', () => {
 
 	it( 'should set the date time picker popup to 12 hour mode', async () => {
 		const { container } = render(
-			<DateTimePickerControl is12Hour={ true } />
+			<DateTimePickerControl is12HourPicker={ true } />
 		);
 
 		const input = container.querySelector( 'input' );

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -229,7 +229,21 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
-	it( 'should set the date time picker popup to 12 hour mode', async () => {
+	it( 'should set the picker popup to date and time by default', async () => {
+		const { container } = render( <DateTimePickerControl /> );
+
+		const input = container.querySelector( 'input' );
+
+		userEvent.click( input! );
+
+		await waitFor( () =>
+			expect(
+				container.querySelector( '.components-datetime' )
+			).toBeInTheDocument()
+		);
+	} );
+
+	it( 'should set the picker to 12 hour mode', async () => {
 		const { container } = render(
 			<DateTimePickerControl is12HourPicker={ true } />
 		);
@@ -245,6 +259,25 @@ describe( 'DateTimePickerControl', () => {
 				)
 			).toBeInTheDocument()
 		);
+	} );
+
+	it( 'should set the picker popup to date only', async () => {
+		const { container } = render(
+			<DateTimePickerControl isDateOnlyPicker={ true } />
+		);
+
+		const input = container.querySelector( 'input' );
+
+		userEvent.click( input! );
+
+		await waitFor( () => {
+			expect(
+				container.querySelector( '.components-datetime' )
+			).not.toBeInTheDocument();
+			expect(
+				container.querySelector( '.components-datetime__date' )
+			).toBeInTheDocument();
+		} );
 	} );
 
 	it( 'should call onBlur when losing focus', async () => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds date-only support to DateTimePickerControl, through the `isDateOnlyPicker` prop. This mode will be needed for the new product management experience, where scheduled sale to and from fields are date only.

Needed for #34538

### How to test the changes in this Pull Request:

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook stories and make sure DateTimePickerControl works as expected, based on the `isDateOnlyPicker` prop: `pnpm --filter=@woocommerce/storybook storybook`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
