### PR TITLE
[HPOS] Implement "Empty Trash" functionality in list table

### DIFF
--- a/plugins/woocommerce/changelog/fix-35367-empty-trash-button
+++ b/plugins/woocommerce/changelog/fix-35367-empty-trash-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add "Empty Trash" functionality to HPOS list table.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2589,6 +2589,10 @@ ul.wc_coupon_list_block {
 				height: 30px;
 			}
 		}
+
+		#order-query-submit {
+			margin: 0 8px 0 0;
+		}
 	}
 
 	.wp-list-table {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -468,7 +468,7 @@ class ListTable extends WP_List_Table {
 			submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, array( 'id' => 'order-query-submit' ) );
 		}
 
-		if ( $this->is_trash && $this->has_items() && current_user_can( 'edit_others_orders' ) ) {
+		if ( $this->is_trash && $this->has_items() && current_user_can( 'edit_others_shop_orders' ) ) {
 			submit_button( __( 'Empty Trash', 'woocommerce' ), 'apply', 'delete_all', false );
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -34,6 +34,13 @@ class ListTable extends WP_List_Table {
 	private $page_controller;
 
 	/**
+	 * Tracks whether we're currently inside the trash.
+	 *
+	 * @var boolean
+	 */
+	private $is_trash = false;
+
+	/**
 	 * Sets up the admin list table for orders (specifically, for orders managed by the OrdersTableDataStore).
 	 *
 	 * @see WC_Admin_List_Table_Orders for the corresponding class used in relation to the traditional WP Post store.
@@ -281,6 +288,9 @@ class ListTable extends WP_List_Table {
 				'total_pages' => $max_num_pages,
 			)
 		);
+
+		// Are we inside the trash?
+		$this->is_trash = isset( $_REQUEST['status'] ) && 'trash' === $_REQUEST['status'];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR implements the "Empty Trash" button in the HPOS list table.

Closes #35367.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Make sure you build the legacy assets (execute `npm run build` from the `plugins/woocommerce/client/legacy` folder) so that you get a CSS fix included in this PR.
2. Enable HPOS and make authoritative.
3. Add some orders.
4. Trash some orders.
5. Go to WC > Orders > Trash.
6. Make sure that the "Empty Trash" button appears.
7. Click "Empty Trash" and confirm that all trashed orders (and only those) are permanently deleted.

**Note:** If, while testing, you notice that the counts for "All" are _all_ out of whack, that's being fixed in #35370.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
