### PR TITLE
Fix unread notes count in inbox panel

### DIFF
--- a/packages/js/data/changelog/fix-34929
+++ b/packages/js/data/changelog/fix-34929
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add is_read query option for notes data store

--- a/packages/js/data/src/notes/types.ts
+++ b/packages/js/data/src/notes/types.ts
@@ -52,6 +52,7 @@ export type Note = {
 // [Notes.php](https://github.com/woocommerce/woocommerce/blob/af97aaf41067bcd0b7ff12df9b6169f97c326c0f/plugins/woocommerce/src/Admin/API/Notes.php#L629-L699)
 export type NoteQuery = Partial< {
 	context: string;
+	is_read: boolean;
 	order: 'asc' | 'desc';
 	orderby: 'note_id' | 'date' | 'type' | 'title' | 'status';
 	page: number;

--- a/packages/js/experimental/changelog/fix-34929
+++ b/packages/js/experimental/changelog/fix-34929
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check for note actions before checking length

--- a/packages/js/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/inbox-note.tsx
@@ -171,7 +171,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 	const actionWrapperClassName = classnames(
 		'woocommerce-inbox-message__actions',
 		{
-			'has-multiple-actions': note.actions.length > 1,
+			'has-multiple-actions': note.actions?.length > 1,
 		}
 	);
 

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -93,6 +93,7 @@ const renderNotes = ( {
 	notes,
 	onDismiss,
 	onNoteActionClick,
+	onNoteVisible,
 	setShowDismissAllModal: onDismissAll,
 	showHeader = true,
 	loadMoreNotes,
@@ -113,17 +114,6 @@ const renderNotes = ( {
 		} );
 		hasFiredPanelViewTrack = true;
 	}
-
-	const screen = getScreenName();
-	const onNoteVisible = ( note ) => {
-		recordEvent( 'inbox_note_view', {
-			note_content: note.content,
-			note_name: note.name,
-			note_title: note.title,
-			note_type: note.type,
-			screen,
-		} );
-	};
 
 	const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
@@ -223,6 +213,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 		triggerNoteAction,
 		invalidateResolutionForStoreSelector,
 	} = useDispatch( NOTES_STORE_NAME );
+	const screen = getScreenName();
 
 	const inboxQuery = useMemo( () => {
 		return {
@@ -284,9 +275,22 @@ const InboxPanel = ( { showHeader = true } ) => {
 
 	const [ showDismissAllModal, setShowDismissAllModal ] = useState( false );
 
-	const onDismiss = async ( note ) => {
-		const screen = getScreenName();
+	const onNoteVisible = ( note ) => {
+		if ( ! note.is_read ) {
+			updateNote( note.id, {
+				is_read: true,
+			} );
+		}
+		recordEvent( 'inbox_note_view', {
+			note_content: note.content,
+			note_name: note.name,
+			note_title: note.title,
+			note_type: note.type,
+			screen,
+		} );
+	};
 
+	const onDismiss = async ( note ) => {
 		recordEvent( 'inbox_action_dismiss', {
 			note_name: note.name,
 			note_title: note.title,
@@ -383,6 +387,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 							onNoteActionClick: ( note, action ) => {
 								triggerNoteAction( note.id, action.id );
 							},
+							onNoteVisible,
 							setShowDismissAllModal,
 							showHeader,
 							allNotesFetched,

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -116,6 +116,12 @@ const renderNotes = ( {
 	}
 
 	const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
+	const unreadNotesCount = notesArray.reduce( ( count, note ) => {
+		if ( ! note.is_read ) {
+			return count + 1;
+		}
+		return count;
+	}, 0 );
 
 	return (
 		<Card size="large">
@@ -125,7 +131,7 @@ const renderNotes = ( {
 						<Text size="20" lineHeight="28px" variant="title.small">
 							{ __( 'Inbox', 'woocommerce' ) }
 						</Text>
-						<Badge count={ notesArray.length } />
+						<Badge count={ unreadNotesCount } />
 					</div>
 					<EllipsisMenu
 						label={ __( 'Inbox Notes Options', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -207,6 +207,7 @@ const InboxPanel = ( { showHeader = true } ) => {
 	);
 	const [ allNotesFetched, setAllNotesFetched ] = useState( false );
 	const [ allNotes, setAllNotes ] = useState( [] );
+	const [ viewedNotes, setViewedNotes ] = useState( {} );
 	const { createNotice } = useDispatch( 'core/notices' );
 	const {
 		removeNote,
@@ -241,7 +242,6 @@ const InboxPanel = ( { showHeader = true } ) => {
 			notes: getNotes( inboxQuery ),
 			unreadNotesCount: getNotes( {
 				...DEFAULT_INBOX_QUERY,
-				_fields: [ 'id' ],
 				is_read: false,
 				per_page: -1,
 			} ).length,
@@ -287,10 +287,13 @@ const InboxPanel = ( { showHeader = true } ) => {
 	const [ showDismissAllModal, setShowDismissAllModal ] = useState( false );
 
 	const onNoteVisible = ( note ) => {
-		if ( ! note.is_read ) {
-			updateNote( note.id, {
-				is_read: true,
-			} );
+		if ( ! viewedNotes[ note.id ] && ! note.is_read ) {
+			setViewedNotes( { ...viewedNotes, [ note.id ]: true } );
+			setTimeout( () => {
+				updateNote( note.id, {
+					is_read: true,
+				} );
+			}, 3000 );
 		}
 		recordEvent( 'inbox_note_view', {
 			note_content: note.content,

--- a/plugins/woocommerce/changelog/fix-34929
+++ b/plugins/woocommerce/changelog/fix-34929
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix unread note count on inbox panel

--- a/plugins/woocommerce/src/Admin/API/Notes.php
+++ b/plugins/woocommerce/src/Admin/API/Notes.php
@@ -263,6 +263,10 @@ class Notes extends \WC_REST_CRUD_Controller {
 		$args['source']     = isset( $request['source'] ) ? $request['source'] : array();
 		$args['is_deleted'] = 0;
 
+		if ( isset( $request['is_read'] ) ) {
+			$args['is_read'] = filter_var( $request['is_read'], FILTER_VALIDATE_BOOLEAN );
+		}
+
 		if ( 'date' === $args['orderby'] ) {
 			$args['orderby'] = 'date_created';
 		}

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -508,6 +508,10 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$where_clauses .= " AND source IN ($escaped_where_source)";
 		}
 
+		if ( isset( $args['is_read'] ) ) {
+			$where_clauses .= $args['is_read'] ? ' AND is_read = 1' : ' AND is_read = 0';
+		}
+
 		$where_clauses .= $escaped_is_deleted ? ' AND is_deleted = 1' : ' AND is_deleted = 0';
 
 		return $where_clauses;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Adds the option to filter notes in the REST endpoint using `is_read`
* Adds the option to filter notes by `is_read` in the data store
* Uses the unread notes count in the inbox panel header
* Adds logic to mark notes as read when viewing a note

@pmcpinto @jarekmorawski This PR marks notes as read when viewing them.  One issue with this is that a note is instantly marked as read and the unread indicator flashes off the screen almost immediately.  It might be worth adding a delay before this occurs or caching the notes read status temporarily to avoid losing the unread indicator immediately.

Also cc @moon0326 to make sure I'm not creating regressions with the existing logic.  It seems like a choice was made in https://github.com/woocommerce/woocommerce-admin/pull/6047 and https://github.com/woocommerce/woocommerce-admin/pull/7896 to only mark notes as read when they were actioned.  This obviously undoes some of that work, but we are unlikely to see read notes if they are not actioned.

<img width="411" alt="Screen Shot 2022-10-28 at 12 44 52 PM" src="https://user-images.githubusercontent.com/10561050/198719641-d03e873e-b236-4bb9-b2aa-1444b22fbad1.png">


Closes #34929 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a site with at least 1 or more unread notes
2. Visit the home page and scroll down to see the notes
3. Note that unread notes are marked as read on viewing
4. Note that the count of notes in the inbox panel header reflects unread notes (all unread notes, not just the visible ones prior to loading the remaining notes).

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
