### PR TITLE
Improve the communication around required and optional

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -79,16 +79,6 @@ export const PricingSection: React.FC = () => {
 		},
 	} );
 
-	const salePriceTitle = interpolateComponents( {
-		mixedString: __(
-			'Sale price {{span}}(optional){{/span}}',
-			'woocommerce'
-		),
-		components: {
-			span: <span className="woocommerce-product-form__optional-input" />,
-		},
-	} );
-
 	const currencyInputProps = {
 		...getCurrencySymbolProps( currencyConfig ),
 		sanitize: ( value: Product[ keyof Product ] ) => {
@@ -159,7 +149,7 @@ export const PricingSection: React.FC = () => {
 					>
 						<InputControl
 							{ ...salePriceProps }
-							label={ salePriceTitle }
+							label={ __( 'Sale price', 'woocommerce' ) }
 							value={ formatCurrencyDisplayValue(
 								String( salePriceProps?.value ),
 								currencyConfig,

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -92,12 +92,17 @@ export const ProductDetailsSection: React.FC = () => {
 						<TextControl
 							label={ interpolateComponents( {
 								mixedString: __(
-									'Name {{span}}(required){{/span}}',
+									'Name {{required/}}',
 									'woocommerce'
 								),
 								components: {
-									span: (
-										<span className="woocommerce-product-form__optional-input" />
+									required: (
+										<span className="woocommerce-product-form__optional-input">
+											{ __(
+												'(required)',
+												'woocommerce'
+											) }
+										</span>
 									),
 								},
 							} ) }

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -90,7 +90,17 @@ export const ProductDetailsSection: React.FC = () => {
 				<CardBody>
 					<div>
 						<TextControl
-							label={ __( 'Name', 'woocommerce' ) }
+							label={ interpolateComponents( {
+								mixedString: __(
+									'Name {{span}}(required){{/span}}',
+									'woocommerce'
+								),
+								components: {
+									span: (
+										<span className="woocommerce-product-form__optional-input" />
+									),
+								},
+							} ) }
 							name={ `${ PRODUCT_DETAILS_SLUG }-name` }
 							placeholder={ __(
 								'e.g. 12 oz Coffee Mug',

--- a/plugins/woocommerce-admin/client/products/sections/test/product-details-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/test/product-details-section.spec.tsx
@@ -78,7 +78,9 @@ describe( 'ProductDetailsSection', () => {
 					</Form>
 				</RegistryProvider>
 			);
-			userEvent.clear( screen.getByLabelText( 'Name' ) );
+			userEvent.clear(
+				screen.getByLabelText( 'Name', { exact: false } )
+			);
 			userEvent.tab();
 
 			expect( screen.queryByText( linkUrl ) ).not.toBeInTheDocument();

--- a/plugins/woocommerce-admin/client/products/sections/test/product-shipping-section.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/test/product-shipping-section.spec.tsx
@@ -32,12 +32,12 @@ function getShippingClassSelect() {
 
 async function getShippingClassNameInput() {
 	const dialog = getShippingClassDialog();
-	return within( dialog ).getByLabelText( __( 'Name', 'woocommerce' ) );
+	return within( dialog ).getByLabelText( 'Name', { exact: false } );
 }
 
 async function getShippingClassSlugInput() {
 	const dialog = getShippingClassDialog();
-	return within( dialog ).getByLabelText( 'Slug', { exact: false } );
+	return within( dialog ).getByLabelText( __( 'Slug', 'woocommerce' ) );
 }
 
 async function openShippingClassDialog() {

--- a/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -39,36 +39,25 @@ function ShippingClassForm( { onAdd, onCancel }: ShippingClassFormProps ) {
 		<div className="woocommerce-add-new-shipping-class-modal__wrapper">
 			<TextControl
 				{ ...getInputProps( 'name' ) }
-				label={ __( 'Name', 'woocommerce' ) }
 				placeholder={ __( 'e.g. Fragile products', 'woocommerce' ) }
+				label={ interpolateComponents( {
+					mixedString: __( 'Name {{required/}}', 'woocommerce' ),
+					components: {
+						required: (
+							<span className="woocommerce-add-new-shipping-class-modal__optional-input">
+								{ __( '(required)', 'woocommerce' ) }
+							</span>
+						),
+					},
+				} ) }
 			/>
 			<TextControl
 				{ ...getInputProps( 'slug' ) }
-				label={ interpolateComponents( {
-					mixedString: __(
-						'Slug {{span}}(optional){{/span}}',
-						'woocommerce'
-					),
-					components: {
-						span: (
-							<span className="woocommerce-add-new-shipping-class-modal__optional-input" />
-						),
-					},
-				} ) }
+				label={ __( 'Slug', 'woocommerce' ) }
 			/>
 			<TextControl
 				{ ...getInputProps( 'description' ) }
-				label={ interpolateComponents( {
-					mixedString: __(
-						'Description {{span}}(optional){{/span}}',
-						'woocommerce'
-					),
-					components: {
-						span: (
-							<span className="woocommerce-add-new-shipping-class-modal__optional-input" />
-						),
-					},
-				} ) }
+				label={ __( 'Description', 'woocommerce' ) }
 				help={
 					errors?.description ??
 					__(

--- a/plugins/woocommerce/changelog/enhancement-35191-improve-req-opt-labels
+++ b/plugins/woocommerce/changelog/enhancement-35191-improve-req-opt-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve the communication around required and optional


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35191.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go the Add new product page
2. The only field with `(required)` hint on the right side of its label should be the `Name` and the `(optional)` hit should not be shown for any field
3. This also apply to the New shipping class dialog form

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
