### PR TITLE
Always output the min and max attributes for the quantity selector.

### DIFF
--- a/plugins/woocommerce/changelog/fix-34282-min-max-attrs
+++ b/plugins/woocommerce/changelog/fix-34282-min-max-attrs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This feature has not been released yet (and a changelog was added in PR#34282). This change simply amends things to improve compatibility with Composite Products.
+
+

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -47,10 +47,10 @@ if ( $max_value && $min_value === $max_value ) {
 		value="<?php echo esc_attr( $input_value ); ?>"
 		title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ); ?>"
 		size="4"
+		min="<?php echo esc_attr( $min_value ); ?>"
+		max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
 		<?php if ( ! $is_readonly ): ?>
 			step="<?php echo esc_attr( $step ); ?>"
-			min="<?php echo esc_attr( $min_value ); ?>"
-			max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
 			placeholder="<?php echo esc_attr( $placeholder ); ?>"
 			inputmode="<?php echo esc_attr( $inputmode ); ?>"
 			autocomplete="<?php echo esc_attr( isset( $autocomplete ) ? $autocomplete : 'on' ); ?>"


### PR DESCRIPTION
This change builds on https://github.com/woocommerce/woocommerce/pull/34282 and makes a small amendment to improve compatibility with extensions like [Composite Products](https://woocommerce.com/products/composite-products/).

In the earlier PR, we made it so that the quantity selector is still visible even if the min and max allowed quantities are set to the same value (for example, if precisely 2 units must be purchased). Whereas, previously, it was still rendered but was invisible.

However, as part of that earlier change, we also stopped outputting the `min` and `max` attributes in some cases ... unfortunately, this posed a compatibility concern for some extensions which expect and depend on the `min` and `max` attributes being available. So, in this PR, we restore them.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Always render the `min` and `max` attributes for product quantity selectors, even in readonly mode where the quantity is fixed.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Start by re-testing as per the original instructions contained in #34282:

1. Add https://github.com/woocommerce/woocommerce-min-max-quantities.
2. Create a simple product with min_qty=max_qty.
3. Go add the product page. You will be able to see the quantity input there.

Optionally, you can continue to test by installing and activating [Composite Products](https://woocommerce.com/products/composite-products/). To learn more about how this extension works [please see these docs](https://woocommerce.com/document/composite-products/) but, in summary, all you need to do is:

1. Add two new products such as "RAM 128KB" ($5) and "RAM 256KB" ($10).
2. Add a new composite product. In the **Components** tab add a new component called "Memory" and link the two products you created in the last step.
    - Initially, set the min to 1 and max to 5.
    - Enable the **priced individually** option.

With that done:

1. As a customer, visit the product page. You should be able to purchase the product and the price in the cart should match your expectations.
2. Now edit the composite product and set the min and max values to the same value. Save.
3. Repeat the process ... of course, you can still specify the type of memory (128KB or 512KB) but can longer specify how much you want. Add to the cart, pricing again should match your expectations (based on the unit cost and the predetermined quantity, etc).

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
