### PR TITLE
Modified get_wp_plugin_id()

### DIFF
--- a/plugins/woocommerce/changelog/fix-35727-plugin-id
+++ b/plugins/woocommerce/changelog/fix-35727-plugin-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improves efficiency of code responsible for determining plugin IDs (during feature compatibility checks).

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -129,7 +129,7 @@ class PluginUtil {
 
 		// Try to match plugin_basename().
 		$plugin_basename = $this->proxy->call_function( 'plugin_basename', $plugin_file );
-		if ( in_array( $plugin_basename, $wp_plugins ) ) {
+		if ( in_array( $plugin_basename, $wp_plugins, true ) ) {
 			return $plugin_basename;
 		}
 

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -129,7 +129,7 @@ class PluginUtil {
 
 		// Try to match plugin_basename().
 		$plugin_basename = $this->proxy->call_function( 'plugin_basename', $plugin_file );
-		if ( array_key_exists( $plugin_basename, $wp_plugins ) ) {
+		if ( in_array( $plugin_basename, $wp_plugins ) ) {
 			return $plugin_basename;
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed the issue as per the issues submitted https://github.com/woocommerce/woocommerce/issues/35725 myself
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35725.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

### Testing instructions

Code review is probably sufficient for this change (since, even prior to the fix, this system generally still worked—albeit less efficiently). However, it should be possible to confirm there are no regressions by running through the following steps:

1. Create a test plugin at `wp-content/plugins/test/test.php`.
2. It should contain the following code:

```php
<?php
/**
 * Plugin name:     Test Code
 * Description:     Can be used to test https://github.com/woocommerce/woocommerce/pull/35727. Remove after use.
 * WC Tested up to: 7.2.0
 */

add_action( 'before_woocommerce_init', function() {
	if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
	}
} );
```

3. Ensure WooCommerce is active, disable everything else, and then go ahead and activate the Test Code plugin.
4. Ensure HPOS is enabled (via **WooCommerce ▸ Settings ▸ Advanced ▸ Features**).
5. You should not initially see any warnings.
6. Modify a line of code from the test plugin to declare **in-**compatibility (change `true` to `false` as follows):

```php
\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
```

7. Refresh the Features settings screen and you should now see the expected warnings:
    - *"WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features. Please [review the details](https://lab.wordpress/wp-admin/plugins.php?plugin_status=incompatible_with_feature)."*
    - *"This feature shouldn't be enabled, the Test Code plugin is active and isn't compatible with it. [Manage incompatible plugins](https://lab.wordpress/wp-admin/plugins.php?plugin_status=incompatible_with_feature&feature_id=custom_order_tables)"*

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->
