### PR TITLE
In-App Marketplace Tour - add custom popper modifier

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/utils.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/utils.ts
@@ -19,6 +19,26 @@ export const waitUntilElementTopNotChange = (
 	return intervalId;
 };
 
+// Observer position changes of an element
+export const observePositionChange = (
+	selector: string,
+	callback: () => void,
+	pollMs: number
+) => {
+	const initialElement = document.querySelector(
+		selector
+	) as HTMLElement | null;
+	let lastInitialElementTop = initialElement?.offsetTop;
+
+	return setInterval( () => {
+		const top = initialElement?.offsetTop;
+		if ( lastInitialElementTop !== top ) {
+			callback();
+		}
+		lastInitialElementTop = top;
+	}, pollMs );
+};
+
 // Overwrite the default behavior of click event for the "Enable guided mode" button
 export const bindEnableGuideModeClickEvent = (
 	onClick: EventListenerOrEventListenerObject

--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/utils.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/utils.ts
@@ -1,0 +1,18 @@
+// Try to make popper element visible on the screen
+export const scrollPopperToVisibleAreaIfNeeded = (
+	popperBoundingRect: DOMRect
+) => {
+	// 8px is added for some extra spacing from the top admin bar
+	const adminBarHeight =
+		( document.getElementById( 'wpadminbar' )?.offsetHeight || 0 ) + 8;
+
+	// check if element is cut from the top
+	if ( popperBoundingRect.top < adminBarHeight ) {
+		window.scrollBy( 0, popperBoundingRect.top - adminBarHeight );
+	} else if (
+		// check if element is cut from the bottom
+		popperBoundingRect.bottom > window.innerHeight
+	) {
+		window.scrollBy( 0, popperBoundingRect.bottom - window.innerHeight );
+	}
+};

--- a/plugins/woocommerce/changelog/fix-tour-scroll-and-arrows
+++ b/plugins/woocommerce/changelog/fix-tour-scroll-and-arrows
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+fix popper position for in-app marketplace tour


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Custom Popper modifier added to better position the popper element:
- Better control popper position - If the focus is on the admin menu, place it on the right. Otherwise, show it in the `top-start` position.
- Ensure that the popper is always visible, even on screens with small height.

Additionally, the initial position (when the page loads) of the popper has been fixed. Without those changes, if admin notices loaded after the tour was shown, the popper could be shown partially (on screens with small height).

Closes 14810-gh-Automattic/woocommerce.com .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch from this PR in your local environment
2. Build assets: `pnpm install && pnpm run build` (how to [get started](https://github.com/woocommerce/woocommerce#getting-started))
3. To run local dev environment: `cd plugins/woocommerce && npm run env:dev`
4. Your `http://localhost:8888/` should be available (assume that it's your base URL)
5. Go to http://localhost:8888/wp-admin/admin.php?page=wc-addons&tutorial=true  to view the tour. Go through the whole tour on screens with height:
   - ~480px
   - ~720px
   - 1280px+
  
   For all those sizes, when moving to the next step you should see the whole popper with step description.
6. Try to make your admin store show admin notices. What I did to show them was:
   - `cd /plugins/woocommerce-admin`
   - `npm run client:watch`
   - Edit file `plugins/woocommerce-admin/client/layout/store-alerts/index.js` and remove from `ALERTS_QUERY` const fields: `type` and `status`.
   - Refresh the page http://localhost:8888/wp-admin/admin.php?page=wc-addons&tutorial=true 
7. Test that the tour behaves properly, even after admin notices are loaded asynchronously (they move the page down when they are displayed).
8. Please test around this issue

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.