### PR TITLE
Improve the warnings about incompatibilites between plugins and features

### DIFF
--- a/plugins/woocommerce/changelog/improve-plugin-feature-compatibility-warnings
+++ b/plugins/woocommerce/changelog/improve-plugin-feature-compatibility-warnings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve the warnings about incompatibilities between plugins and features

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -255,13 +255,15 @@ SELECT(
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		switch ( $type ) {
 			case self::ID_TYPE_MISSING_IN_ORDERS_TABLE:
-				$sql = "
+				$sql = $wpdb->prepare("
 SELECT posts.ID FROM $wpdb->posts posts
 LEFT JOIN $orders_table orders ON posts.ID = orders.id
 WHERE
   posts.post_type IN ($order_post_type_placeholders)
   AND posts.post_status != 'auto-draft'
-  AND orders.id IS NULL";
+  AND orders.id IS NULL",
+					$order_post_types
+				);
 				break;
 			case self::ID_TYPE_MISSING_IN_POSTS_TABLE:
 				$sql = "

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
@@ -68,6 +69,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	public function __construct() {
 		self::add_action( 'deleted_post', array( $this, 'handle_deleted_post' ), 10, 2 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
+		self::add_filter( 'woocommerce_feature_description_tip', array( $this, 'handle_feature_description_tip' ), 10, 3 );
 	}
 
 	/**
@@ -421,5 +423,70 @@ WHERE
 		if ( ! $this->custom_orders_table_is_authoritative() && $this->data_sync_is_enabled() ) {
 			$this->posts_to_cot_migrator->migrate_orders( array( $order_id ) );
 		}
+	}
+
+	/**
+	 * Handle the 'woocommerce_feature_description_tip' filter.
+	 *
+	 * When the COT feature is enabled and there are orders pending sync (in either direction),
+	 * show a "you should ync before disabling" warning under the feature in the features page.
+	 * Skip this if the UI prevents changing the feature enable status.
+	 *
+	 * @param string $desc_tip The original description tip for the feature.
+	 * @param string $feature_id The feature id.
+	 * @param bool   $ui_disabled True if the UI doesn't allow to enable or disable the feature.
+	 * @return string The new description tip for the feature.
+	 */
+	private function handle_feature_description_tip( $desc_tip, $feature_id, $ui_disabled ): string {
+		if ( 'custom_order_tables' !== $feature_id || $ui_disabled ) {
+			return $desc_tip;
+		}
+
+		$features_controller = wc_get_container()->get( FeaturesController::class );
+		$feature_is_enabled  = $features_controller->feature_is_enabled( 'custom_order_tables' );
+		if ( ! $feature_is_enabled ) {
+			return $desc_tip;
+		}
+
+		$pending_sync_count = $this->get_current_orders_pending_sync_count();
+		if ( ! $pending_sync_count ) {
+			return $desc_tip;
+		}
+
+		if ( $this->custom_orders_table_is_authoritative() ) {
+			$extra_tip = sprintf(
+				_n(
+					"⚠ There's one order pending sync from the orders table to the posts table. The feature shouldn't be disabled until this order is synchronized.",
+					"⚠ There are %1\$d orders pending sync from the orders table to the posts table. The feature shouldn't be disabled until these orders are synchronized.",
+					$pending_sync_count,
+					'woocommerce'
+				),
+				$pending_sync_count
+			);
+		} else {
+			$extra_tip = sprintf(
+				_n(
+					"⚠ There's one order pending sync from the posts table to the orders table. The feature shouldn't be disabled until this order is synchronized.",
+					"⚠ There are %%1\$d orders pending sync from the posts table to the orders table. The feature shouldn't be disabled until these orders are synchronized.",
+					$pending_sync_count,
+					'woocommerce'
+				),
+				$pending_sync_count
+			);
+		}
+
+		$cot_settings_url = add_query_arg(
+			array(
+				'page'    => 'wc-settings',
+				'tab'     => 'advanced',
+				'section' => 'custom_data_stores',
+			),
+			admin_url( 'admin.php' )
+		);
+
+		/* translators: %s = URL of the custom data stores settings page */
+		$manage_cot_settings_link = sprintf( __( "<a href='%s'>Manage orders synchronization</a>", 'woocommerce' ), $cot_settings_url );
+
+		return $desc_tip ? "{$desc_tip}<br/>{$extra_tip} {$manage_cot_settings_link}" : "{$extra_tip} {$manage_cot_settings_link}";
 	}
 }

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -656,6 +656,18 @@ class FeaturesController {
 			}
 		}
 
+		/**
+		 * Filter to customize the description tip that appears under the description of each feature in the features settings page.
+		 *
+		 * @since 7.1.0
+		 *
+		 * @param string $desc_tip The original description tip.
+		 * @param string $feature_id The id of the feature for which the description tip is being customized.
+		 * @param bool $disabled True if the UI currently prevents changing the enable/disable status of the feature.
+		 * @return string The new description tip to use.
+		 */
+		$desc_tip = apply_filters( 'woocommerce_feature_description_tip', $desc_tip, $feature_id, $disabled );
+
 		return array(
 			'title'    => $feature['name'],
 			'desc'     => $description,


### PR DESCRIPTION
-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. Introduce a new filter, `woocommerce_feature_description_tip`, that allows customizing the message that appears under the description of each feature in the features settings page.

2. Use the new filter to show a warning under the custom orders table feature if the feature is enabled and there are orders pending synchronization (since it's not really a good idea to disable the feature in this case).

3. Change the styling of the "WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features" notice from warning to error.

4. Display the above error in all the admin pages, except in the plugins page when we are already displaying the "You are viewing plugins that are incompatible with..." notice (since it's redundant in this case).

Related to (but doesn't close): https://github.com/woocommerce/woocommerce/issues/35097

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1.  Enable the COT feature but disable sync, and modify one or more orders. Alternatively, change `DataSynchronizer::handle_feature_description_tip` so that `$pending_sync_count` gets a fixed value.

2. Go to the features page and you should see a warning under the description of the feature:

![image](https://user-images.githubusercontent.com/937723/196719304-4ee71c9e-3fe1-4891-9525-28aa89ff2cd5.png)

Note that the message changes depending on which is the authoritative table and on whether the number of orders pending sync is one or more.

3. Force enable a plugin that is incompatible with the COT feature  (e.g. `wp plugin activate woocommerce-bookings` from CLI)

4. Make sure that you see the "WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features" warning from any admin page, and styled as an error:

![image](https://user-images.githubusercontent.com/937723/196719939-3e43e2a5-4e61-4f2c-b3bb-cc06ec4967df.png)

5. Click "Review the details" in the error and verify that in the plugins page you are redirected to you see the "You are viewing plugins that are incompatible with currently enabled WooCommerce features" notice but _not_ the previous error. However if you go to the "All" view you will see the error again.

![image](https://user-images.githubusercontent.com/937723/196720748-c761da31-8de4-47c0-a25d-57cb42c82188.png)

7. Add `&feature_id=custom_order_tables` to the url and reload, the notice should mention the COT feature this time, but the error should still not be here.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
