### PR TITLE
Fix class name for class FirstDownlaodableProduct

### DIFF
--- a/plugins/woocommerce/changelog/fix-misspelled-first-downlaodable-product
+++ b/plugins/woocommerce/changelog/fix-misspelled-first-downlaodable-product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix class name for class FirstDownlaodableProduct

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -18,7 +18,7 @@ use \Automattic\WooCommerce\Internal\Admin\Notes\CustomizeStoreWithBlocks;
 use \Automattic\WooCommerce\Internal\Admin\Notes\CustomizingProductCatalog;
 use \Automattic\WooCommerce\Internal\Admin\Notes\EditProductsOnTheMove;
 use \Automattic\WooCommerce\Internal\Admin\Notes\EUVATNumber;
-use \Automattic\WooCommerce\Internal\Admin\Notes\FirstDownlaodableProduct;
+use \Automattic\WooCommerce\Internal\Admin\Notes\FirstDownloadableProduct;
 use \Automattic\WooCommerce\Internal\Admin\Notes\FirstProduct;
 use \Automattic\WooCommerce\Internal\Admin\Notes\InsightFirstProductAndPayment;
 use \Automattic\WooCommerce\Internal\Admin\Notes\InsightFirstSale;
@@ -82,7 +82,7 @@ class Events {
 		CustomizingProductCatalog::class,
 		EditProductsOnTheMove::class,
 		EUVATNumber::class,
-		FirstDownlaodableProduct::class,
+		FirstDownloadableProduct::class,
 		FirstProduct::class,
 		InsightFirstProductAndPayment::class,
 		InsightFirstSale::class,

--- a/plugins/woocommerce/src/Internal/Admin/Notes/FirstDownloadableProduct.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/FirstDownloadableProduct.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Admin Digital/Downloadable Producdt Handling note provider
  *
- * Adds a note with a link to the downlaodable product handling
+ * Adds a note with a link to the downloadable product handling
  */
 
 namespace Automattic\WooCommerce\Internal\Admin\Notes;
@@ -13,9 +13,9 @@ use \Automattic\WooCommerce\Admin\Notes\Note;
 use \Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
- * FirstDownlaodableProduct.
+ * FirstDownloadableProduct.
  */
-class FirstDownlaodableProduct {
+class FirstDownloadableProduct {
 	/**
 	 * Note traits.
 	 */


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35307

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
