### PR TITLE
7.1 Final Prep

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo
 Tags: online store, ecommerce, shop, shopping cart, storefront, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce, e-commerce, store, sales, sell, woo, cart
 Requires at least: 5.8
 Tested up to: 6.1
-Requires PHP: 7.2
+Requires PHP: 7.4
 Stable tag: 7.1.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
This PR updates the required PHP version to 7.4 in prep for the release of 7.1.

I didn't make this change in trunk and then cherry-pick it into the release branch, as the `readme.txt` file isn't really synced in trunk. We should update it there as part of the post-release process of updating the stable tag there, etc.