### PR TITLE
In-App Marketplace Tour - track events

### DIFF
--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -25,6 +25,7 @@ export type TaskType = {
 	isActioned: boolean;
 	eventPrefix: string;
 	level: number;
+	recordViewEvent: boolean;
 	additionalData?: {
 		woocommerceTaxCountries?: string[];
 		taxJarActivated?: boolean;

--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-config.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-config.ts
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import { TourKitTypes } from '@woocommerce/components';
-import { __ } from '@wordpress/i18n';
-import { createElement, createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,16 +11,14 @@ import { scrollPopperToVisibleAreaIfNeeded } from './utils';
 export const getTourConfig = ( {
 	closeHandler,
 	onNextStepHandler,
-	onPreviousStepHandler,
 	autoScrollBlock,
+	steps,
 }: {
 	closeHandler: TourKitTypes.CloseHandler;
 	onNextStepHandler: ( currentStepIndex: number ) => void;
-	onPreviousStepHandler: ( currentStepIndex: number ) => void;
 	autoScrollBlock: ScrollLogicalPosition;
+	steps: TourKitTypes.WooStep[];
 } ): TourKitTypes.WooConfig => {
-	const lineBreak = createElement( 'br' );
-
 	let previousPopperTopPosition: number | null = null;
 	let perviousPopperRef: unknown = null;
 	const defaultPlacement = 'top-start';
@@ -121,155 +117,9 @@ export const getTourConfig = ( {
 			],
 			callbacks: {
 				onNextStep: onNextStepHandler,
-				onPreviousStep: onPreviousStepHandler,
 			},
 		},
-		steps: [
-			{
-				referenceElements: {
-					desktop: '#adminmenu a[href="admin.php?page=wc-addons"]',
-				},
-				focusElement: {
-					desktop: '#adminmenu a[href="admin.php?page=wc-addons"]',
-				},
-				meta: {
-					name: 'wc-addons-menu-item',
-					heading: __(
-						'Welcome to the WooCommerce Marketplace',
-						'woocommerce'
-					),
-					descriptions: {
-						desktop: createInterpolateElement(
-							__(
-								'The WooCommerce Marketplace is the place to go to find vetted extensions, themes, and services for your store.<br/><br/>There are hundreds of options available, and new products are added regularly. So start here when you want to enhance your store or discover new ways to grow your business.<br/><br/>The WooCommerce Marketplace is also available at WooCommerce.com.',
-								'woocommerce'
-							),
-							{
-								br: lineBreak,
-							}
-						),
-					},
-				},
-			},
-			{
-				referenceElements: {
-					desktop: '.marketplace-header__search-form',
-				},
-				focusElement: {
-					desktop: '.marketplace-header__search-form',
-				},
-				meta: {
-					name: 'wc-addons-search',
-					heading: __( 'Find exactly what you need', 'woocommerce' ),
-					descriptions: {
-						desktop: __(
-							'You can use the search box to find specific products in the Marketplace.',
-							'woocommerce'
-						),
-					},
-				},
-			},
-			{
-				referenceElements: {
-					desktop: '#marketplace-current-section-dropdown',
-				},
-				focusElement: {
-					desktop: '#marketplace-current-section-dropdown',
-				},
-				meta: {
-					name: 'wc-addons-categories',
-					heading: __( 'Browse for new ideas', 'woocommerce' ),
-					descriptions: {
-						desktop: createInterpolateElement(
-							__(
-								'Or browse all available products by category.<br/><br/>The Featured category is regularly updated with new and noteworthy products.',
-								'woocommerce'
-							),
-							{
-								br: lineBreak,
-							}
-						),
-					},
-				},
-			},
-			{
-				referenceElements: {
-					desktop: '.addon-product-group:first-child',
-				},
-				focusElement: {
-					desktop: '.addon-product-group:first-child',
-				},
-				meta: {
-					name: 'wc-addons-featured',
-					heading: __(
-						'Learn more about available products',
-						'woocommerce'
-					),
-					descriptions: {
-						desktop: createInterpolateElement(
-							__(
-								'All available products will be displayed here (scroll down to see them all), along with a summary about each product.<br/><br/>You can click on any product to see more information about it, including its features, requirements, and available documentation.',
-								'woocommerce'
-							),
-							{
-								br: lineBreak,
-							}
-						),
-					},
-				},
-			},
-			{
-				referenceElements: {
-					desktop: '.marketplace-header__tab-link_helper',
-				},
-				focusElement: {
-					desktop: '.marketplace-header__tab-link_helper',
-				},
-				meta: {
-					name: 'wc-addons-my-subscriptions',
-					heading: __( 'Manage your purchases', 'woocommerce' ),
-					descriptions: {
-						desktop: createInterpolateElement(
-							__(
-								"Products purchased from the WooCommerce Marketplace can be managed in My Subscriptions, either here or on WooCommerce.com after logging in.<br/><br/>Every purchase is backed by our <a1>30-day money-back guarantee</a1> and includes <a2>email and live chat support</a2> from our dedicated Happiness Engineers.<br/><br/>That's it! We hope the Marketplace helps you build the business of your dreams. We’re rooting for you.",
-								'woocommerce'
-							),
-							{
-								a1: createElement(
-									'a',
-									{
-										href: 'https://woocommerce.com/refund-policy/',
-										'aria-label': __(
-											'Refund policy',
-											'woocommerce'
-										),
-									},
-									__(
-										'30-day money-back guarantee',
-										'woocommerce'
-									)
-								),
-								a2: createElement(
-									'a',
-									{
-										href: 'https://woocommerce.com/my-account/create-a-ticket/',
-										'aria-label': __(
-											'Contact support',
-											'woocommerce'
-										),
-									},
-									__(
-										'email and live chat support',
-										'woocommerce'
-									)
-								),
-								br: lineBreak,
-							}
-						),
-					},
-				},
-			},
-		],
+		steps,
 		closeHandler,
 	};
 };

--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
@@ -122,7 +122,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 								'a',
 								{
 									href: 'https://woocommerce.com/refund-policy/',
-									ariaLabel: __(
+									'aria-label': __(
 										'Refund policy',
 										'woocommerce'
 									),
@@ -136,7 +136,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 								'a',
 								{
 									href: 'https://woocommerce.com/my-account/create-a-ticket/',
-									ariaLabel: __(
+									'aria-label': __(
 										'Contact support',
 										'woocommerce'
 									),

--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createElement, createInterpolateElement } from '@wordpress/element';
+import { TourKitTypes } from '@woocommerce/components';
+
+export const getSteps = (): TourKitTypes.WooStep[] => {
+	const lineBreak = createElement( 'br' );
+	return [
+		{
+			referenceElements: {
+				desktop: '#adminmenu a[href="admin.php?page=wc-addons"]',
+			},
+			focusElement: {
+				desktop: '#adminmenu a[href="admin.php?page=wc-addons"]',
+			},
+			meta: {
+				name: 'wc-addons-menu-item',
+				heading: __(
+					'Welcome to the WooCommerce Marketplace',
+					'woocommerce'
+				),
+				descriptions: {
+					desktop: createInterpolateElement(
+						__(
+							'The WooCommerce Marketplace is the place to go to find vetted extensions, themes, and services for your store.<br/><br/>There are hundreds of options available, and new products are added regularly. So start here when you want to enhance your store or discover new ways to grow your business.<br/><br/>The WooCommerce Marketplace is also available at WooCommerce.com.',
+							'woocommerce'
+						),
+						{
+							br: lineBreak,
+						}
+					),
+				},
+			},
+		},
+		{
+			referenceElements: {
+				desktop: '.marketplace-header__search-form',
+			},
+			focusElement: {
+				desktop: '.marketplace-header__search-form',
+			},
+			meta: {
+				name: 'wc-addons-search',
+				heading: __( 'Find exactly what you need', 'woocommerce' ),
+				descriptions: {
+					desktop: __(
+						'You can use the search box to find specific products in the Marketplace.',
+						'woocommerce'
+					),
+				},
+			},
+		},
+		{
+			referenceElements: {
+				desktop: '#marketplace-current-section-dropdown',
+			},
+			focusElement: {
+				desktop: '#marketplace-current-section-dropdown',
+			},
+			meta: {
+				name: 'wc-addons-categories',
+				heading: __( 'Browse for new ideas', 'woocommerce' ),
+				descriptions: {
+					desktop: createInterpolateElement(
+						__(
+							'Or browse all available products by category.<br/><br/>The Featured category is regularly updated with new and noteworthy products.',
+							'woocommerce'
+						),
+						{
+							br: lineBreak,
+						}
+					),
+				},
+			},
+		},
+		{
+			referenceElements: {
+				desktop: '.addon-product-group:first-child',
+			},
+			focusElement: {
+				desktop: '.addon-product-group:first-child',
+			},
+			meta: {
+				name: 'wc-addons-featured',
+				heading: __(
+					'Learn more about available products',
+					'woocommerce'
+				),
+				descriptions: {
+					desktop: createInterpolateElement(
+						__(
+							'All available products will be displayed here (scroll down to see them all), along with a summary about each product.<br/><br/>You can click on any product to see more information about it, including its features, requirements, and available documentation.',
+							'woocommerce'
+						),
+						{
+							br: lineBreak,
+						}
+					),
+				},
+			},
+		},
+		{
+			referenceElements: {
+				desktop: '.marketplace-header__tab-link_helper',
+			},
+			focusElement: {
+				desktop: '.marketplace-header__tab-link_helper',
+			},
+			meta: {
+				name: 'wc-addons-my-subscriptions',
+				heading: __( 'Manage your purchases', 'woocommerce' ),
+				descriptions: {
+					desktop: createInterpolateElement(
+						__(
+							"Products purchased from the WooCommerce Marketplace can be managed in My Subscriptions, either here or on WooCommerce.com after logging in.<br/><br/>Every purchase is backed by our <a1>30-day money-back guarantee</a1> and includes <a2>email and live chat support</a2> from our dedicated Happiness Engineers.<br/><br/>That's it! We hope the Marketplace helps you build the business of your dreams. We’re rooting for you.",
+							'woocommerce'
+						),
+						{
+							a1: createElement(
+								'a',
+								{
+									href: 'https://woocommerce.com/refund-policy/',
+									ariaLabel: __(
+										'Refund policy',
+										'woocommerce'
+									),
+								},
+								__(
+									'30-day money-back guarantee',
+									'woocommerce'
+								)
+							),
+							a2: createElement(
+								'a',
+								{
+									href: 'https://woocommerce.com/my-account/create-a-ticket/',
+									ariaLabel: __(
+										'Contact support',
+										'woocommerce'
+									),
+								},
+								__(
+									'email and live chat support',
+									'woocommerce'
+								)
+							),
+							br: lineBreak,
+						}
+					),
+				},
+			},
+		},
+	];
+};

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -10,7 +10,7 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { TaskItem, useSlot } from '@woocommerce/experimental';
-import { useCallback, useContext } from '@wordpress/element';
+import { useCallback, useContext, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
 
@@ -59,7 +59,20 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		title,
 		level,
 		additionalInfo,
+		recordViewEvent,
 	} = task;
+
+	useEffect( () => {
+		if ( recordViewEvent ) {
+			recordEvent( 'tasklist_item_view', {
+				task_name: id,
+				is_complete: isComplete,
+				context: layoutContext.toString(),
+			} );
+		}
+		// run the effect only when component mounts
+		// eslint-disable-next-line
+	}, [] );
 
 	const slot = useSlot( `woocommerce_onboarding_task_list_item_${ id }` );
 	const hasFills = Boolean( slot?.fills?.length );

--- a/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
@@ -7,6 +7,7 @@ import { SlotFillProvider } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useSlot } from '@woocommerce/experimental';
 import { TaskType } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -85,6 +86,7 @@ const task: TaskType = {
 	isActioned: false,
 	eventPrefix: '',
 	level: 0,
+	recordViewEvent: false,
 };
 
 describe( 'TaskListItem', () => {
@@ -102,6 +104,37 @@ describe( 'TaskListItem', () => {
 			/>
 		);
 		expect( queryByText( task.title ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not record view event on render if recordViewEvent is false', () => {
+		render(
+			<TaskListItem
+				task={ { ...task, recordViewEvent: false } }
+				isExpandable={ false }
+				isExpanded={ false }
+				setExpandedTask={ () => {} }
+			/>
+		);
+
+		expect( recordEvent ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	it( 'should record view event on render if recordViewEvent is true', () => {
+		render(
+			<TaskListItem
+				task={ { ...task, recordViewEvent: true } }
+				isExpandable={ false }
+				isExpanded={ false }
+				setExpandedTask={ () => {} }
+			/>
+		);
+
+		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_item_view', {
+			context: 'root',
+			is_complete: task.isComplete,
+			task_name: task.id,
+		} );
 	} );
 
 	it( 'should call dismissTask and trigger a notice when dismissing a task', () => {

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -52,6 +52,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 		{
 			id: 'required',
@@ -74,6 +75,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 		{
 			id: 'completed',
@@ -95,6 +97,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 	],
 	extension: [
@@ -118,6 +121,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 	],
 };

--- a/plugins/woocommerce-admin/client/tasks/test/task.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task.test.tsx
@@ -28,6 +28,7 @@ const task: TaskType = {
 	isActioned: false,
 	eventPrefix: '',
 	level: 0,
+	recordViewEvent: false,
 };
 
 /**

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -55,6 +55,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 		{
 			id: 'required',
@@ -77,6 +78,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: true,
 		},
 		{
 			id: 'completed',
@@ -98,6 +100,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 	],
 	extension: [
@@ -121,6 +124,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 			isActioned: false,
 			eventPrefix: '',
 			level: 0,
+			recordViewEvent: false,
 		},
 	],
 };

--- a/plugins/woocommerce/changelog/add-in-app-tour-track-events
+++ b/plugins/woocommerce/changelog/add-in-app-tour-track-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+add new track events for in-app marketplace tour

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -435,6 +435,15 @@ abstract class Task {
 	}
 
 	/**
+	 * Check if should record event when task is viewed
+	 *
+	 * @return bool
+	 */
+	public function get_record_view_event(): bool {
+		return false;
+	}
+
+	/**
 	 * Get the task as JSON.
 	 *
 	 * @return array
@@ -443,27 +452,28 @@ abstract class Task {
 		$this->possibly_track_completion();
 
 		return array(
-			'id'             => $this->get_id(),
-			'parentId'       => $this->get_parent_id(),
-			'title'          => $this->get_title(),
-			'canView'        => $this->can_view(),
-			'content'        => $this->get_content(),
-			'additionalInfo' => $this->get_additional_info(),
-			'actionLabel'    => $this->get_action_label(),
-			'actionUrl'      => $this->get_action_url(),
-			'isComplete'     => $this->is_complete(),
-			'time'           => $this->get_time(),
-			'level'          => $this->get_level(),
-			'isActioned'     => $this->is_actioned(),
-			'isDismissed'    => $this->is_dismissed(),
-			'isDismissable'  => $this->is_dismissable(),
-			'isSnoozed'      => $this->is_snoozed(),
-			'isSnoozeable'   => $this->is_snoozeable(),
-			'isVisited'      => $this->is_visited(),
-			'isDisabled'     => $this->is_disabled(),
-			'snoozedUntil'   => $this->get_snoozed_until(),
-			'additionalData' => self::convert_object_to_camelcase( $this->get_additional_data() ),
-			'eventPrefix'    => $this->prefix_event( '' ),
+			'id'              => $this->get_id(),
+			'parentId'        => $this->get_parent_id(),
+			'title'           => $this->get_title(),
+			'canView'         => $this->can_view(),
+			'content'         => $this->get_content(),
+			'additionalInfo'  => $this->get_additional_info(),
+			'actionLabel'     => $this->get_action_label(),
+			'actionUrl'       => $this->get_action_url(),
+			'isComplete'      => $this->is_complete(),
+			'time'            => $this->get_time(),
+			'level'           => $this->get_level(),
+			'isActioned'      => $this->is_actioned(),
+			'isDismissed'     => $this->is_dismissed(),
+			'isDismissable'   => $this->is_dismissable(),
+			'isSnoozed'       => $this->is_snoozed(),
+			'isSnoozeable'    => $this->is_snoozeable(),
+			'isVisited'       => $this->is_visited(),
+			'isDisabled'      => $this->is_disabled(),
+			'snoozedUntil'    => $this->get_snoozed_until(),
+			'additionalData'  => self::convert_object_to_camelcase( $this->get_additional_data() ),
+			'eventPrefix'     => $this->prefix_event( '' ),
+			'recordViewEvent' => $this->get_record_view_event(),
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
@@ -61,4 +61,13 @@ class TourInAppMarketplace extends Task {
 	public function get_action_url() {
 		return admin_url( 'admin.php?page=wc-addons&tutorial=true' );
 	}
+
+	/**
+	 * Check if should record event when task is viewed
+	 *
+	 * @return bool
+	 */
+	public function get_record_view_event(): bool {
+		return true;
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

To be able to track how often the In-App Marketplace Tour is opened and if users complete it, additional tracking had to be added. It will be triggered only for the users that enabled tracking.

Closes 14755-gh-Automattic/woocommerce.com.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch from this PR in your local environment
2. Build assets: `pnpm install && pnpm run build` (how to [get started](https://github.com/woocommerce/woocommerce#getting-started))
3. To run local dev environment: `cd plugins/woocommerce && npm run env:dev`
4. Your `http://localhost:8888/` should be available (assume that it's your base URL)
5. Go to http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com and make sure that "Enable tracking" checkbox is checked 
![image](https://user-images.githubusercontent.com/4765119/197962561-fc9d61b0-6372-4bde-8051-c2530b8bf5f2.png)
6. In dev tools > Console run `localStorage.setItem('debug', 'wc-admin:tracks');`
7. In Chromium-based web browsers (e.g. Brave, Chrome, and Electron), the JavaScript console will—by default—only show messages logged by debug if the "Verbose" log level is enabled. Keep the console open.
![image](https://user-images.githubusercontent.com/4765119/197965019-0a9245c6-18c0-49ca-af1b-1424c89be58f.png)
8. In console settings, check "Preserve log" checkbox 
![image](https://user-images.githubusercontent.com/4765119/197965246-2dda57c7-1f64-4b75-8df8-7c2055f7dd71.png)
9. Go to page http://localhost:8888/wp-admin/admin.php?page=wc-admin - There should be the following event present in the console `recordevent wcadmin_tasklist_item_view` with property `task_name: tour-in-app-marketplace` (it should be present whenever the item is shown for the user)
![image](https://user-images.githubusercontent.com/4765119/197965552-dcd87de0-424e-4374-8590-60c2d8957ef7.png)
10. Click on the "Tour the WooCommerce Marketplace" action. There should be the following event present in the console `recordevent wcadmin_tasklist_click` with property `task_name: tour-in-app-marketplace` 
![image](https://user-images.githubusercontent.com/4765119/197965918-f40b1ef7-09a1-4983-a24c-a36562970765.png)
11. You should be taken to the In-App Marketplace and eventually, the tour will show up. Once it does, there should be an event logged `wcadmin_in_app_marketplace_tour_started` . If tour-related event contains `step` property, please make sure it's correct (applicable also for the next steps).
![image](https://user-images.githubusercontent.com/4765119/197966315-e38d4f21-c409-4662-816e-637d591b0aee.png)
12. Click the "Next button" - there should be `wcadmin_in_app_marketplace_tour_step_viewed` event logged
![image](https://user-images.githubusercontent.com/4765119/197966393-d5380ef1-1d32-47ce-8540-accc8c01ef19.png)
13. Go to the end of the tour and click the "Done" button - there should be `wcadmin_in_app_marketplace_tour_completed` event logged
![image](https://user-images.githubusercontent.com/4765119/197966581-aafef7b9-7a74-4223-8827-5695a8220f73.png)
14. Start the tour again by appending `&tutorial=true` to the URL
15. Dismiss the tour at any step -  event `wcadmin_in_app_marketplace_tour_dismissed`  should be logged
![image](https://user-images.githubusercontent.com/4765119/197966863-acb56000-69e3-47a1-874c-af9586098e30.png)
16. Please test around this issue

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.