### PR TITLE
Update WooCommerce Blocks package to 8.7.4

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Comment: Update WooCommerce Blocks to 8.7.4

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.7.3"
+		"woocommerce/woocommerce-blocks": "8.7.4"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01f8810be9f7fc1f6404f4e02a59f10c",
+    "content-hash": "9d9a10e340f2c9d2366a082eb3b91344",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.7.3",
+            "version": "v8.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "6c3c5d5c7312bcd6c6fac1d9a96ae87141b52ae1"
+                "reference": "8553c41d5141725f2e399dab8527b573492402ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/6c3c5d5c7312bcd6c6fac1d9a96ae87141b52ae1",
-                "reference": "6c3c5d5c7312bcd6c6fac1d9a96ae87141b52ae1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/8553c41d5141725f2e399dab8527b573492402ea",
+                "reference": "8553c41d5141725f2e399dab8527b573492402ea",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.3"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.4"
             },
-            "time": "2022-10-20T17:09:09+00:00"
+            "time": "2022-10-21T15:55:49+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.7.4

## WooCommerce Blocks 8.7.4

- [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7449)
- [Testing notes](https://github.com/woocommerce/woocommerce-blocks/blob/b47cb6b450893a37f5ca0b2ff02a24183a4889cf/docs/internal-developers/testing/releases/874.md)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug fixes
- Compatibility fix for Cart and Checkout inner blocks for WordPress 6.1.


### Changelog entry

> Dev - Update WooCommerce Blocks version to 8.7.4