### PR TITLE
[Enhancement #35636] Allow passing variables to `wc_get_template_part`

### DIFF
--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -239,7 +239,8 @@ function wc_get_path_define_tokens() {
  * @param mixed  $slug Template slug.
  * @param string $name Template name (default: '').
  */
-function wc_get_template_part( $slug, $name = '' ) {
+// TODO test $args
+function wc_get_template_part( $slug, $name = '', $args = array() ) {
 	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, Constants::get_constant( 'WC_VERSION' ) ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
@@ -278,10 +279,10 @@ function wc_get_template_part( $slug, $name = '' ) {
 	}
 
 	// Allow 3rd party plugins to filter template file from their plugin.
-	$template = apply_filters( 'wc_get_template_part', $template, $slug, $name );
+	$template = apply_filters( 'wc_get_template_part', $template, $slug, $name, $args );
 
 	if ( $template ) {
-		load_template( $template, false );
+		load_template( $template, false, $args );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

#### Changing explaination

- Allow passing variables to `wc_get_template_part` through the third param `$args`.
- Refactor code, including rename variable and update comments. It serves readable purpose.


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35636 . The reason is explained in issue 35636.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1.
2.
3.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
