### PR TITLE
Analytics: Fix advanced filtering date selection in WordPress 6.1.

### DIFF
--- a/packages/js/components/changelog/fix-datepicker-moment
+++ b/packages/js/components/changelog/fix-datepicker-moment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed date filter date selection in WordPress 6.1.

--- a/packages/js/components/changelog/fix-datepicker-moment
+++ b/packages/js/components/changelog/fix-datepicker-moment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixed date filter date selection in WordPress 6.1.
+Fixed DatePicker to work in WordPress 6.1 when currentDate is set to a moment instance.

--- a/packages/js/components/src/advanced-filters/date-filter.js
+++ b/packages/js/components/src/advanced-filters/date-filter.js
@@ -179,7 +179,7 @@ class DateFilter extends Component {
 	getFormControl( { date, error, onUpdate, text } ) {
 		return (
 			<DatePicker
-				date={ date }
+				date={ date ? date.toDate() : null }
 				dateFormat={ dateFormat }
 				error={ error }
 				isInvalidDate={ this.isFutureDate }

--- a/packages/js/components/src/advanced-filters/date-filter.js
+++ b/packages/js/components/src/advanced-filters/date-filter.js
@@ -179,7 +179,7 @@ class DateFilter extends Component {
 	getFormControl( { date, error, onUpdate, text } ) {
 		return (
 			<DatePicker
-				date={ date ? date.toDate() : null }
+				date={ date }
 				dateFormat={ dateFormat }
 				error={ error }
 				isInvalidDate={ this.isFutureDate }

--- a/packages/js/components/src/calendar/date-picker.js
+++ b/packages/js/components/src/calendar/date-picker.js
@@ -116,7 +116,11 @@ class DatePicker extends Component {
 						</H>
 						<div className="woocommerce-calendar__react-dates is-core-datepicker">
 							<WpDatePicker
-								currentDate={ date }
+								currentDate={
+									date instanceof moment
+										? date.toDate()
+										: date
+								}
 								onChange={ partial(
 									this.onDateChange,
 									onToggle


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the advanced date filter used on the WCPay Transactions and Disputes page to work when running on WordPress 6.1.

Closes #35630.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install WCPay and use the Date filter on the Transactions or Disputes pages.
2. Select a date.
3. Click again on the date picker. Verify there is no error, and that date selection works properly.
4. Activate the filter and verify that the selected dates for the filter are applied properly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
