### PR TITLE
Prep/release 7.1.0 rc.2

### DIFF
--- a/plugins/woocommerce/changelog/fix-order_type
+++ b/plugins/woocommerce/changelog/fix-order_type
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Check order type is set before returning to prevent notice.

--- a/plugins/woocommerce/changelog/fix-order_type
+++ b/plugins/woocommerce/changelog/fix-order_type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Check order type is set before returning to prevent notice.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -167,6 +167,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 **WooCommerce**
 
+* Fix - Check order type is set before returning to prevent notice. [#35349](https://github.com/woocommerce/woocommerce/pull/35349)
 * Fix - When HPOS is enabled, posts are authoritative, and sync is enabled, ensure the HPOS record correctly tracks the CPT order record. [#35402](https://github.com/woocommerce/woocommerce/pull/35402)
 * Fix - Allow line breaks in order note again. [#35366](https://github.com/woocommerce/woocommerce/pull/35366)
 * Fix - Sync orders for stats table. [#35118](https://github.com/woocommerce/woocommerce/pull/35118)

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -948,7 +948,7 @@ WHERE
 	 */
 	public function get_order_type( $order_id ) {
 		$type = $this->get_orders_type( array( $order_id ) );
-		return $type[ $order_id ];
+		return $type[ $order_id ] ?? '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -75,7 +75,7 @@ class COTMigrationUtil {
 	 */
 	public function is_custom_order_tables_in_sync() : bool {
 		$sync_status = $this->data_synchronizer->get_sync_status();
-		return $sync_status['current_pending_count'] === 0 && $this->data_synchronizer->data_sync_is_enabled();
+		return 0 === $sync_status['current_pending_count'] && $this->data_synchronizer->data_sync_is_enabled();
 	}
 
 	/**
@@ -160,7 +160,7 @@ class COTMigrationUtil {
 	 *
 	 * @return string|null Type of the order.
 	 */
-	public function get_order_type( $order_id ) : ?string {
+	public function get_order_type( $order_id ) {
 		$order_id         = $this->get_post_or_order_id( $order_id );
 		$order_data_store = \WC_Data_Store::load( 'order' );
 		return $order_data_store->get_order_type( $order_id );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1867,4 +1867,49 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$product->save();
 		$this->assertFalse( wc_get_order( $product->get_id() ) );
 	}
+
+	/**
+	 * @testDox Make sure that getting order type for non order return without warning.
+	 */
+	public function test_get_order_type_for_non_order() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+		$this->assertEquals( '', $this->sut->get_order_type( $product->get_id() ) );
+	}
+
+	/**
+	 * @testDox Test get order type working as expected.
+	 */
+	public function test_get_order_type_for_order() {
+		$order = $this->create_complex_cot_order();
+		$this->assertEquals( 'shop_order', $this->sut->get_order_type( $order->get_id() ) );
+	}
+
+	/**
+	 * @testDox Test that we are not duplicating address indexing when updating.
+	 */
+	public function test_address_index_saved_on_update() {
+		global $wpdb;
+		$this->toggle_cot( true );
+		$this->disable_cot_sync();
+		$order = new WC_Order();
+		$order->set_billing_address_1( '123 Main St' );
+		$order->save();
+
+		$this->assertTrue( false !== strpos( $order->get_meta( '_billing_address_index', true ), '123 Main St' ) );
+		$order = wc_get_order( $order->get_id() );
+		$order->set_billing_address_2( 'Apt 1' );
+		$order->save();
+
+		$order_meta_table = $this->sut::get_meta_table_name();
+		// Assert that we are not duplicating address indexes.
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$order_meta_table} WHERE order_id = %d AND meta_key = '_billing_address_index'", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$order->get_id()
+			)
+		);
+
+		$this->assertEquals( 1, $result );
+	}
 }

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 7.1.0-rc.1
+ * Version: 7.1.0-rc.2
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This PR cherry-picks #35349 into the release branch and updates the version number in `woocommerce.php` to prep for 7.1.0-rc.2