### PR TITLE
Add support for the `Product by attribute` template

### DIFF
--- a/plugins/woocommerce/changelog/support-product-attribute-blocks-template
+++ b/plugins/woocommerce/changelog/support-product-attribute-blocks-template
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add support for product attribute taxonomy blocks template
+Add support for product attribute taxonomy template

--- a/plugins/woocommerce/changelog/support-product-attribute-blocks-template
+++ b/plugins/woocommerce/changelog/support-product-attribute-blocks-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add support for product attribute taxonomy blocks template

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -103,13 +103,13 @@ class WC_Template_Loader {
 	/**
 	 * Checks whether a block template for a given taxonomy exists.
 	 *
-	 * **Note: ** This checks both the `templates` and `block-templates` directories
+	 * **Note:** This checks both the `templates` and `block-templates` directories
 	 * as both conventions should be supported.
 	 *
 	 * @param object $taxonomy Object taxonomy to check.
 	 * @return boolean
 	 */
-	private static function taxonomy_has_block_template( $taxonomy ) {
+	private static function taxonomy_has_block_template( $taxonomy ) : bool {
 		if ( taxonomy_is_product_attribute( $taxonomy->taxonomy ) ) {
 			$template_name = 'taxonomy-product_attribute';
 		} else {

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -101,6 +101,25 @@ class WC_Template_Loader {
 	}
 
 	/**
+	 * Checks whether a block template for a given taxonomy exists.
+	 *
+	 * **Note: ** This checks both the `templates` and `block-templates` directories
+	 * as both conventions should be supported.
+	 *
+	 * @param object $taxonomy Object taxonomy to check.
+	 * @return boolean
+	 */
+	private static function taxonomy_has_block_template( $taxonomy ) {
+		if ( taxonomy_is_product_attribute($taxonomy->taxonomy) ) {
+			$template_name = 'taxonomy-product_attribute';
+		} else {
+			$template_name = 'taxonomy-'.$taxonomy->taxonomy;
+		}
+
+		return self::has_block_template($template_name);
+	}
+
+	/**
 	 * Checks whether a block template with that name exists.
 	 *
 	 * **Note: ** This checks both the `templates` and `block-templates` directories
@@ -171,10 +190,12 @@ class WC_Template_Loader {
 		} elseif ( is_product_taxonomy() ) {
 			$object = get_queried_object();
 
-			if ( self::has_block_template( 'taxonomy-' . $object->taxonomy ) ) {
+			if ( self::taxonomy_has_block_template( $object ) ) {
 				$default_file = '';
 			} else {
-				if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
+				if (taxonomy_is_product_attribute( $object->taxonomy )) {
+					$default_file = 'taxonomy-product-attribute.php';
+				} elseif ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 					$default_file = 'taxonomy-' . $object->taxonomy . '.php';
 				} elseif ( ! self::has_block_template( 'archive-product' ) ) {
 					$default_file = 'archive-product.php';
@@ -229,19 +250,25 @@ class WC_Template_Loader {
 		if ( is_product_taxonomy() ) {
 			$object = get_queried_object();
 
-			$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-			$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
-			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
-
-			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-				$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
-				$cs_default  = str_replace( '_', '-', $default_file );
+			if ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
+				$templates[] = 'taxonomy-product_attribute.php';
+				$templates[] = WC()->template_path() . 'taxonomy-product_attribute.php';
+				$templates[] = $default_file;
+			} else {
 				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
 				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
-				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
-				$templates[] = $cs_default;
+				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
+
+				if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
+					$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
+					$cs_default  = str_replace( '_', '-', $default_file );
+					$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+					$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
+					$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
+					$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
+					$templates[] = $cs_default;
+				}
 			}
 		}
 

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -193,7 +193,7 @@ class WC_Template_Loader {
 			if ( self::taxonomy_has_block_template( $object ) ) {
 				$default_file = '';
 			} else {
-				if (taxonomy_is_product_attribute( $object->taxonomy )) {
+				if ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
 					$default_file = 'taxonomy-product-attribute.php';
 				} elseif ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 					$default_file = 'taxonomy-' . $object->taxonomy . '.php';

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -110,13 +110,13 @@ class WC_Template_Loader {
 	 * @return boolean
 	 */
 	private static function taxonomy_has_block_template( $taxonomy ) {
-		if ( taxonomy_is_product_attribute($taxonomy->taxonomy) ) {
+		if ( taxonomy_is_product_attribute( $taxonomy->taxonomy ) ) {
 			$template_name = 'taxonomy-product_attribute';
 		} else {
-			$template_name = 'taxonomy-'.$taxonomy->taxonomy;
+			$template_name = 'taxonomy-' . $taxonomy->taxonomy;
 		}
 
-		return self::has_block_template($template_name);
+		return self::has_block_template( $template_name );
 	}
 
 	/**

--- a/plugins/woocommerce/templates/taxonomy-product-attribute.php
+++ b/plugins/woocommerce/templates/taxonomy-product-attribute.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     4.7.0
+ * @version     7.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/taxonomy-product-attribute.php
+++ b/plugins/woocommerce/templates/taxonomy-product-attribute.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * The Template for displaying products in a product attribute. Simply includes the archive template
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product-attribute.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce\Templates
+ * @version     4.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+wc_get_template( 'archive-product.php' );

--- a/plugins/woocommerce/templates/taxonomy-product-attribute.php
+++ b/plugins/woocommerce/templates/taxonomy-product-attribute.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     7.2.0
+ * @version     7.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/taxonomy-product-cat.php
+++ b/plugins/woocommerce/templates/taxonomy-product-cat.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     7.2.0
+ * @version     4.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/templates/taxonomy-product-cat.php
+++ b/plugins/woocommerce/templates/taxonomy-product-cat.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     4.7.0
+ * @version     7.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -33,9 +33,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-tag' );
 
 		// Check Woo Taxonomy Product Attribute
-		$wp_taxonomies['pa_color'] = new WP_Taxonomy( 'pa_color', 'product' );
-		$wc_product_attributes['pa_color'] = '';
-		$this->load_tax_in_query( 'pa_color' );
+		$this->load_product_attribute_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-attribute' );
 
 		// Check Custom Product Taxonomies
@@ -70,9 +68,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName();
 
 		// Check Woo Taxonomy Product Attribute
-		$wp_taxonomies['pa_color']         = new WP_Taxonomy( 'pa_color', 'product' );
-		$wc_product_attributes['pa_color'] = '';
-		$this->load_tax_in_query( 'pa_color' );
+		$this->load_product_attribute_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName();
 
 		// Check Custom Product Taxonomies
@@ -136,6 +132,14 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 			'taxonomy' => $taxonomy,
 			'slug'     => 'test',
 		);
+	}
+
+	private function load_product_attribute_tax_in_query( $taxonomy ) {
+		global $wp_taxonomies, $wc_product_attributes;
+		$wp_taxonomies[$taxonomy] = new WP_Taxonomy( $taxonomy, 'product' );
+		$wc_product_attributes[$taxonomy] = '';
+
+		$this->load_tax_in_query( $taxonomy );
 	}
 
 	private function assertDefaultTemplateFileName( $expected = '' ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -14,7 +14,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	public function test_wc_template_loader_loads_default_file_without_blocks() {
 
-		global $wp_taxonomies;
+		global $wp_taxonomies, $wc_product_attributes;
 
 		$this->initialize_template_loader();
 
@@ -33,7 +33,9 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-tag' );
 
 		// Check Woo Taxonomy Product Attribute
-		$this->load_tax_in_query( 'product_attribute' );
+		$wp_taxonomies['pa_color'] = new WP_Taxonomy( 'pa_color', 'product' );
+		$wc_product_attributes['pa_color'] = '';
+		$this->load_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-attribute' );
 
 		// Check Custom Product Taxonomies
@@ -49,7 +51,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	public function test_wc_template_loader_loads_template_with_blocks() {
 
-		global $wp_taxonomies;
+		global $wp_taxonomies, $wc_product_attributes;
 
 		$this->initialize_template_loader();
 
@@ -65,6 +67,12 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName();
 
 		$this->load_tax_in_query( 'product_tag' );
+		$this->assertDefaultTemplateFileName();
+
+		// Check Woo Taxonomy Product Attribute
+		$wp_taxonomies['pa_color'] = new WP_Taxonomy( 'pa_color', 'product' );
+		$wc_product_attributes['pa_color'] = '';
+		$this->load_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName();
 
 		// Check Custom Product Taxonomies

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -122,6 +122,13 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Loads a test taxonomy with the given name.
+	 *
+	 * @param string $taxonomy Taxonomy name
+	 *
+	 * @return void
+	 */
 	private function load_tax_in_query( $taxonomy ) {
 		global $wp_query;
 
@@ -134,8 +141,15 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Loads a test product attribute taxonomy with the given name.
+	 *
+	 * @param string $taxonomy Taxonomy name
+	 *
+	 * @return void
+	 */
 	private function load_product_attribute_tax_in_query( $taxonomy ) {
-		register_taxonomy( $taxonomy, 'product' );
+		wc_create_attribute( array( 'name' => $taxonomy ) );
 
 		$this->load_tax_in_query( $taxonomy );
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\WC_Template_Loader.
  */
 
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
+
 
 /**
  * Class WC_Template_Loader
@@ -14,7 +16,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	public function test_wc_template_loader_loads_default_file_without_blocks() {
 
-		global $wp_taxonomies, $wc_product_attributes;
+		global $wp_taxonomies;
 
 		$this->initialize_template_loader();
 
@@ -33,7 +35,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-tag' );
 
 		// Check Woo Taxonomy Product Attribute.
-		$this->load_product_attribute_tax_in_query( 'pa_color' );
+		$this->load_product_attribute_tax_in_query();
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-attribute' );
 
 		// Check Custom Product Taxonomies
@@ -49,7 +51,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	public function test_wc_template_loader_loads_template_with_blocks() {
 
-		global $wp_taxonomies, $wc_product_attributes;
+		global $wp_taxonomies;
 
 		$this->initialize_template_loader();
 
@@ -68,7 +70,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName();
 
 		// Check Woo Taxonomy Product Attribute.
-		$this->load_product_attribute_tax_in_query( 'pa_color' );
+		$this->load_product_attribute_tax_in_query();
 		$this->assertDefaultTemplateFileName();
 
 		// Check Custom Product Taxonomies
@@ -142,16 +144,13 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Loads a test product attribute taxonomy with the given name.
-	 *
-	 * @param string $taxonomy Taxonomy name.
+	 * Loads a test product attribute taxonomy.
 	 *
 	 * @return void
 	 */
-	private function load_product_attribute_tax_in_query( $taxonomy ) {
-		wc_create_attribute( array( 'name' => $taxonomy ) );
-
-		$this->load_tax_in_query( $taxonomy );
+	private function load_product_attribute_tax_in_query() {
+		$attr = ProductHelper::create_attribute( 'color', array( 'red', 'blue' ) );
+		$this->load_tax_in_query( $attr['attribute_taxonomy'] );
 	}
 
 	private function assertDefaultTemplateFileName( $expected = '' ) {

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -32,6 +32,10 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->load_tax_in_query( 'product_tag' );
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-tag' );
 
+		// Check Woo Taxonomy Product Attribute
+		$this->load_tax_in_query( 'product_attribute' );
+		$this->assertDefaultTemplateFileName( 'taxonomy-product-attribute' );
+
 		// Check Custom Product Taxonomies
 		$wp_taxonomies['product_tax'] = new WP_Taxonomy( 'product_tax', 'product' );
 		$this->load_tax_in_query( 'product_tax' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -125,7 +125,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Loads a test taxonomy with the given name.
 	 *
-	 * @param string $taxonomy Taxonomy name
+	 * @param string $taxonomy Taxonomy name.
 	 *
 	 * @return void
 	 */
@@ -144,7 +144,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Loads a test product attribute taxonomy with the given name.
 	 *
-	 * @param string $taxonomy Taxonomy name
+	 * @param string $taxonomy Taxonomy name.
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -32,7 +32,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->load_tax_in_query( 'product_tag' );
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-tag' );
 
-		// Check Woo Taxonomy Product Attribute
+		// Check Woo Taxonomy Product Attribute.
 		$this->load_product_attribute_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName( 'taxonomy-product-attribute' );
 
@@ -67,7 +67,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->load_tax_in_query( 'product_tag' );
 		$this->assertDefaultTemplateFileName();
 
-		// Check Woo Taxonomy Product Attribute
+		// Check Woo Taxonomy Product Attribute.
 		$this->load_product_attribute_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName();
 
@@ -136,8 +136,8 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 
 	private function load_product_attribute_tax_in_query( $taxonomy ) {
 		global $wp_taxonomies, $wc_product_attributes;
-		$wp_taxonomies[$taxonomy] = new WP_Taxonomy( $taxonomy, 'product' );
-		$wc_product_attributes[$taxonomy] = '';
+		$wp_taxonomies[ $taxonomy ]         = new WP_Taxonomy( $taxonomy, 'product' );
+		$wc_product_attributes[ $taxonomy ] = '';
 
 		$this->load_tax_in_query( $taxonomy );
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -70,7 +70,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 		$this->assertDefaultTemplateFileName();
 
 		// Check Woo Taxonomy Product Attribute
-		$wp_taxonomies['pa_color'] = new WP_Taxonomy( 'pa_color', 'product' );
+		$wp_taxonomies['pa_color']         = new WP_Taxonomy( 'pa_color', 'product' );
 		$wc_product_attributes['pa_color'] = '';
 		$this->load_tax_in_query( 'pa_color' );
 		$this->assertDefaultTemplateFileName();

--- a/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-template-loader-test.php
@@ -135,9 +135,7 @@ class WC_Template_Loader_Test extends \WC_Unit_Test_Case {
 	}
 
 	private function load_product_attribute_tax_in_query( $taxonomy ) {
-		global $wp_taxonomies, $wc_product_attributes;
-		$wp_taxonomies[ $taxonomy ]         = new WP_Taxonomy( $taxonomy, 'product' );
-		$wc_product_attributes[ $taxonomy ] = '';
+		register_taxonomy( $taxonomy, 'product' );
 
 		$this->load_tax_in_query( $taxonomy );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

The goal of this PR is to add support for the `Product by attribute` template. It's related to [this task](https://github.com/woocommerce/woocommerce-blocks/issues/7647) and this PR in `woocommerce-blocks`: https://github.com/woocommerce/woocommerce-blocks/pull/7660.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

**Non-FSE theme**
1. Enable the `Storefront` theme (or any non-FSE theme).
2. Make sure on `/wp-admin/edit.php?post_type=product&page=product_attributes` that you have an attribute with the `Enable archive?` option **checked**. Otherwise, create one.
3. On `/wp-admin/edit.php?post_type=product&page=product_attributes` access the attribute terms by clicking on `Configure terms`.
4. If it does not have terms, create one.
5. Click on the `View` option under your term to go to the frontend page of the attribute, you should see the default template loaded.
6. Go to your theme and add a template file on the root with the name `taxonomy-product_attribute.php` and add some identifiable content. Save the file.
7. Reload the page you opened on step 5. You should see the content of the new `taxonomy-product_attribute.php` template file you added to the theme.

**FSE theme**
1. Clone and enable the `trunk` version of `woocommerce-blocks` (since the work on this PR is also needed https://github.com/woocommerce/woocommerce-blocks/pull/7660)
2. Enable the `TT2` theme (or any other FSE theme).
3. Make sure on `/wp-admin/edit.php?post_type=product&page=product_attributes` that you have an attribute with the `Enable archive?` option **checked**. Otherwise, create one.
4. On `/wp-admin/edit.php?post_type=product&page=product_attributes` access the attribute terms by clicking on `Configure terms`.
5. If it does not have terms, create one.
6. Click on the `View` option under your term to go to the frontend page of the attribute, you should see the default template loaded.
7. Go to your theme and add a template file inside the `templates` folder of your theme called `taxonomy-product_attribute.html` and add some identifiable content. Save the file.
8. Reload the page you opened on step 6. You should see the content of the new `taxonomy-product_attribute.html` template file you added to the theme.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
