### PR TITLE
CES exit prompt for product editing screens

### DIFF
--- a/packages/js/customer-effort-score/changelog/add-35126_ces_exit_prompt
+++ b/packages/js/customer-effort-score/changelog/add-35126_ces_exit_prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add description and noticeLabel props to customer feedback components.

--- a/packages/js/customer-effort-score/src/customer-effort-score.tsx
+++ b/packages/js/customer-effort-score/src/customer-effort-score.tsx
@@ -39,6 +39,8 @@ type CustomerEffortScoreProps = {
  * @param {Object}   props                           Component props.
  * @param {Function} props.recordScoreCallback       Function to call when the score should be recorded.
  * @param {string}   props.title                     The title displayed in the modal.
+ * @param {string}   props.description               The description displayed in the modal.
+ * @param {string}   props.noticeLabel               The notice label displayed in the notice.
  * @param {string}   props.firstQuestion             The first survey question.
  * @param {string}   props.secondQuestion            The second survey question.
  * @param {Function} props.onNoticeShownCallback     Function to call when the notice is shown.

--- a/packages/js/customer-effort-score/src/customer-effort-score.tsx
+++ b/packages/js/customer-effort-score/src/customer-effort-score.tsx
@@ -20,6 +20,8 @@ type CustomerEffortScoreProps = {
 		comments: string
 	) => void;
 	title: string;
+	description?: string;
+	noticeLabel?: string;
 	firstQuestion: string;
 	secondQuestion: string;
 	onNoticeShownCallback?: () => void;
@@ -47,6 +49,8 @@ type CustomerEffortScoreProps = {
 const CustomerEffortScore: React.VFC< CustomerEffortScoreProps > = ( {
 	recordScoreCallback,
 	title,
+	description,
+	noticeLabel,
 	firstQuestion,
 	secondQuestion,
 	onNoticeShownCallback = noop,
@@ -63,7 +67,7 @@ const CustomerEffortScore: React.VFC< CustomerEffortScoreProps > = ( {
 			return;
 		}
 
-		createNotice( 'success', title, {
+		createNotice( 'success', noticeLabel || title, {
 			actions: [
 				{
 					label: __( 'Give feedback', 'woocommerce' ),
@@ -94,6 +98,7 @@ const CustomerEffortScore: React.VFC< CustomerEffortScoreProps > = ( {
 	return (
 		<CustomerFeedbackModal
 			title={ title }
+			description={ description }
 			firstQuestion={ firstQuestion }
 			secondQuestion={ secondQuestion }
 			recordScoreCallback={ recordScoreCallback }

--- a/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -35,6 +35,7 @@ import { __ } from '@wordpress/i18n';
 function CustomerFeedbackModal( {
 	recordScoreCallback,
 	title,
+	description,
 	firstQuestion,
 	secondQuestion,
 	defaultScore = NaN,
@@ -47,6 +48,7 @@ function CustomerFeedbackModal( {
 		comments: string
 	) => void;
 	title: string;
+	description?: string;
 	firstQuestion: string;
 	secondQuestion: string;
 	defaultScore?: number;
@@ -142,10 +144,11 @@ function CustomerFeedbackModal( {
 				lineHeight="20px"
 				marginBottom="1.5em"
 			>
-				{ __(
-					'Your feedback will help create a better experience for thousands of merchants like you. Please tell us to what extent you agree or disagree with the statements below.',
-					'woocommerce'
-				) }
+				{ description ||
+					__(
+						'Your feedback will help create a better experience for thousands of merchants like you. Please tell us to what extent you agree or disagree with the statements below.',
+						'woocommerce'
+					) }
 			</Text>
 
 			<Text

--- a/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -26,6 +26,7 @@ import { __ } from '@wordpress/i18n';
  * @param {Object}   props                     Component props.
  * @param {Function} props.recordScoreCallback Function to call when the results are sent.
  * @param {string}   props.title               Title displayed in the modal.
+ * @param {string}   props.description         Description displayed in the modal.
  * @param {string}   props.firstQuestion       The first survey question.
  * @param {string}   props.secondQuestion      The second survey question.
  * @param {string}   props.defaultScore        Default score.

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -145,7 +145,11 @@ export function triggerExitPageCesSurvey() {
 				'exit_' + exitPageItems[ 0 ].replaceAll( '-', '_' ),
 				copy,
 				window.pagenow,
-				window.adminpage
+				window.adminpage,
+				undefined,
+				{
+					ces_location: 'outside',
+				}
 			);
 		}
 		removeExitPage( exitPageItems[ 0 ] );

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -141,7 +141,7 @@ export function triggerExitPageCesSurvey() {
 		const copy = getExitPageCESCopy( exitPageItems[ 0 ] );
 		if ( copy && copy.length > 0 ) {
 			dispatch( 'wc/customer-effort-score' ).addCesSurvey(
-				'exit_' + exitPageItems[ 0 ].replaceAll( '-', '_' ),
+				exitPageItems[ 0 ].replaceAll( '-', '_' ),
 				copy,
 				window.pagenow,
 				window.adminpage,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -19,6 +19,9 @@ resolveSelect( OPTIONS_STORE_NAME )
 		allowTracking = trackingOption === 'yes';
 	} );
 
+/**
+ * Gets the list of exited pages from Localstorage.
+ */
 export const getExitPageData = () => {
 	if ( ! window.localStorage ) {
 		return [];
@@ -33,15 +36,20 @@ export const getExitPageData = () => {
 	return arrayItems;
 };
 
-export const addExitPage = ( pageName: string ) => {
+/**
+ * Adds the page to the exit page list in Localstorage.
+ *
+ * @param {string} pageId of page exited early.
+ */
+export const addExitPage = ( pageId: string ) => {
 	if ( ! window.localStorage ) {
 		return;
 	}
 
 	let items = getExitPageData();
 
-	items = items.filter( ( item ) => item !== pageName );
-	items.push( pageName );
+	items = items.filter( ( item ) => item !== pageId );
+	items.push( pageId );
 	items = items.slice( -10 ); // Upper limit.
 
 	window.localStorage.setItem(
@@ -50,14 +58,19 @@ export const addExitPage = ( pageName: string ) => {
 	);
 };
 
-export const removeExitPage = ( pageName: string ) => {
+/**
+ * Removes the passed in page id from the list in Localstorage.
+ *
+ * @param {string} pageId of page to be removed.
+ */
+export const removeExitPage = ( pageId: string ) => {
 	if ( ! window.localStorage ) {
 		return;
 	}
 
 	let items = getExitPageData();
 
-	items = items.filter( ( item ) => item !== pageName );
+	items = items.filter( ( item ) => item !== pageId );
 	items = items.slice( -10 ); // Upper limit.
 
 	window.localStorage.setItem(
@@ -66,14 +79,20 @@ export const removeExitPage = ( pageName: string ) => {
 	);
 };
 
-const eventListeners: Record< string, ( event: any ) => void > = {};
+const eventListeners: Record< string, ( event: BeforeUnloadEvent ) => void > =
+	{};
 
+/**
+ * Adds unload event listener to add pageId to exit page list incase there were unsaved changes.
+ *
+ * @param {string}   pageId the page id of the page being exited early.
+ * @param {Function} hasUnsavedChanges callback to check if the page had unsaved changes.
+ */
 export const addCustomerEffortScoreExitPageListener = (
 	pageId: string,
 	hasUnsavedChanges: () => boolean
 ) => {
 	eventListeners[ pageId ] = ( event ) => {
-		console.log( event );
 		if ( hasUnsavedChanges() && allowTracking ) {
 			addExitPage( pageId );
 		}
@@ -81,6 +100,11 @@ export const addCustomerEffortScoreExitPageListener = (
 	window.addEventListener( 'unload', eventListeners[ pageId ] );
 };
 
+/**
+ * Removes the unload exit page listener.
+ *
+ * @param {string} pageId the page id to remove the listener from.
+ */
 export const removeCustomerEffortScoreExitPageListener = ( pageId: string ) => {
 	if ( eventListeners[ pageId ] ) {
 		window.removeEventListener( 'unload', eventListeners[ pageId ], {
@@ -89,6 +113,11 @@ export const removeCustomerEffortScoreExitPageListener = ( pageId: string ) => {
 	}
 };
 
+/**
+ * Returns the exit page copy of the passed in pageId.
+ *
+ * @param {string} pageId page id.
+ */
 function getExitPageCESCopy( pageId: string ): string {
 	switch ( pageId ) {
 		case 'edit-product':
@@ -104,6 +133,9 @@ function getExitPageCESCopy( pageId: string ): string {
 	}
 }
 
+/**
+ * checks the exit page list and triggers a CES survey for the first item in the list.
+ */
 export function triggerExitPageCesSurvey() {
 	const exitPageItems: string[] = getExitPageData();
 	if ( exitPageItems && exitPageItems.length > 0 ) {

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -120,10 +120,9 @@ export const removeCustomerEffortScoreExitPageListener = ( pageId: string ) => {
  */
 function getExitPageCESCopy( pageId: string ): string {
 	switch ( pageId ) {
-		case 'edit-product':
-		case 'new-product':
-		case 'edit-product-mvp':
-		case 'new-product-mvp':
+		case 'product_edit_view':
+		case 'product_add_view':
+		case 'new_product':
 			return __(
 				'We noticed you started editing a product, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
 				'woocommerce'

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { dispatch, resolveSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { ALLOW_TRACKING_OPTION_NAME } from './constants';
+
+const CUSTOMER_EFFORT_SCORE_EXIT_PAGE_KEY = 'customer-effort-score-exit-page';
+
+let allowTracking = false;
+resolveSelect( OPTIONS_STORE_NAME )
+	.getOption( ALLOW_TRACKING_OPTION_NAME )
+	.then( ( trackingOption ) => {
+		allowTracking = trackingOption === 'yes';
+	} );
+
+export const getExitPageData = () => {
+	if ( ! window.localStorage ) {
+		return [];
+	}
+
+	const items = window.localStorage.getItem(
+		CUSTOMER_EFFORT_SCORE_EXIT_PAGE_KEY
+	);
+	const parsedJSONItems = items ? JSON.parse( items ) : [];
+	const arrayItems = Array.isArray( parsedJSONItems ) ? parsedJSONItems : [];
+
+	return arrayItems;
+};
+
+export const addExitPage = ( pageName: string ) => {
+	if ( ! window.localStorage ) {
+		return;
+	}
+
+	let items = getExitPageData();
+
+	items = items.filter( ( item ) => item !== pageName );
+	items.push( pageName );
+	items = items.slice( -10 ); // Upper limit.
+
+	window.localStorage.setItem(
+		CUSTOMER_EFFORT_SCORE_EXIT_PAGE_KEY,
+		JSON.stringify( items )
+	);
+};
+
+export const removeExitPage = ( pageName: string ) => {
+	if ( ! window.localStorage ) {
+		return;
+	}
+
+	let items = getExitPageData();
+
+	items = items.filter( ( item ) => item !== pageName );
+	items = items.slice( -10 ); // Upper limit.
+
+	window.localStorage.setItem(
+		CUSTOMER_EFFORT_SCORE_EXIT_PAGE_KEY,
+		JSON.stringify( items )
+	);
+};
+
+const eventListeners: Record< string, ( event: any ) => void > = {};
+
+export const addCustomerEffortScoreExitPageListener = (
+	pageId: string,
+	hasUnsavedChanges: () => boolean
+) => {
+	eventListeners[ pageId ] = ( event ) => {
+		console.log( event );
+		if ( hasUnsavedChanges() && allowTracking ) {
+			addExitPage( pageId );
+		}
+	};
+	window.addEventListener( 'unload', eventListeners[ pageId ] );
+};
+
+export const removeCustomerEffortScoreExitPageListener = ( pageId: string ) => {
+	if ( eventListeners[ pageId ] ) {
+		window.removeEventListener( 'unload', eventListeners[ pageId ], {
+			capture: true,
+		} );
+	}
+};
+
+function getExitPageCESCopy( pageId: string ): string {
+	switch ( pageId ) {
+		case 'edit-product':
+		case 'new-product':
+		case 'edit-product-mvp':
+		case 'new-product-mvp':
+			return __(
+				'We noticed you started editing a product, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
+				'woocommerce'
+			);
+		default:
+			return '';
+	}
+}
+
+export function triggerExitPageCesSurvey() {
+	const exitPageItems: string[] = getExitPageData();
+	if ( exitPageItems && exitPageItems.length > 0 ) {
+		const copy = getExitPageCESCopy( exitPageItems[ 0 ] );
+		if ( copy && copy.length > 0 ) {
+			dispatch( 'wc/customer-effort-score' ).addCesSurvey(
+				'exit_' + exitPageItems[ 0 ].replaceAll( '-', '_' ),
+				copy,
+				window.pagenow,
+				window.adminpage
+			);
+		}
+		removeExitPage( exitPageItems[ 0 ] );
+	}
+}

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -120,16 +120,28 @@ export const removeCustomerEffortScoreExitPageListener = ( pageId: string ) => {
  * @param {string} pageId page id.
  */
 function getExitPageCESCopy( pageId: string ): {
+	action: string;
 	title: string;
 	firstQuestion: string;
 	secondQuestion: string;
+	noticeLabel?: string;
+	description?: string;
 } | null {
 	switch ( pageId ) {
 		case 'product_edit_view':
-		case 'product_add_view':
-		case 'new_product':
+		case 'editing_new_product':
 			return {
+				action:
+					pageId === 'editing_new_product' ? 'new_product' : pageId,
+				noticeLabel: __(
+					'How is your experience with editing products?',
+					'woocommerce'
+				),
 				title: __(
+					"How's your experience with editing products?",
+					'woocommerce'
+				),
+				description: __(
 					'We noticed you started editing a product, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
 					'woocommerce'
 				),
@@ -139,6 +151,31 @@ function getExitPageCESCopy( pageId: string ): {
 				),
 				secondQuestion: __(
 					"The product editing screen's functionality meets my needs",
+					'woocommerce'
+				),
+			};
+		case 'product_add_view':
+		case 'new_product':
+			return {
+				action: pageId,
+				noticeLabel: __(
+					'How is your experience with creating products?',
+					'woocommerce'
+				),
+				title: __(
+					'How is your experience with creating products?',
+					'woocommerce'
+				),
+				description: __(
+					'We noticed you started creating a product, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
+					'woocommerce'
+				),
+				firstQuestion: __(
+					'The product creation screen is easy to use',
+					'woocommerce'
+				),
+				secondQuestion: __(
+					"The product creation screen's functionality meets my needs",
 					'woocommerce'
 				),
 			};
@@ -156,7 +193,6 @@ export function triggerExitPageCesSurvey() {
 		const copy = getExitPageCESCopy( exitPageItems[ 0 ] );
 		if ( copy && copy.title.length > 0 ) {
 			dispatch( 'wc/customer-effort-score' ).addCesSurvey( {
-				action: exitPageItems[ 0 ].replaceAll( '-', '_' ),
 				...copy,
 				pageNow: window.pagenow,
 				adminPage: window.adminpage,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -71,7 +71,7 @@ export const removeExitPage = ( pageId: string ) => {
 
 	let items = getExitPageData();
 
-	items = items.filter( ( item ) => item !== pageId );
+	items = items.filter( ( pageExitedId ) => pageExitedId !== pageId );
 	items = items.slice( -10 ); // Upper limit.
 
 	window.localStorage.setItem(

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-modal-container.tsx
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-modal-container.tsx
@@ -75,6 +75,7 @@ export const CustomerEffortScoreModalContainer: React.FC = () => {
 	return (
 		<CustomerFeedbackModal
 			title={ visibleCESModalData.label }
+			description={ visibleCESModalData.description }
 			firstQuestion={ visibleCESModalData.firstQuestion }
 			secondQuestion={ visibleCESModalData.secondQuestion }
 			recordScoreCallback={ ( ...args ) => {

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { withDispatch, withSelect, dispatch } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import PropTypes from 'prop-types';
 
@@ -11,6 +12,7 @@ import PropTypes from 'prop-types';
  */
 import CustomerEffortScoreTracks from './customer-effort-score-tracks';
 import { STORE_KEY, QUEUE_OPTION_NAME } from './data/constants';
+import { triggerExitPageCesSurvey } from './customer-effort-score-exit-page.ts';
 import './data';
 
 /**
@@ -29,6 +31,10 @@ function CustomerEffortScoreTracksContainer( {
 	resolving,
 	clearQueue,
 } ) {
+	useEffect( () => {
+		triggerExitPageCesSurvey();
+	}, [] );
+
 	if ( resolving ) {
 		return null;
 	}

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -3,7 +3,7 @@
  */
 import { compose } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
-import { withDispatch, withSelect, dispatch } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import PropTypes from 'prop-types';
 

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { compose } from '@wordpress/compose';
-import { useEffect } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import PropTypes from 'prop-types';
@@ -12,7 +11,6 @@ import PropTypes from 'prop-types';
  */
 import CustomerEffortScoreTracks from './customer-effort-score-tracks';
 import { STORE_KEY, QUEUE_OPTION_NAME } from './data/constants';
-import { triggerExitPageCesSurvey } from './customer-effort-score-exit-page.ts';
 import './data';
 
 /**
@@ -31,10 +29,6 @@ function CustomerEffortScoreTracksContainer( {
 	resolving,
 	clearQueue,
 } ) {
-	useEffect( () => {
-		triggerExitPageCesSurvey();
-	}, [] );
-
 	if ( resolving ) {
 		return null;
 	}

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -49,6 +49,8 @@ function CustomerEffortScoreTracksContainer( {
 				<CustomerEffortScoreTracks
 					key={ index }
 					action={ item.action }
+					description={ item.description }
+					noticeLabel={ item.noticeLabel }
 					firstQuestion={ item.firstQuestion }
 					secondQuestion={ item.secondQuestion }
 					title={ item.title }

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -78,6 +78,7 @@ function CustomerEffortScoreTracks( {
 		recordEvent( 'ces_snackbar_view', {
 			action,
 			store_age: storeAgeInWeeks,
+			ces_location: 'inside',
 			...trackProps,
 		} );
 	};
@@ -95,6 +96,7 @@ function CustomerEffortScoreTracks( {
 		recordEvent( 'ces_snackbar_dismiss', {
 			action,
 			store_age: storeAgeInWeeks,
+			ces_location: 'inside',
 			...trackProps,
 		} );
 
@@ -107,6 +109,7 @@ function CustomerEffortScoreTracks( {
 		recordEvent( 'ces_view', {
 			action,
 			store_age: storeAgeInWeeks,
+			ces_location: 'inside',
 			...trackProps,
 		} );
 
@@ -121,6 +124,7 @@ function CustomerEffortScoreTracks( {
 			score_combined: score + secondScore,
 			comments: comments || '',
 			store_age: storeAgeInWeeks,
+			ces_location: 'inside',
 			...trackProps,
 		} );
 		createNotice( 'success', onSubmitLabel );

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -74,7 +74,11 @@ function CustomerEffortScoreTracks( {
 	// (we don't want to return null early), if the modal was shown for this
 	// instantiation, so that the component doesn't go away while we are
 	// still showing it.
-	if ( cesShownForActions.indexOf( action ) !== -1 && ! modalShown ) {
+	if (
+		cesShownForActions &&
+		cesShownForActions.indexOf( action ) !== -1 &&
+		! modalShown
+	) {
 		return null;
 	}
 
@@ -91,7 +95,7 @@ function CustomerEffortScoreTracks( {
 		updateOptions( {
 			[ SHOWN_FOR_ACTIONS_OPTION_NAME ]: [
 				action,
-				...cesShownForActions,
+				...( cesShownForActions || [] ),
 			],
 		} );
 	};
@@ -170,7 +174,7 @@ CustomerEffortScoreTracks.propTypes = {
 	/**
 	 * The label displayed in the modal.
 	 */
-	label: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
 	/**
 	 * The label for the snackbar that appears upon survey submission.
 	 */
@@ -178,7 +182,7 @@ CustomerEffortScoreTracks.propTypes = {
 	/**
 	 * The array of actions that the CES modal has been shown for.
 	 */
-	cesShownForActions: PropTypes.arrayOf( PropTypes.string ).isRequired,
+	cesShownForActions: PropTypes.arrayOf( PropTypes.string ),
 	/**
 	 * Whether tracking is allowed or not.
 	 */
@@ -203,10 +207,10 @@ CustomerEffortScoreTracks.propTypes = {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
 
-		const cesShownForActions =
-			getOption( SHOWN_FOR_ACTIONS_OPTION_NAME ) || [];
+		const cesShownForActions = getOption( SHOWN_FOR_ACTIONS_OPTION_NAME );
 
 		const adminInstallTimestamp =
 			getOption( ADMIN_INSTALL_TIMESTAMP_OPTION_NAME ) || 0;
@@ -217,12 +221,16 @@ export default compose(
 		const allowTracking = allowTrackingOption === 'yes';
 
 		const resolving =
-			isResolving( 'getOption', [ SHOWN_FOR_ACTIONS_OPTION_NAME ] ) ||
+			! hasFinishedResolution( 'getOption', [
+				SHOWN_FOR_ACTIONS_OPTION_NAME,
+			] ) ||
 			storeAgeInWeeks === null ||
-			isResolving( 'getOption', [
+			! hasFinishedResolution( 'getOption', [
 				ADMIN_INSTALL_TIMESTAMP_OPTION_NAME,
 			] ) ||
-			isResolving( 'getOption', [ ALLOW_TRACKING_OPTION_NAME ] );
+			! hasFinishedResolution( 'getOption', [
+				ALLOW_TRACKING_OPTION_NAME,
+			] );
 
 		return {
 			cesShownForActions,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -28,6 +28,8 @@ import { getStoreAgeInWeeks } from './utils';
  * @param {string}   props.action             The action name sent to Tracks.
  * @param {Object}   props.trackProps         Additional props sent to Tracks.
  * @param {string}   props.title              The title displayed in the modal.
+ * @param {string}   props.noticeLabel        Label for notice, defaults to title.
+ * @param {string}   props.description        Description shown in CES modal.
  * @param {string}   props.firstQuestion      The first survey question.
  * @param {string}   props.secondQuestion     The second survey question.
  * @param {string}   props.onSubmitLabel      The label displayed upon survey submission.
@@ -42,6 +44,8 @@ function CustomerEffortScoreTracks( {
 	action,
 	trackProps,
 	title,
+	description,
+	noticeLabel,
 	firstQuestion,
 	secondQuestion,
 	onSubmitLabel = __( 'Thank you for your feedback!', 'woocommerce' ),
@@ -134,6 +138,8 @@ function CustomerEffortScoreTracks( {
 		<CustomerEffortScore
 			recordScoreCallback={ recordScore }
 			title={ title }
+			description={ description }
+			noticeLabel={ noticeLabel }
 			firstQuestion={ firstQuestion }
 			secondQuestion={ secondQuestion }
 			onNoticeShownCallback={ onNoticeShown }

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/actions.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/actions.js
@@ -26,6 +26,8 @@ export function setCesSurveyQueue( queue ) {
  * @param {Object} args                All arguments.
  * @param {string} args.action         action name for the survey
  * @param {string} args.title          title for the snackback
+ * @param {string} args.description    description for feedback modal.
+ * @param {string} args.noticeLabel    noticeLabel for notice.
  * @param {string} args.firstQuestion  first question for modal survey
  * @param {string} args.secondQuestion second question for modal survey
  * @param {string} args.pageNow        value of window.pagenow
@@ -36,6 +38,8 @@ export function setCesSurveyQueue( queue ) {
 export function addCesSurvey( {
 	action,
 	title,
+	description,
+	noticeLabel,
 	firstQuestion,
 	secondQuestion,
 	pageNow = window.pagenow,
@@ -47,6 +51,8 @@ export function addCesSurvey( {
 		type: TYPES.ADD_CES_SURVEY,
 		action,
 		title,
+		description,
+		noticeLabel,
 		firstQuestion,
 		secondQuestion,
 		pageNow,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/reducer.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/reducer.js
@@ -48,6 +48,8 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 			const newTrack = {
 				action: action.action,
 				title: action.title,
+				description: action.description,
+				noticeLabel: action.noticeLabel,
 				firstQuestion: action.firstQuestion,
 				secondQuestion: action.secondQuestion,
 				pagenow: action.pageNow,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/reducer.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/reducer.js
@@ -14,7 +14,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		case TYPES.SET_CES_SURVEY_QUEUE:
 			return {
 				...state,
-				queue: action.queue,
+				queue: [ ...state.queue, ...action.queue ],
 			};
 		case TYPES.HIDE_CES_MODAL:
 			return {

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/test/customer-effort-score-exit-page.test.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/test/customer-effort-score-exit-page.test.ts
@@ -51,7 +51,7 @@ describe( 'triggerExitPageCesSurvey', () => {
 	it( 'should trigger addCESSurvey if copy does exist for item, and clear localStorage still', () => {
 		window.localStorage.setItem(
 			'customer-effort-score-exit-page',
-			JSON.stringify( [ 'edit-product' ] )
+			JSON.stringify( [ 'new_product' ] )
 		);
 		triggerExitPageCesSurvey();
 		expect( addCESSurveyMock ).toHaveBeenCalled();

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/test/customer-effort-score-exit-page.test.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/test/customer-effort-score-exit-page.test.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// import { createElement } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 
 /**

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/test/customer-effort-score-exit-page.test.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/test/customer-effort-score-exit-page.test.ts
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+// import { createElement } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { triggerExitPageCesSurvey } from '../customer-effort-score-exit-page';
+
+jest.mock( '@woocommerce/data', () => ( {
+	OPTIONS_STORE_NAME: 'options',
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+	dispatch: jest.fn(),
+	resolveSelect: jest.fn().mockReturnValue( {
+		getOption: jest.fn().mockResolvedValue( 'yes' ),
+	} ),
+} ) );
+
+describe( 'triggerExitPageCesSurvey', () => {
+	const addCESSurveyMock = jest.fn();
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( dispatch as jest.Mock ).mockReturnValue( {
+			addCesSurvey: addCESSurveyMock,
+		} );
+	} );
+
+	it( 'should not trigger addCESSurvey if local storage is empty', () => {
+		triggerExitPageCesSurvey();
+		expect( addCESSurveyMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not trigger addCESSurvey if copy does not exist for item, but clear localStorage still', () => {
+		window.localStorage.setItem(
+			'customer-effort-score-exit-page',
+			JSON.stringify( [ 'random-id' ] )
+		);
+		triggerExitPageCesSurvey();
+		expect( addCESSurveyMock ).not.toHaveBeenCalled();
+		const list = window.localStorage.getItem(
+			'customer-effort-score-exit-page'
+		);
+		expect( list ).toEqual( '[]' );
+	} );
+
+	it( 'should trigger addCESSurvey if copy does exist for item, and clear localStorage still', () => {
+		window.localStorage.setItem(
+			'customer-effort-score-exit-page',
+			JSON.stringify( [ 'edit-product' ] )
+		);
+		triggerExitPageCesSurvey();
+		expect( addCESSurveyMock ).toHaveBeenCalled();
+		const list = window.localStorage.getItem(
+			'customer-effort-score-exit-page'
+		);
+		expect( list ).toEqual( '[]' );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import {
+	addCustomerEffortScoreExitPageListener,
+	addExitPage,
+	removeCustomerEffortScoreExitPageListener,
+} from './customer-effort-score-exit-page';
+
+export const useCustomerEffortScoreExitPageTracker = (
+	pageId: string,
+	hasUnsavedChanges: boolean
+) => {
+	// Using unmounting as a way to see when the react router changes.
+	useEffect( () => {
+		return () => {
+			addExitPage( pageId );
+		};
+	}, [] );
+
+	// This effect listen to the native beforeunload event to show
+	// a confirmation message
+	useEffect( () => {
+		addCustomerEffortScoreExitPageListener(
+			pageId,
+			() => hasUnsavedChanges
+		);
+
+		return () => {
+			removeCustomerEffortScoreExitPageListener( pageId );
+		};
+	}, [ hasUnsavedChanges ] );
+};

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
@@ -19,9 +19,11 @@ export const useCustomerEffortScoreExitPageTracker = (
 	// Using unmounting as a way to see when the react router changes.
 	useEffect( () => {
 		return () => {
-			addExitPage( pageId );
+			if ( hasUnsavedChanges ) {
+				addExitPage( pageId );
+			}
 		};
-	}, [] );
+	}, [ hasUnsavedChanges ] );
 
 	// This effect listen to the native beforeunload event to show
 	// a confirmation message

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import {
 	addCustomerEffortScoreExitPageListener,
 	addExitPage,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,14 +16,21 @@ export const useCustomerEffortScoreExitPageTracker = (
 	pageId: string,
 	hasUnsavedChanges: boolean
 ) => {
+	const hasUnsavedChangesRef = useRef( hasUnsavedChanges );
+
 	// Using unmounting as a way to see when the react router changes.
 	useEffect( () => {
+		hasUnsavedChangesRef.current = hasUnsavedChanges;
+	}, [ hasUnsavedChanges ] );
+
+	useEffect( () => {
 		return () => {
-			if ( hasUnsavedChanges ) {
+			if ( hasUnsavedChangesRef.current ) {
+				// unmounted.
 				addExitPage( pageId );
 			}
 		};
-	}, [ hasUnsavedChanges ] );
+	}, [] );
 
 	// This effect listen to the native beforeunload event to show
 	// a confirmation message

--- a/plugins/woocommerce-admin/client/embedded-body-layout/embedded-body-layout.tsx
+++ b/plugins/woocommerce-admin/client/embedded-body-layout/embedded-body-layout.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
+import { useEffect } from '@wordpress/element';
 import QueryString, { parse } from 'qs';
 
 /**
@@ -12,6 +13,7 @@ import { ShippingRecommendations } from '../shipping';
 import { EmbeddedBodyProps } from './embedded-body-props';
 import { StoreAddressTour } from '../guided-tours/store-address-tour';
 import './style.scss';
+import { triggerExitPageCesSurvey } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
 
 type QueryParams = EmbeddedBodyProps;
 
@@ -34,6 +36,10 @@ const EMBEDDED_BODY_COMPONENT_LIST: React.ElementType[] = [
  * Each Fill component receives QueryParams, consisting of a page, tab, and section string.
  */
 export const EmbeddedBodyLayout = () => {
+	useEffect( () => {
+		triggerExitPageCesSurvey();
+	}, [] );
+
 	const query = parse( location.search.substring( 1 ) );
 	let queryParams: QueryParams = { page: '', tab: '' };
 	if ( isWPPage( query ) ) {

--- a/plugins/woocommerce-admin/client/embedded-body-layout/test/embedded-body-layout.test.tsx
+++ b/plugins/woocommerce-admin/client/embedded-body-layout/test/embedded-body-layout.test.tsx
@@ -9,6 +9,18 @@ import { addFilter } from '@wordpress/hooks';
  */
 import { EmbeddedBodyLayout } from '../embedded-body-layout';
 
+jest.mock(
+	'~/customer-effort-score-tracks/customer-effort-score-exit-page',
+	() => ( {
+		triggerExitPageCesSurvey: jest.fn(),
+	} )
+);
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	resolveSelect: jest.fn().mockReturnValue( {
+		getOption: jest.fn(),
+	} ),
+} ) );
 jest.mock( '@woocommerce/data', () => ( {
 	useUser: () => ( {
 		currentUserCan: jest.fn(),

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -39,6 +39,7 @@ import Notices from './notices';
 import TransientNotices from './transient-notices';
 import { CustomerEffortScoreModalContainer } from '../customer-effort-score-tracks';
 import { getAdminSetting } from '~/utils/admin-settings';
+import { triggerExitPageCesSurvey } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
 import '~/activity-panel';
 import '~/mobile-banner';
 import './navigation';
@@ -135,6 +136,7 @@ class _Layout extends Component {
 
 	componentDidMount() {
 		this.recordPageViewTrack();
+		triggerExitPageCesSurvey();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -147,6 +149,9 @@ class _Layout extends Component {
 
 		if ( previousPath !== currentPath ) {
 			this.recordPageViewTrack();
+			setTimeout( () => {
+				triggerExitPageCesSurvey();
+			}, 0 );
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -29,6 +29,7 @@ import { WooHeaderItem } from '~/header/utils';
 import { useProductHelper } from './use-product-helper';
 import './product-form-actions.scss';
 import { useProductMVPCESFooter } from '~/customer-effort-score-tracks/use-product-mvp-ces-footer';
+import { useCustomerEffortScoreExitPageTracker } from '~/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker';
 
 export const ProductFormActions: React.FC = () => {
 	const {
@@ -47,6 +48,10 @@ export const ProductFormActions: React.FC = () => {
 		useFormContext< Product >();
 
 	usePreventLeavingPage( isDirty );
+	useCustomerEffortScoreExitPageTracker(
+		! values.id ? 'new-product-mvp' : 'edit-product-mvp',
+		isDirty
+	);
 
 	const { isSmallViewport } = useSelect( ( select ) => {
 		return {

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -48,10 +48,7 @@ export const ProductFormActions: React.FC = () => {
 		useFormContext< Product >();
 
 	usePreventLeavingPage( isDirty );
-	useCustomerEffortScoreExitPageTracker(
-		! values.id ? 'new-product-mvp' : 'edit-product-mvp',
-		isDirty
-	);
+	useCustomerEffortScoreExitPageTracker( 'new_product', isDirty );
 
 	const { isSmallViewport } = useSelect( ( select ) => {
 		return {

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -48,7 +48,10 @@ export const ProductFormActions: React.FC = () => {
 		useFormContext< Product >();
 
 	usePreventLeavingPage( isDirty );
-	useCustomerEffortScoreExitPageTracker( 'new_product', isDirty );
+	useCustomerEffortScoreExitPageTracker(
+		! values.id ? 'new_product' : 'editing_new_product',
+		isDirty
+	);
 
 	const { isSmallViewport } = useSelect( ( select ) => {
 		return {

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -56,6 +56,12 @@ jest.mock( '../use-product-helper', () => {
 	};
 } );
 jest.mock( '~/hooks/usePreventLeavingPage' );
+jest.mock(
+	'~/customer-effort-score-tracks/use-customer-effort-score-exit-page-tracker',
+	() => ( {
+		useCustomerEffortScoreExitPageTracker: jest.fn(),
+	} )
+);
 
 describe( 'ProductFormActions', () => {
 	beforeEach( () => {

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -1,5 +1,7 @@
 declare global {
 	interface Window {
+		pagenow: string;
+		adminpage: string;
 		wcSettings: {
 			preloadOptions: Record< string, unknown >;
 			adminUrl: string;
@@ -31,6 +33,19 @@ declare global {
 			'woo-mobile-welcome': boolean;
 			'shipping-smart-defaults': boolean;
 			'shipping-setting-tour': boolean;
+		};
+		wp: {
+			autosave?: {
+				server: {
+					postChanged: () => boolean;
+				};
+			};
+		};
+		tinymce?: {
+			get: ( name: string ) => {
+				isHidden: () => boolean;
+				isDirty: () => boolean;
+			};
 		};
 	}
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
@@ -16,5 +16,5 @@ const initTracks = () => {
 if ( productScreen && productScreen.name === 'edit' ) {
 	initTracks();
 
-	addExitPageListener( 'edit-product' );
+	addExitPageListener( 'product_edit_view' );
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-edit.ts
@@ -6,7 +6,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { initProductScreenTracks } from './shared';
+import { addExitPageListener, initProductScreenTracks } from './shared';
 
 const initTracks = () => {
 	recordEvent( 'product_edit_view' );
@@ -15,4 +15,6 @@ const initTracks = () => {
 
 if ( productScreen && productScreen.name === 'edit' ) {
 	initTracks();
+
+	addExitPageListener( 'edit-product' );
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-new.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-new.ts
@@ -6,7 +6,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { initProductScreenTracks } from './shared';
+import { addExitPageListener, initProductScreenTracks } from './shared';
 
 const initTracks = () => {
 	recordEvent( 'product_add_view' );
@@ -15,4 +15,6 @@ const initTracks = () => {
 if ( productScreen && productScreen.name === 'new' ) {
 	initTracks();
 	initProductScreenTracks();
+
+	addExitPageListener( 'new-product' );
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-new.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/product-new.ts
@@ -16,5 +16,5 @@ if ( productScreen && productScreen.name === 'new' ) {
 	initTracks();
 	initProductScreenTracks();
 
-	addExitPageListener( 'new-product' );
+	addExitPageListener( 'product_add_view' );
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { recordEvent } from '@woocommerce/tracks';
-import { addCustomerEffortScoreExitPageListener } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
 
 /**
  * Internal dependencies
  */
 import { waitUntilElementIsPresent } from './utils';
+import { addCustomerEffortScoreExitPageListener } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
 
 /**
  * Get the product data.
@@ -474,12 +474,13 @@ export function addExitPageListener( pageId: string ) {
 		return isDisabled;
 	}
 	window.addEventListener( 'beforeunload', function ( event ) {
+		// Check if button disabled or triggered delete to see if user saved or deleted the product instead.
 		if ( checkIfSubmitButtonsDisabled() || triggeredDelete ) {
 			productChanged = false;
 			triggeredDelete = false;
 			return;
 		}
-		var editor = window.tinymce && window.tinymce.get( 'content' );
+		const editor = window.tinymce && window.tinymce.get( 'content' );
 
 		if ( window.wp.autosave ) {
 			productChanged = window.wp.autosave.server.postChanged();

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { recordEvent } from '@woocommerce/tracks';
+import { addCustomerEffortScoreExitPageListener } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
 
 /**
  * Internal dependencies
@@ -444,3 +445,50 @@ export const initProductScreenTracks = () => {
 			} );
 	} );
 };
+
+export function addExitPageListener( pageId: string ) {
+	let productChanged = false;
+	let triggeredDelete = false;
+
+	const deleteButton = document.querySelector( '#submitpost a.submitdelete' );
+
+	if ( deleteButton ) {
+		deleteButton.addEventListener( 'click', function () {
+			triggeredDelete = true;
+		} );
+	}
+
+	function checkIfSubmitButtonsDisabled() {
+		const submitButtonSelectors = [
+			'#submitpost [type="submit"]',
+			'#submitpost #post-preview',
+		];
+		let isDisabled = false;
+		for ( const sel of submitButtonSelectors ) {
+			document.querySelectorAll( sel ).forEach( ( element ) => {
+				if ( element.classList.contains( 'disabled' ) ) {
+					isDisabled = true;
+				}
+			} );
+		}
+		return isDisabled;
+	}
+	window.addEventListener( 'beforeunload', function ( event ) {
+		if ( checkIfSubmitButtonsDisabled() || triggeredDelete ) {
+			productChanged = false;
+			triggeredDelete = false;
+			return;
+		}
+		var editor = window.tinymce && window.tinymce.get( 'content' );
+
+		if ( window.wp.autosave ) {
+			productChanged = window.wp.autosave.server.postChanged();
+		} else if ( editor ) {
+			productChanged = ! editor.isHidden() && editor.isDirty();
+		}
+	} );
+
+	addCustomerEffortScoreExitPageListener( pageId, () => {
+		return productChanged;
+	} );
+}

--- a/plugins/woocommerce/changelog/add-35126_ces_exit_prompt
+++ b/plugins/woocommerce/changelog/add-35126_ces_exit_prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add exit prompt logic to get feedback if users leave product pages without saving when tracking is enabled.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This add's initial logic to make it easy to track if users leave pages with un-saved changes, for showing a feedback notice.
This would only be enabled if the user has enabled tracking.

Partially addresses #35126  .

https://user-images.githubusercontent.com/2240960/203960252-d8a73358-ec2b-405f-a953-55819956152f.mp4

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, build it, and make sure you have the `new-product-management-experience` feature flag enabled (you can do so using the latest version of the Beta tester within the mono repo).
2. Make sure you have tracks enabled and also outputted in the console: localStorage.setItem( 'debug', 'wc-admin:*' );
3. Go to **Product > Add New** and make some changes
4. Now go to another page like **WooCommerce > Home** and select **Leave** when it warns you about unsaved changes.
5. A notice should show on the new page that allows you to share feedback, something to the affect of `We noticed you started editing a product, then left....`
6. Click the share feedback and submit feedback, notice how the `wcadmin_ces_snackbar_view`, `wcadmin_ces_view`, and `wcadmin_ces_feedback` include the `ces_location` prop with the  `outside` value.
You may also want to try dismissing the notice and see if the prop has been added to `wcadmin_ces_snackbar_dismiss`
7. Repeat steps 4-6 for all these pages: Product edit page, New product MVP page, edit product MVP page.
8. Now delete the `woocommerce_ces_shown_for_actions` option and disable tracking under **WooCommerce > Settings > Advanced > Woocommerce.com**
9. Make sure the notice doesn't show up for the above anymore and that `customer-effort-score-exit-page` in local storage does not get updated, but stays empty.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
