### PR TITLE
Add untrash order hook (COT/HPOS).

### DIFF
--- a/plugins/woocommerce/changelog/fix-35018-untrash-order-hook
+++ b/plugins/woocommerce/changelog/fix-35018-untrash-order-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Introduces new hook `woocommerce_untrash_order` as a COT/HPOS analog to `untrash_post`.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1820,6 +1820,16 @@ FROM $order_meta_table
 			return false;
 		}
 
+		/**
+		 * Fires before an order is restored from the trash.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param int    $order_id        Order ID.
+		 * @param string $previous_status The status of the order before it was trashed.
+		 */
+		do_action( 'woocommerce_untrash_order', $order->get_id(), $previous_status );
+
 		$order->set_status( $previous_status );
 		$order->save();
 
@@ -1827,6 +1837,7 @@ FROM $order_meta_table
 		if ( $previous_status === $order->get_status() ) {
 			$order->delete_meta_data( '_wp_trash_meta_status' );
 			$order->delete_meta_data( '_wp_trash_meta_time' );
+
 			return true;
 		}
 


### PR DESCRIPTION
Adds a new action hook: `woocommerce_untrash_order`.

- This is an analog of the core WP hook `untrash_post`, but applies to (COT/HPOS) orders.
- Naming convention follows the hooks we added in https://github.com/woocommerce/woocommerce/pull/34858.
- Essentially replicates the same params as provided by `untrash_post`.

Closes #35018.

### How to test the changes in this Pull Request:

Reviewing the code should be sufficient (by itself, this does not introduce any functional changes), but you could also add a snippet like this to a suitable location:

```php
add_action( 'woocommerce_untrash_order', function ( int $order_id ) {
	wc_get_logger()->info( "woocommerce_untrash_order fired for order #{$order_id}." );
} );
```

Then, after trashing and untrashing an order, look in the logs found in **WooCommerce ▸ Status ▸ Logs** and you should see an entry referencing the order you just untrashed.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
