### PR TITLE
Update WooCommerce blocks package to 8.5.2

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.5.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.5.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 8.5.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.5.1"
+		"woocommerce/woocommerce-blocks": "8.5.2"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5b89843fb6a65d3db7cfdafaccd2c16",
+    "content-hash": "8aed74b39ad6cd344cd7d7b95ff89aa7",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.5.1",
+            "version": "v8.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "b14d64b63cf1edb5871f638e6250dd633504fb38"
+                "reference": "868cf4368546b5ff0de022997fe0e82ad2199e5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/b14d64b63cf1edb5871f638e6250dd633504fb38",
-                "reference": "b14d64b63cf1edb5871f638e6250dd633504fb38",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/868cf4368546b5ff0de022997fe0e82ad2199e5a",
+                "reference": "868cf4368546b5ff0de022997fe0e82ad2199e5a",
                 "shasum": ""
             },
             "require": {
@@ -681,9 +681,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.5.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.5.2"
             },
-            "time": "2022-09-23T12:24:34+00:00"
+            "time": "2022-10-31T15:10:15+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.5.2. 
## Blocks 8.5.2

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7535)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/852.md)



### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

- Fix Mini Cart Global Styles. [7515](https://github.com/woocommerce/woocommerce-blocks/pull/7515)
- Fix inconsistent button styling with TT3. ([7516](https://github.com/woocommerce/woocommerce-blocks/pull/7516))
- Make the Filter by Price block range color dependent of the theme color. [7525](https://github.com/woocommerce/woocommerce-blocks/pull/7525)
- Filter by Price block: fix price slider visibility on dark themes. [7527](https://github.com/woocommerce/woocommerce-blocks/pull/7527)
- Update the Mini Cart block drawer to honor the theme's background. [7510](https://github.com/woocommerce/woocommerce-blocks/pull/7510)
- Add white background to Filter by Attribute block dropdown so text is legible in dark backgrounds. [7506](https://github.com/woocommerce/woocommerce-blocks/pull/7506)





