### PR TITLE
Add an NPM script to run the Playwright API Core Tests

### DIFF
--- a/plugins/woocommerce/changelog/add-api-pw-npm-script
+++ b/plugins/woocommerce/changelog/add-api-pw-npm-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Added npm script for Playwright API Core Tests

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -32,6 +32,7 @@
 		"env:dev": "pnpm wp-env start",
 		"env:test": "pnpm run env:dev && ./tests/e2e-pw/bin/test-env-setup.sh",
 		"e2e-pw": "USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js",
+		"test:api-pw": "USE_WP_ENV=1 pnpm playwright test --config=tests/api-core-tests/playwright.config.js",
 		"env:test:cot": "pnpm run env:dev && ./tests/e2e-pw/bin/test-env-setup.sh --cot",
 		"env:performance-init": "./tests/performance/bin/init-sample-products.sh",
 		"env:down": "pnpm wp-env stop",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds in a new NPM script to run the Playwright API Core Tests to make it easier than needing to run the full command.

### How to test the changes in this Pull Request:

Try out the new command! Have some fun! Run the following from within the `plugins/woocommerce` directory

1. Verify the new command works to run the tests: `npm test:api-pw`
2. Pass in a test file as an argument and verify that the test suites in that file are ran: `npm test:api-pw tests/api-core-tests/tests/payment-gateways/payment-gateways-crud.test.js`
3. Feedback on the command name--does it look good / make sense?