### PR TITLE
Admin redirects for HPOS URLs

### DIFF
--- a/plugins/woocommerce/changelog/fix-35074-hpos-cpt-admin-redirects
+++ b/plugins/woocommerce/changelog/fix-35074-hpos-cpt-admin-redirects
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+When custom order tables are not authoritative, admin UI requests will be redirected to the matching legacy order screen as appropriate.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -6,6 +6,7 @@
  * @version 2.5.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController as Custom_Orders_PageController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Admin\Features\Features;
@@ -316,6 +317,8 @@ class WC_Admin_Menus {
 		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
 			$this->orders_page_controller = new Custom_Orders_PageController();
 			$this->orders_page_controller->setup();
+		} else {
+			wc_get_container()->get( COTRedirectionController::class )->setup();
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
@@ -39,8 +39,8 @@ class COTRedirectionController {
 			return;
 		}
 
-		$params  = wp_unslash( $query_params );
-		$action  = $params['action'] ?? '';
+		$params = wp_unslash( $query_params );
+		$action = $params['action'] ?? '';
 		unset( $params['page'] );
 
 		if ( 'edit' === $action && isset( $params['id'] ) ) {
@@ -50,7 +50,7 @@ class COTRedirectionController {
 		} elseif ( 'new' === $action ) {
 			unset( $params['action'] );
 			$params['post_type'] = 'shop_order';
-			$new_url = add_query_arg( $params, get_admin_url( null, 'post-new.php' ) );
+			$new_url             = add_query_arg( $params, get_admin_url( null, 'post-new.php' ) );
 		} else {
 			// If nonce parameters are present and valid, rebuild them for the CPT admin list table.
 			if ( isset( $params['_wpnonce'] ) && check_admin_referer( 'bulk-orders' ) ) {
@@ -61,11 +61,11 @@ class COTRedirectionController {
 			// If an `order` array parameter is present, rename as `post`.
 			if ( isset( $params['order'] ) && is_array( $params['order'] ) ) {
 				$params['post'] = $params['order'];
-				unset( $params['order']);
+				unset( $params['order'] );
 			}
 
 			$params['post_type'] = 'shop_order';
-			$new_url = add_query_arg( $params, get_admin_url( null, 'edit.php' ) );
+			$new_url             = add_query_arg( $params, get_admin_url( null, 'edit.php' ) );
 		}
 
 		if ( ! empty( $new_url ) && wp_safe_redirect( $new_url, 301 ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Orders;
+
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
+
+/**
+ * When Custom Order Tables are not the default order store (ie, posts are authoritative), we should take care of
+ * redirecting requests for the order editor and order admin list table to the equivalent posts-table screens.
+ *
+ * If the redirect logic is problematic, it can be unhooked using code like the following example:
+ *
+ *     remove_action(
+ *         'admin_page_access_denied',
+ *         array( wc_get_container()->get( COTRedirectionController::class ), 'handle_hpos_admin_requests' )
+ *     );
+ */
+class COTRedirectionController {
+	use AccessiblePrivateMethods;
+
+	/**
+	 * Add hooks needed to perform our magic.
+	 */
+	public function setup(): void {
+		// Only take action in cases where access to the admin screen would otherwise be denied.
+		self::add_action( 'admin_page_access_denied', array( $this, 'handle_hpos_admin_requests' ) );
+	}
+
+	/**
+	 * Listen for denied admin requests and, if they appear to relate to HPOS admin screens, potentially
+	 * redirect the user to the equivalent CPT-driven screens.
+	 *
+	 * @param array|null $query_params The query parameters to use when determining the redirect. If not provided, the $_GET superglobal will be used.
+	 */
+	private function handle_hpos_admin_requests( array $query_params = array() ) {
+		$query_params = ( empty( $query_params ) && isset( $_GET ) ) ? $_GET : $query_params;
+
+		if ( ! isset( $query_params['page'] ) || 'wc-orders' !== $query_params['page'] ) {
+			return;
+		}
+
+		$params  = wp_unslash( $query_params );
+		$action  = $params['action'] ?? '';
+		unset( $params['page'] );
+
+		if ( 'edit' === $action && isset( $params['id'] ) ) {
+			$params['post'] = $params['id'];
+			unset( $params['id'] );
+			$new_url = add_query_arg( $params, get_admin_url( null, 'post.php' ) );
+		} elseif ( 'new' === $action ) {
+			unset( $params['action'] );
+			$params['post_type'] = 'shop_order';
+			$new_url = add_query_arg( $params, get_admin_url( null, 'post-new.php' ) );
+		} else {
+			// If nonce parameters are present and valid, rebuild them for the CPT admin list table.
+			if ( isset( $params['_wpnonce'] ) && check_admin_referer( 'bulk-orders' ) ) {
+				$params['_wp_http_referer'] = get_admin_url( null, 'edit.php?post_type=shop_order' );
+				$params['_wpnonce']         = wp_create_nonce( 'bulk-posts' );
+			}
+
+			// If an `order` array parameter is present, rename as `post`.
+			if ( isset( $params['order'] ) && is_array( $params['order'] ) ) {
+				$params['post'] = $params['order'];
+				unset( $params['order']);
+			}
+
+			$params['post_type'] = 'shop_order';
+			$new_url = add_query_arg( $params, get_admin_url( null, 'edit.php' ) );
+		}
+
+		if ( ! empty( $new_url ) && wp_safe_redirect( $new_url, 301 ) ) {
+			exit;
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
@@ -32,8 +32,8 @@ class COTRedirectionController {
 	 *
 	 * @param array|null $query_params The query parameters to use when determining the redirect. If not provided, the $_GET superglobal will be used.
 	 */
-	private function handle_hpos_admin_requests( array $query_params = array() ) {
-		$query_params = ( empty( $query_params ) && isset( $_GET ) ) ? $_GET : $query_params;
+	private function handle_hpos_admin_requests( $query_params = null ) {
+		$query_params = is_array( $query_params ) ? $query_params : $_GET;
 
 		if ( ! isset( $query_params['page'] ) || 'wc-orders' !== $query_params['page'] ) {
 			return;

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
+use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\Edit;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
@@ -21,6 +22,7 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 	 * @var string[]
 	 */
 	protected $provides = array(
+		COTRedirectionController::class,
 		PageController::class,
 		Edit::class,
 		ListTable::class,
@@ -32,6 +34,7 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
+		$this->share( COTRedirectionController::class );
 		$this->share( PageController::class );
 		$this->share( Edit::class )->addArgument( PageController::class );
 		$this->share( ListTable::class )->addArgument( PageController::class );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/COTRedirectionControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/COTRedirectionControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
+
+/**
+ * Describes our redirection logic covering HPOS admin screens when Custom Order Tables are not authoritative.
+ */
+class COTRedirectionControllerTest extends WC_Unit_Test_Case {
+	/**
+	 * @var COTRedirectionController
+	 */
+	private $sut;
+
+	/**
+	 * Holds the URL of the last attempted redirect.
+	 *
+	 * @var string
+	 */
+	private $redirected_to = '';
+
+	/**
+	 * Setup our SUT and start listening for redirects.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new COTRedirectionController();
+		$this->sut->setup();
+		$this->redirected_to = '';
+
+		add_filter( 'wp_redirect', array( $this, 'watch_and_anull_redirects' ) );
+	}
+
+	/**
+	 * Remove our redirect listener.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_filter( 'wp_redirect', array( $this, 'watch_and_anull_redirects' ) );
+	}
+
+	/**
+	 * Captures the attempted redirect location, and stops the redirect from taking place.
+	 *
+	 * @param string $url Redirect location.
+	 *
+	 * @return null
+	 */
+	public function watch_and_anull_redirects( string $url ) {
+		$this->redirected_to = $url;
+		return null;
+	}
+
+	/**
+	 * Supplies the URL of the last attempted redirect, then resets ready for the next test.
+	 *
+	 * @return string
+	 */
+	private function get_redirect_attempt(): string {
+		$return              = $this->redirected_to;
+		$this->redirected_to = '';
+		return $return;
+	}
+
+	/**
+	 * Test that redirects only occur in relation to HPOS admin screen requests.
+	 *
+	 * @return void
+	 */
+	public function test_redirects_only_impact_hpos_admin_requests() {
+		$this->sut->handle_hpos_admin_requests( array( 'page' => 'wc-orders' ) );
+		$this->assertNotEmpty( $this->get_redirect_attempt(), 'A redirect was attempted in relation to an HPOS admin request.' );
+
+		$this->sut->handle_hpos_admin_requests( array( 'page' => 'foo' ) );
+		$this->assertEmpty( $this->get_redirect_attempt(), 'A redirect was not attempted in relation to a non-HPOS admin request.' );
+	}
+
+	/**
+	 * Test order editor redirects work (in relation to creating new orders).
+	 *
+	 * @return void
+	 */
+	public function test_redirects_to_the_new_order_screen(): void {
+		$this->sut->handle_hpos_admin_requests(
+			array(
+				'action' => 'new',
+				'page'   => 'wc-orders',
+			)
+		);
+
+		$this->assertStringContainsString(
+			'/wp-admin/post-new.php?post_type=shop_order',
+			$this->get_redirect_attempt(),
+			'Attempts to access the new order page (HPOS) are successfully redirected to the new order page (CPT).'
+		);
+	}
+
+	/**
+	 * Test order editor redirects work (in relation to existing orders).
+	 *
+	 * @return void
+	 */
+	public function test_redirects_to_the_order_editor_screen(): void {
+		$this->sut->handle_hpos_admin_requests(
+			array(
+				'action' => 'edit',
+				'id'     => 12345,
+				'page'   => 'wc-orders',
+			)
+		);
+
+		$redirect_url  = $this->get_redirect_attempt();
+		$redirect_base = wp_parse_url( $redirect_url, PHP_URL_PATH );
+		parse_str( wp_parse_url( $redirect_url, PHP_URL_QUERY ), $redirect_query );
+
+		$this->assertStringContainsString(
+			'/post.php',
+			$redirect_base,
+			'Confirm order editor redirects go to the expected WordPress admin controller.'
+		);
+
+		$this->assertEquals(
+			'12345',
+			$redirect_query['post'],
+			'Confirm order editor redirects maintain the correct order ID.'
+		);
+	}
+
+	/**
+	 * Tests order list table redirects work.
+	 *
+	 * @return void
+	 */
+	public function test_redirects_to_the_order_admin_list_screen(): void {
+		$this->sut->handle_hpos_admin_requests(
+			array(
+				'arbitrary' => '3pd-integration',
+				'order'     => array(
+					123,
+					456,
+				),
+				'page'      => 'wc-orders',
+			)
+		);
+
+		$redirect_url  = $this->get_redirect_attempt();
+		$redirect_base = wp_parse_url( $redirect_url, PHP_URL_PATH );
+		parse_str( wp_parse_url( $redirect_url, PHP_URL_QUERY ), $redirect_query );
+
+		$this->assertStringContainsString(
+			'/edit.php',
+			$redirect_base,
+			'Confirm order list table redirects go to the expected WordPress admin controller.'
+		);
+
+		$this->assertEquals(
+			array(
+				'123',
+				'456',
+			),
+			$redirect_query['post'],
+			'Confirm order list table redirects maintain a list of order IDs for bulk action requests (if one was passed).'
+		);
+
+		$this->assertEquals(
+			'shop_order',
+			$redirect_query['post_type'],
+			'Confirm order list table redirects reference the correct custom post type.'
+		);
+
+		$this->assertEquals(
+			'3pd-integration',
+			$redirect_query['arbitrary'],
+			'Confirm that arbitrary query parameters are also passed across via order list table redirects.'
+		);
+	}
+}


### PR DESCRIPTION
If HPOS is disabled, or COT is no longer authoritative, then requests to access HPOS admin screens should result in redirects to the corresponding legacy order screen.

Closes #35074.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. To test, you will first need to setup HPOS—making the custom order tables authoritative and enabling sync (please refer to [this PR](https://github.com/woocommerce/woocommerce/pull/35442) if you need a primer on how do this). You will also need a number of test orders to play with: if you don't have any existing order data, consider using a tool like [WC Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) for that.
2. Next, visit **WooCommerce ‣ Settings ‣ Advanced ‣ Custom Data Stores** and change the data store to the **WordPress Posts Table**.
3. Try accessing the HPOS order admin list table at `/wp-admin/admin.php?page=wc-orders`: you should be redirected to the equivalent order post screen at `wp-admin/edit.php?post_type=shop_order`.
4. Repeat, but use a paged URL such as `wp-admin/edit.php?post_type=shop_order&paged=3`: you should be redirected to `/wp-admin/edit.php?paged=3&post_type=shop_order` (assuming you have at least 3 pages of order data).
5. Now try accessing the order editor via the HPOS new order screen at `/wp-admin/admin.php?page=wc-orders&action=new`: you should be redirected to `/wp-admin/post-new.php?post_type=shop_order` (simulates manually creating a new order).
6. Try acessing the order editor for an existing order, using a URL like `https://wordpress.lab/wp-admin/admin.php?page=wc-orders&action=edit&id=123`: you should be redirected to `/wp-admin/post.php?action=edit&post=123` (of course, change 123 to the ID of an actual existing order within your test site).

Now a more advanced test.

1. Return to **WooCommerce ‣ Settings ‣ Advanced ‣ Custom Data Stores** and change the data store to the **WooCommerce Orders Tables**.
2. Visit the order admin list table at `/wc-admin/admin.php?page=wc-orders` and select one or more orders, then perform a bulk action such as changing the order status to **Completed**.
    - You will also need to use your browser's developer tools for this test (if you are using Firefox, I recommend the Network tab with *Persist Logs* enabled), or some equivalent tool, to capture the **initial** URL that is created when you do this.
    - Typically, it will take the form `/wp-admin/admin.php?page=wc-orders&_wpnonce=ABCDEF&_wp_http_referer=%2Fwp-admin%2Fadmin.php%3Fpage%3Dwc-orders&action=mark_completed&order%5B%5D=1&order%5B%5D=2&action2=mark_completed` (but you may also see some extra query parameters in there).
3. Go back to **WooCommerce ‣ Settings ‣ Advanced ‣ Custom Data Stores** and change the data store to the **WordPress Posts Table**.
4. Now try "re-playing" the URL you captured earlier, but change both instances of `mark_completed` to `mark_processing`. An appropriate redirect should take place and the bulk action should be processed, in this case resulting in the two orders being set back to "Processing".

<!-- End testing instructions -->

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
