### PR TITLE
Add/35126 ces exit prompt settings

### DIFF
--- a/packages/js/customer-effort-score/changelog/add-35126_ces_exit_prompt_settings
+++ b/packages/js/customer-effort-score/changelog/add-35126_ces_exit_prompt_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update CustomerEffortScore tracks to add callback for when Modal is dismissed.

--- a/packages/js/customer-effort-score/src/customer-effort-score.tsx
+++ b/packages/js/customer-effort-score/src/customer-effort-score.tsx
@@ -27,6 +27,7 @@ type CustomerEffortScoreProps = {
 	onNoticeShownCallback?: () => void;
 	onNoticeDismissedCallback?: () => void;
 	onModalShownCallback?: () => void;
+	onModalDismissedCallback?: () => void;
 	icon?: React.ReactElement | null;
 };
 
@@ -46,6 +47,7 @@ type CustomerEffortScoreProps = {
  * @param {Function} props.onNoticeShownCallback     Function to call when the notice is shown.
  * @param {Function} props.onNoticeDismissedCallback Function to call when the notice is dismissed.
  * @param {Function} props.onModalShownCallback      Function to call when the modal is shown.
+ * @param {Function} props.onModalDismissedCallback  Function to call when modal is dismissed.
  * @param {Object}   props.icon                      Icon (React component) to be shown on the notice.
  */
 const CustomerEffortScore: React.VFC< CustomerEffortScoreProps > = ( {
@@ -58,6 +60,7 @@ const CustomerEffortScore: React.VFC< CustomerEffortScoreProps > = ( {
 	onNoticeShownCallback = noop,
 	onNoticeDismissedCallback = noop,
 	onModalShownCallback = noop,
+	onModalDismissedCallback = noop,
 	icon,
 } ) => {
 	const [ shouldCreateNotice, setShouldCreateNotice ] = useState( true );
@@ -104,6 +107,7 @@ const CustomerEffortScore: React.VFC< CustomerEffortScoreProps > = ( {
 			firstQuestion={ firstQuestion }
 			secondQuestion={ secondQuestion }
 			recordScoreCallback={ recordScoreCallback }
+			onCloseModal={ onModalDismissedCallback }
 		/>
 	);
 };

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -179,6 +179,30 @@ function getExitPageCESCopy( pageId: string ): {
 					'woocommerce'
 				),
 			};
+		case 'settings_change':
+			return {
+				action: pageId,
+				noticeLabel: __(
+					'Did you find the right setting?',
+					'woocommerce'
+				),
+				title: __(
+					'How’s your experience with settings?',
+					'woocommerce'
+				),
+				description: __(
+					'We noticed you started changing store settings, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
+					'woocommerce'
+				),
+				firstQuestion: __(
+					'The settings screen is easy to use',
+					'woocommerce'
+				),
+				secondQuestion: __(
+					"The settings screen's functionality meets my needs",
+					'woocommerce'
+				),
+			};
 		default:
 			return null;
 	}

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -126,6 +126,7 @@ function getExitPageCESCopy( pageId: string ): {
 	secondQuestion: string;
 	noticeLabel?: string;
 	description?: string;
+	icon?: string;
 } | null {
 	switch ( pageId ) {
 		case 'product_edit_view':
@@ -182,6 +183,7 @@ function getExitPageCESCopy( pageId: string ): {
 		case 'settings_change':
 			return {
 				action: pageId,
+				icon: '⚙️',
 				noticeLabel: __(
 					'Did you find the right setting?',
 					'woocommerce'

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -53,6 +53,7 @@ function CustomerEffortScoreTracksContainer( {
 					noticeLabel={ item.noticeLabel }
 					firstQuestion={ item.firstQuestion }
 					secondQuestion={ item.secondQuestion }
+					icon={ item.icon }
 					title={ item.title }
 					onSubmitLabel={ item.onsubmit_label }
 					trackProps={ item.props || {} }

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -113,6 +113,15 @@ function CustomerEffortScoreTracks( {
 		addActionToShownOption();
 	};
 
+	const onModalDismissed = () => {
+		recordEvent( 'ces_view_dismiss', {
+			action,
+			store_age: storeAgeInWeeks,
+			ces_location: 'inside',
+			...trackProps,
+		} );
+	};
+
 	const onModalShown = () => {
 		setModalShown( true );
 
@@ -151,6 +160,7 @@ function CustomerEffortScoreTracks( {
 			onNoticeShownCallback={ onNoticeShown }
 			onNoticeDismissedCallback={ onNoticeDismissed }
 			onModalShownCallback={ onModalShown }
+			onModalDismissedCallback={ onModalDismissed }
 			icon={
 				<span
 					style={ { height: 21, width: 21 } }

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks.js
@@ -32,6 +32,7 @@ import { getStoreAgeInWeeks } from './utils';
  * @param {string}   props.description        Description shown in CES modal.
  * @param {string}   props.firstQuestion      The first survey question.
  * @param {string}   props.secondQuestion     The second survey question.
+ * @param {string}   props.icon               Optional icon to show in notice.
  * @param {string}   props.onSubmitLabel      The label displayed upon survey submission.
  * @param {Array}    props.cesShownForActions The array of actions that the CES modal has been shown for.
  * @param {boolean}  props.allowTracking      Whether tracking is allowed or not.
@@ -48,6 +49,7 @@ function CustomerEffortScoreTracks( {
 	noticeLabel,
 	firstQuestion,
 	secondQuestion,
+	icon,
 	onSubmitLabel = __( 'Thank you for your feedback!', 'woocommerce' ),
 	cesShownForActions,
 	allowTracking,
@@ -155,7 +157,7 @@ function CustomerEffortScoreTracks( {
 					role="img"
 					aria-label={ __( 'Pencil icon', 'woocommerce' ) }
 				>
-					✏️
+					{ icon || '✏' }
 				</span>
 			}
 		/>

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/actions.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/actions.js
@@ -30,6 +30,7 @@ export function setCesSurveyQueue( queue ) {
  * @param {string} args.noticeLabel    noticeLabel for notice.
  * @param {string} args.firstQuestion  first question for modal survey
  * @param {string} args.secondQuestion second question for modal survey
+ * @param {string} args.icon           optional icon for notice.
  * @param {string} args.pageNow        value of window.pagenow
  * @param {string} args.adminPage      value of window.adminpage
  * @param {string} args.onsubmitLabel  label for the snackback onsubmit
@@ -42,6 +43,7 @@ export function addCesSurvey( {
 	noticeLabel,
 	firstQuestion,
 	secondQuestion,
+	icon,
 	pageNow = window.pagenow,
 	adminPage = window.adminpage,
 	onsubmitLabel = undefined,
@@ -55,6 +57,7 @@ export function addCesSurvey( {
 		noticeLabel,
 		firstQuestion,
 		secondQuestion,
+		icon,
 		pageNow,
 		adminPage,
 		onsubmit_label: onsubmitLabel,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/reducer.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/data/reducer.js
@@ -52,6 +52,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				noticeLabel: action.noticeLabel,
 				firstQuestion: action.firstQuestion,
 				secondQuestion: action.secondQuestion,
+				icon: action.icon,
 				pagenow: action.pageNow,
 				adminpage: action.adminPage,
 				onSubmitLabel: action.onSubmitLabel,

--- a/plugins/woocommerce-admin/client/utils/static-form-helper.ts
+++ b/plugins/woocommerce-admin/client/utils/static-form-helper.ts
@@ -1,0 +1,44 @@
+/**
+ * Helper function to move all form elements to an object.
+ */
+export function staticFormDataToObject( elForm: HTMLFormElement ) {
+	const formFields = elForm.querySelectorAll<
+		HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+	>( 'input, select, textarea' );
+	const values: Record< string, string | boolean | number | string[] > = {};
+	for ( const field of formFields ) {
+		const sKey = field.name || field.id;
+		if (
+			field.type === 'button' ||
+			field.type === 'image' ||
+			field.type === 'submit' ||
+			! sKey
+		)
+			continue;
+		switch ( field.type ) {
+			case 'checkbox':
+				values[ sKey ] = +( field as HTMLInputElement ).checked;
+				break;
+			case 'radio':
+				if ( values[ sKey ] === undefined ) {
+					values[ sKey ] = '';
+				}
+				if ( ( field as HTMLInputElement ).checked ) {
+					values[ sKey ] = field.value;
+				}
+				break;
+			case 'select-multiple':
+				const options = [];
+				for ( const option of ( field as HTMLSelectElement ).options ) {
+					if ( option.selected ) {
+						options.push( option.value );
+					}
+				}
+				values[ sKey ] = options;
+				break;
+			default:
+				values[ sKey ] = field.value;
+		}
+	}
+	return values;
+}

--- a/plugins/woocommerce-admin/client/utils/test/static-form-helper.spec.tsx
+++ b/plugins/woocommerce-admin/client/utils/test/static-form-helper.spec.tsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { staticFormDataToObject } from '../static-form-helper';
+
+/**
+ * Internal dependencies
+ */
+import { getSegmentsFromPath } from '../url-helpers';
+
+describe( 'staticFormDataToObject', () => {
+	it( 'should create object of all nested input, select, textarea fields within form element', () => {
+		render(
+			<form id="testform">
+				<div>
+					<input type="text" name="Name" value="John" />
+					<select name="Car">
+						<option value="volvo">Volvo</option>
+						<option value="saab">Saab</option>
+						<option value="mercedes">Mercedes</option>
+						<option value="audi" selected>
+							Audi
+						</option>
+					</select>
+				</div>
+				<textarea name="Description" value="Tall" />
+			</form>
+		);
+		type FormElements = {
+			testform?: HTMLFormElement;
+		} & HTMLCollectionOf< HTMLFormElement >;
+		const forms: FormElements = document.forms;
+		let formObject;
+		if ( forms.testform ) {
+			formObject = staticFormDataToObject( forms.testform );
+		}
+		expect( formObject ).toEqual( {
+			Name: 'John',
+			Car: 'audi',
+			Description: 'Tall',
+		} );
+	} );
+
+	it( 'should add array of items for select multiple', () => {
+		render(
+			<form id="testform">
+				<div>
+					<select name="Car" multiple>
+						<option value="volvo" selected>
+							Volvo
+						</option>
+						<option value="saab">Saab</option>
+						<option value="mercedes">Mercedes</option>
+						<option value="audi" selected>
+							Audi
+						</option>
+					</select>
+				</div>
+			</form>
+		);
+		type FormElements = {
+			testform?: HTMLFormElement;
+		} & HTMLCollectionOf< HTMLFormElement >;
+		const forms: FormElements = document.forms;
+		let formObject;
+		if ( forms.testform ) {
+			formObject = staticFormDataToObject( forms.testform );
+		}
+		expect( formObject ).toEqual( {
+			Car: [ 'volvo', 'audi' ],
+		} );
+	} );
+
+	it( 'should skip input types of type button, image, and submit', () => {
+		render(
+			<form id="testform">
+				<div>
+					<input type="text" name="Name" value="John" />
+					<input type="button" value="Add to favorites"></input>
+					<input type="image" name="Image" alt="Image" />
+					<input type="submit" value="Submit" />
+				</div>
+			</form>
+		);
+		type FormElements = {
+			testform?: HTMLFormElement;
+		} & HTMLCollectionOf< HTMLFormElement >;
+		const forms: FormElements = document.forms;
+		let formObject;
+		if ( forms.testform ) {
+			formObject = staticFormDataToObject( forms.testform );
+		}
+		expect( formObject ).toEqual( {
+			Name: 'John',
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/utils/test/static-form-helper.spec.tsx
+++ b/plugins/woocommerce-admin/client/utils/test/static-form-helper.spec.tsx
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import { staticFormDataToObject } from '../static-form-helper';
 
 /**
  * Internal dependencies
  */
-import { getSegmentsFromPath } from '../url-helpers';
+import { staticFormDataToObject } from '../static-form-helper';
 
 describe( 'staticFormDataToObject', () => {
 	it( 'should create object of all nested input, select, textarea fields within form element', () => {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/settings-tracking/exit-setting-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/settings-tracking/exit-setting-page.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { addCustomerEffortScoreExitPageListener } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
+import { staticFormDataToObject } from '~/utils/static-form-helper';
+
+type FormElements = {
+	mainform?: HTMLFormElement;
+} & HTMLCollectionOf< HTMLFormElement >;
+const forms: FormElements = document.forms;
+if ( forms && forms.mainform ) {
+	const formData = staticFormDataToObject( forms.mainform );
+	addCustomerEffortScoreExitPageListener( 'settings_change', () => {
+		const newFormData = forms.mainform
+			? staticFormDataToObject( forms.mainform )
+			: {};
+		let isDirty = false;
+		for ( const key of Object.keys( formData ) ) {
+			const value =
+				typeof formData[ key ] === 'object'
+					? JSON.stringify( formData[ key ] )
+					: formData[ key ];
+			const newValue =
+				typeof newFormData[ key ] === 'object'
+					? JSON.stringify( newFormData[ key ] )
+					: newFormData[ key ];
+			if ( value !== newValue ) {
+				isDirty = true;
+				break;
+			}
+		}
+		return isDirty;
+	} );
+}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/settings-tracking/exit-setting-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/settings-tracking/exit-setting-page.ts
@@ -9,8 +9,19 @@ type FormElements = {
 } & HTMLCollectionOf< HTMLFormElement >;
 const forms: FormElements = document.forms;
 if ( forms && forms.mainform ) {
+	let triggeredSaveButton = false;
+	const saveButton = document.querySelector( '.woocommerce-save-button' );
+
+	if ( saveButton ) {
+		saveButton.addEventListener( 'click', () => {
+			triggeredSaveButton = true;
+		} );
+	}
 	const formData = staticFormDataToObject( forms.mainform );
 	addCustomerEffortScoreExitPageListener( 'settings_change', () => {
+		if ( triggeredSaveButton ) {
+			return false;
+		}
 		const newFormData = forms.mainform
 			? staticFormDataToObject( forms.mainform )
 			: {};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/settings-tracking/index.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/settings-tracking/index.ts
@@ -1,0 +1,1 @@
+export * from './exit-setting-page';

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -57,6 +57,7 @@ const wpAdminScripts = [
 	'tags-tracking',
 	'product-tour',
 	'wc-addons-tour',
+	'settings-tracking',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_settings
+++ b/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add CES exit prompt for setting pages, when tracking is enabled.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tracks
  */
 
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -33,6 +35,7 @@ class WC_Settings_Tracking {
 		add_action( 'woocommerce_settings_page_init', array( $this, 'track_settings_page_view' ) );
 		add_action( 'woocommerce_update_option', array( $this, 'add_option_to_list' ) );
 		add_action( 'woocommerce_update_options', array( $this, 'send_settings_change_event' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_settings_tracking_scripts' ) );
 	}
 
 	/**
@@ -117,5 +120,23 @@ class WC_Settings_Tracking {
 		);
 
 		WC_Tracks::record_event( 'settings_view', $properties );
+	}
+
+	/**
+	 * Adds the tracking scripts for product setting pages.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function possibly_add_settings_tracking_scripts( $hook ) {
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		if (
+			! isset( $_GET['page'] ) ||
+			'wc-settings' !== wp_unslash( $_GET['page'] )
+		) {
+			return;
+		}
+		// phpcs:enable
+
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'settings-tracking', false );
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add's an exit prompt tracking script to the WooCommerce setting pages that will trigger a CES notice if users exit the setting page while having made changes, without saving them.

Part of #35126  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, build it, and make sure you have the `new-product-management-experience` feature flag enabled (you can do so using the latest version of the Beta tester within the mono repo).
2. Make sure you have tracks enabled and also outputted in the console: localStorage.setItem( 'debug', 'wc-admin:*' );
3. Go to **WooCommerce > Settings** and make some changes
4. Now go to another page like **WooCommerce > Home** and select **Leave** when it warns you about unsaved changes.
5. A notice should show on the new page that allows you to share feedback, something to the affect of `⚙️ Did you find the right setting?`
6. Click the share feedback and submit feedback, notice how the `wcadmin_ces_snackbar_view`, `wcadmin_ces_view`, and `wcadmin_ces_feedback` include the `ces_location` prop with the  `outside` value.
7. The Modal description should say something to this effect: `We noticed you started changing store settings, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.`
You may also want to try dismissing the notice and see if the prop has been added to `wcadmin_ces_snackbar_dismiss`
8. Now delete the `woocommerce_ces_shown_for_actions` option and disable tracking under **WooCommerce > Settings > Advanced > Woocommerce.com**
9. Make sure the notice doesn't show up for the above anymore and that `customer-effort-score-exit-page` in local storage does not get updated, but stays empty.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
