### PR TITLE
Fix random failing changelog entry

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -211,45 +211,45 @@ jobs:
                   if ( changelogEntry.match( /comment:/i ) ) {
                     changelogEntry = false;
                   }
-                } );
 
-                if ( changelogEntry === false ) {
-                  continue;
-                }
-
-                fs.readFile( './plugins/woocommerce/readme.txt', 'utf-8', function( err, data ) {
-                  if ( err ) {
-                    console.error( err );
+                  if ( ! changelogEntry ) {
+                    return;
                   }
 
-                  changelogTxt = data.split( "\n" );
-                  let isInRange = false;
-                  let newChangelogTxt = [];
-
-                  for ( const line of changelogTxt ) {
-                    if ( isInRange === false && line === '== Changelog ==' ) {
-                      isInRange = true;
-                    }
-
-                    if ( isInRange === true && line.match( /\*\*WooCommerce Blocks/ ) ) {
-                      isInRange = false;
-                    }
-
-                    // Find the first match of the entry "Type".
-                    if ( isInRange && line.match( `\\* ${changelogEntryType} -` ) ) {
-                      newChangelogTxt.push( '* ' + changelogEntryType + ' - ' + changelogEntry + ` [#${{ needs.prep.outputs.pr }}](https://github.com/woocommerce/woocommerce/pull/${{ needs.prep.outputs.pr }})` );
-                      newChangelogTxt.push( line );
-                      isInRange = false;
-                      continue;
-                    }
-
-                    newChangelogTxt.push( line );
-                  }
-
-                  fs.writeFile( './plugins/woocommerce/readme.txt', newChangelogTxt.join( "\n" ), err => {
+                  fs.readFile( './plugins/woocommerce/readme.txt', 'utf-8', function( err, data ) {
                     if ( err ) {
-                      console.error( `Unable to generate the changelog entry for PR ${{ needs.prep.outputs.pr }}` );
+                      console.error( err );
                     }
+
+                    changelogTxt = data.split( "\n" );
+                    let isInRange = false;
+                    let newChangelogTxt = [];
+
+                    for ( const line of changelogTxt ) {
+                      if ( isInRange === false && line === '== Changelog ==' ) {
+                        isInRange = true;
+                      }
+
+                      if ( isInRange === true && line.match( /\*\*WooCommerce Blocks/ ) ) {
+                        isInRange = false;
+                      }
+
+                      // Find the first match of the entry "Type".
+                      if ( isInRange && line.match( `\\* ${changelogEntryType} -` ) ) {
+                        newChangelogTxt.push( '* ' + changelogEntryType + ' - ' + changelogEntry + ` [#${{ needs.prep.outputs.pr }}](https://github.com/woocommerce/woocommerce/pull/${{ needs.prep.outputs.pr }})` );
+                        newChangelogTxt.push( line );
+                        isInRange = false;
+                        continue;
+                      }
+
+                      newChangelogTxt.push( line );
+                    }
+
+                    fs.writeFile( './plugins/woocommerce/readme.txt', newChangelogTxt.join( "\n" ), err => {
+                      if ( err ) {
+                        console.error( `Unable to generate the changelog entry for PR ${{ needs.prep.outputs.pr }}` );
+                      }
+                    } );
                   } );
                 } );
               }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue with the cherry pick workflow where it sometimes generates a changelog entry that is not needed. It will look something like this https://github.com/woocommerce/woocommerce/pull/35399/commits/9c47cc223b29c2f46c7cdccbd4ed38123f96461e#diff-af9803036f8a727e2311b0ef2971497323c6c4aa67d5e0dab4ee4b68a25464b7L170

Note that the bulk of the changes are only to nest the checks inside the `fs.readFile` because the culprit was that this function call was async.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Fork this repo. All the steps here on out will be done in your fork ONLY!
2. Enable Actions ( by default it is disabled ). `settings/actions`.
3. Enable Issues `settings`. Then add a milestone `7.1.0`.
4. Ensure the repo is setup as squash and merge only.
6. In trunk, merge this branch and push up to trunk.
7. Create a branch `git checkout -b test-cherry-pick`.
8. Make a change to `plugins/woocommerce/woocommerce.php` and add a new changelog file that like:
```
Significance: minor
Type: add

Adding something here
```
9. Commit and push your changes up to your fork.
10. Create the PR, tag it with the `7.1.0` milestone and merge the PR. BECAREFUL here when creating the PR. It defaults to upstream `woocommerce/woocommerce`. So make sure to target your own fork.
11.  At this time, the cherry pick workflow should start running.
12. When done running, ensure 2 PRs are created. One that deletes the changelog entry from `trunk`. And another PR that targets the `release/7.1` branch and shows an updated `readme.txt` changelog entry and also the change you made to `woocommerce.php` file.
13. Repeat the test again but this time use this in the changelog file:
```
Significance: patch
Type: dev
Comment: Update the README, no changelog required
```
14. This time the PR that got created for `release/7.1` should no longer have a commit that updates the `readme.txt` file.
<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
