### PR TITLE
Libyan Dinar not formatted correctly

### DIFF
--- a/plugins/woocommerce/changelog/libyan-dinar
+++ b/plugins/woocommerce/changelog/libyan-dinar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects the currency symbol for Libyan Dinar (LYD).

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -752,7 +752,7 @@ function get_woocommerce_currency_symbols() {
 			'LKR' => '&#xdbb;&#xdd4;',
 			'LRD' => '&#36;',
 			'LSL' => 'L',
-			'LYD' => '&#x644;.&#x62f;',
+			'LYD' => '&#x62f;.&#x644;',
 			'MAD' => '&#x62f;.&#x645;.',
 			'MDL' => 'MDL',
 			'MGA' => 'Ar',

--- a/plugins/woocommerce/tests/api-core-tests/data/settings.js
+++ b/plugins/woocommerce/tests/api-core-tests/data/settings.js
@@ -96,7 +96,7 @@ const currencies = {
 	"LKR": "Sri Lankan rupee (&#xdbb;&#xdd4;)",
 	"LRD": "Liberian dollar (&#36;)",
 	"LSL": "Lesotho loti (L)",
-	"LYD": "Libyan dinar (&#x644;.&#x62f;)",
+	"LYD": "Libyan dinar (&#x62f;.&#x644;)",
 	"MAD": "Moroccan dirham (&#x62f;.&#x645;.)",
 	"MDL": "Moldovan leu (MDL)",
 	"MGA": "Malagasy ariary (Ar)",

--- a/plugins/woocommerce/tests/api-core-tests/tests/data/data-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/data/data-crud.test.js
@@ -26206,7 +26206,7 @@ test.describe('Data API tests', () => {
 			expect.objectContaining({
 				"code": "LYD",
 				"name": "Libyan dinar",
-				"symbol": "&#x644;.&#x62f;",
+				"symbol": "&#x62f;.&#x644;",
 				"_links": {
 					"self": [{
 						"href": expect.stringContaining("data/currencies/LYD")


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Libyan Dinar is formatted like this `ل.د` which is wrong, it's like saying `Dollar US` or `Lira Turkish`.

The correct format is `د.ل`, I went ahead and switched the characters in the following templates.

The problem was [reported in this thread](https://wordpress.org/support/topic/error-in-my-local-currency-name/#post-16129245) a P2 was also made in woohcp2. 

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Visit **WooCommerce ‣ Settings ‣ General**.
2. The symbol for Libyan Dinars (in the currency selector) should render as `د.ل` (previously, it was reversed).
3. If you select this currency and look at the storefront, you should see the same thing there.

![libyan-dinar](https://user-images.githubusercontent.com/3594411/199626669-5c8c2b07-a407-4bbc-bab6-28f4e2aadf71.png)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
