### PR TITLE
Show In-App Marketplace Tour on desktop only

### DIFF
--- a/plugins/woocommerce/changelog/update-show-wc-addons-tour-on-desktop-only
+++ b/plugins/woocommerce/changelog/update-show-wc-addons-tour-on-desktop-only
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Permit showing a guided tour for WooCommerce Extensions page on desktops only

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
@@ -73,7 +73,7 @@ class WC_Admin_Pointers {
 		}
 
 		if ( wp_is_mobile() ) {
-			return; // Permit In-App Marketplace Tour on desktops only
+			return; // Permit In-App Marketplace Tour on desktops only.
 		}
 
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'wc-addons-tour', true );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
@@ -72,6 +72,10 @@ class WC_Admin_Pointers {
 			return;
 		}
 
+		if ( wp_is_mobile() ) {
+			return; // Permit In-App Marketplace Tour on desktops only
+		}
+
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'wc-addons-tour', true );
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedExtendedTask;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\ReviewShippingOptions;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\TourInAppMarketplace;
 /**
  * Task Lists class.
  */
@@ -148,7 +149,6 @@ class TaskLists {
 				'tasks'   => array(
 					'AdditionalPayments',
 					'GetMobileApp',
-					'TourInAppMarketplace',
 				),
 			)
 		);
@@ -187,7 +187,6 @@ class TaskLists {
 				'tasks'        => array(
 					'AdditionalPayments',
 					'GetMobileApp',
-					'TourInAppMarketplace',
 				),
 				'event_prefix' => 'extended_tasklist_',
 			)
@@ -221,6 +220,12 @@ class TaskLists {
 					'visible'      => false,
 				)
 			);
+		}
+
+		if ( ! wp_is_mobile() ) { // Permit In-App Marketplace Tour on desktops only
+			$tour_task = new TourInAppMarketplace();
+			self::add_task( 'extended', $tour_task );
+			self::add_task( 'extended_two_column', $tour_task );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -222,7 +222,7 @@ class TaskLists {
 			);
 		}
 
-		if ( ! wp_is_mobile() ) { // Permit In-App Marketplace Tour on desktops only
+		if ( ! wp_is_mobile() ) { // Permit In-App Marketplace Tour on desktops only.
 			$tour_task = new TourInAppMarketplace();
 			self::add_task( 'extended', $tour_task );
 			self::add_task( 'extended_two_column', $tour_task );


### PR DESCRIPTION
### All Submissions:
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The current In-App Marketplace (WooCommerce Extensions page) Tour implementation (based on TourKit) is not as mobile-friendly as we need. To make sure users won't be confused with how the tour looks on mobile devices we decided to show the tour on desktops only. 

Closes 14834-gh-Automattic/woocommerce.com.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch from this PR in your local environment
2. Build assets: `pnpm install && pnpm run build` (how to [get started](https://github.com/woocommerce/woocommerce#getting-started))
3. Run local dev environment: `cd plugins/woocommerce && npm run env:dev`
4. Your `http://localhost:8888/` should be available (assume that it's your base URL)
5. Go to http://localhost:8888/wp-admin/admin.php?page=wc-admin (make sure you don't hijack your User Agent yet)
6. You should see the task:
<img width="958" alt="Screen Shot 2022-10-28 at 16 28 12" src="https://user-images.githubusercontent.com/115007291/198610938-bfdff0e7-f985-48f9-8188-eb25484ae9a3.png">

7. Change your browser's user agent (e.g. with the use of [User Agent Switcher for Chrome addon](https://chrome.google.com/webstore/detail/user-agent-switcher-for-c/djflhoibgkdhkhhcedjiklpkjnoahfmg)) to a mobile device e.g. `iOS > iPhone 6`.
8. When the page is refreshed, you should not see the regarding the task:
<img width="927" alt="Screen Shot 2022-10-28 at 16 32 04" src="https://user-images.githubusercontent.com/115007291/198613866-a7573e3e-1b2b-4057-97fd-99574245a816.png">

9. While still pretending you use a mobile device open the WooCommerce Extensions page using the URL for starting the tour http://localhost:8888/wp-admin/admin.php?page=wc-addons&tutorial=true
10. You should not see the tour at all
<img width="952" alt="image" src="https://user-images.githubusercontent.com/115007291/198615536-66653a4a-03fd-4954-bb6d-976f7bfb4714.png">

11. Switch back to your default `Chrome > Default` user agent
12. Now you should see the tour
<img width="960" alt="Screen Shot 2022-10-28 at 16 37 12" src="https://user-images.githubusercontent.com/115007291/198616073-becbd9be-8aba-407a-a97a-77d5e37f26f9.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
