### PR TITLE
Guard against cases where `get_current_screen()` is undefined.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35346-features-controller
+++ b/plugins/woocommerce/changelog/fix-35346-features-controller
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: The introduction of the FeaturesController is covered by an earlier changelog entry. Since the feature is unreleased, we probably do not need to itemize this small adjustment.
+
+

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -712,7 +712,7 @@ class FeaturesController {
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification
-		if ( get_current_screen() && 'plugins' !== get_current_screen()->id || 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) {
+		if ( ! function_exists( 'get_current_screen' ) || get_current_screen() && 'plugins' !== get_current_screen()->id || 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) {
 			return $list;
 		}
 


### PR DESCRIPTION
If other code invokes the `all_plugins` filter during non-admin requests, then a fatal error may be experienced because we have a filter callback that attempts to call `get_current_screen()` (which may not be defined outside of the admin environment).

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a check to ensure `get_current_screen()` is defined before attempting to call it. This protects against the possibility of fatal errors for non-admin requests.

I considered some alternative combination of checks that test if we are either in a non-admin-and-non-ajax request, but this seemed cleaner and simpler (however, let me know if there are reasons to prefer that or some other strategy).

Closes #35346.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Add a snippet to a suitable location, such as `wp-content/mu-plugins/test-pr.php` with the following snippet *(and don't forget to remove it once you have finished testing this PR!):*

```php
<?php
add_action( 'wp_head', function () {
	return apply_filters( 'all_plugins', get_plugins() );
} );
```

2. Navigate to the website homepage.
    - Without this change, you will experience a fatal error *("Fatal error: Uncaught Error: Call to undefined function ...\get_current_screen()").*
    - With this change, there should be no fatal error.
3. Optional: consider also testing with JetPack per notes in https://github.com/woocommerce/woocommerce/issues/35346 (you will probably need access to your error logs to observe the fatal error/absence of the fatal error, though—it won't necessarily result in an 'obvious' crash).

Let's also perform a check to ensure the FeaturesController (and the callback we amended) still functions as intended:

1. Setup and enable the HPOS feature first of all. Reminder of how to do this:
    - If necessary, start by running the **WooCommerce ▸ Status ▸ Tools ▸ Create Custom Order Tables**  tool.
    - Then, visit **WooCommerce ▸ Settings ▸ Advanced ▸ Features** and enable **High-Performance Order Storage**.
2. Unless you already have one available, install then activate a plugin that is compatible with WooCommerce but incompatible with HPOS (random example: *WooCommerce Amazon S3 Storage 2.1.22).*
3. You should see a warning about one or more plugins being incompatible with currently enabled features. Follow the provided link (to `.../wp-admin/plugins.php?plugin_status=incompatible_with_feature`).
4. You should see a list of incompatible plugins.

<img width="928" alt="incompat-plugins" src="https://user-images.githubusercontent.com/3594411/198411254-f682c3b7-4a0b-422c-881c-207003472c41.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable? _**No, this just adds some defensive coding and doesn't change the feature/functionality, which is adequately covered by tests [added here](https://github.com/woocommerce/woocommerce/pull/34616/files).**_
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
