### PR TITLE
Update WooCommerce blocks package to 8.7.5

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.5
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.5
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Woo Blocks 8.7.5
+Update WooCommerce Blocks to 8.7.5

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.5
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 8.7.5

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.7.4"
+		"woocommerce/woocommerce-blocks": "8.7.5"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d9a10e340f2c9d2366a082eb3b91344",
+    "content-hash": "08d58a387b373d546fb53025a230e768",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.7.4",
+            "version": "v8.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "8553c41d5141725f2e399dab8527b573492402ea"
+                "reference": "0436c8afb8c3c34dd38aed2b7a0868e771036031"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/8553c41d5141725f2e399dab8527b573492402ea",
-                "reference": "8553c41d5141725f2e399dab8527b573492402ea",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/0436c8afb8c3c34dd38aed2b7a0868e771036031",
+                "reference": "0436c8afb8c3c34dd38aed2b7a0868e771036031",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.5"
             },
-            "time": "2022-10-21T15:55:49+00:00"
+            "time": "2022-10-31T14:54:55+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.7.5. 
## Blocks 8.7.5

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7541)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/875.md)


### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

- Fix Mini Cart Global Styles. [7515](https://github.com/woocommerce/woocommerce-blocks/pull/7515)
- Fix inconsistent button styling with TT3. ([7516](https://github.com/woocommerce/woocommerce-blocks/pull/7516))
- Make the Filter by Price block range color dependent of the theme color. [7525](https://github.com/woocommerce/woocommerce-blocks/pull/7525)
- Filter by Price block: fix price slider visibility on dark themes. [7527](https://github.com/woocommerce/woocommerce-blocks/pull/7527)
- Update the Mini Cart block drawer to honor the theme's background. [7510](https://github.com/woocommerce/woocommerce-blocks/pull/7510)
- Add white background to Filter by Attribute block dropdown so text is legible in dark backgrounds. [7506](https://github.com/woocommerce/woocommerce-blocks/pull/7506)





