### PR TITLE
Fix the display of letter descenders in the shipping class dropdown menu

### DIFF
--- a/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
+++ b/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
@@ -34,9 +34,9 @@
 		color: $gray-900;
 	}
 
-	select.components-select-control__input {
+	.components-base-control select.components-select-control__input {
 		max-width: 100%;
-		line-height: 1;
+		line-height: 1.2rem;
 	}
 
 	.components-panel__body > .components-panel__body-title,

--- a/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
+++ b/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
@@ -36,7 +36,7 @@
 
 	.components-base-control select.components-select-control__input {
 		max-width: 100%;
-		line-height: 1.2rem;
+		line-height: normal;
 	}
 
 	.components-panel__body > .components-panel__body-title,

--- a/plugins/woocommerce/changelog/enhancement-35188-fix-display-letters
+++ b/plugins/woocommerce/changelog/enhancement-35188-fix-display-letters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fix the display of letter descenders in the shipping class dropdown menu


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35188.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to Add new product page
2. The Shipping class dropdown should show the selected option correctly displayed with no visible glitches in all browsers.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
