### PR TITLE
[WIP] Migrate usages of set-output to write to $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -2,69 +2,69 @@ name: Setup WooCommerce Monorepo
 description: Handles the installation, building, and caching of the projects within the monorepo.
 
 inputs:
-  install-filters:
-    description: The PNPM filter used to decide what projects to install. Supports multiline strings for multiple filters.
-    default: ""
-  build:
-    description: Indicates whether or not the action should build any projects.
-    default: "true"
-  build-filters:
-    description: The PNPM filter used to decide what projects to build. Supports multiline strings for multiple filters.
-    default: ""
-  php-version:
-    description: The version of PHP that the action should set up.
-    default: "7.4"
+    install-filters:
+        description: The PNPM filter used to decide what projects to install. Supports multiline strings for multiple filters.
+        default: ''
+    build:
+        description: Indicates whether or not the action should build any projects.
+        default: 'true'
+    build-filters:
+        description: The PNPM filter used to decide what projects to build. Supports multiline strings for multiple filters.
+        default: ''
+    php-version:
+        description: The version of PHP that the action should set up.
+        default: '7.4'
 
 runs:
-  using: composite
-  steps:
-    - name: Parse Action Input
-      id: parse-input
-      shell: bash
-      run: |
-        echo "::set-output name=INSTALL_FILTERS::$(node ./.github/actions/setup-woocommerce-monorepo/scripts/parse-input-filter.js '${{ inputs.install-filters }}')"
-        echo "::set-output name=BUILD_FILTERS::$(node ./.github/actions/setup-woocommerce-monorepo/scripts/parse-input-filter.js '${{ inputs.build-filters }}')"
+    using: composite
+    steps:
+        - name: Parse Action Input
+          id: parse-input
+          shell: bash
+          run: |
+              echo "INSTALL_FILTERS=$(node ./.github/actions/setup-woocommerce-monorepo/scripts/parse-input-filter.js '${{ inputs.install-filters }}')" >> $GITHUB_OUTPUT
+              echo "BUILD_FILTERS=$(node ./.github/actions/setup-woocommerce-monorepo/scripts/parse-input-filter.js '${{ inputs.build-filters }}')" >> $GITHUB_OUTPUT
 
-    - name: Setup PNPM
-      uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
-      with:
-        version: "^7.13.3"
+        - name: Setup PNPM
+          uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
+          with:
+              version: '^7.13.3'
 
-    - name: Setup Node
-      uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
-      with:
-        node-version-file: .nvmrc
-        cache: pnpm
-        registry-url: 'https://registry.npmjs.org'
-    
-    - name: Setup PHP
-      uses: shivammathur/setup-php@e04e1d97f0c0481c6e1ba40f8a538454fe5d7709
-      with:
-        php-version: ${{ inputs.php-version }}
-        coverage: none
-        tools: phpcs, sirbrillig/phpcs-changed
+        - name: Setup Node
+          uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
+          with:
+              node-version-file: .nvmrc
+              cache: pnpm
+              registry-url: 'https://registry.npmjs.org'
 
-    - name: Cache Composer Dependencies
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
-      with:
-        path: ~/.cache/composer/files
-        key: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-
+        - name: Setup PHP
+          uses: shivammathur/setup-php@e04e1d97f0c0481c6e1ba40f8a538454fe5d7709
+          with:
+              php-version: ${{ inputs.php-version }}
+              coverage: none
+              tools: phpcs, sirbrillig/phpcs-changed
 
-    - name: Install Node and PHP Dependencies
-      shell: bash
-      run: |
-        pnpm -w install turbo
-        pnpm install ${{ steps.parse-input.outputs.INSTALL_FILTERS }}
+        - name: Cache Composer Dependencies
+          uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+          with:
+              path: ~/.cache/composer/files
+              key: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+              restore-keys: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-
 
-    - name: Cache Build Output
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
-      with:
-        path: node_modules/.cache/turbo
-        key: ${{ runner.os }}-build-output-${{ hashFiles('node_modules/.cache/turbo/*-meta.json') }}
-        restore-keys: ${{ runner.os }}-build-output-
+        - name: Install Node and PHP Dependencies
+          shell: bash
+          run: |
+              pnpm -w install turbo
+              pnpm install ${{ steps.parse-input.outputs.INSTALL_FILTERS }}
 
