### PR TITLE
HPOS sync/deleted twins

### DIFF
--- a/plugins/woocommerce/changelog/fix-35590-deleted-twins
+++ b/plugins/woocommerce/changelog/fix-35590-deleted-twins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address HPOS synchronization issues relating to the deletion of orders.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -412,7 +412,7 @@ WHERE
 	 * @param WP_Post $post The deleted post.
 	 */
 	private function handle_deleted_post( $postid, $post ): void {
-		if ( 'shop_order' === $post->post_type && ! $this->custom_orders_table_is_authoritative() && $this->data_sync_is_enabled() ) {
+		if ( 'shop_order' === $post->post_type && $this->data_sync_is_enabled() ) {
 			$this->data_store->delete_order_data_from_custom_order_tables( $postid );
 		}
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Exception;
 use WC_Data;
 use WC_Order;
 
@@ -1145,9 +1146,26 @@ WHERE
 			foreach ( $cpt_store_orders[ $cpt_store_name ] as $order_id => $order ) {
 				$cpt_order_class_name = wc_get_order_type( $order->get_type() )['class_name'];
 				$cpt_order            = new $cpt_order_class_name();
-				$cpt_order->set_id( $order_id );
-				$cpt_store->read( $cpt_order );
-				$cpt_orders[ $order_id ] = $cpt_order;
+
+				try {
+					$cpt_order->set_id( $order_id );
+					$cpt_store->read( $cpt_order );
+					$cpt_orders[ $order_id ] = $cpt_order;
+				} catch ( Exception $e ) {
+					// If the post record has been deleted (for instance, by direct query) then an exception may be thrown.
+					$this->error_logger->warning(
+						sprintf(
+							/* translators: %1$d order ID. */
+							__( 'Unable to load the post record for order %1$d', 'woocommerce' ),
+							$order_id
+						),
+						array(
+							'exception_code' => $e->getCode(),
+							'exception_msg'  => $e->getMessage(),
+							'origin'         => __METHOD__,
+						)
+					);
+				}
 			}
 		}
 		return $cpt_orders;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1765,7 +1765,7 @@ FROM $order_meta_table
 			$order->set_id( 0 );
 
 			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
-			if ( ! is_a( $order->get_data_store(), self::class ) ) {
+			if ( $order->get_data_store()->get_current_class_name() !== self::class ) {
 				return;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 /**
  * Tests for DataSynchronizer class.
  */
-	class DataSynchronizerTests extends WC_Unit_Test_Case {
+class DataSynchronizerTests extends WC_Unit_Test_Case {
 
 	/**
 	 * @var DataSynchronizer
@@ -148,7 +148,7 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 	}
 
 	/**
-	 * When sync is enbabled and the posts store is authoritative, creating an order and updating the status from
+	 * When sync is enabled and the posts store is authoritative, creating an order and updating the status from
 	 * draft to some non-draft status (as happens when an order is manually created in the admin environment) should
 	 * result in the same status change being made in the duplicate COT record.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 /**
  * Tests for DataSynchronizer class.
  */
-class DataSynchronizerTests extends WC_Unit_Test_Case {
+	class DataSynchronizerTests extends WC_Unit_Test_Case {
 
 	/**
 	 * @var DataSynchronizer
@@ -190,6 +190,35 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 			'wc-pending',
 			$wpdb->get_var( "SELECT status FROM $orders_table WHERE id = $order_id" ), //phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			'When the order status is updated, the change should be observed by the DataSynhronizer and a matching update will take place in the COT table.'
+		);
+	}
+
+	/**
+	 * When sync is enabled, and an order is deleted either from the post table or the COT table, the
+	 * change should propagate across to the other table.
+	 *
+	 * @return void
+	 */
+	public function test_order_deletions_propagate(): void {
+		// Sync enabled and COT authoritative.
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+
+		$order = OrderHelper::create_order();
+		wp_delete_post( $order->get_id(), true );
+
+		$this->assertFalse(
+			wc_get_order( $order->get_id() ),
+			'After the order post record was deleted, the order was also deleted from COT.'
+		);
+
+		$order    = OrderHelper::create_order();
+		$order_id = $order->get_id();
+		$order->delete( true );
+
+		$this->assertNull(
+			get_post( $order_id ),
+			'After the COT order record was deleted, the order was also deleted from the posts table.'
 		);
 	}
 }


### PR DESCRIPTION
There are a couple of issues with order deletion in the context of HPOS.

1. The first is that if an order exists in the custom order table, but not in the posts table (example: the post record was deleted via a direct query), then the admin list table may die with a fatal error. 
2. The other is that, when sync is enabled, if an order is deleted from the custom order table then the matching post table record survives.

The solution for both problems touches some of the same code, hence handling these from the same PR.

Closes #35590, #35088.

### How to test the changes in this Pull Request:

If you haven't already done so, begin by setting up HPOS (see the [basic instructions here](https://github.com/woocommerce/woocommerce/pull/35442) if you need a reminder of how to do this). In this case, we should ensure that:

* Custom order tables are authoritative.
* Sync is enabled.

Both the above are configured via the **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** screen. Then, ensure you have a range of order data to test with: you may wish to use [WC Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) to quickly create additional records. With that done, let's start testing:

1. Visit **WooCommerce ▸ Orders**. Identify one of the listed orders and make a note of its ID.
2. Delete the corresponding post record. There are various ways to do this:
    - Via WP CLI: `wp post delete 12345 --force`
    - Via PHP: `wp_delete_post( 12345 );`
    - Via direct query: `DELETE FROM wp_posts WHERE ID = 12345`
    - *Of course, whichever method you pick, adjust the ID ('12345') and table name as appropriate for your local environment.*
3. Refresh the order list screen. 
    - There should be no fatal error (by contrast, before this change, you should notice that things fail with an uncaught exception [as described here](https://github.com/woocommerce/woocommerce/issues/35590)).
    - If logging is enabled (ie, via **WooCommerce ▸ Status ▸ Logs**) you should see an entry noting, *"Unable to load the post record for order &lt;ID&gt;."* Example (it may look a little different for you, if you are using a different logging engine):

<img width="838" alt="logged-error" src="https://user-images.githubusercontent.com/3594411/204396226-d1c2c6aa-e921-41c2-a2a9-45d5f35c778b.png">

1. Now let's test synchronization of delete operations. Return to **WooCommerce ▸ Orders** and identify a different order (it **cannot** be one that you used in the earlier testing steps). Take note of the order ID.
2. Fully delete the order.
    - You can do this through the UI by trashing the order then visiting the trash and deleting it completely.
    - Or, you can use a programmatic method such as `wc_get_order( 12345 )->delete( true );`.
3. Confirm that the matching post record for the same ID, and its meta records, have been completely deleted.
    - It is probably best to do this using a tool such as PhpMyAdmin.
    - Or, via WP CLI, you could do `wp post get 12345` (it should return with *Error: Could not find the post with ID 12345*.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
