### PR TITLE
TT3 compatibility 

### DIFF
--- a/plugins/woocommerce/changelog/add-tt3-support
+++ b/plugins/woocommerce/changelog/add-tt3-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Twenty Twenty-Three theme compatibility.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -1,0 +1,36 @@
+/**
+* Fonts
+*/
+@font-face {
+	font-family: star;
+	src: url(../fonts/star.eot);
+	src:
+		url(../fonts/star.eot?#iefix) format("embedded-opentype"),
+		url(../fonts/star.woff) format("woff"),
+		url(../fonts/star.ttf) format("truetype"),
+		url(../fonts/star.svg#star) format("svg");
+	font-weight: 400;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: WooCommerce;
+	src: url(../fonts/WooCommerce.eot);
+	src:
+		url(../fonts/WooCommerce.eot?#iefix) format("embedded-opentype"),
+		url(../fonts/WooCommerce.woff) format("woff"),
+		url(../fonts/WooCommerce.ttf) format("truetype"),
+		url(../fonts/WooCommerce.svg#WooCommerce) format("svg");
+	font-weight: 400;
+	font-style: normal;
+}
+
+@import "mixins";
+@import "animation";
+
+
+.theme-twentytwentythree.woocommerce {
+
+
+
+}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -484,6 +484,10 @@
 			list-style: none;
 			padding-left: 0;
 
+			li {
+				margin-bottom: var(--wp--style--block-gap);
+			}
+
 			img.avatar {
 				float: left;
 			}
@@ -493,7 +497,7 @@
 			}
 
 			.comment-text {
-				display: inline-block;
+				display: flow-root;
 				padding-left: var(--wp--style--block-gap);
 
 				.star-rating {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -423,7 +423,6 @@
 				float: left;
 				border-style: solid;
 				border-width: 1px;
-				border-left-color: var(--wp--preset--color--background);
 				font-weight: 600;
 				font-size: var(--wp--preset--font-size--medium);
 
@@ -433,7 +432,6 @@
 				}
 
 				&.active {
-					box-shadow: 0 1px var(--wp--preset--color--background);
 					background: var(--wp--preset--color--tertiary);
 					color: var(--wp--preset--color--contrast);
 					opacity: 1;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -249,6 +249,7 @@
 				font-size: revert;
 			}
 
+			// Add to cart/Select options/Read more buttons.
 			a.button {
 				padding: 0.8rem 2.7rem;
 				margin-left: auto;
@@ -257,6 +258,11 @@
 				&.loading {
 					opacity: 0.5;
 				}
+			}
+
+			// View cart link.
+			a.added_to_cart {
+				margin: 1rem auto;
 			}
 
 		}
@@ -1069,6 +1075,22 @@
 	// Make sure the floated content of My Account section doesn't overlap with the footer.
 	.woocommerce {
 		overflow: auto;
+
+		table.woocommerce-table--order-downloads,
+		table.woocommerce-MyAccount-orders {
+			thead tr {
+				border-top: 2px solid var(--wp--preset--color--contrast);
+
+				span {
+					font-weight: bold;
+				}
+
+			}
+
+			tbody a.button {
+				margin: calc(var(--wp--style--block-gap) / 6) 0;
+			}
+		}
 	}
 
 	// Make the Log in form on My Account page less wide.
@@ -1076,6 +1098,7 @@
 		max-width: 516px;
 		margin: 0 auto;
 	}
+
 }
 
 // TODO: This could look nicer.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -384,6 +384,7 @@
 
 			display: table-row;
 			margin-bottom: 0;
+			text-align: left;
 
 			td select {
 				margin: calc(var(--wp--style--block-gap) / 4) 0;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -249,8 +249,7 @@
 				font-size: revert;
 			}
 
-			a.add_to_cart_button,
-			a.product_type_grouped {
+			a.button {
 				padding: 0.8rem 2.7rem;
 				margin-left: auto;
 				margin-right: auto;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -126,6 +126,7 @@
 		margin-bottom: 2rem;
 		list-style: none;
 		font-size: var(--wp--preset--font-size--small);
+		display: flow-root;
 
 		&[role="alert"]::before {
 			background: #d5d5d5;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -251,7 +251,7 @@
 
 			// Add to cart/Select options/Read more buttons.
 			a.button {
-				padding: 0.8rem 2.7rem;
+				padding: 0.8rem 10%;
 				margin-left: auto;
 				margin-right: auto;
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -296,6 +296,7 @@
 			z-index: 1;
 		}
 
+		// How price gets displayed
 		.entry-summary {
 			.woocommerce-Price-amount,
 			del,
@@ -362,6 +363,24 @@
 					font-size: 1em;
 				}
 			}
+
+			.quantity {
+				display: inline-block;
+			}
+		}
+
+		table.variations tr {
+
+			display: table-row;
+			margin-bottom: 0;
+
+			td select {
+				margin: calc(var(--wp--style--block-gap) / 4) 0;
+			}
+		}
+
+		.single_variation_wrap {
+			margin-top: var(--wp--style--block-gap);
 		}
 
 		button[name="add-to-cart"],

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -298,7 +298,8 @@
 
 		.entry-summary {
 			.woocommerce-Price-amount,
-			del {
+			del,
+			.price {
 				font-size: var(--wp--preset--font-size--large);
 			}
 		}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -657,7 +657,7 @@
 	// Highlights for specific info, e.g. on the My Account > Orders > Order X: Order ___ was placed on ____
 	mark {
 		font-weight: bold;
-		background-color: var(--wp--preset--color--base);
+		background-color: transparent;
 	}
 
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -138,10 +138,14 @@
 			margin-right: 1rem;
 		}
 
-		a.button {
-			margin-top: -0.5rem;
-			border: none;
-			padding: 0.5rem 1rem;
+		a {
+			color: var(--wp--preset--color--contrast);
+
+			.button {
+				margin-top: -0.5rem;
+				border: none;
+				padding: 0.5rem 1rem;
+			}
 		}
 	}
 
@@ -662,6 +666,12 @@
 		// Make coupon code input less ginormous.
 		#coupon_code {
 			padding: 0 1rem;
+		}
+
+		.actions {
+			button.button {
+				height: initial;
+			}
 		}
 
 		// Cart table, aka review of cart items.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -452,6 +452,10 @@
 			h2 {
 				display: none;
 			}
+
+			table.woocommerce-product-attributes {
+				text-align: left;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -832,6 +832,11 @@
 				&.woocommerce-orders-table__cell-order-actions {
 					a.button {
 						display: block;
+
+						@media only screen and (max-width: 768px) {
+							width: 50%;
+							margin-left: auto;
+						}
 					}
 				}
 			}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -29,8 +29,975 @@
 @import "animation";
 
 
-.theme-twentytwentythree.woocommerce {
+.theme-twentytwentythree {
+	.container-colors {
+		display: flex;
+		flex-direction: row;
+	}
+
+	.cube {
+		width: 20%;
+		height: 100px;
+		text-align: center;
+		vert-align: middle;
+	}
+
+	.base {
+		background-color: var(--wp--preset--color--base);
+	}
+
+	.contrast {
+		background-color: var(--wp--preset--color--contrast);
+		color: var(--wp--preset--color--base);
+	}
+
+	.primary {
+		background-color: var(--wp--preset--color--primary);
+	}
+
+	.secondary {
+		background-color: var(--wp--preset--color--secondary);
+	}
+
+	.tertiary {
+		background-color: var(--wp--preset--color--tertiary);
+	}
 
 
+}
 
+.woocommerce {
+
+	/*
+	    Common/global
+	 */
+
+	// Make quantity selector less wide.
+	.quantity {
+		input[type="number"] {
+			width: 3em;
+		}
+
+		input[type="number"]::-webkit-inner-spin-button,
+		input[type="number"]::-webkit-outer-spin-button {
+			opacity: 1;
+		}
+	}
+
+	// Breadcrumbs are unnecessary on the shop page.
+	&.woocommerce-shop .woocommerce-breadcrumb {
+		display: none;
+	}
+
+	// Make sure breadcrumbs are not overlapping with Sale badge on the Single product page, etc.
+	.woocommerce-breadcrumb {
+		margin-bottom: 1rem;
+	}
+
+	/*
+		Notice messages (like 'Added to cart', 'Billing address needs to be filled in', etc.
+	 */
+	.woocommerce-message,
+	.woocommerce-error,
+	.woocommerce-info {
+		background: var(--wp--preset--color--primary);
+		border-top-color: var(--wp--preset--color--primary);
+		border-top-style: solid;
+		padding: 1rem 1.5rem;
+		margin-bottom: 2rem;
+		list-style: none;
+		font-size: var(--wp--preset--font-size--small);
+
+		&[role="alert"]::before {
+			color: var(--wp--preset--color--contrast);
+			background: var(--wp--preset--color--primary);
+			border-radius: 5rem;
+			font-size: 1rem;
+			padding-left: 3px;
+			padding-right: 3px;
+			margin-right: 1rem;
+		}
+
+		a.button {
+			margin-top: -0.5rem;
+			border: none;
+			//background: #ebe9eb;
+			//color: var(--wp--preset--color--black);
+			padding: 0.5rem 1rem;
+
+			//&:hover,
+			//&:visited {
+			//	color: var(--wp--preset--color--black);
+			//}
+		}
+	}
+
+	.woocommerce-error[role="alert"] {
+		margin: 0;
+
+		&::before {
+			content: "X";
+			padding-right: 4px;
+			padding-left: 4px;
+		}
+
+		li {
+			display: inline-block;
+		}
+	}
+
+	.woocommerce-message {
+		&[role="alert"]::before {
+			content: "\2713";
+		}
+	}
+
+	// Checkout notice group styling.
+	.woocommerce-NoticeGroup-checkout {
+		ul.woocommerce-error[role="alert"] {
+			color: var(--wp--preset--color--contrast);
+			background: var(--wp--preset--color--primary);
+
+			&::before {
+				display: none;
+			}
+			li {
+				display: inherit;
+				margin-bottom: 1rem;
+			}
+		}
+	}
+
+	/*
+	  Shop page.
+	 */
+
+	// Styling the buttons on the Shop page.
+	a.button,
+	button[name="add-to-cart"],
+	input[name="submit"],
+	button.single_add_to_cart_button,
+	button[type="submit"]:not(.wp-block-search__button) {
+		display: inline-block;
+		text-align: center;
+		word-break: break-word;
+		padding: 1rem 2rem;
+		margin-top: 1rem;
+		text-decoration: none;
+		font-size: medium;
+		cursor: pointer;
+
+	}
+
+	// Style the 'Showing A-B of X results' text.
+	.woocommerce-result-count {
+		margin-top: 0;
+	}
+
+	// The 'order by' dropdown on the Shop page is rather tiny unless the font size is increased.
+	select.orderby {
+		font-size: var(--wp--preset--font-size--medium);
+	}
+
+	// Products.
+	ul.products {
+
+		padding-inline-start: 0;
+
+		li.product {
+			list-style: none;
+			margin-top: var(--wp--style--block-gap);
+			text-align: center;
+
+			a.woocommerce-loop-product__link {
+				text-decoration: none;
+				display: block;
+			}
+
+			h2.woocommerce-loop-product__title {
+				color: var(--wp--preset--color--primary);
+				font-family: var(--wp--preset--font-family--system-font);
+				text-decoration: none;
+				margin-bottom: 0;
+			}
+
+			a.add_to_cart_button {
+				padding: 0.8rem 2.7rem;
+
+				&.loading {
+					opacity: 0.5;
+				}
+			}
+
+		}
+	}
+
+	// Position page numbers under list of products horizontally in the centre of the page.
+	ul.page-numbers {
+		text-align: center;
+	}
+
+	// On sale badge.
+	span.onsale {
+		top: -1rem;
+		right: -1rem;
+		position: absolute;
+		background: var(--wp--preset--color--tertiary);
+		color: var(--wp--preset--color--contrast);
+		border-radius: 2rem;
+		line-height: 2.6rem;
+		font-size: 0.8rem;
+		padding: 0 0.5rem 0 0.5rem;
+	}
+
+	/*
+		Single product page.
+	 */
+
+	div.product {
+		position: relative;
+
+		> span.onsale {
+			position: absolute;
+			left: -1rem;
+			top: -1rem;
+			width: 1.8rem;
+			z-index: 1;
+		}
+
+		.entry-summary {
+			.woocommerce-Price-amount,
+			del {
+				font-size: var(--wp--preset--font-size--large);
+			}
+		}
+
+		div.woocommerce-product-gallery {
+			position: relative;
+
+			a.woocommerce-product-gallery__trigger {
+				position: absolute;
+				top: 1rem;
+				right: 1rem;
+				z-index: 1;
+				text-decoration: none;
+				border-radius: 1rem;
+				border-style: solid;
+				line-height: 1.5rem;
+				padding: 0;
+				font-size: 0.6rem;
+				background: var(--wp--preset--color--white);
+				border-color: var(--wp--preset--color--white);
+				height: 1.5rem;
+				width: 1.5rem;
+				overflow: hidden;
+
+				&::before {
+					content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img" focusable="false" viewBox="0 0 24 24" width="24" height="24"><path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z" /></svg>');
+					display: block;
+					transform: rotateY(180deg);
+					margin-left: 1.55rem;
+				}
+			}
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+		}
+
+		div.summary {
+			font-size: 1rem;
+
+			h1.product_title {
+				font-size: var(--wp--preset--font-size--huge);
+				margin: 0;
+			}
+
+			figure.woocommerce-product-gallery__wrapper {
+				margin: 0;
+			}
+
+			.woocommerce-product-rating {
+				.star-rating {
+					display: inline-block;
+				}
+				.woocommerce-review-link {
+					display: inline-block;
+					overflow: hidden;
+					position: relative;
+					top: -0.5em;
+					font-size: 1em;
+				}
+			}
+		}
+
+		button[name="add-to-cart"],
+		button.single_add_to_cart_button {
+			margin-top: 0.5rem;
+			margin-bottom: var(--wp--style--block-gap);
+		}
+
+		ol.flex-control-thumbs {
+			padding-left: 0;
+			float: left;
+
+			li {
+				list-style: none;
+				cursor: pointer;
+				float: left;
+				width: 18%;
+				margin-right: 1rem;
+			}
+
+		}
+
+		a.reset_variations {
+			margin-left: 0.5em;
+		}
+
+		table.group_table {
+			td {
+				padding-right: 0.5rem;
+				padding-bottom: 1rem;
+			}
+
+			margin-bottom: var(--wp--style--block-gap);
+		}
+
+		.related.products {
+			margin-top: 7rem;
+		}
+
+	}
+
+	// Description/Additional info/Reviews tabs.
+	.woocommerce-tabs {
+		padding-top: var(--wp--style--block-gap);
+
+		ul.wc-tabs {
+			padding: 0;
+			border-bottom-style: solid;
+			border-bottom-width: 1px;
+			border-bottom-color: #eae9eb;
+
+			li {
+				opacity: 0.5;
+				color: var(--wp--preset--color--contrast);
+				margin: 0;
+				padding: 0.5em 1em 0.5em 1em;
+				border-color: #eae9eb;
+				border-top-left-radius: 5px;
+				border-top-right-radius: 5px;
+				float: left;
+				border-style: solid;
+				border-width: 1px;
+				border-left-color: var(--wp--preset--color--background);
+				font-weight: 600;
+				font-size: var(--wp--preset--font-size--medium);
+
+				&:first-child {
+					border-left-color: #eae9eb;
+					margin-left: 1em;
+				}
+
+				&.active {
+					box-shadow: 0 1px var(--wp--preset--color--background);
+					background: var(--wp--preset--color--tertiary);
+					color: var(--wp--preset--color--contrast);
+					opacity: 1;
+				}
+
+				a {
+					text-decoration: none;
+					color: var(--wp--preset--color--contrast);
+				}
+			}
+		}
+
+		.woocommerce-Tabs-panel {
+			padding-top: var(--wp--style--block-gap);
+			font-size: var(--wp--preset--font-size--small);
+			margin-left: 1em;
+
+			h2 {
+				display: none;
+			}
+		}
+	}
+
+	// Reviews tab.
+	.woocommerce-Reviews {
+		ol.commentlist {
+			list-style: none;
+			padding-left: 0;
+
+			img.avatar {
+				float: left;
+			}
+
+			p.meta {
+				font-size: 1rem;
+			}
+
+			.comment-text {
+				display: inline-block;
+				padding-left: var(--wp--style--block-gap);
+
+				.star-rating {
+					margin-top: 0;
+					margin-right: unset;
+					margin-left: unset;
+				}
+			}
+		}
+
+		.comment-form-rating {
+			label {
+				display: inline-block;
+				padding-right: var(--wp--style--block-gap);
+				padding-top: var(--wp--style--block-gap);
+			}
+
+			p.stars {
+				display: inline;
+				a::before {
+					color: var(--wp--preset--color--contrast);
+				}
+			}
+		}
+
+		.comment-form-comment {
+			label {
+				float: left;
+				padding-right: var(--wp--style--block-gap);
+			}
+		}
+
+		#review_form_wrapper {
+			margin-top: 5rem;
+		}
+	}
+
+	// Rating: show stars instead of 1, 2, 3, 4, 5.
+	.star-rating {
+		overflow: hidden;
+		position: relative;
+		height: 1em;
+		line-height: 1;
+		width: 5.4rem;
+		font-family: star;
+		font-style: normal;
+		color: var(--wp--preset--color--contrast);
+		margin: 1rem auto 0.7rem auto;
+
+		&::before {
+			content: "\73\73\73\73\73";
+			float: left;
+			top: 0;
+			left: 0;
+			position: absolute;
+			font-size: 1rem;
+		}
+
+		span {
+			overflow: hidden;
+			float: left;
+			top: 0;
+			left: 0;
+			position: absolute;
+			padding-top: 1.5em;
+		}
+
+		span::before {
+			content: "\53\53\53\53\53";
+			top: 0;
+			position: absolute;
+			left: 0;
+			font-size: 1rem;
+		}
+	}
+
+	// Rating stars.
+	p.stars {
+		margin-top: 0;
+
+		a {
+			position: relative;
+			height: 1em;
+			width: 1em;
+			text-indent: -999em;
+			display: inline-block;
+			text-decoration: none;
+			box-shadow: none;
+			font-style: normal;
+
+			&::before {
+				display: block;
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 1em;
+				height: 1em;
+				line-height: 1;
+				font-family: WooCommerce;
+				content: "\e021";
+				text-indent: 0;
+			}
+
+			&:hover {
+
+				~ a::before {
+					content: "\e021";
+				}
+			}
+		}
+
+		&:hover {
+
+			a {
+
+				&::before {
+					content: "\e020";
+				}
+			}
+		}
+
+		&.selected {
+
+			a.active {
+
+				&::before {
+					content: "\e020";
+				}
+
+				~ a::before {
+					content: "\e021";
+				}
+			}
+
+			a:not(.active) {
+
+				&::before {
+					content: "\e020";
+				}
+			}
+		}
+	}
+
+	// Highlights for specific info, e.g. on the My Account > Orders > Order X: Order ___ was placed on ____
+	mark {
+		background: var(--wp--preset--color--primary);
+		color: var(--wp--preset--color--contrast);
+	}
+
+}
+
+.woocommerce-page {
+	.woocommerce-cart-form {
+
+		// Make coupon code input less ginormous.
+		#coupon_code {
+			padding: 0 1rem;
+		}
+
+		// Cart table, aka review of cart items.
+		table.shop_table_responsive {
+
+			td,
+			th {
+				padding: 1rem 0 0.5rem 1rem;
+			}
+
+			tbody {
+
+				tr:last-of-type {
+					border-top: none;
+				}
+
+				@media only screen and (max-width: 768px) {
+					td {
+						padding-left: 0;
+					}
+
+					.product-remove {
+						text-align: left !important;
+					}
+
+					#coupon_code {
+						float: left;
+						margin-bottom: 1rem;
+					}
+				}
+			}
+
+			button[name="apply_coupon"],
+			button[name="update_cart"] {
+				padding: 1rem 2rem;
+				border: 2px solid #ebe9eb;
+				margin: 0;
+			}
+
+			.product-remove {
+				font-size: var(--wp--preset--font-size--large);
+
+				a {
+					text-decoration: none;
+				}
+			}
+		}
+	}
+
+	// Elements around "Proceed to Checkout" button.
+	.cart-collaterals {
+		margin-top: 1.5rem;
+
+		h2 {
+			text-transform: uppercase;
+			font-family: inherit;
+		}
+
+		table.shop_table_responsive {
+
+			tr {
+				border-top: none;
+			}
+
+			th {
+				width: 11rem;
+			}
+
+			td,
+			th {
+				padding: 1rem 0;
+				vertical-align: text-top;
+			}
+		}
+
+		button[name="calc_shipping"] {
+			padding: 1rem 2rem;
+		}
+
+		.woocommerce-Price-amount {
+			font-weight: normal;
+		}
+	}
+
+	// Style the payment gateway selection input--improve the size of the click target, etc
+	input[type="radio"][name="payment_method"],
+	input[type="radio"].shipping_method {
+		display: none;
+
+		& + label {
+
+			&::before {
+				content: "";
+				display: inline-block;
+				width: 1rem;
+				height: 1rem;
+				border: 2px solid var(--wp--preset--color--black);
+				background: var(--wp--preset--color--white);
+				margin-left: 4px;
+				margin-right: 1.2rem;
+				border-radius: 100%;
+				transform: translateY(0.2rem);
+			}
+		}
+
+		& ~ .payment_box {
+			padding-left: 3rem;
+			margin-top: 1rem;
+		}
+
+		&:checked + label {
+
+			&::before {
+				background: radial-gradient(circle at center, black 45%, white 0);
+			}
+		}
+	}
+
+	// Style labels like "Remember me?" or "Ship to different address".
+	label.woocommerce-form__label-for-checkbox {
+		font-weight: normal;
+		cursor: pointer;
+
+		span {
+
+			&::before {
+				content: "";
+				display: inline-block;
+				height: 1rem;
+				width: 1rem;
+				border: 2px solid var(--wp--preset--color--black);
+				background: var(--wp--preset--color--white);
+				margin-right: 0.5rem;
+				transform: translateY(0.2rem);
+			}
+		}
+
+		input[type="checkbox"] {
+			display: none;
+		}
+
+		input[type="checkbox"]:checked + span::before {
+			background: var(--wp--preset--color--black);
+			box-shadow: inset 0.2rem 0.2rem var(--wp--preset--color--white), inset -0.2rem -0.2rem var(--wp--preset--color--white);
+		}
+	}
+
+	// Cart totals, Cart page table or Order list in My Account.
+	table.shop_table_responsive {
+		text-align: left;
+
+		th,
+		td {
+			font-size: var(--wp--preset--font-size--small);
+			font-weight: normal;
+		}
+
+		th {
+			padding-bottom: 1rem;
+		}
+
+		tbody {
+
+			tr {
+				border-top: 1px solid var(--wp--preset--color--black);
+			}
+
+			td {
+				a.button,
+				button {
+					margin-bottom: 1rem;
+					border: none;
+					padding: 0.5rem 1rem 0.5rem 1rem;
+				}
+
+				&.woocommerce-orders-table__cell-order-actions {
+					a.button {
+						display: block;
+					}
+				}
+			}
+		}
+	}
+
+	table.shop_table,
+	table.shop_table_responsive {
+		tbody {
+			.product-name {
+				a:not(:hover) {
+					text-decoration: none;
+				}
+
+				a:hover {
+					text-decoration: underline;
+					text-decoration-thickness: 1px;
+				}
+
+				.variation {
+					dt {
+						font-style: italic;
+						margin-right: 0.25rem;
+						float: left;
+					}
+
+					dd {
+						font-style: normal;
+
+						a {
+							font-style: normal;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Improve styling of the 'Have a coupon?' section on the checkout page.
+	form.checkout_coupon {
+		background-color: transparent;
+		padding-left: 1.5rem;
+		float: left;
+		// 1.5 rem is to account for extra padding we added above.
+		width: calc(100% - 1.5rem);
+
+		.form-row {
+			button[name="apply_coupon"] {
+				margin-top: 0;
+			}
+		}
+	}
+
+	// Hide the dot to the left of list items as we style the checkboxes: Shipping method and Payment method selection.
+	ul.wc_payment_methods,
+	ul.woocommerce-shipping-methods {
+		margin-top: 0;
+		margin-bottom: 0;
+		list-style-type: none;
+		padding-left: 0;
+
+		input[type="radio"] {
+			margin-right: 0.6rem;
+		}
+
+		li.wc_payment_method {
+			margin-bottom: 1rem;
+		}
+	}
+
+	// Layout of the checkout: Billing vs Shipping address, Cart overview, etc.
+	.woocommerce-checkout,
+	&.woocommerce-order-pay {
+		display: table;
+
+		h3 {
+			font-family: inherit;
+			font-size: var(--wp--preset--font-size--normal);
+			font-weight: 700;
+		}
+
+		.col2-set {
+			width: 43%;
+			float: right;
+		}
+
+		.blockUI.blockOverlay {
+			position: relative;
+			@include loader();
+		}
+
+		#customer_details {
+			width: 53%;
+			float: left;
+
+			.col-1,
+			.col-2 {
+				width: 100%;
+				float: none;
+			}
+		}
+
+		@media only screen and (max-width: 768px) {
+			.col2-set,
+			#customer_details {
+				width: 100%;
+				float: none;
+			}
+		}
+
+		.woocommerce-billing-fields__field-wrapper,
+		.woocommerce-checkout-review-order-table,
+		.woocommerce-checkout-payment,
+		#payment {
+			margin-top: 4rem;
+		}
+
+		.woocommerce-checkout-review-order-table,
+		#order_review .shop_table {
+			border-collapse: collapse;
+			width: 100%;
+
+			thead {
+				display: none;
+			}
+
+			th {
+				text-align: left;
+				font-weight: normal;
+			}
+
+			th,
+			td {
+				padding: 1rem 1rem 1rem 0;
+				vertical-align: text-top;
+			}
+
+			tbody {
+				border-bottom: 1px solid #d2ced2;
+			}
+
+			tr.order-total {
+				border-top: 1px solid #d2ced2;
+			}
+
+			.product-quantity {
+				font-weight: normal;
+			}
+
+			.product-total,
+			.cart-subtotal,
+			.order-total,
+			.tax-rate,
+			input[type="radio"].shipping_method:checked + label,
+			input[type="hidden"].shipping_method + label {
+				.woocommerce-Price-amount {
+					font-weight: bold;
+				}
+			}
+		}
+
+		button#place_order {
+			width: 100%;
+			text-transform: uppercase;
+		}
+	}
+}
+
+/*
+	My Account
+ */
+
+.woocommerce-account {
+
+	// Make sure the floated content of My Account section doesn't overlap with the footer.
+	.woocommerce {
+		overflow: auto;
+	}
+
+	// Make the Log in form on My Account page less wide.
+	.woocommerce-form-login {
+		max-width: 516px;
+		margin: 0 auto;
+	}
+}
+
+.select2-container {
+
+	.select2-selection,
+	.select2-dropdown {
+		border: 1px solid var(--wp--preset--color--black);
+		border-radius: 0;
+	}
+
+	.select2-dropdown {
+		border-top: 0;
+
+		.select2-search__field {
+			border: 1px solid var(--wp--preset--color--black);
+			border-radius: 0;
+		}
+	}
+}
+
+
+// Store-wide notice
+.theme-twentytwentythree .woocommerce-store-notice {
+	color: var(--wp--preset--color--contrast);
+	border-top: 2px solid var(--wp--preset--color--primary);
+	background: var(--wp--preset--color--primary);
+	padding: 2rem;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+	margin: 0;
+
+	.woocommerce-store-notice__dismiss-link {
+		float: right;
+		margin-right: 4rem;
+		color: inherit;
+	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -1154,9 +1154,9 @@
 
 // Store-wide notice
 .theme-twentytwentythree .woocommerce-store-notice {
-	color: var(--wp--preset--color--contrast);
+	color: black;
 	border-top: 2px solid var(--wp--preset--color--primary);
-	background: var(--wp--preset--color--primary);
+	background: lightgray;
 	padding: 2rem;
 	position: fixed;
 	bottom: 0;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -631,13 +631,6 @@
 				}
 			}
 
-			button[name="apply_coupon"],
-			button[name="update_cart"] {
-				padding: 1rem 2rem;
-				border: 2px solid #ebe9eb;
-				margin: 0;
-			}
-
 			.product-remove {
 				font-size: var(--wp--preset--font-size--large);
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -812,7 +812,7 @@
 		tbody {
 
 			tr {
-				border-top: 1px solid var(--wp--preset--color--black);
+				border-top: 1px solid var(--wp--preset--color--contrast);
 			}
 
 			td {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -219,7 +219,10 @@
 		align-items: stretch;
 		flex-direction: row;
 		flex-wrap: wrap;
-		justify-content: space-between;
+		justify-content: flex-start;
+		@media only screen and (max-width: 768px) {
+			justify-content: space-between;
+		}
 
 		li.product {
 			list-style: none;
@@ -246,7 +249,8 @@
 				font-size: revert;
 			}
 
-			a.add_to_cart_button {
+			a.add_to_cart_button,
+			a.product_type_grouped {
 				padding: 0.8rem 2.7rem;
 				margin-left: auto;
 				margin-right: auto;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -817,9 +817,7 @@
 
 	// Improve styling of the 'Have a coupon?' section on the checkout page.
 	form.checkout_coupon {
-		background-color: transparent;
 		padding-left: 1.5rem;
-		float: left;
 		// 1.5 rem is to account for extra padding we added above.
 		width: calc(100% - 1.5rem);
 
@@ -943,6 +941,74 @@
 			text-transform: uppercase;
 		}
 	}
+
+	/*
+		Thank you page (after checkout).
+	 */
+
+	// Adds a tiny bit of vertical spacing on the Thank you (after checkout) page.
+	.woocommerce-order > * {
+		margin-bottom: var(--wp--style--block-gap);
+	}
+
+	// Improves the presentation of order overview (order #, date, email, etc, not the line items) on the Thank you page.
+	ul.woocommerce-order-overview {
+
+		li {
+			display: inline;
+			text-transform: uppercase;
+
+			strong {
+				text-transform: none;
+				display: block;
+			}
+		}
+	}
+
+	// Bottom section of the Thank you page---customer details: align, add border, make it look nice.
+	.woocommerce-customer-details {
+		address {
+			border: 1px solid var(--wp--preset--color--black);
+			font-style: inherit;
+
+			p[class^="woocommerce-customer-details--"] {
+				&:first-of-type {
+					margin-top: 2rem;
+				}
+
+				margin-top: 1rem;
+				margin-bottom: 0;
+			}
+
+			.woocommerce-customer-details--phone::before {
+				content: "\01F4DE";
+				margin-right: 1rem;
+			}
+
+			.woocommerce-customer-details--email::before {
+				content: "\2709";
+				margin-right: 1rem;
+				font-size: 1.8rem;
+			}
+		}
+	}
+
+	// Better styling for Order line items on the Thank you page: create a table and align it to the left side.
+	.woocommerce-table--order-details {
+		border: 1px solid var(--wp--preset--color--black);
+
+		th,
+		td {
+			text-align: left;
+			border-top: 1px solid var(--wp--preset--color--black);
+			border-bottom: 1px solid var(--wp--preset--color--black);
+			font-weight: normal;
+		}
+
+		thead th {
+			text-transform: uppercase;
+		}
+	}
 }
 
 /*
@@ -963,6 +1029,7 @@
 	}
 }
 
+// TODO: This could look nicer.
 .select2-container {
 
 	.select2-selection,

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -227,7 +227,7 @@
 			}
 
 			h2.woocommerce-loop-product__title {
-				color: var(--wp--preset--color--primary);
+				color: var(--wp--preset--color--contrast);
 				font-family: var(--wp--preset--font-family--system-font);
 				text-decoration: none;
 				margin-bottom: 0;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -241,6 +241,7 @@
 			a.woocommerce-loop-product__link {
 				text-decoration: none;
 				display: block;
+				border: 0;
 			}
 
 			h2.woocommerce-loop-product__title {
@@ -857,14 +858,6 @@
 	table.shop_table_responsive {
 		tbody {
 			.product-name {
-				a:not(:hover) {
-					text-decoration: none;
-				}
-
-				a:hover {
-					text-decoration: underline;
-					text-decoration-thickness: 1px;
-				}
 
 				.variation {
 					dt {
@@ -1111,6 +1104,24 @@
 				margin: calc(var(--wp--style--block-gap) / 6) 0;
 			}
 		}
+
+		.woocommerce-MyAccount-navigation li {
+			&.is-active a {
+				&::before {
+					content: "> ";
+				}
+			}
+
+			a {
+				text-decoration: initial;
+
+				&:hover {
+					text-decoration: initial;
+				}
+			}
+		}
+
+
 	}
 
 	// Make the Log in form on My Account page less wide.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -215,11 +215,20 @@
 	ul.products {
 
 		padding-inline-start: 0;
+		display: flex;
+		align-items: stretch;
+		flex-direction: row;
+		flex-wrap: wrap;
+		justify-content: space-between;
 
 		li.product {
 			list-style: none;
 			margin-top: var(--wp--style--block-gap);
 			text-align: center;
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			align-items: flex-start;
 
 			a.woocommerce-loop-product__link {
 				text-decoration: none;
@@ -239,6 +248,8 @@
 
 			a.add_to_cart_button {
 				padding: 0.8rem 2.7rem;
+				margin-left: auto;
+				margin-right: auto;
 
 				&.loading {
 					opacity: 0.5;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -29,6 +29,23 @@
 @import "animation";
 
 
+/*
+	Layout fix.
+ */
+.woocommerce-page {
+
+	main {
+		// This is to allow .woocommerce div to have width of 1000px on styles with full width layout (such as Pitch).
+		max-width: calc(1000px + var(--wp--style--root--padding-right) + var(--wp--style--root--padding-left));
+		margin-left: auto;
+		margin-right: auto;
+
+		.woocommerce {
+			@include clearfix();
+		}
+	}
+}
+
 .theme-twentytwentythree {
 	.container-colors {
 		display: flex;
@@ -100,17 +117,19 @@
 	.woocommerce-message,
 	.woocommerce-error,
 	.woocommerce-info {
-		background: var(--wp--preset--color--primary);
+		background-color: rgba(176, 176, 176, 0.6);
+		color: #222;
 		border-top-color: var(--wp--preset--color--primary);
 		border-top-style: solid;
+		border-top-width: 2px;
 		padding: 1rem 1.5rem;
 		margin-bottom: 2rem;
 		list-style: none;
 		font-size: var(--wp--preset--font-size--small);
 
 		&[role="alert"]::before {
-			color: var(--wp--preset--color--contrast);
-			background: var(--wp--preset--color--primary);
+			background: #d5d5d5;
+			color: black;
 			border-radius: 5rem;
 			font-size: 1rem;
 			padding-left: 3px;
@@ -121,14 +140,7 @@
 		a.button {
 			margin-top: -0.5rem;
 			border: none;
-			//background: #ebe9eb;
-			//color: var(--wp--preset--color--black);
 			padding: 0.5rem 1rem;
-
-			//&:hover,
-			//&:visited {
-			//	color: var(--wp--preset--color--black);
-			//}
 		}
 	}
 
@@ -219,6 +231,10 @@
 				font-family: var(--wp--preset--font-family--system-font);
 				text-decoration: none;
 				margin-bottom: 0;
+			}
+
+			h2.woocommerce-loop-category__title {
+				font-size: revert;
 			}
 
 			a.add_to_cart_button {
@@ -587,8 +603,8 @@
 
 	// Highlights for specific info, e.g. on the My Account > Orders > Order X: Order ___ was placed on ____
 	mark {
-		background: var(--wp--preset--color--primary);
-		color: var(--wp--preset--color--contrast);
+		font-weight: bold;
+		background-color: var(--wp--preset--color--base);
 	}
 
 }
@@ -845,7 +861,7 @@
 
 		h3 {
 			font-family: inherit;
-			font-size: var(--wp--preset--font-size--normal);
+			font-size: var(--wp--preset--font-size--large);
 			font-weight: 700;
 		}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -836,7 +836,6 @@
 				a.button,
 				button {
 					margin-bottom: 1rem;
-					border: none;
 					padding: 0.5rem 1rem 0.5rem 1rem;
 				}
 
@@ -883,6 +882,11 @@
 					}
 				}
 			}
+		}
+
+		td,
+		th {
+			padding: 0.5rem;
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -198,7 +198,6 @@ $tt2-gray: #f7f7f7;
 		&:hover {
 			background-color: var(--wp--preset--color--foreground, $primary);
 			color: var(--wp--preset--color--background, $primarytext);
-			opacity: 0.9;
 		}
 
 		&.disabled,
@@ -209,7 +208,6 @@ $tt2-gray: #f7f7f7;
 		&:disabled[disabled]:hover {
 			background-color: var(--wp--preset--color--foreground, $primary);
 			color: var(--wp--preset--color--background, $primarytext);
-			opacity: 0.5;
 		}
 	}
 
@@ -260,7 +258,6 @@ $tt2-gray: #f7f7f7;
 		&:disabled[disabled]:hover {
 			background-color: var(--wp--preset--color--foreground, $primary);
 			color: var(--wp--preset--color--background, $primarytext);
-			opacity: 0.5;
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -27,6 +27,7 @@
 
 @import "mixins";
 @import "animation";
+@import "variables";
 
 $tt2-gray: #f7f7f7;
 
@@ -187,6 +188,31 @@ $tt2-gray: #f7f7f7;
 		}
 	}
 
+	// Moved from blocktheme.css to make sure TT2 won't be changed.
+	#respond input#submit,
+	input.button {
+		// Style primary WooCommerce CTAs in theme colors by default.
+		background-color: var(--wp--preset--color--foreground, $primary);
+		color: var(--wp--preset--color--background, $primarytext);
+
+		&:hover {
+			background-color: var(--wp--preset--color--foreground, $primary);
+			color: var(--wp--preset--color--background, $primarytext);
+			opacity: 0.9;
+		}
+
+		&.disabled,
+		&:disabled,
+		&:disabled[disabled],
+		&.disabled:hover,
+		&:disabled:hover,
+		&:disabled[disabled]:hover {
+			background-color: var(--wp--preset--color--foreground, $primary);
+			color: var(--wp--preset--color--background, $primarytext);
+			opacity: 0.5;
+		}
+	}
+
 	#respond input#submit.alt,
 	a.button.alt,
 	button.button.alt,
@@ -218,6 +244,24 @@ $tt2-gray: #f7f7f7;
 	a.checkout-button {
 		font-size: 18px;
 		padding: 1.5rem 3.5rem;
+	}
+
+	// Moved from blockthemes.css to make sure TT2 won't be changed.
+	button.button,
+	a.button {
+		background-color: var(--wp--preset--color--foreground, $primary);
+		color: var(--wp--preset--color--background, $primarytext);
+
+		&.disabled,
+		&:disabled,
+		&:disabled[disabled],
+		&.disabled:hover,
+		&:disabled:hover,
+		&:disabled[disabled]:hover {
+			background-color: var(--wp--preset--color--foreground, $primary);
+			color: var(--wp--preset--color--background, $primarytext);
+			opacity: 0.5;
+		}
 	}
 
 	// Shop page

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -461,6 +461,14 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
+		// Moved from blocktheme.scss to retain full styling.
+		ul.tabs li.active {
+			// Style active tab in theme colors.
+			background: var(--wp--preset--color--background, $contentbg);
+			border-bottom-color: var(--wp--preset--color--background, $contentbg);
+		}
+
+
 		.woocommerce-Tabs-panel {
 			padding-top: var(--wp--style--block-gap);
 			font-size: var(--wp--preset--font-size--small);

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -17,6 +17,10 @@
 	}
 }
 
