### PR TITLE
[HPOS] Allow line breaks in order notes (admin-side)

### DIFF
--- a/plugins/woocommerce/changelog/fix-35112
+++ b/plugins/woocommerce/changelog/fix-35112
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow line breaks in order note again.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -669,7 +669,7 @@ class WC_Meta_Box_Order_Data {
 
 		// Customer note.
 		if ( isset( $_POST['customer_note'] ) ) {
-			$props['customer_note'] = sanitize_text_field( wp_unslash( $_POST['customer_note'] ) );
+			$props['customer_note'] = sanitize_textarea_field( wp_unslash( $_POST['customer_note'] ) );
 		}
 
 		// Save order data.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -38,6 +38,13 @@ class WC_Meta_Box_Order_Data {
 	 */
 	public static function init_address_fields() {
 
+		/**
+		 * Provides an opportunity to modify the list of order billing fields displayed on the admin.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array Billing fields.
+		 */
 		self::$billing_fields = apply_filters(
 			'woocommerce_admin_billing_fields',
 			array(
@@ -90,6 +97,13 @@ class WC_Meta_Box_Order_Data {
 			)
 		);
 
+		/**
+		 * Provides an opportunity to modify the list of order shipping fields displayed on the admin.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param array Shipping fields.
+		 */
 		self::$shipping_fields = apply_filters(
 			'woocommerce_admin_shipping_fields',
 			array(
@@ -533,6 +547,13 @@ class WC_Meta_Box_Order_Data {
 								}
 							}
 
+							/**
+							 * Allows 3rd parties to alter whether the customer note should be displayed on the admin.
+							 *
+							 * @since 2.1.0
+							 *
+							 * @param bool TRUE if the note should be displayed. FALSE otherwise.
+							 */
 							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) :
 								?>
 								<p class="form-field form-field-wide">


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds back support for line breaks in order notes edited on the admin side.

Closes #35112.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Check out `trunk`.
1. Add an item to the cart and go to the checkout screen.
2. Enter something in the order notes field (under Additional Information).
   <img width="483" alt="Screenshot 2022-10-27 at 12 32 13" src="https://user-images.githubusercontent.com/184724/198382018-831f2293-f496-415c-abb3-1ae6bb636198.png">
4. Complete the purchase.
5. On the confirmation screen (or in My Account > Orders) you'll see that line breaks are respected.
6. Go to WC > Orders > (the recent order) and edit the notes.
7. Click "Update".
8. Confirm that the line breaks have disappeared.
9. Check out this branch.
10. Repeat 5-6 and confirm that line breaks are respected.


<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
