### PR TITLE
Support PHP style date format specifiers in DateTimePickerControl

### DIFF
--- a/packages/js/components/changelog/update-date-time-picker-control-formatting
+++ b/packages/js/components/changelog/update-date-time-picker-control-formatting
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Switch DateTimePickerControl formatting to PHP style, for WP compatibility.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { format as formatDate } from '@wordpress/date';
 import {
 	createElement,
 	useState,
@@ -103,9 +104,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return moment.utc( dateString, moment.ISO_8601, true );
 	}
 
-	function parseMoment( dateString?: string | null ): Moment {
-		// parse input date string as local time
-		return moment( dateString, displayFormat );
+	function parseMoment( dateString: string | null ): Moment {
+		// parse input date string as local time;
+		// be lenient of user input and try to match any format Moment can
+		return moment( dateString );
 	}
 
 	function formatMomentIso( momentDate: Moment ): string {
@@ -113,7 +115,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function formatMoment( momentDate: Moment ): string {
-		return momentDate.local().format( displayFormat );
+		return formatDate( displayFormat, momentDate.local() );
 	}
 
 	function hasFocusLeftInputAndDropdownContent(

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -23,9 +23,11 @@ import {
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 
-export const defaultDateFormat = 'MM/DD/YYYY';
-export const default12HourDateTimeFormat = 'MM/DD/YYYY h:mm a';
-export const default24HourDateTimeFormat = 'MM/DD/YYYY H:mm';
+// PHP style formatting:
+// https://wordpress.org/support/article/formatting-date-and-time/
+export const defaultDateFormat = 'm/d/Y';
+export const default12HourDateTimeFormat = 'm/d/Y h:i a';
+export const default24HourDateTimeFormat = 'm/d/Y H:i';
 
 export type DateTimePickerControlOnChangeHandler = (
 	date: string,

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -28,11 +28,13 @@ Basic.args = {
 	help: 'Type a date and time or use the picker',
 };
 
+const customFormat = 'Y-m-d H:i';
+
 export const CustomDateTimeFormat = Template.bind( {} );
 CustomDateTimeFormat.args = {
 	...Basic.args,
-	help: 'Format: YYYY-MM-DD HH:mm',
-	dateTimeFormat: 'YYYY-MM-DD HH:mm',
+	help: 'Format: ' + customFormat,
+	dateTimeFormat: customFormat,
 };
 
 function ControlledContainer( { children, ...props } ) {

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -3,6 +3,7 @@
  */
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { format as formatDate } from '@wordpress/date';
 import { createElement, Fragment } from '@wordpress/element';
 import moment from 'moment';
 
@@ -102,7 +103,7 @@ describe( 'DateTimePickerControl', () => {
 
 		const input = container.querySelector( 'input' );
 		expect( input?.value ).toBe(
-			dateTime.format( default24HourDateTimeFormat )
+			formatDate( default24HourDateTimeFormat, dateTime )
 		);
 	} );
 
@@ -119,10 +120,10 @@ describe( 'DateTimePickerControl', () => {
 		const input = container.querySelector( 'input' );
 
 		expect( input?.value ).toBe(
-			moment
-				.utc( ambiguousISODateTimeString )
-				.local()
-				.format( default24HourDateTimeFormat )
+			formatDate(
+				default24HourDateTimeFormat,
+				moment.utc( ambiguousISODateTimeString ).local()
+			)
 		);
 	} );
 
@@ -139,10 +140,10 @@ describe( 'DateTimePickerControl', () => {
 		const input = container.querySelector( 'input' );
 
 		expect( input?.value ).toBe(
-			moment
-				.utc( unambiguousISODateTimeString )
-				.local()
-				.format( default24HourDateTimeFormat )
+			formatDate(
+				default24HourDateTimeFormat,
+				moment.utc( unambiguousISODateTimeString ).local()
+			)
 		);
 	} );
 
@@ -158,7 +159,7 @@ describe( 'DateTimePickerControl', () => {
 
 		const input = container.querySelector( 'input' );
 		expect( input?.value ).toBe(
-			dateTime.format( default12HourDateTimeFormat )
+			formatDate( default12HourDateTimeFormat, dateTime )
 		);
 	} );
 
@@ -174,7 +175,7 @@ describe( 'DateTimePickerControl', () => {
 		);
 
 		const input = container.querySelector( 'input' );
-		expect( input?.value ).toBe( dateTime.format( dateTimeFormat ) );
+		expect( input?.value ).toBe( formatDate( dateTimeFormat, dateTime ) );
 	} );
 
 	it( 'should update the input when currentDate is changed', () => {
@@ -197,7 +198,7 @@ describe( 'DateTimePickerControl', () => {
 
 		const input = container.querySelector( 'input' );
 		expect( input?.value ).toBe(
-			updatedDateTime.format( default24HourDateTimeFormat )
+			formatDate( default24HourDateTimeFormat, updatedDateTime )
 		);
 	} );
 
@@ -305,9 +306,9 @@ describe( 'DateTimePickerControl', () => {
 	//       TypeError: Cannot read properties of null (reading 'createEvent')
 	it( 'should call onChange when the input is changed', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
-		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
-		const newDateTimeInputString = '02:04, 06-08-2010';
-		const newDateTime = moment( newDateTimeInputString, dateTimeFormat );
+		const dateTimeFormat = 'm-d-Y, H:i';
+		const newDateTimeInputString = '06-08-2010, 02:04';
+		const newDateTime = moment( newDateTimeInputString );
 		const onChangeHandler = jest.fn();
 
 		const { container } = render(
@@ -377,9 +378,9 @@ describe( 'DateTimePickerControl', () => {
 	//       TypeError: Cannot read properties of null (reading 'createEvent')
 	it( 'should call the current onChange when the input is changed', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
-		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
-		const newDateTimeInputString = '02:04, 06-08-2010';
-		const newDateTime = moment( newDateTimeInputString, dateTimeFormat );
+		const dateTimeFormat = 'm-d-Y, H:i';
+		const newDateTimeInputString = '06-08-2010, 02:04';
+		const newDateTime = moment( newDateTimeInputString );
 		const originalOnChangeHandler = jest.fn();
 		const newOnChangeHandler = jest.fn();
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates DateTimePickerControl to use [PHP style specifiers](https://wordpress.org/support/article/formatting-date-and-time/) for the `dateTimeFormat` prop. This is to have compatibility with WP date formatting options, which use PHP style formatting specifiers.

This PR also updates the parsing to attempt to parse input in any format, which offers much greater flexibility and useability for users of the component. Most "common" formats should be parsed without issue.

Needed for #34538

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook stories and make sure DateTimePickerControl works as expected, especially the "Custom Date Time Format" story: `pnpm --filter=@woocommerce/storybook storybook`
    - You should be able to enter a datetime in most formats (the component does it's best to parse it)... the component keeps the display in the format it was entered in
    - When a datetime is picked from the dropdown picker, the datetime should be formatted with the set format

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