-    - name: Build
-      if: ${{ inputs.build == 'true' }}
-      shell: bash
-      run: pnpm -w exec turbo run turbo:build ${{ steps.parse-input.outputs.BUILD_FILTERS }}
+        - name: Cache Build Output
+          uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+          with:
+              path: node_modules/.cache/turbo
+              key: ${{ runner.os }}-build-output-${{ hashFiles('node_modules/.cache/turbo/*-meta.json') }}
+              restore-keys: ${{ runner.os }}-build-output-
+
+        - name: Build
+          if: ${{ inputs.build == 'true' }}
+          shell: bash
+          run: pnpm -w exec turbo run turbo:build ${{ steps.parse-input.outputs.BUILD_FILTERS }}

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -25,8 +25,8 @@ jobs:
             - name: Load docker images and start containers.
               working-directory: plugins/woocommerce
               env:
-                ENABLE_HPOS: 0
-                WP_ENV_PHP_VERSION: 7.4
+                  ENABLE_HPOS: 0
+                  WP_ENV_PHP_VERSION: 7.4
               run: pnpm run env:test
 
             - name: Download and install Chromium browser.
@@ -40,7 +40,7 @@ jobs:
                   TOTAL_STR=$(pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js --list | grep "Total:")
                   NO_PREFIX=${TOTAL_STR#*"Total: "}
                   COUNT=${NO_PREFIX%" tests in"*}
-                  echo "::set-output name=E2E_GRAND_TOTAL::$COUNT"
+                  echo "E2E_GRAND_TOTAL=$COUNT" >> $GITHUB_OUTPUT
 
             - name: Run Playwright E2E tests.
               timeout-minutes: 60
@@ -91,7 +91,7 @@ jobs:
             - name: Load docker images and start containers.
               working-directory: plugins/woocommerce
               env:
-                ENABLE_HPOS: 0
+                  ENABLE_HPOS: 0
               run: pnpm env:test --filter=woocommerce
 
             - name: Run Playwright API tests.
@@ -138,7 +138,7 @@ jobs:
             - name: Load docker images and start containers.
               working-directory: plugins/woocommerce
               env:
-                ENABLE_HPOS: 0
+                  ENABLE_HPOS: 0
               run: |
                   pnpm env:dev --filter=woocommerce
                   pnpm env:performance-init --filter=woocommerce

--- a/.github/workflows/prepare-package-release.yml
+++ b/.github/workflows/prepare-package-release.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v3
-            
+
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
 
@@ -24,17 +24,17 @@ jobs:
 
             - name: Get current date
               id: date
-              run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+              run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
             - name: Set all package string
               id: all_description
               if: ${{ github.event.inputs.packages == '-a'}}
-              run: echo "::set-output name=str::all packages"
+              run: echo "str=all packages" >> $GITHUB_OUTPUT
 
             - name: Set Specific packages string
               id: specific_description
               if: ${{ github.event.inputs.packages != '-a'}}
-              run: echo "::set-output name=str::${{ github.event.inputs.packages }}"
+              run: echo "str=${{ github.event.inputs.packages }}" >> $GITHUB_OUTPUT
 
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -1,13 +1,13 @@
-name: "Release: Generate changelog"
+name: 'Release: Generate changelog'
 on:
-  workflow_dispatch:
-    inputs:
-      releaseBranch:
-        description: 'The name of the release branch, in the format `release/x.y`'
-        required: true
-      releaseVersion:
-        description: 'The version of the release, in the format `x.y`'
-        required: true
+    workflow_dispatch:
+        inputs:
+            releaseBranch:
+                description: 'The name of the release branch, in the format `release/x.y`'
+                required: true
+            releaseVersion:
+                description: 'The version of the release, in the format `x.y`'
+                required: true
 
 env:
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
@@ -16,96 +16,96 @@ env:
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
 jobs:
-  create-changelog-prs:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    create-changelog-prs:
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build: false
 
-      - name: "Git fetch the release branch"
-        run: git fetch origin ${{ inputs.releaseBranch }}
-        
-      - name: "Checkout the release branch"
-        run: git checkout ${{ inputs.releaseBranch }}
-      
-      - name: "Create a new branch for the changelog update PR"
-        run: git checkout -b ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}
+            - name: 'Git fetch the release branch'
+              run: git fetch origin ${{ inputs.releaseBranch }}
 
