### PR TITLE
Handle ambiguous dates (with no offset) in DateTimePickerControl

### DIFF
--- a/packages/js/components/changelog/fix-date-time-picker-control-ambiguous-date
+++ b/packages/js/components/changelog/fix-date-time-picker-control-ambiguous-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Assume ambiguous dates passed into DateTimePickerControl are UTC.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -75,20 +75,28 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		null
 	);
 
-	function parseMomentIso( dateString?: string | null ): Moment {
-		return moment( dateString, moment.ISO_8601, true );
+	function parseMomentIso(
+		dateString?: string | null,
+		assumeLocalTime = false
+	): Moment {
+		if ( assumeLocalTime ) {
+			return moment( dateString, moment.ISO_8601, true ).utc();
+		}
+
+		return moment.utc( dateString, moment.ISO_8601, true );
 	}
 
 	function parseMoment( dateString?: string | null ): Moment {
+		// parse input date string as local time
 		return moment( dateString, dateTimeFormat );
 	}
 
 	function formatMomentIso( momentDate: Moment ): string {
-		return momentDate.toISOString();
+		return momentDate.utc().toISOString();
 	}
 
 	function formatMoment( momentDate: Moment ): string {
-		return momentDate.format( dateTimeFormat );
+		return momentDate.local().format( dateTimeFormat );
 	}
 
 	function hasFocusLeftInputAndDropdownContent(
@@ -272,8 +280,9 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 							: undefined
 					}
 					onChange={ ( date: string ) => {
+						// the picker returns the date in local time
 						const formattedDate = formatMoment(
-							parseMomentIso( date )
+							parseMomentIso( date, true )
 						);
 						changeImmediate( formattedDate, true );
 					} }

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -118,8 +118,6 @@ describe( 'DateTimePickerControl', () => {
 
 		const input = container.querySelector( 'input' );
 
-		console.log( '*** AMBIGUOUS input?.value: ' + input?.value );
-
 		expect( input?.value ).toBe(
 			moment
 				.utc( ambiguousISODateTimeString )
@@ -139,8 +137,6 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-
-		console.log( '*** UNAMBIGUOUS input?.value: ' + input?.value );
 
 		expect( input?.value ).toBe(
 			moment

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -106,6 +106,50 @@ describe( 'DateTimePickerControl', () => {
 		);
 	} );
 
+	it( 'should assume ambiguous dates are UTC', () => {
+		const ambiguousISODateTimeString = '2202-09-15T22:30:40';
+
+		const { container } = render(
+			<DateTimePickerControl
+				currentDate={ ambiguousISODateTimeString }
+				is12Hour={ false }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+
+		console.log( '*** AMBIGUOUS input?.value: ' + input?.value );
+
+		expect( input?.value ).toBe(
+			moment
+				.utc( ambiguousISODateTimeString )
+				.local()
+				.format( default24HourDateTimeFormat )
+		);
+	} );
+
+	it( 'should handle unambiguous UTC dates', () => {
+		const unambiguousISODateTimeString = '2202-09-15T22:30:40Z';
+
+		const { container } = render(
+			<DateTimePickerControl
+				currentDate={ unambiguousISODateTimeString }
+				is12Hour={ false }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+
+		console.log( '*** UNAMBIGUOUS input?.value: ' + input?.value );
+
+		expect( input?.value ).toBe(
+			moment
+				.utc( unambiguousISODateTimeString )
+				.local()
+				.format( default24HourDateTimeFormat )
+		);
+	} );
+
 	it( 'should use the default 12 hour date time format', () => {
 		const dateTime = moment( '2022-09-15 02:30:40' );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates DateTimePickerControl to assume all `currentDate` prop values passed in without an explicit offset are UTC. The scheduled sale to and from date strings that come back from the API are in UTC but have no offset, so this handles that ambiguity.

Needed for #34538

### How to test the changes in this Pull Request:

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook stories and make sure DateTimePickerControl works as expected, with the time portion of the datetime not changing when a new date is selected in the popup: `pnpm --filter=@woocommerce/storybook storybook`

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
