### PR TITLE
Remove `qs` dependency from `/navigation`

### DIFF
--- a/packages/js/navigation/changelog/remove-qs-nav
+++ b/packages/js/navigation/changelog/remove-qs-nav
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Removed qs dependency, replaced with native `URLSearchParams`.

--- a/packages/js/navigation/package.json
+++ b/packages/js/navigation/package.json
@@ -34,7 +34,6 @@
 		"@wordpress/notices": "^3.3.2",
 		"@wordpress/url": "^3.4.1",
 		"history": "^5.3.0",
-		"qs": "^6.10.3",
 		"react-router-dom": "^6.3.0"
 	},
 	"peerDependencies": {

--- a/packages/js/navigation/src/history.ts
+++ b/packages/js/navigation/src/history.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { BrowserHistory, createBrowserHistory, Location } from 'history';
-import { parse } from 'qs';
 
 // See https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components
 // ^ This is a bit outdated but there's no newer documentation - the replacement for this is to use <unstable_HistoryRouter /> https://reactrouter.com/docs/en/v6/routers/history-router
@@ -41,25 +40,13 @@ function getHistory(): WooBrowserHistory {
 			},
 			get location() {
 				const { location } = browserHistory;
-				const query = parse( location.search.substring( 1 ) );
-				let pathname: string;
 
-				if ( query && typeof query.path === 'string' ) {
-					pathname = query.path;
-				} else if (
-					query &&
-					query.path &&
-					typeof query.path !== 'string'
-				) {
-					// this branch was added when converting to TS as it is technically possible for a query.path to not be a string.
-					// eslint-disable-next-line no-console
-					console.warn(
-						`Query path parameter should be a string but instead was: ${ query.path }, undefined behaviour may occur.`
-					);
-					pathname = query.path as unknown as string; // ts override only, no coercion going on
-				} else {
-					pathname = '/';
-				}
+				const query = new URLSearchParams( location.search );
+				const pathname = query.has( 'path' )
+					? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- We already asserted non-null above.
+					  query.get( 'path' )!
+					: '/';
+
 				return {
 					...location,
 					pathname,

--- a/packages/js/navigation/src/index.js
+++ b/packages/js/navigation/src/index.js
@@ -8,7 +8,6 @@ import {
 	useLayoutEffect,
 } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
-import { parse } from 'qs';
 import { pick } from 'lodash';
 import { applyFilters } from '@wordpress/hooks';
 import { Slot, Fill } from '@wordpress/components';

--- a/packages/js/navigation/src/index.js
+++ b/packages/js/navigation/src/index.js
@@ -176,11 +176,9 @@ export function getNewPath(
  * @return {Object}  Current query object, defaults to empty object.
  */
 export function getQuery() {
-	const search = getHistory().location.search;
-	if ( search.length ) {
-		return parse( search.substring( 1 ) ) || {};
-	}
-	return {};
+	return Object.fromEntries(
+		new URLSearchParams( getHistory().location.search )
+	);
 }
 
 /**

--- a/packages/js/navigation/src/test/history.js
+++ b/packages/js/navigation/src/test/history.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { getHistory } from '../index';
+
+// Unfortunately, we need to use `getHistory` to test `getHistory`.
+// `getHistory` uses `remix-run/history` to observe and manipulate the history.
+// The library ignores changes made using native `window.location` or `history.pushState`.
+// Therefore, to change the location for testing, we need to use `getHistory().push().`
+describe( 'getHistory', () => {
+	it( 'should set returned `location.pathname` to the value of `path` QueryParam if there is one in `window.location`', () => {
+		// Check given value.
+		// window.location = new URL( 'https://www.example.com?path=foo' );
+		getHistory().push( '?path=foo' );
+
+		expect( getHistory().location.pathname ).toEqual( 'foo' );
+
+		// Use empty string.
+		getHistory().push( '?path=' );
+
+		expect( getHistory().location.pathname ).toEqual( '' );
+	} );
+
+	it( 'should set returned `location.pathname` to `/` if there is no `path` QueryParam in `window.location`', () => {
+		// window.location = new URL( '', window.location );
+		getHistory().push( '' );
+
+		expect( getHistory().location.pathname ).toEqual( '/' );
+	} );
+
+	it( 'should set returned `location.pathname` to `/` if there is no `path` QueryParam in `window.location`, even if there is a pathname', () => {
+		// window.location = new URL( '/foo', window.location );
+		const baseURL = window.location || document.location;
+		// Normalize URL to `remix-run/history`'s `Path`, as `URL` is not supported.
+		// See https://github.com/remix-run/history/pull/963.
+		const nextUrl = new URL( '/foo', baseURL );
+		getHistory().push( {
+			pathname: nextUrl.pathname,
+			search: nextUrl.search,
+		} );
+
+		expect( getHistory().location.pathname ).toEqual( '/' );
+	} );
+} );

--- a/packages/js/navigation/src/test/index.js
+++ b/packages/js/navigation/src/test/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	getQuery,
 	getIdsFromQuery,
 	getSetOfIdsFromQuery,
 	getHistory,
@@ -16,6 +17,37 @@ import {
 global.window = Object.create( window );
 global.window.wcNavigation = {};
 
+describe( 'getQuery', () => {
+	it( "should return an empty object if the query doesn't contain any parameters", () => {
+		getHistory().push( { search: '' } );
+
+		expect( getQuery() ).toEqual( {} );
+	} );
+	it( 'should return an object containing all query parameters', () => {
+		getHistory().push( {
+			search: 'foo=bar&biz=1&buz=-1',
+		} );
+
+		expect( getQuery() ).toEqual( {
+			foo: 'bar',
+			biz: '1',
+			buz: '-1',
+		} );
+	} );
+	// Support non-standard array-syntax.
+	it( 'should return an object containing array-like parameters', () => {
+		getHistory().push( {
+			search: 'foo=bar&biz=1&buz[]=a&buz[]=-1&buz[2]=2&fuz=0&fuz=1',
+		} );
+
+		expect( getQuery() ).toEqual( {
+			foo: 'bar',
+			biz: '1',
+			buz: [ 'a', '-1', '2' ],
+			fuz: [ '0', '1' ],
+		} );
+	} );
+} );
 describe( 'getPersistedQuery', () => {
 	beforeEach( () => {
 		getHistory().push(

--- a/packages/js/navigation/src/test/index.js
+++ b/packages/js/navigation/src/test/index.js
@@ -34,7 +34,7 @@ describe( 'getQuery', () => {
 			buz: '-1',
 		} );
 	} );
-	// Support non-standard array-syntax.
+	// Ignore overwritten params, and treat [] as a part of the name.
 	it( 'should return an object containing array-like parameters', () => {
 		getHistory().push( {
 			search: 'foo=bar&biz=1&buz[]=a&buz[]=-1&buz[2]=2&fuz=0&fuz=1',
@@ -43,8 +43,9 @@ describe( 'getQuery', () => {
 		expect( getQuery() ).toEqual( {
 			foo: 'bar',
 			biz: '1',
-			buz: [ 'a', '-1', '2' ],
-			fuz: [ '0', '1' ],
+			'buz[]': '-1',
+			'buz[2]': '2',
+			fuz: '1',
 		} );
 	} );
 } );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1115,7 +1115,6 @@ importers:
       jest: ^27.5.1
       jest-cli: ^27.5.1
       lodash: ^4.17.0
-      qs: ^6.10.3
       react-router-dom: ^6.3.0
       rimraf: ^3.0.2
       ts-jest: ^27.1.3
@@ -1130,7 +1129,6 @@ importers:
       '@wordpress/url': 3.5.1
       history: 5.3.0
       lodash: 4.17.21
-      qs: 6.10.3
       react-router-dom: 6.3.0_prpqlkd37azqwypxturxi7uyci
     devDependencies:
       '@babel/core': 7.17.8
@@ -2836,42 +2834,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-define-polyfill-provider/0.3.0_@babel+core@7.16.12:
-    resolution: {integrity: sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
-    dependencies:
-      '@babel/core': 7.16.12
-      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.16.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/traverse': 7.19.3
-      debug: 4.3.4
-      lodash.debounce: 4.0.8
-      resolve: 1.22.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/helper-define-polyfill-provider/0.3.0_@babel+core@7.17.8:
-    resolution: {integrity: sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0-0
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-compilation-targets': 7.19.3_@babel+core@7.17.8
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.19.0
-      '@babel/traverse': 7.19.3
-      debug: 4.3.4
-      lodash.debounce: 4.0.8
-      resolve: 1.22.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-define-polyfill-provider/0.3.1_@babel+core@7.12.9:
     resolution: {integrity: sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==}
     peerDependencies:
@@ -3530,7 +3492,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.12.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3543,7 +3505,7 @@ packages:
     dependencies:
       '@babel/core': 7.16.12
       '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.16.12
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4211,7 +4173,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.12.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4224,7 +4186,7 @@ packages:
     dependencies:
       '@babel/core': 7.16.12
       '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.16.12
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4263,7 +4225,7 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.12.9
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.12.9
     transitivePeerDependencies:
       - supports-color
@@ -4278,7 +4240,7 @@ packages:
       '@babel/core': 7.16.12
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.16.12
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.16.12
     transitivePeerDependencies:
       - supports-color
@@ -4969,8 +4931,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -4983,8 +4945,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -6503,9 +6465,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-module-imports': 7.16.0
-      '@babel/helper-plugin-utils': 7.14.5
-      babel-plugin-polyfill-corejs2: 0.3.0_@babel+core@7.16.12
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.16.12
       babel-plugin-polyfill-corejs3: 0.4.0_@babel+core@7.16.12
       babel-plugin-polyfill-regenerator: 0.3.0_@babel+core@7.16.12
       semver: 6.3.0
@@ -6520,9 +6482,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-module-imports': 7.16.0
-      '@babel/helper-plugin-utils': 7.14.5
-      babel-plugin-polyfill-corejs2: 0.3.0_@babel+core@7.17.8
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.19.0
+      babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.17.8
       babel-plugin-polyfill-corejs3: 0.4.0_@babel+core@7.17.8
       babel-plugin-polyfill-regenerator: 0.3.0_@babel+core@7.17.8
       semver: 6.3.0
@@ -13982,12 +13944,12 @@ packages:
       '@typescript-eslint/scope-manager': 5.15.0
       '@typescript-eslint/type-utils': 5.15.0_z4bbprzjrhnsfa24uvmcbu7f5q
       '@typescript-eslint/utils': 5.15.0_z4bbprzjrhnsfa24uvmcbu7f5q
-      debug: 4.3.4
+      debug: 4.3.3
       eslint: 8.25.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.3.5
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -14008,12 +13970,12 @@ packages:
       '@typescript-eslint/scope-manager': 5.15.0
       '@typescript-eslint/type-utils': 5.15.0_himlt4eddny2rsb5zkuydvuf7u
       '@typescript-eslint/utils': 5.15.0_himlt4eddny2rsb5zkuydvuf7u
-      debug: 4.3.4
+      debug: 4.3.3
       eslint: 8.11.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.3.5
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -19114,6 +19076,19 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.16.12:
+    resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/compat-data': 7.19.3
+      '@babel/core': 7.16.12
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.16.12
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /babel-plugin-polyfill-corejs2/0.3.3_@babel+core@7.17.8:
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
@@ -19156,7 +19131,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.16.12
-      '@babel/helper-define-polyfill-provider': 0.3.0_@babel+core@7.16.12
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.16.12
       core-js-compat: 3.25.5
     transitivePeerDependencies:
       - supports-color
@@ -19168,7 +19143,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-define-polyfill-provider': 0.3.0_@babel+core@7.17.8
+      '@babel/helper-define-polyfill-provider': 0.3.3_@babel+core@7.17.8
       core-js-compat: 3.25.5
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Remove `qs` dependency from `@woocommerce/navigation`, use native `URLSearchParams` instead.

This is to suppress `pnpm i` warnings, and remove not needed, deprecated dependency.

#### Additional info/doubts
- There is a PR to remove `qs` from `-admin` only https://github.com/woocommerce/woocommerce/pull/35128
- :question: Before, there were no tests for `getQuery`. Now, it's hard to tell if that's a breaking change or not. There are some edge cases where the behavior differs. Specifically, array-like parameters. See https://github.com/woocommerce/woocommerce/pull/35128#issuecomment-1297769716 for details.
   What do we want to do with queries like: `'foo=bar&biz=1&buz[]=a&buz[]=-1&buz[2]=2&fuz=0&fuz=1'`? 
   - Do we care?
   - Do we want to parse them like before?
   - Do we want to parse them more like native `URLQueryParams` do?
   - Do we want to support that for some time, but warn users, that we'll change it eventually?
- Maybe to avoid problems such as the one above, reduce the overhead of parsing backend forth over and over again, and to provide even more features and ergonomics to consumers of our packages, we could simply embrace and use `URLQueryParams` instance where possible.

Seems either way we go, sooner or later we would need to put in some effort and/or introduce a breaking change.
IMHO, it's better to put an effort sooner, to give time to our consumers/developers. Time to adapt to breaking change, and time saved by faster build, smaller bundle, by not being bothered with warnings, and being able to use more future-proof API.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. `pnpm I && pnm run build && pnpm run test`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
