### PR TITLE
Fix release post not parsing certain versions correctly

### DIFF
--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -51,7 +51,14 @@ const program = new Command()
 
 		if ( ! options.previousVersion && previousVersion ) {
 			// e.g 6.8.0 -> 6.7.0
-			previousVersion.minor -= 1;
+			previousVersion.major =
+				previousVersion.minor === 0
+					? previousVersion.major - 1
+					: previousVersion.major;
+
+			previousVersion.minor =
+				previousVersion.minor === 0 ? 9 : previousVersion.minor - 1;
+
 			previousVersion.format();
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the release post tool to correctly parse versions in certain circumstances. For example if you ran `pnpm run release-post -- 7.0.0 --outputOnly` in `trunk`, you would get an error.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout this branch.
2. `pnpm install`
3. `pnpm run build`
4. cd `tools/release-posts`
5. run `pnpm run release-post -- 7.0.0 --outputOnly`
6. Ensure there are no more error and that the generated post is correctly referencing `7.0.0` compared with `6.9.0`.
7. In addition, try running `pnpm run release-post -- 6.9.0 --outputOnly` and ensure there are no errors and that the generated post is correctly referencing `6.9.0` compared with `6.8.0`.

Note: You might have to run `npm i -g pnpm` inbetween tests because there is a chance it installed an older `pnpm` version.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
