### PR TITLE
Fix/unsaved prompt

### DIFF
--- a/packages/js/components/changelog/fix-unsaved-prompt
+++ b/packages/js/components/changelog/fix-unsaved-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set initial values prop from reset form function as optional

--- a/packages/js/components/src/form/form-context.ts
+++ b/packages/js/components/src/form/form-context.ts
@@ -44,7 +44,7 @@ export type FormContext< Values extends Record< string, any > > = {
 	): InputProps< Values, Value >;
 	isValidForm: boolean;
 	resetForm: (
-		initialValues: Values,
+		initialValues?: Values,
 		touchedFields?: { [ P in keyof Values ]?: boolean | undefined },
 		errors?: FormErrors< Values >
 	) => void;

--- a/packages/js/components/src/form/form.tsx
+++ b/packages/js/components/src/form/form.tsx
@@ -166,11 +166,11 @@ function FormComponent< Values extends Record< string, any > >(
 		validate( values );
 	}, [] );
 
-	const resetForm = (
-		newInitialValues = {} as Values,
-		newTouchedFields = {},
-		newErrors = {}
-	) => {
+	const resetForm: (
+		newInitialValues?: Values,
+		newTouchedFields?: { [ P in keyof Values ]?: boolean | undefined },
+		newErrors?: FormErrors< Values >
+	) => void = ( newInitialValues, newTouchedFields = {}, newErrors = {} ) => {
 		const newValues = newInitialValues ?? initialValues.current ?? {};
 		initialValues.current = newValues;
 		setValuesInternal( newValues );
@@ -183,7 +183,7 @@ function FormComponent< Values extends Record< string, any > >(
 	} ) );
 
 	const isValidForm = async () => {
-		await validate( values );
+		validate( values );
 		return ! Object.keys( errors ).length;
 	};
 

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -14,6 +14,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { useFormContext } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
+import { navigateTo } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ export const ProductFormActions: React.FC = () => {
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
-			createProductWithStatus( values, 'draft' );
+			await createProductWithStatus( values, 'draft' );
 		} else {
 			const product = await updateProductWithStatus(
 				values.id,
@@ -73,7 +74,13 @@ export const ProductFormActions: React.FC = () => {
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
-			createProductWithStatus( values, 'publish' );
+			const product = await createProductWithStatus( values, 'publish' );
+			if ( product?.id ) {
+				resetForm();
+				navigateTo( {
+					url: 'admin.php?page=wc-admin&path=/product/' + product.id,
+				} );
+			}
 		} else {
 			const product = await updateProductWithStatus(
 				values.id,
@@ -94,7 +101,7 @@ export const ProductFormActions: React.FC = () => {
 		if ( values.id ) {
 			await updateProductWithStatus( values.id, values, 'publish' );
 		} else {
-			await createProductWithStatus( values, 'publish', false, true );
+			await createProductWithStatus( values, 'publish', false );
 		}
 		await copyProductWithStatus( values );
 	};
@@ -114,13 +121,17 @@ export const ProductFormActions: React.FC = () => {
 		await copyProductWithStatus( values );
 	};
 
-	const onTrash = () => {
+	const onTrash = async () => {
 		recordEvent( 'product_delete', {
 			new_product_page: true,
 			...getProductDataForTracks(),
 		} );
 		if ( values.id ) {
-			deleteProductAndRedirect( values.id );
+			const product = await deleteProductAndRedirect( values.id );
+			if ( product?.id ) {
+				resetForm( product );
+				navigateTo( { url: 'edit.php?post_type=product' } );
+			}
 		}
 	};
 

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -55,7 +55,13 @@ export const ProductFormActions: React.FC = () => {
 			...getProductDataForTracks(),
 		} );
 		if ( ! values.id ) {
-			await createProductWithStatus( values, 'draft' );
+			const product = await createProductWithStatus( values, 'draft' );
+			if ( product?.id ) {
+				resetForm();
+				navigateTo( {
+					url: 'admin.php?page=wc-admin&path=/product/' + product.id,
+				} );
+			}
 		} else {
 			const product = await updateProductWithStatus(
 				values.id,

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -247,7 +247,7 @@ export function useProductHelper() {
 			( error ) => {
 				createNotice(
 					'error',
-					__( 'Failed to moved product to Trash.', 'woocommerce' )
+					__( 'Failed to move product to Trash.', 'woocommerce' )
 				);
 				setIsDeleting( false );
 				return error;

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -14,7 +14,6 @@ import {
 	productReadOnlyProperties,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { navigateTo } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -66,21 +65,19 @@ export function useProductHelper() {
 	 * @param {Product} product the product to be created.
 	 * @param {string}  status the product status.
 	 * @param {boolean} skipNotice if the notice should be skipped (default: false).
-	 * @param {boolean} skipRedirect if the user should skip the redirection to the new product page (default: false).
 	 * @return {Promise<Product>} Returns a promise with the created product.
 	 */
 	const createProductWithStatus = useCallback(
 		async (
 			product: Omit< Product, ReadOnlyProperties >,
 			status: ProductStatus,
-			skipNotice = false,
-			skipRedirect = false
+			skipNotice = false
 		) => {
 			setUpdating( {
 				...updating,
 				[ status ]: true,
 			} );
-			createProduct( {
+			return createProduct( {
 				...product,
 				status,
 			} ).then(
@@ -109,15 +106,9 @@ export function useProductHelper() {
 						...updating,
 						[ status ]: false,
 					} );
-					if ( ! skipRedirect ) {
-						navigateTo( {
-							url:
-								'admin.php?page=wc-admin&path=/product/' +
-								newProduct.id,
-						} );
-					}
+					return newProduct;
 				},
-				() => {
+				( error ) => {
 					if ( ! skipNotice ) {
 						createNotice(
 							'error',
@@ -136,6 +127,7 @@ export function useProductHelper() {
 						...updating,
 						[ status ]: false,
 					} );
+					return error;
 				}
 			);
 		},
@@ -236,13 +228,12 @@ export function useProductHelper() {
 	 * Deletes a product by given id and redirects to the product list page.
 	 *
 	 * @param {number} id the product id to be deleted.
-	 * @param {string} redirectUrl the redirection url, defaults to product list ('edit.php?post_type=product').
 	 * @return {Promise<Product>} promise with the deleted product.
 	 */
-	const deleteProductAndRedirect = useCallback(
-		( id: number, redirectUrl = 'edit.php?post_type=product' ) => {
-			setIsDeleting( true );
-			return deleteProduct( id ).then( () => {
+	const deleteProductAndRedirect = useCallback( async ( id: number ) => {
+		setIsDeleting( true );
+		return deleteProduct( id ).then(
+			( product ) => {
 				createNotice(
 					'success',
 					__(
@@ -250,14 +241,19 @@ export function useProductHelper() {
 						'woocommerce'
 					)
 				);
-				navigateTo( {
-					url: redirectUrl,
-				} );
 				setIsDeleting( false );
-			} );
-		},
-		[]
-	);
+				return product;
+			},
+			( error ) => {
+				createNotice(
+					'error',
+					__( 'Failed to moved product to Trash.', 'woocommerce' )
+				);
+				setIsDeleting( false );
+				return error;
+			}
+		);
+	}, [] );
 
 	/**
 	 * Sanitizes a price.

--- a/plugins/woocommerce/changelog/fix-unsaved-prompt
+++ b/plugins/woocommerce/changelog/fix-unsaved-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unsaved modal propmt to not be shown during form submission


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce/issues/35194

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products -> Add New (MVP)` page
2. After change any product field you should publish the product and get redirected to product edit page without seen any prompt modal.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
