### PR TITLE
Improve element stacking in modals on tablet and mobile

### DIFF
--- a/packages/js/internal-style-build/abstracts/_mixins.scss
+++ b/packages/js/internal-style-build/abstracts/_mixins.scss
@@ -168,6 +168,7 @@
 }
 
 // Hide an element from sighted users, but availble to screen reader users.
+// @deprecated in favor of sr-only
 @mixin visually-hidden() {
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
@@ -180,7 +181,20 @@
 	word-wrap: normal !important;
 }
 
+@mixin sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
 // Unhide a visually hidden element
+// @deprecated in favor of not-sr-only
 @mixin visually-shown() {
 	clip: auto;
 	clip-path: none;
@@ -188,6 +202,17 @@
 	width: auto;
 	margin: unset;
 	overflow: hidden;
+}
+
+@mixin not-sr-only {
+	position: static;
+	width: auto;
+	height: auto;
+	padding: 0;
+	margin: 0;
+	overflow: visible;
+	clip: auto;
+	white-space: normal;
 }
 
 // Create a string-repeat function

--- a/packages/js/internal-style-build/abstracts/_mixins.scss
+++ b/packages/js/internal-style-build/abstracts/_mixins.scss
@@ -1,7 +1,7 @@
 // Rem output with px fallback
 @mixin font-size( $sizeValue: 16, $lineHeight: false ) {
 	font-size: $sizeValue + px;
-	font-size: math.div($sizeValue, 16) + rem;
+	font-size: math.div( $sizeValue, 16 ) + rem;
 	@if ( $lineHeight ) {
 		line-height: $lineHeight;
 	}
@@ -106,7 +106,7 @@
 	background-color: $studio-white;
 	color: $gray-900;
 	box-shadow: inset 0 0 0 1px $gray-400, inset 0 0 0 2px $studio-white,
-		0 1px 1px rgba($gray-900, 0.2);
+		0 1px 1px rgba( $gray-900, 0.2 );
 }
 
 @mixin button-style__active() {
@@ -145,7 +145,6 @@
 }
 /* stylelint-enable */
 
