### PR TITLE
Check if blocks have been added to rich text editors before updating value

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -213,6 +213,9 @@ export const ProductDetailsSection: React.FC = () => {
 						blocks={ summaryBlocks }
 						onChange={ ( blocks ) => {
 							setSummaryBlocks( blocks );
+							if ( ! summaryBlocks.length ) {
+								return;
+							}
 							setValue(
 								'short_description',
 								serialize( blocks )
@@ -224,6 +227,9 @@ export const ProductDetailsSection: React.FC = () => {
 						blocks={ descriptionBlocks }
 						onChange={ ( blocks ) => {
 							setDescriptionBlocks( blocks );
+							if ( ! descriptionBlocks.length ) {
+								return;
+							}
 							setValue( 'description', serialize( blocks ) );
 						} }
 						placeholder={ __(

--- a/plugins/woocommerce/changelog/fix-rich-text-dirty-state
+++ b/plugins/woocommerce/changelog/fix-rich-text-dirty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Check if blocks have been added to rich text editors before updating value


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checks to see if blocks have been added so we don't update the form state on the initial (empty) block addition and inadvertently create a dirty state.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

These instructions are dev specific and do not need to be tested by GlobalStep:

1. Navigate to `Products -> Add new (MVP)`
2. Open React dev tools
3. Find the form component
4. Make sure that on a new untouched product, `isDirty` is still `true`
5. Make changes to either of the rich text fields
6. Make sure `isDirty` is now false
7. Save some changes and refresh the page
8. Check the `isDirty` state and make sure it's initially `false`
9. Make changes again and verify `isDirty` is now `true`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
