### PR TITLE
Introduce woocommerce_order_applied_coupon hook

### DIFF
--- a/plugins/woocommerce/changelog/34473-coupon-applied-to-order
+++ b/plugins/woocommerce/changelog/34473-coupon-applied-to-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add the woocommerce_order_applied_coupon hook

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1211,6 +1211,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 		}
 
+		/**
+		 * woocommerce_order_applied_coupon action hook.
+		 * 
+		 * @param  WC_Coupon $coupon The applied coupon object.
+		 * @param  WC_Order  $order  The current order object.
+		 */
+		do_action( 'woocommerce_order_applied_coupon', $coupon, $this );
+
 		$this->set_coupon_discount_amounts( $discounts );
 		$this->save();
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1212,10 +1212,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		/**
-		 * woocommerce_order_applied_coupon action hook.
-		 * 
+		 * Action to signal that a coupon has been applied to an order.
+		 *
 		 * @param  WC_Coupon $coupon The applied coupon object.
 		 * @param  WC_Order  $order  The current order object.
+		 *
+		 * @since 7.2
 		 */
 		do_action( 'woocommerce_order_applied_coupon', $coupon, $this );
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1217,7 +1217,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		 * @param  WC_Coupon $coupon The applied coupon object.
 		 * @param  WC_Order  $order  The current order object.
 		 *
-		 * @since 7.2
+		 * @since 7.3
 		 */
 		do_action( 'woocommerce_order_applied_coupon', $coupon, $this );
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add hook for applying coupon to an order. Provides parity with `apply_coupon()` in cart class.

This is a duplicate of #34475, which got "broken" in a rebase.

Closes #34473.

### How to test the changes in this Pull Request:

Run this snippet:

```
/**
 * When a coupon is added to an order, add a product.
 * 
 * @param WC_Coupon $coupon
 * @param WC_Order $order
 */
function test_apply_coupon_to_order( $coupon, $order ) {

    $test_product_id = 99; // Adjust to suit.
    
    $test_product = wc_get_product( $test_product_id );
    
    if ( $test_product instanceof WC_Product && $test_product->is_purchasable() ) {
        $order->add_product( $test_product, 1, array( 'total' => 0 ) );
    }
}
add_action( 'woocommerce_order_applied_coupon', 'test_apply_coupon_to_order', 10, 2 );
```

Then create a new order, and add a coupon. Product 99 should now be added to the order (adjust 99 to any simple product ID you have)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you successfully run tests with your changes locally?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.