### PR TITLE
Update WooCommerce Blocks package to 8.7.2

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.2
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update WooCommerce Blocks to 8.7.2
+Comment: Update WooCommerce Blocks to 8.7.2 (composer.json & composer.lock)

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.2
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Comment: Update WooCommerce Blocks to 8.7.2 (composer.json & composer.lock)
+Comment: Update WooCommerce Blocks to 8.7.2

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 8.7.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.7.1"
+		"woocommerce/woocommerce-blocks": "8.7.2"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e0e2721da4db7a3c7474c3e2f14c236",
+    "content-hash": "d1c35e053ae34c5434635a435e326266",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.7.1",
+            "version": "v8.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "5530ea25a060cb0eaf9e930f9097057fb820f22e"
+                "reference": "2ff8573d5426ebee180e50539f113c211362d1b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/5530ea25a060cb0eaf9e930f9097057fb820f22e",
-                "reference": "5530ea25a060cb0eaf9e930f9097057fb820f22e",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2ff8573d5426ebee180e50539f113c211362d1b9",
+                "reference": "2ff8573d5426ebee180e50539f113c211362d1b9",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.2"
             },
-            "time": "2022-10-12T15:27:50+00:00"
+            "time": "2022-10-14T12:13:45+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.7.2 

## WooCommerce Blocks 8.7.2

- [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7396)
- [Testing notes](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/872.md)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes
- Refactor useCheckoutAddress hook to enable "Use same address for billing" option in Editor ([7393](https://github.com/woocommerce/woocommerce-blocks/pull/7393))


### Changelog entry

> Dev - Update WooCommerce Blocks version to 8.7.2