### PR TITLE
Fix wrong return type get shipping tax

### DIFF
--- a/plugins/woocommerce/changelog/fix-wrong-return-type-get-shipping-tax
+++ b/plugins/woocommerce/changelog/fix-wrong-return-type-get-shipping-tax
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix inconsistent return type of class WC_Shipping_Rate->get_shipping_tax()

--- a/plugins/woocommerce/includes/class-wc-shipping-rate.php
+++ b/plugins/woocommerce/includes/class-wc-shipping-rate.php
@@ -226,10 +226,10 @@ class WC_Shipping_Rate {
 	/**
 	 * Get shipping tax.
 	 *
-	 * @return array
+	 * @return float
 	 */
 	public function get_shipping_tax() {
-		return apply_filters( 'woocommerce_get_shipping_tax', count( $this->taxes ) > 0 && ! WC()->customer->get_is_vat_exempt() ? array_sum( $this->taxes ) : 0, $this );
+		return apply_filters( 'woocommerce_get_shipping_tax', count( $this->taxes ) > 0 && ! WC()->customer->get_is_vat_exempt() ? (float) array_sum( $this->taxes ) : 0.0, $this );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix invalid and inconsistent return type for class WC_Shipping_Rate->get_shipping_tax()

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
