### PR TITLE
DateTimePickerControl: Allow time to be set to beginning or end of day when in date-only mode

### DIFF
--- a/packages/js/components/changelog/update-date-time-picker-control-force-time-to
+++ b/packages/js/components/changelog/update-date-time-picker-control-force-time-to
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added ability to force time when DateTimePickerControl is date-only (timeForDateOnly prop).

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -179,9 +179,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		onChangePropFunctionRef.current = onChange;
 	}, [ onChange ] );
 
-	const inputStringChangeHandlerFunctionRef = useRef<
-		( newInputString: string, fireOnChange: boolean ) => void
-	>( ( newInputString: string, fireOnChange: boolean ) => {
+	function inputStringChangeHandlerFunction(
+		newInputString: string,
+		fireOnChange: boolean
+	) {
 		if ( ! isMounted.current ) return;
 
 		let newDateTime = parseMoment( newInputString );
@@ -201,7 +202,17 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				isValid
 			);
 		}
-	} );
+	}
+
+	const inputStringChangeHandlerFunctionRef = useRef<
+		( newInputString: string, fireOnChange: boolean ) => void
+	>( inputStringChangeHandlerFunction );
+	// whenever forceTimeTo changes, we need to reset the ref to inputStringChangeHandlerFunction
+	// so that we are using the most current forceTimeTo value inside of it
+	useEffect( () => {
+		inputStringChangeHandlerFunctionRef.current =
+			inputStringChangeHandlerFunction;
+	}, [ forceTimeTo ] );
 
 	const debouncedInputStringChangeHandler = useDebounce(
 		inputStringChangeHandlerFunctionRef.current,
@@ -247,7 +258,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		} else {
 			changeImmediate( currentDate || '', fireOnChange );
 		}
