### PR TITLE
Azerbaijani Manat Currency Sign Update | AZN - ₼

### DIFF
--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -673,7 +673,7 @@ function get_woocommerce_currency_symbols() {
 			'ARS' => '&#36;',
 			'AUD' => '&#36;',
 			'AWG' => 'Afl.',
-			'AZN' => 'AZN',
+			'AZN' => '.&#x20BC;.&#8380;',
 			'BAM' => 'KM',
 			'BBD' => '&#36;',
 			'BDT' => '&#2547;&nbsp;',


### PR DESCRIPTION
Azerbaijan Currency Symbol

Manat Sign : ₼ 
ISO code: AZN

&#x20BC; HEX CODE
&#8380; HTML CODE
