### PR TITLE
Automatically show attributes in Variations

### DIFF
--- a/plugins/woocommerce/changelog/dev-33551_streamline_first_variation_creation
+++ b/plugins/woocommerce/changelog/dev-33551_streamline_first_variation_creation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Automatically show attributes in Variations

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -49,6 +49,10 @@ jQuery( function ( $ ) {
 					'.wc_input_variations_price',
 					this.maybe_enable_button_to_add_price_to_variations
 				);
+			$( 'ul.wc-tabs a[href=#variable_product_options]' ).on(
+				'click',
+				this.maybe_add_attributes_to_variations
+			);
 		},
 
 		/**
@@ -372,6 +376,24 @@ jQuery( function ( $ ) {
 						.trigger( 'change' );
 				}
 			);
+		},
+
+		/**
+		 * Maybe add attributes to variations
+		 */
+		maybe_add_attributes_to_variations: function () {
+			var has_variation_attributes = $(
+				'select.wc-attribute-search'
+			).data( 'add-attribute-used-for-variations' );
+			if ( has_variation_attributes ) {
+				wc_meta_boxes_product_variations_ajax.link_all_variations(
+					true
+				);
+				$( 'select.wc-attribute-search' ).data(
+					'add-attribute-used-for-variations',
+					false
+				);
+			}
 		},
 	};
 
@@ -995,14 +1017,16 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Bool}
 		 */
-		link_all_variations: function () {
+		link_all_variations: function ( auto_link_variations = false ) {
 			wc_meta_boxes_product_variations_ajax.check_for_changes();
 
-			if (
-				window.confirm(
-					woocommerce_admin_meta_boxes_variations.i18n_link_all_variations
-				)
-			) {
+			var is_confirmed_action = auto_link_variations
+				? true
+				: window.confirm(
+						woocommerce_admin_meta_boxes_variations.i18n_link_all_variations
+				  );
+
+			if ( is_confirmed_action ) {
 				wc_meta_boxes_product_variations_ajax.block();
 
 				var data = {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -383,13 +383,13 @@ jQuery( function ( $ ) {
 		 */
 		maybe_add_attributes_to_variations: function () {
 			var has_variation_attributes = $(
-				'select.wc-attribute-search'
+				'select.attribute_taxonomy'
 			).data( 'add-attribute-used-for-variations' );
 			if ( has_variation_attributes ) {
 				wc_meta_boxes_product_variations_ajax.link_all_variations(
 					true
 				);
-				$( 'select.wc-attribute-search' ).data(
+				$( 'select.attribute_taxonomy' ).data(
 					'add-attribute-used-for-variations',
 					false
 				);

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -384,13 +384,13 @@ jQuery( function ( $ ) {
 		maybe_add_attributes_to_variations: function () {
 			var has_variation_attributes = $(
 				'select.attribute_taxonomy'
-			).data( 'add-attribute-used-for-variations' );
+			).data( 'is-used-for-variations' );
 			if ( has_variation_attributes ) {
 				wc_meta_boxes_product_variations_ajax.link_all_variations(
 					true
 				);
 				$( 'select.attribute_taxonomy' ).data(
-					'add-attribute-used-for-variations',
+					'is-used-for-variations',
 					false
 				);
 			}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -774,8 +774,7 @@ jQuery( function ( $ ) {
 				var isUsedForVariations = $( 'input#used-for-variation' ).is(
 					':checked'
 				);
-
-				$( 'select.wc-attribute-search' ).data(
+				$( 'select.attribute_taxonomy' ).data(
 					'add-attribute-used-for-variations',
 					isUsedForVariations
 				);

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -775,7 +775,7 @@ jQuery( function ( $ ) {
 					':checked'
 				);
 				$( 'select.attribute_taxonomy' ).data(
-					'add-attribute-used-for-variations',
+					'is-used-for-variations',
 					isUsedForVariations
 				);
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -771,6 +771,14 @@ jQuery( function ( $ ) {
 					'disabled-items',
 					newSelectedAttributes
 				);
+				var isUsedForVariations = $( 'input#used-for-variation' ).is(
+					':checked'
+				);
+
+				$( 'select.wc-attribute-search' ).data(
+					'add-attribute-used-for-variations',
+					isUsedForVariations
+				);
 
 				// Reload variations panel.
 				var this_page = window.location.toString();
@@ -1034,7 +1042,6 @@ jQuery( function ( $ ) {
 			delay: 200,
 			keepAlive: true,
 		} );
-
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -83,7 +83,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<tr>
 					<td>
 						<div class="enable_variation show_if_variable">
-							<label><input type="checkbox" class="checkbox" <?php checked( $attribute->get_variation(), true ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
+							<label><input id="used-for-variation" type="checkbox" class="checkbox" <?php checked( $attribute->get_variation(), true ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
 						</div>
 					</td>
 				</tr>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to automatically show attributes with "Used for variations" checked, in Variations.

Fixes partially [issue 33551](https://github.com/woocommerce/woocommerce/issues/33551).

**Acceptance criteria:**

- [x] If there are attributes with "Used for variations" checked: automatically show them in Variations, rather than force people to add them manually

---

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products` > `Add New` > `Product data` > `Attributes`
2. Add a custom attribute by clicking on `Add custom attribute`. Also add a few `values`.
3. Press `Save attributes`.
4. Press `Variations`.
5. You'll see an alert saying the number of variations that will be added.

![Screenshot 2022-12-01 at 16 45 47](https://user-images.githubusercontent.com/1314156/205145717-9e95ba66-1284-4436-9c8e-48b221e22d1e.png)

6. Verify that the attributes have been added correctly. 

![Screenshot 2022-12-01 at 16 48 13](https://user-images.githubusercontent.com/1314156/205145920-c3bf4cba-19be-4d67-ad26-c481888a46f5.png)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
