### PR TITLE
Add name to select control popover slots

### DIFF
--- a/packages/js/components/changelog/fix-select-control-popover-slots
+++ b/packages/js/components/changelog/fix-select-control-popover-slots
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add name to exported popover slot used to display SelectControl Menu, so it is only used for SelectControl menu's.
+Add name to exported popover slot used to display SelectControl Menu, so it is only used for SelectControl menus.

--- a/packages/js/components/changelog/fix-select-control-popover-slots
+++ b/packages/js/components/changelog/fix-select-control-popover-slots
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Add name to exported popover slot so that it is not used for any popover items.
+Add name to exported popover slot used to display SelectControl Menu, so it is only used for SelectControl menu's.

--- a/packages/js/components/changelog/fix-select-control-popover-slots
+++ b/packages/js/components/changelog/fix-select-control-popover-slots
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add name to exported popover slot so that it is not used for any popover items.

--- a/packages/js/components/src/experimental-select-control/menu.tsx
+++ b/packages/js/components/src/experimental-select-control/menu.tsx
@@ -52,6 +52,8 @@ export const Menu = ( {
 			) }
 		>
 			<Popover
+				// @ts-expect-error this prop does exist, see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L180.
+				__unstableSlotName="woocommerce-select-control-menu"
 				focusOnMount={ false }
 				className={ classnames(
 					'woocommerce-experimental-select-control__popover-menu',
@@ -85,7 +87,8 @@ export const Menu = ( {
 export const MenuSlot: React.FC = () =>
 	createPortal(
 		<div aria-live="off">
-			<Popover.Slot />
+			{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }
+			<Popover.Slot name="woocommerce-select-control-menu" />
 		</div>,
 		document.body
 	);

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
@@ -5,7 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { trash } from '@wordpress/icons';
 import { ProductAttribute, ProductAttributeTerm } from '@woocommerce/data';
-import { Form } from '@woocommerce/components';
+import {
+	Form,
+	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
+} from '@woocommerce/components';
 import {
 	Button,
 	Modal,
@@ -310,6 +313,8 @@ export const AddAttributeModal: React.FC< CreateCategoryModalProps > = ( {
 					);
 				} }
 			</Form>
+			{ /* Add slot so select control menu renders correctly within Modal */ }
+			<SelectControlMenuSlot />
 			{ showConfirmClose && (
 				<ConfirmDialog
 					cancelButtonText={ __( 'No thanks', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { sprintf, __ } from '@wordpress/i18n';
-import { Button, Card, CardBody, Popover } from '@wordpress/components';
+import { Button, Card, CardBody } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { ProductAttribute } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
@@ -94,7 +94,6 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 								) }
 							/>
 						) }
-						<Popover.Slot />
 					</div>
 				</CardBody>
 			</Card>
@@ -179,7 +178,6 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
 				/>
 			) }
-			<Popover.Slot />
 		</div>
 	);
 };

--- a/plugins/woocommerce/changelog/fix-select-control-popover-slots
+++ b/plugins/woocommerce/changelog/fix-select-control-popover-slots
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove Popover.Slot usage and make use of exported SelectControlMenuSlot.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a name to the Popover and PopoverSlot so the `Popover.Slot` doesn't get used for all the popovers within the page.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, build it, and make sure you have the `new-product-management-experience` feature flag enabled (you can do so using the latest version of the Beta tester within the mono repo).
2. Go to **Products > Add new (MVP)** and scroll down to the attributes section
3. Click **Add first attribute** and make sure the select control dropdown still shows correctly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
