### PR TITLE
Add priceCurrency to AggregateOffer

### DIFF
--- a/plugins/woocommerce/changelog/35665-erikdemarco-structureddata
+++ b/plugins/woocommerce/changelog/35665-erikdemarco-structureddata
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve structured data for AggregateOffers by adding the priceCurrency field.

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -235,10 +235,10 @@ class WC_Structured_Data {
 					);
 				} else {
 					$markup_offer = array(
-						'@type'      => 'AggregateOffer',
-						'lowPrice'   => wc_format_decimal( $lowest, wc_get_price_decimals() ),
-						'highPrice'  => wc_format_decimal( $highest, wc_get_price_decimals() ),
-						'offerCount' => count( $product->get_children() ),
+						'@type'         => 'AggregateOffer',
+						'lowPrice'      => wc_format_decimal( $lowest, wc_get_price_decimals() ),
+						'highPrice'     => wc_format_decimal( $highest, wc_get_price_decimals() ),
+						'offerCount'    => count( $product->get_children() ),
 						'priceCurrency' => $currency,
 					);
 				}

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -239,6 +239,7 @@ class WC_Structured_Data {
 						'lowPrice'   => wc_format_decimal( $lowest, wc_get_price_decimals() ),
 						'highPrice'  => wc_format_decimal( $highest, wc_get_price_decimals() ),
 						'offerCount' => count( $product->get_children() ),
+						'priceCurrency' => $currency,
 					);
 				}
 			} else {


### PR DESCRIPTION
priceCurrency is required for AggregateOffer
https://developers.google.com/search/docs/appearance/structured-data/product#aggregate-offer-properties

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1.
2.
3.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
