### PR TITLE
[HPOS] Move hook `woocommerce_before_delete_order` before `woocommerce_before_delete_order`

### DIFF
--- a/plugins/woocommerce/changelog/fix-35516-hpos-delete-order-hook
+++ b/plugins/woocommerce/changelog/fix-35516-hpos-delete-order-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Move HPOS hook woocommerce_before_delete_order before deleting order.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1732,13 +1732,6 @@ FROM $order_meta_table
 		}
 
 		if ( ! empty( $args['force_delete'] ) ) {
-			$this->delete_order_data_from_custom_order_tables( $order_id );
-			$order->set_id( 0 );
-
-			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
-			if ( ! is_a( $order->get_data_store(), self::class ) ) {
-				return;
-			}
 
 			/**
 			 * Fires immediately before an order is deleted from the database.
@@ -1749,6 +1742,14 @@ FROM $order_meta_table
 			 * @param WC_Order $order    Instance of the order that is about to be deleted.
 			 */
 			do_action( 'woocommerce_before_delete_order', $order_id, $order );
+
+			$this->delete_order_data_from_custom_order_tables( $order_id );
+			$order->set_id( 0 );
+
+			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
+			if ( ! is_a( $order->get_data_store(), self::class ) ) {
+				return;
+			}
 
 			// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
 			// Once we stop creating posts for orders, we should do the cleanup here instead.


### PR DESCRIPTION
Hook `woocommerce_before_delete_order` is moved before `woocommerce_before_delete_order`

These fire immediately before an (HPOS) order is deleted or trashed, and act as analogs to `delete_post` and `wp_trash_post` in the case of CPT objects.

Closes #35516.

### How to test the changes in this Pull Request:

It should be sufficient to review the code, there are no functional differences (since there is no code within core that uses the action).
