### PR TITLE
Fix missing tooltip in admin orders table. Fixes #33228

### DIFF
--- a/plugins/woocommerce/changelog/fix-tooltip-in-admin-order-table
+++ b/plugins/woocommerce/changelog/fix-tooltip-in-admin-order-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tooltips not appearing in the orders list admin page.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -714,9 +714,9 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	public function render_order_status_column( WC_Order $order ): void {
-		$tooltip                 = '';
+		$tooltip = '';
 		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
-		$comment_count           = get_comment_count( $order->get_id() );
+		$comment_count = get_comment_count( $order->get_id() );
 		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
 		$approved_comments_count = absint( $comment_count['approved'] );
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -715,7 +715,9 @@ class ListTable extends WP_List_Table {
 	 */
 	public function render_order_status_column( WC_Order $order ): void {
 		$tooltip                 = '';
+		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
 		$comment_count           = get_comment_count( $order->get_id() );
+		add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );
 		$approved_comments_count = absint( $comment_count['approved'] );
 
 		if ( $approved_comments_count ) {


### PR DESCRIPTION
Fix for #33228 

I spent some time troubleshooting the root cause of this issue. 

Appears that we're using the following filters at different places in WooCommerce:

> remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );

// Code Stuff

> add_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10, 1 );

comments_clauses filter is causing issues in the line here: https://github.com/woocommerce/woocommerce/blob/ba91c94ca9b1c4903964de70c8658cc7bff67d3f/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php#L718

Removing the filter before calling `get_comment_count` fixes the Tooltip issue.

Could anyone please review this PR, adjust code if applicable, and merge if it is good? 

Result after applying the fix:

![img](https://d.pr/i/SLKzDa+)