+.clear {
+	clear: both;
+}
+
 /**
 * General
 */

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -25,12 +25,6 @@
 * General
 */
 .woocommerce {
-	mark {
-		// Style the mark element in theme colors.
-		// For details see https://github.com/woocommerce/woocommerce/pull/31631.
-		background-color: var(--wp--preset--color--foreground, $highlight);
-		color: var(--wp--preset--color--background, $highlightext);
-	}
 
 	/**
 	* Buttons
@@ -107,9 +101,6 @@
 
 		.woocommerce-tabs {
 			ul.tabs li.active {
-				// Style active tab in theme colors.
-				background: var(--wp--preset--color--background, $contentbg);
-				border-bottom-color: var(--wp--preset--color--background, $contentbg);
 
 				&::before {
 					box-shadow: 2px 2px 0 var(--wp--preset--color--background, $contentbg);

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -42,8 +42,6 @@
 
 	button.button,
 	a.button {
-		background-color: var(--wp--preset--color--foreground, $primary);
-		color: var(--wp--preset--color--background, $primarytext);
 
 		&.disabled,
 		&:disabled,
@@ -51,8 +49,6 @@
 		&.disabled:hover,
 		&:disabled:hover,
 		&:disabled[disabled]:hover {
-			background-color: var(--wp--preset--color--foreground, $primary);
-			color: var(--wp--preset--color--background, $primarytext);
 			opacity: 0.5;
 		}
 	}
@@ -60,13 +56,8 @@
 	#respond input#submit,
 	input.button,
 	a.button.alt {
-		// Style primary WooCommerce CTAs in theme colors by default.
-		background-color: var(--wp--preset--color--foreground, $primary);
-		color: var(--wp--preset--color--background, $primarytext);
 
 		&:hover {
-			background-color: var(--wp--preset--color--foreground, $primary);
-			color: var(--wp--preset--color--background, $primarytext);
 			opacity: 0.9;
 		}
 
@@ -76,8 +67,6 @@
 		&.disabled:hover,
 		&:disabled:hover,
 		&:disabled[disabled]:hover {
-			background-color: var(--wp--preset--color--foreground, $primary);
-			color: var(--wp--preset--color--background, $primarytext);
 			opacity: 0.5;
 		}
 	}

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -329,6 +329,7 @@ p.demo_store,
 				li {
 					border: 1px solid darken($secondary, 10%);
 					background-color: $secondary;
+					color: $secondarytext;
 					display: inline-block;
 					position: relative;
 					z-index: 0;
@@ -351,6 +352,7 @@ p.demo_store,
 
 					&.active {
 						background: $contentbg;
+						color: $secondarytext;
 						z-index: 2;
 						border-bottom-color: $contentbg;
 

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1159,9 +1159,10 @@ class WC_Cart extends WC_Legacy_Cart {
 					 * @param string     $message Message.
 					 * @param WC_Product $product_data Product data.
 					 */
-					$message = apply_filters( 'woocommerce_cart_product_cannot_add_another_message', $message, $product_data );
+					$message         = apply_filters( 'woocommerce_cart_product_cannot_add_another_message', $message, $product_data );
+					$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 
-					throw new Exception( sprintf( '<a href="%s" class="button wc-forward wp-element-button">%s</a> %s', wc_get_cart_url(), __( 'View cart', 'woocommerce' ), $message ) );
+					throw new Exception( sprintf( '<a href="%s" class="button wc-forward%s">%s</a> %s', wc_get_cart_url(), $wp_button_class,  __( 'View cart', 'woocommerce' ), $message ) );
 				}
 			}
 
