### PR TITLE
Add responsiveness to product form header

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-form-actions.scss
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.scss
@@ -8,6 +8,23 @@ $gutenberg-blue-darker: var(--wp-admin-theme-color-darker-20);
 	justify-content: flex-end;
 	padding-right: $gap-smaller;
 
+	@include breakpoint( '<782px' ) {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		width: 100%;
+		background: $white;
+		padding: $gap;
+		border-top: 1px solid $gray-200;
+
+		.components-button-group {
+			width: 100%;
+			> button {
+				width: 100%;
+			}
+		}
+	}
+
 	> .components-button {
 		margin-right: $gap-smaller;
 	}
@@ -34,5 +51,11 @@ $gutenberg-blue-darker: var(--wp-admin-theme-color-darker-20);
 		.components-menu-group .components-button {
 			box-shadow: none;
 		}
+	}
+}
+
+@include breakpoint( '<782px' ) {
+	.woocommerce-layout {
+		margin-bottom: calc(70px + $gap); // Product actions height + gap.
 	}
 }

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -15,6 +15,11 @@ import { useFormContext } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { navigateTo } from '@woocommerce/navigation';
+import { useSelect } from '@wordpress/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { store } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -38,6 +43,14 @@ export const ProductFormActions: React.FC = () => {
 		useFormContext< Product >();
 
 	usePreventLeavingPage( isDirty );
