### PR TITLE
Update version of auto-assign-reviewer

### DIFF
--- a/.github/project-community-pr-assigner.yml
+++ b/.github/project-community-pr-assigner.yml
@@ -1,3 +1,3 @@
 
 ".github/*":
-  - atlas
+  - team: atlas

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -32,7 +32,7 @@ jobs:
           
       - name: "If community PR, assign a reviewer"
         if: github.event.pull_request && steps.check.outputs.is-community == 'yes'
-        uses: shufo/auto-assign-reviewer-by-files@24a9fcbd5c51c4403b64c8b6e087c824b67a5c35
+        uses: shufo/auto-assign-reviewer-by-files@f5f3db9ef06bd72ab6978996988c6462cbdaabf6
         with:
           config: ".github/project-community-pr-assigner.yml"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a follow-up to #35041 and #35082. It updates the version of `auto-assign-reviewer-by-files` to one that includes the fix introduced in https://github.com/shufo/auto-assign-reviewer-by-files/pull/213.

Note: we may still need to follow-up after this with a PR to introduce a token with repo scope, but I want to be sure that's required before introducing a new secret.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Follow the testing instructions from #35041 just to be sure there's no regression with individual assignments. We'll have to test the team assignments outside of a fork anyways.
2.
3.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
