### PR TITLE
Remove the text color definition for notice buttons in TT3

### DIFF
--- a/plugins/woocommerce/changelog/2022-11-01-18-14-53-526294
+++ b/plugins/woocommerce/changelog/2022-11-01-18-14-53-526294
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove text color definition for buttons for TT3 to allow default style to apply.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -139,7 +139,6 @@
 		}
 
 		a {
-			color: var(--wp--preset--color--contrast);
 
 			.button {
 				margin-top: -0.5rem;


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Hopefully provides a more future proof state for a problem introduced in https://github.com/WordPress/twentytwentythree/issues/288#issuecomment-1293504927 by removing the text color definition from TT3. This way, a fix applied in WP 6.1.1 should solve this problem for us as well.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install WP 6.1 RC6, WC and activate TT3 theme.
2. Go to single product page and add product to cart. Hover over the View cart button, you will see black on black in the default style.
3. Open up developer tools and disable the styling added by :visited class. 
![Screenshot 2022-11-01 at 19 19 22](https://user-images.githubusercontent.com/2207451/199308737-960939bc-e882-4386-8deb-60887d0dc1a0.png)

5. The button should behave correctly, the text should be readable.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
