### PR TITLE
Update WooCommerce blocks package to 8.7.6

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.6
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.7.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 8.7.6

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.7.5"
+		"woocommerce/woocommerce-blocks": "8.7.6"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08d58a387b373d546fb53025a230e768",
+    "content-hash": "d3c20f14683e7b8e2f65cda52364971d",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.7.5",
+            "version": "v8.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "0436c8afb8c3c34dd38aed2b7a0868e771036031"
+                "reference": "e4e17dd978f394b529d037c3ab4492c3639614a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/0436c8afb8c3c34dd38aed2b7a0868e771036031",
-                "reference": "0436c8afb8c3c34dd38aed2b7a0868e771036031",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/e4e17dd978f394b529d037c3ab4492c3639614a9",
+                "reference": "e4e17dd978f394b529d037c3ab4492c3639614a9",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.5"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.7.6"
             },
-            "time": "2022-10-31T14:54:55+00:00"
+            "time": "2022-12-01T18:09:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.7.6. 
## Blocks 8.7.6

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7804)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/876.md)


### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Mini Cart block: fix compatibility with Page Optimize and Product Bundles plugins [#7794](https://github.com/woocommerce/woocommerce-blocks/pull/7794)
- Mini Cart block: Load wc-blocks-registry package at the page's load instead of lazy load it [#7813](https://github.com/woocommerce/woocommerce-blocks/pull/7813)



