### PR TITLE
Set page hidden form field based on the order_type

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -969,7 +969,7 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	private function print_hidden_form_fields(): void {
-		echo '<input type="hidden" name="page" value="wc-orders" >';
+		echo '<input type="hidden" name="page" value="wc-orders' . ( 'shop_order' === $this->order_type ? '' : '--' . $this->order_type ) . '" >';
 
 		$state_params = array(
 			'paged',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #35750 

A user should be able to filter by date or customer of a custom order type and the relevant results would be shown. Prior to this PR the filtering instead happens of orders only rather than the custom order type.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. With HPOS on and enabled using PR https://github.com/Automattic/woocommerce-subscriptions-core/pull/297 and https://github.com/woocommerce/woocommerce/pull/35658
2. Click on 'Subscriptions' in wp-admin
3. Filter subscriptions by date or customer.
4. The results show orders instead.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
