### PR TITLE
Fix up rich text editor initial selection and add blocks

### DIFF
--- a/packages/js/components/changelog/fix-rich-text-editor-selection
+++ b/packages/js/components/changelog/fix-rich-text-editor-selection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Fix up initial block selection in RichTextEditor and add media blocks

--- a/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
+++ b/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
@@ -16,37 +16,31 @@ import {
 } from '@wordpress/block-editor';
 
 type EditorWritingFlowProps = {
+	blocks: BlockInstance[];
 	onChange: ( changes: BlockInstance[] ) => void;
 	placeholder?: string;
 };
 
 export const EditorWritingFlow = ( {
+	blocks,
 	onChange,
 	placeholder = '',
 }: EditorWritingFlowProps ) => {
 	const instanceId = useInstanceId( EditorWritingFlow );
+	const firstBlock = blocks[ 0 ];
+	const isEmpty = ! blocks.length;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore This action is available in the block editor data store.
 	const { insertBlock, selectBlock } = useDispatch( blockEditorStore );
+	const { selectedBlockClientIds } = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore This selector is available in the block editor data store.
+		const { getSelectedBlockClientIds } = select( blockEditorStore );
 
-	const { firstBlock, isEmpty, selectedBlockClientIds } = useSelect(
-		( select ) => {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore This selector is available in the block editor data store.
-			const { getBlocks, getSelectedBlockClientIds } =
-				select( blockEditorStore );
-			const blocks = getBlocks();
-
-			return {
-				firstBlock: blocks[ 0 ],
-				isEmpty: blocks.length
-					? blocks.length <= 1 &&
-					  blocks[ 0 ].attributes?.content?.trim() === ''
-					: true,
-				selectedBlockClientIds: getSelectedBlockClientIds(),
-			};
-		}
-	);
+		return {
+			selectedBlockClientIds: getSelectedBlockClientIds(),
+		};
+	} );
 
 	useEffect( () => {
 		if ( selectedBlockClientIds?.length || ! firstBlock ) {
@@ -64,7 +58,7 @@ export const EditorWritingFlow = ( {
 			insertBlock( initialBlock );
 			onChange( [ initialBlock ] );
 		}
-	}, [] );
+	}, [ isEmpty ] );
 
 	return (
 		/* Gutenberg handles the keyboard events when focusing the content editable area. */

--- a/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
+++ b/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
@@ -49,7 +49,7 @@ export const EditorWritingFlow = ( {
 	);
 
 	useEffect( () => {
-		if ( selectedBlockClientIds.length || ! firstBlock ) {
+		if ( selectedBlockClientIds?.length || ! firstBlock ) {
 			return;
 		}
 		selectBlock( firstBlock.clientId );

--- a/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
+++ b/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
@@ -17,9 +17,13 @@ import {
 
 type EditorWritingFlowProps = {
 	onChange: ( changes: BlockInstance[] ) => void;
+	placeholder?: string;
 };
 
-export const EditorWritingFlow = ( { onChange }: EditorWritingFlowProps ) => {
+export const EditorWritingFlow = ( {
+	onChange,
+	placeholder = '',
+}: EditorWritingFlowProps ) => {
 	const instanceId = useInstanceId( EditorWritingFlow );
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore This action is available in the block editor data store.
@@ -55,6 +59,7 @@ export const EditorWritingFlow = ( { onChange }: EditorWritingFlowProps ) => {
 		if ( isEmpty ) {
 			const initialBlock = createBlock( 'core/paragraph', {
 				content: '',
+				placeholder,
 			} );
 			insertBlock( initialBlock );
 			onChange( [ initialBlock ] );

--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -38,7 +38,6 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 } ) => {
 	const blocksRef = useRef( blocks );
 	const { currentUserCan } = useUser();
-
 	const [ , setRefresh ] = useState( 0 );
 
 	// If there is a props change we need to update the ref and force re-render.
@@ -99,6 +98,7 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 				>
 					<ShortcutProvider>
 						<EditorWritingFlow
+							blocks={ blocksRef.current }
 							onChange={ onChange }
 							placeholder={ placeholder }
 						/>

--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -7,6 +7,8 @@ import { BlockInstance } from '@wordpress/blocks';
 import { createElement, useEffect, useState, useRef } from '@wordpress/element';
 import { debounce } from 'lodash';
 import React from 'react';
+import { uploadMedia } from '@wordpress/media-utils';
+import { useUser } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -35,6 +37,7 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 	placeholder = '',
 } ) => {
 	const blocksRef = useRef( blocks );
+	const { currentUserCan } = useUser();
 
 	const [ , setRefresh ] = useState( 0 );
 
@@ -57,6 +60,24 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 		forceRerender();
 	}, 200 );
 
+	const mediaUpload = currentUserCan( 'upload_files' )
+		? ( {
+				onError,
+				...rest
+		  }: {
+				onError: ( message: string ) => void;
+		  } ) => {
+				uploadMedia(
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore The upload function passes the remaining required props.
+					{
+						onError: ( { message } ) => onError( message ),
+						...rest,
+					}
+				);
+		  }
+		: undefined;
+
 	return (
 		<div className="woocommerce-rich-text-editor">
 			{ label && (
@@ -71,7 +92,7 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore This property was recently added in the block editor data store.
 						__experimentalClearBlockSelection: false,
-						mediaUpload: true,
+						mediaUpload,
 					} }
 					onInput={ debounceChange }
 					onChange={ debounceChange }

--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -25,12 +25,14 @@ type RichTextEditorProps = {
 	label?: string;
 	onChange: ( changes: BlockInstance[] ) => void;
 	entryId?: string;
+	placeholder?: string;
 };
 
 export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 	blocks,
 	label,
 	onChange,
+	placeholder = '',
 } ) => {
 	const blocksRef = useRef( blocks );
 
@@ -74,7 +76,10 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 					onChange={ debounceChange }
 				>
 					<ShortcutProvider>
-						<EditorWritingFlow onChange={ onChange } />
+						<EditorWritingFlow
+							onChange={ onChange }
+							placeholder={ placeholder }
+						/>
 					</ShortcutProvider>
 					<Popover.Slot />
 				</BlockEditorProvider>

--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -1,17 +1,11 @@
 /**
  * External dependencies
  */
-import { BaseControl, SlotFillProvider } from '@wordpress/components';
+import { BaseControl, Popover, SlotFillProvider } from '@wordpress/components';
 import { BlockEditorProvider } from '@wordpress/block-editor';
 import { BlockInstance } from '@wordpress/blocks';
+import { createElement, useEffect, useState, useRef } from '@wordpress/element';
 import { debounce } from 'lodash';
-import {
-	createElement,
-	useCallback,
-	useEffect,
-	useState,
-	useRef,
-} from '@wordpress/element';
 import React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -82,6 +76,7 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 					<ShortcutProvider>
 						<EditorWritingFlow />
 					</ShortcutProvider>
+					<Popover.Slot />
 				</BlockEditorProvider>
 			</SlotFillProvider>
 		</div>

--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -71,6 +71,7 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						// @ts-ignore This property was recently added in the block editor data store.
 						__experimentalClearBlockSelection: false,
+						mediaUpload: true,
 					} }
 					onInput={ debounceChange }
 					onChange={ debounceChange }

--- a/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
+++ b/packages/js/components/src/rich-text-editor/rich-text-editor.tsx
@@ -74,7 +74,7 @@ export const RichTextEditor: React.VFC< RichTextEditorProps > = ( {
 					onChange={ debounceChange }
 				>
 					<ShortcutProvider>
-						<EditorWritingFlow />
+						<EditorWritingFlow onChange={ onChange } />
 					</ShortcutProvider>
 					<Popover.Slot />
 				</BlockEditorProvider>

--- a/packages/js/components/src/rich-text-editor/style.scss
+++ b/packages/js/components/src/rich-text-editor/style.scss
@@ -19,11 +19,6 @@
 		border-color: $gray-600;
 	}
 
-	/* Hide rich text placeholder text */
-	.rich-text [data-rich-text-placeholder] {
-		display: none !important;
-	}
-
 	/* hide block boundary background styling */
 	.rich-text:focus *[data-rich-text-format-boundary] {
 		background: none !important;

--- a/packages/js/components/src/rich-text-editor/style.scss
+++ b/packages/js/components/src/rich-text-editor/style.scss
@@ -1,3 +1,5 @@
+$toolbar-height: 40px;
+
 .woocommerce-rich-text-editor {
 	.woocommerce-rich-text-editor__writing-flow {
 		border: 1px solid $gray-600;
@@ -51,11 +53,25 @@
 	}
 
 	.components-accessible-toolbar {
+		height: $toolbar-height;
 		width: 100%;
 		background-color: $white;
 		border-color: $gray-700;
 		border-bottom-left-radius: 0;
 		border-bottom-right-radius: 0;
+
+		.components-button {
+			height: $toolbar-height;
+		}
+	}
+
+	.block-editor-block-mover:not(.is-horizontal) .block-editor-block-mover__move-button-container > * {
+		height: calc( $toolbar-height / 2 );
+	}
+
+	.block-editor-block-contextual-toolbar.is-fixed,
+	.components-toolbar-group {
+		min-height: $toolbar-height;
 	}
 
 	.wp-block-quote {

--- a/packages/js/components/src/rich-text-editor/style.scss
+++ b/packages/js/components/src/rich-text-editor/style.scss
@@ -11,10 +11,6 @@ $toolbar-height: 40px;
 		box-sizing: border-box;
 	}
 
-	.block-editor-inserter {
-		display: none;
-	}
-
 	.block-editor-block-contextual-toolbar.is-fixed,
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-toolbar .components-toolbar-group,
 	.block-editor-block-contextual-toolbar.is-fixed .block-editor-block-toolbar .components-toolbar {
@@ -34,11 +30,6 @@ $toolbar-height: 40px;
 	.block-editor-block-list__block:not([contenteditable]):focus::after {
 		box-shadow: none;
 		outline: none;
-	}
-
-	.block-editor-block-list__empty-block-inserter,
-	.block-editor-block-list__insertion-point {
-		display: none !important;
 	}
 
 	.block-editor-writing-flow {

--- a/packages/js/components/src/rich-text-editor/utils/register-blocks.ts
+++ b/packages/js/components/src/rich-text-editor/utils/register-blocks.ts
@@ -14,6 +14,8 @@ export const HEADING_BLOCK_ID = 'core/heading';
 export const LIST_BLOCK_ID = 'core/list';
 export const LIST_ITEM_BLOCK_ID = 'core/list-item';
 export const QUOTE_BLOCK_ID = 'core/quote';
+export const IMAGE_BLOCK_ID = 'core/image';
+export const VIDEO_BLOCK_ID = 'core/video';
 
 const ALLOWED_CORE_BLOCKS = [
 	PARAGRAPH_BLOCK_ID,
@@ -21,6 +23,8 @@ const ALLOWED_CORE_BLOCKS = [
 	LIST_BLOCK_ID,
 	LIST_ITEM_BLOCK_ID,
 	QUOTE_BLOCK_ID,
+	IMAGE_BLOCK_ID,
+	VIDEO_BLOCK_ID,
 ];
 
 const registerCoreBlocks = () => {

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -226,6 +226,10 @@ export const ProductDetailsSection: React.FC = () => {
 							setDescriptionBlocks( blocks );
 							setValue( 'description', serialize( blocks ) );
 						} }
+						placeholder={ __(
+							'Describe this product. What makes it unique? What are its most important features?',
+							'woocommerce'
+						) }
 					/>
 				</CardBody>
 			</Card>

--- a/plugins/woocommerce/changelog/fix-rich-text-editor-selection
+++ b/plugins/woocommerce/changelog/fix-rich-text-editor-selection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add placeholder to description field


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Fixes initial block selection so the toolbar is shown on page load
* Updates the rich text editor toolbar height
* Adds a prop for placeholder text on initial block
* Adds image and video block types

<img width="438" alt="Screen Shot 2022-10-24 at 3 17 57 PM" src="https://user-images.githubusercontent.com/10561050/197642663-63355f9d-1ad8-440b-b350-8013a76a08f3.png">


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product experience at Products-> Add new (MVP)
2. Note that the description editor has the toolbar buttons initially shown
3. Check that the toolbar is 40px in height
4. Note that the placeholder text is initially shown (`Describe this product...`)
5. Type `/` and insert an image or video block
6. Note that you an insert images via the media library
7. Insert a couple of blocks and hover between blocks to see that the block inserter (+ sign and blue line) is shown between blocks

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
