### PR TITLE
Don't run WooCommerce specific code if WooCommerce is not installed

### DIFF
--- a/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
+++ b/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
@@ -60,7 +60,7 @@ class Tracks_Debug_Log {
 	public function log_event( $event_name, $properties ) {
 		$logger = $this->get_logger();
 		
-		if ($logger != null) {
+		if ( ! $logger ) {
 			$logger->debug(
 				$event_name,
 				array( 'source' => $this->source )
@@ -68,7 +68,7 @@ class Tracks_Debug_Log {
 		}
 		
 		foreach ( $properties as $key => $property ) {
-			if ($logger != null) {
+			if ( ! $logger ) {
 				$logger->debug(
 					"  - {$key}: {$property}",
 					array( 'source' => $this->source )

--- a/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
+++ b/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
@@ -25,7 +25,7 @@ class Tracks_Debug_Log {
 
 	/**
 	 * Get the logger instance.
-	 * 
+	 *
 	 * @return WC_Logger_Interface|null
 	 */
 	private function get_logger() {
@@ -34,7 +34,7 @@ class Tracks_Debug_Log {
 			$this->logger = wc_get_logger();
 		}
 
-		return $this->logger;		
+		return $this->logger;
 	}
 
 	/**
@@ -59,21 +59,21 @@ class Tracks_Debug_Log {
 	 */
 	public function log_event( $event_name, $properties ) {
 		$logger = $this->get_logger();
-		
-		if ( ! $logger ) {
+
+		if ( $logger ) {
 			$logger->debug(
 				$event_name,
 				array( 'source' => $this->source )
 			);
 		}
-		
+
 		foreach ( $properties as $key => $property ) {
-			if ( ! $logger ) {
+			if ( $logger ) {
 				$logger->debug(
 					"  - {$key}: {$property}",
 					array( 'source' => $this->source )
-				);	
-			}	
+				);
+			}
 		}
 	}
 

--- a/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
+++ b/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
@@ -24,14 +24,25 @@ class Tracks_Debug_Log {
 	private $source = 'tracks';
 
 	/**
+	 * Get the logger instance.
+	 * 
+	 * @return WC_Logger_Interface|null
+	 */
+	private function get_logger() {
+		// Sometimes between installations of WC versions the logger will not be available.
+		if ( ! $this->logger && function_exists( 'wc_get_logger' ) ) {
+			$this->logger = wc_get_logger();
+		}
+
+		return $this->logger;		
+	}
+
+	/**
 	 * Initialize hooks.
 	 */
 	public function __construct() {
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-
-		$logger       = wc_get_logger();
-		$this->logger = $logger;
 
 		add_action( 'admin_footer', array( $this, 'log_footer_pixels' ), 5 );
 		add_action( 'pre_http_request', array( $this, 'log_remote_pixels' ), 10, 3 );
@@ -44,15 +55,22 @@ class Tracks_Debug_Log {
 	 * @param array  $properties Event properties.
 	 */
 	public function log_event( $event_name, $properties ) {
-		$this->logger->debug(
-			$event_name,
-			array( 'source' => $this->source )
-		);
-		foreach ( $properties as $key => $property ) {
-			$this->logger->debug(
-				"  - {$key}: {$property}",
+		$logger = $this->get_logger();
+		
+		if ($logger != null) {
+			$logger->debug(
+				$event_name,
 				array( 'source' => $this->source )
 			);
+		}
+		
+		foreach ( $properties as $key => $property ) {
+			if ($logger != null) {
+				$logger->debug(
+					"  - {$key}: {$property}",
+					array( 'source' => $this->source )
+				);	
+			}	
 		}
 	}
 

--- a/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
+++ b/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
@@ -41,11 +41,14 @@ class Tracks_Debug_Log {
 	 * Initialize hooks.
 	 */
 	public function __construct() {
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		// WooCommerce might not be installed/activated between installs of WC versions.
+		if ( class_exists( 'WooCommerce' ) ) {
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
 
-		add_action( 'admin_footer', array( $this, 'log_footer_pixels' ), 5 );
-		add_action( 'pre_http_request', array( $this, 'log_remote_pixels' ), 10, 3 );
+			add_action( 'admin_footer', array( $this, 'log_footer_pixels' ), 5 );
+			add_action( 'pre_http_request', array( $this, 'log_remote_pixels' ), 10, 3 );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce-beta-tester/changelog/dev-check-logger-exists
+++ b/plugins/woocommerce-beta-tester/changelog/dev-check-logger-exists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where between WC installs the beta tester would crash trying to log.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There is a crash that happens in some cases in WooCommerce Beta Tester due to `wc_get_logger` not being available. This would most likely be due to WooCommerce not being installed/activated at a time this code is called in the beta tester. The idea of this change is to guard against these calls happening unless WooCommerce is activated. I'm not sure overall how safe it is, for example to completely disable loading the tracking PHP code in the constructor of this class.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing steps to be done in JN, because this fix needs to be confirmed working in JN.

1. Create a JN site. Install WooCommerce (latest is fine). **do not activate it**

2. Checkout this branch and build a zip of beta tester (navigate to plugins/woocommerce-beta-tester and run `pnpm run build:zip`

3. Install the zip of beta tester on your JN site. Activate it

4. There should not be any errors or exceptions thrown on your site. 

Note: If you want to see the behaviour where it crashes, follow these steps, but install a build of beta-tester from `trunk`. An exception should be thrown on activation of Beta Tester.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
