### PR TITLE
Update biling and shipping address indexes.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34989
+++ b/plugins/woocommerce/changelog/fix-34989
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add billing and shipping address indexes on order update.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1008,8 +1008,8 @@ WHERE
 	 * @return bool Whether the order should be synced.
 	 */
 	private function should_sync_order( \WC_Abstract_Order $order ) : bool {
-		$draft_order    = in_array( $order->get_status(), array( 'draft', 'auto-draft' ) );
-		$already_synced = in_array( $order->get_id(), self::$reading_order_ids );
+		$draft_order    = in_array( $order->get_status(), array( 'draft', 'auto-draft' ), true );
+		$already_synced = in_array( $order->get_id(), self::$reading_order_ids, true );
 		return ! $draft_order && ! $already_synced;
 	}
 
@@ -1017,8 +1017,8 @@ WHERE
 	 * Helper method to initialize order object from DB data.
 	 *
 	 * @param \WC_Abstract_Order $order Order object.
-	 * @param int       $order_id Order ID.
-	 * @param \stdClass $order_data Order data fetched from DB.
+	 * @param int                $order_id Order ID.
+	 * @param \stdClass          $order_data Order data fetched from DB.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1544,6 +1544,9 @@ FROM $order_meta_table
 				throw new \Exception( sprintf( __( 'Could not persist order to database table "%s".', 'woocommerce' ), $update['table'] ) );
 			}
 		}
+
+		$changes = $order->get_changes();
+		$this->update_address_index_meta( $order, $changes );
 	}
 
 	/**
@@ -2025,7 +2028,17 @@ FROM $order_meta_table
 	 */
 	public function update_order_meta( &$order ) {
 		$changes = $order->get_changes();
+		$this->update_address_index_meta( $order, $changes );
+	}
 
