### PR TITLE
Fix version typo in form-login.php

### DIFF
--- a/plugins/woocommerce/changelog/fix-version-typo-form-login
+++ b/plugins/woocommerce/changelog/fix-version-typo-form-login
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix @version header in form-login.php

--- a/plugins/woocommerce/templates/global/form-login.php
+++ b/plugins/woocommerce/templates/global/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     7.1.0
+ * @version     7.0.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

WooCommerce 7.0.1 ships a lot of updated template files. However there is a typo mistake in `/templates/global/form-login.php` using 7.1.0 instead of 7.0.1.

<!-- Begin testing instructions -->




### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