@@ -1220,10 +1221,12 @@ class WC_Cart extends WC_Legacy_Cart {
 				if ( isset( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] ) && ! $product_data->has_enough_stock( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] + $quantity ) ) {
 					$stock_quantity         = $product_data->get_stock_quantity();
 					$stock_quantity_in_cart = $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ];
+					$wp_button_class        = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 
 					$message = sprintf(
-						'<a href="%s" class="button wc-forward wp-element-button">%s</a> %s',
+						'<a href="%s" class="button wc-forward%s">%s</a> %s',
 						wc_get_cart_url(),
+						$wp_button_class,
 						__( 'View cart', 'woocommerce' ),
 						/* translators: 1: quantity in stock 2: current quantity */
 						sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_quantity, $product_data ), wc_format_stock_quantity_for_display( $stock_quantity_in_cart, $product_data ) )

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1161,7 +1161,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					 */
 					$message = apply_filters( 'woocommerce_cart_product_cannot_add_another_message', $message, $product_data );
 
-					throw new Exception( sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', wc_get_cart_url(), __( 'View cart', 'woocommerce' ), $message ) );
+					throw new Exception( sprintf( '<a href="%s" class="button wc-forward wp-element-button">%s</a> %s', wc_get_cart_url(), __( 'View cart', 'woocommerce' ), $message ) );
 				}
 			}
 
