### PR TITLE
Add a blank space between the emoji and the message within a notice popup

### DIFF
--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -85,10 +85,7 @@ export function useProductHelper() {
 					if ( ! skipNotice ) {
 						const noticeContent =
 							newProduct.status === 'publish'
-								? __(
-										'Product published. View in store.',
-										'woocommerce'
-								  )
+								? __( 'Product published.', 'woocommerce' )
 								: __(
 										'Product successfully created.',
 										'woocommerce'
@@ -161,10 +158,7 @@ export function useProductHelper() {
 						const noticeContent =
 							product.status === 'draft' &&
 							updatedProduct.status === 'publish'
-								? __(
-										'Product published. View in store.',
-										'woocommerce'
-								  )
+								? __( 'Product published.', 'woocommerce' )
 								: __(
 										'Product successfully updated.',
 										'woocommerce'

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -82,25 +82,23 @@ export function useProductHelper() {
 				status,
 			} ).then(
 				( newProduct ) => {
+					const noticeContent =
+						newProduct.status === 'publish'
+							? __(
+									'Product published. View in store.',
+									'woocommerce'
+							  )
+							: __(
+									'Product successfully created.',
+									'woocommerce'
+							  );
 					if ( ! skipNotice ) {
-						createNotice(
-							'success',
-							newProduct.status === 'publish'
-								? __(
-										'🎉 Product published. View in store',
-										'woocommerce'
-								  )
-								: __(
-										'🎉 Product successfully created.',
-										'woocommerce'
-								  ),
-							{
-								actions: getNoticePreviewActions(
-									newProduct.status,
-									newProduct.permalink
-								),
-							}
-						);
+						createNotice( 'success', `🎉‎ ${ noticeContent }`, {
+							actions: getNoticePreviewActions(
+								newProduct.status,
+								newProduct.permalink
+							),
+						} );
 					}
 					setUpdating( {
 						...updating,
@@ -159,26 +157,24 @@ export function useProductHelper() {
 				status,
 			} ).then(
 				( updatedProduct ) => {
+					const noticeContent =
+						product.status === 'draft' &&
+						updatedProduct.status === 'publish'
+							? __(
+									'Product published. View in store.',
+									'woocommerce'
+							  )
+							: __(
+									'Product successfully updated.',
+									'woocommerce'
+							  );
 					if ( ! skipNotice ) {
-						createNotice(
-							'success',
-							product.status === 'draft' &&
-								updatedProduct.status === 'publish'
-								? __(
-										'🎉 Product published. View in store.',
-										'woocommerce'
-								  )
-								: __(
-										'🎉 Product successfully updated.',
-										'woocommerce'
-								  ),
-							{
-								actions: getNoticePreviewActions(
-									updatedProduct.status,
-									updatedProduct.permalink
-								),
-							}
-						);
+						createNotice( 'success', `🎉‎ ${ noticeContent }`, {
+							actions: getNoticePreviewActions(
+								updatedProduct.status,
+								updatedProduct.permalink
+							),
+						} );
 					}
 					setUpdating( {
 						...updating,
@@ -234,13 +230,11 @@ export function useProductHelper() {
 		setIsDeleting( true );
 		return deleteProduct( id ).then(
 			( product ) => {
-				createNotice(
-					'success',
-					__(
-						'🎉 Successfully moved product to Trash.',
-						'woocommerce'
-					)
+				const noticeContent = __(
+					'Successfully moved product to Trash.',
+					'woocommerce'
 				);
+				createNotice( 'success', `🎉‎ ${ noticeContent }` );
 				setIsDeleting( false );
 				return product;
 			},

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -82,17 +82,17 @@ export function useProductHelper() {
 				status,
 			} ).then(
 				( newProduct ) => {
-					const noticeContent =
-						newProduct.status === 'publish'
-							? __(
-									'Product published. View in store.',
-									'woocommerce'
-							  )
-							: __(
-									'Product successfully created.',
-									'woocommerce'
-							  );
 					if ( ! skipNotice ) {
+						const noticeContent =
+							newProduct.status === 'publish'
+								? __(
+										'Product published. View in store.',
+										'woocommerce'
+								  )
+								: __(
+										'Product successfully created.',
+										'woocommerce'
+								  );
 						createNotice( 'success', `🎉‎ ${ noticeContent }`, {
 							actions: getNoticePreviewActions(
 								newProduct.status,
@@ -157,18 +157,18 @@ export function useProductHelper() {
 				status,
 			} ).then(
 				( updatedProduct ) => {
-					const noticeContent =
-						product.status === 'draft' &&
-						updatedProduct.status === 'publish'
-							? __(
-									'Product published. View in store.',
-									'woocommerce'
-							  )
-							: __(
-									'Product successfully updated.',
-									'woocommerce'
-							  );
 					if ( ! skipNotice ) {
+						const noticeContent =
+							product.status === 'draft' &&
+							updatedProduct.status === 'publish'
+								? __(
+										'Product published. View in store.',
+										'woocommerce'
+								  )
+								: __(
+										'Product successfully updated.',
+										'woocommerce'
+								  );
 						createNotice( 'success', `🎉‎ ${ noticeContent }`, {
 							actions: getNoticePreviewActions(
 								updatedProduct.status,

--- a/plugins/woocommerce/changelog/fix-35541-add-space-notice-content
+++ b/plugins/woocommerce/changelog/fix-35541-add-space-notice-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add a blank space between the emoji and the message within a notice popup


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
What happened here was that anytime we want to use an emoji as part of a text message inside of a notice the following happends:
We expect the message to looks like `🎉 Product successfully updated.`
but that string is converted to:
```jsx
<>
  <image src="..." class="emoji" />
  "Product successfully updated."
</>
```
so any blank space between the image and the string literal is trimmed, resulting in `🎉Product successfully updated.`.

To avoid this behaviour my suggestions here is to add an invisible charater + the blank space at the begining of the string literal `🎉[U+200E] Product successfully updated.` to prevent the trimming process. So the rendered result should looks like:
```jsx
<>
  <image src="..." class="emoji" />
  "[U+200E] Product successfully updated."
</>
```

Note: `[U+200E]` is an invisible unicode character and not a blank space.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35541
Closes https://github.com/woocommerce/woocommerce/issues/35716

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products -> Add New (MVP)` page
2. Create, update, save as draft a product and a notice should be shown.
3. If the notice message contains an emoji, it should has a visible blank space between the emoji and the message.
4. Like: `🎉 Product successfully updated.`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
