### PR TITLE
Increase the spacing between the shipping box illustration and the dimensions fields

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.scss
@@ -15,7 +15,7 @@
 	&__dimensions {
 		&-body {
 			display: grid;
-			gap: $gap-large;
+			gap: $gap-largest;
 			grid-template-columns: 1fr;
 			@media ( min-width: #{ ($break-medium) } ) {
 				grid-template-columns: 1fr 1fr;
@@ -28,15 +28,14 @@
 				}
 			}
 		}
+		&-image {
+			width: 100%;
+			height: 100%;
+		}
 		.product-shipping-section__spinner-wrapper {
 			@media ( min-width: #{ ($break-medium) } ) {
 				min-height: 326px;
 			}
-		}
-	}
-	&-image {
-		@media ( min-width: #{ ($break-medium) } ) {
-			width: 100%;
 		}
 	}
 }

--- a/plugins/woocommerce/changelog/enhancement-35189-increase-gap
+++ b/plugins/woocommerce/changelog/enhancement-35189-increase-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Increase the spacing between the shipping box illustration and the dimensions fields


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35189.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to Add new product page
2. In Shipping class section, the space between dimensions and the image should be 40px

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