-      - name: "Generate the changelog file"
-        run: pnpm --filter=woocommerce run changelog write --add-pr-num -n -vvv --use-version ${{ inputs.releaseVersion }}
-        
-      - name: "git rm deleted files"
-        run: git rm $(git ls-files --deleted)
-        
-      - name: "Commit deletion"
-        run: git commit -m "Delete changelog files from ${{ inputs.releaseVersion }} release"
-        
-      - name: "Remember the deletion commit hash"
-        id: rev-parse
-        run: echo "::set-output name=hash::$(git rev-parse HEAD)"
-        
-      - name: "Insert NEXT_CHANGELOG contents into readme.txt"
-        run: php .github/workflows/scripts/release-changelog.php
-      
-      - name: "git add readme.txt"
-        run: git add plugins/woocommerce/readme.txt
-      
-      - name: "Commit readme"
-        run: git commit -m "Update the readme files for the ${{ inputs.releaseVersion }} release"
-        
-      - name: "Push update branch to origin"
-        run: git push origin ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}
-        
-      - name: "Stash any other undesired changes"
-        run: git stash
-        
-      - name: "Checkout trunk"
-        run: git checkout trunk
-      
-      - name: "Create a branch for the changelog files deletion"
-        run: git checkout -b ${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}
-        
-      - name: "Cherry-pick the deletion commit"
-        run: git cherry-pick ${{ steps.rev-parse.outputs.hash }}
-        
-      - name: "Push deletion branch to origin"
-        run: git push origin ${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}
-        
-      - name: "Create release branch PR"
-        id: release-pr
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const result = await github.rest.pulls.create( {
-              owner: "${{ github.repository_owner }}",
-              repo: "${{ github.event.repository.name }}",
-              head: "${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}",
-              base: "${{ inputs.releaseBranch }}",
-              title: "${{ format( 'Release: Prepare the changelog for {0}', inputs.releaseVersion ) }}",
-              body: "${{ format( 'This pull request was automatically generated during the code freeze to prepare the changelog for {0}', inputs.releaseVersion ) }}"
-            } );
-            
-            return result.data.number;
-            
-      - name: "Create trunk PR"
-        id: trunk-pr
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const result = await github.rest.pulls.create( {
-              owner: "${{ github.repository_owner }}",
-              repo: "${{ github.event.repository.name }}",
-              head: "${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}",
-              base: "trunk",
-              title: "${{ format( 'Release: Remove {0} change files', inputs.releaseVersion ) }}",
-              body: "${{ format( 'This pull request was automatically generated during the code freeze to remove the changefiles from {0} that are compiled into the `{1}` branch via #{2}', inputs.releaseVersion, inputs.releaseBranch, steps.release-pr.outputs.result ) }}"
-            } );
-            
-            return result.data.number;
+            - name: 'Checkout the release branch'
+              run: git checkout ${{ inputs.releaseBranch }}
+
+            - name: 'Create a new branch for the changelog update PR'
+              run: git checkout -b ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}
+
+            - name: 'Generate the changelog file'
+              run: pnpm --filter=woocommerce run changelog write --add-pr-num -n -vvv --use-version ${{ inputs.releaseVersion }}
+
+            - name: 'git rm deleted files'
+              run: git rm $(git ls-files --deleted)
+
+            - name: 'Commit deletion'
+              run: git commit -m "Delete changelog files from ${{ inputs.releaseVersion }} release"
+
+            - name: 'Remember the deletion commit hash'
+              id: rev-parse
+              run: echo "hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+            - name: 'Insert NEXT_CHANGELOG contents into readme.txt'
+              run: php .github/workflows/scripts/release-changelog.php
+
+            - name: 'git add readme.txt'
+              run: git add plugins/woocommerce/readme.txt
+
+            - name: 'Commit readme'
+              run: git commit -m "Update the readme files for the ${{ inputs.releaseVersion }} release"
+
+            - name: 'Push update branch to origin'
+              run: git push origin ${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}
+
+            - name: 'Stash any other undesired changes'
+              run: git stash
+
+            - name: 'Checkout trunk'
+              run: git checkout trunk
+
+            - name: 'Create a branch for the changelog files deletion'
+              run: git checkout -b ${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}
+
+            - name: 'Cherry-pick the deletion commit'
+              run: git cherry-pick ${{ steps.rev-parse.outputs.hash }}
+
+            - name: 'Push deletion branch to origin'
+              run: git push origin ${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}
+
+            - name: 'Create release branch PR'
+              id: release-pr
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const result = await github.rest.pulls.create( {
+                        owner: "${{ github.repository_owner }}",
+                        repo: "${{ github.event.repository.name }}",
+                        head: "${{ format( 'update/{0}-changelog', inputs.releaseVersion ) }}",
+                        base: "${{ inputs.releaseBranch }}",
+                        title: "${{ format( 'Release: Prepare the changelog for {0}', inputs.releaseVersion ) }}",
+                        body: "${{ format( 'This pull request was automatically generated during the code freeze to prepare the changelog for {0}', inputs.releaseVersion ) }}"
+                      } );
+
+                      return result.data.number;
+
+            - name: 'Create trunk PR'
+              id: trunk-pr
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const result = await github.rest.pulls.create( {
+                        owner: "${{ github.repository_owner }}",
+                        repo: "${{ github.event.repository.name }}",
+                        head: "${{ format( 'delete/{0}-changelog', inputs.releaseVersion ) }}",
+                        base: "trunk",
+                        title: "${{ format( 'Release: Remove {0} change files', inputs.releaseVersion ) }}",
+                        body: "${{ format( 'This pull request was automatically generated during the code freeze to remove the changefiles from {0} that are compiled into the `{1}` branch via #{2}', inputs.releaseVersion, inputs.releaseBranch, steps.release-pr.outputs.result ) }}"
+                      } );
+
+                      return result.data.number;

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -1,17 +1,17 @@
-name: "Release: Code freeze"
+name: 'Release: Code freeze'
 on:
