### PR TITLE
fix: woocommerce admin cart modal header clips header text

### DIFF
--- a/plugins/woocommerce-admin/client/dashboard/style.scss
+++ b/plugins/woocommerce-admin/client/dashboard/style.scss
@@ -90,3 +90,11 @@
 .components-card .woocommerce-ellipsis-menu__toggle {
 	padding: 0;
 }
+
+.components-modal__frame.woocommerce-cart-modal .components-modal__content {
+	margin-top: 6rem;
+
+	@include breakpoint( '<600px' ) {
+		margin-top: 7rem;
+	}
+}

--- a/plugins/woocommerce/changelog/fix-woocommerce-cart-modal-margin
+++ b/plugins/woocommerce/changelog/fix-woocommerce-cart-modal-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Increased margin so that overflow modal content doesn't clip header


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When modal content overflows and requires a scrollbar, the scroll content clips the modal title text.

The root cause of this is that the modal header is `position: absolute` (which means its not factored into layout calculation), and the content is given a static margin to accommodate the modal header. The previous value was probably set for 1 line of text, but we have two lines with the current text.

Ideally the fix is to revamp the modal to use flexbox positioning so that we don't need to manually adjust the gap, but that would require a fairly large change to Modal from `@wordpress/components`.

In the interim we can adjust the padding so that it does not clip. The downside of this is that if the title text is only a single line (e.g because translated string is shorter), then the gap will look a bit too big.

Closes #35712.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create any test site using the JN site.
2. Install all the required plugins.
3. Navigate to WooCommerce -> Settings -> Help
4. Click Setup Wizard button.
5. Start with OBW.
6. Go to Product Types screen. 
7. Add all available product types and complete the OBW.
8. Navigate to WooCommerce -> Home -> Setup List
9. Click on 'Add Subscriptions and 4 more products to my store'
10. Observe Product Types Modal opens up
11. Reduce your browser window height so that the scrollbar on the modal content appears 
12. Scroll down and observe no text overlap with Modal Header

<!-- End testing instructions -->

Before:


https://user-images.githubusercontent.com/27843274/204729702-35c9079b-9ce9-40b3-beb5-9081b65974ad.mp4



After:



https://user-images.githubusercontent.com/27843274/204729719-dd941b16-cdc2-4035-854f-c3593fcd1c26.mp4


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
