### PR TITLE
Update readme.txt

### DIFF
--- a/plugins/woocommerce/changelog/Timstreep-patch-1
+++ b/plugins/woocommerce/changelog/Timstreep-patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update the list of tags for WC plugin on .org

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
-Tags: online store, ecommerce, shop, shopping cart, storefront, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce, e-commerce, store, sales, sell, woo, cart
+Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
 Requires at least: 5.8
 Tested up to: 6.0
 Requires PHP: 7.2


### PR DESCRIPTION
Proposed change includes reducing the number of tags to 12 to be in line with guidelines detailed here: https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/
