### PR TITLE
Check before getting order classname to see if it exists.

### DIFF
--- a/plugins/woocommerce/changelog/fix-warning_order
+++ b/plugins/woocommerce/changelog/fix-warning_order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check whether order has classname before returning.

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -233,7 +233,7 @@ class WC_Order_Factory {
 	 */
 	private static function get_class_name_for_order_id( $order_id ) {
 		$classname = self::get_class_names_for_order_ids( array( $order_id ) );
-		return $classname[ $order_id ];
+		return $classname[ $order_id ] ?? false;
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1822,4 +1822,15 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$this->sut->read_multiple( $orders );
 		$this->assertFalse( $should_sync_callable->call( $this->sut, $order ) );
 	}
+
+	/**
+	 * @testDox Make sure get_order return false when checking an order of different order types without warning.
+	 */
+	public function test_get_order_with_id_for_different_type() {
+		$this->toggle_cot( true );
+		$this->disable_cot_sync();
+		$product = new \WC_Product();
+		$product->save();
+		$this->assertFalse( wc_get_order( $product->get_id() ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We were not checking whether a class name existed for an order before returning. This was fine with CPT because then post_id will have presumably have some status, but it's not necessary with COT. 

This PR fixes this by adding a check whether a class name exists for an order.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->


### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. With COT as authoritative and sync disable, open the edit screen for any product.
2. Without this PR you will get a warning in the logs, with this PR it will go away.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