-  schedule:
-    - cron: '0 16 * * 4' # Run at 1600 UTC on Thursdays.
-  workflow_dispatch:
-    inputs:
-      timeOverride:
-        description: "Time Override: The time to use in checking whether the action should run (default: 'now')."
-        default: 'now'
-      skipSlackPing:
-        description: "Skip Slack Ping: If true, the Slack ping will be skipped (useful for testing)"
-        type: boolean
-      slackChannelOverride:
-        description: "Slack Channel Override: The channel ID to send the Slack ping about the freeze"
+    schedule:
+        - cron: '0 16 * * 4' # Run at 1600 UTC on Thursdays.
+    workflow_dispatch:
+        inputs:
+            timeOverride:
+                description: "Time Override: The time to use in checking whether the action should run (default: 'now')."
+                default: 'now'
+            skipSlackPing:
+                description: 'Skip Slack Ping: If true, the Slack ping will be skipped (useful for testing)'
+                type: boolean
+            slackChannelOverride:
+                description: 'Slack Channel Override: The channel ID to send the Slack ping about the freeze'
 
 env:
     TIME_OVERRIDE: ${{ inputs.timeOverride }}
@@ -21,142 +21,142 @@ env:
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
 jobs:
-  verify-code-freeze:
-    name: "Verify that today is the day of the code freeze"
-    runs-on: ubuntu-20.04
-    outputs:
-      freeze: ${{ steps.check-freeze.outputs.freeze }}
-    steps:
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
+    verify-code-freeze:
+        name: 'Verify that today is the day of the code freeze'
+        runs-on: ubuntu-20.04
+        outputs:
+            freeze: ${{ steps.check-freeze.outputs.freeze }}
+        steps:
+            - name: 'Install PHP'
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
 
-      - name: "Check whether today is the code freeze day"
-        id: check-freeze
-        shell: php {0}
-        run: |
-          <?php
-          $now = time();
-          if ( getenv( 'TIME_OVERRIDE' ) ) {
-            $now = strtotime( getenv( 'TIME_OVERRIDE' ) );
-          }
+            - name: 'Check whether today is the code freeze day'
+              id: check-freeze
+              shell: php {0}
+              run: |
+                  <?php
+                  $now = time();
+                  if ( getenv( 'TIME_OVERRIDE' ) ) {
+                    $now = strtotime( getenv( 'TIME_OVERRIDE' ) );
+                  }
 
