### PR TITLE
Deb/assets cleanup

### DIFF
--- a/plugins/woocommerce/bin/build-zip.sh
+++ b/plugins/woocommerce/bin/build-zip.sh
@@ -9,6 +9,9 @@ echo "Generating build directory..."
 rm -rf "$BUILD_PATH"
 mkdir -p "$DEST_PATH"
 
+echo "Cleaning up assets..."
+find "$PROJECT_PATH/assets/css/." ! -name '.gitkeep' -type f -exec rm -f {} + && find "$PROJECT_PATH/assets/client/." ! -name '.gitkeep' -type f -exec rm -f {} + && find "$PROJECT_PATH/assets/js/." ! -name '.gitkeep' -type f -exec rm -f {} +
+
 echo "Installing PHP and JS dependencies..."
 pnpm install
 echo "Running JS Build..."

--- a/plugins/woocommerce/changelog/assets-cleanup
+++ b/plugins/woocommerce/changelog/assets-cleanup
@@ -1,0 +1,3 @@
+Significance: patch
+Type: dev
+Comment: Clean up assets when building zip.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/34663

This is the second take as the first take had issues with caching. This time around, since this mostly affects the build assets, I've isolated the fix only for that.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Pull down this branch.
2. Run `pnpm run --filter=woocommerce build:zip`
3. Ensure the zip package contains all the `css` and `js` assets inside `assets` folder.
4. Run `pnpm run --filter=woocommerce build:zip` again to make sure you get same results even after Turbo cache.
5. Run the `Build release zip` action manually seen [here](https://github.com/woocommerce/woocommerce/actions/workflows/build-release-zip-file.yml) targeting this `deb/assets-cleanup`. For example `refs/heads/deb/assets-cleanup`.
6. Ensure the zip package contains all the `css` and `js` assets inside `assets` folder.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
