### PR TITLE
Add summary field to new product experience

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -47,6 +47,9 @@ export const ProductDetailsSection: React.FC = () => {
 	const [ descriptionBlocks, setDescriptionBlocks ] = useState<
 		BlockInstance[]
 	>( parse( values.description || '' ) );
+	const [ summaryBlocks, setSummaryBlocks ] = useState< BlockInstance[] >(
+		parse( values.short_description || '' )
+	);
 	const { permalinkPrefix, permalinkSuffix } = useSelect(
 		( select: WCDataSelector ) => {
 			const { getPermalinkParts } = select( PRODUCTS_STORE_NAME );
@@ -190,6 +193,17 @@ export const ProductDetailsSection: React.FC = () => {
 							}
 						/>
 					) }
+					<RichTextEditor
+						label={ __( 'Summary', 'woocommerce' ) }
+						blocks={ summaryBlocks }
+						onChange={ ( blocks ) => {
+							setSummaryBlocks( blocks );
+							setValue(
+								'short_description',
+								serialize( blocks )
+							);
+						} }
+					/>
 					<RichTextEditor
 						label={ __( 'Description', 'woocommerce' ) }
 						blocks={ descriptionBlocks }

--- a/plugins/woocommerce/changelog/add-35165
+++ b/plugins/woocommerce/changelog/add-35165
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add summary to new product page experience


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the summary field to the new product page experience.

Closes #35165 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Visit the new experience (Products-> Add new (MVP))
2. Add some content to the summary field
3. Publish the product
4. Make sure the data persists on refresh

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
