### PR TITLE
Image Gallery: Update toolbar position and tooltips

### DIFF
--- a/packages/js/components/changelog/fix-product-images-toolbar-positioning
+++ b/packages/js/components/changelog/fix-product-images-toolbar-positioning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Updated image gallery toolbar position and tooltips.

--- a/packages/js/components/src/image-gallery/image-gallery-toolbar.scss
+++ b/packages/js/components/src/image-gallery/image-gallery-toolbar.scss
@@ -3,5 +3,6 @@
 	top: -58px;
 	left: 50%;
 	transform: translateX(-50%);
+	z-index: 1000;
 	background-color: white;
 }

--- a/packages/js/components/src/image-gallery/image-gallery-toolbar.scss
+++ b/packages/js/components/src/image-gallery/image-gallery-toolbar.scss
@@ -1,6 +1,6 @@
 .woocommerce-image-gallery__toolbar {
 	position: absolute;
-	top: -50px;
+	top: -58px;
 	left: 50%;
 	transform: translateX(-50%);
 	background-color: white;

--- a/packages/js/components/src/image-gallery/image-gallery-toolbar.tsx
+++ b/packages/js/components/src/image-gallery/image-gallery-toolbar.tsx
@@ -64,7 +64,7 @@ export const ImageGalleryToolbar: React.FC< ImageGalleryToolbarProps > = ( {
 							icon={ () => (
 								<SortableHandle itemIndex={ childIndex } />
 							) }
-							label={ __( 'Drag', 'woocommerce' ) }
+							label={ __( 'Drag to reorder', 'woocommerce' ) }
 						/>
 						<ToolbarButton
 							disabled={ childIndex < 2 }
@@ -85,7 +85,7 @@ export const ImageGalleryToolbar: React.FC< ImageGalleryToolbarProps > = ( {
 						<ToolbarButton
 							onClick={ () => setAsCoverImage( childIndex ) }
 							icon={ CoverImageIcon }
-							label={ __( 'Set as cover image', 'woocommerce' ) }
+							label={ __( 'Set as cover', 'woocommerce' ) }
 						/>
 					</ToolbarGroup>
 				) }
@@ -106,7 +106,7 @@ export const ImageGalleryToolbar: React.FC< ImageGalleryToolbarProps > = ( {
 					<ToolbarButton
 						onClick={ () => removeItem( childIndex ) }
 						icon={ trash }
-						label={ __( 'Delete', 'woocommerce' ) }
+						label={ __( 'Remove', 'woocommerce' ) }
 					/>
 				</ToolbarGroup>
 			</Toolbar>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The position of the toolbar has been adjusted to provide an `8px` margin between the toolbar and the image. The z-index of the toolbar has also been updated to prevent the tooltips from appears behind images.

The toolbar tooltips have also been updated:
- The drag handle tooltip says `Drag to reorder`
- The left arrow icon tooltip says `Move previous`
- The right arrow icon tooltip says `Move next`
- The cover icon tooltip says `Set as cover`
- The trash icon tooltip says `Remove`

Closes #35182
Closes #35184

#### Before

<img width="704" alt="Screenshot 2022-11-09 at 22 37 42" src="https://user-images.githubusercontent.com/2098816/200957259-8896178f-0b4d-476a-af48-2425d993bc7f.png">

- Note the lack of margin between the image and the toolbar
- Note the lack of the "Remove" tooltip... it is hiding behind the next image

#### After

<img width="704" alt="Screenshot 2022-11-09 at 22 16 50" src="https://user-images.githubusercontent.com/2098816/200956963-a92492dc-e0d1-40df-82ce-3d22963d33b0.png">

- Note the margin between the image and the toolbar
- Note the "Remove" tooltip appears properly

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products` > `Add new (MVP)`
2. Add a few images to the image gallery
3. Verify that the toolbar appears properly, along with the tooltips

Note: If the image gallery is tested in Storybook, it will not show the tooltips in the correct location, as we are still dependent on an older version of `@wordpress/components` when not running in WordPress (where we use whatever version of `@wordpress/components` it supplies; WordPress 6.1 supplies a version that fixes the tooltip positioning issue).

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
