### PR TITLE
Ensure the HPOS/COT order status correctly tracks the CPT order status

### DIFF
--- a/plugins/woocommerce/changelog/fix-35360-sync-on-manual-order-creation
+++ b/plugins/woocommerce/changelog/fix-35360-sync-on-manual-order-creation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When HPOS is enabled, posts are authoritative, and sync is enabled, ensure the HPOS record correctly tracks the CPT order record.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -256,13 +256,17 @@ SELECT(
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		switch ( $type ) {
 			case self::ID_TYPE_MISSING_IN_ORDERS_TABLE:
-				$sql = "
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $order_post_type_placeholders is prepared.
+				$sql = $wpdb->prepare(
+					"
 SELECT posts.ID FROM $wpdb->posts posts
 LEFT JOIN $orders_table orders ON posts.ID = orders.id
 WHERE
   posts.post_type IN ($order_post_type_placeholders)
   AND posts.post_status != 'auto-draft'
-  AND orders.id IS NULL";
+  AND orders.id IS NULL",
+					$order_post_types
+				);
 				break;
 			case self::ID_TYPE_MISSING_IN_POSTS_TABLE:
 				$sql = "

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -68,6 +68,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 */
 	public function __construct() {
 		self::add_action( 'deleted_post', array( $this, 'handle_deleted_post' ), 10, 2 );
+		self::add_action( 'woocommerce_new_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_filter( 'woocommerce_feature_description_tip', array( $this, 'handle_feature_description_tip' ), 10, 3 );
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -256,15 +256,13 @@ SELECT(
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		switch ( $type ) {
 			case self::ID_TYPE_MISSING_IN_ORDERS_TABLE:
-				$sql = $wpdb->prepare("
+				$sql = "
 SELECT posts.ID FROM $wpdb->posts posts
 LEFT JOIN $orders_table orders ON posts.ID = orders.id
 WHERE
   posts.post_type IN ($order_post_type_placeholders)
   AND posts.post_status != 'auto-draft'
-  AND orders.id IS NULL",
-					$order_post_types
-				);
+  AND orders.id IS NULL";
 				break;
 			case self::ID_TYPE_MISSING_IN_POSTS_TABLE:
 				$sql = "

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -162,7 +162,7 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 
 		// When a new order is manually created in the admin environment, WordPress automatically creates an empty
 		// draft post for us.
-		$order_id = wp_insert_post(
+		$order_id = (int) wp_insert_post(
 			array(
 				'post_type'   => 'shop_order',
 				'post_status' => 'draft',
@@ -177,7 +177,7 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 		// record in the COT table.
 		$this->assertEquals(
 			'draft',
-			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ),
+			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			'When HPOS is enabled but the posts data store is authoritative, saving an order will result in a duplicate with the same status being saved in the COT table.'
 		);
 
@@ -188,7 +188,7 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 		$order->save();
 		$this->assertEquals(
 			'wc-pending',
-			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ),
+			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ), //phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			'When the order status is updated, the change should be observed by the DataSynhronizer and a matching update will take place in the COT table.'
 		);
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -146,4 +146,50 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 			'The order was successfully copied to the COT table, outside of a dedicated synchronization batch.'
 		);
 	}
+
+	/**
+	 * When sync is enbabled and the posts store is authoritative, creating an order and updating the status from
+	 * draft to some non-draft status (as happens when an order is manually created in the admin environment) should
+	 * result in the same status change being made in the duplicate COT record.
+	 */
+	public function test_status_syncs_correctly_after_order_creation() {
+		global $wpdb;
+		$orders_table = OrdersTableDataStore::get_orders_table_name();
+
+		// Enable sync, make the posts table authoritative.
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+
+		// When a new order is manually created in the admin environment, WordPress automatically creates an empty
+		// draft post for us.
+		$order_id = wp_insert_post(
+			array(
+				'post_type'   => 'shop_order',
+				'post_status' => 'draft',
+			)
+		);
+
+		// Once the admin user decides to go ahead and save the order (ie, they click 'Create'), we start performing
+		// various updates to the order record.
+		wc_get_order( $order_id )->save();
+
+		// As soon as the order is saved via our own internal API, the DataSynchronizer should create a copy of the
+		// record in the COT table.
+		$this->assertEquals(
+			'draft',
+			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ),
+			'When HPOS is enabled but the posts data store is authoritative, saving an order will result in a duplicate with the same status being saved in the COT table.'
+		);
+
+		// In a separate operation, the status will be updated to an actual non-draft order status. This should also be
+		// observed by the DataSynchronizer and a further update made to the COT table.
+		$order = wc_get_order( $order_id );
+		$order->set_status( 'pending' );
+		$order->save();
+		$this->assertEquals(
+			'wc-pending',
+			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ),
+			'When the order status is updated, the change should be observed by the DataSynhronizer and a matching update will take place in the COT table.'
+		);
+	}
 }


### PR DESCRIPTION
When HPOS is enabled, and sync is also enabled, but the authoritative data store is still the posts store, we need to ensure that if an order is created manually (to be clear, I mean if an admin user creates a new order through the admin UI) a corresponding record should be created in the `wc_orders` table, and the status should stay in sync with the CPT record.

Closes #35360.

### User-Facing Testing Instructions

Another set of testing instructions are available in the parent issue, consider also following those. The instructions I've added below are a variation of those that don't require the use of WC Smooth Generator.

1. Enable HPOS, enable sync, but leave the posts table authoritative. Reminder of how to get to this point:
     - If necessary, start by running the **WooCommerce ▸ Status ▸ Tools ▸ Create Custom Order Tables** tool.
    - Then, visit **WooCommerce ▸ Settings ▸ Advanced ▸ Features** and enable **High-Performance Order Storage**.
    - Next, head on over to **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** and:
        - Select **Use the WordPress posts table**.
        - Select **Keep the posts table and the orders tables synchronized**.
2. Manually create a new order via **WooCommerce ▸ Orders ▸ Add Order**. This should open a blank order editor and, because the posts table is authoritative, the URL should contain `wp-admin/post-new.php?post_type=shop_order`.
3. Click on `Create` (you don't need to add any customer details or order items).
4. Once the editor reloads, take note of the new order number. Unless you explicitly specified something else, the status should be `Pending Payment`.
5. Return to **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** and enable the use of the **WooCommerce Orders Tables**.
6. Now return to the list of orders (this time, because COT is authoritative, the URL should contain `page=wc-orders`).
    - If you test with this change, it should be possible to locate the order (or search for it by ID). The order should be the same status (again, unless you specified something else earlier, this will be `Pending Payment`) and the original CPT order.
    - If you test without this change, you probably will not be able to locate the order (though it will exist within the `wc_orders` table in the database—albeit the status will be `draft`).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

Additionally:

1. Keeping as a draft, because this change adds some additional overhead (which I believe will be minimal in practice) ... but I still want to check that out in a little more detail before we forge ahead. However, I'll still go ahead and request a preliminary review in any case.
2. If you comment out the newly added line in `DataSynchronizer` then the newly added test should fail.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
