### PR TITLE
Display correct order pending sync count on feature enabled screen.

### DIFF
--- a/plugins/woocommerce/changelog/fix-percentage_type
+++ b/plugins/woocommerce/changelog/fix-percentage_type
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor type fix.
+
+

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -472,7 +472,7 @@ WHERE
 			$extra_tip = sprintf(
 				_n(
 					"⚠ There's one order pending sync from the posts table to the orders table. The feature shouldn't be disabled until this order is synchronized.",
-					"⚠ There are %%1\$d orders pending sync from the posts table to the orders table. The feature shouldn't be disabled until these orders are synchronized.",
+					"⚠ There are %1\$d orders pending sync from the posts table to the orders table. The feature shouldn't be disabled until these orders are synchronized.",
 					$pending_sync_count,
 					'woocommerce'
 				),


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a typo in displaying the order count pending sync.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. With posts table as authoritative and HPOS feature enabled and syncing disbled, add two new orders.
2. Go to WooCommerce > Settings > Advanced > Features.
3. Make sure that feature disable warning is displayed correctly.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