-
 // Gutenberg Switch.
 @mixin switch-style__focus-active() {
 	box-shadow: 0 0 0 2px $studio-white, 0 0 0 3px $gray-700;
@@ -158,20 +157,20 @@
 // Sets positions for children of grid elements
 @mixin set-grid-item-position( $wrap-after, $number-of-items ) {
 	@for $i from 1 through $number-of-items {
-		&:nth-child(#{$i}) {
-			grid-column-start: #{($i - 1) % $wrap-after + 1};
-			grid-column-end: #{($i - 1) % $wrap-after + 2};
-			grid-row-start: #{floor(math.div($i - 1, $wrap-after)) + 1};
-			grid-row-end: #{floor(math.div($i - 1, $wrap-after)) + 2};
+		&:nth-child( #{$i} ) {
+			grid-column-start: #{( $i - 1 ) % $wrap-after + 1};
+			grid-column-end: #{( $i - 1 ) % $wrap-after + 2};
+			grid-row-start: #{floor( math.div( $i - 1, $wrap-after ) ) + 1};
+			grid-row-end: #{floor( math.div( $i - 1, $wrap-after ) ) + 2};
 		}
 	}
 }
 
 // Hide an element from sighted users, but availble to screen reader users.
-// @deprecated in favor of sr-only
+// @deprecated in favor of screen-reader-only
 @mixin visually-hidden() {
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
+	clip: rect( 1px, 1px, 1px, 1px );
+	clip-path: inset( 50% );
 	height: 1px;
 	width: 1px;
 	margin: -1px;
@@ -181,20 +180,20 @@
 	word-wrap: normal !important;
 }
 
-@mixin sr-only {
+@mixin screen-reader-only {
 	position: absolute;
 	width: 1px;
 	height: 1px;
 	padding: 0;
 	margin: -1px;
 	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
+	clip: rect( 0, 0, 0, 0 );
 	white-space: nowrap;
 	border-width: 0;
 }
 
 // Unhide a visually hidden element
-// @deprecated in favor of not-sr-only
+// @deprecated in favor of not-screen-reader-only
 @mixin visually-shown() {
 	clip: auto;
 	clip-path: none;
@@ -204,7 +203,7 @@
 	overflow: hidden;
 }
 
-@mixin not-sr-only {
+@mixin not-screen-reader-only {
 	position: static;
 	width: auto;
 	height: auto;

--- a/packages/js/internal-style-build/changelog/enhancement-35565
+++ b/packages/js/internal-style-build/changelog/enhancement-35565
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add updated versions of sr-only and not-sr-only mixins 

--- a/packages/js/internal-style-build/changelog/enhancement-35565
+++ b/packages/js/internal-style-build/changelog/enhancement-35565
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Add updated versions of sr-only and not-sr-only mixins 
+Add updated versions of screen-reader-only and not-screen-reader-only mixins 

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.scss
@@ -32,6 +32,12 @@
 		width: 100%;
 		margin-top: $gap-large;
 
+		@include breakpoint('<782px') {
+			thead {
+				@include sr-only();
+			}
+		}
+
 		th {
 			text-align: left;
 			color: $gray-700;
@@ -54,10 +60,37 @@
 		td:not(:last-child) {
 			margin-right: $gap;
 		}
+
+		@include breakpoint('<782px') {
+			position: relative;
+			grid-template-columns: 1fr;
+			padding-right: 42px;
+		}
+
+		@include breakpoint('>782px') {
+			.woocommerce-experimental-select-control__label {
+				@include sr-only();
+			}
+			.woocommerce-experimental-select-control__combo-box-wrapper {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	&__table-attribute-trash-column {
 		display: flex;
 		justify-content: center;
+
+		@include breakpoint('<782px') {
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			align-items: center;
+		}
+
+		.components-button.has-icon {
+			padding: 8px;
+		}
 	}
 }

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.scss
@@ -32,7 +32,7 @@
 		width: 100%;
 		margin-top: $gap-large;
 
-		@include breakpoint('<782px') {
+		@include breakpoint( '<782px' ) {
 			thead {
 				@include sr-only();
 			}
@@ -57,17 +57,19 @@
 	}
 	&__table-row {
 		padding: $gap-large 0;
-		td:not(:last-child) {
+		td:not( :last-child ) {
 			margin-right: $gap;
 		}
 
-		@include breakpoint('<782px') {
+		@include breakpoint( '<782px' ) {
 			position: relative;
 			grid-template-columns: 1fr;
+			// Added the width of the trash icon as padding
+			// so that it can be displayed correctly
 			padding-right: 42px;
 		}
 
-		@include breakpoint('>782px') {
+		@include breakpoint( '>782px' ) {
 			.woocommerce-experimental-select-control__label {
 				@include sr-only();
 			}
@@ -81,7 +83,7 @@
 		display: flex;
 		justify-content: center;
 
-		@include breakpoint('<782px') {
+		@include breakpoint( '<782px' ) {
 			position: absolute;
 			top: 0;
 			right: 0;

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.scss
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.scss
@@ -34,7 +34,7 @@
 
 		@include breakpoint( '<782px' ) {
 			thead {
-				@include sr-only();
+				@include screen-reader-only();
 			}
 		}
 
@@ -57,7 +57,7 @@
 	}
 	&__table-row {
 		padding: $gap-large 0;
-		td:not( :last-child ) {
+		td:not(:last-child) {
 			margin-right: $gap;
 		}
 
@@ -71,7 +71,7 @@
 
 		@include breakpoint( '>782px' ) {
 			.woocommerce-experimental-select-control__label {
-				@include sr-only();
+				@include screen-reader-only();
 			}
 			.woocommerce-experimental-select-control__combo-box-wrapper {
 				margin-bottom: 0;

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/add-attribute-modal.tsx
@@ -124,6 +124,9 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 		}
 	};
 
+	const attributeLabel = __( 'Attribute', 'woocommerce' );
+	const valueLabel = __( 'Values', 'woocommerce' );
+
 	return (
 		<>
 			<Form< AttributeForm >
@@ -167,8 +170,8 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 								<table className="woocommerce-add-attribute-modal__table">
 									<thead>
 										<tr className="woocommerce-add-attribute-modal__table-header">
-											<th>Attribute</th>
-											<th>Values</th>
+											<th>{ attributeLabel }</th>
+											<th>{ valueLabel }</th>
 										</tr>
 									</thead>
 									<tbody>
@@ -185,6 +188,9 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 																'woocommerce'
 															) }
 															value={ attribute }
+															label={
+																attributeLabel
+															}
 															onChange={ (
 																val
 															) => {
@@ -246,6 +252,9 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 																		? []
 																		: attribute.terms
 																}
+																label={
+																	valueLabel
+																}
 																onChange={ (
 																	val
 																) =>
@@ -268,6 +277,9 @@ export const AddAttributeModal: React.FC< AddAttributeModalProps > = ( {
 																}
 																value={
 																	attribute.options
+																}
+																label={
+																	valueLabel
 																}
 																onChange={ (
 																	val

--- a/plugins/woocommerce/changelog/enhancement-35565
+++ b/plugins/woocommerce/changelog/enhancement-35565
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve element stacking in modals on tablet and mobile


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35565

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Got to `Products -> Add New (MVP)` page
2. Under Attributes section click `Add first attribute` button
3. The `Add attribute` modal should be shown
4. When on mobile screen the table's header should be hidden, the attribute and values field have labels and are stacked in rows while the trash icon remains on the right with 8px margin right. 

<img width="390" alt="image" src="https://user-images.githubusercontent.com/13334210/204028803-2bdd8436-e1b4-4489-b2e4-f6d9b18f4a0b.png">

5. When on tablet screen the table's header should be hidden, the attribute and values field have labels and are stacked in rows while the trash icon remains on the right with 8px margin right. 

<img width="768" alt="image" src="https://user-images.githubusercontent.com/13334210/204028641-d97cc082-dd20-452d-ae03-ab96ceb3aac9.png">

6. When on desktop screen the table's header should be shown, the attribute and values field don't have labels and are stacked in columns as well as the trash icon that has 8px margin right.

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/13334210/204028735-a5d6c1ee-08db-46dc-a4f7-613dff45120a.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
