### PR TITLE
FSE: Fix icon fonts not being loaded in the Site Editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-35495-site-editor-icons
+++ b/plugins/woocommerce/changelog/fix-35495-site-editor-icons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix WooCommerce icons not loading in the site editor. 

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -2,6 +2,7 @@
 * woocommerce-blocktheme.scss
 * Block theme default styles to ensure WooCommerce looks better out of the box with block themes that are not optimised for WooCommerce specifically.
 */
+@import "fonts";
 @import "variables";
 
 /**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -56,7 +56,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			if ( $screen && $screen->is_block_editor() ) {
 				wp_register_style( 'woocommerce-general', WC()->plugin_url() . '/assets/css/woocommerce.css', array(), $version );
+				wp_register_style( 'woocommerce-blocktheme', WC()->plugin_url() . '/assets/css/woocommerce-blocktheme.css', array(), $version );
 				wp_style_add_data( 'woocommerce-general', 'rtl', 'replace' );
+				wp_style_add_data( 'woocommerce-blocktheme', 'rtl', 'replace' );
+				wp_enqueue_style( 'woocommerce-blocktheme' );
 			}
 
 			// Sitewide menu CSS.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -56,10 +56,12 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 			if ( $screen && $screen->is_block_editor() ) {
 				wp_register_style( 'woocommerce-general', WC()->plugin_url() . '/assets/css/woocommerce.css', array(), $version );
-				wp_register_style( 'woocommerce-blocktheme', WC()->plugin_url() . '/assets/css/woocommerce-blocktheme.css', array(), $version );
 				wp_style_add_data( 'woocommerce-general', 'rtl', 'replace' );
-				wp_style_add_data( 'woocommerce-blocktheme', 'rtl', 'replace' );
-				wp_enqueue_style( 'woocommerce-blocktheme' );
+				if ( wc_current_theme_is_fse_theme() ) {
+					wp_register_style( 'woocommerce-blocktheme', WC()->plugin_url() . '/assets/css/woocommerce-blocktheme.css', array(), $version );
+					wp_style_add_data( 'woocommerce-blocktheme', 'rtl', 'replace' );
+					wp_enqueue_style( 'woocommerce-blocktheme' );
+				}
 			}
 
 			// Sitewide menu CSS.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WooCommerce loads icon fonts on the frontend, but doesn't in FSE, resulting in broken icons in the Site Editor. This PR ensures the fonts get loaded in the Site Editor.

- woocommerce/assets/fonts/star.woff
- woocommerce/assets/fonts/WooCommerce.woff

Closes #35495

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Enable **WooCommerce** and **WooCommerce Blocks**.
2. Enable a block theme, and make sure you have some products with ratings.
3. Add the **All Products** block in the Site Editor.
4. Confirm that the 'Rating Star' icon is loading and the same goes for the '1 in cart' icon.

### Screenshots
|Before|After|
|-|-|
|![before-4](https://user-images.githubusercontent.com/905781/200891049-b6d92290-44db-49f4-8602-3dbb67d4de89.jpg)| ![after-4](https://user-images.githubusercontent.com/905781/200891110-a8ca438e-0824-4fda-958e-ba7f83b9ec09.jpg)|

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
