### PR TITLE
Updated possibly_schedule_import function

### DIFF
--- a/plugins/woocommerce/changelog/pr-35743
+++ b/plugins/woocommerce/changelog/pr-35743
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Modify the possibly_schedule_import function to return the order id

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -40,7 +40,7 @@ class OrdersScheduler extends ImportScheduler {
 
 		// Order and refund data must be run on these hooks to ensure meta data is set.
 		add_action( 'woocommerce_update_order', array( __CLASS__, 'possibly_schedule_import' ) );
-		add_action( 'woocommerce_create_order', array( __CLASS__, 'possibly_schedule_import' ) );
+		add_filter( 'woocommerce_create_order', array( __CLASS__, 'possibly_schedule_import' ) );
 		add_action( 'woocommerce_refund_created', array( __CLASS__, 'possibly_schedule_import' ) );
 
 		OrdersStatsDataStore::init();
@@ -210,6 +210,7 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	 * @param int $order_id Post ID.
 	 *
 	 * @internal
+	 * @returns int The order id
 	 */
 	public static function possibly_schedule_import( $order_id ) {
 		if ( ! OrderUtil::is_order( $order_id, array( 'shop_order' ) ) && 'woocommerce_refund_created' !== current_filter() ) {

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/OrdersScheduler.php
@@ -213,10 +213,11 @@ AND status NOT IN ( 'wc-auto-draft', 'trash', 'auto-draft' )
 	 */
 	public static function possibly_schedule_import( $order_id ) {
 		if ( ! OrderUtil::is_order( $order_id, array( 'shop_order' ) ) && 'woocommerce_refund_created' !== current_filter() ) {
-			return;
+			return $order_id;
 		}
 
 		self::schedule_action( 'import', array( $order_id ) );
+		return $order_id;
 	}
 
 	/**


### PR DESCRIPTION
The function 'possibly_schedule_import' is called while creating orders ( using the "woocommerce_create_order" filter ). The function returns null values instead of order id. This prevents the third-party plugin from having the opportunity to create an order (generating multiple orders).

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
 Fix for the issue #35599
Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

You can reproduce the issue using our "Deposits & Partial Payments for WooCommerce" plugin. You can use the version 1.1.5 plugin for testing: https://downloads.wordpress.org/plugin/deposits-partial-payments-for-woocommerce.1.1.5.zip

After installing the plugin, enable deposit and set deposit type and deposit value from plugin settings (Dashboard -> Deposits). Select deposit from the frontend product page and create an order. Then you can see two orders are created instead of a single order.

In our deposit plugin, we are using the "woocommerce_create_order" to create our own orders and override the default order creation. Because of this "possibly_schedule_import" function not returning anything, it creates multiple orders ( orders from our plugin code and default orders )

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
