### PR TITLE
[HPOS] Improve plugin matching for compatibility check

### DIFF
--- a/plugins/woocommerce/changelog/fix-compat-check
+++ b/plugins/woocommerce/changelog/fix-compat-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Improve the matching of plugins during the compatibility check.

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -60,6 +60,7 @@ class FeaturesUtil {
 		if ( ! $plugin_id ) {
 			$logger = wc_get_logger();
 			$logger->error( "FeaturesUtil::declare_compatibility: ${plugin_file} is not a known WordPress plugin." );
+			return false;
 		}
 
 		return wc_get_container()->get( FeaturesController::class )->declare_compatibility( $feature_id, $plugin_id, $positive_compatibility );

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -46,22 +46,23 @@ class FeaturesUtil {
 	 * Declare (in)compatibility with a given feature for a given plugin.
 	 *
 	 * This method MUST be executed from inside a handler for the 'before_woocommerce_init' hook and
-	 * SHOULD be executed from the main plugin file passing __FILE__ for the $plugin_file argument.
+	 * SHOULD be executed from the main plugin file passing __FILE__ or 'my-plugin/my-plugin.php' for the
+	 * $plugin_file argument.
 	 *
 	 * @param string $feature_id Unique feature id.
 	 * @param string $plugin_file The full plugin file path.
 	 * @param bool   $positive_compatibility True if the plugin declares being compatible with the feature, false if it declares being incompatible.
 	 * @return bool True on success, false on error (feature doesn't exist or not inside the required hook).
-	 * @throws \Exception A plugin attempted to declare itself as compatible and incompatible with a given feature at the same time.
 	 */
 	public static function declare_compatibility( string $feature_id, string $plugin_file, bool $positive_compatibility = true ): bool {
-		$plugin_name = StringUtil::plugin_name_from_plugin_file( $plugin_file );
+		$plugin_id = wc_get_container()->get( PluginUtil::class )->get_wp_plugin_id( $plugin_file );
 
-		if ( ! isset( get_plugins()[ $plugin_name ] ) ) {
-			throw new \Exception( "FeaturesUtil::declare_compatibility: ${plugin_name} is not a known WordPress plugin." );
+		if ( ! $plugin_id ) {
+			$logger = wc_get_logger();
+			$logger->error( "FeaturesUtil::declare_compatibility: ${plugin_file} is not a known WordPress plugin." );
 		}
 
-		return wc_get_container()->get( FeaturesController::class )->declare_compatibility( $feature_id, $plugin_name, $positive_compatibility );
+		return wc_get_container()->get( FeaturesController::class )->declare_compatibility( $feature_id, $plugin_id, $positive_compatibility );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -118,6 +118,39 @@ class PluginUtil {
 	}
 
 	/**
+	 * Match plugin identifier passed as a parameter with the output from `get_plugins()`.
+	 *
+	 * @param string $plugin_file Plugin identifier, either 'my-plugin/my-plugin.php', or output from __FILE__.
+	 *
+	 * @return string|false
+	 */
+	public function get_wp_plugin_id( $plugin_file ) {
+		$wp_plugins = array_keys( $this->proxy->call_function( 'get_plugins' ) );
+
+		// Try to match plugin_basename().
+		$plugin_basename = $this->proxy->call_function( 'plugin_basename', $plugin_file );
+		if ( array_key_exists( $plugin_basename, $wp_plugins ) ){
+			return $plugin_basename;
+		}
+
+		// Try to match by the my-file.php (file name only)
+		$file_name_parts = explode( DIRECTORY_SEPARATOR, $plugin_file );
+		$file_name = array_pop( $file_name_parts );
+		$matches = array();
+		foreach ( $wp_plugins as $wp_plugin ){
+			if ( false !== strpos( $wp_plugin, $file_name ) ){
+				$matches[] = $wp_plugin;
+			}
+		}
+
+		if ( 1 === count( $matches ) ){
+			return $matches[0];
+		}
+
+		return false;
+	}
+
+	/**
 	 * Handle plugin activation and deactivation by clearing the WooCommerce aware plugin ids cache.
 	 */
 	private function handle_plugin_de_activation(): void {

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -129,32 +129,32 @@ class PluginUtil {
 
 		// Try to match plugin_basename().
 		$plugin_basename = $this->proxy->call_function( 'plugin_basename', $plugin_file );
-		if ( array_key_exists( $plugin_basename, $wp_plugins ) ){
+		if ( array_key_exists( $plugin_basename, $wp_plugins ) ) {
 			return $plugin_basename;
 		}
 
 		// Try to match by the my-file/my-file.php (dir + file name), then by my-file.php (file name only).
-		$plugin_file     = str_replace( [ '\\', '/' ], DIRECTORY_SEPARATOR, $plugin_file );
+		$plugin_file     = str_replace( array( '\\', '/' ), DIRECTORY_SEPARATOR, $plugin_file );
 		$file_name_parts = explode( DIRECTORY_SEPARATOR, $plugin_file );
 		$file_name       = array_pop( $file_name_parts );
 		$directory_name  = array_pop( $file_name_parts );
 		$full_matches    = array();
 		$partial_matches = array();
 		foreach ( $wp_plugins as $wp_plugin ){
-			if ( false !== strpos( $wp_plugin, $directory_name . DIRECTORY_SEPARATOR . $file_name ) ){
+			if ( false !== strpos( $wp_plugin, $directory_name . DIRECTORY_SEPARATOR . $file_name ) ) {
 				$full_matches[] = $wp_plugin;
 			}
 
-			if ( false !== strpos( $wp_plugin, $file_name ) ){
+			if ( false !== strpos( $wp_plugin, $file_name ) ) {
 				$partial_matches[] = $wp_plugin;
 			}
 		}
 
-		if ( 1 === count( $full_matches ) ){
+		if ( 1 === count( $full_matches ) ) {
 			return $full_matches[0];
 		}
 
-		if ( 1 === count( $partial_matches ) ){
+		if ( 1 === count( $partial_matches ) ) {
 			return $partial_matches[0];
 		}
 

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -122,7 +122,7 @@ class PluginUtil {
 	 *
 	 * @param string $plugin_file Plugin identifier, either 'my-plugin/my-plugin.php', or output from __FILE__.
 	 *
-	 * @return string|false
+	 * @return string|false Key from the array returned by `get_plugins` if matched. False if no match.
 	 */
 	public function get_wp_plugin_id( $plugin_file ) {
 		$wp_plugins = array_keys( $this->proxy->call_function( 'get_plugins' ) );
@@ -133,18 +133,29 @@ class PluginUtil {
 			return $plugin_basename;
 		}
 
-		// Try to match by the my-file.php (file name only)
+		// Try to match by the my-file/my-file.php (dir + file name), then by my-file.php (file name only).
+		$plugin_file     = str_replace( [ '\\', '/' ], DIRECTORY_SEPARATOR, $plugin_file );
 		$file_name_parts = explode( DIRECTORY_SEPARATOR, $plugin_file );
-		$file_name = array_pop( $file_name_parts );
-		$matches = array();
+		$file_name       = array_pop( $file_name_parts );
+		$directory_name  = array_pop( $file_name_parts );
+		$full_matches    = array();
+		$partial_matches = array();
 		foreach ( $wp_plugins as $wp_plugin ){
+			if ( false !== strpos( $wp_plugin, $directory_name . DIRECTORY_SEPARATOR . $file_name ) ){
+				$full_matches[] = $wp_plugin;
+			}
+
 			if ( false !== strpos( $wp_plugin, $file_name ) ){
-				$matches[] = $wp_plugin;
+				$partial_matches[] = $wp_plugin;
 			}
 		}
 
-		if ( 1 === count( $matches ) ){
-			return $matches[0];
+		if ( 1 === count( $full_matches ) ){
+			return $full_matches[0];
+		}
+
+		if ( 1 === count( $partial_matches ) ){
+			return $partial_matches[0];
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -140,7 +140,7 @@ class PluginUtil {
 		$directory_name  = array_pop( $file_name_parts );
 		$full_matches    = array();
 		$partial_matches = array();
-		foreach ( $wp_plugins as $wp_plugin ){
+		foreach ( $wp_plugins as $wp_plugin ) {
 			if ( false !== strpos( $wp_plugin, $directory_name . DIRECTORY_SEPARATOR . $file_name ) ) {
 				$full_matches[] = $wp_plugin;
 			}

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -133,10 +133,17 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 			)
 		);
 
+		// Unix style
 		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( 'woocommerce/woocommerce.php' ) );
 		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '6.9.2/woocommerce.php' ) );
 		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '/srv/htdocs/woocommerce/latest/woocommerce.php' ) );
 		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '../../../../wordpress/plugins/woocommerce/latest/woocommerce.php' ) );
+
+		// Windows style
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( 'woocommerce\\woocommerce.php' ) );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '6.9.2\\woocommerce.php' ) );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( 'D:\\WordPress\\plugins\\woocommerce\\6.9.2\\woocommerce.php' ) );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '..\\..\\..\\..\\WordPress\\plugins\\woocommerce\\6.9.2\\woocommerce.php' ) );
 
 		// This shouldn't throw an exception.
 		$this->assertFalse( $this->sut->get_wp_plugin_id( 'woocommerce-bookings/woocommerce-bookings.php' ) );

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -117,6 +117,32 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox 'get_wp_plugin_id' works with output from __FILE__ and manual 'my-plugin/my-plugin.php' input.
+	 */
+	public function test_get_wp_plugin_id() {
+		$this->reset_legacy_proxy_mocks();
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'get_plugins'      => function() {
+					return array(
+						'woocommerce/woocommerce.php'       => array( 'WC tested up to' => '1.0' ),
+						'jetpack/jetpack.php'               => array( 'foo' => 'bar' ),
+						'classic-editor/classic-editor.php' => array( 'foo' => 'bar' ),
+					);
+				},
+			)
+		);
+
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( 'woocommerce/woocommerce.php' ) );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '6.9.2/woocommerce.php' ) );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '/srv/htdocs/woocommerce/latest/woocommerce.php' ) );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $this->sut->get_wp_plugin_id( '../../../../wordpress/plugins/woocommerce/latest/woocommerce.php' ) );
+
+		// This shouldn't throw an exception.
+		$this->assertFalse( $this->sut->get_wp_plugin_id( 'woocommerce-bookings/woocommerce-bookings.php' ) );
+	}
+
+	/**
 	 * Forces a fake list of plugins to be used by the tests.
 	 */
 	private function mock_plugin_functions() {

--- a/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/PluginUtilTests.php
@@ -123,10 +123,10 @@ class PluginUtilTests extends \WC_Unit_Test_Case {
 		$this->reset_legacy_proxy_mocks();
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'get_plugins'      => function() {
+				'get_plugins' => function() {
 					return array(
-						'woocommerce/woocommerce.php'       => array( 'WC tested up to' => '1.0' ),
-						'jetpack/jetpack.php'               => array( 'foo' => 'bar' ),
+						'woocommerce/woocommerce.php' => array( 'WC tested up to' => '1.0' ),
+						'jetpack/jetpack.php' => array( 'foo' => 'bar' ),
 						'classic-editor/classic-editor.php' => array( 'foo' => 'bar' ),
 					);
 				},


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When plugins declare their compatibility, they can use either of these ways:
1. `\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('feature-name', 'my-plugin-name/my-plugin-name.php', true);`
2. `\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('feature-name', __FILE__, true);` 

Especially `__FILE__` can return somewhat unexpected result depending if it's symlinked. 

This PR adds a matching mechanism against the list of plugins as returned from `get_plugins()` function:
1. First it tries to match `plugin_basename($input)`
2. Then it tries to partially match `file-name.php` with keys from  array returned from `get_plugins()`. If there's no match, or there are multiple matches, it returns false.

In both cases, it returns the matched key from `get_plugins()` to use a canonical form for further matching. This also corresponds to the expectation previously used for the subsequent code.

Also, the declaration code no longer throws an Exception. Instead, it just logs an error to the error log.

### How to test the changes in this Pull Request:

1. Download and install 3 plugins, update the code for the first one to declare compatibility, the second to declare incompatibility, no declaration in the third one.  
3. Check that the compatibility is correctly assigned, e.g. via `\Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature`
4. Now symlink those plugins to different folders in your WP install.
5. Check that the compatibility is still correctly assigned, e.g. via `\Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
