### PR TITLE
Revert change that auto collapses the short description field

### DIFF
--- a/plugins/woocommerce/changelog/fix-33537_revert_closing_short_description_by_default
+++ b/plugins/woocommerce/changelog/fix-33537_revert_closing_short_description_by_default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert change that auto collapses the product short description field.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -24,11 +24,6 @@ class WC_Admin_Meta_Boxes {
 	public const ERROR_STORE = 'woocommerce_meta_box_errors';
 
 	/**
-	 * The css class used to close the meta box
-	 */
-	private const CLOSED_CSS_CLASS = 'closed';
-
-	/**
 	 * Is meta boxes saved once?
 	 *
 	 * @var boolean
@@ -138,8 +133,6 @@ class WC_Admin_Meta_Boxes {
 		add_meta_box( 'woocommerce-product-data', __( 'Product data', 'woocommerce' ), 'WC_Meta_Box_Product_Data::output', 'product', 'normal', 'high' );
 		add_meta_box( 'woocommerce-product-images', __( 'Product gallery', 'woocommerce' ), 'WC_Meta_Box_Product_Images::output', 'product', 'side', 'low' );
 
-		add_filter( 'postbox_classes_product_postexcerpt', array( $this, 'collapse_postexcerpt' ) );
-
 		// Orders.
 		foreach ( wc_get_order_types( 'order-meta-boxes' ) as $type ) {
 			$order_type_object = get_post_type_object( $type );
@@ -153,18 +146,6 @@ class WC_Admin_Meta_Boxes {
 		if ( 'comment' === $screen_id && isset( $_GET['c'] ) && metadata_exists( 'comment', wc_clean( wp_unslash( $_GET['c'] ) ), 'rating' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_meta_box( 'woocommerce-rating', __( 'Rating', 'woocommerce' ), 'WC_Meta_Box_Product_Reviews::output', 'comment', 'normal', 'high' );
 		}
-	}
-
-	/**
-	 * Collapse product short description meta box by default
-	 *
-	 * @param array $classes The css class array applied to the meta box.
-	 */
-	public function collapse_postexcerpt( $classes ) {
-		if ( ! in_array( self::CLOSED_CSS_CLASS, $classes, true ) ) {
-			array_push( $classes, self::CLOSED_CSS_CLASS );
-		}
-		return $classes;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change reverts a change added as part of this issue's requirement originally that auto collapses the product short description ([original PR](https://github.com/woocommerce/woocommerce/pull/34619)).
[From user feedback received](https://github.com/woocommerce/woocommerce/issues/33537#issuecomment-1282384608), the short description is quite popular and having to expand it each time is more of a time cost instead of saving.

Closes #33537  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, run `pnpm run build`
2. Go to **Products > Add New** or edit an existing product
3. Scrolld own and check if the **Product short description** is expanded by default.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
