### PR TITLE
Deploy the stacked layout in the Products Task experiment

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { loadExperimentAssignment } from '@woocommerce/explat';
 
 type Layout = 'control' | 'card' | 'stacked';
 

--- a/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/experimental-products/use-product-layout-experiment.ts
@@ -7,20 +7,8 @@ import { loadExperimentAssignment } from '@woocommerce/explat';
 type Layout = 'control' | 'card' | 'stacked';
 
 export const getProductLayoutExperiment = async (): Promise< Layout > => {
-	const [ cardAssignment, stackedAssignment ] = await Promise.all( [
-		loadExperimentAssignment( `woocommerce_products_task_layout_card_v3` ),
-		loadExperimentAssignment(
-			`woocommerce_products_task_layout_stacked_v3`
-		),
-	] );
-	// This logic may look flawed as in both looks like they can be assigned treatment at the same time,
-	// but in backend we segment the experiments by store country, so it will never be.
-	if ( cardAssignment?.variationName === 'treatment' ) {
-		return 'card';
-	} else if ( stackedAssignment?.variationName === 'treatment' ) {
-		return 'stacked';
-	}
-	return 'control';
+	// Deploy the stacked layout. Todo: cleanup the experiment code.
+	return 'stacked';
 };
 
 export const isProductTaskExperimentTreatment =

--- a/plugins/woocommerce/changelog/fix-deploy-stacked-products-task
+++ b/plugins/woocommerce/changelog/fix-deploy-stacked-products-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update products task list UI


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Deploys the stacked layout in the Products Task experiment. 

This is a quick change in time for the 7.2 code freeze to deploy the stacked layout in the Products Task experiment by always returning it as the chosen layout. A follow-up PR will be made to cleanup the experiment code completely.

![Screen Shot 2022-11-17 at 16 14 33](https://user-images.githubusercontent.com/9312929/202392369-f4eb646b-f603-4737-b2ca-505796b15b6b.png)

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

On a new install,
1. Click "Add Products" from the task list.
2. See that the new stacked layout screen is shown (compare to screenshot above).
3. Check the accordion functionality works by clicking "View more product types".
4. Click the "Physical product" list item.
5. See that the "New Product " screen is shown and is pre-filled to a "simple product" type.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
