### PR TITLE
Migrate merchant daily smoke tests to Playwright

### DIFF
--- a/.github/workflows/scripts/prepare-test-summary-daily.js
+++ b/.github/workflows/scripts/prepare-test-summary-daily.js
@@ -92,7 +92,7 @@ const addSummaryHeadingAndTable = ( core ) => {
 	const apiTableRow = createAPITableRow();
 	const e2eTableRow = createE2ETableRow();
 
-	core.summary.addHeading( 'Smoke tests on trunk' ).addTable( [
+	core.summary.addHeading( 'Smoke tests on nightly build' ).addTable( [
 		[
 			{ data: 'Test :test_tube:', header: true },
 			{ data: 'Passed :white_check_mark:', header: true },

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
     e2e-tests:
-        name: E2E tests on trunk
+        name: E2E tests on nightly build
         runs-on: ubuntu-20.04
         env:
             ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
@@ -74,7 +74,7 @@ jobs:
                   retention-days: 5
 
     api-tests:
-        name: API tests on trunk
+        name: API tests on nightly build
         runs-on: ubuntu-20.04
         needs: [e2e-tests]
         if: success() || failure()
@@ -118,7 +118,7 @@ jobs:
                   retention-days: 5
 
     k6-tests:
-        name: k6 tests on trunk
+        name: k6 tests on nightly build
         runs-on: ubuntu-20.04
         needs: [api-tests]
         if: success() || failure()
@@ -168,7 +168,7 @@ jobs:
                   ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
 
     test-plugins:
-        name: Smoke tests with ${{ matrix.plugin }} plugin installed
+        name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed
         runs-on: ubuntu-20.04
         env:
             USE_WP_ENV: 1
@@ -230,7 +230,7 @@ jobs:
               if: success() || failure()
               uses: actions/upload-artifact@v3
               with:
-                  name: Smoke tests with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
+                  name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
                   path: |
                       ${{ env.ALLURE_RESULTS_DIR }}
                       ${{ env.ALLURE_REPORT_DIR }}
@@ -238,7 +238,7 @@ jobs:
                   retention-days: 5
 
     trunk-results:
-        name: Publish report on smoke tests on trunk
+        name: Publish report on smoke tests on nightly build
         if: |
             ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
@@ -294,7 +294,7 @@ jobs:
                     --repo woocommerce/woocommerce-test-reports
 
     plugins-results:
-        name: Publish report on smoke tests with plugins
+        name: Publish report on Smoke tests on trunk with plugins
         if: |
             ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
@@ -303,7 +303,7 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
             RUN_ID: ${{ github.run_id }}
-            ARTIFACT: Smoke tests with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
+            ARTIFACT: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -18,15 +18,17 @@ jobs:
     e2e-tests:
         name: E2E tests on trunk
         runs-on: ubuntu-20.04
-        if: always()
         env:
-            BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
-            ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
             ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+            ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
             ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
-            CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+            BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
             CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+            CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
             DEFAULT_TIMEOUT_OVERRIDE: 120000
+
         steps:
             - uses: actions/checkout@v3
               with:
@@ -44,36 +46,24 @@ jobs:
 
             - name: Run 'Update WooCommerce' test.
               working-directory: plugins/woocommerce
-              id: e2e-update
               env:
                   UPDATE_WC: true
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js update-woocommerce.spec.js
+              run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js update-woocommerce.spec.js
 
             - name: Run the rest of E2E tests.
               timeout-minutes: 60
               working-directory: plugins/woocommerce
-              id: e2e
               env:
-                  E2E_MAX_FAILURES: 15
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js basic.spec.js
+                  E2E_MAX_FAILURES: 25
+              run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js
 
             - name: Generate Playwright E2E Test report.
-              id: generate_e2e_report
-              if: |
-                  always() &&
-                  (
-                    steps.e2e-update.conclusion != 'cancelled' ||
-                    steps.e2e-update.conclusion != 'skipped' ||
-                    steps.e2e.conclusion != 'cancelled' ||
-                    steps.e2e.conclusion != 'skipped' 
-                  )
+              if: success() || failure()
               working-directory: plugins/woocommerce
               run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
             - name: Archive E2E test report
-              if: |
-                  always() &&
-                  steps.generate_e2e_report.conclusion == 'success'
+              if: success() || failure()
               uses: actions/upload-artifact@v3
               with:
                   name: ${{ env.E2E_ARTIFACT }}
@@ -87,7 +77,7 @@ jobs:
         name: API tests on trunk
         runs-on: ubuntu-20.04
         needs: [e2e-tests]
-        if: always()
+        if: success() || failure()
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
@@ -103,8 +93,6 @@ jobs:
                   build: false
 
             - name: Run API tests.
-              if: always()
-              id: run_playwright_api_tests
               working-directory: plugins/woocommerce
               env:
                   BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
@@ -114,20 +102,12 @@ jobs:
               run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js hello.test.js
 
             - name: Generate API Test report.
-              id: generate_api_report
-              if: |
-                  always() &&
-                  (
-                    steps.run_playwright_api_tests.conclusion != 'cancelled' ||
-                    steps.run_playwright_api_tests.conclusion != 'skipped' 
-                  )
+              if: success() || failure()
               working-directory: plugins/woocommerce
               run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
             - name: Archive API test report
-              if: |
-                  always() &&
-                  steps.generate_api_report.conclusion == 'success'
+              if: success() || failure()
               uses: actions/upload-artifact@v3
               with:
                   name: ${{ env.API_ARTIFACT }}
@@ -141,7 +121,7 @@ jobs:
         name: k6 tests on trunk
         runs-on: ubuntu-20.04
         needs: [api-tests]
-        if: always()
+        if: success() || failure()
         steps:
             - uses: actions/checkout@v3
               with:
@@ -158,7 +138,6 @@ jobs:
               run: pnpm exec playwright install chromium
 
             - name: Update performance test site with E2E test
-              if: always()
               working-directory: plugins/woocommerce
               env:
                   BASE_URL: ${{ secrets.SMOKE_TEST_PERF_URL }}/
@@ -173,12 +152,10 @@ jobs:
               continue-on-error: true
 
             - name: Install k6
-              if: always()
               run: |
                   curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
 
             - name: Run k6 smoke tests
-              if: always()
               env:
                   URL: ${{ secrets.SMOKE_TEST_PERF_URL }}
                   HOST: ${{ secrets.SMOKE_TEST_PERF_HOST }}
@@ -193,8 +170,6 @@ jobs:
     test-plugins:
         name: Smoke tests with ${{ matrix.plugin }} plugin installed
         runs-on: ubuntu-20.04
-        needs: [k6-tests]
-        if: always()
         env:
             USE_WP_ENV: 1
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
@@ -233,7 +208,6 @@ jobs:
               run: pnpm exec playwright install chromium
 
             - name: Run 'Upload plugin' test
-              id: e2e-upload
               working-directory: plugins/woocommerce
               env:
                   PLUGIN_REPOSITORY: ${{ matrix.private && secrets[matrix.repo] || matrix.repo }}
@@ -242,29 +216,18 @@ jobs:
               run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js upload-plugin.spec.js
 
             - name: Run the rest of E2E tests
-              id: e2e
               working-directory: plugins/woocommerce
               env:
                   E2E_MAX_FAILURES: 15
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js basic.spec.js
+              run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js
 
             - name: Generate E2E Test report.
-              id: report
-              if: |
-                  always() &&
-                  (
-                    steps.e2e-upload.conclusion != 'cancelled' ||
-                    steps.e2e-upload.conclusion != 'skipped' ||
-                    steps.e2e.conclusion != 'cancelled' ||
-                    steps.e2e.conclusion != 'skipped' 
-                  )
+              if: success() || failure()
               working-directory: plugins/woocommerce
               run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
             - name: Archive E2E test report
-              if: |
-                  always() &&
-                  steps.report.conclusion == 'success'
+              if: success() || failure()
               uses: actions/upload-artifact@v3
               with:
                   name: Smoke tests with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
@@ -276,15 +239,16 @@ jobs:
 
     trunk-results:
         name: Publish report on smoke tests on trunk
-        if: always() &&
+        if: |
+            ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
         runs-on: ubuntu-20.04
-        needs: [test-plugins]
+        needs: [test-plugins, k6-tests]
         steps:
             - name: Create dirs
               run: |
                   mkdir -p repo
-                  mkdir -p artifacts/api 
+                  mkdir -p artifacts/api
                   mkdir -p artifacts/e2e
                   mkdir -p output
 
@@ -332,10 +296,10 @@ jobs:
     plugins-results:
         name: Publish report on smoke tests with plugins
         if: |
-            always() &&
+            ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
         runs-on: ubuntu-20.04
-        needs: [test-plugins]
+        needs: [test-plugins, k6-tests]
         env:
             GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
             RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -1,7 +1,7 @@
 name: Smoke test daily
 on:
-    # schedule:
-    #     - cron: '25 3 * * *'
+    schedule:
+        - cron: '25 3 * * *'
     workflow_dispatch:
 
 env:

--- a/plugins/woocommerce/changelog/e2e-daily-playwright-compatible
+++ b/plugins/woocommerce/changelog/e2e-daily-playwright-compatible
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Make e2e tests compatible with nightly and release smoke test sites.

--- a/plugins/woocommerce/tests/e2e-pw/daily.playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/daily.playwright.config.js
@@ -1,0 +1,8 @@
+const defaultConfig = require( './playwright.config' );
+
+const config = {
+	...defaultConfig,
+	testIgnore: '**/shopper/**',
+};
+
+module.exports = config;

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -2,20 +2,6 @@ const { chromium, expect } = require( '@playwright/test' );
 const { admin, customer } = require( './test-data/data' );
 const fs = require( 'fs' );
 
-const setupPermalinks = async ( adminPage ) => {
-	console.log( 'Trying to setup permalinks!' );
-	await adminPage.goto( '/wp-admin/options-permalink.php' );
-	await expect( adminPage.locator( 'div.wrap > h1' ) ).toHaveText(
-		'Permalink Settings'
-	);
-
-	await adminPage.click( '#custom_selection' );
-	await adminPage.fill( '#permalink_structure', '/%postname%/' );
-	await adminPage.click( '#submit' );
-
-	console.log( 'Permalinks Set!' );
-};
-
 module.exports = async ( config ) => {
 	const { stateDir, baseURL, userAgent } = config.projects[ 0 ].use;
 
@@ -130,30 +116,6 @@ module.exports = async ( config ) => {
 	if ( ! customerKeyConfigured ) {
 		console.error(
 			'Cannot proceed e2e test, as we could not set the customer key. Please check if the test site has been setup correctly.'
-		);
-		process.exit( 1 );
-	}
-
-	// Ensure that permalinks are correctly setup since we can't set it up using wp-env when not using the default WP version.
-	// More info here: https://github.com/WordPress/gutenberg/issues/28201
-	let permalinkConfigured = false;
-	const permalinkRetries = 5;
-	for ( let i = 0; i < permalinkRetries; i++ ) {
-		try {
-			await setupPermalinks( adminPage );
-			permalinkConfigured = true;
-			break;
-		} catch ( e ) {
-			console.log(
-				`Setting permalink failed, Retrying... ${ i }/${ permalinkRetries }`
-			);
-			console.log( e );
-		}
-	}
-
-	if ( ! permalinkConfigured ) {
-		console.error(
-			'Cannot proceed e2e test, as we could not setup permalinks. Please check if the test site has been setup correctly.'
 		);
 		process.exit( 1 );
 	}

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -1,7 +1,5 @@
 const { chromium } = require( '@playwright/test' );
-const { ADMIN_USER, ADMIN_PASSWORD } = process.env;
-const adminUsername = ADMIN_USER ?? 'admin';
-const adminPassword = ADMIN_PASSWORD ?? 'password';
+const { admin } = require( './test-data/data' );
 
 module.exports = async ( config ) => {
 	const { baseURL, userAgent } = config.projects[ 0 ].use;
@@ -21,8 +19,8 @@ module.exports = async ( config ) => {
 		try {
 			console.log( 'Trying to clear consumer token... Try:' + i );
 			await adminPage.goto( `/wp-admin` );
-			await adminPage.fill( 'input[name="log"]', adminUsername );
-			await adminPage.fill( 'input[name="pwd"]', adminPassword );
+			await adminPage.fill( 'input[name="log"]', admin.username );
+			await adminPage.fill( 'input[name="pwd"]', admin.password );
 			await adminPage.click( 'text=Log In' );
 			await adminPage.goto(
 				`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -32,6 +32,8 @@ const config = {
 			{
 				outputFolder:
 					ALLURE_RESULTS_DIR ?? 'tests/e2e-pw/allure-results',
+				detail: true,
+				suiteTitle: true,
 			},
 		],
 		[ 'json', { outputFile: 'tests/e2e-pw/test-results.json' } ],

--- a/plugins/woocommerce/tests/e2e-pw/test-data/data.js
+++ b/plugins/woocommerce/tests/e2e-pw/test-data/data.js
@@ -1,7 +1,51 @@
-const adminEmail =
-	process.env.USE_WP_ENV === '1'
-		? 'wordpress@example.com'
-		: 'admin@woocommercecoree2etestsuite.com';
+const {
+	ADMIN_USER,
+	ADMIN_PASSWORD,
+	ADMIN_USER_EMAIL,
+	CUSTOMER_USER,
+	CUSTOMER_PASSWORD,
+	CUSTOMER_USER_EMAIL,
+	USE_WP_ENV,
+} = process.env;
+
+const admin = {
+	username: ADMIN_USER ?? 'admin',
+	password: ADMIN_PASSWORD ?? 'password',
+	email:
+		ADMIN_USER_EMAIL ??
+		( !! USE_WP_ENV
+			? 'wordpress@example.com'
+			: 'admin@woocommercecoree2etestsuite.com' ),
+};
+
+const customer = {
+	username: CUSTOMER_USER ?? 'customer',
+	password: CUSTOMER_PASSWORD ?? 'password',
+	email: CUSTOMER_USER_EMAIL ?? 'customer@woocommercecoree2etestsuite.com',
+	billing: {
+		us: {
+			first_name: 'Maggie',
+			last_name: 'Simpson',
+			address: '123 Evergreen Terrace',
+			city: 'Springfield',
+			country: 'US',
+			state: 'OR',
+			zip: '97403',
+			phone: '555 555-5555',
+			email: 'customer@example.com',
+		},
+		malta: {
+			first_name: 'Maggie',
+			last_name: 'Simpson',
+			address: '123 Evergreen Terrace',
+			city: 'Valletta',
+			country: 'MT',
+			zip: 'VT 1011',
+			phone: '555 555-5555',
+			email: 'vt-customer@example.com',
+		},
+	},
+};
 
 const storeDetails = {
 	us: {
@@ -9,7 +53,7 @@ const storeDetails = {
 			address: 'addr1',
 			city: 'San Francisco',
 			zip: '94107',
-			email: adminEmail,
+			email: admin.email,
 			country: 'United States (US) — California', // corresponding to the text value of the option,
 			countryCode: 'US:CA',
 		},
@@ -28,7 +72,7 @@ const storeDetails = {
 			address: 'addr1',
 			city: 'Valletta',
 			zip: 'VT 1011',
-			email: adminEmail,
+			email: admin.email,
 			country: 'Malta', // corresponding to the text value of the option,
 			countryCode: 'MT',
 		},
@@ -43,31 +87,8 @@ const storeDetails = {
 	},
 };
 
-const customerDetails = {
-	us: {
-		first_name: 'Maggie',
-		last_name: 'Simpson',
-		address: '123 Evergreen Terrace',
-		city: 'Springfield',
-		country: 'US',
-		state: 'OR',
-		zip: '97403',
-		phone: '555 555-5555',
-		email: 'customer@example.com',
-	},
-	malta: {
-		first_name: 'Maggie',
-		last_name: 'Simpson',
-		address: '123 Evergreen Terrace',
-		city: 'Valletta',
-		country: 'MT',
-		zip: 'VT 1011',
-		phone: '555 555-5555',
-		email: 'vt-customer@example.com',
-	},
-};
-
 module.exports = {
 	storeDetails,
-	customerDetails,
+	admin,
+	customer,
 };

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -1,60 +1,67 @@
-const { test, expect } = require('@playwright/test');
-const { onboarding } = require('../../utils');
-const { storeDetails } = require('../../test-data/data');
+const { test, expect } = require( '@playwright/test' );
+const { onboarding } = require( '../../utils' );
+const { storeDetails } = require( '../../test-data/data' );
+const { api } = require( '../../utils' );
 
-test.describe('Store owner can complete onboarding wizard', () => {
-	test.use({ storageState: process.env.ADMINSTATE });
+test.describe( 'Store owner can complete onboarding wizard', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeEach(async ({ page }) => {
+	test.beforeEach( async () => {
+		// Complete "Store Details" step through the API to prevent flakiness when run on external sites.
+		await api.update.storeDetails( storeDetails.us.store );
+	} );
+
+	// eslint-disable-next-line jest/expect-expect
+	test( 'can complete the "Store Details" section', async ( { page } ) => {
 		await onboarding.completeStoreDetailsSection(
 			page,
 			storeDetails.us.store
 		);
-	});
+	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	test('can complete the industry section', async ({ page }) => {
+	test( 'can complete the industry section', async ( { page } ) => {
 		await onboarding.completeIndustrySection(
 			page,
 			storeDetails.us.industries,
 			storeDetails.us.expectedIndustries
 		);
-		await page.click('button >> text=Continue');
-	});
+		await page.click( 'button >> text=Continue' );
+	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	test('can complete the product types section', async ({ page }) => {
+	test( 'can complete the product types section', async ( { page } ) => {
 		await onboarding.completeProductTypesSection(
 			page,
 			storeDetails.us.products
 		);
-		await page.click('button >> text=Continue');
-	});
+		await page.click( 'button >> text=Continue' );
+	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	test('can complete the business section', async ({ page }) => {
+	test( 'can complete the business section', async ( { page } ) => {
 		// We have to ensure that previous steps are complete to avoid generating an error
 		await onboarding.completeIndustrySection(
 			page,
 			storeDetails.us.industries,
 			storeDetails.us.expectedIndustries
 		);
-		await page.click('button >> text=Continue');
+		await page.click( 'button >> text=Continue' );
 
 		await onboarding.completeProductTypesSection(
 			page,
 			storeDetails.us.products
 		);
-		await page.click('button >> text=Continue');
+		await page.click( 'button >> text=Continue' );
 
-		await onboarding.completeBusinessDetailsSection(page);
-		await page.click('button >> text=Continue');
-	});
+		await onboarding.completeBusinessDetailsSection( page );
+		await page.click( 'button >> text=Continue' );
+	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	test.skip('can unselect all business features and continue', async ({
+	test.skip( 'can unselect all business features and continue', async ( {
 		page,
-	}) => {
+	} ) => {
 		// We have to ensure that previous steps are complete to avoid generating an error
 		await onboarding.completeIndustrySection(
 			page,
@@ -71,48 +78,48 @@ test.describe('Store owner can complete onboarding wizard', () => {
 			storeDetails.us.products
 		);
 
-		await onboarding.unselectBusinessFeatures(page);
-		await page.click('button >> text=Continue');
-	});
+		await onboarding.unselectBusinessFeatures( page );
+		await page.click( 'button >> text=Continue' );
+	} );
 
-	test('can complete the theme selection section', async ({ page }) => {
+	test( 'can complete the theme selection section', async ( { page } ) => {
 		await page.goto(
 			'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=theme'
 		);
 		const pageHeading = await page.textContent(
 			'div.woocommerce-profile-wizard__step-header > h2'
 		);
-		expect(pageHeading).toContain('Choose a theme');
+		expect( pageHeading ).toContain( 'Choose a theme' );
 		// Just continue with the current theme
-		await page.click('button >> text=Continue with my active theme');
-	});
-});
+		await page.click( 'button >> text=Continue with my active theme' );
+	} );
+} );
 
 // !Changed from Japanese to Malta store, as Japanese Yen does not use decimals
 test.describe(
 	'A Malta store can complete the selective bundle install but does not include WCPay.',
 	() => {
-		test.use({ storageState: process.env.ADMINSTATE });
+		test.use( { storageState: process.env.ADMINSTATE } );
 
-		test.beforeEach(async ({ page }) => {
-			await onboarding.completeStoreDetailsSection(
-				page,
-				storeDetails.malta.store
-			);
-		});
+		test.beforeEach( async () => {
+			// Complete "Store Details" step through the API to prevent flakiness when run on external sites.
+			await api.update.storeDetails( storeDetails.malta.store );
+		} );
 
 		// eslint-disable-next-line jest/expect-expect
-		test('can choose the "Other" industry', async ({ page }) => {
+		test( 'can choose the "Other" industry', async ( { page } ) => {
 			await onboarding.completeIndustrySection(
 				page,
 				storeDetails.malta.industries,
 				storeDetails.malta.expectedIndustries
 			);
-			await page.click('button >> text=Continue');
-		});
+			await page.click( 'button >> text=Continue' );
+		} );
 
 		// eslint-disable-next-line jest/expect-expect
-		test('can choose not to install any extensions', async ({ page }) => {
+		test( 'can choose not to install any extensions', async ( {
+			page,
+		} ) => {
 			const expect_wp_pay = false;
 
 			await onboarding.completeIndustrySection(
@@ -120,7 +127,7 @@ test.describe(
 				storeDetails.malta.industries,
 				storeDetails.malta.expectedIndustries
 			);
-			await page.click('button >> text=Continue');
+			await page.click( 'button >> text=Continue' );
 
 			await onboarding.completeProductTypesSection(
 				page,
@@ -131,95 +138,99 @@ test.describe(
 				page.locator(
 					'.woocommerce-admin__business-details__selective-extensions-bundle__description a[href*=woocommerce-payments]'
 				)
-			).toHaveCount(0);
+			).toHaveCount( 0 );
 
-			await page.click('button >> text=Continue');
+			await page.click( 'button >> text=Continue' );
 
-			await onboarding.completeBusinessDetailsSection(page);
-			await page.click('button >> text=Continue');
+			await onboarding.completeBusinessDetailsSection( page );
+			await page.click( 'button >> text=Continue' );
 
-			await onboarding.unselectBusinessFeatures(page, expect_wp_pay);
+			await onboarding.unselectBusinessFeatures( page, expect_wp_pay );
 
-			await page.click('button >> text=Continue');
-		});
+			await page.click( 'button >> text=Continue' );
+		} );
 
 		// Skipping this test because it's very flaky.  Onboarding checklist changed so that the text
 		// changes when a task is completed.
 		// eslint-disable-next-line jest/no-disabled-tests
-		test.skip('should display the choose payments task, and not the WC Pay task', async ({
+		test.skip( 'should display the choose payments task, and not the WC Pay task', async ( {
 			page,
-		}) => {
+		} ) => {
 			// If payment has previously been setup, the setup checklist will show something different
 			// This step resets it
-			await page.goto('wp-admin/admin.php?page=wc-settings&tab=checkout');
+			await page.goto(
+				'wp-admin/admin.php?page=wc-settings&tab=checkout'
+			);
 			// Ensure that all payment methods are disabled
 			await expect(
-				page.locator('.woocommerce-input-toggle--disabled')
-			).toHaveCount(3);
+				page.locator( '.woocommerce-input-toggle--disabled' )
+			).toHaveCount( 3 );
 			// Checklist shows when completing setup wizard
 			await page.goto(
 				'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=theme'
 			);
-			await page.click('button >> text=Continue with my active theme');
+			await page.click( 'button >> text=Continue with my active theme' );
 			// Start test
-			await page.waitForLoadState('networkidle');
+			await page.waitForLoadState( 'networkidle' );
 			await expect(
 				page.locator(
 					':nth-match(.woocommerce-task-list__item-title, 3)'
 				)
-			).toContainText('Set up payments');
+			).toContainText( 'Set up payments' );
 			await expect(
 				page.locator(
 					':nth-match(.woocommerce-task-list__item-title, 3)'
 				)
-			).not.toContainText('Set up WooCommerce Payments');
-		});
+			).not.toContainText( 'Set up WooCommerce Payments' );
+		} );
 	}
 );
 
 // Skipping this test because it's very flaky.
-test.describe.skip('Store owner can go through setup Task List', () => {
-	test.use({ storageState: process.env.ADMINSTATE });
+test.describe.skip( 'Store owner can go through setup Task List', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeEach(async ({ page }) => {
-		await page.goto('wp-admin/admin.php?page=wc-admin&path=/setup-wizard');
-		await page.click('#woocommerce-select-control-0__control-input');
+	test.beforeEach( async ( { page } ) => {
+		await page.goto(
+			'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
+		);
+		await page.click( '#woocommerce-select-control-0__control-input' );
 		await page.fill(
 			'#woocommerce-select-control-0__control-input',
 			'United States (US) — California'
 		);
-		await page.click('button >> text=United States (US) — California');
-		await page.fill('#inspector-text-control-0', 'addr 1');
-		await page.fill('#inspector-text-control-1', '94107');
-		await page.fill('#inspector-text-control-2', 'San Francisco');
+		await page.click( 'button >> text=United States (US) — California' );
+		await page.fill( '#inspector-text-control-0', 'addr 1' );
+		await page.fill( '#inspector-text-control-1', '94107' );
+		await page.fill( '#inspector-text-control-2', 'San Francisco' );
 		await page.fill(
 			'#inspector-text-control-3',
 			storeDetails.us.store.email
 		);
-		await page.check('#inspector-checkbox-control-0');
-		await page.click('button >> text=Continue');
-		await page.click('button >> text=No thanks');
-		await page.click('button >> text=Continue');
-		await page.click('button >> text=Continue');
-		await page.click('button >> text=Continue');
+		await page.check( '#inspector-checkbox-control-0' );
+		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=No thanks' );
+		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=Continue' );
 		// Uncheck all business features
-		if (page.isChecked('.components-checkbox-control__input')) {
-			await page.click('.components-checkbox-control__input');
+		if ( page.isChecked( '.components-checkbox-control__input' ) ) {
+			await page.click( '.components-checkbox-control__input' );
 		}
-		await page.click('button >> text=Continue');
-		await page.click('button >> text=Continue with my active theme');
-		await page.waitForLoadState('networkidle'); // not autowaiting for form submission
-	});
+		await page.click( 'button >> text=Continue' );
+		await page.click( 'button >> text=Continue with my active theme' );
+		await page.waitForLoadState( 'networkidle' ); // not autowaiting for form submission
+	} );
 
-	test('can setup shipping', async ({ page }) => {
-		await page.goto('/wp-admin/admin.php?page=wc-admin');
-		await page.click('div >> text=Review Shipping Options');
+	test( 'can setup shipping', async ( { page } ) => {
+		await page.goto( '/wp-admin/admin.php?page=wc-admin' );
+		await page.click( 'div >> text=Review Shipping Options' );
 
 		// dismiss tourkit if visible
 		const tourkitVisible = await page
-			.locator('button.woocommerce-tour-kit-step-controls__close-btn')
+			.locator( 'button.woocommerce-tour-kit-step-controls__close-btn' )
 			.isVisible();
-		if (tourkitVisible) {
+		if ( tourkitVisible ) {
 			await page.click(
 				'button.woocommerce-tour-kit-step-controls__close-btn'
 			);
@@ -227,15 +238,15 @@ test.describe.skip('Store owner can go through setup Task List', () => {
 
 		// check for automatically added shipping zone
 		await expect(
-			page.locator('tr[data-id="1"] >> td.wc-shipping-zone-name > a')
-		).toContainText('United States (US)');
+			page.locator( 'tr[data-id="1"] >> td.wc-shipping-zone-name > a' )
+		).toContainText( 'United States (US)' );
 		await expect(
-			page.locator('tr[data-id="1"] >> td.wc-shipping-zone-region')
-		).toContainText('United States (US)');
+			page.locator( 'tr[data-id="1"] >> td.wc-shipping-zone-region' )
+		).toContainText( 'United States (US)' );
 		await expect(
 			page.locator(
 				'tr[data-id="1"] >> td.wc-shipping-zone-methods > div > ul > li'
 			)
-		).toContainText('Free shipping');
-	});
-});
+		).toContainText( 'Free shipping' );
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
@@ -72,19 +72,23 @@ test.describe( 'Analytics pages', () => {
 			await page.goto(
 				'wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview'
 			);
-			// check the top section (Performance)
-			await page.click(
-				'//button[@title="Choose which analytics to display and the section name"]'
-			);
+			// check the top section
+			await page
+				.locator( 'button.woocommerce-ellipsis-menu__toggle' )
+				.first()
+				.click();
 			await expect( page.locator( 'text=Move up' ) ).not.toBeVisible();
 			await expect( page.locator( 'text=Move down' ) ).toBeVisible();
+			await page.keyboard.press( 'Escape' );
 
-			// check the bottom section (Leaderboards)
-			await page.click(
-				'//button[@title="Choose which leaderboards to display and other settings"]'
-			);
+			// check the bottom section
+			await page
+				.locator( 'button.woocommerce-ellipsis-menu__toggle' )
+				.last()
+				.click();
 			await expect( page.locator( 'text=Move down' ) ).not.toBeVisible();
 			await expect( page.locator( 'text=Move up' ) ).toBeVisible();
+			await page.keyboard.press( 'Escape' );
 		} );
 
 		test( 'should allow a user to move a section down', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-coupon.spec.js
@@ -25,12 +25,17 @@ test.describe( 'Add New Coupon Page', () => {
 	} );
 
 	test( 'can create new coupon', async ( { page } ) => {
-		await page.goto( 'wp-admin/post-new.php?post_type=shop_coupon' );
+		await page.goto( 'wp-admin/post-new.php?post_type=shop_coupon', {
+			waitUntil: 'networkidle',
+		} );
+
 		await page.fill( '#title', couponCode );
+
 		await page.fill( '#woocommerce-coupon-description', 'test coupon' );
 
 		await page.fill( '#coupon_amount', '100' );
 
+		await expect( page.locator( '#publish:not(.disabled)' ) ).toBeVisible();
 		await page.click( '#publish' );
 
 		await expect( page.locator( 'div.notice.notice-success' ) ).toHaveText(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -10,6 +10,30 @@ const shippingZoneNameLocalPickup = 'Mayne Island with Local pickup';
 test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
+	test.beforeAll( async ( { baseURL } ) => {
+		// Set selling location to all countries.
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.put( 'settings/general/woocommerce_allowed_countries', {
+			value: 'all',
+		} );
+
+		// Delete all pre-existing shipping zones
+		const { data: zones } = await api.get( 'shipping/zones' );
+
+		const zoneIds = zones
+			.filter( ( { id } ) => id > 0 )
+			.map( ( { id } ) => id );
+
+		for ( const id of zoneIds ) {
+			await api.delete( `shipping/zones/${ id }`, { force: true } );
+		}
+	} );
+
 	test.afterAll( async ( { baseURL } ) => {
 		const api = new wcApi( {
 			url: baseURL,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-simple-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-simple-product.spec.js
@@ -4,7 +4,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const virtualProductName = 'Virtual Product Name';
 const nonVirtualProductName = 'Non Virtual Product Name';
 const productPrice = '9.99';
-let shippingZoneId;
+let shippingZoneId, virtualProductPermalink, nonVirtualProductPermalink;
 
 test.describe( 'Add New Simple Product Page', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
@@ -83,13 +83,22 @@ test.describe( 'Add New Simple Product Page', () => {
 		await expect( page.locator( 'div.notice-success > p' ) ).toContainText(
 			'Product published.'
 		);
+
+		virtualProductPermalink = await page
+			.locator( '#sample-permalink a' )
+			.getAttribute( 'href' );
 	} );
 
 	test( 'can have a shopper add the simple virtual product to the cart', async ( {
 		page,
 	} ) => {
-		await page.goto( 'shop/' );
-		await page.click( `h2:has-text("${ virtualProductName }")` );
+		await page.goto( virtualProductPermalink );
+		await expect( page.locator( '.product_title' ) ).toHaveText(
+			virtualProductName
+		);
+		await expect(
+			page.locator( '.summary .woocommerce-Price-amount' )
+		).toContainText( productPrice );
 		await page.click( 'text=Add to cart' );
 		await page.click( 'text=View cart' );
 		await expect( page.locator( 'td[data-title=Product]' ) ).toContainText(
@@ -105,6 +114,7 @@ test.describe( 'Add New Simple Product Page', () => {
 		await page.goto( 'wp-admin/post-new.php?post_type=product' );
 		await page.fill( '#title', nonVirtualProductName );
 		await page.fill( '#_regular_price', productPrice );
+		await expect( page.locator( '#publish:not(.disabled)' ) ).toBeVisible();
 		await page.click( '#publish' );
 		await page.waitForLoadState( 'networkidle' );
 
@@ -121,13 +131,22 @@ test.describe( 'Add New Simple Product Page', () => {
 		await expect( page.locator( 'div.notice-success > p' ) ).toContainText(
 			'Product published.'
 		);
+
+		nonVirtualProductPermalink = await page
+			.locator( '#sample-permalink a' )
+			.getAttribute( 'href' );
 	} );
 
 	test( 'can have a shopper add the simple non-virtual product to the cart', async ( {
 		page,
 	} ) => {
-		await page.goto( 'shop/' );
-		await page.click( `h2:has-text("${ nonVirtualProductName }")` );
+		await page.goto( nonVirtualProductPermalink );
+		await expect( page.locator( '.product_title' ) ).toHaveText(
+			nonVirtualProductName
+		);
+		await expect(
+			page.locator( '.summary .woocommerce-Price-amount' )
+		).toContainText( productPrice );
 		await page.click( 'text=Add to cart' );
 		await page.click( 'text=View cart' );
 		await expect( page.locator( 'td[data-title=Product]' ) ).toContainText(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -14,7 +14,7 @@ const defaultAttributes = [ 'val2', 'val1', 'val2' ];
 const stockAmount = '100';
 const lowStockAmount = '10';
 
-test.describe( 'Add New Variable Product Page', () => {
+test.describe.serial( 'Add New Variable Product Page', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.afterAll( async ( { baseURL } ) => {
@@ -101,10 +101,13 @@ test.describe( 'Add New Variable Product Page', () => {
 	} ) => {
 		await page.goto( 'wp-admin/edit.php?post_type=product' );
 		await page.locator( `a:has-text("${ variableProductName }")` ).click();
+		await page.waitForLoadState( 'networkidle' );
 		await page.click( 'a[href="#variable_product_options"]' );
 
 		// set the variation attributes
-		await page.click( 'div.variations-pagenav > span > a.expand_all' );
+		await page.click(
+			'#variable_product_options .toolbar-top a.expand_all'
+		);
 		await page.check( 'input[name="variable_is_virtual[0]"]' );
 		await page.fill(
 			'input[name="variable_regular_price[0]"]',
@@ -127,7 +130,9 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page.click( 'button.save-variation-changes' );
 
 		// bulk-edit variations
-		await page.click( 'div.variations-pagenav > span > a.expand_all' );
+		await page.click(
+			'#variable_product_options .toolbar-top a.expand_all'
+		);
 		for ( let i = 0; i < 8; i++ ) {
 			const checkBox = page.locator(
 				`input[name="variable_is_downloadable[${ i }]"]`
@@ -138,7 +143,9 @@ test.describe( 'Add New Variable Product Page', () => {
 			force: true,
 		} );
 		await page.click( 'a.do_variation_action' );
-		await page.click( 'div.variations-pagenav > span > a.expand_all' );
+		await page.click(
+			'#variable_product_options .toolbar-top a.expand_all'
+		);
 		for ( let i = 0; i < 8; i++ ) {
 			const checkBox = page.locator(
 				`input[name="variable_is_downloadable[${ i }]"]`
@@ -152,6 +159,7 @@ test.describe( 'Add New Variable Product Page', () => {
 	test( 'can delete all variations', async ( { page } ) => {
 		await page.goto( 'wp-admin/edit.php?post_type=product' );
 		await page.locator( `a:has-text("${ variableProductName }")` ).click();
+		await page.waitForLoadState( 'networkidle' );
 		await page.click( 'a[href="#variable_product_options"]' );
 		page.on( 'dialog', ( dialog ) => dialog.accept() );
 		await Promise.all( [
@@ -225,10 +233,14 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page
 			.locator( `a:has-text("${ manualVariableProduct }")` )
 			.click();
+		await page.waitForLoadState( 'networkidle' );
 		await page.click( 'a[href="#variable_product_options"]' );
+		await page.waitForLoadState( 'networkidle' );
 
 		// manage stock at variation level
-		await page.click( 'div.variations-pagenav > span > a.expand_all' );
+		await page.click(
+			'#variable_product_options .toolbar-top a.expand_all'
+		);
 		await page.check( 'input.checkbox.variable_manage_stock' );
 		await page.fill( 'input#variable_regular_price_0', variationOnePrice );
 		await expect(
@@ -240,7 +252,9 @@ test.describe( 'Add New Variable Product Page', () => {
 		} );
 		await page.fill( 'input#variable_low_stock_amount0', lowStockAmount );
 		await page.click( 'button.save-variation-changes' );
-		await page.click( 'div.variations-pagenav > span > a.expand_all' );
+		await page.click(
+			'#variable_product_options .toolbar-top a.expand_all'
+		);
 		await expect( page.locator( '#variable_stock0' ) ).toHaveValue(
 			stockAmount
 		);
@@ -257,6 +271,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page
 			.locator( `a:has-text("${ manualVariableProduct }")` )
 			.click();
+		await page.waitForLoadState( 'networkidle' );
 		await page.click( 'a[href="#variable_product_options"]' );
 
 		// set variation defaults
@@ -284,6 +299,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page
 			.locator( `a:has-text("${ manualVariableProduct }")` )
 			.click();
+		await page.waitForLoadState( 'networkidle' );
 		await page.click( 'a[href="#variable_product_options"]' );
 
 		// remove a variation

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -95,7 +95,39 @@ test.describe( 'Edit order > Downloadable product permissions', () => {
 		email: 'john.doe@example.com',
 	};
 
-	let orderId, productId, product2Id, noProductOrderId;
+	let orderId,
+		productId,
+		product2Id,
+		noProductOrderId,
+		initialGrantAccessAfterPaymentSetting;
+
+	/**
+	 * Enable the "Grant access to downloadable products after payment" setting in WooCommerce > Settings > Products > Downloadable products.
+	 */
+	const enableGrantAccessAfterPaymentSetting = async ( api ) => {
+		const endpoint =
+			'settings/products/woocommerce_downloads_grant_access_after_payment';
+
+		// Get current value
+		const response = await api.get( endpoint );
+		initialGrantAccessAfterPaymentSetting = response.data.value;
+
+		// Enable
+		if ( initialGrantAccessAfterPaymentSetting !== 'yes' ) {
+			await api.put( endpoint, {
+				value: 'yes',
+			} );
+		}
+	};
+
+	const revertGrantAccessAfterPaymentSetting = async ( api ) => {
+		const endpoint =
+			'settings/products/woocommerce_downloads_grant_access_after_payment';
+
+		await api.put( endpoint, {
+			value: initialGrantAccessAfterPaymentSetting,
+		} );
+	};
 
 	test.beforeEach( async ( { baseURL } ) => {
 		const api = new wcApi( {
@@ -113,13 +145,17 @@ test.describe( 'Edit order > Downloadable product permissions', () => {
 					{
 						id: uuid.v4(),
 						name: 'Single',
-						file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+						file:
+							'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
 					},
 				],
 			} )
 			.then( ( response ) => {
 				productId = response.data.id;
 			} );
+
+		await enableGrantAccessAfterPaymentSetting( api );
+
 		await api
 			.post( 'products', {
 				name: product2Name,
@@ -129,7 +165,8 @@ test.describe( 'Edit order > Downloadable product permissions', () => {
 					{
 						id: uuid.v4(),
 						name: 'Single',
-						file: 'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
+						file:
+							'https://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2017/08/single.jpg',
 					},
 				],
 			} )
@@ -171,6 +208,7 @@ test.describe( 'Edit order > Downloadable product permissions', () => {
 		await api.delete( `products/${ product2Id }`, { force: true } );
 		await api.delete( `orders/${ orderId }`, { force: true } );
 		await api.delete( `orders/${ noProductOrderId }`, { force: true } );
+		await revertGrantAccessAfterPaymentSetting( api );
 	} );
 
 	// these tests aren't completely independent.  Needs some refactoring.
@@ -229,18 +267,19 @@ test.describe( 'Edit order > Downloadable product permissions', () => {
 		// verify new downloadable product permission details
 		await expect(
 			page.locator(
-				'#woocommerce-order-downloads > div.inside > div > div.wc-metaboxes > div > h3 > strong >> nth=1'
+				'#woocommerce-order-downloads > div.inside > div > div.wc-metaboxes > div > h3 > strong',
+				{ hasText: product2Name }
 			)
-		).toContainText( product2Name );
+		).toBeVisible();
 
 		await expect(
 			page.locator(
-				'#woocommerce-order-downloads > div.inside > div > div.wc-metaboxes > div > table > tbody > tr > td:nth-child(1) > input.short >> nth=1'
+				'#woocommerce-order-downloads input[name^="downloads_remaining"] >> nth=-1'
 			)
 		).toHaveAttribute( 'placeholder', 'Unlimited' );
 		await expect(
 			page.locator(
-				'#woocommerce-order-downloads > div.inside > div > div.wc-metaboxes > div > table > tbody > tr > td:nth-child(2) > input.short >> nth=1'
+				'#woocommerce-order-downloads input[name^="access_expires"] >> nth=-1'
 			)
 		).toHaveAttribute( 'placeholder', 'Never' );
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
-const { ADMIN_USER_EMAIL } = process.env;
+const { admin } = require( '../../test-data/data' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 test.describe( 'Merchant > Order Action emails received', () => {
@@ -9,10 +9,6 @@ test.describe( 'Merchant > Order Action emails received', () => {
 		email: 'john.doe.merchant.test@example.com',
 	};
 
-	const adminEmail =
-		process.env.USE_WP_ENV === '1'
-			? 'wordpress@example.com'
-			: ADMIN_USER_EMAIL ?? 'admin@woocommercecoree2etestsuite.com';
 	const storeName = 'WooCommerce Core E2E Test Suite';
 	let orderId, newOrderId;
 
@@ -83,7 +79,7 @@ test.describe( 'Merchant > Order Action emails received', () => {
 		);
 		await expect(
 			page.locator( 'td.column-receiver >> nth=1' )
-		).toContainText( adminEmail );
+		).toContainText( admin.email );
 		await expect(
 			page.locator( 'td.column-subject >> nth=1' )
 		).toContainText( `[${ storeName }]: New order #${ newOrderId }` );
@@ -106,7 +102,7 @@ test.describe( 'Merchant > Order Action emails received', () => {
 			) }`
 		);
 		await expect( page.locator( 'td.column-receiver' ) ).toContainText(
-			adminEmail
+			admin.email
 		);
 		await expect( page.locator( 'td.column-subject' ) ).toContainText(
 			`[${ storeName }]: New order #${ orderId }`

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -66,6 +66,21 @@ for ( const currentPage of wcPages ) {
 						await page.waitForLoadState( 'networkidle' );
 						await page.goto( 'wp-admin/admin.php?page=wc-admin' );
 					}
+
+					// deal with cases where the 'Coupons' legacy menu had already been removed.
+					if ( currentPage.subpages[ i ].name === 'Coupons' ) {
+						const couponsMenuVisible = await page
+							.locator(
+								`li.wp-menu-open > ul.wp-submenu > li:has-text("${ currentPage.subpages[ i ].name }")`
+							)
+							.isVisible();
+
+						test.skip(
+							! couponsMenuVisible,
+							'Skipping this test because the legacy Coupons menu was not found and may have already been removed.'
+						);
+					}
+
 					await page.click(
 						`li.wp-menu-open > ul.wp-submenu > li:has-text("${ currentPage.subpages[ i ].name }")`,
 						{ waitForLoadState: 'networkidle' }

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-import-csv.spec.js
@@ -92,7 +92,7 @@ const productAttributes = [ 'Color', 'Size' ];
 const errorMessage =
 	'Invalid file type. The importer supports CSV and TXT file formats.';
 
-test.describe( 'Import Products from a CSV file', () => {
+test.describe.serial( 'Import Products from a CSV file', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-search.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/product-search.spec.js
@@ -2,7 +2,9 @@ const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
 let productId;
-const productName = 'Unique thing that we sell';
+const productName = `Unique thing that we sell ${ new Date()
+	.getTime()
+	.toString() }`;
 const productPrice = '9.99';
 
 test.describe( 'Products > Search and View a product', () => {
@@ -54,6 +56,8 @@ test.describe( 'Products > Search and View a product', () => {
 	} );
 
 	test( "can view a product's details after search", async ( { page } ) => {
+		const productIdInURL = new RegExp( `post=${ productId }` );
+
 		await page.goto( 'wp-admin/edit.php?post_type=product' );
 
 		await page.fill( '#post-search-input', productName );
@@ -61,6 +65,7 @@ test.describe( 'Products > Search and View a product', () => {
 
 		await page.click( '.row-title' );
 
+		await expect( page ).toHaveURL( productIdInURL );
 		await expect( page.locator( '#title' ) ).toHaveValue( productName );
 		await expect( page.locator( '#_regular_price' ) ).toHaveValue(
 			productPrice

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-general.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/settings-general.spec.js
@@ -11,7 +11,7 @@ test.describe( 'WooCommerce General Settings', () => {
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
 		} );
-		api.put( 'settings/general/woocommerce_allowed_countries', {
+		await api.put( 'settings/general/woocommerce_allowed_countries', {
 			value: 'all',
 		} );
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require( '@playwright/test' );
-const { customerDetails, storeDetails } = require( '../../test-data/data' );
+const { customer, storeDetails } = require( '../../test-data/data' );
 const { api } = require( '../../utils' );
 
 let productId, orderId;
@@ -10,7 +10,6 @@ const product = {
 	price: '42.77',
 };
 
-const customerEmail = 'order-email-test@example.com';
 const storeName = 'WooCommerce Core E2E Test Suite';
 
 test.describe( 'Shopper Order Email Receiving', () => {
@@ -24,7 +23,7 @@ test.describe( 'Shopper Order Email Receiving', () => {
 	test.beforeEach( async ( { page } ) => {
 		await page.goto(
 			`wp-admin/tools.php?page=wpml_plugin_log&s=${ encodeURIComponent(
-				customerEmail
+				customer.email
 			) }`
 		);
 		// clear out the email logs before each test
@@ -54,20 +53,23 @@ test.describe( 'Shopper Order Email Receiving', () => {
 
 		await page.goto( '/checkout/' );
 
-		await page.fill( '#billing_first_name', customerDetails.us.first_name );
-		await page.fill( '#billing_last_name', customerDetails.us.last_name );
-		await page.fill( '#billing_address_1', customerDetails.us.address );
-		await page.fill( '#billing_city', customerDetails.us.city );
+		await page.fill(
+			'#billing_first_name',
+			customer.billing.us.first_name
+		);
+		await page.fill( '#billing_last_name', customer.billing.us.last_name );
+		await page.fill( '#billing_address_1', customer.billing.us.address );
+		await page.fill( '#billing_city', customer.billing.us.city );
 		await page.selectOption(
 			'#billing_country',
-			customerDetails.us.country
+			customer.billing.us.country
 		);
 
-		await page.selectOption( '#billing_state', customerDetails.us.state );
+		await page.selectOption( '#billing_state', customer.billing.us.state );
 
-		await page.fill( '#billing_postcode', customerDetails.us.zip );
-		await page.fill( '#billing_phone', customerDetails.us.phone );
-		await page.fill( '#billing_email', customerEmail );
+		await page.fill( '#billing_postcode', customer.billing.us.zip );
+		await page.fill( '#billing_phone', customer.billing.us.phone );
+		await page.fill( '#billing_email', customer.email );
 
 		await page.click( 'text=Place order' );
 
@@ -81,13 +83,13 @@ test.describe( 'Shopper Order Email Receiving', () => {
 		// search to narrow it down to just the messages we want
 		await page.goto(
 			`wp-admin/tools.php?page=wpml_plugin_log&s=${ encodeURIComponent(
-				customerEmail
+				customer.email
 			) }`
 		);
 		await page.waitForLoadState( 'networkidle' );
 		await expect(
 			page.locator( 'td.column-receiver >> nth=0' )
-		).toContainText( customerEmail );
+		).toContainText( customer.email );
 		await expect(
 			page.locator( 'td.column-subject >> nth=1' )
 		).toContainText( `[${ storeName }]: New order #${ orderId }` );

--- a/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/update-woocommerce.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/update-woocommerce.spec.js
@@ -1,4 +1,5 @@
-const { ADMINSTATE, UPDATE_WC, ADMIN_USER, ADMIN_PASSWORD } = process.env;
+const { ADMINSTATE, UPDATE_WC } = process.env;
+const { admin } = require( '../../test-data/data' );
 const { test, expect } = require( '@playwright/test' );
 const path = require( 'path' );
 const {
@@ -7,115 +8,123 @@ const {
 	deleteZip,
 } = require( '../../utils/plugin-utils' );
 
-const pluginZipPath = path.resolve( __dirname, '../../tmp/woocommerce.zip' );
+let pluginZipPath;
 
-test.describe( 'WooCommerce plugin can be uploaded and activated', () => {
-	// Skip test if UPDATE_WC is falsy.
-	test.skip(
-		! Boolean( UPDATE_WC ),
-		`Skipping this test because UPDATE_WC is falsy: ${ UPDATE_WC }`
-	);
-
-	test.use( { storageState: ADMINSTATE } );
-
-	test.beforeAll( async () => {
-		// Download WooCommerce ZIP
-		await downloadZip( {
-			url:
-				'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip',
-			downloadPath: pluginZipPath,
-		} );
-	} );
-
-	test.afterAll( async () => {
-		// Clean up downloaded zip
-		await deleteZip( pluginZipPath );
-	} );
-
-	test( 'can upload and activate the WooCommerce plugin', async ( {
-		page,
-		playwright,
-		baseURL,
-	} ) => {
-		// Delete WooCommerce if it's installed.
-		await deletePlugin( {
-			request: playwright.request,
-			baseURL,
-			slug: 'woocommerce',
-			username: ADMIN_USER,
-			password: ADMIN_PASSWORD,
-		} );
-
-		// Open the plugin install page
-		await page.goto( 'wp-admin/plugin-install.php', {
-			waitUntil: 'networkidle',
-		} );
-
-		// Upload the plugin zip
-		await page.click( 'a.upload-view-toggle' );
-		await expect( page.locator( 'p.install-help' ) ).toBeVisible();
-		await expect( page.locator( 'p.install-help' ) ).toContainText(
-			'If you have a plugin in a .zip format, you may install or update it by uploading it here.'
-		);
-		const [ fileChooser ] = await Promise.all( [
-			page.waitForEvent( 'filechooser' ),
-			page.click( '#pluginzip' ),
-		] );
-		await fileChooser.setFiles( pluginZipPath );
-		await page.click( '#install-plugin-submit' );
-		await page.waitForLoadState( 'networkidle' );
-
-		// Activate the plugin
-		await page.click( '.button-primary' );
-		await page.waitForLoadState( 'networkidle' );
-
-		// Go to 'Installed plugins' page
-		await page.goto( 'wp-admin/plugins.php', {
-			waitUntil: 'networkidle',
-		} );
-
-		// Assert that 'WooCommerce' is listed and active
-		await expect(
-			page.locator( '.plugin-title strong', { hasText: /^WooCommerce$/ } )
-		).toBeVisible();
-		await expect( page.locator( '#deactivate-woocommerce' ) ).toBeVisible();
-	} );
-
-	test( 'can run the database update', async ( { page } ) => {
-		const updateButton = page.locator( 'text=Update WooCommerce Database' );
-		const updateCompleteMessage = page.locator(
-			'text=WooCommerce database update complete.'
-		);
-
-		// Navigate to 'Installed Plugins' page
-		await page.goto( 'wp-admin/plugins.php', {
-			waitUntil: 'networkidle',
-		} );
-
-		// Skip this test if the "Update WooCommerce Database" button didn't appear.
+test.describe.serial(
+	'WooCommerce plugin can be uploaded and activated',
+	() => {
+		// Skip test if UPDATE_WC is falsy.
 		test.skip(
-			! ( await updateButton.isVisible() ),
-			'The "Update WooCommerce Database" button did not appear after updating WooCommerce. Verify with the team if the WooCommerce version being tested does not really trigger a database update.'
+			! Boolean( UPDATE_WC ),
+			`Skipping this test because UPDATE_WC is falsy: ${ UPDATE_WC }`
 		);
 
-		// If the notice appears, start DB update
-		await updateButton.click();
-		await page.waitForLoadState( 'networkidle' );
+		test.use( { storageState: ADMINSTATE } );
 
-		// Repeatedly reload the Plugins page up to 10 times until the message "WooCommerce database update complete." appears.
-		for (
-			let reloads = 0;
-			reloads < 10 && ! ( await updateCompleteMessage.isVisible() );
-			reloads++
-		) {
+		test.beforeAll( async () => {
+			// Download WooCommerce ZIP
+			pluginZipPath = await downloadZip( {
+				url:
+					'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip',
+			} );
+		} );
+
+		test.afterAll( async () => {
+			// Clean up downloaded zip
+			await deleteZip( pluginZipPath );
+		} );
+
+		test( 'can upload and activate the WooCommerce plugin', async ( {
+			page,
+			playwright,
+			baseURL,
+		} ) => {
+			// Delete WooCommerce if it's installed.
+			await deletePlugin( {
+				request: playwright.request,
+				baseURL,
+				slug: 'woocommerce',
+				username: admin.username,
+				password: admin.password,
+			} );
+
+			// Open the plugin install page
+			await page.goto( 'wp-admin/plugin-install.php', {
+				waitUntil: 'networkidle',
+			} );
+
+			// Upload the plugin zip
+			await page.click( 'a.upload-view-toggle' );
+			await expect( page.locator( 'p.install-help' ) ).toBeVisible();
+			await expect( page.locator( 'p.install-help' ) ).toContainText(
+				'If you have a plugin in a .zip format, you may install or update it by uploading it here.'
+			);
+			const [ fileChooser ] = await Promise.all( [
+				page.waitForEvent( 'filechooser' ),
+				page.click( '#pluginzip' ),
+			] );
+			await fileChooser.setFiles( pluginZipPath );
+			await page.click( '#install-plugin-submit' );
+			await page.waitForLoadState( 'networkidle' );
+
+			// Activate the plugin
+			await page.click( '.button-primary' );
+			await page.waitForLoadState( 'networkidle' );
+
+			// Go to 'Installed plugins' page
 			await page.goto( 'wp-admin/plugins.php', {
 				waitUntil: 'networkidle',
 			} );
 
-			// Wait 10s before the next reload.
-			await page.waitForTimeout( 10000 );
-		}
+			// Assert that 'WooCommerce' is listed and active
+			await expect(
+				page.locator( '.plugin-title strong', {
+					hasText: /^WooCommerce$/,
+				} )
+			).toBeVisible();
+			await expect(
+				page.locator( '#deactivate-woocommerce' )
+			).toBeVisible();
+		} );
 
-		await expect( updateCompleteMessage ).toBeVisible();
-	} );
-} );
+		test( 'can run the database update', async ( { page } ) => {
+			const updateButton = page.locator(
+				'text=Update WooCommerce Database'
+			);
+			const updateCompleteMessage = page.locator(
+				'text=WooCommerce database update complete.'
+			);
+
+			// Navigate to 'Installed Plugins' page
+			await page.goto( 'wp-admin/plugins.php', {
+				waitUntil: 'networkidle',
+			} );
+
+			// Skip this test if the "Update WooCommerce Database" button didn't appear.
+			test.skip(
+				! ( await updateButton.isVisible() ),
+				'The "Update WooCommerce Database" button did not appear after updating WooCommerce. Verify with the team if the WooCommerce version being tested does not really trigger a database update.'
+			);
+
+			// If the notice appears, start DB update
+			await updateButton.click();
+			await page.waitForLoadState( 'networkidle' );
+
+			// Repeatedly reload the Plugins page up to 10 times until the message "WooCommerce database update complete." appears.
+			for (
+				let reloads = 0;
+				reloads < 10 && ! ( await updateCompleteMessage.isVisible() );
+				reloads++
+			) {
+				await page.goto( 'wp-admin/plugins.php', {
+					waitUntil: 'networkidle',
+				} );
+
+				// Wait 10s before the next reload.
+				await page.waitForTimeout( 10000 );
+			}
+
+			await expect( updateCompleteMessage ).toBeVisible();
+		} );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
@@ -1,91 +1,56 @@
 const {
 	ADMINSTATE,
-	ADMIN_USER,
-	ADMIN_PASSWORD,
 	GITHUB_TOKEN,
 	PLUGIN_NAME,
 	PLUGIN_REPOSITORY,
 } = process.env;
 const { test, expect } = require( '@playwright/test' );
+const { admin } = require( '../../test-data/data' );
 const path = require( 'path' );
 const {
-	createPlugin,
 	deletePlugin,
-	downloadZip,
 	deleteZip,
-	getLatestReleaseZipUrl,
+	downloadZip,
+	installPluginThruWpCli,
 } = require( '../../utils/plugin-utils' );
 
-const adminUsername = ADMIN_USER ?? 'admin';
-const adminPassword = ADMIN_PASSWORD ?? 'password';
-
-let pluginZipPath;
+let pluginPath;
 let pluginSlug;
 
 test.describe( `${ PLUGIN_NAME } plugin can be uploaded and activated`, () => {
-	// Skip test if PLUGIN_REPOSITORY is falsy.
 	test.skip(
 		! PLUGIN_REPOSITORY,
-		`Skipping this test because value of PLUGIN_REPOSITORY was falsy: ${ PLUGIN_REPOSITORY }`
+		`SKIPPED: PLUGIN_REPOSITORY is falsy: ${ PLUGIN_REPOSITORY }`
 	);
 
 	test.use( { storageState: ADMINSTATE } );
 
-	test.beforeAll( async () => {
-		pluginSlug = PLUGIN_REPOSITORY.split( '/' ).pop();
+	test.beforeAll( async ( { playwright, baseURL } ) => {
+		pluginSlug = path.basename( PLUGIN_REPOSITORY );
 
-		// Get the download URL and filename of the plugin
-		const pluginDownloadURL = await getLatestReleaseZipUrl( {
+		// Download plugin.
+		pluginPath = await downloadZip( {
 			repository: PLUGIN_REPOSITORY,
 			authorizationToken: GITHUB_TOKEN,
 		} );
-		const zipFilename = pluginDownloadURL.split( '/' ).pop();
-		pluginZipPath = path.resolve( __dirname, `../../tmp/${ zipFilename }` );
 
-		// Download the needed plugin.
-		await downloadZip( {
-			url: pluginDownloadURL,
-			downloadPath: pluginZipPath,
-			authToken: GITHUB_TOKEN,
+		// Delete plugin from test site if it's installed.
+		await deletePlugin( {
+			request: playwright.request,
+			baseURL,
+			slug: pluginSlug,
+			username: admin.username,
+			password: admin.password,
 		} );
 	} );
 
-	test.afterAll( async ( { baseURL, playwright } ) => {
+	test.afterAll( async ( {} ) => {
 		// Delete the downloaded zip.
-		await deleteZip( pluginZipPath );
-
-		// Delete the plugin from the test site.
-		await deletePlugin( {
-			request: playwright.request,
-			baseURL,
-			slug: pluginSlug,
-			username: adminUsername,
-			password: adminPassword,
-		} );
+		await deleteZip( pluginPath );
 	} );
 
-	test( `can upload and activate ${ PLUGIN_NAME }`, async ( {
-		page,
-		playwright,
-		baseURL,
-	} ) => {
-		// Delete the plugin if it's installed.
-		await deletePlugin( {
-			request: playwright.request,
-			baseURL,
-			slug: pluginSlug,
-			username: adminUsername,
-			password: adminPassword,
-		} );
-
-		// Install and activate plugin
-		await createPlugin( {
-			request: playwright.request,
-			baseURL,
-			slug: pluginSlug.split( '/' ).pop(),
-			username: adminUsername,
-			password: adminPassword,
-		} );
+	test( `can upload and activate ${ PLUGIN_NAME }`, async ( { page } ) => {
+		await installPluginThruWpCli( pluginPath );
 
 		// Go to 'Installed plugins' page.
 		// Repeat in case the newly installed plugin redirects to their own onboarding screen upon first install, like what Yoast SEO does.

--- a/plugins/woocommerce/tests/e2e-pw/utils/onboarding.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/onboarding.js
@@ -1,9 +1,12 @@
 const { expect } = require( '@playwright/test' );
 
 const STORE_DETAILS_URL = 'wp-admin/admin.php?page=wc-admin&path=/setup-wizard';
-const INDUSTRY_DETAILS_URL = 'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry';
-const PRODUCT_TYPES_URL = 'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types';
-const BUSIENSS_DETAILS_URL = 'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details';
+const INDUSTRY_DETAILS_URL =
+	'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry';
+const PRODUCT_TYPES_URL =
+	'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types';
+const BUSIENSS_DETAILS_URL =
+	'wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details';
 
 const onboarding = {
 	completeStoreDetailsSection: async ( page, store ) => {
@@ -46,7 +49,7 @@ const onboarding = {
 		const numCheckboxes = await page.$$(
 			'.components-checkbox-control__input'
 		);
-		expect( numCheckboxes.length === expectedIndustries ).toBeTruthy();
+		expect( numCheckboxes ).toHaveLength( expectedIndustries );
 		// Uncheck any currently checked industries
 		for ( let i = 0; i < expectedIndustries; i++ ) {
 			const currentCheck = `#inspector-checkbox-control-${ i }`;
@@ -72,7 +75,7 @@ const onboarding = {
 		const numCheckboxes = await page.$$(
 			'.components-checkbox-control__input'
 		);
-		expect( numCheckboxes.length === expectedProductTypes ).toBeTruthy();
+		expect( numCheckboxes ).toHaveLength( expectedProductTypes );
 		// Uncheck any currently checked products
 		for ( let i = 0; i < expectedProductTypes; i++ ) {
 			const currentCheck = `#inspector-checkbox-control-${ i }`;

--- a/plugins/woocommerce/tests/e2e-pw/utils/plugin-utils.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/plugin-utils.js
@@ -2,6 +2,8 @@ const { APIRequest } = require( '@playwright/test' );
 const axios = require( 'axios' ).default;
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { promisify } = require( 'util' );
+const execAsync = promisify( require( 'child_process' ).exec );
 
 /**
  * Encode basic auth username and password to be used in HTTP Authorization header.
@@ -52,15 +54,38 @@ export const deletePlugin = async ( {
 	// If installed, get its `plugin` value and use it to deactivate and delete it.
 	if ( pluginToDelete ) {
 		const { plugin } = pluginToDelete;
+		const requestURL = `/wp-json/wp/v2/plugins/${ plugin }`;
+		let response;
 
-		await apiContext.put( `/wp-json/wp/v2/plugins/${ plugin }`, {
+		// Some plugins do not respond to some of the WP REST API endpoints like Contact Form 7.
+		// Print warning in such cases.
+		const warn = async ( response, warningMsg ) => {
+			console.warn( warningMsg );
+			console.warn(
+				`Response status: ${ response.status() } ${ response.statusText() }`
+			);
+			console.warn( `Response body:` );
+			console.warn( await response.json() );
+			console.warn( '\n' );
+		};
+
+		response = await apiContext.put( requestURL, {
 			data: { status: 'inactive' },
-			failOnStatusCode: true,
 		} );
+		if ( ! response.ok() ) {
+			await warn(
+				response,
+				`WARNING: Failed to deactivate plugin ${ plugin }`
+			);
+		}
 
-		await apiContext.delete( `/wp-json/wp/v2/plugins/${ plugin }`, {
-			failOnStatusCode: true,
-		} );
+		response = await apiContext.delete( requestURL );
+		if ( ! response.ok() ) {
+			await warn(
+				response,
+				`WARNING: Failed to delete plugin ${ plugin }`
+			);
+		}
 	}
 };
 
@@ -68,31 +93,62 @@ export const deletePlugin = async ( {
  * Download the zip file from a remote location.
  *
  * @param {object} param
- * @param {string} param.url The URL where the zip file is located.
- * @param {string} param.downloadPath The location where to download the zip to.
- * @param {string} param.authToken Authorization token used to authenticate with the GitHub API if required.
+ * @param {string} param.url
+ * @param {string} param.repository
+ * @param {string} param.authorizationToken
+ * @param {boolean} param.prerelease
+ * @param {string} param.downloadDir
+ *
+ * @param {string} url The URL where the zip file is located. Takes precedence over `repository`.
+ * @param {string} repository The repository owner and name. For example: `woocommerce/woocommerce`. Ignored when `url` was given.
+ * @param {string} authorizationToken Authorization token used to authenticate with the GitHub API if required.
+ * @param {boolean} prerelease Flag on whether to get a prelease or not. Default `false`.
+ * @param {string} downloadDir Relative path to the download directory. Non-existing folders will be auto-created. Defaults to `tmp` under current working directory.
+ *
+ * @return {string} Absolute path to the downloaded zip.
  */
-export const downloadZip = async ( { url, downloadPath, authToken } ) => {
+export const downloadZip = async ( {
+	url,
+	repository,
+	authorizationToken,
+	prerelease = false,
+	downloadDir = 'tmp',
+} ) => {
+	let zipFilename = path.basename( url || repository );
+	zipFilename = zipFilename.endsWith( '.zip' )
+		? zipFilename
+		: zipFilename.concat( '.zip' );
+	const zipFilePath = path.resolve( downloadDir, zipFilename );
+
+	let response;
+
 	// Create destination folder.
-	const dir = path.dirname( downloadPath );
-	fs.mkdirSync( dir, { recursive: true } );
+	fs.mkdirSync( downloadDir, { recursive: true } );
+
+	const downloadURL =
+		url ??
+		( await getLatestReleaseZipUrl( {
+			repository,
+			authorizationToken,
+			prerelease,
+		} ) );
 
 	// Download the zip.
 	const options = {
-		url,
+		method: 'get',
+		url: downloadURL,
 		responseType: 'stream',
 		headers: {
-			'user-agent': 'node.js',
+			Authorization: authorizationToken
+				? `token ${ authorizationToken }`
+				: '',
+			Accept: 'application/octet-stream',
 		},
 	};
+	response = await axios( options );
+	response.data.pipe( fs.createWriteStream( zipFilePath ) );
 
-	// If provided with a token, use it for authorization
-	if ( authToken ) {
-		options.headers.Authorization = `token ${ authToken }`;
-	}
-
-	const response = await axios( options );
-	response.data.pipe( fs.createWriteStream( downloadPath ) );
+	return zipFilePath;
 };
 
 /**
@@ -109,7 +165,7 @@ export const deleteZip = async ( zipFilePath ) => {
 };
 
 /**
- * Get the download URL of the latest release zip for a plugin using GitHub's {@link https://docs.github.com/en/rest/releases/releases Releases API}.
+ * Get the download URL of the latest release zip for a plugin using GitHub API.
  *
  * @param {{repository: string, authorizationToken: string, prerelease: boolean, perPage: number}} param
  * @param {string} repository The repository owner and name. For example: `woocommerce/woocommerce`.
@@ -124,73 +180,100 @@ export const getLatestReleaseZipUrl = async ( {
 	prerelease = false,
 	perPage = 3,
 } ) => {
+	let release;
+
 	const requesturl = prerelease
 		? `https://api.github.com/repos/${ repository }/releases?per_page=${ perPage }`
 		: `https://api.github.com/repos/${ repository }/releases/latest`;
 
 	const options = {
+		method: 'get',
 		url: requesturl,
-		headers: { 'user-agent': 'node.js' },
+		headers: {
+			Authorization: authorizationToken
+				? `token ${ authorizationToken }`
+				: '',
+		},
 	};
 
-	// If provided with a token, use it for authorization
-	if ( authorizationToken ) {
-		options.headers.Authorization = `token ${ authorizationToken }`;
+	// Get the first prerelease, or the latest release.
+	let response;
+	try {
+		response = await axios( options );
+	} catch ( error ) {
+		let errorMessage =
+			'Something went wrong when downloading the plugin.\n';
+
+		if ( error.response ) {
+			// The request was made and the server responded with a status code
+			// that falls out of the range of 2xx
+			errorMessage = errorMessage.concat(
+				`Response status: ${ error.response.status } ${ error.response.statusText }`,
+				'\n',
+				`Response body:`,
+				'\n',
+				JSON.stringify( error.response.data, null, 2 ),
+				'\n'
+			);
+		} else if ( error.request ) {
+			// The request was made but no response was received
+			// `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+			// http.ClientRequest in node.js
+			errorMessage = errorMessage.concat(
+				JSON.stringify( error.request, null, 2 ),
+				'\n'
+			);
+		} else {
+			// Something happened in setting up the request that triggered an Error
+			errorMessage = errorMessage.concat( error.toJSON(), '\n' );
+		}
+
+		throw new Error( errorMessage );
 	}
 
-	// Call the List releases API endpoint in GitHub
-	const response = await axios( options );
-	const body = response.data;
+	release = prerelease
+		? response.data.find( ( { prerelease } ) => prerelease )
+		: response.data;
 
-	// If it's a prerelease, find the first one and return its download URL.
-	if ( prerelease ) {
-		const latestPrerelease = body.find( ( { prerelease } ) => prerelease );
-
-		return latestPrerelease.assets[ 0 ].browser_download_url;
-	} else if ( authorizationToken ) {
-		// If it's a private repo, we need to download the archive this way.
-		// Use uploaded assets over downloading the zip archive.
-		if (
-			body.assets &&
-			body.assets.length > 0 &&
-			body.assets[ 0 ].browser_download_url
-		) {
-			return body.assets[ 0 ].browser_download_url;
-		} else {
-			const tagName = body.tag_name;
-			return `https://github.com/${ repository }/archive/${ tagName }.zip`;
-		}
+	// If response contains assets, return URL of first asset.
+	// Otherwise, return the github.com URL from the tag name.
+	const { assets } = release;
+	if ( assets && assets.length ) {
+		return assets[ 0 ].url;
 	} else {
-		return body.assets[ 0 ].browser_download_url;
+		const tagName = release.tag_name;
+		return `https://github.com/${ repository }/archive/${ tagName }.zip`;
 	}
 };
 
 /**
- * Use the {@link https://developer.wordpress.org/rest-api/reference/plugins/#create-a-plugin Create plugin endpoint} to install and activate a plugin.
+ * Install a plugin using WP CLI within a WP ENV environment.
+ * This is a workaround to the "The uploaded file exceeds the upload_max_filesize directive in php.ini" error encountered when uploading a plugin to the local WP Env E2E environment through the UI.
  *
- * @param {object} params
- * @param {APIRequest} params.request
- * @param {string} params.baseURL
- * @param {string} params.slug
- * @param {string} params.username
- * @param {string} params.password
+ * @see https://github.com/WordPress/gutenberg/issues/29430
+ *
+ * @param {string} pluginPath
  */
-export const createPlugin = async ( {
-	request,
-	baseURL,
-	slug,
-	username,
-	password,
-} ) => {
-	const apiContext = await request.newContext( {
-		baseURL,
-		extraHTTPHeaders: {
-			Authorization: `Basic ${ encodeCredentials( username, password ) }`,
-		},
-	} );
+export const installPluginThruWpCli = async ( pluginPath ) => {
+	const runWpCliCommand = async ( command ) => {
+		const { stdout, stderr } = await execAsync(
+			`pnpm exec wp-env run tests-cli "${ command }"`
+		);
 
-	await apiContext.post( '/wp-json/wp/v2/plugins', {
-		data: { slug, status: 'active' },
-		failOnStatusCode: true,
-	} );
+		console.log( stdout );
+		console.error( stderr );
+	};
+
+	const wpEnvPluginPath = pluginPath.replace(
+		/.*\/plugins\/woocommerce/,
+		'wp-content/plugins/woocommerce'
+	);
+
+	await runWpCliCommand( `ls  ${ wpEnvPluginPath }` );
+
+	await runWpCliCommand(
+		`wp plugin install --activate --force ${ wpEnvPluginPath }`
+	);
+
+	await runWpCliCommand( `wp plugin list` );
 };


### PR DESCRIPTION
### All Submissions:

- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, our E2E tests have a 100% passing rate on PR's where they're run against localhost. However, our E2E tests fail when they're run against our nightly smoke test site due to causes like:

- hardcoded values like login credentials, assertions, and other kinds of test data that are only valid on localhost
- timeouts due to slower performance of our nightly smoke test site compared to a local testing environment
- some pages and menu items in the nightly smoke test site looking a bit differently from localhost
- the fact that our nightly smoke test site is not in a pristine state. It doesn't have the default settings anymore, and it most often contains leftover products, orders, and other items from previous test runs

This pull request therefore aims to make our E2E tests pass on the nightly smoke test site. Additionally, it aims to run the E2E tests on `trunk` with certain plugins just like what we used to do on the Puppeteer tests previously.

Note to PR reviewer:

1. I placed PR comments on certain parts of the code to hopefully help with the review.
1. This PR runs all E2E tests except for the `shopper` ones. Shopper tests will be addressed on a separate PR soon.
1. The job `API tests on nightly build` currently passes just because only the `hello.test.js` test was being run.

Closes https://github.com/woocommerce/woocommerce-quality/issues/418.

### How to test the changes in this Pull Request:

1. Navigate to the [Smoke test daily](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml) workflow runs page.
2. In the "Run workflow" dropdown, select this branch (`e2e/daily-playwright-2`), then click "Run workflow".
3. Refresh the page, and click on the in-progress "Smoke test daily" run.
4. Wait for the workflow to finish. You should see all tests pass like so:
   <img width="1004" alt="ZwAQJbELXU" src="https://user-images.githubusercontent.com/4509348/200018533-dbaba51c-38ac-487e-a044-ed0dd22d707f.png">
5. Rerun the workflow if it had any failures. Occasionally, a few tests fail due to very weird reasons like:
   - the login page doesn't load at all for some reason despite the retries
   - `E2E_GH_TOKEN` wasn't being accepted for some reason
6. Scroll down the summary page of the workflow run. You should see:
   - Test report artifacts
   - "Smoke tests on trunk" job summary
      <img width="661" alt="aaHepaR2Pi" src="https://user-images.githubusercontent.com/4509348/200018623-6bd06b2a-b344-42be-b22c-2e48137def9d.png">

7. In the "Smoke tests on trunk" job summary, click on each of the links at the footer to verify if you're correctly taken to the API and E2E Allure reports, and to the WooCommerce Test Reports Dashboard.
8. Go to [`#woo-test-reports-daily`](https://a8c.slack.com/archives/C03H038EV2R) and notice that the E2E test stats are not TBC anymore. They now show actual numbers:
   <img width="463" alt="rKVYvefjYX" src="https://user-images.githubusercontent.com/4509348/200018755-6d78f748-dcc3-4015-af9f-a6038ba4a38a.png">

9. Click on the 'View full E2E report' button. You should be taken to the "Daily E2E Smoke Test Report".

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

- [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
