### PR TITLE
Fix invalid `wcadmin_install_plugin_error` event props

### DIFF
--- a/plugins/woocommerce/changelog/fix-103-install-plugin-error-track
+++ b/plugins/woocommerce/changelog/fix-103-install-plugin-error-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix invalid wcadmin_install_plugin_error event props

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -150,6 +150,7 @@ class PluginsHelper {
 		 * Filter the list of plugins to install.
 		 *
 		 * @param array $plugins A list of the plugins to install.
+		 * @since 6.4.0
 		 */
 		$plugins = apply_filters( 'woocommerce_admin_plugins_pre_install', $plugins );
 
@@ -199,6 +200,13 @@ class PluginsHelper {
 				);
 				wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 
+				/**
+				 * Action triggered when a plugin API call failed.
+				 *
+				 * @param string $slug The plugin slug.
+				 * @param \WP_Error $api The API response.
+				 * @since 6.4.0
+				 */
 				do_action( 'woocommerce_plugins_install_api_error', $slug, $api );
 
 				$errors->add(
@@ -230,6 +238,15 @@ class PluginsHelper {
 				);
 				wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 
+				/**
+				 * Action triggered when a plugin installation fails.
+				 *
+				 * @param string $slug The plugin slug.
+				 * @param object $api The plugin API object.
+				 * @param \WP_Error|null $result The result of the plugin installation.
+				 * @param \Plugin_Upgrader $upgrader The plugin upgrader.
+				 * @since 6.4.0
+				*/
 				do_action( 'woocommerce_plugins_install_error', $slug, $api, $result, $upgrader );
 
 				$errors->add(
@@ -293,6 +310,7 @@ class PluginsHelper {
 		 * Filter the list of plugins to activate.
 		 *
 		 * @param array $plugins A list of the plugins to activate.
+		 * @since 6.4.0
 		 */
 		$plugins = apply_filters( 'woocommerce_admin_plugins_pre_activate', $plugins );
 
@@ -315,6 +333,12 @@ class PluginsHelper {
 
 			$result = activate_plugin( $path );
 			if ( ! is_null( $result ) ) {
+				/**
+				 * Action triggered when a plugin activation fails.
+				 * @param string $slug The plugin slug.
+				 * @param null|\WP_Error $result The result of the plugin activation.
+				 * @since 6.4.0
+				 */
 				do_action( 'woocommerce_plugins_activate_error', $slug, $result );
 
 				$errors->add(

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -194,9 +194,9 @@ class PluginsHelper {
 			if ( is_wp_error( $api ) ) {
 				$properties = array(
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					'error_message' => sprintf( __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce' ), $slug ),
-					'api'           => $api->get_error_message(),
-					'slug'          => $slug,
+					'error_message'     => sprintf( __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce' ), $slug ),
+					'api_error_message' => $api->get_error_message(),
+					'slug'              => $slug,
 				);
 				wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -193,8 +193,8 @@ class PluginsHelper {
 			if ( is_wp_error( $api ) ) {
 				$properties = array(
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					'error_message' => __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce' ),
-					'api'           => $api,
+					'error_message' => sprintf( __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce' ), $slug ),
+					'api'           => $api->get_error_message(),
 					'slug'          => $slug,
 				);
 				wc_admin_record_tracks_event( 'install_plugin_error', $properties );
@@ -221,11 +221,12 @@ class PluginsHelper {
 			if ( is_wp_error( $result ) || is_null( $result ) ) {
 				$properties = array(
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					'error_message' => __( 'The requested plugin `%s` could not be installed.', 'woocommerce' ),
-					'slug'          => $slug,
-					'api'           => $api,
-					'upgrader'      => $upgrader,
-					'result'        => $result,
+					'error_message'         => sprintf( __( 'The requested plugin `%s` could not be installed.', 'woocommerce' ), $slug ),
+					'slug'                  => $slug,
+					'api_version'           => $api->version,
+					'api_download_link'     => $api->download_link,
+					'upgrader_skin_message' => implode( ',', $upgrader->skin->get_upgrade_messages() ),
+					'result'                => $result,
 				);
 				wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -335,6 +335,7 @@ class PluginsHelper {
 			if ( ! is_null( $result ) ) {
 				/**
 				 * Action triggered when a plugin activation fails.
+				 *
 				 * @param string $slug The plugin slug.
 				 * @param null|\WP_Error $result The result of the plugin activation.
 				 * @since 6.4.0


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 103-gh-woocommerce/team-ghidorah.

> we're [passing](https://github.com/woocommerce/woocommerce/blob/43eeb0c997a34c146088c5ce7a5cab1a73ed10af/plugins/woocommerce/src/Admin/PluginsHelper.php#L227) packed objects to tracks, which causes it to have object names:

Instead of passing the objects, this PR change to pass strings to tracks. Besides, I also fixed the `error_message`  translation string and docblock lint issues.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install `Code Snippets` and woocommerce-beta-tester
2. Create a new snipeet with the following code
```php
function pre_install_plugins( $value ) {
    return array( 'invalid-plugin-slug' );
}

add_filter( 'woocommerce_admin_plugins_pre_install', 'pre_install_plugins', 999 );
```
4. Go to WooCommerce > Home
5. Go to marketing task
6. Click "Activate" button on Google Listings & Ads
7. Visit the WooCommerce->Status->Logs page wp-admin/admin.php?page=wc-status&tab=logs in a new tab
8. Select a tracks-* log from the dropdown
9. Search the `wcadmin_install_plugin_error` string
10. Observe that all event props are in snake_case like below:

```
2022-10-31T08:38:13+00:00 DEBUG wcadmin_install_plugin_error
2022-10-31T08:38:13+00:00 DEBUG   - error_message: The requested plugin `invalid-plugin-slug` could not be installed. Plugin API call failed.
2022-10-31T08:38:13+00:00 DEBUG   - api: Plugin not found.
2022-10-31T08:38:13+00:00 DEBUG   - slug: invalid-plugin-slug
```
11. Update the snippets with the following code

```php
function plugins_api_result( $res, $action, $args ) {
	$res->download_link = 'invalid link';
    return $res;
}

add_filter( 'plugins_api_result', 'plugins_api_result', 999, 3 );
```
12. Repeat 4~9 steps
13. Observe that all event props are in snake_case like below:
```
2022-10-31T08:44:41+00:00 DEBUG wcadmin_install_plugin_error
2022-10-31T08:44:41+00:00 DEBUG   - error_message: The requested plugin `google-listings-and-ads` could not be installed.
2022-10-31T08:44:41+00:00 DEBUG   - slug: google-listings-and-ads
2022-10-31T08:44:41+00:00 DEBUG   - api_version: 2.2.0
2022-10-31T08:44:41+00:00 DEBUG   - api_download_link: invalid link
2022-10-31T08:44:41+00:00 DEBUG   - upgrader_skin_message: Downloading installation package from invalid link…,Download failed. A valid URL was not provided.
2022-10-31T08:44:41+00:00 DEBUG   - result: 
```

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
