### PR TITLE
Update shipping label banner add meta boxes function

### DIFF
--- a/plugins/woocommerce/changelog/fix-35211_shipping_label_banner_add_meta_boxes_function
+++ b/plugins/woocommerce/changelog/fix-35211_shipping_label_banner_add_meta_boxes_function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update ShippingLabelBanner add_meta_box action to only trigger on shop_order pages and remove deprecated function call.

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -46,7 +46,7 @@ class ShippingLabelBanner {
 			}
 
 			if ( class_exists( Jetpack_Connection_Manager::class ) ) {
-				$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
+				$jetpack_connected = ( new Jetpack_Connection_Manager() )->has_connected_owner();
 			}
 
 			if ( class_exists( '\WC_Connect_Loader' ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -82,6 +82,9 @@ class ShippingLabelBanner {
 	 * @param \WP_Post $post Current post object.
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
+		if ( $post_type !== 'shop_order' ) {
+			return;
+		}
 		$order = wc_get_order( $post );
 		if ( $this->should_show_meta_box() ) {
 			add_meta_box(

--- a/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
+++ b/plugins/woocommerce/src/Internal/Admin/ShippingLabelBanner.php
@@ -82,7 +82,7 @@ class ShippingLabelBanner {
 	 * @param \WP_Post $post Current post object.
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
-		if ( $post_type !== 'shop_order' ) {
+		if ( 'shop_order' !== $post_type ) {
 			return;
 		}
 		$order = wc_get_order( $post );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the ShippingLabelBanner class to only run `add_meta_boxes` action when on a `shop_order` page. I also updated the Jetpack connected function call as `is_active()` has be deprecated for quite some time and this meta box only gets shown if Jetpack is on the latest version.

Closes #35211  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

We should check if the banner still shows, it would look like this:
<img width="1372" alt="Screen Shot 2022-10-20 at 12 13 58 PM" src="https://user-images.githubusercontent.com/2240960/196990173-59b3dea5-aea9-4609-9560-8cae645b47f5.png">


1. The easiest would be to load up a Jurassic site with a zip of this branch: `pnpm --filter=woocommerce build:zip`, unless you have a local version of WooCommerce setup with a connected Jetpack site.
2. Make sure your store is in the USA and the currency is USD, if you click the **Personalize your store** task you can add sample products (which will include shippable products)
3. Create an order with a shippable product (ex: Hoodie)
4. The banner should show up if you are on the edit order page and these criteria are met:
- Jetpack is up to date and you are connected (this includes the user being connected)
- None of the UPS, Fedex, ShippingEasy, or ShipStation shipping plugins are installed
- Your store is in the USA and the currency is USD
- WooCommerce Shipping is not installed or it is installed but the Terms of Service hasn't been accepted (probably easier to just not have it installed) 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
