### PR TITLE
Make HPOS feature and "Delete custom order tables" tool work nicely together

### DIFF
--- a/plugins/woocommerce/changelog/create_cot_tables_on_feature_enable
+++ b/plugins/woocommerce/changelog/create_cot_tables_on_feature_enable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Automatically create the custom order tables if the corresponding feature is enabled

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -102,6 +102,7 @@ class CustomOrdersTableController {
 		self::add_filter( DataSynchronizer::PENDING_SYNCHRONIZATION_FINISHED_ACTION, array( $this, 'process_sync_finished' ), 10, 0 );
 		self::add_action( 'woocommerce_update_options_advanced_custom_data_stores', array( $this, 'process_options_updated' ), 10, 0 );
 		self::add_action( 'woocommerce_after_register_post_type', array( $this, 'register_post_type_for_order_placeholders' ), 10, 0 );
+		self::add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'handle_feature_enabled_changed' ), 10, 2 );
 	}
 
 	/**
@@ -225,38 +226,34 @@ class CustomOrdersTableController {
 	 * @return array The updated array of tools-
 	 */
 	private function add_initiate_regeneration_entry_to_tools_array( array $tools_array ): array {
-		if ( ! $this->is_feature_visible() ) {
+		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
 			return $tools_array;
 		}
 
-		if ( $this->data_synchronizer->check_orders_table_exists() ) {
-			$tools_array['delete_custom_orders_table'] = array(
-				'name'             => __( 'Delete the custom orders tables', 'woocommerce' ),
-				'desc'             => sprintf(
-					'<strong class="red">%1$s</strong> %2$s',
-					__( 'Note:', 'woocommerce' ),
-					__( 'This will delete the custom orders tables. The tables can be deleted only if they are not not in use (via Settings > Advanced > Custom data stores). You can create them again at any time with the "Create the custom orders tables" tool.', 'woocommerce' )
-				),
-				'requires_refresh' => true,
-				'callback'         => function () {
-					$this->delete_custom_orders_tables();
-					return __( 'Custom orders tables have been deleted.', 'woocommerce' );
-				},
-				'button'           => __( 'Delete', 'woocommerce' ),
-				'disabled'         => $this->custom_orders_table_usage_is_enabled(),
-			);
+		if ( $this->is_feature_visible() ) {
+			$disabled = true;
+			$message  = __( 'This will delete the custom orders tables. The tables can be deleted only if the "High-Performance order storage" feature is disabled (via Settings > Advanced > Features).', 'woocommerce' );
 		} else {
-			$tools_array['create_custom_orders_table'] = array(
-				'name'             => __( 'Create the custom orders tables', 'woocommerce' ),
-				'desc'             => __( 'This tool will create the custom orders tables. Once created you can go to WooCommerce > Settings > Advanced > Custom data stores and configure the usage of the tables.', 'woocommerce' ),
-				'requires_refresh' => true,
-				'callback'         => function() {
-					$this->create_custom_orders_tables();
-					return __( 'Custom orders tables have been created. You can now go to WooCommerce > Settings > Advanced > Custom data stores.', 'woocommerce' );
-				},
-				'button'           => __( 'Create', 'woocommerce' ),
-			);
+			$disabled = false;
+			$message  = __( 'This will delete the custom orders tables. To create them again enable the "High-Performance order storage" feature (via Settings > Advanced > Features).', 'woocommerce' );
 		}
+
+		$tools_array['delete_custom_orders_table'] = array(
+			'name'             => __( 'Delete the custom orders tables', 'woocommerce' ),
+			'desc'             => sprintf(
+				'<strong class="red">%1$s</strong> %2$s',
+				__( 'Note:', 'woocommerce' ),
+				$message
+			),
+			'requires_refresh' => true,
+			'callback'         => function () {
+				$this->features_controller->change_feature_enable( 'custom_order_tables', false );
+				$this->delete_custom_orders_tables();
+				return __( 'Custom orders tables have been deleted.', 'woocommerce' );
+			},
+			'button'           => __( 'Delete', 'woocommerce' ),
+			'disabled'         => $disabled,
+		);
 
 		return $tools_array;
 	}
@@ -264,16 +261,14 @@ class CustomOrdersTableController {
 	/**
 	 * Create the custom orders tables in response to the user pressing the tool button.
 	 *
+	 * @param bool $verify_nonce True to perform the nonce verification, false to skip it.
+	 *
 	 * @throws \Exception Can't create the tables.
 	 */
-	private function create_custom_orders_tables() {
+	private function create_custom_orders_tables( bool $verify_nonce = true ) {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		if ( ! isset( $_REQUEST['_wpnonce'] ) || wp_verify_nonce( $_REQUEST['_wpnonce'], 'debug_action' ) === false ) {
+		if ( $verify_nonce && ( ! isset( $_REQUEST['_wpnonce'] ) || wp_verify_nonce( $_REQUEST['_wpnonce'], 'debug_action' ) === false ) ) {
 			throw new \Exception( 'Invalid nonce' );
-		}
-
-		if ( ! $this->is_feature_visible() ) {
-			throw new \Exception( "Can't create the custom orders tables: the feature isn't enabled" );
 		}
 
 		$this->data_synchronizer->create_database_tables();
@@ -323,111 +318,98 @@ class CustomOrdersTableController {
 			return $settings;
 		}
 
-		if ( $this->data_synchronizer->check_orders_table_exists() ) {
-			$settings[] = array(
-				'title' => __( 'Custom orders tables', 'woocommerce' ),
-				'type'  => 'title',
-				'id'    => 'cot-title',
-				'desc'  => sprintf(
-					/* translators: %1$s = <strong> tag, %2$s = </strong> tag. */
-					__( '%1$sWARNING:%2$s This feature is currently under development and may cause database instability. For contributors only.', 'woocommerce' ),
-					'<strong>',
-					'</strong>'
-				),
-			);
+		$settings[] = array(
+			'title' => __( 'Custom orders tables', 'woocommerce' ),
+			'type'  => 'title',
+			'id'    => 'cot-title',
+			'desc'  => sprintf(
+				/* translators: %1$s = <strong> tag, %2$s = </strong> tag. */
+				__( '%1$sWARNING:%2$s This feature is currently under development and may cause database instability. For contributors only.', 'woocommerce' ),
+				'<strong>',
+				'</strong>'
+			),
+		);
 
-			$sync_status     = $this->data_synchronizer->get_sync_status();
+		$sync_status     = $this->data_synchronizer->get_sync_status();
 		$sync_is_pending = 0 !== $sync_status['current_pending_count'];
 
-			$settings[] = array(
-				'title'         => __( 'Data store for orders', 'woocommerce' ),
-				'id'            => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
-				'default'       => 'no',
-				'type'          => 'radio',
-				'options'       => array(
-					'yes' => __( 'Use the WooCommerce orders tables', 'woocommerce' ),
-					'no'  => __( 'Use the WordPress posts table', 'woocommerce' ),
-				),
-				'checkboxgroup' => 'start',
-				'disabled'      => $sync_is_pending ? array( 'yes', 'no' ) : array(),
-			);
+		$settings[] = array(
+			'title'         => __( 'Data store for orders', 'woocommerce' ),
+			'id'            => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+			'default'       => 'no',
+			'type'          => 'radio',
+			'options'       => array(
+				'yes' => __( 'Use the WooCommerce orders tables', 'woocommerce' ),
+				'no'  => __( 'Use the WordPress posts table', 'woocommerce' ),
+			),
+			'checkboxgroup' => 'start',
+			'disabled'      => $sync_is_pending ? array( 'yes', 'no' ) : array(),
+		);
 
-			if ( $sync_is_pending ) {
-				$initial_pending_count = $sync_status['initial_pending_count'];
-				$current_pending_count = $sync_status['current_pending_count'];
-				if ( $initial_pending_count ) {
-					$text =
-						sprintf(
-							/* translators: %1$s=current number of orders pending sync, %2$s=initial number of orders pending sync */
-							_n( 'There\'s %1$s order (out of a total of %2$s) pending sync!', 'There are %1$s orders (out of a total of %2$s) pending sync!', $current_pending_count, 'woocommerce' ),
-							$current_pending_count,
-							$initial_pending_count
-						);
-				} else {
-					$text =
-						/* translators: %s=initial number of orders pending sync */
-						sprintf( _n( 'There\'s %s order pending sync!', 'There are %s orders pending sync!', $current_pending_count, 'woocommerce' ), $current_pending_count, 'woocommerce' );
-				}
-
-				if ( $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) ) ) {
-					$text .= __( "<br/>Synchronization for these orders is currently in progress.<br/>The authoritative table can't be changed until sync completes.", 'woocommerce' );
-				} else {
-					$text .= __( "<br/>The authoritative table can't be changed until these orders are synchronized.", 'woocommerce' );
-				}
-
-				$settings[] = array(
-					'type' => 'info',
-					'id'   => 'cot-out-of-sync-warning',
-					'css'  => 'color: #C00000',
-					'text' => $text,
-				);
-			}
-
-			$settings[] = array(
-				'desc' => __( 'Keep the posts table and the orders tables synchronized', 'woocommerce' ),
-				'id'   => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
-				'type' => 'checkbox',
-			);
-
-			if ( $sync_is_pending ) {
-				if ( $this->data_synchronizer->data_sync_is_enabled() ) {
-					$message    = $this->custom_orders_table_usage_is_enabled() ?
-						__( 'Switch to using the posts table as the authoritative data store for orders when sync finishes', 'woocommerce' ) :
-						__( 'Switch to using the orders table as the authoritative data store for orders when sync finishes', 'woocommerce' );
-					$settings[] = array(
-						'desc' => $message,
-						'id'   => self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION,
-						'type' => 'checkbox',
+		if ( $sync_is_pending ) {
+			$initial_pending_count = $sync_status['initial_pending_count'];
+			$current_pending_count = $sync_status['current_pending_count'];
+			if ( $initial_pending_count ) {
+				$text =
+					sprintf(
+						/* translators: %1$s=current number of orders pending sync, %2$s=initial number of orders pending sync */
+						_n( 'There\'s %1$s order (out of a total of %2$s) pending sync!', 'There are %1$s orders (out of a total of %2$s) pending sync!', $current_pending_count, 'woocommerce' ),
+						$current_pending_count,
+						$initial_pending_count
 					);
-				}
+			} else {
+				$text =
+					/* translators: %s=initial number of orders pending sync */
+					sprintf( _n( 'There\'s %s order pending sync!', 'There are %s orders pending sync!', $current_pending_count, 'woocommerce' ), $current_pending_count, 'woocommerce' );
+			}
+
+			if ( $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) ) ) {
+				$text .= __( "<br/>Synchronization for these orders is currently in progress.<br/>The authoritative table can't be changed until sync completes.", 'woocommerce' );
+			} else {
+				$text .= __( "<br/>The authoritative table can't be changed until these orders are synchronized.", 'woocommerce' );
 			}
 
 			$settings[] = array(
-				'desc' => __( 'Use database transactions for the orders data synchronization', 'woocommerce' ),
-				'id'   => self::USE_DB_TRANSACTIONS_OPTION,
-				'type' => 'checkbox',
-			);
-
-			$isolation_level_names = self::get_valid_transaction_isolation_levels();
-			$settings[]            = array(
-				'desc'    => __( 'Database transaction isolation level to use', 'woocommerce' ),
-				'id'      => self::DB_TRANSACTIONS_ISOLATION_LEVEL_OPTION,
-				'type'    => 'select',
-				'options' => array_combine( $isolation_level_names, $isolation_level_names ),
-				'default' => self::DEFAULT_DB_TRANSACTIONS_ISOLATION_LEVEL,
-			);
-		} else {
-			$settings[] = array(
-				'title' => __( 'Custom orders tables', 'woocommerce' ),
-				'type'  => 'title',
-				'desc'  => sprintf(
-					/* translators: %1$s = <em> tag, %2$s = </em> tag. */
-					__( 'Create the tables first by going to %1$sWooCommerce > Status > Tools%2$s and running %1$sCreate the custom orders tables%2$s.', 'woocommerce' ),
-					'<em>',
-					'</em>'
-				),
+				'type' => 'info',
+				'id'   => 'cot-out-of-sync-warning',
+				'css'  => 'color: #C00000',
+				'text' => $text,
 			);
 		}
+
+		$settings[] = array(
+			'desc' => __( 'Keep the posts table and the orders tables synchronized', 'woocommerce' ),
+			'id'   => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+			'type' => 'checkbox',
+		);
+
+		if ( $sync_is_pending ) {
+			if ( $this->data_synchronizer->data_sync_is_enabled() ) {
+				$message    = $this->custom_orders_table_usage_is_enabled() ?
+					__( 'Switch to using the posts table as the authoritative data store for orders when sync finishes', 'woocommerce' ) :
+					__( 'Switch to using the orders table as the authoritative data store for orders when sync finishes', 'woocommerce' );
+				$settings[] = array(
+					'desc' => $message,
+					'id'   => self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION,
+					'type' => 'checkbox',
+				);
+			}
+		}
+
+		$settings[] = array(
+			'desc' => __( 'Use database transactions for the orders data synchronization', 'woocommerce' ),
+			'id'   => self::USE_DB_TRANSACTIONS_OPTION,
+			'type' => 'checkbox',
+		);
+
+		$isolation_level_names = self::get_valid_transaction_isolation_levels();
+		$settings[]            = array(
+			'desc'    => __( 'Database transaction isolation level to use', 'woocommerce' ),
+			'id'      => self::DB_TRANSACTIONS_ISOLATION_LEVEL_OPTION,
+			'type'    => 'select',
+			'options' => array_combine( $isolation_level_names, $isolation_level_names ),
+			'default' => self::DEFAULT_DB_TRANSACTIONS_ISOLATION_LEVEL,
+		);
 
 		$settings[] = array( 'type' => 'sectionend' );
 
@@ -534,6 +516,24 @@ class CustomOrdersTableController {
 			$this->batch_processing_controller->enqueue_processor( DataSynchronizer::class );
 		} else {
 			$this->batch_processing_controller->remove_processor( DataSynchronizer::class );
+		}
+	}
+
+	/**
+	 * Handle the 'woocommerce_feature_enabled_changed' action,
+	 * if the custom orders table feature is enabled create the database tables if they don't exist.
+	 *
+	 * @param string $feature_id The id of the feature that is being enabled or disabled.
+	 * @param bool   $is_enabled True if the feature is being enabled, false if it's being disabled.
+	 */
+	private function handle_feature_enabled_changed( $feature_id, $is_enabled ): void {
+		if ( 'custom_order_tables' !== $feature_id || ! $is_enabled ) {
+			return;
+		}
+
+		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
+			update_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, 'no' );
+			$this->create_custom_orders_tables( false );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -319,7 +319,7 @@ class CustomOrdersTableController {
 	 * @return array The updated settings array.
 	 */
 	private function get_settings( array $settings, string $section_id ): array {
-		if ( ! $this->is_feature_visible() || $section_id !== 'custom_data_stores' ) {
+		if ( ! $this->is_feature_visible() || 'custom_data_stores' !== $section_id ) {
 			return $settings;
 		}
 
@@ -337,7 +337,7 @@ class CustomOrdersTableController {
 			);
 
 			$sync_status     = $this->data_synchronizer->get_sync_status();
-			$sync_is_pending = $sync_status['current_pending_count'] !== 0;
+		$sync_is_pending = 0 !== $sync_status['current_pending_count'];
 
 			$settings[] = array(
 				'title'         => __( 'Data store for orders', 'woocommerce' ),
@@ -456,7 +456,7 @@ class CustomOrdersTableController {
 	 * @param mixed  $value New value of the setting.
 	 */
 	private function process_updated_option( $option, $old_value, $value ) {
-		if ( $option === DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION && $value === 'no' ) {
+		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option && 'no' === $value ) {
 			$this->data_synchronizer->cleanup_synchronization_state();
 		}
 	}
@@ -472,7 +472,7 @@ class CustomOrdersTableController {
 	 * @throws \Exception Attempt to change the authoritative orders table while orders sync is pending.
 	 */
 	private function process_pre_update_option( $value, $option, $old_value ) {
-		if ( $option !== self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION || $value === $old_value || $old_value === false ) {
+		if ( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION !== $option || $value === $old_value || false === $old_value ) {
 			return $value;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -280,6 +280,7 @@ WHERE
   AND orders.id IS NULL",
 					$order_post_types
 				);
+				// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				break;
 			case self::ID_TYPE_MISSING_IN_POSTS_TABLE:
 				$sql = "


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. The HPOS related tables are now created automatically (if needed) when the feature is enabled from the tools page.
2. Enabling HPOS from the features page is now the only way to create the tables (this was actually already the case, since the "Create tables" tool wasn't showing when the feature was disabled; but now the code for the tool has been removed).
3. The "Delete tables" tool will be disabled if the feature is enabled (and will show a message indicating so).

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

Start with the COT tables deleted and the feature disabled.

1. Go to the tools page and verify that there is no tool related to the HPOS tables.
2. Go to the features page and enable the feature.
3. Verify that the tables have been created.
4. Reload the features page and verify that the "Delete the custom orders tables" tool is present, but the button is disabled.
5. Go back to the features page and disable the feature.
6. Reload the features page and verify that the tool is now enabled.
7. Run the tool and verify that the tables are deleted.

At this point you should be able to start over at 1 and all the steps should work again consistently.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
