### PR TITLE
Set In-App Marketplace Tour as completed on close

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/index.tsx
@@ -3,6 +3,8 @@
  */
 import { useEffect, useState } from '@wordpress/element';
 import { TourKit, TourKitTypes } from '@woocommerce/components';
+import { useDispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import qs from 'qs';
 
 /**
@@ -15,11 +17,22 @@ const WCAddonsTour = () => {
 	const [ showTour, setShowTour ] = useState( false );
 	const [ tourConfig, setTourConfig ] = useState< TourKitTypes.WooConfig >();
 
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+
 	const closeHandler: TourKitTypes.CloseHandler = (
 		steps,
 		currentStepIndex
 	) => {
 		setShowTour( false );
+		// mark tour as completed
+		updateOptions( {
+			woocommerce_admin_dismissed_in_app_marketplace_tour: 'yes',
+		} );
+		// remove `tutorial` from search query, so it's not shown on page refresh
+		const url = new URL( window.location.href );
+		url.searchParams.delete( 'tutorial' );
+		window.history.replaceState( null, '', url );
+
 		if ( steps.length - 1 === currentStepIndex ) {
 			// TODO: Track Tour as completed
 		} else {

--- a/plugins/woocommerce/changelog/add-in-app-tour-make-it-dismissible
+++ b/plugins/woocommerce/changelog/add-in-app-tour-make-it-dismissible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Set In-App Marketplace Tour as completed on tour close

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
@@ -59,6 +59,6 @@ class TourInAppMarketplace extends Task {
 	 * @return string
 	 */
 	public function get_action_url() {
-		return admin_url( 'admin.php?page=wc-addons' );
+		return admin_url( 'admin.php?page=wc-addons&tutorial=true' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # 14754-gh-Automattic/woocommerce.com

When user closes In-App Marketplace Tour it's marked as completed and `tutorial` search param is removed from the URL (to prevent tour showing up on page refresh).

Changes include:
- added `tutorial` search parameter to "Tour the WooCommerce Marketplace" task
- updated option `woocommerce_admin_dismissed_in_app_marketplace_tour` to `yes` when the tour is closed
- removed `tutorial` search param from the URL when the tour is closed (to prevent tour popping up when navigating through the site - page refresh, go back)

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch from this PR in your local environment
2. Build assets: `pnpm install && pnpm run build` (how to [get started](https://github.com/woocommerce/woocommerce#getting-started))
3. To run local dev environment: `cd plugins/woocommerce && npm run env:dev`
4. Your `http://localhost:8888/` should be available (assume that it's your base URL)
5. Go to http://localhost:8888/wp-admin/admin.php?page=wc-admin , notice that "Tour the WooCommerce Marketplace" is not marked as complete 
![Screenshot 2022-10-25 at 11 43 21](https://user-images.githubusercontent.com/4765119/197779873-176eb98c-5d22-4be7-977c-a97ef2707260.png)

6. Click on the "Tour the WooCommerce Marketplace" task
7. You should see the In-App Marketplace Tour once you are redirected to the new page (added in https://github.com/woocommerce/woocommerce/pull/35268) 
8. Close the tour by clicking X icon or complete it by cliking the Done button 
![Screenshot 2022-10-25 at 11 43 43](https://user-images.githubusercontent.com/4765119/197780090-15ce421c-0f83-45f6-9ed8-19663ac51637.png)
9. Notice that URL doesn't contain `tutorial` param anymore
10. Go back to http://localhost:8888/wp-admin/admin.php?page=wc-admin , notice that "Tour the WooCommerce Marketplace" is now marked as complete 
![Screenshot 2022-10-25 at 11 44 00](https://user-images.githubusercontent.com/4765119/197780337-27fe3745-6a9a-45a2-af08-54f60a770211.png)
11. Please test around this issue.


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.