### PR TITLE
Remove extraneous readme entry

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -167,7 +167,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 **WooCommerce**
 
-* Fix - false [#35480](https://github.com/woocommerce/woocommerce/pull/35480)
 * Fix - Fix business details step when Gutenberg is active [#35448](https://github.com/woocommerce/woocommerce/pull/35448)
 * Fix - Check order type is set before returning to prevent notice. [#35349](https://github.com/woocommerce/woocommerce/pull/35349)
 * Fix - When HPOS is enabled, posts are authoritative, and sync is enabled, ensure the HPOS record correctly tracks the CPT order record. [#35402](https://github.com/woocommerce/woocommerce/pull/35402)


### PR DESCRIPTION
This PR removes an extraneous entry inadvertently merged via #35483 

The tooling for this has been fixed in trunk, but those tooling changes do not yet exist in the release branch.