### PR TITLE
Update WooCommerce blocks package to 8.9.2

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-8.9.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-8.9.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 8.9.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "8.9.1"
+		"woocommerce/woocommerce-blocks": "8.9.2"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e2e56ecdb3eb102d32d989551d76fa8",
+    "content-hash": "1a309c0d12d2fb4b53ea3a7d68fe7003",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v8.9.1",
+            "version": "v8.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "47f482575c0c76751319c3900f51523b16ca21ff"
+                "reference": "9c732fe65c4137e23cff9a247fe2bb58c9a64e03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/47f482575c0c76751319c3900f51523b16ca21ff",
-                "reference": "47f482575c0c76751319c3900f51523b16ca21ff",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/9c732fe65c4137e23cff9a247fe2bb58c9a64e03",
+                "reference": "9c732fe65c4137e23cff9a247fe2bb58c9a64e03",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.9.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v8.9.2"
             },
-            "time": "2022-11-14T08:56:26+00:00"
+            "time": "2022-12-01T18:00:35+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 8.9.2. 
## Blocks 8.9.2

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/7803)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/892.md)


### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Mini Cart block: fix compatibility with Page Optimize and Product Bundles plugins [#7794](https://github.com/woocommerce/woocommerce-blocks/pull/7794)
- Mini Cart block: Load wc-blocks-registry package at the page's load instead of lazy load it [#7813](https://github.com/woocommerce/woocommerce-blocks/pull/7813)



