### PR TITLE
Fix custom_orders_table_usage_is_enabled returning true when HPOS feature is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-35527
+++ b/plugins/woocommerce/changelog/fix-35527
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+CustomOrdersTableController::custom_orders_table_usage_is_enabled returns now false if the HPOS feature is disabled

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -171,7 +171,7 @@ class CustomOrdersTableController {
 	 * @return bool True if the custom orders table usage is enabled
 	 */
 	public function custom_orders_table_usage_is_enabled(): bool {
-		return get_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) === 'yes';
+		return $this->is_feature_visible() && get_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) === 'yes';
 	}
 
 	/**
@@ -205,7 +205,7 @@ class CustomOrdersTableController {
 	 * @return \WC_Object_Data_Store_Interface|string The actual data store to use.
 	 */
 	private function get_data_store_instance( $default_data_store, string $type ) {
-		if ( $this->is_feature_visible() && $this->custom_orders_table_usage_is_enabled() ) {
+		if ( $this->custom_orders_table_usage_is_enabled() ) {
 			switch ( $type ) {
 				case 'order_refund':
 					return $this->refund_data_store;


### PR DESCRIPTION
-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the HPOS feature is disabled `CustomOrdersTableController::custom_orders_table_usage_is_enabled` (and the corresponding proxy method in `OrderUtil`) will now return false even if the orders table was authoritative when the feature was disabled (and thus the `woocommerce_custom_orders_table_enabled` option is still `yes`).

Closes #35527.
- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Enable the HPOS feature (WooCommerce - Settings - Advanced - Features), sort out any pending orders sync if needed (`wp wc cot sync`), then enable the orders table as authoritative (WooCommerce - Settings - Advanced - Custom data stores).
2. Run the following, you should get "1": `wp eval 'echo(Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled());'`
3. With the orders table still being authoritative disable the HPOS feature.
4. Run the `wp` command again. Without the fix you still get `1`, with the fix you get nothing.
5. Enable the HPOS feature again and verify that the orders table is still authoritative and that the `wp` command returns "1" again.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
