### PR TITLE
Remove the global wc-cart-fragments enqueue

### DIFF
--- a/plugins/woocommerce/changelog/update-cart-fragments-enqueue
+++ b/plugins/woocommerce/changelog/update-cart-fragments-enqueue
@@ -1,4 +1,4 @@
 Significance: minor
 Type: performance
 
-Removed global enqueue of wc-cart-fragments. Moved to the cart widget (it's main consumer).
+Removed global enqueue of wc-cart-fragments. Moved to the cart widget (its main consumer).

--- a/plugins/woocommerce/changelog/update-cart-fragments-enqueue
+++ b/plugins/woocommerce/changelog/update-cart-fragments-enqueue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Removed global enqueue of wc-cart-fragments. Moved to the cart widget (it's main consumer).

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -430,7 +430,6 @@ class WC_Frontend_Scripts {
 
 		// Global frontend scripts.
 		self::enqueue_script( 'woocommerce' );
-		self::enqueue_script( 'wc-cart-fragments' );
 
 		// CSS Styles.
 		$enqueue_styles = self::get_styles();

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -56,6 +56,8 @@ class WC_Widget_Cart extends WC_Widget {
 			return;
 		}
 
+		wp_enqueue_script( 'wc-cart-fragments' );
+
 		$hide_if_empty = empty( $instance['hide_if_empty'] ) ? 0 : 1;
 
 		if ( ! isset( $instance['title'] ) ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

`wc-cart-fragments` allows statically rendered elements to be updated when a product is added to the cart. It does this with an additional AJAX call to the `get_refreshed_fragments` endpoint. This does create a performance issue where extra requests are made to the server to support it.

There are several articles on the web detailing how this is a problem and recommending to dequeue it [1], as well as workarounds which replace the functionality entirely [2].

Given that the main consumer of this functionality is the **Cart Widget**, and that the Cart Widget is being superseded by the **Mini Cart Block**, I propose we remove this from the global enqueues and move it to the Cart Widget only, so the widget can continue to use fragments, but other pages in the store do not need to load the script.

This was proposed here: https://github.com/woocommerce/woocommerce-blocks/issues/7168

We plan on removing support for fragments in WooCommerce Blocks, and potentially dequeuing it completely in the interim.

- [1] https://wpengine.com/support/how-to-disable-cart-fragments-for-woocommerce/
- [2] https://wpengine.com/blog/solving-cart-fragment-dilemma-introducing-live-cart/

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. With the patch applied, and with no widgets setup, visit the shop page.
2. View the page source and confirm the `cart-fragments.js` script is not loaded.
3. Add the cart widget to a sidebar in the theme. 
4. View the page source and confirm the `cart-fragments.js` script is loaded.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
