### PR TITLE
[HPOS] Add order data store info to SSR

### DIFF
--- a/plugins/woocommerce/changelog/add-34864-order-data-store-in-ssr
+++ b/plugins/woocommerce/changelog/add-34864-order-data-store-in-ssr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Include order datastore information in status report.

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -7,7 +7,6 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
-use Automattic\WooCommerce\Utilities\OrderUtil as OrderUtil;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -769,9 +769,9 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Datastore currently in use for orders.', 'woocommerce' ) ); ?></td>
 			<td><?php echo esc_html( WC_Data_Store::load( 'order' )->get_current_class_name() ); ?></td>
 		</tr>
-		<?php if ( wc_get_container()->get( OrderUtil::class )->custom_orders_table_usage_is_enabled() ): ?>
+		<?php if ( wc_get_container()->get( OrderUtil::class )->custom_orders_table_usage_is_enabled() ) : ?>
 		<tr>
-			<td data-export-label="HPOS data sync enabled"><?php esc_html_e( 'HPOS data sync enabled:' ); ?></td>
+			<td data-export-label="HPOS data sync enabled"><?php esc_html_e( 'HPOS data sync enabled:', 'woocommerce' ); ?></td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is data sync enabled for HPOS?', 'woocommerce' ) ); ?></td>
 			<td><?php echo wc_get_container()->get( Order_DataSynchronizer::class )->data_sync_is_enabled() ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -7,6 +7,8 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
+use Automattic\WooCommerce\Utilities\OrderUtil as OrderUtil;
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -762,6 +764,18 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is your site enforcing the use of Approved Product Download Directories?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo wc_get_container()->get( Download_Directories::class )->get_mode() === Download_Directories::MODE_ENABLED ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
+		<tr>
+			<td data-export-label="Order datastore"><?php esc_html_e( 'Order datastore:', 'woocommerce' ); ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Datastore currently in use for orders.', 'woocommerce' ) ); ?></td>
+			<td><?php echo esc_html( WC_Data_Store::load( 'order' )->get_current_class_name() ); ?></td>
+		</tr>
+		<?php if ( wc_get_container()->get( OrderUtil::class )->custom_orders_table_usage_is_enabled() ): ?>
+		<tr>
+			<td data-export-label="HPOS data sync enabled"><?php esc_html_e( 'HPOS data sync enabled:' ); ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is data sync enabled for HPOS?', 'woocommerce' ) ); ?></td>
+			<td><?php echo wc_get_container()->get( Order_DataSynchronizer::class )->data_sync_is_enabled() ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+		</tr>
+		<?php endif; ?>
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -769,7 +769,7 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Datastore currently in use for orders.', 'woocommerce' ) ); ?></td>
 			<td><?php echo esc_html( WC_Data_Store::load( 'order' )->get_current_class_name() ); ?></td>
 		</tr>
-		<?php if ( wc_get_container()->get( OrderUtil::class )->custom_orders_table_usage_is_enabled() ) : ?>
+		<?php if ( wc_get_container()->get( Automattic\WooCommerce\Internal\Features\FeaturesController::class )->feature_is_enabled( 'custom_order_tables' ) ) : ?>
 		<tr>
 			<td data-export-label="HPOS data sync enabled"><?php esc_html_e( 'HPOS data sync enabled:', 'woocommerce' ); ?></td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is data sync enabled for HPOS?', 'woocommerce' ) ); ?></td>


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a couple of new rows to the "Settings" section of the Status Report, with info about the order datastore in use and whether data sync is enabled or not (when HPOS is enabled).

<img width="1333" alt="Screenshot 2022-11-03 at 12 23 09" src="https://user-images.githubusercontent.com/184724/199792743-4700a9bb-54a3-425d-a185-adb3bb9214e3.png">

**Note:** I've added the new rows under "Settings" but maybe we'll eventually need a different section for this sort of information (such as current implementations of product or other data stores). Not sure if that's worth doing now.

Closes #34864.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to WC > Status.
2. Scroll down to "Settings".
3. Confirm that there is a new row "Order datastore" with the classname for the current order datastore.
4. If HPOS is enabled, there should be another row "HPOS data sync enabled" indicating whether data sync has been enabled or not.
5. Repeat the above with different configurations of HPOS and data sync (enabled/disabled).

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
