### PR TITLE
Set editor mode on initialization to prevent initial text editor focus

### DIFF
--- a/packages/js/components/changelog/fix-35697
+++ b/packages/js/components/changelog/fix-35697
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Set editor mode on initialization to prevent initial text editor focus

--- a/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
+++ b/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
@@ -45,15 +45,24 @@ export const EditorWritingFlow = ( {
 		};
 	} );
 
+	// This is a workaround to prevent focusing the block on intialization.
+	// Changing to a mode other than "edit" ensures that no initial position
+	// is found and no element gets subsequently focused.
+	// See https://github.com/WordPress/gutenberg/blob/411b6eee8376e31bf9db4c15c92a80524ae38e9b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js#L42
+	const setEditorIsInitializing = ( val: boolean ) => {
+		if ( typeof __unstableSetEditorMode !== 'function' ) {
+			return;
+		}
+
+		__unstableSetEditorMode( val ? 'initialized' : 'edit' );
+	};
+
 	useEffect( () => {
 		if ( selectedBlockClientIds?.length || ! firstBlock ) {
 			return;
 		}
-		// This is a workaround to prevent focusing the block on intialization.
-		// Changing to a mode other than "edit" ensures that no initial position
-		// is found and no element gets subsequently focused.
-		// See https://github.com/WordPress/gutenberg/blob/411b6eee8376e31bf9db4c15c92a80524ae38e9b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js#L42
-		__unstableSetEditorMode( 'initialized' );
+
+		setEditorIsInitializing( true );
 		selectBlock( firstBlock.clientId );
 	}, [ firstBlock, selectedBlockClientIds ] );
 
@@ -72,7 +81,7 @@ export const EditorWritingFlow = ( {
 		if ( editorMode === 'edit' ) {
 			return;
 		}
-		__unstableSetEditorMode( 'edit' );
+		setEditorIsInitializing( false );
 	};
 
 	return (

--- a/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
+++ b/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
@@ -49,12 +49,12 @@ export const EditorWritingFlow = ( {
 	// Changing to a mode other than "edit" ensures that no initial position
 	// is found and no element gets subsequently focused.
 	// See https://github.com/WordPress/gutenberg/blob/411b6eee8376e31bf9db4c15c92a80524ae38e9b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js#L42
-	const setEditorIsInitializing = ( val: boolean ) => {
+	const setEditorIsInitializing = ( isInitializing: boolean ) => {
 		if ( typeof __unstableSetEditorMode !== 'function' ) {
 			return;
 		}
 
-		__unstableSetEditorMode( val ? 'initialized' : 'edit' );
+		__unstableSetEditorMode( isInitializing ? 'initialized' : 'edit' );
 	};
 
 	useEffect( () => {

--- a/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
+++ b/packages/js/components/src/rich-text-editor/editor-writing-flow.tsx
@@ -31,13 +31,16 @@ export const EditorWritingFlow = ( {
 	const isEmpty = ! blocks.length;
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore This action is available in the block editor data store.
-	const { insertBlock, selectBlock } = useDispatch( blockEditorStore );
-	const { selectedBlockClientIds } = useSelect( ( select ) => {
+	const { insertBlock, selectBlock, __unstableSetEditorMode } =
+		useDispatch( blockEditorStore );
+
+	const { selectedBlockClientIds, editorMode } = useSelect( ( select ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore This selector is available in the block editor data store.
-		const { getSelectedBlockClientIds } = select( blockEditorStore );
-
+		const { getSelectedBlockClientIds, __unstableGetEditorMode } =
+			select( blockEditorStore );
 		return {
+			editorMode: __unstableGetEditorMode(),
 			selectedBlockClientIds: getSelectedBlockClientIds(),
 		};
 	} );
@@ -46,6 +49,11 @@ export const EditorWritingFlow = ( {
 		if ( selectedBlockClientIds?.length || ! firstBlock ) {
 			return;
 		}
+		// This is a workaround to prevent focusing the block on intialization.
+		// Changing to a mode other than "edit" ensures that no initial position
+		// is found and no element gets subsequently focused.
+		// See https://github.com/WordPress/gutenberg/blob/411b6eee8376e31bf9db4c15c92a80524ae38e9b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js#L42
+		__unstableSetEditorMode( 'initialized' );
 		selectBlock( firstBlock.clientId );
 	}, [ firstBlock, selectedBlockClientIds ] );
 
@@ -60,6 +68,13 @@ export const EditorWritingFlow = ( {
 		}
 	}, [ isEmpty ] );
 
+	const maybeSetEditMode = () => {
+		if ( editorMode === 'edit' ) {
+			return;
+		}
+		__unstableSetEditorMode( 'edit' );
+	};
+
 	return (
 		/* Gutenberg handles the keyboard events when focusing the content editable area. */
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
@@ -71,7 +86,12 @@ export const EditorWritingFlow = ( {
 			} }
 		>
 			<BlockTools>
-				<WritingFlow>
+				<WritingFlow
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore These are forwarded as props to the WritingFlow component.
+					onClick={ maybeSetEditMode }
+					onFocus={ maybeSetEditMode }
+				>
 					<ObserveTyping>
 						<BlockList />
 					</ObserveTyping>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a workaround to prevent Gutenberg's focus of initially selected elements.  Note that we need to select an element initially in order to get the toolbar to show, but we don't the focus to immediately go to these editors.

Closes #35697  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load the new product management experience ("Products -> Add new (MVP)")
2. On page load, make sure that the rich text editor toolbars are shown
3. Make sure that neither of the editors are focused
4. Make some changes inside an editor and make sure things continue to work as expected

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
