### PR TITLE
Add tracks events to a few sections

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
@@ -8,7 +8,7 @@ import {
 	Form,
 	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
 } from '@woocommerce/components';
-
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	Modal,
@@ -77,6 +77,7 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 			value: AttributeForm[ keyof AttributeForm ]
 		) => void
 	) => {
+		recordEvent( 'product_remove_attribute_button' );
 		if ( values.attributes.length > 1 ) {
 			setValue(
 				'attributes',
@@ -284,9 +285,12 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 										'Add another attribute',
 										'woocommerce'
 									) }
-									onClick={ () =>
-										addAnother( values, setValue )
-									}
+									onClick={ () => {
+										recordEvent(
+											'product_add_another_attribute_button'
+										);
+										addAnother( values, setValue );
+									} }
 								>
 									+&nbsp;
 									{ __( 'Add another', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
@@ -77,7 +77,9 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 			value: AttributeForm[ keyof AttributeForm ]
 		) => void
 	) => {
-		recordEvent( 'product_remove_attribute_button' );
+		recordEvent(
+			'product_add_attributes_modal_remove_attribute_button_click'
+		);
 		if ( values.attributes.length > 1 ) {
 			setValue(
 				'attributes',
@@ -287,7 +289,7 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 									) }
 									onClick={ () => {
 										recordEvent(
-											'product_add_another_attribute_button'
+											'product_add_attributes_modal_add_another_attribute_button_click'
 										);
 										addAnother( values, setValue );
 									} }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -127,9 +127,11 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	};
 
 	const onRemove = ( attribute: ProductAttribute ) => {
-		recordEvent( 'product_remove_attribute_button_click' );
 		// eslint-disable-next-line no-alert
 		if ( window.confirm( __( 'Remove this attribute?', 'woocommerce' ) ) ) {
+			recordEvent(
+				'product_remove_attribute_confirmation_confirm_click'
+			);
 			updateAttributes(
 				hydratedAttributes.filter(
 					( attr ) =>
@@ -137,6 +139,8 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 						fetchAttributeId( attribute )
 				)
 			);
+		} else {
+			recordEvent( 'product_remove_attribute_confirmation_cancel_click' );
 		}
 	};
 

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -184,7 +184,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 								className="woocommerce-attribute-field__add-new"
 								onClick={ () => {
 									recordEvent(
-										'product_add_first_attribute_button'
+										'product_add_first_attribute_button_click'
 									);
 									setShowAddAttributeModal( true );
 								} }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -124,7 +124,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	};
 
 	const onRemove = ( attribute: ProductAttribute ) => {
-		recordEvent( 'product_remove_attribute_button' );
+		recordEvent( 'product_remove_attribute_button_click' );
 		// eslint-disable-next-line no-alert
 		if ( window.confirm( __( 'Remove this attribute?', 'woocommerce' ) ) ) {
 			updateAttributes(

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -57,6 +57,9 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 		null | string
 	>( null );
 
+	const CANCEL_BUTTON_EVENT_NAME =
+		'product_add_attributes_modal_cancel_button_click';
+
 	const fetchTerms = useCallback(
 		( attributeId: number ) => {
 			return resolveSelect(
@@ -192,9 +195,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 						{ showAddAttributeModal && (
 							<AddAttributeModal
 								onCancel={ () => {
-									recordEvent(
-										'product_modal_attribute_cancel_button'
-									);
+									recordEvent( CANCEL_BUTTON_EVENT_NAME );
 									setShowAddAttributeModal( false );
 								} }
 								onAdd={ onAddNewAttributes }
@@ -294,7 +295,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 			{ showAddAttributeModal && (
 				<AddAttributeModal
 					onCancel={ () => {
-						recordEvent( 'product_modal_attribute_cancel_button' );
+						recordEvent( CANCEL_BUTTON_EVENT_NAME );
 						setShowAddAttributeModal( false );
 					} }
 					onAdd={ onAddNewAttributes }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -152,6 +152,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 					return newAttr;
 				} ),
 		] );
+		recordEvent( 'product_modal_attribute_add_button' );
 		setShowAddAttributeModal( false );
 	};
 
@@ -178,18 +179,24 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 							<Button
 								variant="secondary"
 								className="woocommerce-attribute-field__add-new"
-								onClick={ () =>
-									setShowAddAttributeModal( true )
-								}
+								onClick={ () => {
+									recordEvent(
+										'product_add_first_attribute_button'
+									);
+									setShowAddAttributeModal( true );
+								} }
 							>
 								{ __( 'Add first attribute', 'woocommerce' ) }
 							</Button>
 						</div>
 						{ showAddAttributeModal && (
 							<AddAttributeModal
-								onCancel={ () =>
-									setShowAddAttributeModal( false )
-								}
+								onCancel={ () => {
+									recordEvent(
+										'product_modal_attribute_cancel_button'
+									);
+									setShowAddAttributeModal( false );
+								} }
 								onAdd={ onAddNewAttributes }
 								selectedAttributeIds={ ( value || [] ).map(
 									( attr ) => attr.id
@@ -286,7 +293,10 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 			</ListItem>
 			{ showAddAttributeModal && (
 				<AddAttributeModal
-					onCancel={ () => setShowAddAttributeModal( false ) }
+					onCancel={ () => {
+						recordEvent( 'product_modal_attribute_cancel_button' );
+						setShowAddAttributeModal( false );
+					} }
 					onAdd={ onAddNewAttributes }
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
 				/>

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -159,7 +159,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 					return newAttr;
 				} ),
 		] );
-		recordEvent( 'product_modal_attribute_add_button' );
+		recordEvent( 'product_add_attributes_modal_add_button_click' );
 		setShowAddAttributeModal( false );
 	};
 

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -17,6 +17,7 @@ import {
 	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
 } from '@woocommerce/components';
 import { closeSmall } from '@wordpress/icons';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -123,6 +124,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	};
 
 	const onRemove = ( attribute: ProductAttribute ) => {
+		recordEvent( 'product_remove_attribute_button' );
 		// eslint-disable-next-line no-alert
 		if ( window.confirm( __( 'Remove this attribute?', 'woocommerce' ) ) ) {
 			updateAttributes(
@@ -274,7 +276,10 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 				<Button
 					variant="secondary"
 					className="woocommerce-attribute-field__add-attribute"
-					onClick={ () => setShowAddAttributeModal( true ) }
+					onClick={ () => {
+						recordEvent( 'product_add_attribute_button' );
+						setShowAddAttributeModal( true );
+					} }
 				>
 					{ __( 'Add attribute', 'woocommerce' ) }
 				</Button>

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -173,7 +173,7 @@ export const ImagesSection: React.FC = () => {
 											) === undefined
 										) {
 											recordEvent(
-												'product_choose_image_button'
+												'product_image_add_from_media_library'
 											);
 											setValue( 'images', [
 												...images,

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -182,8 +182,10 @@ export const ImagesSection: React.FC = () => {
 										}
 									} }
 									onUpload={ ( files ) => {
-										recordEvent( 'product_image_upload' );
 										if ( files[ 0 ].id ) {
+											recordEvent(
+												'product_image_upload'
+											);
 											setValue( 'images', [
 												...images,
 												...files,

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -125,6 +125,9 @@ export const ImagesSection: React.FC = () => {
 								setValue( 'images', images );
 							}
 						} }
+						onSelectAsCover={ () =>
+							recordEvent( 'product_image_select_as_cover' )
+						}
 					>
 						{ images.map( ( image ) => (
 							<ImageGalleryItem

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -48,6 +48,7 @@ export const ImagesSection: React.FC = () => {
 				( file ) => file.id === parseInt( image?.props?.id, 10 )
 			);
 		} );
+		recordEvent( 'product_image_change_order' );
 		setValue( 'images', orderedImages );
 	};
 
@@ -100,6 +101,7 @@ export const ImagesSection: React.FC = () => {
 						} }
 						onDragEnd={ () => {
 							if ( isRemoving && draggedImageId ) {
+								recordEvent( 'product_image_remove' );
 								setValue(
 									'images',
 									images.filter(
@@ -119,6 +121,7 @@ export const ImagesSection: React.FC = () => {
 								) === undefined
 							) {
 								images[ replaceIndex ] = media as Image;
+								recordEvent( 'product_image_replace' );
 								setValue( 'images', images );
 							}
 						} }
@@ -169,6 +172,9 @@ export const ImagesSection: React.FC = () => {
 												( img ) => file.id === img.id
 											) === undefined
 										) {
+											recordEvent(
+												'product_choose_image_button'
+											);
 											setValue( 'images', [
 												...images,
 												file,
@@ -176,6 +182,7 @@ export const ImagesSection: React.FC = () => {
 										}
 									} }
 									onUpload={ ( files ) => {
+										recordEvent( 'product_image_upload' );
 										if ( files[ 0 ].id ) {
 											setValue( 'images', [
 												...images,

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -176,7 +176,7 @@ export const ImagesSection: React.FC = () => {
 											) === undefined
 										) {
 											recordEvent(
-												'product_image_add_from_media_library'
+												'product_images_add_via_media_library'
 											);
 											setValue( 'images', [
 												...images,
@@ -187,7 +187,7 @@ export const ImagesSection: React.FC = () => {
 									onUpload={ ( files ) => {
 										if ( files[ 0 ].id ) {
 											recordEvent(
-												'product_image_upload'
+												'product_images_add_via_drag_and_drop_upload'
 											);
 											setValue( 'images', [
 												...images,

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -48,7 +48,7 @@ export const ImagesSection: React.FC = () => {
 				( file ) => file.id === parseInt( image?.props?.id, 10 )
 			);
 		} );
-		recordEvent( 'product_image_change_order' );
+		recordEvent( 'product_images_change_image_order_via_image_gallery' );
 		setValue( 'images', orderedImages );
 	};
 

--- a/plugins/woocommerce-admin/client/products/sections/images-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/images-section.tsx
@@ -101,7 +101,9 @@ export const ImagesSection: React.FC = () => {
 						} }
 						onDragEnd={ () => {
 							if ( isRemoving && draggedImageId ) {
-								recordEvent( 'product_image_remove' );
+								recordEvent(
+									'product_images_remove_image_button_click'
+								);
 								setValue(
 									'images',
 									images.filter(
@@ -121,12 +123,16 @@ export const ImagesSection: React.FC = () => {
 								) === undefined
 							) {
 								images[ replaceIndex ] = media as Image;
-								recordEvent( 'product_image_replace' );
+								recordEvent(
+									'product_images_replace_image_button_click'
+								);
 								setValue( 'images', images );
 							}
 						} }
 						onSelectAsCover={ () =>
-							recordEvent( 'product_image_select_as_cover' )
+							recordEvent(
+								'product_images_select_image_as_cover_button_click'
+							)
 						}
 					>
 						{ images.map( ( image ) => (

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -400,9 +400,6 @@ export function ProductShippingSection( {
 							.catch( handleShippingClassServerError )
 					}
 					onCancel={ () => {
-						recordEvent(
-							'product_new_shipping_class_modal_cancel_button_click'
-						);
 						setShowShippingClassModal( false );
 					} }
 				/>

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -399,9 +399,7 @@ export function ProductShippingSection( {
 							} )
 							.catch( handleShippingClassServerError )
 					}
-					onCancel={ () => {
-						setShowShippingClassModal( false );
-					} }
+					onCancel={ () => setShowShippingClassModal( false ) }
 				/>
 			) }
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -245,7 +245,7 @@ export function ProductShippingSection( {
 												type="external"
 												onClick={ () => {
 													recordEvent(
-														'product_shipping_global_settings'
+														'product_shipping_global_settings_link_click'
 													);
 												} }
 											>
@@ -389,7 +389,7 @@ export function ProductShippingSection( {
 						>( shippingClassValues )
 							.then( ( value ) => {
 								recordEvent(
-									'product_modal_new_shipping_class_add_button'
+									'product_new_shipping_class_modal_add_button_click'
 								);
 								invalidateResolution(
 									'getProductShippingClasses'
@@ -401,7 +401,7 @@ export function ProductShippingSection( {
 					}
 					onCancel={ () => {
 						recordEvent(
-							'product_modal_new_shipping_class_cancel_button'
+							'product_new_shipping_class_modal_cancel_button_click'
 						);
 						setShowShippingClassModal( false );
 					} }

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -399,7 +399,12 @@ export function ProductShippingSection( {
 							} )
 							.catch( handleShippingClassServerError )
 					}
-					onCancel={ () => setShowShippingClassModal( false ) }
+					onCancel={ () => {
+						recordEvent(
+							'product_modal_new_shipping_class_cancel_button'
+						);
+						setShowShippingClassModal( false );
+					} }
 				/>
 			) }
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -388,6 +388,9 @@ export function ProductShippingSection( {
 							Promise< ProductShippingClass >
 						>( shippingClassValues )
 							.then( ( value ) => {
+								recordEvent(
+									'product_modal_new_shipping_class_add_button'
+								);
 								invalidateResolution(
 									'getProductShippingClasses'
 								);

--- a/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-shipping-section.tsx
@@ -12,6 +12,7 @@ import {
 	ProductShippingClass,
 } from '@woocommerce/data';
 import interpolateComponents from '@automattic/interpolate-components';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	BaseControl,
 	Card,
@@ -242,6 +243,11 @@ export function ProductShippingSection( {
 												href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping&section=classes` }
 												target="_blank"
 												type="external"
+												onClick={ () => {
+													recordEvent(
+														'product_shipping_global_settings'
+													);
+												} }
 											>
 												<></>
 											</Link>

--- a/plugins/woocommerce/changelog/update-39_image_section_tracks_events
+++ b/plugins/woocommerce/changelog/update-39_image_section_tracks_events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add missing tracks events


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds the code to record a few tracks events that we didn't have in the new product creation experience.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35456.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

Request:
1.  Install the [WC-Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper) and go to `Tools > WCA Test Helper > Tools` and `Enable wc-admin Tracking`. Also enable the `new-product-management-experience`.
2. Go to `Products > Add New (MVP)`.
3. Go to the Images section and press `Choose Images`. Select an image and confirm that the event `wcadmin_product_image_add_from_media_library` is being recorded.
4. Select the image that has been added and press `Replace`. Replace the image with another. The event `wcadmin_product_image_replace` should be recorded.
5. Select the image and press the trash can and check that the event `wcadmin_product_image_change_order` is recorded.
6. Drag and drop an image and confirm that the event `wcadmin_product_image_upload` has been recorded.
7. Add (or choose from the media library) more than 2 images and change the images' order and confirm that the event `wcadmin_product_image_change_order` is recorded.
8. Select an image (not the cover image) and select it as the cover image. Verify that the event `wcadmin_product_image_select_as_cover` is being recorded. You'll see that the event `wcadmin_product_image_change_order` will be recorded as well because the order of the images changed.
9. Go to the `Shipping` section and select `Add new shipping class`. A modal will be visible, press `Add` and confirm that the event `wcadmin_product_modal_new_shipping_class_add_button` is recorded.
10. Verify that the cancel button is being recorded too (event name: `wcadmin_product_modal_new_shipping_class_cancel_button`)
10. Now press the link `global settings` and verify that the event `wcadmin_product_shipping_global_settings` is being recorded.
11. Go to `Attributes` and press `Add first attribute`. The event `wcadmin_product_add_first_attribute_button` should be recorded.
12. Verify that the buttons Add (`wcadmin_product_modal_attribute_add_button`) and Cancel (`wcadmin_product_modal_attribute_cancel_button`) are being recorded correctly.
13. Verify that the event `wcadmin_product_add_another_attribute_button` is being recorded after pressing `+ Add another`
14. Select an `Attribute` and then press the trash can. Verify the event `wcadmin_product_remove_attribute_button` is recorded.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
