### PR TITLE
Fix wrong version typo

### DIFF
--- a/plugins/woocommerce/changelog/fix-wrong-template-version
+++ b/plugins/woocommerce/changelog/fix-wrong-template-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix version in template and function docblocks.

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -531,7 +531,7 @@ function wc_current_theme_supports_woocommerce_or_fse() {
  *
  * @param string $element The name of the element.
  *
- * @since 7.1.0
+ * @since 7.0.1
  * @return string
  */
 function wc_wp_theme_get_element_class_name( $element ) {

--- a/plugins/woocommerce/templates/global/form-login.php
+++ b/plugins/woocommerce/templates/global/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     7.1.0
+ * @version     7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I sent this pull request because I believe there is a version error in the template:
`templates/global/form-login.php`

The installed version is 7.0.1 but the template is updated to 7.1.0.