### PR TITLE
Revise logic to update changelog.txt entries

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Git fetch trunk branch
         run: git fetch origin trunk
 
-      - name: Copy changelog.txt to vm root
-        run: cp changelog.txt ../../changelog.txt
+      - name: Copy readme.txt to vm root
+        run: cp ./plugins/woocommerce/readme.txt ../../readme.txt
 
       - name: Switch to trunk branch
         run: git checkout trunk
@@ -28,11 +28,9 @@ jobs:
       - name: Create a new branch based on trunk
         run: git checkout -b prep/post-release-tasks-${{ github.event.release.tag_name }}
 
-      - name: Copy saved changelog.txt to monorepo
-        run: cp ../../changelog.txt ./changelog.txt
-
-      - name: Bump readme.txt stable to the released version
+      - name: Check if we need to continue processing
         uses: actions/github-script@v6
+        id: check
         with:
           script: |
             const fs = require( 'node:fs' );
@@ -43,33 +41,80 @@ jobs:
                 console.error( err );
               }
 
-              const regex = /Stable\stag:(\s\d+\.\d+\.\d+)/g;
+              const regex = /Stable\stag:\s(\d+\.\d+\.\d+)/;
 
-              const newReadme = data.replace( regex, `Stable tag: ${version}` );
+              const stableVersion = data.match( regex )[1];
 
-              fs.writeFile( './plugins/woocommerce/readme.txt', newReadme, err => {
+              // If the release version is less than stable version we can bail.
+              if ( version.localeCompare( stableVersion, undefined, { numeric: true, sensitivity: 'base' } ) == -1 ) {
+                console.log( 'Release version is less than stable version. No automated action taken. A manual process is required.' );
+                console.log( `::set-output name=continue::false` )
+                return;
+              } else {
+                console.log( `::set-output name=continue::true` )
+              }
+            } )
+
+      - name: Update changelog.txt entries
+        uses: actions/github-script@v6
+        id: update-entries
+        if: steps.check.outputs.continue == 'true'
+        with:
+          script: |
+            const fs = require( 'node:fs' );
+            const version = ${{ toJSON( github.event.release.tag_name ) }}
+
+            // Read the saved readme.txt file from earlier.
+            fs.readFile( '../../readme.txt', 'utf-8', function( err, readme ) {
+              if ( err ) {
+                console.log( `::set-output name=continue::false` )
+                console.error( err );
+              }
+
+              const regex = /(== Changelog ==[\s\S]+)\s{2}\[See changelog for all versions\]\(https:\/\/raw\.githubusercontent\.com\/woocommerce\/woocommerce\/trunk\/changelog\.txt\)\./;
+
+              const entries = readme.match( regex )[1];
+
+              fs.readFile( './changelog.txt', 'utf-8', function( err, changelog ) {
                 if ( err ) {
-                  console.error( 'Unable to bump the stable version in readme.txt' );
+                  console.log( `::set-output name=continue::false` )
+                  console.error( err );
                 }
+
+                const regex = /== Changelog ==/;
+
+                const updatedChangelog = changelog.replace( regex, entries );
+
+                fs.writeFile( './changelog.txt', updatedChangelog, err => {
+                  if ( err ) {
+                    console.log( `::set-output name=continue::false` )
+                    console.error( 'Unable to update changelog entries in changelog.txt' );
+                  }
+
+                  console.log( `::set-output name=continue::true` )
+                } )
               } )
             } )
 
       - name: Commit changes
+        if: steps.update-entries.outputs.continue == 'true'
         run: git commit -am "Prep trunk post release ${{ github.event.release.tag_name }}"
 
       - name: Push branch up
+        if: steps.update-entries.outputs.continue == 'true'
         run: git push origin prep/post-release-tasks-${{ github.event.release.tag_name }}
 
       - name: Create the PR
+        if: steps.update-entries.outputs.continue == 'true'
         uses: actions/github-script@v6
         with:
           script: |
-            const body = "This PR updates the changelog.txt entries and version in Stable tag based on the latest release: ${{ github.event.release.tag_name }}"
+            const body = "This PR updates the changelog.txt entries based on the latest release: ${{ github.event.release.tag_name }}"
 
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Update changelog.txt and Stable Version from release ${{ github.event.release.tag_name }}",
+              title: "Update changelog.txt from release ${{ github.event.release.tag_name }}",
               head: "prep/post-release-tasks-${{ github.event.release.tag_name }}",
               base: "trunk",
               body: body

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -10,19 +10,11 @@ env:
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
 jobs:
-  update-changelog-in-trunk:
-    name: Update changelog in trunk
+  changelog-version-update:
+    name: Update changelog and version
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Get tag name
-        id: tag
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const tag = ${{ toJSON( github.event.release.tag_name ) }}
-
-            console.log( `::set-output name=tag::release/${ tag.substring( 0, 3 ) }` )
 
       - name: Git fetch trunk branch
         run: git fetch origin trunk
@@ -32,30 +24,53 @@ jobs:
 
       - name: Switch to trunk branch
         run: git checkout trunk
-      
+
       - name: Create a new branch based on trunk
-        run: git checkout -b update/changelog-from-release-${{ github.event.release.tag_name }}
+        run: git checkout -b prep/post-release-tasks-${{ github.event.release.tag_name }}
 
       - name: Copy saved changelog.txt to monorepo
         run: cp ../../changelog.txt ./changelog.txt
 
+      - name: Bump readme.txt stable to the released version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require( 'node:fs' );
+            const version = ${{ toJSON( github.event.release.tag_name ) }}
+
+            fs.readFile( './plugins/woocommerce/readme.txt', 'utf-8', function( err, data ) {
+              if ( err ) {
+                console.error( err );
+              }
+
+              const regex = /Stable\stag:(\s\d+\.\d+\.\d+)/g;
+
+              const newReadme = data.replace( regex, `Stable tag: ${version}` );
+
+              fs.writeFile( './plugins/woocommerce/readme.txt', newReadme, err => {
+                if ( err ) {
+                  console.error( 'Unable to bump the stable version in readme.txt' );
+                }
+              } )
+            } )
+
       - name: Commit changes
-        run: git commit -am "Update changelog.txt from release ${{ github.event.release.tag_name }}"
+        run: git commit -am "Prep trunk post release ${{ github.event.release.tag_name }}"
 
       - name: Push branch up
-        run: git push origin update/changelog-from-release-${{ github.event.release.tag_name }}
+        run: git push origin prep/post-release-tasks-${{ github.event.release.tag_name }}
 
       - name: Create the PR
         uses: actions/github-script@v6
         with:
           script: |
-            const body = "This PR updates the changelog.txt based on the latest release: ${{ github.event.release.tag_name }}"
+            const body = "This PR updates the changelog.txt entries and version in Stable tag based on the latest release: ${{ github.event.release.tag_name }}"
 
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Update changelog.txt from release ${{ github.event.release.tag_name }}",
-              head: "update/changelog-from-release-${{ github.event.release.tag_name }}",
+              title: "Update changelog.txt and Stable Version from release ${{ github.event.release.tag_name }}",
+              head: "prep/post-release-tasks-${{ github.event.release.tag_name }}",
               base: "trunk",
               body: body
             })


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR automates the process so that when there is a new release, the changelog entries from `readme.txt` is copied over to the `changelog.txt` in trunk. Note that this will only proceed if the out going version is new and will not proceed if it is a fix/patch version. Also we won't need to update the stable tag as it is irrelevant in `trunk`.

### How to test the changes in this Pull Request:

1. Fork this repo. All steps following will be in your fork.
2. Create a `6.9.0` release based on `release/6.9`.
3. Merge this branch into trunk. Make sure the changes in this PR is also present in `release/6.9` and `release/7.1`.
4. Make sure actions are enabled.
5. Create a new release - select to create a new tag `6.9.5`,  target the `release/6.9` branch and click on `Publish release` button.
6. At this point the event should trigger the workflow. After it is done, check the logs of the action and you should see a message stating it did not proceed as the version is older than current release.
7. Create a new release - select to create a new tag `7.1.0`, target the `release/7.1` branch and click on `Publish release` button.
8. At this point the event should trigger the workflow. Check that a PR is created and  contains changes to the `changelog.txt` with the new entries from the `readme.txt` of `release/7.1` branch. It should also have the PR reviewer assigned. It assigns the person who created the release. In this case it usually is the release lead.
9. Check that this event should NOT run if it is a prerelease or if it is a draft release.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.