### PR TITLE
Fix DateTimePickerControl suffix style

### DIFF
--- a/packages/js/components/changelog/fix-date-time-picker-control-suffix-style
+++ b/packages/js/components/changelog/fix-date-time-picker-control-suffix-style
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Just a minor tweak to the CSS for the DateTimePickerControl suffix.
+
+

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
@@ -1,8 +1,8 @@
 .woocommerce-date-time-picker-control {
 	display: block;
 
-	.woocommerce-date-time-picker-control__input-control__suffix {
-		padding-right: 8px;
+	.components-input-control__suffix {
+		margin-right: 8px;
 	}
 
 	.components-datetime__date {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the styling of the DateTimePickerControl's suffix to use `margin` instead of `padding`. Margin is more correct, and will make the styling of the DateTimePickerControl more robust when used in a variety of scenarios.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Interact with Storybook stories and make sure DateTimePickerControl's suffix (the calendar icon) looks correct: `pnpm --filter=@woocommerce/storybook storybook`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
