### PR TITLE
Fix price field currency symbol position

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -21,6 +21,9 @@
 		.components-input-control__prefix {
 			color: $gray-700;
 		}
+		.components-input-control__input {
+			text-align: right;
+		}
 	}
 	.components-checkbox-control {
 		&__label {

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -17,6 +17,11 @@
 			margin-right: $gap-smaller;
 		}
 	}
+	.components-currency-control {
+		.components-input-control__prefix {
+			color: $gray-700;
+		}
+	}
 	.components-checkbox-control {
 		&__label {
 			display: flex;

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -167,6 +167,26 @@ export const PricingSection: React.FC = () => {
 				event.currentTarget
 			);
 		},
+		onKeyUp( event: React.KeyboardEvent< HTMLInputElement > ) {
+			const name = event.currentTarget.name as keyof Pick<
+				Product,
+				'regular_price' | 'sale_price'
+			>;
+			const amount = Number.parseFloat(
+				sanitizePrice( values[ name ] || '0' )
+			);
+			const step = Number( event.currentTarget.step || '1' );
+			if ( event.code === 'ArrowUp' ) {
+				setValues( {
+					[ name ]: String( amount + step ),
+				} as unknown as Product );
+			}
+			if ( event.code === 'ArrowDown' ) {
+				setValues( {
+					[ name ]: String( amount - step ),
+				} as unknown as Product );
+			}
+		},
 	};
 	const regularPriceProps = getInputProps(
 		'regular_price',
@@ -216,6 +236,7 @@ export const PricingSection: React.FC = () => {
 					>
 						<InputControl
 							{ ...regularPriceProps }
+							name="regular_price"
 							label={ __( 'List price', 'woocommerce' ) }
 							value={ formatCurrencyDisplayValue(
 								String( regularPriceProps?.value ),
@@ -236,6 +257,7 @@ export const PricingSection: React.FC = () => {
 					>
 						<InputControl
 							{ ...salePriceProps }
+							name="sale_price"
 							label={ __( 'Sale price', 'woocommerce' ) }
 							value={ formatCurrencyDisplayValue(
 								String( salePriceProps?.value ),

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -153,6 +153,20 @@ export const PricingSection: React.FC = () => {
 		sanitize: ( value: Product[ keyof Product ] ) => {
 			return sanitizePrice( String( value ) );
 		},
+		onFocus( event: React.FocusEvent< HTMLInputElement > ) {
+			// In some browsers like safari .select() function inside
+			// the onFocus event doesn't work as expected because it
+			// conflicts with onClick the first time user click the
+			// input. Using setTimeout defers the text selection and
+			// avoid the unexpected behaviour.
+			setTimeout(
+				function deferSelection( element: HTMLInputElement ) {
+					element.select();
+				},
+				0,
+				event.currentTarget
+			);
+		},
 	};
 	const regularPriceProps = getInputProps(
 		'regular_price',

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -149,7 +149,7 @@ export const PricingSection: React.FC = () => {
 
 	const currencyInputProps = {
 		prefix: currencyConfig.symbol,
-		className: 'half-width-field',
+		className: 'half-width-field components-currency-control',
 		sanitize: ( value: Product[ keyof Product ] ) => {
 			return sanitizePrice( String( value ) );
 		},

--- a/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/pricing-section.tsx
@@ -32,7 +32,7 @@ import {
  * Internal dependencies
  */
 import './pricing-section.scss';
-import { formatCurrencyDisplayValue, getCurrencySymbolProps } from './utils';
+import { formatCurrencyDisplayValue } from './utils';
 import { ProductSectionLayout } from '../layout/product-section-layout';
 import { ADMIN_URL } from '../../utils/admin-settings';
 import { CurrencyContext } from '../../lib/currency-context';
@@ -148,7 +148,7 @@ export const PricingSection: React.FC = () => {
 	} );
 
 	const currencyInputProps = {
-		...getCurrencySymbolProps( currencyConfig ),
+		prefix: currencyConfig.symbol,
 		className: 'half-width-field',
 		sanitize: ( value: Product[ keyof Product ] ) => {
 			return sanitizePrice( String( value ) );

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -81,3 +81,5 @@ export const formatCurrencyDisplayValue = (
 
 	return value === undefined ? value : format( value ).replace( regex, '' );
 };
+
+export function stepUp() {}

--- a/plugins/woocommerce-admin/client/products/sections/utils.ts
+++ b/plugins/woocommerce-admin/client/products/sections/utils.ts
@@ -81,5 +81,3 @@ export const formatCurrencyDisplayValue = (
 
 	return value === undefined ? value : format( value ).replace( regex, '' );
 };
-
-export function stepUp() {}

--- a/plugins/woocommerce/changelog/enhancement-35558
+++ b/plugins/woocommerce/changelog/enhancement-35558
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fix price field currency symbol position


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35558

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products -> Add New (MVP)`
2. Any price input field should has
3. Currency unit follows the store's locale
4. The symbol aligned always left
5. The symbol color now is `gray-700`
6. The value is aligned right
7. Field formatting respects the store's setting, including thousand and decimal separators
8. On blur, commas are added when the user enters a value
9. On focus, we highlight the field's content
10. On focus, the user can press the up and down arrow keys to increase or decrease the value by 1

<video src="https://user-images.githubusercontent.com/13334210/203852582-01598c36-46a8-4a7c-b55b-9cdbca9b5329.mov"></video>

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