@@ -1222,7 +1222,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					$stock_quantity_in_cart = $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ];
 
 					$message = sprintf(
-						'<a href="%s" class="button wc-forward">%s</a> %s',
+						'<a href="%s" class="button wc-forward wp-element-button">%s</a> %s',
 						wc_get_cart_url(),
 						__( 'View cart', 'woocommerce' ),
 						/* translators: 1: quantity in stock 2: current quantity */

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1162,7 +1162,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					$message         = apply_filters( 'woocommerce_cart_product_cannot_add_another_message', $message, $product_data );
 					$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 
-					throw new Exception( sprintf( '<a href="%s" class="button wc-forward%s">%s</a> %s', wc_get_cart_url(), $wp_button_class,  __( 'View cart', 'woocommerce' ), $message ) );
+					throw new Exception( sprintf( '<a href="%s" class="button wc-forward%s">%s</a> %s', wc_get_cart_url(), esc_attr( $wp_button_class ),  __( 'View cart', 'woocommerce' ), $message ) );
 				}
 			}
 
@@ -1226,7 +1226,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					$message = sprintf(
 						'<a href="%s" class="button wc-forward%s">%s</a> %s',
 						wc_get_cart_url(),
-						$wp_button_class,
+						esc_attr( $wp_button_class ),
 						__( 'View cart', 'woocommerce' ),
 						/* translators: 1: quantity in stock 2: current quantity */
 						sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_quantity, $product_data ), wc_format_stock_quantity_for_display( $stock_quantity_in_cart, $product_data ) )

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1162,7 +1162,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					$message         = apply_filters( 'woocommerce_cart_product_cannot_add_another_message', $message, $product_data );
 					$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 
