### PR TITLE
Fix business details step fails to display when Gutenberg plugin is active

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -766,7 +766,11 @@ class BusinessDetails extends Component {
 				activeClass="is-active"
 				initialTabName="current-tab"
 				onSelect={ ( tabName ) => {
-					if ( this.state.currentTab !== tabName ) {
+					if (
+						this.state.currentTab !== tabName &&
+						// TabPanel calls onSelect on mount when initialTabName is provided, so we need to check if the tabName is valid.
+						tabName !== 'current-tab'
+					) {
 						this.setState( {
 							currentTab: tabName,
 							savedValues:

--- a/plugins/woocommerce/changelog/fix-35417-bussiness-details-with-gutenberg
+++ b/plugins/woocommerce/changelog/fix-35417-bussiness-details-with-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix business details step when Gutenberg is active


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35417.

This PR fixes a business details UI display issue when Gutenberg 14.4.0 is active. 

`TabPanel` has been changed to call `onSelect` immediately since Gutenberg 14.4.0 when component `initialTabName` is provided (https://github.com/WordPress/gutenberg/pull/44935). Because we have [a trick logic](https://github.com/woocommerce/woocommerce/blob/ba5a4186ab908cce5c1eeae01e5ceff8537fd9e5/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js#L760-L763) in business details, that makes the state set to a wrong tab name.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install and activate Gutenberg plugin
2. Go to OBW
3. Continue until the business details step 
4. Observe that "Business details" and "Free features" options are displayed on Business details step

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