+	/**
+	 * Helper function to update billing and shipping address metadata.
+	 * @param \WC_Abstract_Order $order Order Object
+	 * @param array              $changes Array of changes.
+	 *
+	 * @return void
+	 */
+	private function update_address_index_meta( $order, $changes ) {
 		// If address changed, store concatenated version to make searches faster.
 		foreach ( array( 'billing', 'shipping' ) as $address_type ) {
 			if ( isset( $changes[ $address_type ] ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -187,10 +187,12 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			'status'             => 'on-hold',
 			'cart_hash'          => 'YET-ANOTHER-CART-HASH',
 		);
+
 		static $datastore_updates = array(
 			'email_sent'          => true,
 			'order_stock_reduced' => true,
 		);
+
 		static $meta_to_update = array(
 			'my_meta_key' => array( 'my', 'custom', 'meta' ),
 		);
@@ -1003,10 +1005,14 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * @testDox Test `get_unpaid_orders()`.
 	 */
 	public function test_get_unpaid_orders(): void {
+		// phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested -- Intentional usage since timezone is changed for this file.
 		$now = current_time( 'timestamp' );
 
 		// Create a few orders.
-		$orders_by_status = array( 'wc-completed' => 3, 'wc-pending' => 2 );
+		$orders_by_status = array(
+			'wc-completed' => 3,
+			'wc-pending'   => 2,
+		);
 		$unpaid_ids       = array();
 		foreach ( $orders_by_status as $order_status => $order_count ) {
 			foreach ( range( 1, $order_count ) as $_ ) {
@@ -1206,7 +1212,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	/**
 	 * Helper method to allow switching data stores.
 	 *
-	 * @param WC_Order $order Order object.
+	 * @param WC_Order      $order Order object.
 	 * @param WC_Data_Store $data_store Data store object to switch order to.
 	 */
 	private function switch_data_store( $order, $data_store ) {
@@ -1258,7 +1264,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		);
 
 		// Order 1's billing address references "Quality" and so does one of Order 2's order items.
-		$query = new OrdersTableQuery( array( 's' => 'Quality' ) );
+		$query        = new OrdersTableQuery( array( 's' => 'Quality' ) );
 		$orders_array = $query->orders;
 		sort( $orders_array );
 		$this->assertEquals(
@@ -1404,7 +1410,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			array(
 				'field' => 'order_key',
 				'value' => 'planck_1',
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[1] ), $query->orders );
@@ -1438,8 +1444,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			array(
 				'field'   => 'order_key',
 				'value'   => '[0-9]$',
-				'compare' => 'RLIKE'
-			)
+				'compare' => 'RLIKE',
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertEqualsCanonicalizing( $order_ids, $query->orders );
@@ -1449,8 +1455,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			array(
 				'field'   => 'order_key',
 				'value'   => '[^0-9]$',
-				'compare' => 'NOT RLIKE'
-			)
+				'compare' => 'NOT RLIKE',
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertCount( 0, $query->posts );
@@ -1462,7 +1468,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				'value'   => '10.0',
 				'compare' => '<=',
 				'type'    => 'NUMERIC',
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertEqualsCanonicalizing( array( $order_ids[2] ), $query->orders );
@@ -1472,7 +1478,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			array(
 				'field' => 'non_existing_field',
 				'value' => 'any-value',
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertCount( 0, $query->posts );
@@ -1483,7 +1489,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				'field'   => 'wc_orders.total_amount',
 				'value'   => 5.5,
 				'compare' => 'IN',
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertCount( 0, $query->posts );
@@ -1494,7 +1500,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				'field'   => 'wc_orders.total_amount',
 				'value'   => 10.0,
 				'compare' => 'EXOSTS',
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertCount( 0, $query->posts );
@@ -1505,7 +1511,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				'field'   => 'total',
 				'compare' => 'BETWEEN',
 				'value'   => 10.0,
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertCount( 0, $query->posts );
@@ -1516,12 +1522,12 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 				'field'   => 'total',
 				'compare' => 'NOT BETWEEN',
 				'value'   => array( 1.0 ),
-			)
+			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
 		$this->assertCount( 0, $query->posts );
 
-		// Test combinations of field_query with regular query args:
+		// Test combinations of field_query with regular query args.
 		$args  = array(
 			'id' => array( $order_ids[0], $order_ids[1] ),
 		);
@@ -1536,7 +1542,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			array(
 				'field' => 'id',
 				'value' => $order_ids[1],
-			)
+			),
 		);
 		$query               = new OrdersTableQuery( $args );
 		$this->assertEqualsCanonicalizing( array( $order_ids[1] ), $query->orders );
@@ -1550,7 +1556,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$query                 = new OrdersTableQuery( $args );
 		$this->assertCount( 0, $query->orders );
 
-		// Now a more complex query with meta_query and date_query:
+		// Now a more complex query with meta_query and date_query.
 		$args = array(
 			'shipping_address' => 'The Universe',
 			'field_query'      => array(
@@ -1567,12 +1573,13 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$this->assertEqualsCanonicalizing( array( $order_ids[0], $order_ids[1] ), $query->orders );
 
 		// ... but only Planck is more than 80 years old.
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Intentional usage for test.
 		$args['meta_query'] = array(
 			array(
 				'key'     => 'customer_age',
 				'value'   => 80,
-				'compare' => '>='
-			)
+				'compare' => '>=',
+			),
 		);
 		$query              = new OrdersTableQuery( $args );
 		$this->assertEqualsCanonicalizing( array( $order_ids[1] ), $query->orders );
@@ -1634,10 +1641,10 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	/**
 	 * Helper method to assert props are set.
 	 *
-	 * @param array $props List of props to test.
+	 * @param array    $props List of props to test.
 	 * @param WC_Order $order Order object.
-	 * @param mixed $value Value to assert.
-	 * @param array $ds_getter_setter_names List of props with custom getter/setter names.
+	 * @param mixed    $value Value to assert.
+	 * @param array    $ds_getter_setter_names List of props with custom getter/setter names.
 	 */
 	private function assert_get_prop_via_ds_object_and_metadata( array $props, WC_Order $order, $value, array $ds_getter_setter_names ) {
 		wp_cache_flush();
@@ -1710,8 +1717,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * Helper function to set prop via data store.
 	 *
 	 * @param WC_Order $order Order object.
-	 * @param array $props List of props and their setter names.
-	 * @param mixed $value value to set.
+	 * @param array    $props List of props and their setter names.
+	 * @param mixed    $value value to set.
 	 */
 	private function set_props_via_data_store( $order, $props, $value ) {
 		foreach ( $props as $meta_key_name => $prop_name ) {
@@ -1723,8 +1730,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * Helper function to set prop value via object.
 	 *
 	 * @param WC_Order $order Order object.
-	 * @param array $props List of props and their setter names.
-	 * @param mixed $value value to set.
+	 * @param array    $props List of props and their setter names.
+	 * @param mixed    $value value to set.
 	 */
 	private function set_props_via_order_object( $order, $props, $value ) {
 		foreach ( $props as $meta_key_name => $prop_name ) {
@@ -1737,8 +1744,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * Helper function to assert prop value via data store.
 	 *
 	 * @param WC_Order $order Order object.
-	 * @param array $props List of props and their getter names.
-	 * @param mixed $value value to assert.
+	 * @param array    $props List of props and their getter names.
+	 * @param mixed    $value value to assert.
 	 */
 	private function assert_props_value_via_data_store( $order, $props, $value ) {
 		foreach ( $props as $meta_key_name => $prop_name ) {
@@ -1750,8 +1757,8 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	 * Helper function to assert prop value via order object.
 	 *
 	 * @param WC_Order $order Order object.
-	 * @param array $props List of props and their getter names.
-	 * @param mixed $value value to assert.
+	 * @param array    $props List of props and their getter names.
+	 * @param mixed    $value value to assert.
 	 */
 	private function assert_props_value_via_order_object( $order, $props, $value ) {
 		foreach ( $props as $meta_key_name => $prop_name ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1228,6 +1228,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$order_1 = new WC_Order();
 		$order_1->set_billing_city( 'Fort Quality' );
 		$this->switch_data_store( $order_1, $this->sut );
+		$this->disable_cot_sync();
 		$order_1->save();
 
 		$product = new WC_Product_Simple();
@@ -1258,10 +1259,39 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		// Order 1's billing address references "Quality" and so does one of Order 2's order items.
 		$query = new OrdersTableQuery( array( 's' => 'Quality' ) );
+		$orders_array = $query->orders;
+		sort( $orders_array );
 		$this->assertEquals(
 			array( $order_1->get_id(), $order_2->get_id() ),
-			$query->orders,
+			$orders_array,
 			'Search terms match against address data as well as order item names.'
+		);
+	}
+
+	/**
+	 * @testDox Ensure search works as expected on updated orders.
+	 */
+	public function test_cot_query_search_update() {
+		$order_1 = new WC_Order();
+		$this->switch_data_store( $order_1, $this->sut );
+		$this->disable_cot_sync();
+		$order_1->save();
+
+		$order_1->set_billing_city( 'New Cybertron' );
+		$order_1->save();
+
+		$order_2 = new WC_Order();
+		$this->switch_data_store( $order_2, $this->sut );
+		$order_2->save();
+
+		$order_2->set_billing_city( 'Gigantian City' );
+		$order_2->save();
+
+		$query = new OrdersTableQuery( array( 's' => 'Cybertron' ) );
+		$this->assertEquals(
+			array( $order_1->get_id() ),
+			$query->orders,
+			'Search terms match against updated address data.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Looks like we were not saving _billing_address_index and _shipping_address_index metadata on update (we were doing it on create, though). This PR addresses the issue by updating the index metadata on updates as well.

Closes #34989 .

### How to test the changes in this Pull Request:

1. With COT enabled and sync off, create an order with no address field set. Update the status to anything other than draft.
2. Update the address now to some value, and search for it in the admin list screen. Without this PR you won't see the order listed. Checkout this PR and update the order again with another address, you will now be able to search for it.

Note that after #35150 , these meta fields won't be needed anymore.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
