### PR TITLE
Do not use $_POST directly in validate_checkout

### DIFF
--- a/plugins/woocommerce/changelog/35328-post-data
+++ b/plugins/woocommerce/changelog/35328-post-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove the direct dependency on `$_POST` when validating checkout data.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -672,6 +672,7 @@ class WC_Checkout {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$data = array(
 			'terms'                              => (int) isset( $_POST['terms'] ),
+			'terms-field'                        => (int) isset( $_POST['terms-field'] ),
 			'createaccount'                      => (int) ( $this->is_registration_enabled() ? ! empty( $_POST['createaccount'] ) : false ),
 			'payment_method'                     => isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : '',
 			'shipping_method'                    => isset( $_POST['shipping_method'] ) ? wc_clean( wp_unslash( $_POST['shipping_method'] ) ) : '',
@@ -851,7 +852,7 @@ class WC_Checkout {
 		$this->check_cart_items();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $_POST['terms-field'] ) ) {
+		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $data['terms-field'] ) ) {
 			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ) );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -60,6 +60,8 @@ class WC_Checkout {
 
 			/**
 			 * Runs once when the WC_Checkout class is first instantiated.
+			 *
+			 * @since 3.0.0 or earlier
 			 */
 			do_action( 'woocommerce_checkout_init', self::$instance );
 		}
@@ -159,6 +161,8 @@ class WC_Checkout {
 				/**
 				 * Provides an opportunity to modify the customer ID associated with the current checkout process.
 				 *
+				 * @since 3.0.0 or earlier
+				 *
 				 * @param int The current user's ID (this may be 0 if no user is logged in).
 				 */
 				return apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() );
@@ -191,6 +195,8 @@ class WC_Checkout {
 		/**
 		 * Controls if registration is required in order for checkout to be completed.
 		 *
+		 * @since 3.0.0
+		 *
 		 * @param bool $checkout_registration_required If customers must be registered to checkout.
 		 */
 		return apply_filters( 'woocommerce_checkout_registration_required', 'yes' !== get_option( 'woocommerce_enable_guest_checkout' ) );
@@ -205,6 +211,8 @@ class WC_Checkout {
 	public function is_registration_enabled() {
 		/**
 		 * Determines if customer registration is enabled during checkout.
+		 *
+		 * @since 3.0.0
 		 *
 		 * @param bool $checkout_registration_enabled If checkout registration is enabled.
 		 */
@@ -285,6 +293,8 @@ class WC_Checkout {
 		/**
 		 * Sets the fields used during checkout.
 		 *
+		 * @since 3.0.0 or earlier
+		 *
 		 * @param array[] $checkout_fields
 		 */
 		$this->fields = apply_filters( 'woocommerce_checkout_fields', $this->fields );
@@ -313,6 +323,7 @@ class WC_Checkout {
 		 * Provides an opportunity to check cart items before checkout. This generally occurs during checkout validation.
 		 *
 		 * @see WC_Checkout::validate_checkout()
+		 * @since 3.0.0 or earlier
 		 */
 		do_action( 'woocommerce_check_cart_items' );
 	}
@@ -350,6 +361,8 @@ class WC_Checkout {
 		/**
 		 * Gives plugins an opportunity to create a new order themselves.
 		 *
+		 * @since 3.0.0 or earlier
+		 *
 		 * @param int|null    $order_id Can be set to an order ID to short-circuit the default order creation process.
 		 * @param WC_Checkout $checkout Reference to the current WC_Checkout instance.
 		 */
@@ -374,6 +387,8 @@ class WC_Checkout {
 				/**
 				 * Indicates that we are resuming checkout for an existing order (which is pending payment, and which
 				 * has not changed since it was added to the current shopping session).
+				 *
+				 * @since 3.0.0 or earlier
 				 *
 				 * @param int $order_id The ID of the order being resumed.
 				 */
@@ -411,6 +426,8 @@ class WC_Checkout {
 			$order->set_cart_hash( $cart_hash );
 			/**
 			 * This action is documented in woocommerce/includes/class-wc-checkout.php
+			 *
+			 * @since 3.0.0 or earlier
 			 */
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
 			$order->set_currency( get_woocommerce_currency() );
@@ -626,6 +643,8 @@ class WC_Checkout {
 			 * Controls the zero rate tax ID.
 			 *
 			 * An order item tax will not be created for this ID (which by default is 'zero-rated').
+			 *
+			 * @since 3.0.0 or earlier
 			 *
 			 * @param string $tax_rate_id The ID of the zero rate tax.
 			 */
@@ -1081,6 +1100,8 @@ class WC_Checkout {
 	protected function process_customer( $data ) {
 		/**
 		 * This action is documented in woocommerce/includes/class-wc-checkout.php
+		 *
+		 * @since 3.0.0 or earlier
 		 */
 		$customer_id = apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

During checkout validation, there are points where we specifically rely on various `$_POST` superglobal values being set, which made reuse of our validation functionality difficult. This change tidies this up.

Closes #35328.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Checkout validation should continue to work as it did previously. More specifically, we should ensure that we are still validating if the custom has agreed to the shop's terms and conditions (since the change touches that check):

1. Ensure you have designated a terms and conditions page (via **WooCommerce ▸ Settings ▸ Advanced ▸ Page Setup**):

<img width="800" alt="terms-and-conditions" src="https://user-images.githubusercontent.com/3594411/198156779-a3cae656-de7c-481e-ae03-15d1d8f1e20c.png">

2. As a customer, add a product to your cart and attempt to checkout. In the first instance, populate the checkout form correctly but avoid checking the box that indicates you agree with the terms and conditions:

<img width="300" src="https://user-images.githubusercontent.com/3594411/198157195-8ccc1c90-6e42-40ad-bf59-d967a434a94d.png" />

3. Consequently, on trying to checkout, you should see a warning as follows:

![tc-error](https://user-images.githubusercontent.com/3594411/198157251-a741ea19-5a37-4b9b-9600-acd2acb0c5f8.png)

4. Rinse and repeat; except agree to the terms and conditions. If all other fields are correctly populated, you should be able to checkout successfully.
5. Repeat again, but try to supply invalid values to other checkout fields (for example, you might provide an invalid postal code) and confirm validation successfully prevents this. 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