-	}, [ currentDate, displayFormat ] );
+	}, [ currentDate, displayFormat, forceTimeTo ] );
 
 	return (
 		<Dropdown

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -53,7 +53,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	currentDate,
 	isDateOnlyPicker = false,
 	is12HourPicker = true,
-	timeForDateOnly,
+	timeForDateOnly = 'start-of-day',
 	dateTimeFormat,
 	disabled = false,
 	onChange,

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -40,7 +40,7 @@ export type DateTimePickerControlProps = {
 	disabled?: boolean;
 	isDateOnlyPicker?: boolean;
 	is12HourPicker?: boolean;
-	forceTimeTo?: 'start-of-day' | 'end-of-day';
+	timeForDateOnly?: 'start-of-day' | 'end-of-day';
 	onChange?: DateTimePickerControlOnChangeHandler;
 	onBlur?: () => void;
 	label?: string;
@@ -53,7 +53,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	currentDate,
 	isDateOnlyPicker = false,
 	is12HourPicker = true,
-	forceTimeTo,
+	timeForDateOnly,
 	dateTimeFormat,
 	disabled = false,
 	onChange,
@@ -123,11 +123,13 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	}
 
 	function maybeForceTime( momentDate: Moment ): Moment {
+		if ( ! isDateOnlyPicker ) return momentDate;
+
 		const updatedMomentDate = momentDate.clone();
 
-		if ( forceTimeTo === 'start-of-day' ) {
+		if ( timeForDateOnly === 'start-of-day' ) {
 			updatedMomentDate.startOf( 'day' );
-		} else if ( forceTimeTo === 'end-of-day' ) {
+		} else if ( timeForDateOnly === 'end-of-day' ) {
 			updatedMomentDate.endOf( 'day' );
 		}
 
@@ -212,7 +214,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	useEffect( () => {
 		inputStringChangeHandlerFunctionRef.current =
 			inputStringChangeHandlerFunction;
-	}, [ forceTimeTo ] );
+	}, [ timeForDateOnly ] );
 
 	const debouncedInputStringChangeHandler = useDebounce(
 		inputStringChangeHandlerFunctionRef.current,
@@ -258,7 +260,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		} else {
 			changeImmediate( currentDate || '', fireOnChange );
 		}
-	}, [ currentDate, displayFormat, forceTimeTo ] );
+	}, [ currentDate, displayFormat, timeForDateOnly ] );
 
 	return (
 		<Dropdown

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -40,6 +40,7 @@ export type DateTimePickerControlProps = {
 	disabled?: boolean;
 	isDateOnlyPicker?: boolean;
 	is12HourPicker?: boolean;
+	forceTimeTo?: 'start-of-day' | 'end-of-day';
 	onChange?: DateTimePickerControlOnChangeHandler;
 	onBlur?: () => void;
 	label?: string;
@@ -52,6 +53,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	currentDate,
 	isDateOnlyPicker = false,
 	is12HourPicker = true,
+	forceTimeTo,
 	dateTimeFormat,
 	disabled = false,
 	onChange,
@@ -120,6 +122,18 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return formatDate( displayFormat, momentDate.local() );
 	}
 
+	function maybeForceTime( momentDate: Moment ): Moment {
+		const updatedMomentDate = momentDate.clone();
+
+		if ( forceTimeTo === 'start-of-day' ) {
+			updatedMomentDate.startOf( 'day' );
+		} else if ( forceTimeTo === 'end-of-day' ) {
+			updatedMomentDate.endOf( 'day' );
+		}
+
+		return updatedMomentDate;
+	}
+
 	function hasFocusLeftInputAndDropdownContent(
 		event: React.FocusEvent< HTMLInputElement >
 	): boolean {
@@ -170,10 +184,11 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	>( ( newInputString: string, fireOnChange: boolean ) => {
 		if ( ! isMounted.current ) return;
 
-		const newDateTime = parseMoment( newInputString );
+		let newDateTime = parseMoment( newInputString );
 		const isValid = newDateTime.isValid();
 
 		if ( isValid ) {
+			newDateTime = maybeForceTime( newDateTime );
 			setLastValidDate( newDateTime );
 		}
 

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -99,3 +99,10 @@ ControlledDateOnly.args = {
 	isDateOnlyPicker: true,
 };
 ControlledDateOnly.decorators = Controlled.decorators;
+
+export const ControlledDateOnlyEndOfDay = Template.bind( {} );
+ControlledDateOnlyEndOfDay.args = {
+	...ControlledDateOnly.args,
+	timeForDateOnly: 'end-of-day',
+};
+ControlledDateOnlyEndOfDay.decorators = Controlled.decorators;

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -343,20 +343,16 @@ describe( 'DateTimePickerControl', () => {
 	// tearing down the component while test microtasks are still being executed
 	// (see https://github.com/facebook/jest/issues/12670)
 	//       TypeError: Cannot read properties of null (reading 'createEvent')
-	it( 'should force time to the start of the day', async () => {
-		const originalDateTime = moment( '2022-09-15 02:30:40' );
-		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
-		const newDateTimeInputString = '02:04, 06-08-2010';
-		const newDateTime = moment(
-			newDateTimeInputString,
-			dateTimeFormat
-		).startOf( 'day' );
+	it( 'should force time to the start of the day if date only', async () => {
+		const originalDateTime = moment( '09-15-2022' );
+		const newDateTimeInputString = '06-08-2010';
+		const newDateTime = moment( newDateTimeInputString ).startOf( 'day' );
 		const onChangeHandler = jest.fn();
 
 		const { container } = render(
 			<DateTimePickerControl
-				dateTimeFormat={ dateTimeFormat }
-				forceTimeTo={ 'start-of-day' }
+				isDateOnlyPicker
+				timeForDateOnly={ 'start-of-day' }
 				currentDate={ originalDateTime.toISOString() }
 				onChange={ onChangeHandler }
 				onChangeDebounceWait={ 10 }
@@ -386,20 +382,54 @@ describe( 'DateTimePickerControl', () => {
 	// tearing down the component while test microtasks are still being executed
 	// (see https://github.com/facebook/jest/issues/12670)
 	//       TypeError: Cannot read properties of null (reading 'createEvent')
-	it( 'should force time to the end of the day', async () => {
-		const originalDateTime = moment( '2022-09-15 02:30:40' );
-		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
-		const newDateTimeInputString = '02:04, 06-08-2010';
-		const newDateTime = moment(
-			newDateTimeInputString,
-			dateTimeFormat
-		).endOf( 'day' );
+	it( 'should force time to the end of the day if date only', async () => {
+		const originalDateTime = moment( '09-15-2022' );
+		const newDateTimeInputString = '06-08-2010';
+		const newDateTime = moment( newDateTimeInputString ).endOf( 'day' );
 		const onChangeHandler = jest.fn();
 
 		const { container } = render(
 			<DateTimePickerControl
-				dateTimeFormat={ dateTimeFormat }
-				forceTimeTo={ 'end-of-day' }
+				isDateOnlyPicker
+				timeForDateOnly={ 'end-of-day' }
+				currentDate={ originalDateTime.toISOString() }
+				onChange={ onChangeHandler }
+				onChangeDebounceWait={ 10 }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		userEvent.type(
+			input!,
+			'{selectall}{backspace}' + newDateTimeInputString
+		);
+
+		await waitFor(
+			() =>
+				expect( onChangeHandler ).toHaveBeenLastCalledWith(
+					newDateTime.toISOString(),
+					true
+				),
+			{ timeout: 100 }
+		);
+	}, 10000 );
+
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
+	it( 'should not force time to the start of the day if not date only', async () => {
+		const originalDateTime = moment( '09-15-2022' );
+		const newDateTimeInputString = '06-08-2010 7:00';
+		const newDateTime = moment( newDateTimeInputString );
+		const onChangeHandler = jest.fn();
+
+		const { container } = render(
+			<DateTimePickerControl
+				timeForDateOnly={ 'start-of-day' }
 				currentDate={ originalDateTime.toISOString() }
 				onChange={ onChangeHandler }
 				onChangeDebounceWait={ 10 }

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -343,6 +343,92 @@ describe( 'DateTimePickerControl', () => {
 	// tearing down the component while test microtasks are still being executed
 	// (see https://github.com/facebook/jest/issues/12670)
 	//       TypeError: Cannot read properties of null (reading 'createEvent')
+	it( 'should force time to the start of the day', async () => {
+		const originalDateTime = moment( '2022-09-15 02:30:40' );
+		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
+		const newDateTimeInputString = '02:04, 06-08-2010';
+		const newDateTime = moment(
+			newDateTimeInputString,
+			dateTimeFormat
+		).startOf( 'day' );
+		const onChangeHandler = jest.fn();
+
+		const { container } = render(
+			<DateTimePickerControl
+				dateTimeFormat={ dateTimeFormat }
+				forceTimeTo={ 'start-of-day' }
+				currentDate={ originalDateTime.toISOString() }
+				onChange={ onChangeHandler }
+				onChangeDebounceWait={ 10 }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		userEvent.type(
+			input!,
+			'{selectall}{backspace}' + newDateTimeInputString
+		);
+
+		await waitFor(
+			() =>
+				expect( onChangeHandler ).toHaveBeenLastCalledWith(
+					newDateTime.toISOString(),
+					true
+				),
+			{ timeout: 100 }
+		);
+	}, 10000 );
+
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
+	it( 'should force time to the end of the day', async () => {
+		const originalDateTime = moment( '2022-09-15 02:30:40' );
+		const dateTimeFormat = 'HH:mm, MM-DD-YYYY';
+		const newDateTimeInputString = '02:04, 06-08-2010';
+		const newDateTime = moment(
+			newDateTimeInputString,
+			dateTimeFormat
+		).endOf( 'day' );
+		const onChangeHandler = jest.fn();
+
+		const { container } = render(
+			<DateTimePickerControl
+				dateTimeFormat={ dateTimeFormat }
+				forceTimeTo={ 'end-of-day' }
+				currentDate={ originalDateTime.toISOString() }
+				onChange={ onChangeHandler }
+				onChangeDebounceWait={ 10 }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		userEvent.type(
+			input!,
+			'{selectall}{backspace}' + newDateTimeInputString
+		);
+
+		await waitFor(
+			() =>
+				expect( onChangeHandler ).toHaveBeenLastCalledWith(
+					newDateTime.toISOString(),
+					true
+				),
+			{ timeout: 100 }
+		);
+	}, 10000 );
+
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
 	it( 'should call onChange with isValid false when the input is invalid', async () => {
 		const originalDateTime = moment( '2022-09-15 02:30:40' );
 		const onChangeHandler = jest.fn();


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Needed for #34538

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook and make sure DateTimePickerControl "Controlled Date Only End Of Day" story returns the end of the day for the selected date: `pnpm --filter=@woocommerce/storybook storybook`
    - View the `onChange` entries in the Storybook "Actions" tab to confirm that the time is set to "23:59:59"

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
