### PR TITLE
Add a states migrator helper method and migrate states for New Zealand and Ukraine

### DIFF
--- a/plugins/woocommerce/changelog/fix-35535
+++ b/plugins/woocommerce/changelog/fix-35535
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a data migration for changed New Zealand and Ukraine state codes

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -218,7 +218,8 @@ class WC_Install {
 			'wc_update_700_remove_recommended_marketing_plugins_transient',
 		),
 		'7.2.0' => array(
-			'wc_update_720_adjust_new_zealand_and_ukraine_states',
+			'wc_update_720_adjust_new_zealand_states',
+			'wc_update_720_adjust_ukraine_states',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -217,6 +217,9 @@ class WC_Install {
 			'wc_update_700_remove_download_log_fk',
 			'wc_update_700_remove_recommended_marketing_plugins_transient',
 		),
+		'7.2.0' => array(
+			'wc_update_720_adjust_new_zealand_and_ukraine_states',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -25,9 +25,6 @@ use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchronize as Download_Directories_Sync;
-use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
-use Automattic\WooCommerce\Utilities\OrderUtil;
-use Automattic\WooCommerce\Utilities\StringUtil;
 
 /**
  * Update file paths for 2.0
@@ -2477,11 +2474,11 @@ function wc_update_700_remove_recommended_marketing_plugins_transient() {
 }
 
 /**
- * Update the New Zealand state codes in shipping locations and store location
+ * Update the New Zealand state codes in the database
  * after they were updated in code to the CLDR standard.
  */
-function wc_update_720_adjust_new_zealand_and_ukraine_states() {
-	MigrationHelper::migrate_country_states(
+function wc_update_720_adjust_new_zealand_states() {
+	return MigrationHelper::migrate_country_states(
 		'NZ',
 		array(
 			'NL' => 'NTL',
@@ -2502,8 +2499,14 @@ function wc_update_720_adjust_new_zealand_and_ukraine_states() {
 			'SL' => 'STL',
 		)
 	);
+}
 
-	MigrationHelper::migrate_country_states(
+/**
+ * Update the Ukraine state codes in the database
+ * after they were updated in code to the CLDR standard.
+ */
+function wc_update_720_adjust_ukraine_states() {
+	return MigrationHelper::migrate_country_states(
 		'UA',
 		array(
 			'VN' => 'UA05',
@@ -2533,3 +2536,4 @@ function wc_update_720_adjust_new_zealand_and_ukraine_states() {
 		)
 	);
 }
+

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -18,12 +18,16 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Database\Migrations\MigrationHelper;
 use Automattic\WooCommerce\Internal\Admin\Marketing;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchronize as Download_Directories_Sync;
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 /**
  * Update file paths for 2.0
@@ -2470,4 +2474,62 @@ function wc_update_700_remove_download_log_fk() {
  */
 function wc_update_700_remove_recommended_marketing_plugins_transient() {
 	delete_transient( Marketing::RECOMMENDED_PLUGINS_TRANSIENT );
+}
+
+/**
+ * Update the New Zealand state codes in shipping locations and store location
+ * after they were updated in code to the CLDR standard.
+ */
+function wc_update_720_adjust_new_zealand_and_ukraine_states() {
+	MigrationHelper::migrate_country_states(
+		'NZ',
+		array(
+			'NL' => 'NTL',
+			'AK' => 'AUK',
+			'WA' => 'WKO',
+			'BP' => 'BOP',
+			'TK' => 'TKI',
+			'GI' => 'GIS',
+			'HB' => 'HKB',
+			'MW' => 'MWT',
+			'WE' => 'WGN',
+			'NS' => 'NSN',
+			'MB' => 'MBH',
+			'TM' => 'TAS',
+			'WC' => 'WTC',
+			'CT' => 'CAN',
+			'OT' => 'OTA',
+			'SL' => 'STL',
+		)
+	);
+
+	MigrationHelper::migrate_country_states(
+		'UA',
+		array(
+			'VN' => 'UA05',
+			'LH' => 'UA09',
+			'VL' => 'UA07',
+			'DP' => 'UA12',
+			'DT' => 'UA14',
+			'ZT' => 'UA18',
+			'ZK' => 'UA21',
+			'ZP' => 'UA23',
+			'IF' => 'UA26',
+			'KV' => 'UA32',
+			'KH' => 'UA35',
+			'LV' => 'UA46',
+			'MY' => 'UA48',
+			'OD' => 'UA51',
+			'PL' => 'UA53',
+			'RV' => 'UA56',
+			'SM' => 'UA59',
+			'TP' => 'UA61',
+			'KK' => 'UA63',
+			'KS' => 'UA65',
+			'KM' => 'UA68',
+			'CK' => 'UA71',
+			'CH' => 'UA74',
+			'CV' => 'UA77',
+		)
+	);
 }

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -6,6 +6,8 @@
 namespace Automattic\WooCommerce\Database\Migrations;
 
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 /**
  * Helper class to assist with migration related operations.
@@ -75,4 +77,163 @@ class MigrationHelper {
 		return $db_util->generate_on_duplicate_statement_clause( $columns );
 	}
 
+	/**
+	 * Migrate state codes in all the required places in the database (hopefully) when they change for a given country.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return void
+	 */
+	public static function migrate_country_states( string $country_code, array $old_to_new_states_mapping ): void {
+		self::migrate_country_states_for_shipping_locations( $country_code, $old_to_new_states_mapping );
+
+		// We'll migrate only the authoritative orders table,
+		// the sync mechanism (if enabled) will take care of updating the backup table.
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			self::migrate_country_states_for_cot_orders( $country_code, $old_to_new_states_mapping );
+		} else {
+			self::migrate_country_states_for_post_orders( $country_code, $old_to_new_states_mapping );
+		}
+
+		self::migrate_country_states_for_store_location( $country_code, $old_to_new_states_mapping );
+	}
+
+	/**
+	 * Migrate state codes in the shipping locations table.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return void
+	 */
+	private static function migrate_country_states_for_shipping_locations( string $country_code, array $old_to_new_states_mapping ): void {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+
+		$sql            = "SELECT location_id, location_code FROM {$wpdb->prefix}woocommerce_shipping_zone_locations WHERE location_code LIKE '{$country_code}:%'";
+		$locations_data = $wpdb->get_results( $sql, ARRAY_A );
+
+		foreach ( $locations_data as $location_data ) {
+			$old_state_code = substr( $location_data['location_code'], 3 );
+			if ( array_key_exists( $old_state_code, $old_to_new_states_mapping ) ) {
+				$new_location_code = "{$country_code}:{$old_to_new_states_mapping[$old_state_code]}";
+				$update_query      = $wpdb->prepare(
+					"UPDATE {$wpdb->prefix}woocommerce_shipping_zone_locations SET location_code=%s WHERE location_id=%d",
+					$new_location_code,
+					$location_data['location_id']
+				);
+				$wpdb->query( $update_query );
+			}
+		}
+
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Migrate state codes for orders in the orders table.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return void
+	 */
+	private static function migrate_country_states_for_cot_orders( string $country_code, array $old_to_new_states_mapping ): void {
+		global $wpdb;
+
+		$current_date_gmt          = current_time( 'Y-m-d H:i:s', true );
+		$states_as_comma_separated = "('" . join( "','", array_keys( $old_to_new_states_mapping ) ) . "')";
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$sql            = $wpdb->prepare(
+			"SELECT id, order_id, state FROM {$wpdb->prefix}wc_order_addresses WHERE country=%s AND state IN {$states_as_comma_separated}",
+			$country_code
+		);
+		$addresses_data = $wpdb->get_results( $sql, ARRAY_A );
+
+		foreach ( $addresses_data as $address_data ) {
+			$update_query = $wpdb->prepare(
+				"UPDATE {$wpdb->prefix}wc_order_addresses SET state=%s WHERE id=%d",
+				$old_to_new_states_mapping[ $address_data['state'] ],
+				$address_data['id']
+			);
+			$wpdb->query( $update_query );
+
+			$update_query = $wpdb->prepare(
+				"UPDATE {$wpdb->prefix}wc_orders SET date_updated_gmt=%s WHERE id=%d",
+				$current_date_gmt,
+				$address_data['order_id']
+			);
+			$wpdb->query( $update_query );
+		}
+
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Migrate state codes for orders in the posts table.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return void
+	 */
+	private static function migrate_country_states_for_post_orders( string $country_code, array $old_to_new_states_mapping ): void {
+		global $wpdb;
+
+		$current_date              = current_time( 'Y-m-d H:i:s', false );
+		$current_date_gmt          = current_time( 'Y-m-d H:i:s', true );
+		$states_as_comma_separated = "('" . join( "','", array_keys( $old_to_new_states_mapping ) ) . "')";
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare(
+			"SELECT meta_id, post_id, meta_value FROM {$wpdb->prefix}postmeta
+				WHERE (meta_key='_billing_state' OR meta_key='_shipping_state')
+				AND meta_value IN {$states_as_comma_separated}
+				AND post_id IN (
+					SELECT post_id FROM {$wpdb->prefix}postmeta WHERE
+					(meta_key = '_billing_country' OR meta_key='_shipping_country')
+					AND meta_value=%s
+				)",
+			$country_code
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$addresses_data = $wpdb->get_results( $sql, ARRAY_A );
+
+		foreach ( $addresses_data as $address_data ) {
+			$update_query = $wpdb->prepare(
+				"UPDATE {$wpdb->prefix}postmeta SET meta_value=%s WHERE meta_id=%d",
+				$old_to_new_states_mapping[ $address_data['meta_value'] ],
+				$address_data['meta_id']
+			);
+			$wpdb->query( $update_query );
+
+			$update_query = $wpdb->prepare(
+				"UPDATE {$wpdb->prefix}posts SET post_modified=%s, post_modified_gmt=%s WHERE ID=%d",
+				$current_date,
+				$current_date_gmt,
+				$address_data['post_id']
+			);
+			$wpdb->query( $update_query );
+		}
+		//phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Migrate the state code for the store location.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return void
+	 */
+	private static function migrate_country_states_for_store_location( string $country_code, array $old_to_new_states_mapping ): void {
+		$store_location = get_option( 'woocommerce_default_country', '' );
+		if ( StringUtil::starts_with( $store_location, "{$country_code}:" ) ) {
+			$old_location_code = substr( $store_location, 3 );
+			if ( array_key_exists( $old_location_code, $old_to_new_states_mapping ) ) {
+				$new_location_code = "{$country_code}:{$old_to_new_states_mapping[$old_location_code]}";
+				update_option( 'woocommerce_default_country', $new_location_code );
+			}
+		}
+	}
 }

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -175,7 +175,7 @@ class MigrationHelper {
 		 *
 		 * @since 7.2.0
 		 */
-		$limit      = apply_filters( 'woocommerce_migrate_country_states_for_orders_batch_size', 100, $country_code, $old_to_new_states_mapping );
+		$limit      = apply_filters( 'woocommerce_migrate_country_states_for_orders_batch_size', 5, $country_code, $old_to_new_states_mapping );
 		$cot_exists = wc_get_container()->get( DataSynchronizer::class )->check_orders_table_exists();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -194,19 +194,18 @@ class MigrationHelper {
 			}
 
 			$update_query = $wpdb->prepare(
-				"UPDATE {$wpdb->prefix}postmeta
+				"UPDATE /*+ NO_MERGE(posts_with_address_in_country) */ {$wpdb->prefix}postmeta,
+					(SELECT DISTINCT post_id FROM {$wpdb->prefix}postmeta
+					WHERE (meta_key = '_billing_country' OR meta_key='_shipping_country') AND meta_value=%s)
+					AS posts_with_address_in_country
 				SET meta_value=%s
 				WHERE (meta_key='_billing_state' OR meta_key='_shipping_state')
 				AND meta_value=%s
-				AND post_id IN (
-					SELECT post_id FROM {$wpdb->prefix}postmeta WHERE
-					(meta_key = '_billing_country' OR meta_key='_shipping_country')
-					AND meta_value=%s
-				)
+				AND {$wpdb->prefix}postmeta.post_id = posts_with_address_in_country.post_id
 				LIMIT %d",
+				$country_code,
 				$new_state,
 				$old_state,
-				$country_code,
 				$limit
 			);
 
@@ -244,7 +243,7 @@ class MigrationHelper {
 			$more_exist_query = "SELECT EXISTS ({$posts_exist_query})";
 		}
 
-		return $wpdb->get_var( $more_exist_query ) !== 0;
+		return intval( $wpdb->get_var( $more_exist_query ) ) !== 0;
 
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -5,8 +5,8 @@
 
 namespace Automattic\WooCommerce\Database\Migrations;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
-use Automattic\WooCommerce\Utilities\OrderUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
 
 /**
@@ -78,23 +78,29 @@ class MigrationHelper {
 	}
 
 	/**
-	 * Migrate state codes in all the required places in the database (hopefully) when they change for a given country.
+	 * Migrate state codes in all the required places in the database, needed after they change for a given country.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return bool True if there are more records that need to be migrated, false otherwise.
+	 */
+	public static function migrate_country_states( string $country_code, array $old_to_new_states_mapping ): bool {
+		$more_remaining = self::migrate_country_states_for_orders( $country_code, $old_to_new_states_mapping );
+		if ( ! $more_remaining ) {
+			self::migrate_country_states_for_misc_data( $country_code, $old_to_new_states_mapping );
+		}
+		return $more_remaining;
+	}
+
+	/**
+	 * Migrate state codes in all the required places in the database (except orders).
 	 *
 	 * @param string $country_code The country that has the states for which the migration is needed.
 	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
 	 * @return void
 	 */
-	public static function migrate_country_states( string $country_code, array $old_to_new_states_mapping ): void {
+	private static function migrate_country_states_for_misc_data( string $country_code, array $old_to_new_states_mapping ): void {
 		self::migrate_country_states_for_shipping_locations( $country_code, $old_to_new_states_mapping );
-
-		// We'll migrate only the authoritative orders table,
-		// the sync mechanism (if enabled) will take care of updating the backup table.
-		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			self::migrate_country_states_for_cot_orders( $country_code, $old_to_new_states_mapping );
-		} else {
-			self::migrate_country_states_for_post_orders( $country_code, $old_to_new_states_mapping );
-		}
-
 		self::migrate_country_states_for_store_location( $country_code, $old_to_new_states_mapping );
 	}
 
@@ -130,96 +136,6 @@ class MigrationHelper {
 	}
 
 	/**
-	 * Migrate state codes for orders in the orders table.
-	 *
-	 * @param string $country_code The country that has the states for which the migration is needed.
-	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
-	 * @return void
-	 */
-	private static function migrate_country_states_for_cot_orders( string $country_code, array $old_to_new_states_mapping ): void {
-		global $wpdb;
-
-		$current_date_gmt          = current_time( 'Y-m-d H:i:s', true );
-		$states_as_comma_separated = "('" . join( "','", array_keys( $old_to_new_states_mapping ) ) . "')";
-
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		$sql            = $wpdb->prepare(
-			"SELECT id, order_id, state FROM {$wpdb->prefix}wc_order_addresses WHERE country=%s AND state IN {$states_as_comma_separated}",
-			$country_code
-		);
-		$addresses_data = $wpdb->get_results( $sql, ARRAY_A );
-
-		foreach ( $addresses_data as $address_data ) {
-			$update_query = $wpdb->prepare(
-				"UPDATE {$wpdb->prefix}wc_order_addresses SET state=%s WHERE id=%d",
-				$old_to_new_states_mapping[ $address_data['state'] ],
-				$address_data['id']
-			);
-			$wpdb->query( $update_query );
-
-			$update_query = $wpdb->prepare(
-				"UPDATE {$wpdb->prefix}wc_orders SET date_updated_gmt=%s WHERE id=%d",
-				$current_date_gmt,
-				$address_data['order_id']
-			);
-			$wpdb->query( $update_query );
-		}
-
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	}
-
-	/**
-	 * Migrate state codes for orders in the posts table.
-	 *
-	 * @param string $country_code The country that has the states for which the migration is needed.
-	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
-	 * @return void
-	 */
-	private static function migrate_country_states_for_post_orders( string $country_code, array $old_to_new_states_mapping ): void {
-		global $wpdb;
-
-		$current_date              = current_time( 'Y-m-d H:i:s', false );
-		$current_date_gmt          = current_time( 'Y-m-d H:i:s', true );
-		$states_as_comma_separated = "('" . join( "','", array_keys( $old_to_new_states_mapping ) ) . "')";
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$sql = $wpdb->prepare(
-			"SELECT meta_id, post_id, meta_value FROM {$wpdb->prefix}postmeta
-				WHERE (meta_key='_billing_state' OR meta_key='_shipping_state')
-				AND meta_value IN {$states_as_comma_separated}
-				AND post_id IN (
-					SELECT post_id FROM {$wpdb->prefix}postmeta WHERE
-					(meta_key = '_billing_country' OR meta_key='_shipping_country')
-					AND meta_value=%s
-				)",
-			$country_code
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$addresses_data = $wpdb->get_results( $sql, ARRAY_A );
-
-		foreach ( $addresses_data as $address_data ) {
-			$update_query = $wpdb->prepare(
-				"UPDATE {$wpdb->prefix}postmeta SET meta_value=%s WHERE meta_id=%d",
-				$old_to_new_states_mapping[ $address_data['meta_value'] ],
-				$address_data['meta_id']
-			);
-			$wpdb->query( $update_query );
-
-			$update_query = $wpdb->prepare(
-				"UPDATE {$wpdb->prefix}posts SET post_modified=%s, post_modified_gmt=%s WHERE ID=%d",
-				$current_date,
-				$current_date_gmt,
-				$address_data['post_id']
-			);
-			$wpdb->query( $update_query );
-		}
-		//phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-	}
-
-	/**
 	 * Migrate the state code for the store location.
 	 *
 	 * @param string $country_code The country that has the states for which the migration is needed.
@@ -235,5 +151,101 @@ class MigrationHelper {
 				update_option( 'woocommerce_default_country', $new_location_code );
 			}
 		}
+	}
+
+	/**
+	 * Migrate state codes for orders in the orders table and in the posts table.
+	 * It will migrate only N*2*(number of states) records, being N equal to 100 by default
+	 * but this number can be modified via the woocommerce_migrate_country_states_for_orders_batch_size filter.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return bool True if there are more records that need to be migrated, false otherwise.
+	 */
+	private static function migrate_country_states_for_orders( string $country_code, array $old_to_new_states_mapping ): bool {
+		global $wpdb;
+
+		/**
+		 * Filters the value of N, where the maximum count of database records that will be updated in one single run of migrate_country_states_for_orders
+		 * is N*2*count($old_to_new_states_mapping) if the woocommerce_orders table exists, or N*count($old_to_new_states_mapping) otherwise.
+		 *
+		 * @param int $batch_size Default value for the count of records to update.
+		 * @param string $country_code Country code for the update.
+		 * @param array  $old_to_new_states_mapping Associative array of old to new state codes.
+		 *
+		 * @since 7.2.0
+		 */
+		$limit      = apply_filters( 'woocommerce_migrate_country_states_for_orders_batch_size', 100, $country_code, $old_to_new_states_mapping );
+		$cot_exists = wc_get_container()->get( DataSynchronizer::class )->check_orders_table_exists();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		foreach ( $old_to_new_states_mapping as $old_state => $new_state ) {
+			if ( $cot_exists ) {
+				$update_query = $wpdb->prepare(
+					"UPDATE {$wpdb->prefix}wc_order_addresses SET state=%s WHERE country=%s AND state=%s LIMIT %d",
+					$new_state,
+					$country_code,
+					$old_state,
+					$limit
+				);
+
+				$wpdb->query( $update_query );
+			}
+
+			$update_query = $wpdb->prepare(
+				"UPDATE {$wpdb->prefix}postmeta
+				SET meta_value=%s
+				WHERE (meta_key='_billing_state' OR meta_key='_shipping_state')
+				AND meta_value=%s
+				AND post_id IN (
+					SELECT post_id FROM {$wpdb->prefix}postmeta WHERE
+					(meta_key = '_billing_country' OR meta_key='_shipping_country')
+					AND meta_value=%s
+				)
+				LIMIT %d",
+				$new_state,
+				$old_state,
+				$country_code,
+				$limit
+			);
+
+			$wpdb->query( $update_query );
+		}
+
+		$states_as_comma_separated = "('" . join( "','", array_keys( $old_to_new_states_mapping ) ) . "')";
+
+		$posts_exist_query = $wpdb->prepare(
+			"
+			SELECT 1 FROM {$wpdb->prefix}postmeta
+			WHERE (meta_key='_billing_state' OR meta_key='_shipping_state')
+			AND meta_value IN {$states_as_comma_separated}
+			AND post_id IN (
+				SELECT post_id FROM {$wpdb->prefix}postmeta WHERE
+				(meta_key = '_billing_country' OR meta_key='_shipping_country')
+				AND meta_value=%s
+			)",
+			$country_code
+		);
+
+		if ( $cot_exists ) {
+			$more_exist_query = $wpdb->prepare(
+				"
+			SELECT EXISTS(
+				SELECT 1 FROM {$wpdb->prefix}wc_order_addresses
+				WHERE country=%s AND state IN {$states_as_comma_separated}
+			)
+			OR EXISTS (
+			  {$posts_exist_query}
+			)",
+				$country_code
+			);
+		} else {
+			$more_exist_query = "SELECT EXISTS ({$posts_exist_query})";
+		}
+
+		return $wpdb->get_var( $more_exist_query ) !== 0;
+
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }


### PR DESCRIPTION
-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/35011 and https://github.com/woocommerce/woocommerce/pull/35493 have converted the state codes for New Zealand and Ukraine to the CLDR standard, but no change happened in the database records that were holding these codes, leading to issues in the following areas:

* Shipping locations
* Orders
* The store address

This pull request adds a `MigrationHelper::migrate_country_states` method that performs all the required database changes, and two database migrations to do the changes for New Zealand and Ukraine.

`MigrationHelper::migrate_country_states` will only migrate a maximum of `100*count(states)` records per table (orders meta table if it exists, and posts meta table), this number can be changed via the `woocommerce_migrate_country_states_for_orders_batch_size` filter.

Closes #35535.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Switch to WooCommerce 7.0.
2. Create shipping locations (Settings - Shipping) for states in New Zealand and Ukraine.
3. Set the store country/state (Settings - General) to a state of New Zealand or Ukraine.
4. Create a few orders with shipping and billing addresses in New Zealand and Ukraine.
5. Switch to the branch of this pull request and notice how now:
  * The shipping locations you had created appear as an empty list (just commas).
  * The store country appears as Afghanistan.
  * The orders appear as having no associated state.
6. Run the database update.
7. If you have a big number of orders in the database you'll need to wait for multiple Action Scheduler runs (or force it manually).
8. Verify that shipping locations, store address and orders are now correct (with the updated state names).

Both the orders meta table (if it exists) and the posts meta table are updated, and no change is made to the update date field of the orders nor posts table. Thus the orders sync mechanism is not affected, and which is the authoritative table for orders is irrelevant.

Note that for orders only the authoritative table is changed. Once the database is updated there should be pending syncs for the affected orders (in Settings - Advanced - Custom data stores) and once the sync finishes all the data should be adjusted in all the affected tables (`wp_wc_order_addresses` and `wp_postmeta`, the later for the `_billing_state` and `_shipping_state` keys).

If it's helpful for testing the database update can also be forced with the following cli commands:

```
wp option set woocommerce_db_version 7.0.0
wp eval 'WC_Install::run_manual_database_update();'
wp action-scheduler run
```

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
