### PR TITLE
fix/35250: Moved `woocommerce_before_delete_order` before order data deleted from the custom order tables.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35250
+++ b/plugins/woocommerce/changelog/fix-35250
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Moved hook `woocommerce_before_delete_order` before delete order data from custom order tables.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1703,14 +1703,6 @@ FROM $order_meta_table
 		}
 
 		if ( ! empty( $args['force_delete'] ) ) {
-			$this->delete_order_data_from_custom_order_tables( $order_id );
-			$order->set_id( 0 );
-
-			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
-			if ( ! is_a( $order->get_data_store(), self::class ) ) {
-				return;
-			}
-
 			/**
 			 * Fires immediately before an order is deleted from the database.
 			 *
@@ -1720,6 +1712,14 @@ FROM $order_meta_table
 			 * @param WC_Order $order    Instance of the order that is about to be deleted.
 			 */
 			do_action( 'woocommerce_before_delete_order', $order_id, $order );
+
+			$this->delete_order_data_from_custom_order_tables( $order_id );
+			$order->set_id( 0 );
+
+			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
+			if ( ! is_a( $order->get_data_store(), self::class ) ) {
+				return;
+			}
 
 			// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
 			// Once we stop creating posts for orders, we should do the cleanup here instead.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:
As described in #35250, `woocommerce_before_delete_order` action should fire before order data is deleted from custom tables. This PR contains minor changes for move action hook before the order data get deleted from the custom tables.


Closes #35250 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Make sure HPOS is enabled.
2. Add the below snippet in theme's functions.php
```php
add_action( 'woocommerce_before_delete_order', function ( int $order_id ) {
	wc_get_logger()->info( "woocommerce_before_delete_order fired for order #{$order_id}." );
} );
```
3. Go to `WooCommece` > `Orders`
4. Permentatley delete the order
5. See logs and confirm that the log is there.


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
