### PR TITLE
Add open on focus to attribute fields

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/attribute-input-field/attribute-input-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-input-field/attribute-input-field.tsx
@@ -124,6 +124,7 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 				);
 			} }
 			onRemove={ () => onChange() }
+			__experimentalOpenMenuOnFocus
 		>
 			{ ( {
 				items: renderItems,

--- a/plugins/woocommerce-admin/client/products/fields/attribute-term-input-field/attribute-term-input-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-term-input-field/attribute-term-input-field.tsx
@@ -188,6 +188,7 @@ export const AttributeTermInputField: React.FC<
 					'woocommerce-attribute-term-field ' +
 					attributeTermInputId.current
 				}
+				__experimentalOpenMenuOnFocus
 			>
 				{ ( {
 					items,

--- a/plugins/woocommerce/changelog/add-35576_open_on_focus_to_attribute_fields
+++ b/plugins/woocommerce/changelog/add-35576_open_on_focus_to_attribute_fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add experimental open menu on focus option to the attribute and attribute term input fields.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the `__experimentalOpenMenuOnFocus` prop to the attribute and attribute term input select control fields.

Related to #35576  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, build it, and make sure you have the `new-product-management-experience` feature flag enabled (you can do so using the latest version of the Beta tester within the mono repo).
2. Go to **Products > Attributes** and add some attributes
3. Go to **Product > Add New** and scroll down to the attributes field
4. Select **Add first attribute** and select the attribute input field
5. The menu should open with the initial list of attributes
6. Select an attribute that contains a couple terms
7. Once selected the attribute term field should auto focus and open, it might initially show a loading icon, but then a list of terms.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
