### PR TITLE
Fix missing use FQCN for WP_Error

### DIFF
--- a/plugins/woocommerce/changelog/fix-missing-use-fqcn-wp_error
+++ b/plugins/woocommerce/changelog/fix-missing-use-fqcn-wp_error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+FQCN for WP_Error in PHPDoc.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -262,7 +262,7 @@ class TaskLists {
 	 * Add a task list.
 	 *
 	 * @param array $args Task list properties.
-	 * @return WP_Error|TaskList
+	 * @return \WP_Error|TaskList
 	 */
 	public static function add_list( $args ) {
 		if ( isset( self::$lists[ $args['id'] ] ) ) {
@@ -281,7 +281,7 @@ class TaskLists {
 	 *
 	 * @param string $list_id List ID to add the task to.
 	 * @param array  $args Task properties.
-	 * @return WP_Error|Task
+	 * @return \WP_Error|Task
 	 */
 	public static function add_task( $list_id, $args ) {
 		if ( ! isset( self::$lists[ $list_id ] ) ) {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -9,6 +9,8 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedExtendedTask;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\ReviewShippingOptions;
+use WP_Error;
+
 /**
  * Task Lists class.
  */
@@ -266,7 +268,7 @@ class TaskLists {
 	 */
 	public static function add_list( $args ) {
 		if ( isset( self::$lists[ $args['id'] ] ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'woocommerce_task_list_exists',
 				__( 'Task list ID already exists', 'woocommerce' )
 			);
@@ -285,7 +287,7 @@ class TaskLists {
 	 */
 	public static function add_task( $list_id, $args ) {
 		if ( ! isset( self::$lists[ $list_id ] ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'woocommerce_task_list_invalid_list',
 				__( 'Task list ID does not exist', 'woocommerce' )
 			);

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -9,8 +9,6 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedExtendedTask;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\ReviewShippingOptions;
-use WP_Error;
-
 /**
  * Task Lists class.
  */
@@ -268,7 +266,7 @@ class TaskLists {
 	 */
 	public static function add_list( $args ) {
 		if ( isset( self::$lists[ $args['id'] ] ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'woocommerce_task_list_exists',
 				__( 'Task list ID already exists', 'woocommerce' )
 			);
@@ -287,7 +285,7 @@ class TaskLists {
 	 */
 	public static function add_task( $list_id, $args ) {
 		if ( ! isset( self::$lists[ $list_id ] ) ) {
-			return new WP_Error(
+			return new \WP_Error(
 				'woocommerce_task_list_invalid_list',
 				__( 'Task list ID does not exist', 'woocommerce' )
 			);


### PR DESCRIPTION
phpdoc was not using FQCN for WP_Error, however use is preferred to FQCN anyway
Fix: https://github.com/woocommerce/woocommerce/issues/35304

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35304

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
