### PR TITLE
Allow changelogger regex to find directories with woocommerce* names 

### DIFF
--- a/tools/changelogger/class-package-formatter.php
+++ b/tools/changelogger/class-package-formatter.php
@@ -49,7 +49,7 @@ class Package_Formatter extends Formatter implements FormatterPlugin {
 	 */
 	public function getReleaseLink( $version ) {
 		// Catpure anything past /woocommerce in the current working directory.
-		preg_match( '/\/woocommerce\/packages\/js\/(.+)/', getcwd(), $path );
+		preg_match( '/\/woocommerce[^\/]*\/packages\/js\/(.+)/', getcwd(), $path );
 
 		if ( ! count( $path ) ) {
 			throw new \InvalidArgumentException( 'Invalid directory.' );

--- a/tools/changelogger/class-package-formatter.php
+++ b/tools/changelogger/class-package-formatter.php
@@ -49,7 +49,7 @@ class Package_Formatter extends Formatter implements FormatterPlugin {
 	 */
 	public function getReleaseLink( $version ) {
 		// Catpure anything past /woocommerce in the current working directory.
-		preg_match( '/\/woocommerce[^\/]*\/packages\/js\/(.+)/', getcwd(), $path );
+		preg_match( '/\/packages\/js\/(.+)/', getcwd(), $path );
 
 		if ( ! count( $path ) ) {
 			throw new \InvalidArgumentException( 'Invalid directory.' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes the regex used to find package names in the `changelogger` tool.

Previously the command to generate changelogs would break if the repository was not in a directory called `woocommerce`. Since I have my repo in a folder called `woocommerce-monorepo` this caused an error when running `./tools/package-release/bin/dev prepare @woocommerce/extend-cart-checkout-block`

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Clone this repository into a directory called `woocommerce-monorepo`.
2. Add a change file to the `extend-cart-checkout-block` package. Example formatting and location: https://github.com/woocommerce/woocommerce/blob/c539e5614fab45358b6641af2e6b4811b61205e4/packages/js/extend-cart-checkout-block/changelog/add-inner-block-example 
2. Run `./tools/package-release/bin/dev prepare @woocommerce/extend-cart-checkout-block` from the repo root.
3. Ensure the changelog file generates correctly and no errors occur.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
- **I couldn't see anywhere to add changelogs for this tool**

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
