### PR TITLE
Add/35126 ces exit prompt orders

### DIFF
--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -205,6 +205,31 @@ function getExitPageCESCopy( pageId: string ): {
 					'woocommerce'
 				),
 			};
+		case 'order_change':
+			return {
+				action: pageId,
+				icon: '📦',
+				noticeLabel: __(
+					'How easy or difficult was it to update this order?',
+					'woocommerce'
+				),
+				title: __(
+					"How's your experience with orders?",
+					'woocommerce'
+				),
+				description: __(
+					'We noticed you started editing an order, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
+					'woocommerce'
+				),
+				firstQuestion: __(
+					'The order editing screen is easy to use',
+					'woocommerce'
+				),
+				secondQuestion: __(
+					"The order details screen's functionality meets my needs",
+					'woocommerce'
+				),
+			};
 		default:
 			return null;
 	}

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -205,7 +205,7 @@ function getExitPageCESCopy( pageId: string ): {
 					'woocommerce'
 				),
 			};
-		case 'order_change':
+		case 'shop_order_update':
 			return {
 				action: pageId,
 				icon: '📦',

--- a/plugins/woocommerce-admin/client/utils/static-form-helper.ts
+++ b/plugins/woocommerce-admin/client/utils/static-form-helper.ts
@@ -12,6 +12,7 @@ export function staticFormDataToObject( elForm: HTMLFormElement ) {
 			field.type === 'button' ||
 			field.type === 'image' ||
 			field.type === 'submit' ||
+			field.type === 'hidden' ||
 			! sKey
 		)
 			continue;

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
@@ -24,7 +24,7 @@ if ( forms && forms.post ) {
 		} );
 	}
 	const formData = staticFormDataToObject( forms.post );
-	addCustomerEffortScoreExitPageListener( 'order_change', () => {
+	addCustomerEffortScoreExitPageListener( 'shop_order_update', () => {
 		if ( triggeredSaveOrDeleteButton ) {
 			return false;
 		}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import { addCustomerEffortScoreExitPageListener } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
+import { staticFormDataToObject } from '~/utils/static-form-helper';
+
+type FormElements = {
+	post?: HTMLFormElement;
+} & HTMLCollectionOf< HTMLFormElement >;
+const forms: FormElements = document.forms;
+if ( forms && forms.post ) {
+	let triggeredSaveOrDeleteButton = false;
+	const saveButton = document.querySelector( '.save_order' );
+	const deleteButton = document.querySelector( '.submitdelete' );
+
+	if ( saveButton ) {
+		saveButton.addEventListener( 'click', () => {
+			triggeredSaveOrDeleteButton = true;
+		} );
+	}
+	if ( deleteButton ) {
+		deleteButton.addEventListener( 'click', () => {
+			triggeredSaveOrDeleteButton = true;
+		} );
+	}
+	const formData = staticFormDataToObject( forms.post );
+	addCustomerEffortScoreExitPageListener( 'order_change', () => {
+		if ( triggeredSaveOrDeleteButton ) {
+			return false;
+		}
+		const newFormData = forms.post
+			? staticFormDataToObject( forms.post )
+			: {};
+		let isDirty = false;
+		for ( const key of Object.keys( formData ) ) {
+			const value =
+				typeof formData[ key ] === 'object'
+					? JSON.stringify( formData[ key ] )
+					: formData[ key ];
+			const newValue =
+				typeof newFormData[ key ] === 'object'
+					? JSON.stringify( newFormData[ key ] )
+					: newFormData[ key ];
+			if ( value !== newValue ) {
+				isDirty = true;
+				break;
+			}
+		}
+		return isDirty;
+	} );
+}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/exit-order-page.ts
@@ -8,7 +8,7 @@ type FormElements = {
 	post?: HTMLFormElement;
 } & HTMLCollectionOf< HTMLFormElement >;
 const forms: FormElements = document.forms;
-if ( forms && forms.post ) {
+if ( forms?.post ) {
 	let triggeredSaveOrDeleteButton = false;
 	const saveButton = document.querySelector( '.save_order' );
 	const deleteButton = document.querySelector( '.submitdelete' );
@@ -31,7 +31,6 @@ if ( forms && forms.post ) {
 		const newFormData = forms.post
 			? staticFormDataToObject( forms.post )
 			: {};
-		let isDirty = false;
 		for ( const key of Object.keys( formData ) ) {
 			const value =
 				typeof formData[ key ] === 'object'
@@ -42,10 +41,9 @@ if ( forms && forms.post ) {
 					? JSON.stringify( newFormData[ key ] )
 					: newFormData[ key ];
 			if ( value !== newValue ) {
-				isDirty = true;
-				break;
+				return true;
 			}
 		}
-		return isDirty;
+		return false;
 	} );
 }

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/index.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/order-tracking/index.ts
@@ -1,0 +1,1 @@
+export * from './exit-order-page';

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -58,6 +58,7 @@ const wpAdminScripts = [
 	'product-tour',
 	'wc-addons-tour',
 	'settings-tracking',
+	'order-tracking',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_orders
+++ b/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_orders
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add exit prompt CES for users editing orders when tracking is enabled.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-orders-tracking.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -24,6 +25,7 @@ class WC_Orders_Tracking {
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_order_action' ), 51 );
 		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
 		add_filter( 'woocommerce_shop_order_search_results', array( $this, 'track_order_search' ), 10, 3 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_order_tracking_scripts' ) );
 	}
 
 	/**
@@ -174,5 +176,21 @@ class WC_Orders_Tracking {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Adds the tracking scripts for product setting pages.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function possibly_add_order_tracking_scripts( $hook ) {
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		if (
+			( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) ||
+			( 'post.php' === $hook && isset( $_GET['post'] ) && 'shop_order' === get_post_type( intval( $_GET['post'] ) ) )
+		) {
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'order-tracking', false );
+		}
+		// phpcs:enable
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds order exit tracking, to show a notice when user exits the order page when having made changes without updating them.
Part of #35126  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, build it, and make sure you have the `new-product-management-experience` feature flag enabled (you can do so using the latest version of the Beta tester within the mono repo).
2. Make sure you have tracks enabled and also outputted in the console: localStorage.setItem( 'debug', 'wc-admin:*' );
3. Go to **WooCommerce > Orders** and select an existing order or create a new one, and make some changes
4. Now go to another page like **WooCommerce > Home** and select **Leave** if it warns you about unsaved changes (it may not).
5. A notice should show on the new page that allows you to share feedback, something to the affect of `How easy or difficult was it to update this order?`
6. Click the share feedback and submit feedback, notice how the `wcadmin_ces_snackbar_view`, `wcadmin_ces_view`, and `wcadmin_ces_feedback` include the `ces_location` prop with the  `outside` value.
7. For the CES modal check if the copy matches that listed in this document for the Edit order usage action: [copy](https://docs.google.com/spreadsheets/d/1t0JplRZL3cC3vNCATmMy95surJzYH_uhsitznelYcRI/edit?usp=sharing).
You may also want to try dismissing the notice and see if the prop has been added to `wcadmin_ces_snackbar_dismiss`
8. Now delete the `woocommerce_ces_shown_for_actions` option and disable tracking under **WooCommerce > Settings > Advanced > Woocommerce.com**
9. Make sure the notice doesn't show up for the above anymore and that `customer-effort-score-exit-page` in local storage does not get updated, but stays empty.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
