### PR TITLE
DateTimePickerControl: Only call onChange when the date actually changes

### DIFF
--- a/packages/js/components/changelog/fix-date-time-picker-control-onchange
+++ b/packages/js/components/changelog/fix-date-time-picker-control-onchange
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+DateTimePickerControl's onChange now only fires when there is an actual change to the datetime.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -268,12 +268,16 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		}
 	}
 
-	const isInitialUpdate = useRef( true );
-	useEffect( () => {
-		const newDateTime = parseMomentIso( currentDate );
+	function updateStateWithNewDateTime(
+		newDateTimeIsoString: string,
+		assumeLocalTime: boolean,
+		maybeFireOnChange: boolean
+	) {
+		const newDateTime = parseMomentIso(
+			newDateTimeIsoString,
+			assumeLocalTime
+		);
 		const isValid = newDateTime.isValid();
-		const fireOnChange =
-			! isInitialUpdate.current && ! newDateTime.isSame( lastValidDate );
 
 		if ( isValid ) {
 			setLastValidDate( newDateTime );
@@ -281,13 +285,18 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 
 		updateInputString( newDateTime );
 
-		if ( fireOnChange ) {
+		if ( maybeFireOnChange && ! newDateTime.isSame( lastValidDate ) ) {
 			callOnChange( newDateTime );
 		}
+	}
 
-		if ( isInitialUpdate.current ) {
-			isInitialUpdate.current = false;
-		}
+	const isInitialUpdate = useRef( true );
+	useEffect( () => {
+		updateStateWithNewDateTime(
+			currentDate || '',
+			false,
+			! isInitialUpdate.current
+		);
 	}, [ currentDate, displayFormat, timeForDateOnly ] );
 
 	return (
@@ -359,12 +368,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 								? formatMomentIso( lastValidDate )
 								: undefined
 						}
-						onChange={ ( date: string ) => {
-							// the picker returns the date in local time
-							const formattedDate = formatMoment(
-								parseMomentIso( date, true )
+						onChange={ ( localDateTimeIsoString: string ) => {
+							updateStateWithNewDateTime(
+								localDateTimeIsoString,
+								true,
+								true
 							);
-							changeImmediate( formattedDate, true );
 						} }
 						is12Hour={ is12HourPicker }
 					/>

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -112,10 +112,6 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return moment( dateString );
 	}
 
-	function formatMomentIso( momentDate: Moment ): string {
-		return momentDate.utc().toISOString();
-	}
-
 	function maybeForceTime( momentDate: Moment ): Moment {
 		if ( ! isDateOnlyPicker ) return momentDate;
 
@@ -183,10 +179,14 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			: dateTime.creationData().input?.toString() || '';
 	}
 
-	function callOnChange( dateTime: Moment ) {
-		const valueToSend = dateTime.isValid()
-			? formatMomentIso( dateTime )
+	function formatDateTimeAsISO( dateTime: Moment ): string {
+		return dateTime.isValid()
+			? dateTime.utc().toISOString()
 			: dateTime.creationData().input?.toString() || '';
+	}
+
+	function callOnChange( dateTime: Moment ) {
+		const valueToSend = formatDateTimeAsISO( dateTime );
 
 		if ( typeof onChangeRef.current === 'function' ) {
 			onChangeRef.current( valueToSend, dateTime.isValid() );
@@ -369,7 +369,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 					<Picker
 						currentDate={
 							lastValidDate.current
-								? formatMomentIso( lastValidDate.current )
+								? formatDateTimeAsISO( lastValidDate.current )
 								: undefined
 						}
 						onChange={ updateStateWithNewSelectedLocalDateTime }

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -116,10 +116,6 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return momentDate.utc().toISOString();
 	}
 
-	function formatMoment( momentDate: Moment ): string {
-		return formatDate( displayFormat, momentDate.local() );
-	}
-
 	function maybeForceTime( momentDate: Moment ): Moment {
 		if ( ! isDateOnlyPicker ) return momentDate;
 
@@ -181,12 +177,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		onChangeRef.current = onChange;
 	}, [ onChange ] );
 
-	function setInputStringWithMoment( dateTime: Moment ) {
-		const newInputString = dateTime.isValid()
-			? formatMoment( dateTime )
+	function formatDateTimeForDisplay( dateTime: Moment ): string {
+		return dateTime.isValid()
+			? formatDate( displayFormat, dateTime.local() )
 			: dateTime.creationData().input?.toString() || '';
-
-		setInputString( newInputString );
 	}
 
 	function callOnChange( dateTime: Moment ) {
@@ -220,7 +214,9 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			// We don't want to reformat what the user typed in
 			setInputString( newDateTimeString );
 		} else {
-			setInputStringWithMoment( newDateTime );
+			const formattedDateTimeString =
+				formatDateTimeForDisplay( newDateTime );
+			setInputString( formattedDateTimeString );
 		}
 
 		if (

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -77,9 +77,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	} );
 
 	const [ inputString, setInputString ] = useState( '' );
-	const [ lastValidDate, setLastValidDate ] = useState< Moment | null >(
-		null
-	);
+	const lastValidDate = useRef< Moment | null >( null );
 
 	const displayFormat = ( () => {
 		if ( dateTimeFormat ) {
@@ -207,6 +205,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		isManuallyTypedInput: boolean,
 		maybeFireOnChange: boolean
 	) {
+		const previousLastValidDate = lastValidDate.current;
 		let newDateTime = isManuallyTypedInput
 			? parseMoment( newDateTimeString )
 			: parseMomentIso( newDateTimeString, isLocalTime );
@@ -214,7 +213,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 
 		if ( isValid ) {
 			newDateTime = maybeForceTime( newDateTime );
-			setLastValidDate( newDateTime );
+			lastValidDate.current = newDateTime;
 		}
 
 		if ( isManuallyTypedInput ) {
@@ -224,7 +223,10 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			setInputStringWithMoment( newDateTime );
 		}
 
-		if ( maybeFireOnChange && ! newDateTime.isSame( lastValidDate ) ) {
+		if (
+			maybeFireOnChange &&
+			! newDateTime.isSame( previousLastValidDate )
+		) {
 			callOnChange( newDateTime );
 		}
 	}
@@ -271,7 +273,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	const updateStateWithNewInputStringRef = useRef<
 		( newInputString: string, fireOnChange: boolean ) => void
 	>( updateStateWithNewInputString );
-	// whenever currentDate or timeForDateOnly changes, we need to reset the ref to inputStringChangeHandlerFunction
+	// whenever currentDate or timeForDateOnly changes,
+	// we need to reset the ref to inputStringChangeHandlerFunction
 	// so that we are using the most current values inside of it
 	useEffect( () => {
 		updateStateWithNewInputStringRef.current =
@@ -369,8 +372,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				return (
 					<Picker
 						currentDate={
-							lastValidDate
-								? formatMomentIso( lastValidDate )
+							lastValidDate.current
+								? formatMomentIso( lastValidDate.current )
 								: undefined
 						}
 						onChange={ updateStateWithNewSelectedLocalDateTime }

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -283,16 +283,6 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		onChangeDebounceWait
 	);
 
-	function change( newInputString: string ) {
-		debouncedUpdateStateWithNewInputString( newInputString, true );
-	}
-
-	function blur() {
-		if ( onBlur ) {
-			onBlur();
-		}
-	}
-
 	function focusInputControl() {
 		if ( inputControl.current ) {
 			inputControl.current.focus();
@@ -319,8 +309,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			focusOnMount={ false }
 			// @ts-expect-error `onToggle` does exist.
 			onToggle={ ( willOpen ) => {
-				if ( ! willOpen ) {
-					blur();
+				if ( ! willOpen && typeof onBlur === 'function' ) {
+					onBlur();
 				}
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -330,7 +320,12 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 						ref={ inputControl }
 						disabled={ disabled }
 						value={ inputString }
-						onChange={ change }
+						onChange={ ( newInputString: string ) =>
+							debouncedUpdateStateWithNewInputString(
+								newInputString,
+								true
+							)
+						}
 						onBlur={ (
 							event: React.FocusEvent< HTMLInputElement >
 						) => {

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -95,7 +95,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return default24HourDateTimeFormat;
 	} )();
 
-	function parseMomentIso(
+	function parseAsISODateTime(
 		dateString?: string | null,
 		assumeLocalTime = false
 	): Moment {
@@ -106,7 +106,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		return moment.utc( dateString, moment.ISO_8601, true );
 	}
 
-	function parseMoment( dateString: string | null ): Moment {
+	function parseAsLocalDateTime( dateString: string | null ): Moment {
 		// parse input date string as local time;
 		// be lenient of user input and try to match any format Moment can
 		return moment( dateString );
@@ -201,8 +201,8 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 	) {
 		const previousLastValidDate = lastValidDate.current;
 		let newDateTime = isManuallyTypedInput
-			? parseMoment( newDateTimeString )
-			: parseMomentIso( newDateTimeString, isLocalTime );
+			? parseAsLocalDateTime( newDateTimeString )
+			: parseAsISODateTime( newDateTimeString, isLocalTime );
 		const isValid = newDateTime.isValid();
 
 		if ( isValid ) {

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -248,14 +248,6 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 		debouncedInputStringChangeHandler( newInputString, true );
 	}
 
-	function changeImmediate( newInputString: string, fireOnChange: boolean ) {
-		setInputString( newInputString );
-		inputStringChangeHandlerFunctionRef.current(
-			newInputString,
-			fireOnChange
-		);
-	}
-
 	function blur() {
 		if ( onBlur ) {
 			onBlur();

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -38,8 +38,15 @@ CustomDateTimeFormat.args = {
 };
 
 function ControlledContainer( { children, ...props } ) {
+	function nowWithZeroedSeconds() {
+		const now = new Date();
+		now.setSeconds( 0 );
+		now.setMilliseconds( 0 );
+		return now;
+	}
+
 	const [ controlledDate, setControlledDate ] = useState(
-		new Date().toISOString()
+		nowWithZeroedSeconds().toISOString()
 	);
 
 	return (
@@ -48,7 +55,9 @@ function ControlledContainer( { children, ...props } ) {
 			<div>
 				<Button
 					onClick={ () =>
-						setControlledDate( new Date().toISOString() )
+						setControlledDate(
+							nowWithZeroedSeconds().toISOString()
+						)
 					}
 				>
 					Reset to now

--- a/packages/js/components/src/date-time-picker-control/stories/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/stories/index.tsx
@@ -62,6 +62,12 @@ function ControlledContainer( { children, ...props } ) {
 				>
 					Reset to now
 				</Button>
+				<div>
+					<div>
+						Controlled date:
+						<br /> <span>{ controlledDate }</span>
+					</div>
+				</div>
 			</div>
 		</div>
 	);
@@ -79,28 +85,54 @@ CustomClassName.args = {
 	className: 'custom-class-name',
 };
 
+function ControlledDecorator( Story, props ) {
+	function nowWithZeroedSeconds() {
+		const now = new Date();
+		now.setSeconds( 0 );
+		now.setMilliseconds( 0 );
+		return now;
+	}
+
+	const [ controlledDate, setControlledDate ] = useState(
+		nowWithZeroedSeconds().toISOString()
+	);
+
+	return (
+		<div>
+			<Story
+				args={ {
+					...props.args,
+					currentDate: controlledDate,
+					onChange: setControlledDate,
+				} }
+			/>
+			<div>
+				<Button
+					onClick={ () =>
+						setControlledDate(
+							nowWithZeroedSeconds().toISOString()
+						)
+					}
+				>
+					Reset to now
+				</Button>
+				<div>
+					<div>
+						Controlled date:
+						<br /> <span>{ controlledDate }</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 export const Controlled = Template.bind( {} );
 Controlled.args = {
 	...Basic.args,
 	help: "I'm controlled by a container that uses React state",
 };
-Controlled.decorators = [
-	( story, props ) => {
-		return (
-			<ControlledContainer>
-				{ ( controlledDate, setControlledDate ) =>
-					story( {
-						args: {
-							currentDate: controlledDate,
-							onChange: setControlledDate,
-							...props.args,
-						},
-					} )
-				}
-			</ControlledContainer>
-		);
-	},
-];
+Controlled.decorators = [ ControlledDecorator ];
 
 export const ControlledDateOnly = Template.bind( {} );
 ControlledDateOnly.args = {

--- a/packages/js/components/src/date-time-picker-control/test/index.tsx
+++ b/packages/js/components/src/date-time-picker-control/test/index.tsx
@@ -659,4 +659,112 @@ describe( 'DateTimePickerControl', () => {
 
 		await waitFor( () => expect( onChangeHandler ).not.toHaveBeenCalled() );
 	} );
+
+	it( 'should not call onChange if currentDate is set to an equivalent UTC date without Zulu offset specifier', async () => {
+		const originalDateTime = '2023-01-01T00:00:00Z';
+		const equivalentDateTimeWithoutZulu = '2023-01-01T00:00:00';
+		const onChangeHandler = jest.fn();
+
+		const { rerender } = render(
+			<DateTimePickerControl
+				currentDate={ originalDateTime }
+				onChange={ onChangeHandler }
+			/>
+		);
+
+		// re-render the component; we do this to then test whether our onChange still gets called
+		rerender(
+			<DateTimePickerControl
+				currentDate={ equivalentDateTimeWithoutZulu }
+				onChange={ onChangeHandler }
+			/>
+		);
+
+		await waitFor( () => expect( onChangeHandler ).not.toHaveBeenCalled() );
+	} );
+
+	it( 'should not call onChange if currentDate is set to an equivalent UTC date without time', async () => {
+		const originalDateTime = '2023-01-01T00:00:00Z';
+		const equivalentDateTimeWithoutTime = '2023-01-01';
+		const onChangeHandler = jest.fn();
+
+		const { rerender } = render(
+			<DateTimePickerControl
+				currentDate={ originalDateTime }
+				onChange={ onChangeHandler }
+			/>
+		);
+
+		// re-render the component; we do this to then test whether our onChange still gets called
+		rerender(
+			<DateTimePickerControl
+				currentDate={ equivalentDateTimeWithoutTime }
+				onChange={ onChangeHandler }
+			/>
+		);
+
+		await waitFor( () => expect( onChangeHandler ).not.toHaveBeenCalled() );
+	} );
+
+	it( 'should not call onChange when the dateTimeFormat changes', async () => {
+		// we are specifically using a date with seconds in it, with a format
+		// without seconds in it; this helps us to determine if the currentDate
+		// is getting re-parsed from the input string (if it does this, it
+		// would result in a different date)
+		const originalDateTime = moment( '2022-11-15 02:30:40' );
+		const originalDateTimeFormat = 'm-d-Y, H:i';
+		const newDateTimeFormat = 'Y-m-d H:i';
+		const onChangeHandler = jest.fn();
+
+		const { rerender } = render(
+			<DateTimePickerControl
+				dateTimeFormat={ originalDateTimeFormat }
+				currentDate={ originalDateTime.toISOString() }
+				onChange={ onChangeHandler }
+			/>
+		);
+
+		// re-render the component; we do this to then test whether our onChange still gets called
+		rerender(
+			<DateTimePickerControl
+				dateTimeFormat={ newDateTimeFormat }
+				currentDate={ originalDateTime.toISOString() }
+				onChange={ onChangeHandler }
+			/>
+		);
+
+		await waitFor( () => expect( onChangeHandler ).not.toHaveBeenCalled() );
+	} );
+
+	// We need to bump up the timeout for this test because:
+	//     1. userEvent.type() is slow (see https://github.com/testing-library/user-event/issues/577)
+	//     2. moment.js is slow
+	// Otherwise, the following error can occur on slow machines (such as our CI), because Jest times out and starts
+	// tearing down the component while test microtasks are still being executed
+	// (see https://github.com/facebook/jest/issues/12670)
+	//       TypeError: Cannot read properties of null (reading 'createEvent')
+	it( 'should not call onChange when the input is changed to an equivalent date', async () => {
+		const originalDateTime = moment( '2022-09-15' );
+		const newDateTimeInputString = 'September 9, 2022';
+		const onChangeHandler = jest.fn();
+
+		const { container } = render(
+			<DateTimePickerControl
+				isDateOnlyPicker={ true }
+				currentDate={ originalDateTime.toISOString() }
+				onChange={ onChangeHandler }
+				onChangeDebounceWait={ 5000 }
+			/>
+		);
+
+		const input = container.querySelector( 'input' );
+		userEvent.type(
+			input!,
+			'{selectall}{backspace}' + newDateTimeInputString
+		);
+
+		await waitFor( () => expect( onChangeHandler ).not.toHaveBeenCalled(), {
+			timeout: 10000,
+		} );
+	}, 10000 );
 } );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the change handling to only call onChange when the date actually changes.

In addition, the change-related code has been refactored to reduce duplication, needless re-parsing, and increase readability.

Needed for #34538

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/date-time-picker-control`
2. Interact with Storybook and make sure DateTimePickerControl stories work as expected.
    - View the `onChange` entries in the Storybook "Actions" tab to confirm correct behavior.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
