### PR TITLE
fixed spacing issue of thumb image

### DIFF
--- a/plugins/woocommerce/changelog/woocommer-thumb-issue
+++ b/plugins/woocommerce/changelog/woocommer-thumb-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve spacing of product gallery thumbs when using the Twenty Twenty-Two theme.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -591,7 +591,7 @@ a.reset_variations {
 
 	.flex-control-thumbs li {
 		width: 14.2857142857%;
-		margin: 0 14.2857142857% 1.6em 0;
+		margin: 0 1em 1.6em 0;
 	}
 
 	.flex-control-thumbs li:nth-child(4n) {


### PR DESCRIPTION
I have solved the issue which is mentioned in https://github.com/woocommerce/woocommerce/issues/34253
1)Activate twenty twenty theme.
2)Install woocommerce plugin and move on single product page.
3)Single product thumb image right spacing occur.

### Testing instructions

- Activate Twenty Twenty-Two.
- Compare our current stable release with this branch.
- Note that if you are not using live branches, you should be sure to rebuild assets between branch switches: `pnpm run --filter='woocommerce/client/legacy' build`.
- Visit a single product that contains a gallery and review in a range of different viewport sizes.
- Consider adding/removing images to change the number of thumbnails.
- With this branch, the amount of space between thumbnail images is reduced significantly.