### PR TITLE
Update the summary placeholder text in the product management  form.

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -222,7 +222,7 @@ export const ProductDetailsSection: React.FC = () => {
 							);
 						} }
 						placeholder={ __(
-							'Summarize this product in 1-2 short sentences. We\'ll show it at the top of the page.',
+							"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
 							'woocommerce'
 						) }
 					/>

--- a/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-details-section.tsx
@@ -221,6 +221,10 @@ export const ProductDetailsSection: React.FC = () => {
 								serialize( blocks )
 							);
 						} }
+						placeholder={ __(
+							'Summarize this product in 1-2 short sentences. We\'ll show it at the top of the page.',
+							'woocommerce'
+						) }
 					/>
 					<RichTextEditor
 						label={ __( 'Description', 'woocommerce' ) }

--- a/plugins/woocommerce/changelog/fix-35715
+++ b/plugins/woocommerce/changelog/fix-35715
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Adapt the summary text in the product management form.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35715 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Enable the new product management form.
2. Go to `wp-admin/admin.php?page=wc-admin&path=%2Fadd-product`.
3. Verify that the copy in the summary section is as follows:

<img width="761" alt="Screenshot 2022-11-24 at 19 29 23" src="https://user-images.githubusercontent.com/13561163/203848046-879ebd29-bb51-48ef-aff3-913b7fa48809.png">


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
