### PR TITLE
Select the current new added shipping class

### DIFF
--- a/plugins/woocommerce-admin/client/products/constants.js
+++ b/plugins/woocommerce-admin/client/products/constants.js
@@ -1,3 +1,0 @@
-export const NUMBERS_AND_ALLOWED_CHARS = '[^-0-9%s1%s2]';
-export const NUMBERS_AND_DECIMAL_SEPARATOR = '[^-\\d\\%s]+';
-export const ONLY_ONE_DECIMAL_SEPARATOR = '[%s](?=%s*[%s])';

--- a/plugins/woocommerce-admin/client/products/constants.ts
+++ b/plugins/woocommerce-admin/client/products/constants.ts
@@ -1,0 +1,7 @@
+export const NUMBERS_AND_ALLOWED_CHARS = '[^-0-9%s1%s2]';
+export const NUMBERS_AND_DECIMAL_SEPARATOR = '[^-\\d\\%s]+';
+export const ONLY_ONE_DECIMAL_SEPARATOR = '[%s](?=%s*[%s])';
+// This should never be a real slug value of any existing shipping class
+export const ADD_NEW_SHIPPING_CLASS_OPTION_VALUE =
+	'__ADD_NEW_SHIPPING_CLASS_OPTION__';
+export const UNCATEGORIZED_CATEGORY_SLUG = 'uncategorized';

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -94,7 +94,7 @@ function extractDefaultShippingClassFromProduct(
 export function ProductShippingSection( {
 	product,
 }: ProductShippingSectionProps ) {
-	const { getInputProps } = useFormContext< PartialProduct >();
+	const { getInputProps, setValue } = useFormContext< PartialProduct >();
 	const { formatNumber, parseNumber } = useProductHelper();
 	const [ highlightSide, setHighlightSide ] =
 		useState< ShippingDimensionsImageProps[ 'highlight' ] >();
@@ -373,7 +373,7 @@ export function ProductShippingSection( {
 							Promise< ProductShippingClass >
 						>( values ).then( ( value ) => {
 							invalidateResolution( 'getProductShippingClasses' );
-							selectShippingClassProps?.onChange( value.slug );
+							setValue( 'shipping_class', value.slug );
 							return value;
 						} )
 					}

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -374,6 +374,7 @@ export function ProductShippingSection( {
 							Promise< ProductShippingClass >
 						>( values ).then( ( value ) => {
 							invalidateResolution( 'getProductShippingClasses' );
+							selectShippingClassProps?.onChange( value.slug );
 							return value;
 						} )
 					}

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -34,23 +34,22 @@ import { useProductHelper } from '../use-product-helper';
 import { AddNewShippingClassModal } from '../shared/add-new-shipping-class-modal';
 import { getTextControlProps } from './utils';
 import './product-shipping-section.scss';
+import {
+	ADD_NEW_SHIPPING_CLASS_OPTION_VALUE,
+	UNCATEGORIZED_CATEGORY_SLUG,
+} from '../constants';
 
 export type ProductShippingSectionProps = {
 	product?: PartialProduct;
 };
 
-// This should never be a real slug value of any existing shipping class
-const ADD_NEW_SHIPPING_CLASS_OPTION_VALUE = '__ADD_NEW_SHIPPING_CLASS_OPTION__';
-
-const DEFAULT_SHIPPING_CLASS_OPTIONS: SelectControl.Option[] = [
+export const DEFAULT_SHIPPING_CLASS_OPTIONS: SelectControl.Option[] = [
 	{ value: '', label: __( 'No shipping class', 'woocommerce' ) },
 	{
 		value: ADD_NEW_SHIPPING_CLASS_OPTION_VALUE,
 		label: __( 'Add new shipping class', 'woocommerce' ),
 	},
 ];
-
-const UNCATEGORIZED_CATEGORY_SLUG = 'uncategorized';
 
 function mapShippingClassToSelectOption(
 	shippingClasses: ProductShippingClass[]

--- a/plugins/woocommerce-admin/client/products/sections/test/product-shipping-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/test/product-shipping-section.spec.tsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Form } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { ProductShippingSection } from '../product-shipping-section';
+import { validate } from '../../product-validation';
+import { ADD_NEW_SHIPPING_CLASS_OPTION_VALUE } from '~/products/constants';
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+describe( 'ProductShippingSection', () => {
+	const useSelectMock = useSelect as jest.Mock;
+	const useDispatchMock = useDispatch as jest.Mock;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'when creating a product', () => {
+		describe( 'when creating a shipping class', () => {
+			const newShippingClass = {
+				name: 'New shipping class',
+				slug: 'new-shipping-class',
+			};
+			const createProductShippingClass = jest
+				.fn()
+				.mockReturnValue( Promise.resolve( newShippingClass ) );
+			const invalidateResolution = jest.fn();
+
+			beforeEach( () => {
+				useSelectMock.mockReturnValue( {
+					shippingClasses: [ newShippingClass ],
+					hasResolvedShippingClasses: true,
+				} );
+
+				useDispatchMock.mockReturnValue( {
+					createProductShippingClass,
+					invalidateResolution,
+				} );
+
+				render(
+					<Form initialValues={ {} } validate={ validate }>
+						<ProductShippingSection />
+					</Form>
+				);
+			} );
+
+			it( 'should be selected as the current option', async () => {
+				const select = screen.getByLabelText( 'Shipping class' );
+				act( () =>
+					userEvent.selectOptions(
+						select,
+						ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
+					)
+				);
+
+				const dialog = screen.getByRole( 'dialog' );
+				const addButton = within( dialog ).getByText( 'Add' );
+				await act( async () => userEvent.click( addButton ) );
+
+				expect( select ).toHaveDisplayValue( [
+					newShippingClass.name,
+				] );
+			} );
+		} );
+	} );
+} );

--- a/plugins/woocommerce/changelog/add-35036-select-created-class
+++ b/plugins/woocommerce/changelog/add-35036-select-created-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Select the current new added shipping class


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35036.

### How to test the changes in this Pull Request:

1. Go to the Add new product page
2. Click on `Shipping class` dropdown field
3. Select `Add new shipping class` option from the list
4. From `New shipping class` modal form, add a new shipping class name then click `Add` button.
5. When the modal closed the new shipping class added should be shown as the selected value of the `Shipping class` dropdown.

<video src="https://user-images.githubusercontent.com/13334210/196242399-ac7f38c9-4e6a-41ff-893c-be7db4fbbf56.mov"></video>

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
