### PR TITLE
Add Denmark postcode validation

### DIFF
--- a/plugins/woocommerce/changelog/denmark-post-code-validation
+++ b/plugins/woocommerce/changelog/denmark-post-code-validation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Denmark postcode validation.

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -68,6 +68,9 @@ class WC_Validation {
 			case 'DE':
 				$valid = (bool) preg_match( '/^([0]{1}[1-9]{1}|[1-9]{1}[0-9]{1})[0-9]{3}$/', $postcode );
 				break;
+			case 'DK':
+				$valid = (bool) preg_match( '/^(DK-)?[1-24-9]\d{3}|3[0-8]\d{2}$/', $postcode );
+				break;
 			case 'ES':
 			case 'FR':
 			case 'IT':

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -69,7 +69,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^([0]{1}[1-9]{1}|[1-9]{1}[0-9]{1})[0-9]{3}$/', $postcode );
 				break;
 			case 'DK':
-				$valid = (bool) preg_match( '/^(DK-)?[1-24-9]\d{3}|3[0-8]\d{2}$/', $postcode );
+				$valid = (bool) preg_match( '/^(DK-)?([1-24-9]\d{3}|3[0-8]\d{2})$/', $postcode );
 				break;
 			case 'ES':
 			case 'FR':

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1001,7 +1001,7 @@ function wc_format_postcode( $postcode, $country ) {
 			}
 			break;
 		case 'DK':
-			$postcode = preg_replace('/^(DK)(.+)$/', '${1}-${2}', $postcode);
+			$postcode = preg_replace( '/^(DK)(.+)$/', '${1}-${2}', $postcode );
 			break;
 	}
 

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1000,6 +1000,9 @@ function wc_format_postcode( $postcode, $country ) {
 				$postcode = count( $matches ) >= 2 ? "LV-$matches[1]" : $postcode;
 			}
 			break;
+		case 'DK':
+			$postcode = preg_replace('/^(DK)(.+)$/', '${1}-${2}', $postcode);
+			break;
 	}
 
 	return apply_filters( 'woocommerce_format_postcode', trim( $postcode ), $country );

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/validation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/validation.php
@@ -131,16 +131,16 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '0123', 'JP' ) ),
 		);
 
-        $dk = array(
-            array( true, WC_Validation::is_postcode( 'DK-9000', 'DK' ) ),
-            array( true, WC_Validation::is_postcode( 'DK-1448', 'DK' ) ),
-            array( true, WC_Validation::is_postcode( '1448', 'DK' ) ),
-            array( true, WC_Validation::is_postcode( '1050', 'DK' ) ),
-            array( false, WC_Validation::is_postcode( 'FO-110', 'DK' ) ),
-            array( false, WC_Validation::is_postcode( 'DK-3900', 'DK' ) ),
-            array( false, WC_Validation::is_postcode( '3900', 'DK' ) ),
-            array( false, WC_Validation::is_postcode( '51467', 'DK' ) ),
-        );
+		$dk = array(
+			array( true, WC_Validation::is_postcode( 'DK-9000', 'DK' ) ),
+			array( true, WC_Validation::is_postcode( 'DK-1448', 'DK' ) ),
+			array( true, WC_Validation::is_postcode( '1448', 'DK' ) ),
+			array( true, WC_Validation::is_postcode( '1050', 'DK' ) ),
+			array( false, WC_Validation::is_postcode( 'FO-110', 'DK' ) ),
+			array( false, WC_Validation::is_postcode( 'DK-3900', 'DK' ) ),
+			array( false, WC_Validation::is_postcode( '3900', 'DK' ) ),
+			array( false, WC_Validation::is_postcode( '51467', 'DK' ) ),
+		);
 
 		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl, $si, $ba, $jp, $dk );
 	}

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/validation.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/validation.php
@@ -131,7 +131,18 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '0123', 'JP' ) ),
 		);
 
-		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl, $si, $ba, $jp );
+        $dk = array(
+            array( true, WC_Validation::is_postcode( 'DK-9000', 'DK' ) ),
+            array( true, WC_Validation::is_postcode( 'DK-1448', 'DK' ) ),
+            array( true, WC_Validation::is_postcode( '1448', 'DK' ) ),
+            array( true, WC_Validation::is_postcode( '1050', 'DK' ) ),
+            array( false, WC_Validation::is_postcode( 'FO-110', 'DK' ) ),
+            array( false, WC_Validation::is_postcode( 'DK-3900', 'DK' ) ),
+            array( false, WC_Validation::is_postcode( '3900', 'DK' ) ),
+            array( false, WC_Validation::is_postcode( '51467', 'DK' ) ),
+        );
+
+		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl, $si, $ba, $jp, $dk );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The PR adds Denmark postcode validation according to https://en.wikipedia.org/wiki/Postal_codes_in_Denmark. Essentially it's a minor modification of  https://rgxdb.com/r/335G4K1S with an optional DB prefix.

As the Denmark postcode can contain `DK-` prefix I restored it in the `wc_format_postcode` function (as I can see `LV` has already).

Regarding the unit tests, I was a bit confused because the current `\WC_Validation::is_postcode` tests are included just in `\WC_Tests_Validation::data_provider_test_is_postcode` method. It should not be touched according to `README.md`. Should I add a new testing class to `plugins/woocommerce/tests/php/includes`? 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to the checkout page to finish your order.
2. Select Denmark as the billing (or shipping) country.
3. Paste the postcode in the wrong format (like `DK-3900`).
4. Try to complete the purchase.
5. You get a notification about the wrong Postal code.
6. Change the postal code to the valid one (like `1448` or `DK-1448`).
7. You are able to complete the purchase.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
