### PR TITLE
Declare npm registry when setting up node to allow NPM auth to work

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -36,7 +36,6 @@ runs:
         node-version-file: .nvmrc
         cache: pnpm
         registry-url: 'https://registry.npmjs.org'
-        node-version: '16.x'
     
     - name: Setup PHP
       uses: shivammathur/setup-php@e04e1d97f0c0481c6e1ba40f8a538454fe5d7709

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -35,6 +35,8 @@ runs:
       with:
         node-version-file: .nvmrc
         cache: pnpm
+        registry-url: 'https://registry.npmjs.org'
+        node-version: '16.x'
     
     - name: Setup PHP
       uses: shivammathur/setup-php@e04e1d97f0c0481c6e1ba40f8a538454fe5d7709


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we consolidated the monorepo setup in https://github.com/woocommerce/woocommerce/pull/34607 we missed that it would break auth for publishing to NPM. Right now trying to publish packages causes a `ENEEDSAUTH` error.

It's required that you pass in `registry-url` to the `setup-node` action. This is what causes the `.npmrc` file to be correctly generated with the auth token we set. @psealock recognized this when he implemented the manual workflow the first time around, but we obviously missed migrating that across to the monorepo setup script. Docs about this [are here](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I'm not certain of an easy way to test these changes. I think it would be a lot of effort to test properly since you need a dummy NPM account to publish to.

I suggest since these changes won't cause harm, that we should merge them then test by running the workflow (this is a manually run workflow so it won't interrupt any CI or other stuff).
<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
