### PR TITLE
Add breadcrumbs to new product management experience

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-breadcrumbs.scss
+++ b/plugins/woocommerce-admin/client/products/product-breadcrumbs.scss
@@ -1,0 +1,22 @@
+.woocommerce-product-breadcrumbs {
+    display: flex;
+    align-items: center;
+}
+
+.woocommerce-product-breadcrumbs__item {
+    font-weight: 400;
+    a {
+        color: $gray-700;
+        text-decoration: none;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+.woocommerce-product-breadcrumbs__separator {
+    display: inline-flex;
+    path {
+        fill: $gray-700;
+    }
+}

--- a/plugins/woocommerce-admin/client/products/product-breadcrumbs.scss
+++ b/plugins/woocommerce-admin/client/products/product-breadcrumbs.scss
@@ -5,6 +5,8 @@
 
 .woocommerce-product-breadcrumbs__item {
     font-weight: 400;
+    color: $gray-700;
+
     a {
         color: $gray-700;
         text-decoration: none;

--- a/plugins/woocommerce-admin/client/products/product-breadcrumbs.scss
+++ b/plugins/woocommerce-admin/client/products/product-breadcrumbs.scss
@@ -1,24 +1,24 @@
 .woocommerce-product-breadcrumbs {
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 .woocommerce-product-breadcrumbs__item {
-    font-weight: 400;
-    color: $gray-700;
+	font-weight: 400;
+	color: $gray-700;
 
-    a {
-        color: $gray-700;
-        text-decoration: none;
-        &:hover {
-            text-decoration: underline;
-        }
-    }
+	a {
+		color: $gray-700;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
+	}
 }
 
 .woocommerce-product-breadcrumbs__separator {
-    display: inline-flex;
-    path {
-        fill: $gray-700;
-    }
+	display: inline-flex;
+	path {
+		fill: $gray-700;
+	}
 }

--- a/plugins/woocommerce-admin/client/products/product-breadcrumbs.tsx
+++ b/plugins/woocommerce-admin/client/products/product-breadcrumbs.tsx
@@ -9,27 +9,42 @@ import { Link } from '@woocommerce/components';
  */
 import './product-breadcrumbs.scss';
 
-type BreadCrumb = {
-	href: string;
-	title: string;
+type Breadcrumb = {
+	href?: string;
+	title: string | JSX.Element;
 	type?: 'wp-admin' | 'wc-admin';
 };
 
 export const ProductBreadcrumbs = ( {
 	breadcrumbs,
 }: {
-	breadcrumbs: BreadCrumb[];
+	breadcrumbs: Breadcrumb[];
 } ) => {
+	const visibleBreadcrumbs =
+		breadcrumbs.length > 3
+			? [
+					breadcrumbs[ 0 ],
+					{
+						title: <>&hellip;</>,
+					},
+					breadcrumbs[ breadcrumbs.length - 1 ],
+			  ]
+			: breadcrumbs;
+
 	return (
 		<span className="woocommerce-product-breadcrumbs">
-			{ breadcrumbs.map( ( breadcrumb ) => {
+			{ visibleBreadcrumbs.map( ( breadcrumb ) => {
 				const { href, title, type } = breadcrumb;
 				return (
 					<>
 						<span className="woocommerce-product-breadcrumbs__item">
-							<Link href={ href } type={ type || 'wp-admin' }>
-								{ title }
-							</Link>
+							{ href ? (
+								<Link href={ href } type={ type || 'wp-admin' }>
+									{ title }
+								</Link>
+							) : (
+								title
+							) }
 						</span>
 						<span className="woocommerce-product-breadcrumbs__separator">
 							<Icon icon={ chevronRightSmall } />

--- a/plugins/woocommerce-admin/client/products/product-breadcrumbs.tsx
+++ b/plugins/woocommerce-admin/client/products/product-breadcrumbs.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { chevronRightSmall, Icon } from '@wordpress/icons';
+import { Fragment } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 
 /**
@@ -36,7 +37,7 @@ export const ProductBreadcrumbs = ( {
 			{ visibleBreadcrumbs.map( ( breadcrumb ) => {
 				const { href, title, type } = breadcrumb;
 				return (
-					<>
+					<Fragment key={ href }>
 						<span className="woocommerce-product-breadcrumbs__item">
 							{ href ? (
 								<Link href={ href } type={ type || 'wp-admin' }>
@@ -49,7 +50,7 @@ export const ProductBreadcrumbs = ( {
 						<span className="woocommerce-product-breadcrumbs__separator">
 							<Icon icon={ chevronRightSmall } />
 						</span>
-					</>
+					</Fragment>
 				);
 			} ) }
 		</span>

--- a/plugins/woocommerce-admin/client/products/product-breadcrumbs.tsx
+++ b/plugins/woocommerce-admin/client/products/product-breadcrumbs.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { chevronRightSmall, Icon } from '@wordpress/icons';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import './product-breadcrumbs.scss';
+
+type BreadCrumb = {
+	href: string;
+	title: string;
+	type?: 'wp-admin' | 'wc-admin';
+};
+
+export const ProductBreadcrumbs = ( {
+	breadcrumbs,
+}: {
+	breadcrumbs: BreadCrumb[];
+} ) => {
+	return (
+		<span className="woocommerce-product-breadcrumbs">
+			{ breadcrumbs.map( ( breadcrumb ) => {
+				const { href, title, type } = breadcrumb;
+				return (
+					<>
+						<span className="woocommerce-product-breadcrumbs__item">
+							<Link href={ href } type={ type || 'wp-admin' }>
+								{ title }
+							</Link>
+						</span>
+						<span className="woocommerce-product-breadcrumbs__separator">
+							<Icon icon={ chevronRightSmall } />
+						</span>
+					</>
+				);
+			} ) }
+		</span>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/product-title.tsx
+++ b/plugins/woocommerce-admin/client/products/product-title.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { getAdminLink } from '@woocommerce/settings';
 import {
 	Product,
 	PRODUCTS_STORE_NAME,
@@ -15,6 +16,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getProductTitle } from './utils/get-product-title';
+import { ProductBreadcrumbs } from './product-breadcrumbs';
 import { ProductStatusBadge } from './product-status-badge';
 import { WooHeaderPageTitle } from '~/header/utils';
 
@@ -34,10 +36,17 @@ export const ProductTitle: React.FC = () => {
 		};
 	} );
 
+	const breadcrumbs = [
+		{
+			href: getAdminLink( 'edit.php?post_type=product' ),
+			title: __( 'Products', 'woocommerce' ),
+		},
+	];
 	const title = getProductTitle( values.name, values.type, persistedName );
 
 	return (
 		<WooHeaderPageTitle>
+			<ProductBreadcrumbs breadcrumbs={ breadcrumbs } />
 			{ title }
 			<ProductStatusBadge />
 		</WooHeaderPageTitle>

--- a/plugins/woocommerce-admin/client/products/test/product-breadcrumbs.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-breadcrumbs.spec.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ProductBreadcrumbs } from '../product-breadcrumbs';
+
+describe( 'ProductBreadcrumbs', () => {
+	it( 'should render a breadcrumb', () => {
+		const { getByText } = render(
+			<ProductBreadcrumbs
+				breadcrumbs={ [
+					{
+						href: '/test-url',
+						title: 'Test breadcrumb',
+					},
+				] }
+			/>
+		);
+		const breadcrumb = getByText( 'Test breadcrumb' ) as HTMLAnchorElement;
+		expect( breadcrumb ).toBeInTheDocument();
+		expect( breadcrumb.href ).toBe( 'http://localhost/test-url' );
+	} );
+
+	it( 'should render multiple breadcrumbs', () => {
+		const { getByText } = render(
+			<ProductBreadcrumbs
+				breadcrumbs={ [
+					{
+						href: '/test-url',
+						title: 'Breadcrumb 1',
+					},
+					{
+						href: '/test-url',
+						title: 'Breadcrumb 2',
+					},
+				] }
+			/>
+		);
+		expect( getByText( 'Breadcrumb 1' ) ).toBeInTheDocument();
+		expect( getByText( 'Breadcrumb 2' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should truncate breadcrumbs when more than 3 exist', () => {
+		const { getByText, queryByText } = render(
+			<ProductBreadcrumbs
+				breadcrumbs={ [
+					{
+						href: '/test-url',
+						title: 'Breadcrumb 1',
+					},
+					{
+						href: '/test-url',
+						title: 'Breadcrumb 2',
+					},
+					{
+						href: '/test-url',
+						title: 'Breadcrumb 3',
+					},
+					{
+						href: '/test-url',
+						title: 'Breadcrumb 4',
+					},
+				] }
+			/>
+		);
+		expect( getByText( 'Breadcrumb 1' ) ).toBeInTheDocument();
+		expect( queryByText( 'Breadcrumb 2' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'Breadcrumb 3' ) ).not.toBeInTheDocument();
+		expect( getByText( 'Breadcrumb 4' ) ).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/changelog/add-35170
+++ b/plugins/woocommerce/changelog/add-35170
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new product management breadcrumbs to header


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds breadcrumbs to the header of the new product management experience.


<img width="246" alt="Screen Shot 2022-11-15 at 12 07 03 PM" src="https://user-images.githubusercontent.com/10561050/202016790-c7efee4c-e357-4649-b55b-90c3b06db127.png">
<img width="348" alt="Screen Shot 2022-11-15 at 12 05 27 PM" src="https://user-images.githubusercontent.com/10561050/202016792-a27a25bb-77c0-4279-8e06-10db44422fe1.png">

Closes #35170 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product management experience ("Products -> Add new (MVP)")
2. Note the breadcrumbs in the header next to the title
3. Currently, breadcrumbs should always be `Products > {product_name}` or `Products > New product`
4. Clicking on the breadcrumb should navigate to the product page
5. Hovering the breadcrumb should show an underline

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
