### PR TITLE
Add tracking support for key HPOS options.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34898-hpos-tracker
+++ b/plugins/woocommerce/changelog/fix-34898-hpos-tracker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add HPOS information to WC Tracker.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -690,6 +690,11 @@ class WC_Tracker {
 			'enable_myaccount_registration'         => get_option( 'woocommerce_enable_myaccount_registration' ),
 			'registration_generate_username'        => get_option( 'woocommerce_registration_generate_username' ),
 			'registration_generate_password'        => get_option( 'woocommerce_registration_generate_password' ),
+			'hpos_enabled'                          => get_option( 'woocommerce_custom_orders_table_enabled' ),
+			'hpos_sync_enabled'                     => get_option( 'woocommerce_custom_orders_table_data_sync_enabled' ),
+			'hpos_cot_authoritative'                => get_option( 'woocommerce_feature_custom_order_tables_enabled' ),
+			'hpos_transactions_enabled'             => get_option( 'woocommerce_use_db_transactions_for_custom_orders_table_data_sync' ),
+			'hpos_transactions_level'               => get_option( 'woocommerce_db_transactions_isolation_level_for_custom_orders_table_data_sync' ),
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -690,9 +690,9 @@ class WC_Tracker {
 			'enable_myaccount_registration'         => get_option( 'woocommerce_enable_myaccount_registration' ),
 			'registration_generate_username'        => get_option( 'woocommerce_registration_generate_username' ),
 			'registration_generate_password'        => get_option( 'woocommerce_registration_generate_password' ),
-			'hpos_enabled'                          => get_option( 'woocommerce_custom_orders_table_enabled' ),
+			'hpos_enabled'                          => get_option( 'woocommerce_feature_custom_order_tables_enabled' ),
 			'hpos_sync_enabled'                     => get_option( 'woocommerce_custom_orders_table_data_sync_enabled' ),
-			'hpos_cot_authoritative'                => get_option( 'woocommerce_feature_custom_order_tables_enabled' ),
+			'hpos_cot_authoritative'                => get_option( 'woocommerce_custom_orders_table_enabled' ),
 			'hpos_transactions_enabled'             => get_option( 'woocommerce_use_db_transactions_for_custom_orders_table_data_sync' ),
 			'hpos_transactions_level'               => get_option( 'woocommerce_db_transactions_isolation_level_for_custom_orders_table_data_sync' ),
 		);


### PR DESCRIPTION
Track if HPOS is enabled—including relevant details such as if COT or CPT is the authoritative data store, if transactions are in use, etc. Replaces https://github.com/woocommerce/woocommerce/pull/35270 (which tried to do the same with Tracks, instead of WC Tracker).

Closes #34898.

### How to test the changes in this Pull Request:

Using WP CLI, try running:

`wp eval "print_r( WC_Tracker::get_tracking_data()['settings'] );"` 

At the end of the output, you should see a number of HPOS-related options, looking something like this:

```
    [hpos_enabled] => yes
    [hpos_sync_enabled] => yes
    [hpos_cot_authoritative] => yes
    [hpos_transactions_enabled] => no
    [hpos_transactions_level] => REPEATABLE READ
```

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