-					throw new Exception( sprintf( '<a href="%s" class="button wc-forward%s">%s</a> %s', wc_get_cart_url(), esc_attr( $wp_button_class ),  __( 'View cart', 'woocommerce' ), $message ) );
+					throw new Exception( sprintf( '<a href="%s" class="button wc-forward%s">%s</a> %s', wc_get_cart_url(), esc_attr( $wp_button_class ), __( 'View cart', 'woocommerce' ), $message ) );
 				}
 			}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -601,6 +601,9 @@ final class WooCommerce {
 				case 'twentytwentytwo':
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-two.php';
 					break;
+				case 'twentytwentythree':
+				include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-three.php';
+				break;
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -602,8 +602,8 @@ final class WooCommerce {
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-two.php';
 					break;
 				case 'twentytwentythree':
-				include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-three.php';
-				break;
+					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-three.php';
+					break;
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-three.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-three.php
@@ -2,7 +2,7 @@
 /**
  * Twenty Twenty-Three support.
  *
- * @since   7.0.2
+ * @since   7.0.1
  * @package WooCommerce\Classes
  */
 

--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-three.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-three.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Twenty Twenty-Three support.
+ *
+ * @since   7.0.2
+ * @package WooCommerce\Classes
+ */
+
+use Automattic\Jetpack\Constants;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Twenty_Twenty_One class.
+ */
+class WC_Twenty_Twenty_Three {
+
+	/**
+	 * Theme init.
+	 */
+	public static function init() {
+
+		// This theme doesn't have a traditional sidebar.
+		remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
+
+		// Enqueue theme compatibility styles.
+		add_filter( 'woocommerce_enqueue_styles', array( __CLASS__, 'enqueue_styles' ) );
+
+		// Wrap checkout form elements for styling.
+		add_action( 'woocommerce_checkout_before_order_review_heading', array( __CLASS__, 'before_order_review' ) );
+		add_action( 'woocommerce_checkout_after_order_review', array( __CLASS__, 'after_order_review' ) );
+
+		// Register theme features.
+		add_theme_support( 'wc-product-gallery-zoom' );
+		add_theme_support( 'wc-product-gallery-lightbox' );
+		add_theme_support( 'wc-product-gallery-slider' );
+		add_theme_support(
+			'woocommerce',
+			array(
+				'thumbnail_image_width' => 450,
+				'single_image_width'    => 600,
+			)
+		);
+
+	}
+
+	/**
+	 * Enqueue CSS for this theme.
+	 *
+	 * @param  array $styles Array of registered styles.
+	 * @return array
+	 */
+	public static function enqueue_styles( $styles ) {
+		unset( $styles['woocommerce-general'] );
+
+		$styles['woocommerce-general'] = array(
+			'src'     => str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/css/twenty-twenty-three.css',
+			'deps'    => '',
+			'version' => Constants::get_constant( 'WC_VERSION' ),
+			'media'   => 'all',
+			'has_rtl' => true,
+		);
+
+		return apply_filters( 'woocommerce_twenty_twenty_three_styles', $styles );
+	}
+
+	/**
+	 * Wrap checkout order review with a `col2-set` div.
+	 */
+	public static function before_order_review() {
+		echo '<div class="col2-set">';
+	}
+
+	/**
+	 * Close the div wrapper.
+	 */
+	public static function after_order_review() {
+		echo '</div>';
+	}
+}
+
+WC_Twenty_Twenty_Three::init();

--- a/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-three.php
+++ b/plugins/woocommerce/includes/theme-support/class-wc-twenty-twenty-three.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Constants;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Twenty_Twenty_One class.
+ * WC_Twenty_Twenty_Three class.
  */
 class WC_Twenty_Twenty_Three {
 

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -118,11 +118,12 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	$added_text = sprintf( _n( '%s has been added to your cart.', '%s have been added to your cart.', $count, 'woocommerce' ), wc_format_list_of_items( $titles ) );
 
 	// Output success messages.
+	$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 	if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
-		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward wp-element-button">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
+		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward%s">%s</a> %s', esc_url( $return_to ), $wp_button_class, esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
 	} else {
-		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward wp-element-button">%s</a> %s', esc_url( wc_get_cart_url() ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
+		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward%s">%s</a> %s', esc_url( wc_get_cart_url() ), $wp_button_class, esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
 	}
 
 	if ( has_filter( 'wc_add_to_cart_message' ) ) {

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -121,9 +121,9 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
 	if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
-		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward%s">%s</a> %s', esc_url( $return_to ), $wp_button_class, esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
+		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward%s">%s</a> %s', esc_url( $return_to ), esc_attr( $wp_button_class ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
 	} else {
-		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward%s">%s</a> %s', esc_url( wc_get_cart_url() ), $wp_button_class, esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
+		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward%s">%s</a> %s', esc_url( wc_get_cart_url() ), esc_attr( $wp_button_class ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
 	}
 
 	if ( has_filter( 'wc_add_to_cart_message' ) ) {

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -120,9 +120,9 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	// Output success messages.
 	if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
-		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
+		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward wp-element-button">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
 	} else {
-		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( wc_get_cart_url() ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
+		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward wp-element-button">%s</a> %s', esc_url( wc_get_cart_url() ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
 	}
 
 	if ( has_filter( 'wc_add_to_cart_message' ) ) {

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -500,7 +500,7 @@ function wc_is_file_valid_csv( $file, $check_path = true ) {
 /**
  * Check if the current theme is a block theme.
  *
- * @since x.x.x
+ * @since 6.0.0
  * @return bool
  */
 function wc_current_theme_is_fse_theme() {
@@ -517,10 +517,27 @@ function wc_current_theme_is_fse_theme() {
 /**
  * Check if the current theme has WooCommerce support or is a FSE theme.
  *
- * @since x.x.x
+ * @since 6.0.0
  * @return bool
  */
 function wc_current_theme_supports_woocommerce_or_fse() {
 	return (bool) current_theme_supports( 'woocommerce' ) || wc_current_theme_is_fse_theme();
 }
 
+/**
+ * Given an element name, returns a class name.
+ *
+ * If the WP-related function is not defined, return empty string.
+ *
+ * @param string $element The name of the element.
+ *
+ * @since 7.1.0
+ * @return string
+ */
+function wc_wp_theme_get_element_class_name( $element ) {
+	if ( function_exists( 'wp_theme_get_element_class_name' ) ) {
+		return wp_theme_get_element_class_name( $element );
+	}
+
+	return '';
+}

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2397,6 +2397,7 @@ function wc_is_active_theme( $theme ) {
 function wc_is_wp_default_theme_active() {
 	return wc_is_active_theme(
 		array(
+			'twentytwentythree',
 			'twentytwentytwo',
 			'twentytwentyone',
 			'twentytwenty',

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2194,7 +2194,7 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_button_view_cart' ) ) 
 	 * Output the view cart button.
 	 */
 	function woocommerce_widget_shopping_cart_button_view_cart() {
-		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
+		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward wp-element-button">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
 	}
 }
 
@@ -2204,7 +2204,7 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_proceed_to_checkout' )
 	 * Output the proceed to checkout button.
 	 */
 	function woocommerce_widget_shopping_cart_proceed_to_checkout() {
-		echo '<a href="' . esc_url( wc_get_checkout_url() ) . '" class="button checkout wc-forward">' . esc_html__( 'Checkout', 'woocommerce' ) . '</a>';
+		echo '<a href="' . esc_url( wc_get_checkout_url() ) . '" class="button checkout wc-forward wp-element-button">' . esc_html__( 'Checkout', 'woocommerce' ) . '</a>';
 	}
 }
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1345,6 +1345,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 					array_filter(
 						array(
 							'button',
+							'wp-element-button',
 							'product_type_' . $product->get_type(),
 							$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
 							$product->supports( 'ajax_add_to_cart' ) && $product->is_purchasable() && $product->is_in_stock() ? 'ajax_add_to_cart' : '',

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1345,7 +1345,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 					array_filter(
 						array(
 							'button',
-							'wp-element-button',
+							wc_wp_theme_get_element_class_name( 'button' ),
 							'product_type_' . $product->get_type(),
 							$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
 							$product->supports( 'ajax_add_to_cart' ) && $product->is_purchasable() && $product->is_in_stock() ? 'ajax_add_to_cart' : '',
@@ -2194,7 +2194,8 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_button_view_cart' ) ) 
 	 * Output the view cart button.
 	 */
 	function woocommerce_widget_shopping_cart_button_view_cart() {
-		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward wp-element-button">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
+		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward' . $wp_button_class . '">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
 	}
 }
 
@@ -2204,7 +2205,8 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_proceed_to_checkout' )
 	 * Output the proceed to checkout button.
 	 */
 	function woocommerce_widget_shopping_cart_proceed_to_checkout() {
-		echo '<a href="' . esc_url( wc_get_checkout_url() ) . '" class="button checkout wc-forward wp-element-button">' . esc_html__( 'Checkout', 'woocommerce' ) . '</a>';
+		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
+		echo '<a href="' . esc_url( wc_get_checkout_url() ) . '" class="button checkout wc-forward' . $wp_button_class . '">' . esc_html__( 'Checkout', 'woocommerce' ) . '</a>';
 	}
 }
 
@@ -3208,6 +3210,7 @@ if ( ! function_exists( 'woocommerce_account_orders' ) ) {
 				'current_page'    => absint( $current_page ),
 				'customer_orders' => $customer_orders,
 				'has_orders'      => 0 < $customer_orders->total,
+				'wp_button_class' => wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '',
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1345,7 +1345,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 					array_filter(
 						array(
 							'button',
-							wc_wp_theme_get_element_class_name( 'button' ),
+							wc_wp_theme_get_element_class_name( 'button' ), // escaped in the template.
 							'product_type_' . $product->get_type(),
 							$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
 							$product->supports( 'ajax_add_to_cart' ) && $product->is_purchasable() && $product->is_in_stock() ? 'ajax_add_to_cart' : '',
@@ -2195,7 +2195,7 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_button_view_cart' ) ) 
 	 */
 	function woocommerce_widget_shopping_cart_button_view_cart() {
 		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
-		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward' . $wp_button_class . '">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
+		echo '<a href="' . esc_url( wc_get_cart_url() ) . '" class="button wc-forward' . esc_attr( $wp_button_class ) . '">' . esc_html__( 'View cart', 'woocommerce' ) . '</a>';
 	}
 }
 
@@ -2206,7 +2206,7 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_proceed_to_checkout' )
 	 */
 	function woocommerce_widget_shopping_cart_proceed_to_checkout() {
 		$wp_button_class = wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '';
-		echo '<a href="' . esc_url( wc_get_checkout_url() ) . '" class="button checkout wc-forward' . $wp_button_class . '">' . esc_html__( 'Checkout', 'woocommerce' ) . '</a>';
+		echo '<a href="' . esc_url( wc_get_checkout_url() ) . '" class="button checkout wc-forward' . esc_attr( $wp_button_class ) . '">' . esc_html__( 'Checkout', 'woocommerce' ) . '</a>';
 	}
 }
 

--- a/plugins/woocommerce/templates/auth/form-login.php
+++ b/plugins/woocommerce/templates/auth/form-login.php
@@ -46,7 +46,7 @@ do_action( 'woocommerce_auth_page_header' ); ?>
 	</p>
 	<p class="wc-auth-actions">
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-		<button type="submit" class="button button-large button-primary wc-auth-login-button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
+		<button type="submit" class="button button-large button-primary wc-auth-login-button wp-element-button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect_url ); ?>" />
 	</p>
 </form>

--- a/plugins/woocommerce/templates/auth/form-login.php
+++ b/plugins/woocommerce/templates/auth/form-login.php
@@ -46,7 +46,7 @@ do_action( 'woocommerce_auth_page_header' ); ?>
 	</p>
 	<p class="wc-auth-actions">
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-		<button type="submit" class="button button-large button-primary wc-auth-login-button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
+		<button type="submit" class="button button-large button-primary wc-auth-login-button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect_url ); ?>" />
 	</p>
 </form>

--- a/plugins/woocommerce/templates/auth/form-login.php
+++ b/plugins/woocommerce/templates/auth/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Auth
- * @version 3.4.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -46,7 +46,7 @@ do_action( 'woocommerce_auth_page_header' ); ?>
 	</p>
 	<p class="wc-auth-actions">
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-		<button type="submit" class="button button-large button-primary wc-auth-login-button wp-element-button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
+		<button type="submit" class="button button-large button-primary wc-auth-login-button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect_url ); ?>" />
 	</p>
 </form>

--- a/plugins/woocommerce/templates/auth/form-login.php
+++ b/plugins/woocommerce/templates/auth/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Auth
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/cart/cart-empty.php
+++ b/plugins/woocommerce/templates/cart/cart-empty.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/cart/cart-empty.php
+++ b/plugins/woocommerce/templates/cart/cart-empty.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -24,7 +24,7 @@ do_action( 'woocommerce_cart_is_empty' );
 
 if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 	<p class="return-to-shop">
-		<a class="button wc-backward wp-element-button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
+		<a class="button wc-backward<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
 			<?php
 				/**
 				 * Filter "Return To Shop" text.

--- a/plugins/woocommerce/templates/cart/cart-empty.php
+++ b/plugins/woocommerce/templates/cart/cart-empty.php
@@ -24,7 +24,7 @@ do_action( 'woocommerce_cart_is_empty' );
 
 if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 	<p class="return-to-shop">
-		<a class="button wc-backward<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
+		<a class="button wc-backward<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
 			<?php
 				/**
 				 * Filter "Return To Shop" text.

--- a/plugins/woocommerce/templates/cart/cart-empty.php
+++ b/plugins/woocommerce/templates/cart/cart-empty.php
@@ -24,7 +24,7 @@ do_action( 'woocommerce_cart_is_empty' );
 
 if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 	<p class="return-to-shop">
-		<a class="button wc-backward" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
+		<a class="button wc-backward wp-element-button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
 			<?php
 				/**
 				 * Filter "Return To Shop" text.

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -144,12 +144,12 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 					<?php if ( wc_coupons_enabled() ) { ?>
 						<div class="coupon">
-							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
+							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
 							<?php do_action( 'woocommerce_cart_coupon' ); ?>
 						</div>
 					<?php } ?>
 
-					<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
+					<button type="submit" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
 
 					<?php do_action( 'woocommerce_cart_actions' ); ?>
 

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.8.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -144,12 +144,12 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 					<?php if ( wc_coupons_enabled() ) { ?>
 						<div class="coupon">
-							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button wp-element-button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
+							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
 							<?php do_action( 'woocommerce_cart_coupon' ); ?>
 						</div>
 					<?php } ?>
 
-					<button type="submit" class="button wp-element-button" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
+					<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
 
 					<?php do_action( 'woocommerce_cart_actions' ); ?>
 

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -144,12 +144,12 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 					<?php if ( wc_coupons_enabled() ) { ?>
 						<div class="coupon">
-							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
+							<label for="coupon_code"><?php esc_html_e( 'Coupon:', 'woocommerce' ); ?></label> <input type="text" name="coupon_code" class="input-text" id="coupon_code" value="" placeholder="<?php esc_attr_e( 'Coupon code', 'woocommerce' ); ?>" /> <button type="submit" class="button wp-element-button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?></button>
 							<?php do_action( 'woocommerce_cart_coupon' ); ?>
 						</div>
 					<?php } ?>
 
-					<button type="submit" class="button" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
+					<button type="submit" class="button wp-element-button" name="update_cart" value="<?php esc_attr_e( 'Update cart', 'woocommerce' ); ?>"><?php esc_html_e( 'Update cart', 'woocommerce' ); ?></button>
 
 					<?php do_action( 'woocommerce_cart_actions' ); ?>
 

--- a/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
+++ b/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
@@ -22,6 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward">
+<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward wp-element-button">
 	<?php esc_html_e( 'Proceed to checkout', 'woocommerce' ); ?>
 </a>

--- a/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
+++ b/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
@@ -22,6 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>">
+<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>">
 	<?php esc_html_e( 'Proceed to checkout', 'woocommerce' ); ?>
 </a>

--- a/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
+++ b/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
@@ -14,7 +14,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
+++ b/plugins/woocommerce/templates/cart/proceed-to-checkout-button.php
@@ -14,7 +14,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 2.4.0
+ * @version 7.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,6 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward wp-element-button">
+<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>">
 	<?php esc_html_e( 'Proceed to checkout', 'woocommerce' ); ?>
 </a>

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -88,7 +88,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 			</p>
 		<?php endif; ?>
 
-		<p><button type="submit" name="calc_shipping" value="1" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php esc_html_e( 'Update', 'woocommerce' ); ?></button></p>
+		<p><button type="submit" name="calc_shipping" value="1" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php esc_html_e( 'Update', 'woocommerce' ); ?></button></p>
 		<?php wp_nonce_field( 'woocommerce-shipping-calculator', 'woocommerce-shipping-calculator-nonce' ); ?>
 	</section>
 </form>

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -88,7 +88,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 			</p>
 		<?php endif; ?>
 
-		<p><button type="submit" name="calc_shipping" value="1" class="button"><?php esc_html_e( 'Update', 'woocommerce' ); ?></button></p>
+		<p><button type="submit" name="calc_shipping" value="1" class="button wp-element-button"><?php esc_html_e( 'Update', 'woocommerce' ); ?></button></p>
 		<?php wp_nonce_field( 'woocommerce-shipping-calculator', 'woocommerce-shipping-calculator-nonce' ); ?>
 	</section>
 </form>

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.0.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -88,7 +88,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 			</p>
 		<?php endif; ?>
 
-		<p><button type="submit" name="calc_shipping" value="1" class="button wp-element-button"><?php esc_html_e( 'Update', 'woocommerce' ); ?></button></p>
+		<p><button type="submit" name="calc_shipping" value="1" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php esc_html_e( 'Update', 'woocommerce' ); ?></button></p>
 		<?php wp_nonce_field( 'woocommerce-shipping-calculator', 'woocommerce-shipping-calculator-nonce' ); ?>
 	</section>
 </form>

--- a/plugins/woocommerce/templates/cart/shipping-calculator.php
+++ b/plugins/woocommerce/templates/cart/shipping-calculator.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/checkout/form-coupon.php
+++ b/plugins/woocommerce/templates/checkout/form-coupon.php
@@ -36,7 +36,7 @@ if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 	</p>
 
 	<p class="form-row form-row-last">
-		<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
+		<button type="submit" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
 	</p>
 
 	<div class="clear"></div>

--- a/plugins/woocommerce/templates/checkout/form-coupon.php
+++ b/plugins/woocommerce/templates/checkout/form-coupon.php
@@ -36,7 +36,7 @@ if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 	</p>
 
 	<p class="form-row form-row-last">
-		<button type="submit" class="button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
+		<button type="submit" class="button wp-element-button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
 	</p>
 
 	<div class="clear"></div>

--- a/plugins/woocommerce/templates/checkout/form-coupon.php
+++ b/plugins/woocommerce/templates/checkout/form-coupon.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.4
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -36,7 +36,7 @@ if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 	</p>
 
 	<p class="form-row form-row-last">
-		<button type="submit" class="button wp-element-button" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
+		<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="apply_coupon" value="<?php esc_attr_e( 'Apply coupon', 'woocommerce' ); ?>"><?php esc_html_e( 'Apply coupon', 'woocommerce' ); ?></button>
 	</p>
 
 	<div class="clear"></div>

--- a/plugins/woocommerce/templates/checkout/form-coupon.php
+++ b/plugins/woocommerce/templates/checkout/form-coupon.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -88,7 +88,7 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 
 			<?php do_action( 'woocommerce_pay_order_before_submit' ); ?>
 
-			<?php echo apply_filters( 'woocommerce_pay_order_button_html', '<button type="submit" class="button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
+			<?php echo apply_filters( 'woocommerce_pay_order_button_html', '<button type="submit" class="button alt' . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
 
 			<?php do_action( 'woocommerce_pay_order_after_submit' ); ?>
 

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 5.2.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -88,7 +88,7 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 
 			<?php do_action( 'woocommerce_pay_order_before_submit' ); ?>
 
-			<?php echo apply_filters( 'woocommerce_pay_order_button_html', '<button type="submit" class="button alt wp-element-button" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
+			<?php echo apply_filters( 'woocommerce_pay_order_button_html', '<button type="submit" class="button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
 
 			<?php do_action( 'woocommerce_pay_order_after_submit' ); ?>
 

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -88,7 +88,7 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 
 			<?php do_action( 'woocommerce_pay_order_before_submit' ); ?>
 
-			<?php echo apply_filters( 'woocommerce_pay_order_button_html', '<button type="submit" class="button alt" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
+			<?php echo apply_filters( 'woocommerce_pay_order_button_html', '<button type="submit" class="button alt wp-element-button" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
 
 			<?php do_action( 'woocommerce_pay_order_after_submit' ); ?>
 

--- a/plugins/woocommerce/templates/checkout/payment.php
+++ b/plugins/woocommerce/templates/checkout/payment.php
@@ -41,14 +41,14 @@ if ( ! wp_doing_ajax() ) {
 			/* translators: $1 and $2 opening and closing emphasis tags respectively */
 			printf( esc_html__( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the %1$sUpdate Totals%2$s button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'woocommerce' ), '<em>', '</em>' );
 			?>
-			<br/><button type="submit" class="button alt" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
+			<br/><button type="submit" class="button alt wp-element-button" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
 		</noscript>
 
 		<?php wc_get_template( 'checkout/terms.php' ); ?>
 
 		<?php do_action( 'woocommerce_review_order_before_submit' ); ?>
 
-		<?php echo apply_filters( 'woocommerce_order_button_html', '<button type="submit" class="button alt" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
+		<?php echo apply_filters( 'woocommerce_order_button_html', '<button type="submit" class="button alt wp-element-button" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
 
 		<?php do_action( 'woocommerce_review_order_after_submit' ); ?>
 

--- a/plugins/woocommerce/templates/checkout/payment.php
+++ b/plugins/woocommerce/templates/checkout/payment.php
@@ -41,14 +41,14 @@ if ( ! wp_doing_ajax() ) {
 			/* translators: $1 and $2 opening and closing emphasis tags respectively */
 			printf( esc_html__( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the %1$sUpdate Totals%2$s button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'woocommerce' ), '<em>', '</em>' );
 			?>
-			<br/><button type="submit" class="button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
+			<br/><button type="submit" class="button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
 		</noscript>
 
 		<?php wc_get_template( 'checkout/terms.php' ); ?>
 
 		<?php do_action( 'woocommerce_review_order_before_submit' ); ?>
 
-		<?php echo apply_filters( 'woocommerce_order_button_html', '<button type="submit" class="button alt' . (wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '') . '" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
+		<?php echo apply_filters( 'woocommerce_order_button_html', '<button type="submit" class="button alt' . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
 
 		<?php do_action( 'woocommerce_review_order_after_submit' ); ?>
 

--- a/plugins/woocommerce/templates/checkout/payment.php
+++ b/plugins/woocommerce/templates/checkout/payment.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.3
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -41,14 +41,14 @@ if ( ! wp_doing_ajax() ) {
 			/* translators: $1 and $2 opening and closing emphasis tags respectively */
 			printf( esc_html__( 'Since your browser does not support JavaScript, or it is disabled, please ensure you click the %1$sUpdate Totals%2$s button before placing your order. You may be charged more than the amount stated above if you fail to do so.', 'woocommerce' ), '<em>', '</em>' );
 			?>
-			<br/><button type="submit" class="button alt wp-element-button" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
+			<br/><button type="submit" class="button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="woocommerce_checkout_update_totals" value="<?php esc_attr_e( 'Update totals', 'woocommerce' ); ?>"><?php esc_html_e( 'Update totals', 'woocommerce' ); ?></button>
 		</noscript>
 
 		<?php wc_get_template( 'checkout/terms.php' ); ?>
 
 		<?php do_action( 'woocommerce_review_order_before_submit' ); ?>
 
-		<?php echo apply_filters( 'woocommerce_order_button_html', '<button type="submit" class="button alt wp-element-button" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
+		<?php echo apply_filters( 'woocommerce_order_button_html', '<button type="submit" class="button alt' . (wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '') . '" name="woocommerce_checkout_place_order" id="place_order" value="' . esc_attr( $order_button_text ) . '" data-value="' . esc_attr( $order_button_text ) . '">' . esc_html( $order_button_text ) . '</button>' ); // @codingStandardsIgnoreLine ?>
 
 		<?php do_action( 'woocommerce_review_order_after_submit' ); ?>
 

--- a/plugins/woocommerce/templates/checkout/payment.php
+++ b/plugins/woocommerce/templates/checkout/payment.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/content-widget-price-filter.php
+++ b/plugins/woocommerce/templates/content-widget-price-filter.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.7.1
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 			<label class="screen-reader-text" for="max_price"><?php esc_html_e( 'Max price', 'woocommerce' ); ?></label>
 			<input type="text" id="max_price" name="max_price" value="<?php echo esc_attr( $current_max_price ); ?>" data-max="<?php echo esc_attr( $max_price ); ?>" placeholder="<?php echo esc_attr__( 'Max price', 'woocommerce' ); ?>" />
 			<?php /* translators: Filter: verb "to filter" */ ?>
-			<button type="submit" class="button wp-element-button"><?php echo esc_html__( 'Filter', 'woocommerce' ); ?></button>
+			<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html__( 'Filter', 'woocommerce' ); ?></button>
 			<div class="price_label" style="display:none;">
 				<?php echo esc_html__( 'Price:', 'woocommerce' ); ?> <span class="from"></span> &mdash; <span class="to"></span>
 			</div>

--- a/plugins/woocommerce/templates/content-widget-price-filter.php
+++ b/plugins/woocommerce/templates/content-widget-price-filter.php
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 			<label class="screen-reader-text" for="max_price"><?php esc_html_e( 'Max price', 'woocommerce' ); ?></label>
 			<input type="text" id="max_price" name="max_price" value="<?php echo esc_attr( $current_max_price ); ?>" data-max="<?php echo esc_attr( $max_price ); ?>" placeholder="<?php echo esc_attr__( 'Max price', 'woocommerce' ); ?>" />
 			<?php /* translators: Filter: verb "to filter" */ ?>
-			<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html__( 'Filter', 'woocommerce' ); ?></button>
+			<button type="submit" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html__( 'Filter', 'woocommerce' ); ?></button>
 			<div class="price_label" style="display:none;">
 				<?php echo esc_html__( 'Price:', 'woocommerce' ); ?> <span class="from"></span> &mdash; <span class="to"></span>
 			</div>

--- a/plugins/woocommerce/templates/content-widget-price-filter.php
+++ b/plugins/woocommerce/templates/content-widget-price-filter.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/content-widget-price-filter.php
+++ b/plugins/woocommerce/templates/content-widget-price-filter.php
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 			<label class="screen-reader-text" for="max_price"><?php esc_html_e( 'Max price', 'woocommerce' ); ?></label>
 			<input type="text" id="max_price" name="max_price" value="<?php echo esc_attr( $current_max_price ); ?>" data-max="<?php echo esc_attr( $max_price ); ?>" placeholder="<?php echo esc_attr__( 'Max price', 'woocommerce' ); ?>" />
 			<?php /* translators: Filter: verb "to filter" */ ?>
-			<button type="submit" class="button"><?php echo esc_html__( 'Filter', 'woocommerce' ); ?></button>
+			<button type="submit" class="button wp-element-button"><?php echo esc_html__( 'Filter', 'woocommerce' ); ?></button>
 			<div class="price_label" style="display:none;">
 				<?php echo esc_html__( 'Price:', 'woocommerce' ); ?> <span class="from"></span> &mdash; <span class="to"></span>
 			</div>

--- a/plugins/woocommerce/templates/global/form-login.php
+++ b/plugins/woocommerce/templates/global/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     3.6.0
+ * @version     7.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -48,7 +48,7 @@ if ( is_user_logged_in() ) {
 		</label>
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ); ?>" />
-		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit wp-element-button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 	</p>
 	<p class="lost_password">
 		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/templates/global/form-login.php
+++ b/plugins/woocommerce/templates/global/form-login.php
@@ -48,7 +48,7 @@ if ( is_user_logged_in() ) {
 		</label>
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ); ?>" />
-		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 	</p>
 	<p class="lost_password">
 		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/templates/global/form-login.php
+++ b/plugins/woocommerce/templates/global/form-login.php
@@ -48,7 +48,7 @@ if ( is_user_logged_in() ) {
 		</label>
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ); ?>" />
-		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-button button woocommerce-form-login__submit wp-element-button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
 	</p>
 	<p class="lost_password">
 		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
+++ b/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
@@ -51,7 +51,7 @@ if ( $available_gateways ) : ?>
 
 			<div class="form-row">
 				<?php wp_nonce_field( 'woocommerce-add-payment-method', 'woocommerce-add-payment-method-nonce' ); ?>
-				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>
 				<input type="hidden" name="woocommerce_add_payment_method" id="woocommerce_add_payment_method" value="1" />
 			</div>
 		</div>

--- a/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
+++ b/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
@@ -51,7 +51,7 @@ if ( $available_gateways ) : ?>
 
 			<div class="form-row">
 				<?php wp_nonce_field( 'woocommerce-add-payment-method', 'woocommerce-add-payment-method-nonce' ); ?>
-				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt wp-element-button" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>
 				<input type="hidden" name="woocommerce_add_payment_method" id="woocommerce_add_payment_method" value="1" />
 			</div>
 		</div>

--- a/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
+++ b/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.3.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -51,7 +51,7 @@ if ( $available_gateways ) : ?>
 
 			<div class="form-row">
 				<?php wp_nonce_field( 'woocommerce-add-payment-method', 'woocommerce-add-payment-method-nonce' ); ?>
-				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt wp-element-button" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>
 				<input type="hidden" name="woocommerce_add_payment_method" id="woocommerce_add_payment_method" value="1" />
 			</div>
 		</div>

--- a/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
+++ b/plugins/woocommerce/templates/myaccount/form-add-payment-method.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/form-edit-account.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -66,7 +66,7 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
-		<button type="submit" class="woocommerce-Button button wp-element-button" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 

--- a/plugins/woocommerce/templates/myaccount/form-edit-account.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-account.php
@@ -66,7 +66,7 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
-		<button type="submit" class="woocommerce-Button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 

--- a/plugins/woocommerce/templates/myaccount/form-edit-account.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-account.php
@@ -66,7 +66,7 @@ do_action( 'woocommerce_before_edit_account_form' ); ?>
 
 	<p>
 		<?php wp_nonce_field( 'save_account_details', 'save-account-details-nonce' ); ?>
-		<button type="submit" class="woocommerce-Button button" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button wp-element-button" name="save_account_details" value="<?php esc_attr_e( 'Save changes', 'woocommerce' ); ?>"><?php esc_html_e( 'Save changes', 'woocommerce' ); ?></button>
 		<input type="hidden" name="action" value="save_account_details" />
 	</p>
 

--- a/plugins/woocommerce/templates/myaccount/form-edit-account.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/form-edit-address.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-address.php
@@ -43,7 +43,7 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 			<?php do_action( "woocommerce_after_edit_address_form_{$load_address}" ); ?>
 
 			<p>
-				<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
+				<button type="submit" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'woocommerce-edit_address', 'woocommerce-edit-address-nonce' ); ?>
 				<input type="hidden" name="action" value="edit_address" />
 			</p>

--- a/plugins/woocommerce/templates/myaccount/form-edit-address.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-address.php
@@ -43,7 +43,7 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 			<?php do_action( "woocommerce_after_edit_address_form_{$load_address}" ); ?>
 
 			<p>
-				<button type="submit" class="button" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
+				<button type="submit" class="button wp-element-button" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'woocommerce-edit_address', 'woocommerce-edit-address-nonce' ); ?>
 				<input type="hidden" name="action" value="edit_address" />
 			</p>

--- a/plugins/woocommerce/templates/myaccount/form-edit-address.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-address.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.6.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -43,7 +43,7 @@ do_action( 'woocommerce_before_edit_account_address_form' ); ?>
 			<?php do_action( "woocommerce_after_edit_address_form_{$load_address}" ); ?>
 
 			<p>
-				<button type="submit" class="button wp-element-button" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
+				<button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="save_address" value="<?php esc_attr_e( 'Save address', 'woocommerce' ); ?>"><?php esc_html_e( 'Save address', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'woocommerce-edit_address', 'woocommerce-edit-address-nonce' ); ?>
 				<input type="hidden" name="action" value="edit_address" />
 			</p>

--- a/plugins/woocommerce/templates/myaccount/form-edit-address.php
+++ b/plugins/woocommerce/templates/myaccount/form-edit-address.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 6.0.0
+ * @version 7.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -51,7 +51,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 				</label>
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit wp-element-button" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
 			<p class="woocommerce-LostPassword lost_password">
 				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
@@ -104,7 +104,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 			<p class="woocommerce-form-row form-row">
 				<?php wp_nonce_field( 'woocommerce-register', 'woocommerce-register-nonce' ); ?>
-				<button type="submit" class="woocommerce-Button woocommerce-button button wp-element-button woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-Button woocommerce-button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?> woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
 			</p>
 
 			<?php do_action( 'woocommerce_register_form_end' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -51,7 +51,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 				</label>
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
 			<p class="woocommerce-LostPassword lost_password">
 				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
@@ -104,7 +104,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 			<p class="woocommerce-form-row form-row">
 				<?php wp_nonce_field( 'woocommerce-register', 'woocommerce-register-nonce' ); ?>
-				<button type="submit" class="woocommerce-Button woocommerce-button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?> woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-Button woocommerce-button button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?> woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
 			</p>
 
 			<?php do_action( 'woocommerce_register_form_end' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -51,7 +51,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 					<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 				</label>
 				<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
-				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-button button woocommerce-form-login__submit wp-element-button" name="login" value="<?php esc_attr_e( 'Log in', 'woocommerce' ); ?>"><?php esc_html_e( 'Log in', 'woocommerce' ); ?></button>
 			</p>
 			<p class="woocommerce-LostPassword lost_password">
 				<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'woocommerce' ); ?></a>
@@ -104,7 +104,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 			<p class="woocommerce-form-row form-row">
 				<?php wp_nonce_field( 'woocommerce-register', 'woocommerce-register-nonce' ); ?>
-				<button type="submit" class="woocommerce-Button woocommerce-button button woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
+				<button type="submit" class="woocommerce-Button woocommerce-button button wp-element-button woocommerce-form-register__submit" name="register" value="<?php esc_attr_e( 'Register', 'woocommerce' ); ?>"><?php esc_html_e( 'Register', 'woocommerce' ); ?></button>
 			</p>
 
 			<?php do_action( 'woocommerce_register_form_end' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-login.php
+++ b/plugins/woocommerce/templates/myaccount/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/myaccount/form-lost-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-lost-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.2
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_lost_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="woocommerce-Button button wp-element-button" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'lost_password', 'woocommerce-lost-password-nonce' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-lost-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-lost-password.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_lost_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="woocommerce-Button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'lost_password', 'woocommerce-lost-password-nonce' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-lost-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-lost-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/form-lost-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-lost-password.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_lost_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="woocommerce-Button button" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button wp-element-button" value="<?php esc_attr_e( 'Reset password', 'woocommerce' ); ?>"><?php esc_html_e( 'Reset password', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'lost_password', 'woocommerce-lost-password-nonce' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-reset-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-reset-password.php
@@ -42,7 +42,7 @@ do_action( 'woocommerce_before_reset_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="woocommerce-Button button" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button wp-element-button" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'reset_password', 'woocommerce-reset-password-nonce' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-reset-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.5
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -42,7 +42,7 @@ do_action( 'woocommerce_before_reset_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="woocommerce-Button button wp-element-button" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'reset_password', 'woocommerce-reset-password-nonce' ); ?>

--- a/plugins/woocommerce/templates/myaccount/form-reset-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/form-reset-password.php
+++ b/plugins/woocommerce/templates/myaccount/form-reset-password.php
@@ -42,7 +42,7 @@ do_action( 'woocommerce_before_reset_password_form' );
 
 	<p class="woocommerce-form-row form-row">
 		<input type="hidden" name="wc_reset_password" value="true" />
-		<button type="submit" class="woocommerce-Button button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
+		<button type="submit" class="woocommerce-Button button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" value="<?php esc_attr_e( 'Save', 'woocommerce' ); ?>"><?php esc_html_e( 'Save', 'woocommerce' ); ?></button>
 	</p>
 
 	<?php wp_nonce_field( 'reset_password', 'woocommerce-reset-password-nonce' ); ?>

--- a/plugins/woocommerce/templates/myaccount/orders.php
+++ b/plugins/woocommerce/templates/myaccount/orders.php
@@ -67,7 +67,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 								if ( ! empty( $actions ) ) {
 									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . $wp_button_class . ' button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . esc_attr( $wp_button_class ) . ' button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
 									}
 								}
 								?>

--- a/plugins/woocommerce/templates/myaccount/orders.php
+++ b/plugins/woocommerce/templates/myaccount/orders.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/myaccount/orders.php
+++ b/plugins/woocommerce/templates/myaccount/orders.php
@@ -14,7 +14,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.7.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -67,7 +67,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 								if ( ! empty( $actions ) ) {
 									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button wp-element-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button' . $wp_button_class . ' button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
 									}
 								}
 								?>

--- a/plugins/woocommerce/templates/myaccount/orders.php
+++ b/plugins/woocommerce/templates/myaccount/orders.php
@@ -67,7 +67,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 
 								if ( ! empty( $actions ) ) {
 									foreach ( $actions as $key => $action ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
+										echo '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button wp-element-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>';
 									}
 								}
 								?>

--- a/plugins/woocommerce/templates/order/form-tracking.php
+++ b/plugins/woocommerce/templates/order/form-tracking.php
@@ -46,7 +46,7 @@ global $post;
 	do_action( 'woocommerce_order_tracking_form' );
 	?>
 
-	<p class="form-row"><button type="submit" class="button" name="track" value="<?php esc_attr_e( 'Track', 'woocommerce' ); ?>"><?php esc_html_e( 'Track', 'woocommerce' ); ?></button></p>
+	<p class="form-row"><button type="submit" class="button wp-element-button" name="track" value="<?php esc_attr_e( 'Track', 'woocommerce' ); ?>"><?php esc_html_e( 'Track', 'woocommerce' ); ?></button></p>
 	<?php wp_nonce_field( 'woocommerce-order_tracking', 'woocommerce-order-tracking-nonce' ); ?>
 
 	<?php

--- a/plugins/woocommerce/templates/order/form-tracking.php
+++ b/plugins/woocommerce/templates/order/form-tracking.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 6.5.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -46,7 +46,7 @@ global $post;
 	do_action( 'woocommerce_order_tracking_form' );
 	?>
 
-	<p class="form-row"><button type="submit" class="button wp-element-button" name="track" value="<?php esc_attr_e( 'Track', 'woocommerce' ); ?>"><?php esc_html_e( 'Track', 'woocommerce' ); ?></button></p>
+	<p class="form-row"><button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="track" value="<?php esc_attr_e( 'Track', 'woocommerce' ); ?>"><?php esc_html_e( 'Track', 'woocommerce' ); ?></button></p>
 	<?php wp_nonce_field( 'woocommerce-order_tracking', 'woocommerce-order-tracking-nonce' ); ?>
 
 	<?php

--- a/plugins/woocommerce/templates/order/form-tracking.php
+++ b/plugins/woocommerce/templates/order/form-tracking.php
@@ -46,7 +46,7 @@ global $post;
 	do_action( 'woocommerce_order_tracking_form' );
 	?>
 
-	<p class="form-row"><button type="submit" class="button<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>" name="track" value="<?php esc_attr_e( 'Track', 'woocommerce' ); ?>"><?php esc_html_e( 'Track', 'woocommerce' ); ?></button></p>
+	<p class="form-row"><button type="submit" class="button<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="track" value="<?php esc_attr_e( 'Track', 'woocommerce' ); ?>"><?php esc_html_e( 'Track', 'woocommerce' ); ?></button></p>
 	<?php wp_nonce_field( 'woocommerce-order_tracking', 'woocommerce-order-tracking-nonce' ); ?>
 
 	<?php

--- a/plugins/woocommerce/templates/order/form-tracking.php
+++ b/plugins/woocommerce/templates/order/form-tracking.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/product-searchform.php
+++ b/plugins/woocommerce/templates/product-searchform.php
@@ -23,6 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 <form role="search" method="get" class="woocommerce-product-search" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label class="screen-reader-text" for="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'woocommerce' ); ?></label>
 	<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'woocommerce' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
-	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>" class="<?php echo wc_wp_theme_get_element_class_name( 'button' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
+	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>" class="<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
 	<input type="hidden" name="post_type" value="product" />
 </form>

--- a/plugins/woocommerce/templates/product-searchform.php
+++ b/plugins/woocommerce/templates/product-searchform.php
@@ -23,6 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 <form role="search" method="get" class="woocommerce-product-search" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label class="screen-reader-text" for="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'woocommerce' ); ?></label>
 	<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'woocommerce' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
-	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
+	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>" class="wp-element-button"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
 	<input type="hidden" name="post_type" value="product" />
 </form>

--- a/plugins/woocommerce/templates/product-searchform.php
+++ b/plugins/woocommerce/templates/product-searchform.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.3.0
+ * @version 7.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,6 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 <form role="search" method="get" class="woocommerce-product-search" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label class="screen-reader-text" for="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'woocommerce' ); ?></label>
 	<input type="search" id="woocommerce-product-search-field-<?php echo isset( $index ) ? absint( $index ) : 0; ?>" class="search-field" placeholder="<?php echo esc_attr__( 'Search products&hellip;', 'woocommerce' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
-	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>" class="wp-element-button"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
+	<button type="submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'woocommerce' ); ?>" class="<?php echo wc_wp_theme_get_element_class_name( 'button' ); ?>"><?php echo esc_html_x( 'Search', 'submit button', 'woocommerce' ); ?></button>
 	<input type="hidden" name="post_type" value="product" />
 </form>

--- a/plugins/woocommerce/templates/product-searchform.php
+++ b/plugins/woocommerce/templates/product-searchform.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/single-product/add-to-cart/external.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/external.php
@@ -22,7 +22,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 <form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $button_text ); ?></button>
 
 	<?php wc_query_string_form_fields( $product_url ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/external.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/external.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -22,7 +22,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 <form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-	<button type="submit" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $button_text ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $button_text ); ?></button>
 
 	<?php wc_query_string_form_fields( $product_url ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/external.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/external.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/external.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/external.php
@@ -22,7 +22,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 <form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-	<button type="submit" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $button_text ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html( $button_text ); ?></button>
 
 	<?php wc_query_string_form_fields( $product_url ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.8.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -117,7 +117,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-		<button type="submit" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -117,7 +117,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-		<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/grouped.php
@@ -117,7 +117,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-		<button type="submit" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -46,7 +46,7 @@ if ( $product->is_in_stock() ) : ?>
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
-		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 	</form>

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -46,7 +46,7 @@ if ( $product->is_in_stock() ) : ?>
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
-		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 	</form>

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -46,7 +46,7 @@ if ( $product->is_in_stock() ) : ?>
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
-		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 	</form>

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -28,7 +28,7 @@ global $product;
 	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>
 
-	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -4,7 +4,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.1.0
+ * @version 7.0.1
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -4,7 +4,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.0
+ * @version 7.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ global $product;
 	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>
 
-	<button type="submit" class="single_add_to_cart_button button alt wp-element-button"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -28,7 +28,7 @@ global $product;
 	do_action( 'woocommerce_after_add_to_cart_quantity' );
 	?>
 
-	<button type="submit" class="single_add_to_cart_button button alt<?php echo wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : ''; ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
@@ -137,24 +137,25 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	 * Test wc_add_to_cart_message
 	 */
 	public function test_wc_add_to_cart_message() {
-		$product = WC_Helper_Product::create_simple_product();
+		$product         = WC_Helper_Product::create_simple_product();
+		$wp_button_class = esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), false, true );
-		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward' . $wp_button_class . '">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), false, true );
-		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward' . $wp_button_class . '">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), true, true );
-		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward' . $wp_button_class . '">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), true, true );
-		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> 3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward' . $wp_button_class . '">View cart</a> 3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( $product->get_id(), false, true );
-		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward' . $wp_button_class . '">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( $product->get_id(), true, true );
-		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward' . $wp_button_class . '">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/functions.php
@@ -15,23 +15,23 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	 */
 	private function get_checkout_url() {
 
-		// Get the checkout URL
+		// Get the checkout URL.
 		$checkout_page_id = wc_get_page_id( 'checkout' );
 
 		$checkout_url = '';
 
-		// Check if there is a checkout page
+		// Check if there is a checkout page.
 		if ( $checkout_page_id ) {
 
-			// Get the permalink
+			// Get the permalink.
 			$checkout_url = get_permalink( $checkout_page_id );
 
-			// Force SSL if needed
+			// Force SSL if needed.
 			if ( is_ssl() || 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) ) {
 				$checkout_url = str_replace( 'http:', 'https:', $checkout_url );
 			}
 
-			// Allow filtering of checkout URL
+			// Allow filtering of checkout URL.
 			$checkout_url = apply_filters( 'woocommerce_get_checkout_url', $checkout_url );
 		}
 
@@ -44,10 +44,10 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	 * @since 2.5.0
 	 */
 	public function test_get_checkout_url_regular() {
-		// Make sure pages exist
+		// Make sure pages exist.
 		WC_Install::create_pages();
 
-		// Force SSL checkout
+		// Force SSL checkout.
 		update_option( 'woocommerce_force_ssl_checkout', 'no' );
 
 		$this->assertEquals( $this->get_checkout_url(), wc_get_checkout_url() );
@@ -59,10 +59,10 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	 * @since 2.5.0
 	 */
 	public function test_get_checkout_url_ssl() {
-		// Make sure pages exist
+		// Make sure pages exist.
 		WC_Install::create_pages();
 
-		// Force SSL checkout
+		// Force SSL checkout.
 		update_option( 'woocommerce_force_ssl_checkout', 'yes' );
 
 		$this->assertEquals( $this->get_checkout_url(), wc_get_checkout_url() );
@@ -74,16 +74,16 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 	 * @since 2.3.0
 	 */
 	public function test_wc_empty_cart() {
-		// Create dummy product
+		// Create dummy product.
 		$product = WC_Helper_Product::create_simple_product();
 
-		// Add the product to the cart
+		// Add the product to the cart.
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
-		// Empty the cart
+		// Empty the cart.
 		wc_empty_cart();
 
-		// Check if the cart is empty
+		// Check if the cart is empty.
 		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This work builds on the great cleanup done by Rubik/Kirigami earlier this year. I did a tiny cleanup of colors from blocktheme.scss, where I moved the unnecessary definitions to TT2 theme's CSS to retain the same styling for TT2. 

Besides, did a quick analysis and comparison for all CSS rules and added the relevant ones from TT2 styling to TT3. Added also the WP class to buttons to enable all the style definitions that come with WP 6.1 and TT3.

Layout-wise, it's very similar to TT2. The colors got tricky here and there as some styles have effectively only 2 colors while some define 5 distinct colors, but I tried to make it work for all styles.

Style colors overview:
![TT3colors](https://user-images.githubusercontent.com/2207451/197823153-b07f8f82-a5f5-492f-a944-92241bd5f89b.jpg)


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install WP 6.1 RC and TT3
2. Install WC and activate this branch
3. Explore all the important screens: 

- Shop, 
- Single product for simple product
- Single product for variable products
- Examine gallery when having multiple images, photoswipe fullscreen image
- Check the Sale! badge looks reasonable in Shop and in single product page
- Check the tabs: Additional info/Details/Reviews
- Make sure the reviews are visible, rating looks reasonable
- Cart (try with or without shipping options set up), adding coupon
- Checkout
- Thank you page after submitting the order
- Log in to My account, with or without registration
- My account page
- Check out My Account submenus
- Test store notices (Added to cart on single product page, Error on the checkout page, Add coupon on the checkout page, Log in on the checkout page)
- Test store-wide "demo store" notice
- Check this in different viewport sizes
- Check all of this with different browsers
- Check all of this with each style in TT3 (Appearance > Editor > Click on Styles (half moon icon to the top right) and switch to another one)
![Screenshot 2022-10-25 at 17 49 45](https://user-images.githubusercontent.com/2207451/197823191-114bcbd7-dda0-4748-b7e6-20dc654f31b0.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