-          // Code freeze comes 26 days prior to release day.
-          $release_time         = strtotime( '+26 days', $now );
-          $release_day_of_week  = date( 'l', $release_time );
-          $release_day_of_month = (int) date( 'j', $release_time );
+                  // Code freeze comes 26 days prior to release day.
+                  $release_time         = strtotime( '+26 days', $now );
+                  $release_day_of_week  = date( 'l', $release_time );
+                  $release_day_of_month = (int) date( 'j', $release_time );
 
-          // If 26 days from now isn't the second Tuesday, then it's not code freeze day.
-          if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
-            echo '::set-output name=freeze::1';
-          } else {
-            echo '::set-output name=freeze::0';
-          }
+                  // If 26 days from now isn't the second Tuesday, then it's not code freeze day.
+                  if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
+                    echo 'freeze=1' >> $GITHUB_OUTPUT;
+                  } else {
+                    echo 'freeze=0' >> $GITHUB_OUTPUT;
+                  }
 
-  maybe-create-next-milestone-and-release-branch:
-    name: "Maybe create next milestone and release branch"
-    runs-on: ubuntu-20.04
-    needs: verify-code-freeze
-    if: needs.verify-code-freeze.outputs.freeze == 0
-    outputs:
-      branch: ${{ steps.freeze.outputs.branch }}
-      release_version: ${{ steps.freeze.outputs.release_version }}
-      next_version: ${{ steps.freeze.outputs.next_version }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 100
+    maybe-create-next-milestone-and-release-branch:
+        name: 'Maybe create next milestone and release branch'
+        runs-on: ubuntu-20.04
+        needs: verify-code-freeze
+        if: needs.verify-code-freeze.outputs.freeze == 0
+        outputs:
+            branch: ${{ steps.freeze.outputs.branch }}
+            release_version: ${{ steps.freeze.outputs.release_version }}
+            next_version: ${{ steps.freeze.outputs.next_version }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 100
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build: false
 
-      - name: "Run the script to enforce the code freeze"
-        id: freeze
-        run: php .github/workflows/scripts/release-code-freeze.php
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_OUTPUTS: 1
+            - name: 'Run the script to enforce the code freeze'
+              id: freeze
+              run: php .github/workflows/scripts/release-code-freeze.php
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_OUTPUTS: 1
 
-  prep-trunk:
-    name: Preps trunk for next development cycle
-    runs-on: ubuntu-20.04
-    needs: maybe-create-next-milestone-and-release-branch
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 100
+    prep-trunk:
+        name: Preps trunk for next development cycle
+        runs-on: ubuntu-20.04
+        needs: maybe-create-next-milestone-and-release-branch
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 100
 
-      - name: fetch-trunk
-        run: git fetch origin trunk
+            - name: fetch-trunk
+              run: git fetch origin trunk
 
-      - name: checkout-trunk
-        run: git checkout trunk
+            - name: checkout-trunk
+              run: git checkout trunk
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-      - name: Create branch
-        run: git checkout -b prep/trunk-for-next-dev-cycle-${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}
+            - name: Create branch
+              run: git checkout -b prep/trunk-for-next-dev-cycle-${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}
 
-      - name: Bump versions
-        working-directory: ./tools/version-bump
-        run: pnpm run version bump woocommerce -v ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}.0-dev
+            - name: Bump versions
+              working-directory: ./tools/version-bump
+              run: pnpm run version bump woocommerce -v ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}.0-dev
 
-      - name: Checkout pnpm-lock.yaml to prevent issues
-        run: git checkout pnpm-lock.yaml
+            - name: Checkout pnpm-lock.yaml to prevent issues
+              run: git checkout pnpm-lock.yaml
 
-      - name: Commit changes
-        run: git commit -am "Prep trunk for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} cycle"
+            - name: Commit changes
+              run: git commit -am "Prep trunk for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} cycle"
 
-      - name: Push branch up
-        run: git push --no-verify origin prep/trunk-for-next-dev-cycle-${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}
+            - name: Push branch up
+              run: git push --no-verify origin prep/trunk-for-next-dev-cycle-${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}
 
