### PR TITLE
Replace the trash can icon in the attribute list

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import { ProductAttribute } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
 import { Sortable, ListItem } from '@woocommerce/components';
-import { trash } from '@wordpress/icons';
+import { closeSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -112,7 +112,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 								{ __( 'edit', 'woocommerce' ) }
 							</Button>
 							<Button
-								icon={ trash }
+								icon={ closeSmall }
 								label={ __(
 									'Remove attribute',
 									'woocommerce'

--- a/plugins/woocommerce/changelog/enhancement-35092-replace-trash-icon
+++ b/plugins/woocommerce/changelog/enhancement-35092-replace-trash-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Replace the trash can icon in the attribute list


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35092.

### How to test the changes in this Pull Request:

1. Locate a created product with attributes. 
2. Visit `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}` replace `productId` with your `id`
3. A `close-small` icon should be shown to remove the attribute instead the `trash-can` icon.
 
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/13334210/196259537-54163dbc-0fb8-4bf6-928f-7b3d4a87161a.png">


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
