### PR TITLE
fix: handle error loading and error states for magic link button

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/JetpackInstallationStepper.tsx
@@ -14,14 +14,17 @@ import {
 	SendMagicLinkButton,
 	useJetpackPluginState,
 	JetpackPluginStates,
+	SendMagicLinkStates,
 } from './';
 
 export const JetpackInstallationStepper = ( {
 	step,
 	sendMagicLinkHandler,
+	sendMagicLinkStatus,
 }: {
 	step: 'first' | 'second';
 	sendMagicLinkHandler: () => void;
+	sendMagicLinkStatus: SendMagicLinkStates;
 } ) => {
 	const { installHandler, jetpackConnectionData, state } =
 		useJetpackPluginState();
@@ -115,6 +118,10 @@ export const JetpackInstallationStepper = ( {
 					),
 					content: (
 						<SendMagicLinkButton
+							isFetching={
+								sendMagicLinkStatus ===
+								SendMagicLinkStates.FETCHING
+							}
 							onClickHandler={ sendMagicLinkHandler }
 						/>
 					),
@@ -128,6 +135,7 @@ export const JetpackInstallationStepper = ( {
 		isWaitingForRedirect,
 		jetpackConnectionData?.currentUser?.wpcomUser?.email,
 		sendMagicLinkHandler,
+		sendMagicLinkStatus,
 	] );
 
 	return (

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/SendMagicLinkButton.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/SendMagicLinkButton.tsx
@@ -2,14 +2,27 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { Spinner } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 
 export const SendMagicLinkButton = ( {
 	onClickHandler,
+	isFetching,
 }: {
 	onClickHandler: () => void;
+	isFetching: boolean;
 } ) => (
 	<Button className="send-magic-link-button" onClick={ onClickHandler }>
-		{ __( '✨️ Send the sign-in link', 'woocommerce' ) }
+		{ isFetching && <Spinner className="send-magic-link-spinner" /> }
+		<div
+			style={ {
+				visibility: isFetching ? 'hidden' : 'visible',
+			} }
+			className="send-magic-link-button-contents"
+		>
+			<div className="send-magic-link-button-text">
+				{ __( '✨️ Send the sign-in link', 'woocommerce' ) }
+			</div>
+		</div>
 	</Button>
 );

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/index.tsx
@@ -3,5 +3,5 @@ export {
 	useJetpackPluginState,
 	JetpackPluginStates,
 } from './useJetpackPluginState';
-export { useSendMagicLink } from './useSendMagicLink';
+export { useSendMagicLink, SendMagicLinkStates } from './useSendMagicLink';
 export { SendMagicLinkButton } from './SendMagicLinkButton';

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/index.tsx
@@ -21,6 +21,7 @@ import {
 	useJetpackPluginState,
 	JetpackPluginStates,
 	useSendMagicLink,
+	SendMagicLinkStates,
 } from './components';
 import {
 	EmailSentPage,
@@ -58,13 +59,19 @@ export const MobileAppModal = () => {
 	const [ isRetryingMagicLinkSend, setIsRetryingMagicLinkSend ] =
 		useState( false );
 
-	const { fetchMagicLinkApiCall } = useSendMagicLink();
+	const { requestState: magicLinkRequestStatus, fetchMagicLinkApiCall } =
+		useSendMagicLink();
 
 	const sendMagicLink = useCallback( () => {
 		fetchMagicLinkApiCall();
-		setHasSentEmail( true );
 		recordEvent( 'magic_prompt_send_signin_link_click' );
 	}, [ fetchMagicLinkApiCall ] );
+
+	useEffect( () => {
+		if ( magicLinkRequestStatus === SendMagicLinkStates.SUCCESS ) {
+			setHasSentEmail( true );
+		}
+	}, [ magicLinkRequestStatus ] );
 
 	useEffect( () => {
 		if ( hasSentEmail ) {
@@ -93,6 +100,7 @@ export const MobileAppModal = () => {
 					}
 					isRetryingMagicLinkSend={ isRetryingMagicLinkSend }
 					sendMagicLinkHandler={ sendMagicLink }
+					sendMagicLinkStatus={ magicLinkRequestStatus }
 				/>
 			);
 		} else if (
@@ -108,6 +116,7 @@ export const MobileAppModal = () => {
 						wordpressAccountEmailAddress
 					}
 					isRetryingMagicLinkSend={ isRetryingMagicLinkSend }
+					sendMagicLinkStatus={ magicLinkRequestStatus }
 					sendMagicLinkHandler={ sendMagicLink }
 				/>
 			);
@@ -119,6 +128,7 @@ export const MobileAppModal = () => {
 		jetpackConnectionData?.currentUser?.wpcomUser?.email,
 		state,
 		isRetryingMagicLinkSend,
+		magicLinkRequestStatus,
 	] );
 
 	return (

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackAlreadyInstalledPage.tsx
@@ -12,11 +12,13 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
  */
 import { ModalContentLayoutWithTitle } from '../layouts/ModalContentLayoutWithTitle';
 import { SendMagicLinkButton } from '../components';
+import { SendMagicLinkStates } from '../components/useSendMagicLink';
 
 interface JetpackAlreadyInstalledPageProps {
 	wordpressAccountEmailAddress: string | undefined;
 	isRetryingMagicLinkSend: boolean;
 	sendMagicLinkHandler: () => void;
+	sendMagicLinkStatus: SendMagicLinkStates;
 }
 
 export const JetpackAlreadyInstalledPage: React.FC<
@@ -24,6 +26,7 @@ export const JetpackAlreadyInstalledPage: React.FC<
 > = ( {
 	wordpressAccountEmailAddress,
 	sendMagicLinkHandler,
+	sendMagicLinkStatus,
 	isRetryingMagicLinkSend,
 } ) => {
 	const DISMISSED_MOBILE_APP_MODAL_OPTION =
@@ -67,7 +70,12 @@ export const JetpackAlreadyInstalledPage: React.FC<
 						) }
 					</h3>
 				</div>
-				<SendMagicLinkButton onClickHandler={ sendMagicLinkHandler } />
+				<SendMagicLinkButton
+					isFetching={
+						sendMagicLinkStatus === SendMagicLinkStates.FETCHING
+					}
+					onClickHandler={ sendMagicLinkHandler }
+				/>
 			</>
 		</ModalContentLayoutWithTitle>
 	);

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackInstallStepperPage.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/pages/JetpackInstallStepperPage.tsx
@@ -14,11 +14,13 @@ import {
 	useJetpackPluginState,
 	JetpackPluginStates,
 } from '../components/useJetpackPluginState';
+import { SendMagicLinkStates } from '../components';
 
 interface JetpackInstallStepperPageProps {
 	isReturningFromWordpressConnection: boolean;
 	isRetryingMagicLinkSend: boolean;
 	sendMagicLinkHandler: () => void;
+	sendMagicLinkStatus: SendMagicLinkStates;
 }
 
 export const JetpackInstallStepperPage: React.FC<
@@ -27,6 +29,7 @@ export const JetpackInstallStepperPage: React.FC<
 	isReturningFromWordpressConnection,
 	sendMagicLinkHandler,
 	isRetryingMagicLinkSend,
+	sendMagicLinkStatus,
 } ) => {
 	const { state: jetpackPluginState } = useJetpackPluginState();
 	const jetpackPluginStateRef =
@@ -67,6 +70,7 @@ export const JetpackInstallStepperPage: React.FC<
 			<JetpackInstallationStepper
 				step={ isReturningFromWordpressConnection ? 'second' : 'first' }
 				sendMagicLinkHandler={ sendMagicLinkHandler }
+				sendMagicLinkStatus={ sendMagicLinkStatus }
 			/>
 		</ModalContentLayoutWithTitle>
 	);

--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/style.scss
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/style.scss
@@ -163,9 +163,32 @@
 button.components-button.send-magic-link-button {
 	background: #007cba;
 	color: #fff;
+	position: relative;
 	:hover {
 		// the hover state makes the text invisible so we need to override it
 		color: #fff;
+	}
+
+	.send-magic-link-spinner {
+		position: absolute;
+		background-color: transparent;
+		// below rules are to center the spinner
+		margin-left: auto;
+		margin-right: auto;
+		left: 0;
+		right: 0;
+
+		.woocommerce-spinner__circle {
+			stroke: #fff;
+		}
+	}
+
+	.send-magic-link-button-contents {
+		visibility: hidden;
+		.send-magic-link-button-text {
+			display: inline-block;
+			vertical-align: top;
+		}
 	}
 }
 

--- a/plugins/woocommerce/changelog/fix-magic-link-error-loading-statuses
+++ b/plugins/woocommerce/changelog/fix-magic-link-error-loading-statuses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Handle loading and error states for magic link button


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added error handling for the send magic link status

Note that the snackbar notice is still under the modal overlay, this needs to be fixed either in layout or in the `@wordpress/components` Guide component so that'll be done in a separate PR

Closes #34796.

### How to test the changes in this Pull Request:

(Skip to 4 if you have set up the mobile app magic link feature previously)

1. Install WooCommerce, skip OBW and do not install Jetpack 
2. Click on the "Get the WooCommerce Mobile App" additional task list item
3. Go through with connection process
4. When you click on the "Send Magic Link" button you should see a spinner. Use devtools throttling if its too fast for you 😁 
5. Go back by clicking on send magic link again
6. Block the  URL in your devtools network panel (see screenshot)
7. You should see the error notice at the bottom of the screen

![image](https://user-images.githubusercontent.com/27843274/195525570-762085e0-f366-40d9-a0ea-b74b48685222.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
