### PR TITLE
Add a confirmation modal when the user tries to navigate away with unsaved changes

### DIFF
--- a/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
+++ b/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+export default function usePreventLeavingPage(
+	hasUnsavedChanges: boolean,
+	message = ''
+) {
+	useEffect( () => {
+		if ( hasUnsavedChanges ) {
+			function onBeforeUnload( event: BeforeUnloadEvent ) {
+				event.preventDefault();
+				event.returnValue = message;
+			}
+
+			window.addEventListener( 'beforeunload', onBeforeUnload, {
+				capture: true,
+			} );
+
+			return () => {
+				window.removeEventListener( 'beforeunload', onBeforeUnload, {
+					capture: true,
+				} );
+			};
+		}
+	}, [ hasUnsavedChanges, message ] );
+}

--- a/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
+++ b/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
@@ -1,17 +1,55 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useContext, useEffect, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { UNSAFE_NavigationContext as NavigationContext } from 'react-router-dom';
 
 export default function usePreventLeavingPage(
 	hasUnsavedChanges: boolean,
-	message = ''
+	/**
+	 * Some browsers ignore this message currently on before unload event.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#compatibility_notes
+	 */
+	message?: string
 ) {
+	const confirmMessage = useMemo(
+		() =>
+			message ??
+			__( 'Changes you made may not be saved.', 'woocommerce' ),
+		[ message ]
+	);
+	const { navigator } = useContext( NavigationContext );
+
+	// This effect prevent react router from navigate and show
+	// a confirmation message. It's a work around to beforeunload
+	// because react router does not triggers that event.
+	useEffect( () => {
+		if ( hasUnsavedChanges ) {
+			const push = navigator.push;
+
+			navigator.push = ( ...args: Parameters< typeof push > ) => {
+				/* eslint-disable-next-line no-alert */
+				const result = window.confirm( confirmMessage );
+				if ( result !== false ) {
+					push( ...args );
+				}
+			};
+
+			return () => {
+				navigator.push = push;
+			};
+		}
+	}, [ navigator, hasUnsavedChanges, confirmMessage ] );
+
+	// This effect listen to the native beforeunload event to show
+	// a confirmation message
 	useEffect( () => {
 		if ( hasUnsavedChanges ) {
 			function onBeforeUnload( event: BeforeUnloadEvent ) {
 				event.preventDefault();
-				event.returnValue = message;
+				return ( event.returnValue = confirmMessage );
 			}
 
 			window.addEventListener( 'beforeunload', onBeforeUnload, {
@@ -24,5 +62,5 @@ export default function usePreventLeavingPage(
 				} );
 			};
 		}
-	}, [ hasUnsavedChanges, message ] );
+	}, [ hasUnsavedChanges, confirmMessage ] );
 }

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -18,6 +18,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import usePreventLeavingPage from '~/hooks/usePreventLeavingPage';
 import { WooHeaderItem } from '~/header/utils';
 import { useProductHelper } from './use-product-helper';
 import './product-form-actions.scss';
@@ -34,6 +35,8 @@ export const ProductFormActions: React.FC = () => {
 	} = useProductHelper();
 	const { isDirty, isValidForm, values, resetForm } =
 		useFormContext< Product >();
+
+	usePreventLeavingPage( isDirty );
 
 	const getProductDataForTracks = () => {
 		return {

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -37,6 +37,7 @@ jest.mock( '../use-product-helper', () => {
 		} ),
 	};
 } );
+jest.mock( '~/hooks/usePreventLeavingPage' );
 
 describe( 'ProductFormActions', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce/changelog/enhancement-35194-confirm-when-exiting
+++ b/plugins/woocommerce/changelog/enhancement-35194-confirm-when-exiting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add a confirmation modal when the user tries to navigate away with unsaved changes


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35194

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products -> Add New (MVP)`
2. Change any field without saving it
3. Try to leave the page
4. A confirmation dialog should be shown preventing you from leaving the page without saving the changes first

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
