### PR TITLE
Fixes typo mistake in coupon error message

### DIFF
--- a/plugins/woocommerce/changelog/fix-coupon-error-notice-text
+++ b/plugins/woocommerce/changelog/fix-coupon-error-notice-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fixes grammar in coupon error message.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -1022,7 +1022,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			case self::E_WC_COUPON_USAGE_LIMIT_COUPON_STUCK:
 				if ( is_user_logged_in() && wc_get_page_id( 'myaccount' ) > 0 ) {
 					/* translators: %s: myaccount page link. */
-					$err = sprintf( __( 'Coupon usage limit has been reached. If you were using this coupon just now but order was not complete, you can retry or cancel the order by going to the <a href="%s">my account page</a>.', 'woocommerce' ), wc_get_endpoint_url( 'orders', '', wc_get_page_permalink( 'myaccount' ) ) );
+					$err = sprintf( __( 'Coupon usage limit has been reached. If you were using this coupon just now but your order was not complete, you can retry or cancel the order by going to the <a href="%s">my account page</a>.', 'woocommerce' ), wc_get_endpoint_url( 'orders', '', wc_get_page_permalink( 'myaccount' ) ) );
 				} else {
 					$err = $this->get_coupon_error( self::E_WC_COUPON_USAGE_LIMIT_REACHED );
 				}


### PR DESCRIPTION
Improves the grammar in one of our coupon error messages.

Closes #34889

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Testing instructions

- Visit **Marketing ▸ Coupons** and create a new coupon. Suggested settings:
    - An appropriate name, such as **test-pr-35110**.
    - Set **usage limit per coupon** to **1**.
- Visit the frontend. It's fine to test this as an admin user, but you could also switch to an existing customer account.
- Add an item to the cart, and within the cart apply the newly created coupon. Checkout. This should be successful.
- Stay logged in as the same user and repeat the process. This time, after trying to apply the coupon, you should see an error reading (italicized segment represents the change in the text): **Coupon usage limit has been reached. If you were using this coupon just now but _your_ order was not complete, you can retry or cancel the order by going to the [my account page](https://lab.wordpress/my-account/orders/).**

<div align="center"><img width="700" alt="Screenshot 2023-09-25 at 22 43 01" src="https://github.com/woocommerce/woocommerce/assets/3594411/5406dd09-51b4-43b7-8822-77e105b22e97"></div>

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
