### PR TITLE
Add filter hook `handle_bulk_actions-woocommerce_page_wc-orders`

### DIFF
--- a/plugins/woocommerce/changelog/fix-35414-custom-bulk-actions
+++ b/plugins/woocommerce/changelog/fix-35414-custom-bulk-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Make it possible to add custom bulk action handling to the admin order list screen (when HPOS is enabled).

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -941,9 +941,24 @@ class ListTable extends WP_List_Table {
 			if ( isset( $order_statuses[ 'wc-' . $new_status ] ) ) {
 				$changed = $this->do_bulk_action_mark_orders( $ids, $new_status );
 			}
+		} else {
+			$screen = get_current_screen()->id;
+
+			/**
+			 * This action is documented in /wp-admin/edit.php (it is a core WordPress hook).
+			 *
+			 * @since 7.2.0
+			 *
+			 * @param string $redirect_to The URL to redirect to after processing the bulk actions.
+			 * @param string $action      The current bulk action.
+			 * @param int[]  $ids         IDs for the orders to be processed.
+			 */
+			$custom_sendback = apply_filters( "handle_bulk_actions-{$screen}", $redirect_to, $action, $ids ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 
-		if ( $changed ) {
+		if ( ! empty( $custom_sendback ) ) {
+			$redirect_to = $custom_sendback;
+		} elseif ( $changed ) {
 			$redirect_to = add_query_arg(
 				array(
 					'bulk_action' => $report_action,


### PR DESCRIPTION
Adds filter hook `handle_bulk_actions-woocommerce_page_wc-orders` to the HPOS admin list table.

This is a duplicate of core WP hook `handle_bulk_actions-<SCREEN_ID>` and allows for custom bulk actions to be handled in the context of the admin list table for HPOS orders.

Closes #35414.

### All Submissions:

- [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?
- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

> **First, in case handy, here is a quick reminder on how to enable HPOS, etc** :bulb:
>
> - If necessary, start by running the **WooCommerce ▸ Status ▸ Tools ▸ Create Custom Order Tables** tool.
> - Then, visit **WooCommerce ▸ Settings ▸ Advanced ▸ Features** and enable **High-Performance Order Storage**.
> - Next, head on over to **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** and:
>     - Select **Use the WordPress posts table**.
>     - Select **Keep the posts table and the orders tables synchronized**.

1. Start by adding the following snippet to a suitable location, such as a `wp-content/mu-plugin` file (the goal of this snippet is to simulate how a 3PD might add a custom bulk action for orders):

```php
$add_custom_bulk_action = function ( array $bulk_actions ) {
	return array_merge( $bulk_actions, [ 'custom-bulk-action' => 'Perform Custom Action!' ] );
};

$custom_bulk_action_handler = function ( string $redirect_to, string $action, array $ids ) {
	return $action === 'custom-bulk-action'
		? add_query_arg( 'bulk_action', 'custom-bulk-action-notice', $redirect_to )
		: $redirect_to;
};

$custom_bulk_action_notice = function () {
	if ( isset( $_GET['bulk_action'] ) && 'custom-bulk-action-notice' === $_GET['bulk_action'] ) {
		print '<div class="updated" style="border-left-color: #d7f"><p>Custom Bulk Action Handler Fired</p></div>';
	}
};

add_filter( 'bulk_actions-woocommerce_page_wc-orders', $add_custom_bulk_action );
add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', $custom_bulk_action_handler, 10, 3 );
add_action( 'admin_notices', $custom_bulk_action_notice );
```

2. With HPOS enabled (and **WooCommerce Orders Tables** set as the authoritative data store for orders), visit the order list screen. You should see a new bulk action *("Perform Custom Action!"):*

<img width="915" alt="hpos-custom-bulk-action" src="https://user-images.githubusercontent.com/3594411/199123043-ecab1580-ee67-4ea1-a63a-366ee6b19842.png">

3. Check the boxes for one or more order rows, select the above bulk action, and click on the *"Apply"* button. Once the page finishes reloading, you should see an admin notice like the following one:

<img width="856" alt="hpos-custom-bulk-action-notice" src="https://user-images.githubusercontent.com/3594411/199123267-559e84ff-9ecc-4d77-8848-1aadd26f14fd.png">

<!-- End testing instructions -->

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes, as applicable? _**No, we generally don't add tests when we add new hooks in isolation (within WooCommerce, nothing functional is actually changing).**_
- [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
