### PR TITLE
Remove non-gmt scheduled sale properties from Product type

### DIFF
--- a/packages/js/data/changelog/update-data-products-exclude-non-gmt-scheduled-sale
+++ b/packages/js/data/changelog/update-data-products-exclude-non-gmt-scheduled-sale
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Remove `Product` `date_on_sale_from` and `date_on_sale_to` properties. Use `date_on_sale_from_gmt` and `date_on_sale_to_gmt` instead.

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -52,9 +52,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	description: string;
 	short_description: string;
 	sku: string;
-	date_on_sale_from: string | null;
 	date_on_sale_from_gmt: string | null;
-	date_on_sale_to: string | null;
 	date_on_sale_to_gmt: string | null;
 	virtual: boolean;
 	downloadable: boolean;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the non-gmt scheduled sale properties from the `Product` type:

* `date_on_sale_from`
* `date_on_sale_to`

This will force the use of the gmt scheduled sale properties instead:

* `date_on_sale_from_gmt`
* `date_on_sale_to_gmt`

By removing the non-gmt properties, we can write code that only deals with changes to the gmt properties, not having to worry about whether some piece of code has mistakenly set the non-gmt properties instead (especially third-party extensions, but even our own core code).

If we didn't remove these non-gmt properties, we would have to keep the non-gmt and gmt properties in sync in order to robustly handle things like validation.

By removing the non-gmt properties, we also force code to use the non-ambiguous gmt properties. With the non-gmt properties, they are in "local" time, which can be confusing (which local time, the local time of the server? the local time of the web browser client?). 

Of course, technically those fields are still there in the `Product` objects that come back from the API. This is just a TypeScript change that will cause a compilation error if attempting to access the non-gmt properties. If using JavaScript, you would still be able to access these.

Actually removing the properties from the object (in a generic manner) would be more involved and probably not worth it.

This is technically a breaking change, if any TypeScript code out there was using these non-gmt properties, so I've noted it as so in the changelog entry.

### How to test the changes in this Pull Request:

1. Make sure `pnpm run build` executes without any errors 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
