### PR TITLE
Allow HPOS screens to work for custom order types

### DIFF
--- a/plugins/woocommerce/changelog/issue-35601
+++ b/plugins/woocommerce/changelog/issue-35601
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for custom order types in HPOS admin UI.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -540,8 +540,16 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * @return bool Whether the current screen is an order edit screen.
 		 */
 		private function is_order_meta_box_screen( $screen_id ) {
-			return in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ), true ) ||
-						wc_get_page_screen_id( 'shop-order' ) === $screen_id;
+			$screen_id = str_replace( 'edit-', '', $screen_id );
+
+			$types_with_metaboxes_screen_ids = array_filter(
+				array_map(
+					'wc_get_page_screen_id',
+					wc_get_order_types( 'order-meta-boxes' )
+				)
+			);
+
+			return in_array( $screen_id, $types_with_metaboxes_screen_ids, true );
 		}
 
 	}

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -8,6 +8,7 @@
  * @version     2.1.0
  */
 
+use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -97,7 +98,8 @@ class WC_Meta_Box_Order_Actions {
 	 */
 	private static function get_trash_or_delete_order_link( int $order_id ): string {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$order_list_url  = admin_url( 'admin.php?page=wc-orders' );
+			$order_type      = wc_get_order( $order_id )->get_type();
+			$order_list_url  = wc_get_container()->get( PageController::class )->get_base_page_url( $order_type );
 			$trash_order_url = add_query_arg(
 				array(
 					'action'           => 'trash',

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -6,6 +6,8 @@
  * @version  2.4.0
  */
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -67,14 +69,16 @@ function wc_get_screen_ids() {
  *
  * @return string Page ID. Empty string if resource not found.
  */
-function wc_get_page_screen_id( $for ) {
-	$order_types_with_ui = wc_get_order_types( 'admin-menu' );
+function wc_get_page_screen_id( $for, $context = '' ) {
+	$screen_id = '';
+	$for       = str_replace( '-', '_', $for );
 
-	$for_ = str_replace( '-', '_', $for );
-	if ( in_array( $for_, $order_types_with_ui, true ) ) {
-		$screen_id = 'woocommerce_page_wc-orders' . ( 'shop_order' === $for_ ? '' : '--' . $for_ );
-	} else {
-		$screen_id = '';
+	if ( in_array( $for, wc_get_order_types( 'admin-menu' ), true ) ) {
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$screen_id = 'woocommerce_page_wc-orders' . ( 'shop_order' === $for ? '' : '--' . $for );
+		} else {
+			$screen_id = ( 'edit' === $context ? 'edit-' : '' ) . $for;
+		}
 	}
 
 	return $screen_id;

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -69,7 +69,7 @@ function wc_get_screen_ids() {
  *
  * @return string Page ID. Empty string if resource not found.
  */
-function wc_get_page_screen_id( $for, $context = '' ) {
+function wc_get_page_screen_id( $for ) {
 	$screen_id = '';
 	$for       = str_replace( '-', '_', $for );
 
@@ -77,7 +77,7 @@ function wc_get_page_screen_id( $for, $context = '' ) {
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$screen_id = 'woocommerce_page_wc-orders' . ( 'shop_order' === $for ? '' : '--' . $for );
 		} else {
-			$screen_id = ( 'edit' === $context ? 'edit-' : '' ) . $for;
+			$screen_id = $for;
 		}
 	}
 

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -68,11 +68,14 @@ function wc_get_screen_ids() {
  * @return string Page ID. Empty string if resource not found.
  */
 function wc_get_page_screen_id( $for ) {
-	switch ( $for ) {
-		case 'shop-order':
-			return 'woocommerce_page_wc-orders';
+	$order_types_with_ui = wc_get_order_types( 'admin-menu' );
+
+	$for_ = str_replace( '-', '_', $for );
+	if ( in_array( $for_, $order_types_with_ui, true ) ) {
+		$screen_id = 'woocommerce_page_wc-orders' . ( 'shop_order' === $for_ ? '' : '--' . $for_ );
 	}
-	return '';
+
+	return $screen_id;
 }
 
 /**

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -39,12 +39,12 @@ function wc_get_screen_ids() {
 		'edit-product_tag',
 		'profile',
 		'user-edit',
-		wc_get_page_screen_id( 'shop-order' ),
 	);
 
 	foreach ( wc_get_order_types() as $type ) {
 		$screen_ids[] = $type;
 		$screen_ids[] = 'edit-' . $type;
+		$screen_ids[] = wc_get_page_screen_id( $type );
 	}
 
 	$attributes = wc_get_attribute_taxonomies();
@@ -73,6 +73,8 @@ function wc_get_page_screen_id( $for ) {
 	$for_ = str_replace( '-', '_', $for );
 	if ( in_array( $for_, $order_types_with_ui, true ) ) {
 		$screen_id = 'woocommerce_page_wc-orders' . ( 'shop_order' === $for_ ? '' : '--' . $for_ );
+	} else {
+		$screen_id = '';
 	}
 
 	return $screen_id;

--- a/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
+++ b/plugins/woocommerce/includes/react-admin/connect-existing-pages.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
  * Returns core WC pages to connect to WC-Admin.
@@ -135,16 +136,6 @@ wc_admin_connect_page(
 	)
 );
 
-// WooCommerce > Orders (COT).
-wc_admin_connect_page(
-	array(
-		'id'        => 'woocommerce-custom-orders',
-		'screen_id' => wc_get_page_screen_id( 'shop-order' ),
-		'title'     => __( 'Orders', 'woocommerce' ),
-		'path'      => 'admin.php?page=wc-orders',
-	)
-);
-
 // WooCommerce > Orders > Add New.
 wc_admin_connect_page(
 	array(
@@ -164,6 +155,18 @@ wc_admin_connect_page(
 		'title'     => __( 'Edit Order', 'woocommerce' ),
 	)
 );
+
+if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+	// WooCommerce > Orders (COT).
+	wc_admin_connect_page(
+		array(
+			'id'        => 'woocommerce-custom-orders',
+			'screen_id' => wc_get_page_screen_id( 'shop-order' ),
+			'title'     => __( 'Orders', 'woocommerce' ),
+			'path'      => 'admin.php?page=wc-orders',
+		)
+	);
+}
 
 // WooCommerce > Coupons.
 wc_admin_connect_page(

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -249,7 +249,7 @@ function wc_get_order_types( $for = '' ) {
 				array_keys( $wc_order_types ),
 				get_post_types(
 					array(
-						'show_ui' => true,
+						'show_ui'      => true,
 						'show_in_menu' => 'woocommerce',
 					)
 				)

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -244,6 +244,12 @@ function wc_get_order_types( $for = '' ) {
 				}
 			}
 			break;
+		case 'admin-menu':
+			$order_types = array_intersect(
+				array_keys( $wc_order_types ),
+				get_post_types( array( 'show_ui' => true, 'show_in_menu' => 'woocommerce' ) )
+			);
+			break;
 		default:
 			$order_types = array_keys( $wc_order_types );
 			break;

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -247,7 +247,12 @@ function wc_get_order_types( $for = '' ) {
 		case 'admin-menu':
 			$order_types = array_intersect(
 				array_keys( $wc_order_types ),
-				get_post_types( array( 'show_ui' => true, 'show_in_menu' => 'woocommerce' ) )
+				get_post_types(
+					array(
+						'show_ui' => true,
+						'show_in_menu' => 'woocommerce',
+					)
+				)
 			);
 			break;
 		default:

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -188,18 +188,20 @@ class Edit {
 	 * @param string $message Message to display, if any.
 	 */
 	private function render_wrapper_start( $notice = '', $message = '' ) {
-		$edit_page_url = admin_url( 'admin.php?page=wc-orders&action=edit&id=' . $this->order->get_id() );
+		$post_type = get_post_type_object( $this->order->get_type() );
+
+		$edit_page_url = wc_get_container()->get( PageController::class )->get_edit_url( $this->order->get_id() );
 		$form_action   = 'edit_order';
 		$referer       = wp_get_referer();
-		$new_page_url  = wc_get_container()->get( PageController::class )->get_new_page_url();
+		$new_page_url  = wc_get_container()->get( PageController::class )->get_new_page_url( $this->order->get_type() );
 
 		?>
 		<div class="wrap">
 		<h1 class="wp-heading-inline">
-			<?php echo esc_html( 'Edit order' ); ?>
+			<?php echo esc_html( $post_type->labels->edit_item ); ?>
 		</h1>
 		<?php
-		echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action"> Add order </a>';
+		echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new )  . '</a>';
 		?>
 		<hr class="wp-header-end">
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -201,7 +201,7 @@ class Edit {
 			<?php echo esc_html( $post_type->labels->edit_item ); ?>
 		</h1>
 		<?php
-		echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new )  . '</a>';
+		echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
 		?>
 		<hr class="wp-header-end">
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -113,15 +113,19 @@ class ListTable extends WP_List_Table {
 	 * @param string    $column_name Identifier for the custom column.
 	 */
 	public function column_default( $order, $column_name ) {
-		/**
-		 * Fires for each custom column in the Custom Order Table in the administrative screen.
-		 *
-		 * @param string    $column_name Identifier for the custom column.
-		 * @param \WC_Order $order       Current WooCommerce order object.
-		 *
-		 * @since 7.0.0
-		 */
-		do_action( "manage_{$this->screen->id}_custom_column", $column_name, $order );
+		if ( has_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column' ) ) {
+			do_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column', $column_name, $order );
+		} else {
+			/**
+			 * Fires for each custom column in the Custom Order Table in the administrative screen.
+			 *
+			 * @param string    $column_name Identifier for the custom column.
+			 * @param \WC_Order $order       Current WooCommerce order object.
+			 *
+			 * @since 7.0.0
+			 */
+			do_action( "manage_{$this->screen->id}_custom_column", $column_name, $order );
+		}
 	}
 
 	/**
@@ -279,6 +283,7 @@ class ListTable extends WP_List_Table {
 		 * @param array $query_args Arguments to be passed to `wc_get_orders()`.
 		 */
 		$order_query_args = (array) apply_filters( 'woocommerce_order_list_table_prepare_items_query_args', $this->order_query_args );
+		$order_query_args = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_prepare_items_query_args', $this->order_query_args );
 
 		// We must ensure the 'paginate' argument is set.
 		$order_query_args['paginate'] = true;
@@ -606,15 +611,18 @@ class ListTable extends WP_List_Table {
 	 * @return array
 	 */
 	public function get_columns() {
-		return array(
-			'cb'               => '<input type="checkbox" />',
-			'order_number'     => esc_html__( 'Order', 'woocommerce' ),
-			'order_date'       => esc_html__( 'Date', 'woocommerce' ),
-			'order_status'     => esc_html__( 'Status', 'woocommerce' ),
-			'billing_address'  => esc_html__( 'Billing', 'woocommerce' ),
-			'shipping_address' => esc_html__( 'Ship to', 'woocommerce' ),
-			'order_total'      => esc_html__( 'Total', 'woocommerce' ),
-			'wc_actions'       => esc_html__( 'Actions', 'woocommerce' ),
+		return apply_filters(
+			'woocommerce_' . $this->order_type . '_list_table_columns',
+			array(
+				'cb'               => '<input type="checkbox" />',
+				'order_number'     => esc_html__( 'Order', 'woocommerce' ),
+				'order_date'       => esc_html__( 'Date', 'woocommerce' ),
+				'order_status'     => esc_html__( 'Status', 'woocommerce' ),
+				'billing_address'  => esc_html__( 'Billing', 'woocommerce' ),
+				'shipping_address' => esc_html__( 'Ship to', 'woocommerce' ),
+				'order_total'      => esc_html__( 'Total', 'woocommerce' ),
+				'wc_actions'       => esc_html__( 'Actions', 'woocommerce' ),
+			)
 		);
 	}
 
@@ -624,10 +632,13 @@ class ListTable extends WP_List_Table {
 	 * @return string[]
 	 */
 	public function get_sortable_columns() {
-		return array(
-			'order_number' => 'ID',
-			'order_date'   => 'date',
-			'order_total'  => 'order_total',
+		return apply_filters(
+			'woocommerce_' . $this->order_type . '_list_table_sortable_columns',
+			array(
+				'order_number' => 'ID',
+				'order_date'   => 'date',
+				'order_total'  => 'order_total',
+			)
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -132,28 +132,26 @@ class ListTable extends WP_List_Table {
 	 * @param string    $column_name Identifier for the custom column.
 	 */
 	public function column_default( $order, $column_name ) {
-		if ( has_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column' ) ) {
-			/**
-			 * Fires for each custom column for a specific order type. This hook takes precedence over the generic
-			 * action `manage_{$this->screen->id}_custom_column`.
-			 *
-			 * @param string    $column_name Identifier for the custom column.
-			 * @param \WC_Order $order       Current WooCommerce order object.
-			 *
-			 * @since 7.3.0
-			 */
-			do_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column', $column_name, $order );
-		} else {
-			/**
-			 * Fires for each custom column in the Custom Order Table in the administrative screen.
-			 *
-			 * @param string    $column_name Identifier for the custom column.
-			 * @param \WC_Order $order       Current WooCommerce order object.
-			 *
-			 * @since 7.0.0
-			 */
-			do_action( "manage_{$this->screen->id}_custom_column", $column_name, $order );
-		}
+		/**
+		 * Fires for each custom column for a specific order type. This hook takes precedence over the generic
+		 * action `manage_{$this->screen->id}_custom_column`.
+		 *
+		 * @param string    $column_name Identifier for the custom column.
+		 * @param \WC_Order $order       Current WooCommerce order object.
+		 *
+		 * @since 7.3.0
+		 */
+		do_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column', $column_name, $order );
+
+		/**
+		 * Fires for each custom column in the Custom Order Table in the administrative screen.
+		 *
+		 * @param string    $column_name Identifier for the custom column.
+		 * @param \WC_Order $order       Current WooCommerce order object.
+		 *
+		 * @since 7.0.0
+		 */
+		do_action( "manage_{$this->screen->id}_custom_column", $column_name, $order );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -552,10 +552,26 @@ class ListTable extends WP_List_Table {
 		echo '<div class="alignleft actions">';
 
 		if ( 'top' === $which ) {
+			ob_start();
+
 			$this->months_filter();
 			$this->customers_filter();
 
-			submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, array( 'id' => 'order-query-submit' ) );
+			/**
+			 * Fires before the "Filter" button on the list table for orders and other order types.
+			 *
+			 * @since x.x.x
+			 * @param string $order_type  The order type.
+			 * @param string $which       The location of the extra table nav: 'top' or 'bottom'.
+			 */
+			do_action( 'woocommerce_order_list_table_extra_tablenav', $this->order_type, $which );
+
+			$output = ob_get_clean();
+
+			if ( ! empty( $output ) ) {
+				echo $output;
+				submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, array( 'id' => 'order-query-submit' ) );
+			}
 		}
 
 		if ( $this->is_trash && $this->has_items() && current_user_can( 'edit_others_shop_orders' ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -408,7 +408,7 @@ class ListTable extends WP_List_Table {
 	 * Implements filtering of orders by status.
 	 */
 	private function set_status_args() {
-		$status = array_map( 'trim', (array) $this->request['status'] );
+		$status = array_filter( array_map( 'trim', (array) $this->request['status'] ) );
 
 		if ( empty( $status ) || in_array( 'all', $status, true ) ) {
 			/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -569,7 +569,7 @@ class ListTable extends WP_List_Table {
 			$output = ob_get_clean();
 
 			if ( ! empty( $output ) ) {
-				echo $output;
+				echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, array( 'id' => 'order-query-submit' ) );
 			}
 		}
@@ -1008,7 +1008,7 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	private function print_hidden_form_fields(): void {
-		echo '<input type="hidden" name="page" value="wc-orders' . ( 'shop_order' === $this->order_type ? '' : '--' . $this->order_type ) . '" >';
+		echo '<input type="hidden" name="page" value="wc-orders' . ( 'shop_order' === $this->order_type ? '' : '--' . $this->order_type ) . '" >'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		$state_params = array(
 			'paged',

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -254,7 +254,7 @@ class ListTable extends WP_List_Table {
 	 * Prepares the list of items for displaying.
 	 */
 	public function prepare_items() {
-		$limit = $this->get_items_per_page( 'edit_orders_per_page' );
+		$limit = $this->get_items_per_page( 'edit_' . $this->order_type . '_per_page' );
 
 		$this->order_query_args = array(
 			'limit'    => $limit,

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -79,7 +79,7 @@ class ListTable extends WP_List_Table {
 		$this->order_type = $args['order_type'] ?? 'shop_order';
 
 		add_action( 'admin_notices', array( $this, 'bulk_action_notices' ) );
-		add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'get_columns' ), 0 );
+		add_filter( "manage_{$this->screen->id}_columns", array( $this, 'get_columns' ), 0 );
 		add_filter( 'set_screen_option_edit_' . $this->order_type . '_per_page', array( $this, 'set_items_per_page' ), 10, 3 );
 		add_filter( 'default_hidden_columns', array( $this, 'default_hidden_columns' ), 10, 2 );
 		add_action( 'admin_footer', array( $this, 'enqueue_scripts' ) );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -992,7 +992,7 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	private function print_hidden_form_fields(): void {
-		echo '<input type="hidden" name="page" value="wc-orders" >';
+		echo '<input type="hidden" name="page" value="wc-orders' . ( 'shop_order' === $this->order_type ? '' : '--' . $this->order_type ) . '" >';
 
 		$state_params = array(
 			'paged',

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -13,8 +13,18 @@ use WP_Screen;
  */
 class ListTable extends WP_List_Table {
 
+	/**
+	 * Order type.
+	 *
+	 * @var string
+	 */
 	private $order_type;
 
+	/**
+	 * Request vars.
+	 *
+	 * @var array
+	 */
 	private $request = array();
 
 	/**
@@ -73,6 +83,8 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Performs setup work required before rendering the table.
 	 *
+	 * @param array $args Args to initialize this list table.
+	 *
 	 * @return void
 	 */
 	public function setup( $args = array() ): void {
@@ -114,6 +126,15 @@ class ListTable extends WP_List_Table {
 	 */
 	public function column_default( $order, $column_name ) {
 		if ( has_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column' ) ) {
+			/**
+			 * Fires for each custom column for a specific order type. This hook takes precedence over the generic
+			 * action `manage_{$this->screen->id}_custom_column`.
+			 *
+			 * @param string    $column_name Identifier for the custom column.
+			 * @param \WC_Order $order       Current WooCommerce order object.
+			 *
+			 * @since 7.3.0
+			 */
 			do_action( 'woocommerce_' . $this->order_type . '_list_table_custom_column', $column_name, $order );
 		} else {
 			/**
@@ -266,6 +287,14 @@ class ListTable extends WP_List_Table {
 		foreach ( array( 'status', 's', 'm', '_customer_user' ) as $query_var ) {
 			$this->request[ $query_var ] = sanitize_text_field( wp_unslash( $_REQUEST[ $query_var ] ?? '' ) );
 		}
+
+		/**
+		 * Allows 3rd parties to filter the initial request vars before defaults and other logic is applied.
+		 *
+		 * @param array $request Request to be passed to `wc_get_orders()`.
+		 *
+		 * @since 7.3.0
+		 */
 		$this->request = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_request', $this->request );
 
 		$this->set_status_args();
@@ -283,6 +312,14 @@ class ListTable extends WP_List_Table {
 		 * @param array $query_args Arguments to be passed to `wc_get_orders()`.
 		 */
 		$order_query_args = (array) apply_filters( 'woocommerce_order_list_table_prepare_items_query_args', $this->order_query_args );
+
+		/**
+		 * Same as `woocommerce_order_list_table_prepare_items_query_args` but for a specific order type.
+		 *
+		 * @param array $query_args Arguments to be passed to `wc_get_orders()`.
+		 *
+		 * @since 7.3.0
+		 */
 		$order_query_args = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_prepare_items_query_args', $this->order_query_args );
 
 		// We must ensure the 'paginate' argument is set.
@@ -371,9 +408,16 @@ class ListTable extends WP_List_Table {
 	 * Implements filtering of orders by status.
 	 */
 	private function set_status_args() {
-		$status         = array_map( 'trim', (array) $this->request['status'] );
+		$status = array_map( 'trim', (array) $this->request['status'] );
 
 		if ( empty( $status ) || in_array( 'all', $status, true ) ) {
+			/**
+			 * Allows 3rd parties to set the default list of statuses for a given order type.
+			 *
+			 * @param string[] $statuses Statuses.
+			 *
+			 * @since 7.3.0
+			 */
 			$status = apply_filters(
 				'woocommerce_' . $this->order_type . '_list_table_default_statuses',
 				array_intersect(
@@ -611,6 +655,13 @@ class ListTable extends WP_List_Table {
 	 * @return array
 	 */
 	public function get_columns() {
+		/**
+		 * Filters the list of columns.
+		 *
+		 * @param array $columns List of sortable columns.
+		 *
+		 * @since 7.3.0
+		 */
 		return apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_columns',
 			array(
@@ -632,6 +683,13 @@ class ListTable extends WP_List_Table {
 	 * @return string[]
 	 */
 	public function get_sortable_columns() {
+		/**
+		 * Filters the list of sortable columns.
+		 *
+		 * @param array $sortable_columns List of sortable columns.
+		 *
+		 * @since 7.3.0
+		 */
 		return apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_sortable_columns',
 			array(

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -455,6 +455,7 @@ class ListTable extends WP_List_Table {
 		$view_links  = array();
 		$statuses    = $this->get_visible_statuses();
 		$current     = ! empty( $this->request['status'] ) ? sanitize_text_field( $this->request['status'] ) : 'all';
+		$all_count   = 0;
 
 		foreach ( array_keys( $statuses ) as $slug ) {
 			$total_in_status = $this->count_orders_by_status( $slug );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -15,6 +15,8 @@ class ListTable extends WP_List_Table {
 
 	private $order_type;
 
+	private $request = array();
+
 	/**
 	 * Contains the arguments to be used in the order query.
 	 *
@@ -257,6 +259,11 @@ class ListTable extends WP_List_Table {
 			'type'     => $this->order_type,
 		);
 
+		foreach ( array( 'status', 's', 'm', '_customer_user' ) as $query_var ) {
+			$this->request[ $query_var ] = sanitize_text_field( wp_unslash( $_REQUEST[ $query_var ] ?? '' ) );
+		}
+		$this->request = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_request', $this->request );
+
 		$this->set_status_args();
 		$this->set_order_args();
 		$this->set_date_args();
@@ -299,7 +306,7 @@ class ListTable extends WP_List_Table {
 		);
 
 		// Are we inside the trash?
-		$this->is_trash = isset( $_REQUEST['status'] ) && 'trash' === $_REQUEST['status'];
+		$this->is_trash = 'trash' === $this->request['status'];
 	}
 
 	/**
@@ -359,27 +366,28 @@ class ListTable extends WP_List_Table {
 	 * Implements filtering of orders by status.
 	 */
 	private function set_status_args() {
-		$status         = trim( sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ) );
-		$query_statuses = array();
+		$status         = array_map( 'trim', (array) $this->request['status'] );
 
-		if ( empty( $status ) || 'all' === $status ) {
-			$query_statuses = array_intersect(
-				array_keys( wc_get_order_statuses() ),
-				get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
+		if ( empty( $status ) || in_array( 'all', $status, true ) ) {
+			$status = apply_filters(
+				'woocommerce_' . $this->order_type . '_list_table_default_statuses',
+				array_intersect(
+					array_keys( wc_get_order_statuses() ),
+					get_post_stati( array( 'show_in_admin_all_list' => true ), 'names' )
+				)
 			);
 		} else {
-			$query_statuses[] = $status;
 			$this->has_filter = true;
 		}
 
-		$this->order_query_args['status'] = $query_statuses;
+		$this->order_query_args['status'] = $status;
 	}
 
 	/**
 	 * Implements order search.
 	 */
 	private function set_search_args(): void {
-		$search_term = trim( sanitize_text_field( wp_unslash( $_REQUEST['s'] ?? '' ) ) );
+		$search_term = trim( sanitize_text_field( $this->request['s'] ) );
 
 		if ( ! empty( $search_term ) ) {
 			$this->order_query_args['s'] = $search_term;
@@ -397,8 +405,7 @@ class ListTable extends WP_List_Table {
 		$view_counts = array();
 		$view_links  = array();
 		$statuses    = $this->get_visible_statuses();
-		$current     = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ) : 'all';
-		$all_count   = 0;
+		$current     = ! empty( $this->request['status'] ) ? sanitize_text_field( $this->request['status'] ) : 'all';
 
 		foreach ( array_keys( $statuses ) as $slug ) {
 			$total_in_status = $this->count_orders_by_status( $slug );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -330,7 +330,7 @@ class PageController {
 		return $url;
 	}
 
-	private function get_base_page_url( $order_type ) {
+	public function get_base_page_url( $order_type ) {
 		$order_types_with_ui = wc_get_order_types( 'admin-menu' );
 
 		if ( ! in_array( $order_type, $order_types_with_ui, true ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -11,6 +11,11 @@ class PageController {
 
 	use AccessiblePrivateMethods;
 
+	/**
+	 * The order type.
+	 *
+	 * @var string
+	 */
 	private $order_type = '';
 
 	/**
@@ -118,6 +123,11 @@ class PageController {
 		}
 	}
 
+	/**
+	 * Determines the order type for the current screen.
+	 *
+	 * @return void
+	 */
 	private function set_order_type() {
 		global $plugin_page, $pagenow;
 
@@ -281,6 +291,11 @@ class PageController {
 		$theorder = $this->order;
 	}
 
+	/**
+	 * Returns the current order type.
+	 *
+	 * @return string
+	 */
 	public function get_order_type() {
 		return $this->order_type;
 	}
@@ -311,7 +326,7 @@ class PageController {
 		return add_query_arg(
 			array(
 				'action' => 'edit',
-				'id' => absint( $order_id ),
+				'id'     => absint( $order_id ),
 			),
 			$this->get_base_page_url( wc_get_order( $order_id )->get_type() )
 		);
@@ -320,6 +335,7 @@ class PageController {
 	/**
 	 * Helper method to generate a link for creating order.
 	 *
+	 * @param string $order_type The order type. Defaults to 'shop_order'.
 	 * @return string
 	 */
 	public function get_new_page_url( $order_type = 'shop_order' ) : string {
@@ -330,11 +346,21 @@ class PageController {
 		return $url;
 	}
 
-	public function get_base_page_url( $order_type ) {
+	/**
+	 * Helper method to generate a link to the main screen for a custom order type.
+	 *
+	 * @param string $order_type The order type.
+	 *
+	 * @return string
+	 *
+	 * @throws \Exception When an invalid order type is passed.
+	 */
+	public function get_base_page_url( $order_type ): string {
 		$order_types_with_ui = wc_get_order_types( 'admin-menu' );
 
 		if ( ! in_array( $order_type, $order_types_with_ui, true ) ) {
-			throw new \Exception('invalid order type');
+			// translators: %s is a custom order type.
+			throw new \Exception( sprintf( __( 'Invalid order type: %s.', 'woocommerce' ), esc_html( $order_type ) ) );
 		}
 
 		return admin_url( 'admin.php?page=wc-orders' . ( 'shop_order' === $order_type ? '' : '--' . $order_type ) );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -131,21 +131,29 @@ class PageController {
 	 * @return void
 	 */
 	public function register_menu(): void {
-		add_submenu_page(
-			'woocommerce',
-			__( 'Orders', 'woocommerce' ),
-			__( 'Orders', 'woocommerce' ),
-			'edit_others_shop_orders',
-			'wc-orders',
-			array( $this, 'output' )
-		);
+		$order_types = wc_get_order_types( 'admin-menu' );
+
+		foreach ( $order_types as $order_type ) {
+			$post_type = get_post_type_object( $order_type );
+
+			add_submenu_page(
+				'woocommerce',
+				$post_type->labels->name,
+				$post_type->labels->menu_name,
+				$post_type->cap->edit_posts,
+				'wc-orders' . ( 'shop_order' === $order_type ? '' : '--' . $order_type ),
+				array( $this, 'output' )
+			);
+		}
 
 		// In some cases (such as if the authoritative order store was changed earlier in the current request) we
 		// need an extra step to remove the menu entry for the menu post type.
 		add_action(
 			'admin_init',
-			function() {
-				remove_submenu_page( 'woocommerce', 'edit.php?post_type=shop_order' );
+			function() use ( $order_types ) {
+				foreach ( $order_types as $order_type ) {
+					remove_submenu_page( 'woocommerce', 'edit.php?post_type=' . $order_type );
+				}
 			}
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -56,7 +56,7 @@ class PostsRedirectionController {
 	 * @return void
 	 */
 	private function maybe_redirect_to_orders_page(): void {
-		$post_type = $_GET['post_type'] ?? '';
+		$post_type = $_GET['post_type'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( ! $post_type || ! in_array( $post_type, wc_get_order_types( 'admin-menu' ), true ) ) {
 			return;
@@ -102,7 +102,7 @@ class PostsRedirectionController {
 	 * @return void
 	 */
 	private function maybe_redirect_to_new_order_page(): void {
-		$post_type = $_GET['post_type'] ?? '';
+		$post_type = $_GET['post_type'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( ! $post_type || ! in_array( $post_type, wc_get_order_types( 'admin-menu' ), true ) ) {
 			return;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -56,7 +56,9 @@ class PostsRedirectionController {
 	 * @return void
 	 */
 	private function maybe_redirect_to_orders_page(): void {
-		if ( ! isset( $_GET['post_type'] ) || 'shop_order' !== $_GET['post_type'] ) {
+		$post_type = $_GET['post_type'] ?? '';
+
+		if ( ! $post_type || ! in_array( $post_type, wc_get_order_types( 'admin-menu' ), true ) ) {
 			return;
 		}
 
@@ -72,7 +74,7 @@ class PostsRedirectionController {
 			unset( $query_args['post_status'] );
 		}
 
-		$new_url = $this->page_controller->get_orders_url();
+		$new_url = $this->page_controller->get_base_page_url( $post_type );
 		$new_url = add_query_arg( $query_args, $new_url );
 
 		// Handle bulk actions.
@@ -100,7 +102,9 @@ class PostsRedirectionController {
 	 * @return void
 	 */
 	private function maybe_redirect_to_new_order_page(): void {
-		if ( ! isset( $_GET['post_type'] ) || 'shop_order' !== $_GET['post_type'] ) {
+		$post_type = $_GET['post_type'] ?? '';
+
+		if ( ! $post_type || ! in_array( $post_type, wc_get_order_types( 'admin-menu' ), true ) ) {
 			return;
 		}
 
@@ -108,7 +112,7 @@ class PostsRedirectionController {
 		$query_args = wp_unslash( $_GET );
 		unset( $query_args['post_type'] );
 
-		$new_url = $this->page_controller->get_new_page_url();
+		$new_url = $this->page_controller->get_new_page_url( $post_type );
 		$new_url = add_query_arg( $query_args, $new_url );
 
 		wp_safe_redirect( $new_url, 301 );
@@ -123,7 +127,10 @@ class PostsRedirectionController {
 	private function maybe_redirect_to_edit_order_page(): void {
 		$post_id = absint( $_GET['post'] ?? 0 );
 
-		if ( ! $post_id || ! in_array( get_post_type( $post_id ), array( 'shop_order_placehold', 'shop_order' ), true ) || ! isset( $_GET['action'] ) ) {
+		$redirect_from_types   = wc_get_order_types( 'admin-menu' );
+		$redirect_from_types[] = 'shop_order_placehold';
+
+		if ( ! $post_id || ! in_array( get_post_type( $post_id ), $redirect_from_types, true ) || ! isset( $_GET['action'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds a few new APIs mainly to `ListTable` and `PageController` to support custom order types.
It also enhances `wc_get_page_screen_id()` so that it returns screen IDs for custom order types too.

The PR also updates some strings in the UI that were hardcoded with "Orders" or "Edit Order" for the corresponding label taken from the WordPress post type.

Most of this work was done in order to support Subscriptions but it benefits custom order types in general.

Closes #35601.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

#### Test general support for custom types
1. Start with HPOS disabled. That is, "High performance order storage" disabled in WC > Settings > Features.
1. Add and activate the following snippet either as a standalone plugin (or add to `functions.php` or similar). The job of this snippet is to create a custom order type so that there's actually something to test.
   <details>
     <summary>(PHP snippet)</summary>

    ```php
    add_action(
	    'plugins_loaded',
	    function() {
    
		    class WC_Shop_Ticket extends \WC_Order {
    
			    public function get_type() {
				    return 'shop_ticket';
			    }
    
		    }
    
		    add_action(
			    'init',
			    function() {
				    wc_register_order_type(
					    'shop_ticket',
					    array(
						    'labels'                           => array(
							    'name'               => __( 'Tickets', 'cust-ord-typ' ),
							    'singular_name'      => __( 'Ticket', 'cust-ord-typ' ),
							    'add_new'            => _x( 'Add Ticket', 'custom post type setting', 'cust-ord-typ' ),
							    'add_new_item'       => _x( 'Add New Ticket', 'custom post type setting', 'cust-ord-typ' ),
							    'edit'               => _x( 'Edit', 'custom post type setting', 'cust-ord-typ' ),
							    'edit_item'          => _x( 'Edit Ticket', 'custom post type setting', 'cust-ord-typ' ),
							    'new_item'           => _x( 'New Ticket', 'custom post type setting', 'cust-ord-typ' ),
							    'view'               => _x( 'View Ticket', 'custom post type setting', 'cust-ord-typ' ),
							    'view_item'          => _x( 'View Ticket', 'custom post type setting', 'cust-ord-typ' ),
							    'search_items'       => __( 'Search Tickets', 'cust-ord-typ' ),
							    'not_found'          => __( 'Tickets Not Found', 'cust-ord-typ' ),
							    'not_found_in_trash' => _x( 'No tickets found in trash', 'custom post type setting', 'cust-ord-typ' ),
							    'parent'             => _x( 'Parent Tickets', 'custom post type setting', 'cust-ord-typ' ),
							    'menu_name'          => __( 'Tickets', 'cust-ord-typ' ),
						    ),
						    'description'                      => __( 'This is where tickets are stored.', 'cust-ord-typ' ),
						    'public'                           => false,
						    'show_ui'                          => true,
						    'capability_type'                  => 'shop_order',
						    'map_meta_cap'                     => true,
						    'publicly_queryable'               => false,
						    'exclude_from_search'              => true,
						    'show_in_menu'                     => current_user_can( 'manage_woocommerce' ) ? 'woocommerce' : true,
						    'hierarchical'                     => false,
						    'show_in_nav_menus'                => false,
						    'rewrite'                          => false,
						    'query_var'                        => false,
						    'supports'                         => array( 'title', 'comments', 'custom-fields' ),
						    'has_archive'                      => false,
    
						    // wc_register_order_type() params
						    'exclude_from_orders_screen'       => true,
						    'add_order_meta_boxes'             => true,
						    'exclude_from_order_count'         => true,
						    'exclude_from_order_views'         => true,
						    'exclude_from_order_webhooks'      => true,
						    'exclude_from_order_reports'       => true,
						    'exclude_from_order_sales_reports' => true,
						    'class_name'                       => 'WC_Shop_Ticket',
					    )
				    );
			    }
		    );
    
	    }
    );
    ```
   </details>
1. With the above snippet enabled, you should see a new "Tickets" menu item under the WooCommerce menu.
   Notice this is a regular WP post type (i.e. the URL is `edit.php?post_type=shop_ticket`).
1. Go to WC > Tickets and create a few tickets for testing purposes.
1. Now go to WC > Settings > Features and enable HPOS.
1. Make sure to enable sync so that the created tickets are migrated over to HPOS.
1. Confirm the "Tickets" menu item still appears under the WooCommerce menu, but now its URL no longer refers to a custom post type URL. The new one should be `admin.php?page=wc-orders--shop_ticket`.
1. Confirm the tickets you created in step 4 are present.
1. Confirm you can add or edit tickets.
1. Check that the labels around the UI use the correct text, such as "Add Ticket" or "Edit Ticket".

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
