### PR TITLE
Fix reference to HEAD to work with community PRs

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -18,8 +18,9 @@ jobs:
               id: run
               working-directory: tools/code-analyzer
               run: |
-                  version=$(pnpm run analyzer major-minor "${{ github.head_ref || github.ref_name }}" "plugins/woocommerce/woocommerce.php" | tail -n 1)
-                  pnpm run analyzer "$GITHUB_HEAD_REF" $version -o "github"
+                  HEAD_REF=$(git rev-parse HEAD)
+                  version=$(pnpm run analyzer major-minor "$HEAD_REF" "plugins/woocommerce/woocommerce.php" | tail -n 1)
+                  pnpm run analyzer "$HEAD_REF" $version -o "github"
             - name: Print results
               id: results
               run: echo "::set-output name=results::${{ steps.run.outputs.templates }}${{ steps.run.outputs.wphooks }}${{ steps.run.outputs.schema }}${{ steps.run.outputs.database }}"


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR uses the current reference to HEAD as the value passed into the code analyzer. This works because `actions/checkout` handles fetching the PR from the remote branch and checking it out properly, so HEAD is already set to the correct reference just prior to the analyzer running.

Closes #33286

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a fork of this repo (if you do not have one already).
2. Create a new branch in your fork. The new branch should have a name that doesn't match any of the branches within this repo, as this previously gave the illusion that this action was working correctly when it was not. For example, `yourname/trunk` would appear to work, but it would actually just be executing the action against `woocommerce/trunk`.
3. If you'd like to verify it breaks with the prior behavior, don't merge this change into your branch and confirm that it's broken.
4. Merge this branch into your branch, and verify that the action runs on this branch successfully. Any changes you make in your PR to templates, etc should be detected.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
