### PR TITLE
Track enabling/disabling features.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34898-track-features
+++ b/plugins/woocommerce/changelog/fix-34898-track-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tracks the enabling and disabling of features.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -19,12 +19,27 @@ class WC_Settings_Tracking {
 	 */
 	protected $allowed_options = array();
 
+
+
 	/**
 	 * WooCommerce settings that have been updated (and will be tracked).
 	 *
 	 * @var array
 	 */
 	protected $updated_options = array();
+
+	/**
+	 * Options for which we also want to monitor the setting values.
+	 *
+	 * @var string[]
+	 */
+	private $record_values = array(
+		'woocommerce_custom_orders_table_enabled',
+		'woocommerce_custom_orders_table_data_sync_enabled',
+		'woocommerce_db_transactions_isolation_level_for_custom_orders_table_data_sync',
+		'woocommerce_feature_custom_order_tables_enabled',
+		'woocommerce_use_db_transactions_for_custom_orders_table_data_sync',
+	);
 
 	/**
 	 * Init tracking.
@@ -78,7 +93,11 @@ class WC_Settings_Tracking {
 			return;
 		}
 
-		$this->updated_options[] = $option_name;
+		if ( in_array( $option_name, $this->record_values, true ) ) {
+			$this->updated_options[] = $option_name . ':' . $new_value;
+		} else {
+			$this->updated_options[] = $option_name;
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\PluginUtil;
+use WC_Tracks;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -229,7 +230,13 @@ class FeaturesController {
 			return false;
 		}
 
-		return update_option( $this->feature_enable_option_name( $feature_id ), $enable ? 'yes' : 'no' );
+		$updated = update_option( $this->feature_enable_option_name( $feature_id ), $enable ? 'yes' : 'no' );
+
+		if ( $updated ) {
+			WC_Tracks::record_event( 'feature_' . $feature_id . '_' . ( $enable ? 'enabled' : 'disabled' ) );
+		}
+
+		return $updated;
 	}
 
 	/**


### PR DESCRIPTION
We want to track when HPOS is enabled and when changes to HPOS settings take place.

Closes #34898.

### Background

- We're making use of Tracks here, which means you won't see any data being sent back unless you have opted in. This is accomplished via the **Enable Tracking** setting, found in **WooCommerce ▸ Settings ▸ Advanced ▸ WooCommerce.com**. So, before testing this, be sure to opt in!
- Data is sent back to [pixel.wp.com](https://pixel.wp.com) through one of two methods. The first is an image tag, which conveys data through its URL query: it is easy to monitor for these by using your browser dev tools to record network activity. If you use this approach, you will probably also want to ensure network requests are not deleted on each new page request, and you may wish to reduce noise by filtering down to requests involving the keyword `pixel`. Screenshot:

<img width="1994" alt="browser-network-tab" src="https://user-images.githubusercontent.com/3594411/198141614-3312ac2e-f408-47dd-9c12-8ebc46b8b28e.png">

- The other way tracking pixels work is via server-side HTTP requests. In these cases, the URL will follow the same pattern as for the actual image tag but, since these requests will not be visible to the browser, you will need to use a tool such as [Log HTTP Requests](https://wordpress.org/plugins/log-http-requests/) to record them. This method is used instead of image tags in situations where an event is recorded but there is no opportunity to render HTML (a common scenario being cases where a redirect happens immediately after a setting is saved). Screenshot:

<img width="1522" alt="log-http-requests" src="https://user-images.githubusercontent.com/3594411/198141872-1a9d83b6-203c-4e01-9789-ecf1ac13f4fa.png">

- If you prefer to use other tools to monitor the creation of tracking pixels, that's also fine (I just found it convenient to use the two strategies I described above).
- Prior to this change, if a setting was changed we were already trying to track that—but we would only track the *name* of the option that was changed and not the *value* it was changed to. As of this change, we will track the new value for a specific subset of settings (those related to HPOS). Regarding tracking pixel URLs:
    -  The basic form for settings changes is a URL including a query like `?settings=option_name1,option_name2` (comma separated list of changed settings).
    - In the case of HPOS settings we also track the new value, in this style `?settings=hpos_option:new_value`.

### Testing

Let's confirm we are successfully tracking HPOS related settings changes via tracking pixels. We are specifically interested in triggering changes via two different settings screens:

- Start with **WooCommerce ▸ Settings ▸ Advanced ▸ Features**. Try enabling and disabling HPOS, alongside other features listed on this page and ensure a tracking pixel was created.
    - In general, if you change either of the WC Admin settings present on this screen then the tracking pixel will be implemented via a server-side request (ie, use [Log HTTP Requests](https://wordpress.org/plugins/log-http-requests/) to check that these happened).
    - On the other hand, if you only change the HPOS setting, then the output will probably be an actual image tag.
    - You can expect to see something like `?settings=woocommerce_custom_order_tables_enabled:yes,woocommerce_analytics_enabled` being passed via the generated tracking pixel (the order doesn't really matter).
    - Note that only *changed* settings will be reflected in the tracking pixel. So, for example, if you do not change the HPOS setting on this screen, you will not see `woocommerce_custom_order_tables_enabled:<yes|no>` in the tracking pixel URL.
- Repeat the process but in relation to the settings found in the **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** screen. Generally, in these cases, you will be looking for an actual image tag.

Apologies in advance if any of the above is confusing, don't hesitate to reach out for clarification as needed.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
