### PR TITLE
Enhancement/35756: Open filter 'woocommerce_coupon_get_discount_amount' for 'WC_Order' object as well

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-35756
+++ b/plugins/woocommerce/changelog/enhancement-35756
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Allow changing coupon discount amount when adding a coupon during order creation via REST API

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -371,7 +371,7 @@ class WC_Discounts {
 			// Run coupon calculations.
 			$discount = floor( $price_to_discount * ( $coupon_amount / 100 ) );
 
-			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
+			if ( ( is_a( $this->object, 'WC_Cart' ) || is_a( $this->object, 'WC_Order' ) ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
 				$filtered_discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 
@@ -436,7 +436,7 @@ class WC_Discounts {
 				$discount       = $amount * $apply_quantity;
 			}
 
-			if ( is_a( $this->object, 'WC_Cart' ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
+			if ( ( is_a( $this->object, 'WC_Cart' ) || is_a( $this->object, 'WC_Order' ) ) && has_filter( 'woocommerce_coupon_get_discount_amount' ) ) {
 				// Send through the legacy filter, but not as cents.
 				$discount = wc_add_number_precision( apply_filters( 'woocommerce_coupon_get_discount_amount', wc_remove_number_precision( $discount ), wc_remove_number_precision( $price_to_discount ), $item->object, false, $coupon ) );
 			}


### PR DESCRIPTION

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce core provides a filter `woocommerce_coupon_get_discount_amount` in the class `WC_Discounts` ([ref](https://github.com/woocommerce/woocommerce/blob/7.1.0/plugins/woocommerce/includes/class-wc-discounts.php#L376)). This filter helps us in some specific use case by allowing us to change the coupon discount amount. 

An example use case is: We want to create a coupon such that it'll give 75% off up to $50 (max discount).

But this feature is not available when adding a coupon during order creation via REST API. Because the filter `woocommerce_coupon_get_discount_amount` is restricted to be used with only `WC_Cart` object.

As the class `WC_Discounts` is used by both `WC_Cart` & `WC_Order`, the filter `woocommerce_coupon_get_discount_amount` should be accessible to `WC_Order` object as well. Therefore this pull request.

Closes #35756 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
