### PR TITLE
Fixing bug with CES modal styles after breaking change in GB radio component.

### DIFF
--- a/packages/js/customer-effort-score/changelog/fix-35570
+++ b/packages/js/customer-effort-score/changelog/fix-35570
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixing bug with CES modal styles after breaking change in GB radio component.

--- a/packages/js/customer-effort-score/src/style.scss
+++ b/packages/js/customer-effort-score/src/style.scss
@@ -3,6 +3,15 @@
 .woocommerce-customer-effort-score__selection {
 	margin: 1em 0;
 
+	.components-v-stack {
+		display: flex;
+		flex-direction: column;
+
+		@include breakpoint( '>600px' ) {
+			flex-direction: row;
+		}
+	}
+
 	.components-base-control__field {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is to resolve a styling issue on the CES modal that cropped up in stores running WP 6.1:

![image](https://user-images.githubusercontent.com/444632/202575486-e89a09f5-9797-4c1e-8bf8-d8845332e5bb.png)


It looks like this was due to a breaking change in the GB RadioControl component within [this PR](https://github.com/WordPress/gutenberg/pull/43868). In effect users that are running on top of WP 6.0 had no issue, while those with 6.1 saw the above vertical layout within the CES modal. 

I've added styles to address the change, and currently I've left the previous styles intact to ensure we don't have the same issue crop on on 6.0 and earlier installations. Ideally these should eventually be removed. 

We could also potentially target both successfully with the [`:has` selector,](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) , but that is not supported in Firefox currently.

Closes #35570 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch on new store running WP 6.1
2. Ensure you enable event tracking when asked. 
3. Create your first product, and then click "Give feedback" on the popup after publishing. 
4. Observe that the modal layout is correct:

![image](https://user-images.githubusercontent.com/444632/202576390-a24cb84d-92eb-417b-8341-ac8cffc4c064.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
