### PR TITLE
Live Branches: Avoid running job on community PRs

### DIFF
--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -1,83 +1,84 @@
 name: Build Live Branch
 on:
-  pull_request:
+    pull_request:
 
 concurrency:
-  # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.
-  group: build-${{ github.event_name == 'push' && github.run_id || 'pr' }}-${{ github.ref }}
-  cancel-in-progress: true
+    # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.
+    group: build-${{ github.event_name == 'push' && github.run_id || 'pr' }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      
-      - name: Get current version
-        id: version
-        uses: actions/github-script@v6.3.3
-        with:
-          script:
-            const { getVersion } = require( './.github/workflows/scripts/get-plugin-version' );
-            const version = await getVersion( 'woocommerce' );
-            core.setOutput( 'version', version );
-      
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          build: false
+    build:
+        if: github.repository_owner == 'woocommerce'
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Prepare plugin zips
-        id: prepare
-        env:
-          CURRENT_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-        
-          # Current version must compare greather than any previously used current version for this PR.
-          # Assume GH run IDs are monotonic.
-          VERSUFFIX="${GITHUB_RUN_ID}-g$(git rev-parse --short HEAD)"
-          
-          CURRENT_VERSION="$CURRENT_VERSION-$VERSUFFIX"
-          
-          sed -i -e 's/Version: .*$/Version: '"$CURRENT_VERSION"'/' "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.php"
-          echo "$CURRENT_VERSION" > "$GITHUB_WORKSPACE/plugins/woocommerce/version.txt"
-          
-          cd "$GITHUB_WORKSPACE/plugins/woocommerce"
-          bash bin/build-zip.sh
-          
-          mkdir "$GITHUB_WORKSPACE/zips"
-          cp "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
-          cd "$GITHUB_WORKSPACE/zips"
-          unzip woocommerce.zip
-          rm woocommerce.zip
-          mv woocommerce woocommerce-dev
-          zip -q -r "woocommerce-dev.zip" "woocommerce-dev/"
-          rm -fR "$GITHUB_WORKSPACE/zips/woocommerce-dev"
-        
-          # Plugin data is passed as a JSON object.
-          PLUGIN_DATA="{}"          
-          PLUGIN_DATA=$( jq -c --arg slug "woocommerce" --arg ver "$CURRENT_VERSION" '.[ $slug ] = { version: $ver }' <<<"$PLUGIN_DATA" )
-          echo "plugin-data=$PLUGIN_DATA" >> $GITHUB_OUTPUT
-          
-      - name: Create plugins artifact
-        uses: actions/upload-artifact@v3
-        if: steps.prepare.outputs.plugin-data != '{}'
-        with:
-          name: plugins
-          path: zips
-          # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: 1
-          
-      - name: Inform Beta Download webhook
-        if: steps.prepare.outputs.plugin-data != '{}'
-        env:
-          SECRET: ${{ secrets.WOOBETA_SECRET }}
-          PLUGIN_DATA: ${{ steps.prepare.outputs.plugin-data }}
-          PR: ${{ github.event.number }}
-        run: |
-          curl -v --fail -L \
-            --url "https://betadownload.jetpack.me/gh-action.php?run_id=$GITHUB_RUN_ID&pr=$PR&commit=$GITHUB_SHA" \
-            --form-string "repo=$GITHUB_REPOSITORY" \
-            --form-string "branch=${GITHUB_REF#refs/heads/}" \
-            --form-string "plugins=$PLUGIN_DATA" \
-            --form-string "secret=$SECRET"
+            - name: Get current version
+              id: version
+              uses: actions/github-script@v6.3.3
+              with:
+                  script:
+                      const { getVersion } = require( './.github/workflows/scripts/get-plugin-version' );
+                      const version = await getVersion( 'woocommerce' );
+                      core.setOutput( 'version', version );
+
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build: false
+
+            - name: Prepare plugin zips
+              id: prepare
+              env:
+                  CURRENT_VERSION: ${{ steps.version.outputs.version }}
+              run: |
+
+                  # Current version must compare greather than any previously used current version for this PR.
+                  # Assume GH run IDs are monotonic.
+                  VERSUFFIX="${GITHUB_RUN_ID}-g$(git rev-parse --short HEAD)"
+
+                  CURRENT_VERSION="$CURRENT_VERSION-$VERSUFFIX"
+
+                  sed -i -e 's/Version: .*$/Version: '"$CURRENT_VERSION"'/' "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.php"
+                  echo "$CURRENT_VERSION" > "$GITHUB_WORKSPACE/plugins/woocommerce/version.txt"
+
+                  cd "$GITHUB_WORKSPACE/plugins/woocommerce"
+                  bash bin/build-zip.sh
+
+                  mkdir "$GITHUB_WORKSPACE/zips"
+                  cp "$GITHUB_WORKSPACE/plugins/woocommerce/woocommerce.zip" "$GITHUB_WORKSPACE/zips/woocommerce.zip"
+                  cd "$GITHUB_WORKSPACE/zips"
+                  unzip woocommerce.zip
+                  rm woocommerce.zip
+                  mv woocommerce woocommerce-dev
+                  zip -q -r "woocommerce-dev.zip" "woocommerce-dev/"
+                  rm -fR "$GITHUB_WORKSPACE/zips/woocommerce-dev"
+
+                  # Plugin data is passed as a JSON object.
+                  PLUGIN_DATA="{}"          
+                  PLUGIN_DATA=$( jq -c --arg slug "woocommerce" --arg ver "$CURRENT_VERSION" '.[ $slug ] = { version: $ver }' <<<"$PLUGIN_DATA" )
+                  echo "plugin-data=$PLUGIN_DATA" >> $GITHUB_OUTPUT
+
+            - name: Create plugins artifact
+              uses: actions/upload-artifact@v3
+              if: steps.prepare.outputs.plugin-data != '{}' && github.repository_owner == 'woocommerce'
+              with:
+                  name: plugins
+                  path: zips
+                  # Only need to retain for a day since the beta builder slurps it up to distribute.
+                  retention-days: 1
+
+            - name: Inform Beta Download webhook
+              if: steps.prepare.outputs.plugin-data != '{}' && github.repository_owner == 'woocommerce'
+              env:
+                  SECRET: ${{ secrets.WOOBETA_SECRET }}
+                  PLUGIN_DATA: ${{ steps.prepare.outputs.plugin-data }}
+                  PR: ${{ github.event.number }}
+              run: |
+                  curl -v --fail -L \
+                    --url "https://betadownload.jetpack.me/gh-action.php?run_id=$GITHUB_RUN_ID&pr=$PR&commit=$GITHUB_SHA" \
+                    --form-string "repo=$GITHUB_REPOSITORY" \
+                    --form-string "branch=${GITHUB_REF#refs/heads/}" \
+                    --form-string "plugins=$PLUGIN_DATA" \
+                    --form-string "secret=$SECRET"

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -62,7 +62,7 @@ jobs:
 
             - name: Create plugins artifact
               uses: actions/upload-artifact@v3
-              if: steps.prepare.outputs.plugin-data != '{}' && github.repository_owner == 'woocommerce'
+              if: steps.prepare.outputs.plugin-data != '{}'
               with:
                   name: plugins
                   path: zips
@@ -70,7 +70,7 @@ jobs:
                   retention-days: 1
 
             - name: Inform Beta Download webhook
-              if: steps.prepare.outputs.plugin-data != '{}' && github.repository_owner == 'woocommerce'
+              if: steps.prepare.outputs.plugin-data != '{}'
               env:
                   SECRET: ${{ secrets.WOOBETA_SECRET }}
                   PLUGIN_DATA: ${{ steps.prepare.outputs.plugin-data }}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35633

Live branches job should not be run on community PRs because there is no access to the secret required to interact with Jetpack's Betadownload. This PR makes sure the Live Branches job only runs on internal PRs by checking the `repository_owner` is `woocommerce`.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. See the Live Branches job succeed on this PR
2. Make sure the logic makes sense. Its just a few if statement additions but Prettier formatted the file. See https://github.com/woocommerce/woocommerce/pull/35795/files?w=1 for whitespace only changes

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
