### PR TITLE
Fix bg color that was not covering the full page

### DIFF
--- a/plugins/woocommerce/changelog/fix-35298-background-color
+++ b/plugins/woocommerce/changelog/fix-35298-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bg color that was not covering the full page

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use \Automattic\WooCommerce\Admin\PageController;
 use \Automattic\WooCommerce\Internal\Admin\Loader;
 
 /**
@@ -16,14 +17,17 @@ class NewProductManagementExperience {
 	 * Constructor
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'enqueue_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 	}
 
 	/**
 	 * Enqueue styles needed for the rich text editor.
 	 */
 	public function enqueue_styles() {
-		wp_enqueue_style( 'wp-edit-post' );
+		if ( ! PageController::is_admin_or_embed_page() ) {
+			return;
+		}
+		wp_enqueue_style( 'wp-edit-blocks' );
 		wp_enqueue_style( 'wp-format-library' );
 		wp_enqueue_editor();
 		/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35298.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to the Add New (MVP) product page
2. The gray background should cover the full screen

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