-      - name: Create the PR
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const body = "This PR updates the versions in trunk to ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} for next development cycle."
+            - name: Create the PR
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const body = "This PR updates the versions in trunk to ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} for next development cycle."
 
-            const pr = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: "Prep trunk for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} cycle",
-              head: "prep/trunk-for-next-dev-cycle-${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}",
-              base: "trunk",
-              body: body
-            })
+                      const pr = await github.rest.pulls.create({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        title: "Prep trunk for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} cycle",
+                        head: "prep/trunk-for-next-dev-cycle-${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}",
+                        base: "trunk",
+                        body: body
+                      })
 
-  notify-slack:
-    name: "Sends code freeze notification to Slack"
-    if: ${{ inputs.skipSlackPing != true }}
-    runs-on: ubuntu-20.04
-    needs: maybe-create-next-milestone-and-release-branch
-    steps:
-      - name: Slack
-        uses: archive/github-actions-slack@v2.0.0
-        id: notify
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
-          slack-channel: ${{ inputs.slackChannelOverride || secrets.WOO_RELEASE_SLACK_CHANNEL }}
-          slack-text: |
-            :warning-8c: ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} Code Freeze :ice_cube:
-            
-            The automation to cut the release branch for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} has run. Any PRs that were not already merged will be a part of ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} by default. If you have something that needs to make ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} that hasn't yet been merged, please see the <${{ secrets.FG_LINK }}/code-freeze-for-woocommerce-core-release/|fieldguide page for the code freeze>.
+    notify-slack:
+        name: 'Sends code freeze notification to Slack'
+        if: ${{ inputs.skipSlackPing != true }}
+        runs-on: ubuntu-20.04
+        needs: maybe-create-next-milestone-and-release-branch
+        steps:
+            - name: Slack
+              uses: archive/github-actions-slack@v2.0.0
+              id: notify
+              with:
+                  slack-bot-user-oauth-access-token: ${{ secrets.CODE_FREEZE_BOT_TOKEN }}
+                  slack-channel: ${{ inputs.slackChannelOverride || secrets.WOO_RELEASE_SLACK_CHANNEL }}
+                  slack-text: |
+                      :warning-8c: ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} Code Freeze :ice_cube:
 
-  trigger-changelog-action:
-    name: "Trigger changelog action"
-    runs-on: ubuntu-20.04
-    needs: maybe-create-next-milestone-and-release-branch
-    steps:
-      - run: |
-          curl \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.WC_BOT_TRIAGE_TOKEN }}" \
-            -d '{"ref":"refs/heads/trunk","inputs":{"releaseBranch":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.branch }}","releaseVersion":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }}"}}' \
-            https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-changelog.yml/dispatches
+                      The automation to cut the release branch for ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} has run. Any PRs that were not already merged will be a part of ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }} by default. If you have something that needs to make ${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }} that hasn't yet been merged, please see the <${{ secrets.FG_LINK }}/code-freeze-for-woocommerce-core-release/|fieldguide page for the code freeze>.
+
+    trigger-changelog-action:
+        name: 'Trigger changelog action'
+        runs-on: ubuntu-20.04
+        needs: maybe-create-next-milestone-and-release-branch
+        steps:
+            - run: |
+                  curl \
+                    -X POST \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -H "Authorization: token ${{ secrets.WC_BOT_TRIAGE_TOKEN }}" \
+                    -d '{"ref":"refs/heads/trunk","inputs":{"releaseBranch":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.branch }}","releaseVersion":"${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }}"}}' \
+                    https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-changelog.yml/dispatches


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`set-output` is deprecated so we need to move our actions in the next few months towards writing to `$GITHUB_OUTPUT`. 

This does not replace every use of `set-output`. This only replaces scripts inline in GH workflows that were doing `echo` of `set-output`. For other usages we frequently used `console.log` inside a JS script. For those I think it would be better to use the setOutput command from the actions/core package. See the [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for more info.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Most of these workflows are in CI checks so them passing should give us enough confidence.

1 of them is a release code freeze workflow. @jonathansadowski wondering if you have any ideas about testing that one?

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
