### PR TITLE
Update woocommerce-blocks to 8.9.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.9.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.9.1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Comment: Update WooCommerce Blocks to 8.9.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.9.0"
+		"woocommerce/woocommerce-blocks": "8.9.1"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ba153cfcffe43c11a5c994e21a822bb",
+    "content-hash": "1e2e56ecdb3eb102d32d989551d76fa8",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.9.0",
+            "version": "v8.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "9ed8e59f2f78a2bd0198750ed314590802d8f3d5"
+                "reference": "47f482575c0c76751319c3900f51523b16ca21ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/9ed8e59f2f78a2bd0198750ed314590802d8f3d5",
-                "reference": "9ed8e59f2f78a2bd0198750ed314590802d8f3d5",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/47f482575c0c76751319c3900f51523b16ca21ff",
+                "reference": "47f482575c0c76751319c3900f51523b16ca21ff",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.9.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.9.1"
             },
-            "time": "2022-11-08T11:37:31+00:00"
+            "time": "2022-11-14T08:56:26+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.9.1. It includes changes from WooCommerce Blocks 8.9.1 and is intended to target WooCommerce 7.2 for release.
Details from all the different releases included in this pull:

## Blocks 8.9.1

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7670)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/891.md)

### Changelog entry
The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Display correct block template when filtering by attribute. ([7640](https://github.com/woocommerce/woocommerce-blocks/pull/7640))

### Changelog entry

> Dev - Update WooCommerce Blocks version to 8.9.1
