### PR TITLE
Site Health: Add WC-specific criteria for persistent object cache

### DIFF
--- a/plugins/woocommerce/changelog/add-site-health-cache
+++ b/plugins/woocommerce/changelog/add-site-health-cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WC-specific criteria to the Site Health test for persistent object caches

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -67,6 +67,7 @@ class Loader {
 		Translations::get_instance();
 		WCAdminUser::get_instance();
 		Settings::get_instance();
+		SiteHealth::get_instance();
 		SystemStatusReport::get_instance();
 
 		wc_get_container()->get( Reviews::class );

--- a/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
+++ b/plugins/woocommerce/src/Internal/Admin/SiteHealth.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Customize Site Health recommendations for WooCommerce.
+ */
+
+namespace Automattic\WooCommerce\Internal\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * SiteHealth class.
+ */
+class SiteHealth {
+	/**
+	 * Class instance.
+	 *
+	 * @var SiteHealth instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Hook into WooCommerce.
+	 */
+	public function __construct() {
+		add_filter( 'site_status_should_suggest_persistent_object_cache', array( $this, 'should_suggest_persistent_object_cache' ) );
+	}
+
+	/**
+	 * Counts specific types of WooCommerce entities to determine if a persistent object cache would be beneficial.
+	 *
+	 * Note that if all measured WooCommerce entities are below their thresholds, this will return null so that the
+	 * other normal WordPress checks will still be run.
+	 *
+	 * @param true|null $check A non-null value will short-circuit WP's normal tests for this.
+	 *
+	 * @return true|null True if the store would benefit from a persistent object cache. Otherwise null.
+	 */
+	public function should_suggest_persistent_object_cache( $check ) {
+		// Skip this if some other filter has already determined yes.
+		if ( true === $check ) {
+			return $check;
+		}
+
+		$thresholds = array(
+			'orders'   => 100,
+			'products' => 100,
+		);
+
+		foreach ( $thresholds as $key => $threshold ) {
+			try {
+				switch ( $key ) {
+					case 'orders':
+						$orders_query   = new \WC_Order_Query(
+							array(
+								'status'   => 'any',
+								'limit'    => 1,
+								'paginate' => true,
+								'return'   => 'ids',
+							)
+						);
+						$orders_results = $orders_query->get_orders();
+						if ( $orders_results->total >= $threshold ) {
+							$check = true;
+						}
+						break;
+
+					case 'products':
+						$products_query   = new \WC_Product_Query(
+							array(
+								'status'   => 'any',
+								'limit'    => 1,
+								'paginate' => true,
+								'return'   => 'ids',
+							)
+						);
+						$products_results = $products_query->get_products();
+						if ( $products_results->total >= $threshold ) {
+							$check = true;
+						}
+						break;
+				}
+			} catch ( \Exception $exception ) {
+				break;
+			}
+
+			if ( ! is_null( $check ) ) {
+				break;
+			}
+		}
+
+		return $check;
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

WP 6.1 [introduced](https://make.wordpress.org/core/2022/10/06/new-cache-site-health-checks-in-wordpress-6-1/) a new test in the Site Health module for whether the site has an external object cache, and if not, whether it would benefit from having one. However, the criteria it uses are based largely on posts, terms, and comments. This introduces WooCommerce-specific criteria based on orders and products. It uses much lower numbers for the thresholds (100 instead of 1000). These thresholds are somewhat arbitrary, but reflect that the data objects in a WooCommerce store are larger and more complex than in a simple blog.

The default WP test, notably, always returns `true` (i.e. will recommend using a persistent object cache) if the site is part of a multisite network, presumably because of the extra complexity and lower performance that comes with each site having its own set of database tables. One alternative we could explore here would be to also always return `true` when WooCommerce is installed, regardless of how many orders or products there are. It might be a bit overkill, but on the other hand, a merchant might be better off knowing about the benefits of persistent object caches when they first start their store, rather than after it's already established with >100 orders, especially if using a POC would mean switching to a different host.

Additional context: p7bje6-4pT-p2

### How to test the changes in this Pull Request:

1. Ensure your testing environment does not already have a persistent object cache activated.
1. You may need to do a `composer dump-autoload` after you've checked this branch out so that the autoloader class map will update to include the new SiteHealth.php file.
3. Even though you're probably using a local development environment to test this, make sure that the `WP_ENVIRONMENT_TYPE` constant is defined in wp-config.php and set to `production`. The persistent object cache test only runs in this environment type.
4. If you don't want to generate 100+ orders or products in your test site, you can modify either or both of the items in the `$thresholds` array in the new SiteHealth.php file to a lower number in order to see the result of crossing the threshold.
5. Once you have enough orders and/or products to cross one of the thresholds, open your WP Admin and go to Tools > Site Health. You should see an item about persistent object caches under "recommended improvements":
![poc](https://user-images.githubusercontent.com/916023/196827209-5a01433e-67c1-447e-ae49-f6f4586a2407.jpg)
6. Now if you adjust the thresholds so that your orders and products _do not_ cross them, you should see an item about persistent object caches under "Passed tests".

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.