### PR TITLE
Improve unit test install script for db connection over socket

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-install-script
+++ b/plugins/woocommerce/changelog/fix-test-install-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update unit test install script for db sockets.

--- a/plugins/woocommerce/tests/bin/install.sh
+++ b/plugins/woocommerce/tests/bin/install.sh
@@ -131,7 +131,6 @@ install_test_suite() {
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
 	fi
 
 }
@@ -145,7 +144,7 @@ install_db() {
 	# If we're trying to connect to a socket we want to handle it differently.
 	if [[ "$DB_HOST" == *.sock ]]; then
 		# create database using the socket
-		mysqladmin create $DB_NAME --socket="$DB_HOST"
+		mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS" --socket="$DB_HOST"
 	else
 		# Decide whether or not there is a port.
 		local PARTS=(${DB_HOST//\:/ })

--- a/plugins/woocommerce/tests/bin/install.sh
+++ b/plugins/woocommerce/tests/bin/install.sh
@@ -131,6 +131,11 @@ install_test_suite() {
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		if [[ "$DB_HOST" == *.sock ]]; then
+			sed $ioption "s|localhost|:${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+		else
+			sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+		fi
 	fi
 
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Db scoket used in LocalWP needs a username and password. Additionally, when WP parses the db connection config in `wordpress-tests-lib/wp-tests-config.php`, it won't work if just the path to the socket is supplied, but it needs a `:` character to parse it correctly. Parsing happens over here: https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/class-wpdb.php#L2062-L2067

### How to test the changes in this Pull Request:

1. Install [LocalWP](https://localwp.com/) and create one WP environment, ideally with PHP 7.4 so you can run the tests easily (or if you have any db running over sockets, use that instead)
2. Copy the socket location from the environment you just created:
3. 
![Screenshot 2022-10-18 at 12 16 11](https://user-images.githubusercontent.com/2207451/196403502-7c41bc28-16df-4cf1-8814-55526ea819a3.png)

4. Open the environment shell and symlink your GH WC repo to the new WP environment
![Screenshot 2022-10-18 at 12 17 22](https://user-images.githubusercontent.com/2207451/196403747-500d0fe9-1983-4d81-b2f8-369b84996423.png)

6. Try to run the unit tests, first install script: `cd wp-content/woocommerce && ./tests/bin/install.sh wc_tests root root "/Users/peter/Library/Application Support/Local/run/eV5af8R77/mysql/mysqld.sock"` 
7. It should fail on trunk, but work with this PR
8. Then trying to run the tests via `./tests/bin/phpunit.sh`, on trunk you should get the error below, but it should work with this PR.
```
PHP Warning:  mysqli_real_connect(): (HY000/2002): No such file or directory in /private/var/folders/rh/s6k2nr3s6qnc7bt1zz0glxwr0000gn/T/wordpress/wp-includes/wp-db.php on line 1753

wp_die called
Message: <p><code>No such file or directory</code></p>
<h1>Error establishing a database connection</h1>
<p>This either means that the username and password information in your <code>wp-config.php</code> file is incorrect or that contact with the database server at <code>/Users/peter/Library/Application Support/Local/run/eV5af8R77/mysql/mysqld.sock</code> could not be established. This could mean your host&#8217;s database server is down.</p>
<ul>
<li>Are you sure you have the correct username and password?</li>
<li>Are you sure you have typed the correct hostname?</li>
<li>Are you sure the database server is running?</li>
</ul>
<p>If you are unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="https://wordpress.org/support/forums/">WordPress Support Forums</a>.</p>
```

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
