### PR TITLE
In shopping Product page dropdown misaligned css update

### DIFF
--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -348,6 +348,9 @@ $tt2-gray: #f7f7f7;
 
 				th {
 					padding-right: 1rem;
+					max-width: 100px; 
+					width: 100%; 
+					text-align: right;
 				}
 
 				td select {


### PR DESCRIPTION
I have fixed this issue as mentioned in #31686
For Twenty Twenty-two theme,"Dropdown" option is misaligned on "Variable Product" page.

