### PR TITLE
array_key_exists shall not be called on non array

### DIFF
--- a/plugins/woocommerce/changelog/fix-35513
+++ b/plugins/woocommerce/changelog/fix-35513
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix call of array_key_exists in SSR.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-options.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-options.php
@@ -51,7 +51,7 @@ class WC_Helper_Options {
 	 */
 	public static function get( $key, $default = false ) {
 		$options = get_option( self::$option_name, array() );
-		if ( array_key_exists( $key, $options ) ) {
+		if ( is_array( $options ) && array_key_exists( $key, $options ) ) {
 			return $options[ $key ];
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -10,6 +10,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper;
 /**
  * System status controller class.
  *
@@ -1235,13 +1236,6 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			$product_visibility_terms[ $term->slug ] = strtolower( $term->name );
 		}
 
-		// Check if WooCommerce.com account is connected.
-		$woo_com_connected = 'no';
-		$helper_options    = get_option( 'woocommerce_helper_data', array() );
-		if ( array_key_exists( 'auth', $helper_options ) && ! empty( $helper_options['auth'] ) ) {
-			$woo_com_connected = 'yes';
-		}
-
 		// Return array of useful settings for debugging.
 		return array(
 			'api_enabled'               => 'yes' === get_option( 'woocommerce_api_enabled' ),
@@ -1255,7 +1249,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			'geolocation_enabled'       => in_array( get_option( 'woocommerce_default_customer_address' ), array( 'geolocation_ajax', 'geolocation' ), true ),
 			'taxonomies'                => $term_response,
 			'product_visibility_terms'  => $product_visibility_terms,
-			'woocommerce_com_connected' => $woo_com_connected,
+			'woocommerce_com_connected' => ConnectionHelper::is_connected() ? 'yes' : 'no',
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/WCCom/ConnectionHelper.php
+++ b/plugins/woocommerce/src/Internal/WCCom/ConnectionHelper.php
@@ -21,7 +21,7 @@ final class ConnectionHelper {
 	 */
 	public static function is_connected() {
 		$helper_options    = get_option( 'woocommerce_helper_data', array() );
-		if ( array_key_exists( 'auth', $helper_options ) && ! empty( $helper_options['auth'] ) ) {
+		if ( is_array( $helper_options ) && array_key_exists( 'auth', $helper_options ) && ! empty( $helper_options['auth'] ) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35513 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

The following should be tested with WC.com connection a) not yet initiated, b) connected, c) disconnected.

1. On a testing site with WC, use PHP 8
2. Insert a snippet that acts as if the option was set to false (if it was set in the database, the data type would be a string, so apparently, something else filters this option in this specific issue, but the error would be almost the same)
```
add_filter( 'default_option_woocommerce_helper_data', '__return_false' );
add_filter( "option_woocommerce_helper_data", '__return_false' );
```
4. Upon activation of the snippet, the site will become broken
5. Go to WP-cli and disable the snippet plugin (or remove the snippet from the file/location you put it)
6. Apply this branch and try to activate the snippet again, nothing should break.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
