### PR TITLE
Remove change file for 35349

### DIFF
--- a/plugins/woocommerce/changelog/fix-order_type
+++ b/plugins/woocommerce/changelog/fix-order_type
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Check order type is set before returning to prevent notice.


### PR DESCRIPTION
This PR removes from trunk the changelog for #35349 as it was included in `release/7.1` via #35441