### PR TITLE
PHPCS: Lint only changes

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         coverage: none
-        tools: cs2pr, phpcs
+        tools: cs2pr, phpcs, sirbrillig/phpcs-changed
 
     - name: Cache Composer Dependencies
       uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         coverage: none
-        tools: cs2pr, phpcs, sirbrillig/phpcs-changed
+        tools: phpcs, sirbrillig/phpcs-changed
 
     - name: Cache Composer Dependencies
       uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -6,6 +6,8 @@ defaults:
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
+env:
+    PHPCS: ./plugins/woocommerce/vendor/bin/phpcs
 jobs:
     test:
         name: Code sniff (PHP 7.4, WP Latest)
@@ -39,10 +41,6 @@ jobs:
             - name: Run PHPCS
               if: steps.changed-files.outputs.any_changed == 'true'
               run: |
-                  git status
-                  git log -1
                   HEAD_REF=$(git rev-parse HEAD)
                   git checkout $HEAD_REF 
-                  git status
-                  git log -1
                   phpcs-changed --git --git-base ${{ github.base_ref }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -17,7 +17,6 @@ jobs:
                   fetch-depth: 0
 
             - name: Setup WooCommerce Monorepo
-              if: steps.changed-files.outputs.any_changed == 'true'
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
                   build: false

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -16,18 +16,28 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Get Changed Files
+              id: changed-files
+              uses: tj-actions/changed-files@v32
+              with:
+                  files: |
+                      **/*.php
+
             - name: Setup WooCommerce Monorepo
+              if: steps.changed-files.outputs.any_changed == 'true'
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
                   build: false
 
             - name: Tool versions
+              if: steps.changed-files.outputs.any_changed == 'true'
               run: |
                   php --version
                   composer --version
                   phpcs-changed --version
 
             - name: Run PHPCS
+              if: steps.changed-files.outputs.any_changed == 'true'
               run: |
                   git status
                   git log -1
@@ -35,4 +45,4 @@ jobs:
                   git checkout $HEAD_REF 
                   git status
                   git log -1
-                  phpcs-changed --git --git-base ${{ github.base_ref }} **/*.php
+                  phpcs-changed --git --git-base ${{ github.base_ref }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -22,9 +22,6 @@ jobs:
               with:
                   build: false
 
-            - name: Install PHPCS Changed
-              run: composer require sirbrillig/phpcs-changed
-
             - name: Tool versions
               run: |
                   php --version

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -1,41 +1,30 @@
 name: Run code sniff on PR
-on:
-  pull_request
+on: pull_request
 defaults:
-  run:
-    shell: bash
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    run:
+        shell: bash
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 jobs:
-  test:
-    name: Code sniff (PHP 7.4, WP Latest)
-    timeout-minutes: 15
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      
-      - name: Get Changed Files
-        id: changed-files
-        uses: tj-actions/changed-files@v32  
-        with:
-          files: |
-            **/*.php
+    test:
+        name: Code sniff (PHP 7.4, WP Latest)
+        timeout-minutes: 15
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
-      - name: Setup WooCommerce Monorepo
-        if: steps.changed-files.outputs.any_changed == 'true'
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          build: false
+            - name: Setup WooCommerce Monorepo
+              if: steps.changed-files.outputs.any_changed == 'true'
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build: false
 
-      - name: Tool versions
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
-          php --version
-          composer --version
-
-      - name: Run PHPCS
-        if: steps.changed-files.outputs.any_changed == 'true'
-        run: ./plugins/woocommerce/vendor/bin/phpcs -n -q --report=checkstyle ${{ steps.changed-files.outputs.all_changed_files }} | cs2pr        
+            - name: Tool versions
+              run: |
+                  php --version
+                  composer --version
+                  git status
+                  composer global require sirbrillig/phpcs-changed

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -26,5 +26,15 @@ jobs:
               run: |
                   php --version
                   composer --version
+
+            - name: Install PHPCS Changed
+              run: composer global require sirbrillig/phpcs-changed
+
+            - name: Run PHPCS
+              run: |
                   git status
-                  composer global require sirbrillig/phpcs-changed
+                  git log -1
+                  HEAD_REF=$(git rev-parse HEAD)
+                  git status
+                  git log -1
+                  phpcs-changed --git --git-base ${{ github.base_ref }} **/*.php

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -22,19 +22,21 @@ jobs:
               with:
                   build: false
 
+            - name: Install PHPCS Changed
+              run: composer require sirbrillig/phpcs-changed
+
             - name: Tool versions
               run: |
                   php --version
                   composer --version
-
-            - name: Install PHPCS Changed
-              run: composer global require sirbrillig/phpcs-changed
+                  phpcs-changed --version
 
             - name: Run PHPCS
               run: |
                   git status
                   git log -1
                   HEAD_REF=$(git rev-parse HEAD)
+                  git checkout $HEAD_REF 
                   git status
                   git log -1
                   phpcs-changed --git --git-base ${{ github.base_ref }} **/*.php

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -7,7 +7,7 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 env:
-    PHPCS: ./plugins/woocommerce/vendor/bin/phpcs
+    PHPCS: ./plugins/woocommerce/vendor/bin/phpcs # Run WooCommerce phpcs setup in phpcs-changed instead of default
 jobs:
     test:
         name: Code sniff (PHP 7.4, WP Latest)
@@ -42,5 +42,5 @@ jobs:
               if: steps.changed-files.outputs.any_changed == 'true'
               run: |
                   HEAD_REF=$(git rev-parse HEAD)
-                  git checkout $HEAD_REF 
+                  git checkout $HEAD_REF
                   phpcs-changed --git --git-base ${{ github.base_ref }} ${{ steps.changed-files.outputs.all_changed_files }}

--- a/plugins/woocommerce/changelog/try-add-phpcs-changed
+++ b/plugins/woocommerce/changelog/try-add-phpcs-changed
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Just whitespace change, no entry required
+
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-exporters.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-exporters.php
@@ -47,10 +47,6 @@ class WC_Admin_Exporters {
 		);
 	}
 
-	public function foo() {
-		return 'bar';
-	}
-
 	/**
 	 * Return true if WooCommerce export is allowed for current user, false otherwise.
 	 *

--- a/plugins/woocommerce/includes/admin/class-wc-admin-exporters.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-exporters.php
@@ -47,6 +47,10 @@ class WC_Admin_Exporters {
 		);
 	}
 
+	public function foo() {
+		return 'bar';
+	}
+
 	/**
 	 * Return true if WooCommerce export is allowed for current user, false otherwise.
 	 *
@@ -199,7 +203,7 @@ class WC_Admin_Exporters {
 	 * @return array The product types keys and labels.
 	 */
 	public static function get_product_types() {
-		$product_types = wc_get_product_types();
+		$product_types              = wc_get_product_types();
 		$product_types['variation'] = __( 'Product variations', 'woocommerce' );
 
 		/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35369

This PR uses https://github.com/sirbrillig/phpcs-changed to run PHPCS only on changes instead of entire files.

In order to enable annotations, we will need to make an upstream contribution to allow that. Since this is a blocker for some folks, I think the trade off is ok and we can come back to this.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Pull this down locally and create a new branch.
2. Introduce a code sniffer violation to a PHP file that already has one. `plugins/woocommerce/includes/admin/class-wc-admin-exporters.php` is an example.
3. Confirm your error and the existing error are present, `phpcs -n -q plugins/woocommerce/includes/admin/class-wc-admin-exporters.php`
4. Push your branch and create a test PR. Confirm only the error you introduced causes the Code Sniff check to fail
5. Resolve your introduced violation, push to Github and see the code sniff check pass

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
