### PR TITLE
Update DateTimePickerControl's popover styling to work with slot-fill

### DIFF
--- a/packages/js/components/changelog/update-date-time-picker-control-picker-classname
+++ b/packages/js/components/changelog/update-date-time-picker-control-picker-classname
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix DateTimePickerControl's popover styling when slot-fill is used.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.scss
@@ -5,7 +5,9 @@
 		margin-right: 8px;
 	}
 
-	.components-datetime__date {
-		border-top: 0;
+	&__popover {
+		.components-datetime__date {
+			border-top: 0;
+		}
 	}
 }

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -280,6 +280,9 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 					/>
 				</BaseControl>
 			) }
+			popoverProps={ {
+				className: 'woocommerce-date-time-picker-control__popover',
+			} }
 			renderContent={ () => {
 				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;
 				const inputDateTime = parseAsLocalDateTime( inputString );

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { Button, Popover, SlotFillProvider } from '@wordpress/components';
 import { createElement, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { DateTimePickerControl } from '../';
+import { DateTimePickerControl, defaultDateFormat } from '../';
 
 export default {
 	title: 'WooCommerce Admin/components/DateTimePickerControl',
@@ -147,3 +147,30 @@ ControlledDateOnlyEndOfDay.args = {
 	timeForDateOnly: 'end-of-day',
 };
 ControlledDateOnlyEndOfDay.decorators = Controlled.decorators;
+
+function PopoverSlotDecorator( Story, props ) {
+	return (
+		<div>
+			<SlotFillProvider>
+				<div>
+					<Story
+						args={ {
+							...props.args,
+						} }
+					/>
+				</div>
+				<Popover.Slot />
+			</SlotFillProvider>
+		</div>
+	);
+}
+
+export const WithPopoverSlot = Template.bind( {} );
+WithPopoverSlot.args = {
+	...Basic.args,
+	label: 'Start date',
+	placeholder: 'Enter the start date',
+	help: 'There is a SlotFillProvider and Popover.Slot on the page',
+	isDateOnlyPicker: true,
+};
+WithPopoverSlot.decorators = [ PopoverSlotDecorator ];


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the styling of the DateTimePickeControl's popover to work correctly with slot-fill (when there is a `<SlotFillProvider>` and `<Popover.Slot>` on the page). (This is the case with the new product experience.)

Needed for #34538

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Interact with Storybook and make sure DateTimePickerControl "Controlled Date Only" and "With Popover Slot" stories both render the popover correctly: `pnpm --filter=@woocommerce/storybook storybook`
    - There should be no border/line at the top of the popover

#### Bad (before fix)

<img width="547" alt="Screen Shot 2022-10-26 at 19 55 49" src="https://user-images.githubusercontent.com/2098816/198162289-11f4ea9c-d0de-4125-806e-f9fa4dbae85a.png">

#### Good (after fix)

<img width="547" alt="Screen Shot 2022-10-26 at 19 58 59" src="https://user-images.githubusercontent.com/2098816/198162301-82626b16-4c1c-494f-8697-cc1ea1e68450.png">


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
