### PR TITLE
Fix deprecated error in PageController

### DIFF
--- a/plugins/woocommerce/changelog/2022-11-24-08-07-11-448089
+++ b/plugins/woocommerce/changelog/2022-11-24-08-07-11-448089
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Fix deprecated error in PageController ini PHP v8.0

--- a/plugins/woocommerce/changelog/2022-11-24-08-07-11-448089
+++ b/plugins/woocommerce/changelog/2022-11-24-08-07-11-448089
@@ -1,4 +1,4 @@
-Significance: major
-Type: enhancement
+Significance: patch
+Type: tweak
 
 Fix deprecated error in PageController ini PHP v8.0

--- a/plugins/woocommerce/changelog/2022-11-24-08-07-11-448089
+++ b/plugins/woocommerce/changelog/2022-11-24-08-07-11-448089
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Fix deprecated error in PageController ini PHP v8.0
+Avoid deprecation notices under PHP 8.1 when calling wp_parse_url().

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -125,7 +125,7 @@ class PageController {
 		}
 
 		$current_query = wp_parse_url( $current_url, PHP_URL_QUERY );
-		parse_str( $current_query ? $current_query : '', $current_pieces );
+		parse_str( (string) $current_query, $current_pieces );
 		$current_path  = empty( $current_pieces['page'] ) ? '' : $current_pieces['page'];
 		$current_path .= empty( $current_pieces['path'] ) ? '' : '&path=' . $current_pieces['path'];
 

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -125,7 +125,7 @@ class PageController {
 		}
 
 		$current_query = wp_parse_url( $current_url, PHP_URL_QUERY );
-		parse_str( $current_query, $current_pieces );
+		parse_str( $current_query ? $current_query : '', $current_pieces );
 		$current_path  = empty( $current_pieces['page'] ) ? '' : $current_pieces['page'];
 		$current_path .= empty( $current_pieces['path'] ) ? '' : '&path=' . $current_pieces['path'];
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

Since the parse_str doesn't accept the null in PHP v8.1, In some cases, the input is null.
```
Deprecated: parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /xxx/wp-content/plugins/woocommerce/src/Admin/PageController.php on line 128
```

### Testing instructions

Code review should be sufficient here, no particular need for manual testing. However ...

It is possible to trigger the execution path by browsing through various WordPress and WooCommerce admin screens (for instance, just visiting `/wp-admin/` when WooCommerce is active will trigger a call to `PageController::determine_current_page()`—which is the method changed in this PR). By monitoring for *fresh* errors (specifically, looking for the error cited above) we should be able to tell if this is indeed fixed.