### PR TITLE
Show a dismissible snackbar if the server responds an error

### DIFF
--- a/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
@@ -4,7 +4,7 @@
 	position: fixed;
 	bottom: $gap-small;
 	left: $admin-menu-width + $gap;
-	z-index: 99999;
+	z-index: calc( z-index( '.components-snackbar-list' ) + 1 );
 	width: auto;
 
 	@media ( max-width: 960px ) {

--- a/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
@@ -4,7 +4,7 @@
 	position: fixed;
 	bottom: $gap-small;
 	left: $admin-menu-width + $gap;
-	z-index: calc( z-index( '.components-snackbar-list' ) + 1 );
+	z-index: calc(z-index('.components-snackbar-list') + 1);
 	width: auto;
 
 	@media ( max-width: 960px ) {

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -139,6 +139,7 @@ export function ProductShippingSection( {
 	const { createProductShippingClass, invalidateResolution } = useDispatch(
 		EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
 	);
+	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	const dimensionProps = {
 		onBlur: () => {
@@ -346,11 +347,26 @@ export function ProductShippingSection( {
 					onAdd={ ( shippingClassValues ) =>
 						createProductShippingClass<
 							Promise< ProductShippingClass >
-						>( shippingClassValues ).then( ( value ) => {
-							invalidateResolution( 'getProductShippingClasses' );
-							setValue( 'shipping_class', value.slug );
-							return value;
-						} )
+						>( shippingClassValues )
+							.then( ( value ) => {
+								invalidateResolution(
+									'getProductShippingClasses'
+								);
+								setValue( 'shipping_class', value.slug );
+								return value;
+							} )
+							.catch( ( error: Error ) => {
+								createErrorNotice(
+									__(
+										'We couldn’t add this shipping class. Try again in a few seconds.',
+										'woocommerce'
+									),
+									{
+										explicitDismiss: true,
+									}
+								);
+								throw error;
+							} )
 					}
 					onCancel={ () => setShowShippingClassModal( false ) }
 				/>

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -70,19 +70,26 @@ function getInterpolatedSizeLabel( mixedString: string ) {
 
 /**
  * This extracts a shipping class from the product categories. Using
- * the first category different to `Uncategorized`.
+ * the first category different to `Uncategorized` and check if the
+ * category was not added to the shipping class list
  *
  * @see https://github.com/woocommerce/woocommerce/issues/34657
- * @param  product The product
+ * @see https://github.com/woocommerce/woocommerce/issues/35037
+ * @param product The product
+ * @param shippingClasses The shipping classes
  * @return The default shipping class
  */
 function extractDefaultShippingClassFromProduct(
-	product: PartialProduct
+	product?: PartialProduct,
+	shippingClasses?: ProductShippingClass[]
 ): Partial< ProductShippingClass > | undefined {
 	const category = product?.categories?.find(
 		( { slug } ) => slug !== UNCATEGORIZED_CATEGORY_SLUG
 	);
-	if ( category ) {
+	if (
+		category &&
+		! shippingClasses?.some( ( { slug } ) => slug === category.slug )
+	) {
 		return {
 			name: category.name,
 			slug: category.slug,
@@ -340,10 +347,10 @@ export function ProductShippingSection( {
 
 			{ showShippingClassModal && (
 				<AddNewShippingClassModal
-					shippingClass={
-						product &&
-						extractDefaultShippingClassFromProduct( product )
-					}
+					shippingClass={ extractDefaultShippingClassFromProduct(
+						product,
+						shippingClasses
+					) }
 					onAdd={ ( shippingClassValues ) =>
 						createProductShippingClass<
 							Promise< ProductShippingClass >

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -42,6 +42,10 @@ export type ProductShippingSectionProps = {
 	product?: PartialProduct;
 };
 
+type ServerErrorResponse = {
+	code: string;
+};
+
 export const DEFAULT_SHIPPING_CLASS_OPTIONS: SelectControl.Option[] = [
 	{ value: '', label: __( 'No shipping class', 'woocommerce' ) },
 	{
@@ -171,6 +175,28 @@ export function ProductShippingSection( {
 			parseNumber( String( value ) ),
 	} );
 	const shippingClassProps = getInputProps( 'shipping_class' );
+
+	function handleShippingClassServerError(
+		error: ServerErrorResponse
+	): Promise< ProductShippingClass > {
+		let message = __(
+			'We couldn’t add this shipping class. Try again in a few seconds.',
+			'woocommerce'
+		);
+
+		if ( error.code === 'term_exists' ) {
+			message = __(
+				'A shipping class with that slug already exists.',
+				'woocommerce'
+			);
+		}
+
+		createErrorNotice( message, {
+			explicitDismiss: true,
+		} );
+
+		throw error;
+	}
 
 	return (
 		<ProductSectionLayout
@@ -362,18 +388,7 @@ export function ProductShippingSection( {
 								setValue( 'shipping_class', value.slug );
 								return value;
 							} )
-							.catch( ( error: Error ) => {
-								createErrorNotice(
-									__(
-										'We couldn’t add this shipping class. Try again in a few seconds.',
-										'woocommerce'
-									),
-									{
-										explicitDismiss: true,
-									}
-								);
-								throw error;
-							} )
+							.catch( handleShippingClassServerError )
 					}
 					onCancel={ () => setShowShippingClassModal( false ) }
 				/>

--- a/plugins/woocommerce-admin/client/products/sections/test/product-shipping-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/test/product-shipping-section.spec.tsx
@@ -39,6 +39,36 @@ describe( 'ProductShippingSection', () => {
 			const invalidateResolution = jest.fn();
 			const createErrorNotice = jest.fn();
 
+			function getShippingClassSelect() {
+				return screen.getByLabelText(
+					__( 'Shipping class', 'woocommerce' )
+				);
+			}
+
+			async function addNewShippingClass(
+				name: string = 'New shipping class'
+			) {
+				const select = getShippingClassSelect();
+
+				act( () =>
+					userEvent.selectOptions(
+						select,
+						ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
+					)
+				);
+
+				const dialog = screen.getByRole( 'dialog' );
+				const inputName = within( dialog ).getByLabelText(
+					__( 'Name', 'woocommerce' )
+				);
+				const buttonAdd = within( dialog ).getByText(
+					__( 'Add', 'woocommerce' )
+				);
+
+				await act( async () => userEvent.type( inputName, name ) );
+				await act( async () => userEvent.click( buttonAdd ) );
+			}
+
 			beforeEach( () => {
 				useSelectMock.mockReturnValue( {
 					shippingClasses: [ newShippingClass ],
@@ -63,17 +93,9 @@ describe( 'ProductShippingSection', () => {
 					newShippingClass
 				);
 
-				const select = screen.getByLabelText( 'Shipping class' );
-				act( () =>
-					userEvent.selectOptions(
-						select,
-						ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
-					)
-				);
+				await addNewShippingClass();
 
-				const dialog = screen.getByRole( 'dialog' );
-				const addButton = within( dialog ).getByText( 'Add' );
-				await act( async () => userEvent.click( addButton ) );
+				const select = getShippingClassSelect();
 
 				expect( select ).toHaveDisplayValue( [
 					newShippingClass.name,
@@ -85,18 +107,7 @@ describe( 'ProductShippingSection', () => {
 					new Error( 'Server Error' )
 				);
 
-				const select = screen.getByLabelText( 'Shipping class' );
-				act( () =>
-					userEvent.selectOptions(
-						select,
-						ADD_NEW_SHIPPING_CLASS_OPTION_VALUE
-					)
-				);
-
-				const dialog = screen.getByRole( 'dialog' );
-				const addButton = within( dialog ).getByText( 'Add' );
-
-				await act( async () => userEvent.click( addButton ) );
+				await addNewShippingClass();
 
 				expect( createErrorNotice ).toHaveBeenNthCalledWith(
 					1,

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -40,6 +40,7 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 			<TextControl
 				{ ...getInputProps( 'name' ) }
 				label={ __( 'Name', 'woocommerce' ) }
+				placeholder={ __( 'e.g. Fragile products', 'woocommerce' ) }
 			/>
 			<TextControl
 				{ ...getInputProps( 'slug' ) }
@@ -116,11 +117,6 @@ export type AddNewShippingClassModalProps = {
 	onCancel: () => void;
 };
 
-const INITIAL_VALUES = {
-	name: __( 'New shipping class', 'woocommerce' ),
-	slug: __( 'new-shipping-class', 'woocommerce' ),
-};
-
 export function AddNewShippingClassModal( {
 	shippingClass,
 	onAdd,
@@ -133,7 +129,7 @@ export function AddNewShippingClassModal( {
 			onRequestClose={ onCancel }
 		>
 			<Form< Partial< ProductShippingClass > >
-				initialValues={ shippingClass ?? INITIAL_VALUES }
+				initialValues={ shippingClass }
 				validate={ validateForm }
 				errors={ {} }
 				onSubmit={ onAdd }

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -117,6 +117,8 @@ export type AddNewShippingClassModalProps = {
 	onCancel: () => void;
 };
 
+const INITIAL_VALUES = { name: '', slug: '', description: '' };
+
 export function AddNewShippingClassModal( {
 	shippingClass,
 	onAdd,
@@ -129,7 +131,7 @@ export function AddNewShippingClassModal( {
 			onRequestClose={ onCancel }
 		>
 			<Form< Partial< ProductShippingClass > >
-				initialValues={ shippingClass }
+				initialValues={ shippingClass ?? INITIAL_VALUES }
 				validate={ validateForm }
 				errors={ {} }
 				onSubmit={ onAdd }

--- a/plugins/woocommerce/changelog/add-35037-error-handling
+++ b/plugins/woocommerce/changelog/add-35037-error-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Show a dismissible snackbar if the server responds an error

--- a/plugins/woocommerce/changelog/add-35037-error-handling
+++ b/plugins/woocommerce/changelog/add-35037-error-handling
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Show a dismissible snackbar if the server responds an error
+Show a dismissible snackbar if the server responds with an error


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35037.

### How to test the changes in this Pull Request:

1. Go to Add new product page
2. If you add a new shipping class you should see a placeholder: `e.g. Fragile products` in the name field of the Shipping Class dialog
3. Add a category to the product and then publish it.
4. When editing that product and try to add a new shipping class the first time in the shipping class name and slug fields of the Shipping Class dialog should be filled with the name and slug of the first product category.
5. If you added that new shipping class with the prefilled category data and try to add a new shipping class again then no prefilled name and slug should happend anymore per product edition.

<video src="https://user-images.githubusercontent.com/13334210/196699024-f4761ef7-630e-4604-98c8-19023bfd0e29.mov"></video>

6. If you try to add a new shipping class with any of the previous added slugs you should see a snackbar error with this message: `We couldn’t add this shipping class. Try again in a few seconds.`

<video src="https://user-images.githubusercontent.com/13334210/196705438-676997dc-28ef-4a24-a2eb-efe2556a8107.mov"></video>

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