+
+	const { isSmallViewport } = useSelect( ( select ) => {
+		return {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			//@ts-ignore Types don't appear to be working correctly on this package.
+			isSmallViewport: select( store ).isViewportMatch( '< medium' ),
+		};
+	} );
 
 	const getProductDataForTracks = () => {
 		return {
@@ -142,59 +155,63 @@ export const ProductFormActions: React.FC = () => {
 	};
 
 	const isPublished = values.id && values.status === 'publish';
+	const SecondaryActionsComponent = isSmallViewport ? MenuItem : Button;
+	const secondaryActions = (
+		<>
+			<SecondaryActionsComponent
+				onClick={ onSaveDraft }
+				disabled={
+					! isValidForm ||
+					( ! isDirty &&
+						!! values.id &&
+						values.status !== 'publish' ) ||
+					isUpdatingDraft ||
+					isUpdatingPublished ||
+					isDeleting
+				}
+			>
+				{ ! isDirty && values.id && values.status !== 'publish' && (
+					<Icon icon={ check } />
+				) }
+				{ isUpdatingDraft ? __( 'Saving', 'woocommerce' ) : null }
+				{ ( isDirty || ! values.id ) &&
+				! isUpdatingDraft &&
+				values.status !== 'publish'
+					? __( 'Save draft', 'woocommerce' )
+					: null }
+				{ values.status === 'publish' && ! isUpdatingDraft
+					? __( 'Switch to draft', 'woocommerce' )
+					: null }
+				{ ! isDirty &&
+				values.id &&
+				! isUpdatingDraft &&
+				values.status !== 'publish'
+					? __( 'Saved', 'woocommerce' )
+					: null }
+			</SecondaryActionsComponent>
+			<SecondaryActionsComponent
+				onClick={ () =>
+					recordEvent( 'product_preview_changes', {
+						new_product_page: true,
+						...getProductDataForTracks(),
+					} )
+				}
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				//@ts-ignore The `href` prop works for both Buttons and MenuItem's.
+				href={ values.permalink + '?preview=true' }
+				disabled={ ! isValidForm || ! values.permalink }
+				target="_blank"
+			>
+				{ __( 'Preview', 'woocommerce' ) }
+			</SecondaryActionsComponent>
+		</>
+	);
 
 	return (
 		<WooHeaderItem>
 			{ () => (
 				<div className="woocommerce-product-form-actions">
-					<Button
-						onClick={ onSaveDraft }
-						disabled={
-							! isValidForm ||
-							( ! isDirty &&
-								!! values.id &&
-								values.status !== 'publish' ) ||
-							isUpdatingDraft ||
-							isUpdatingPublished ||
-							isDeleting
-						}
-					>
-						{ ! isDirty &&
-							values.id &&
-							values.status !== 'publish' && (
-								<Icon icon={ check } />
-							) }
-						{ isUpdatingDraft
-							? __( 'Saving', 'woocommerce' )
-							: null }
-						{ ( isDirty || ! values.id ) &&
-						! isUpdatingDraft &&
-						values.status !== 'publish'
-							? __( 'Save draft', 'woocommerce' )
-							: null }
-						{ values.status === 'publish' && ! isUpdatingDraft
-							? __( 'Switch to draft', 'woocommerce' )
-							: null }
-						{ ! isDirty &&
-						values.id &&
-						! isUpdatingDraft &&
-						values.status !== 'publish'
-							? __( 'Saved', 'woocommerce' )
-							: null }
-					</Button>
-					<Button
-						onClick={ () =>
-							recordEvent( 'product_preview_changes', {
-								new_product_page: true,
-								...getProductDataForTracks(),
-							} )
-						}
-						href={ values.permalink + '?preview=true' }
-						disabled={ ! isValidForm || ! values.permalink }
-						target="_blank"
-					>
-						{ __( 'Preview', 'woocommerce' ) }
-					</Button>
+					{ ! isSmallViewport && secondaryActions }
 					<ButtonGroup className="woocommerce-product-form-actions__publish-button-group">
 						<Button
 							onClick={ onPublish }
@@ -231,6 +248,7 @@ export const ProductFormActions: React.FC = () => {
 							{ () => (
 								<>
 									<MenuGroup>
+										{ isSmallViewport && secondaryActions }
 										<MenuItem
 											onClick={ onPublishAndDuplicate }
 											disabled={ ! isValidForm }

--- a/plugins/woocommerce-admin/client/products/product-settings/product-settings.scss
+++ b/plugins/woocommerce-admin/client/products/product-settings/product-settings.scss
@@ -1,4 +1,4 @@
-.product-settings__panel {
+.woocommerce-product-settings__panel {
 	position: absolute;
 	top: 100%;
 	right: 0;
@@ -25,5 +25,12 @@
 		padding: 0;
 		min-width: 24px;
 		height: 24px;
+	}
+}
+
+@include breakpoint( '<782px' ) {
+	.woocommerce-product-settings__toggle,
+	.woocommerce-product-settings__panel {
+		display: none;
 	}
 }

--- a/plugins/woocommerce-admin/client/products/product-settings/product-settings.tsx
+++ b/plugins/woocommerce-admin/client/products/product-settings/product-settings.tsx
@@ -35,9 +35,10 @@ export const ProductSettings = () => {
 					icon={ cog }
 					isPressed={ isOpen }
 					onClick={ () => setIsOpen( ! isOpen ) }
+					className="woocommerce-product-settings__toggle"
 				/>
 				{ isOpen && (
-					<Panel className="product-settings__panel">
+					<Panel className="woocommerce-product-settings__panel">
 						<PanelHeader label={ __( 'Settings', 'woocommerce' ) }>
 							<Button
 								icon={ closeSmall }

--- a/plugins/woocommerce-admin/client/products/product-title.scss
+++ b/plugins/woocommerce-admin/client/products/product-title.scss
@@ -1,0 +1,13 @@
+.woocommerce-product-title {
+	display: flex;
+	align-items: center;
+
+	@include breakpoint( '<782px' ) {
+		flex-direction: column;
+		align-items: baseline;
+
+		.woocommerce-product-breadcrumbs {
+			font-size: 13px;
+		}
+	}
+}

--- a/plugins/woocommerce-admin/client/products/product-title.tsx
+++ b/plugins/woocommerce-admin/client/products/product-title.tsx
@@ -19,6 +19,7 @@ import { getProductTitle } from './utils/get-product-title';
 import { ProductBreadcrumbs } from './product-breadcrumbs';
 import { ProductStatusBadge } from './product-status-badge';
 import { WooHeaderPageTitle } from '~/header/utils';
+import './product-title.scss';
 
 export const ProductTitle: React.FC = () => {
 	const { values } = useFormContext< Product >();
@@ -46,9 +47,13 @@ export const ProductTitle: React.FC = () => {
 
 	return (
 		<WooHeaderPageTitle>
-			<ProductBreadcrumbs breadcrumbs={ breadcrumbs } />
-			{ title }
-			<ProductStatusBadge />
+			<span className="woocommerce-product-title">
+				<ProductBreadcrumbs breadcrumbs={ breadcrumbs } />
+				<span className="woocommerce-product-title__wrapper">
+					{ title }
+					<ProductStatusBadge />
+				</span>
+			</span>
 		</WooHeaderPageTitle>
 	);
 };

--- a/plugins/woocommerce/changelog/update-35168
+++ b/plugins/woocommerce/changelog/update-35168
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Make product form header and actions responsive for smaller viewports


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes up the product form header on smaller screens and move some secondary buttons into the menu group.

<img width="282" alt="Screen Shot 2022-11-17 at 5 40 55 AM" src="https://user-images.githubusercontent.com/10561050/202502411-8f324314-5b09-49fb-abc4-91a36ad80e7e.png">
<img width="439" alt="Screen Shot 2022-11-17 at 5 40 45 AM" src="https://user-images.githubusercontent.com/10561050/202502413-6f348ea8-197f-4815-93bf-7d6830d18132.png">
<img width="437" alt="Screen Shot 2022-11-17 at 5 40 42 AM" src="https://user-images.githubusercontent.com/10561050/202502416-e3b6a879-8fc4-4e96-a786-9d0f89b57d25.png">


Closes #35168  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product page `Products -> Add new (MVP)`
2. Check that the header is unchanged on larger screens
3. Narrow your viewport to < 782px.
4. Note the styling changes
5. Under the "Publish" menu button group, check that Save draft / Switch to draft and Preview options are shown

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
