### PR TITLE
Fix the `wcadmin_product_update` Tracks event `menu_order` custom property value

### DIFF
--- a/plugins/woocommerce/changelog/fix-tracks_product_update_menu_order
+++ b/plugins/woocommerce/changelog/fix-tracks_product_update_menu_order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Corrected the `wcadmin_product_update` Tracks event `menu_order` property value.
+
+

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -153,7 +153,7 @@ class WC_Products_Tracking {
 					if ( ! isBlockEditor ) {
 						tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
 						if ( $( '#content' ).is( ':visible' ) ) {
-							description_value = $( '#content' ).val();	
+							description_value = $( '#content' ).val();
 						} else if ( typeof tinymce === 'object' && tinymce.get( 'content' ) ) {
 							description_value = tinymce.get( 'content' ).getContent();
 						}
@@ -171,7 +171,7 @@ class WC_Products_Tracking {
 						is_block_editor:		isBlockEditor,
 						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
 						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
-						menu_order:				$( '#menu_order' ).val() ? 'Yes' : 'No',
+						menu_order:				parseInt( $( '#menu_order' ).val(), 10 ) !== 0 ? 'Yes' : 'No',
 						product_gallery:		$( '#product_images_container .product_images > li' ).length,
 						product_image:			$( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
 						product_type:			$( '#product-type' ).val(),


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35392 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a new store with Tracks enabled
2. Create a product without changing the menu order
3. Update the product without changing the menu order
4. Confirm that the `menu_order` prop of the `wcadmin_product_update` Tracks event was set as `No`
5. Update the product, changing the menu order to something other than `0`
6. Confirm that the `menu_order` prop of the `wcadmin_product_update` Tracks event was set as `Yes`

Note: To check the Tracks event, you can filter network requests to `t.gif` and inspect the query params on those requests.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
