### PR TITLE
Add inventory advanced section

### DIFF
--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
@@ -11,7 +11,8 @@
 		text-transform: none;
 	}
 
-	.components-card__body h4:first-child {
+	.components-card__body h4:first-child,
+	.components-radio-control:first-child .components-base-control__label {
 		margin-top: 0;
 	}
 

--- a/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-section-layout.scss
@@ -32,6 +32,10 @@
 		.components-radio-control .components-v-stack {
 			gap: $gap-small;
 		}
+
+		.woocommerce-collapsible-content {
+			margin-top: $gap-large;
+		}
 	}
 
 	&__header {

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/advanced-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/advanced-stock-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { CheckboxControl, RadioControl } from '@wordpress/components';
 import { Product } from '@woocommerce/data';
 import { useFormContext } from '@woocommerce/components';
 
@@ -12,10 +12,41 @@ import { useFormContext } from '@woocommerce/components';
 import { getCheckboxProps } from '../utils';
 
 export const AdvancedStockSection: React.FC = () => {
-	const { getInputProps } = useFormContext< Product >();
+	const { getInputProps, values } = useFormContext< Product >();
+
+	const backordersProp = getInputProps( 'backorders' );
+	// These properties cause issues with the RadioControl component.
+	// A fix to form upstream would help if we can identify what type of input is used.
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	delete backordersProp.checked;
+	delete backordersProp.value;
 
 	return (
 		<>
+			{ values.manage_stock && (
+				<RadioControl
+					label={ __( 'When out of stock', 'woocommerce' ) }
+					options={ [
+						{
+							label: __( 'Allow purchases', 'woocommerce' ),
+							value: 'yes',
+						},
+						{
+							label: __(
+								'Allow purchases, but notify customers',
+								'woocommerce'
+							),
+							value: 'notify',
+						},
+						{
+							label: __( "Don't allow purchases", 'woocommerce' ),
+							value: 'no',
+						},
+					] }
+					{ ...backordersProp }
+				/>
+			) }
 			<h4>{ __( 'Restrictions', 'woocommerce' ) }</h4>
 			<CheckboxControl
 				label={ __(

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/advanced-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/advanced-stock-section.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { Product } from '@woocommerce/data';
+import { useFormContext } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { getCheckboxProps } from '../utils';
+
+export const AdvancedStockSection: React.FC = () => {
+	const { getInputProps } = useFormContext< Product >();
+
+	return (
+		<>
+			<h4>{ __( 'Restrictions', 'woocommerce' ) }</h4>
+			<CheckboxControl
+				label={ __(
+					'Limit purchases to 1 item per order',
+					'woocommerce'
+				) }
+				{ ...getCheckboxProps( {
+					...getInputProps( 'sold_individually' ),
+				} ) }
+			/>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/advanced-stock-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/advanced-stock-section.tsx
@@ -9,10 +9,11 @@ import { useFormContext } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { getCheckboxProps } from '../utils';
+import { getCheckboxTracks } from '../utils';
 
 export const AdvancedStockSection: React.FC = () => {
-	const { getInputProps, values } = useFormContext< Product >();
+	const { getCheckboxControlProps, getInputProps, values } =
+		useFormContext< Product >();
 
 	const backordersProp = getInputProps( 'backorders' );
 	// These properties cause issues with the RadioControl component.
@@ -53,9 +54,10 @@ export const AdvancedStockSection: React.FC = () => {
 					'Limit purchases to 1 item per order',
 					'woocommerce'
 				) }
-				{ ...getCheckboxProps( {
-					...getInputProps( 'sold_individually' ),
-				} ) }
+				{ ...getCheckboxControlProps(
+					'sold_individually',
+					getCheckboxTracks( 'sold_individually' )
+				) }
 			/>
 		</>
 	);

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/product-inventory-section.tsx
@@ -3,14 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	CollapsibleContent,
 	__experimentalConditionalWrapper as ConditionalWrapper,
 	Link,
 	useFormContext,
 } from '@woocommerce/components';
-import { cloneElement } from '@wordpress/element';
-import { getAdminLink } from '@woocommerce/settings';
-import { Product } from '@woocommerce/data';
-import { recordEvent } from '@woocommerce/tracks';
 import {
 	Card,
 	CardBody,
@@ -18,10 +15,14 @@ import {
 	TextControl,
 	Tooltip,
 } from '@wordpress/components';
+import { getAdminLink } from '@woocommerce/settings';
+import { Product } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
+import { AdvancedStockSection } from './advanced-stock-section';
 import { getCheckboxTracks } from '../utils';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { ProductSectionLayout } from '../../layout/product-section-layout';
@@ -109,6 +110,11 @@ export const ProductInventorySection: React.FC = () => {
 					) : (
 						<ManualStockSection />
 					) }
+					<CollapsibleContent
+						toggleText={ __( 'Advanced', 'woocommerce' ) }
+					>
+						<AdvancedStockSection />
+					</CollapsibleContent>
 				</CardBody>
 			</Card>
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/test/product-inventory-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/test/product-inventory-section.spec.tsx
@@ -76,7 +76,7 @@ describe( 'ProductInventorySection', () => {
 		).toHaveClass( 'is-disabled' );
 	} );
 
-	it( 'should not render the manage stock section if inventory management is turned on', () => {
+	it( 'should not disable the manage stock section if inventory management is turned on', () => {
 		render(
 			<Form initialValues={ product }>
 				<ProductInventorySection />
@@ -84,8 +84,9 @@ describe( 'ProductInventorySection', () => {
 		);
 
 		expect(
-			screen.getByLabelText( 'Track quantity for this product' )
-		).toBeInTheDocument();
+			screen.getByText( 'Track quantity for this product' )
+				.previousSibling
+		).not.toHaveClass( 'is-disabled' );
 	} );
 
 	it( 'should render the quantity field when product stock is being managed', () => {

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/test/product-inventory-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/test/product-inventory-section.spec.tsx
@@ -23,7 +23,7 @@ describe( 'ProductInventorySection', () => {
 		( getAdminSetting as jest.Mock ).mockImplementation(
 			( key, value = false ) => {
 				const values = {
-					manage_stock: 'yes',
+					manageStock: 'yes',
 					notifyLowStockAmount: 5,
 				};
 				if ( values.hasOwnProperty( key ) ) {
@@ -53,10 +53,16 @@ describe( 'ProductInventorySection', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should not render the manage stock section if inventory management is turned off', () => {
-		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
-			manage_stock: 'no',
-		} ) );
+	it( 'should disable the manage stock section if inventory management is turned off', () => {
+		( getAdminSetting as jest.Mock ).mockImplementation( ( key, value ) => {
+			const values = {
+				manageStock: 'no',
+			};
+			if ( values.hasOwnProperty( key ) ) {
+				return values[ key as keyof typeof values ];
+			}
+			return value;
+		} );
 
 		render(
 			<Form initialValues={ product }>
@@ -65,8 +71,9 @@ describe( 'ProductInventorySection', () => {
 		);
 
 		expect(
-			screen.queryByLabelText( 'Track quantity for this product' )
-		).not.toBeInTheDocument();
+			screen.getByText( 'Track quantity for this product' )
+				.previousSibling
+		).toHaveClass( 'is-disabled' );
 	} );
 
 	it( 'should not render the manage stock section if inventory management is turned on', () => {

--- a/plugins/woocommerce-admin/client/products/sections/product-inventory-section/test/product-inventory-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-inventory-section/test/product-inventory-section.spec.tsx
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import { Form } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '~/utils/admin-settings';
+import { ProductInventorySection } from '../';
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+jest.mock( '~/utils/admin-settings', () => ( {
+	getAdminSetting: jest.fn(),
+} ) );
+
+describe( 'ProductInventorySection', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( getAdminSetting as jest.Mock ).mockImplementation(
+			( key, value = false ) => {
+				const values = {
+					manage_stock: 'yes',
+					notifyLowStockAmount: 5,
+				};
+				if ( values.hasOwnProperty( key ) ) {
+					return values[ key as keyof typeof values ];
+				}
+				return value;
+			}
+		);
+	} );
+
+	const product: Partial< Product > = {
+		id: 1,
+		name: 'Lorem',
+		slug: 'lorem',
+		manage_stock: false,
+	};
+
+	it( 'should render the sku field', () => {
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.getByLabelText( 'SKU (Stock Keeping Unit)' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render the manage stock section if inventory management is turned off', () => {
+		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
+			manage_stock: 'no',
+		} ) );
+
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.queryByLabelText( 'Track quantity for this product' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render the manage stock section if inventory management is turned on', () => {
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.getByLabelText( 'Track quantity for this product' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the quantity field when product stock is being managed', () => {
+		render(
+			<Form initialValues={ { ...product, manage_stock: true } }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.getByLabelText( 'Current quantity' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render the quantity field when product stock is not being managed', () => {
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.queryByLabelText( 'Current quantity' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the default low stock amount in placeholder', () => {
+		render(
+			<Form initialValues={ { ...product, manage_stock: true } }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.getByPlaceholderText( '5 (store default)' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render the advanced section until clicked', () => {
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		expect(
+			screen.queryByLabelText( 'Limit purchases to 1 item per order' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the advanced section after clicked', () => {
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		userEvent.click( screen.getByText( 'Advanced' ) );
+		expect(
+			screen.getByLabelText( 'Limit purchases to 1 item per order' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not allow backorder settings when not managing stock', () => {
+		render(
+			<Form initialValues={ product }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		userEvent.click( screen.getByText( 'Advanced' ) );
+		expect(
+			screen.queryByText( 'When out of stock' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should allow backorder settings when managing stock', () => {
+		render(
+			<Form initialValues={ { ...product, manage_stock: true } }>
+				<ProductInventorySection />
+			</Form>
+		);
+
+		userEvent.click( screen.getByText( 'Advanced' ) );
+		expect( screen.queryByText( 'When out of stock' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/changelog/add-34389
+++ b/plugins/woocommerce/changelog/add-34389
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product inventory advanced section


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds the advanced section for product inventory management.  Note that some styling changes around radios and radio labels exist in https://github.com/woocommerce/woocommerce/pull/35047.
<img width="464" alt="Screen Shot 2022-10-18 at 3 46 51 PM" src="https://user-images.githubusercontent.com/10561050/196559686-505ce94d-68b3-4e17-89c8-aeb360907960.png">



Closes #34389  .

### How to test the changes in this Pull Request:

1. Enable/disable the stock management for products at `wp-admin/admin.php?page=wc-settings&tab=products&section=inventory`
2. Under the product page (Products -> Add new (MVP)), click "Advanced" in the inventory section
3. Note that when stock management is enabled, the "out of stock" options exist
4. Note that in both cases, the limit 1 per purchase checkbox exists

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> run changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
