### PR TITLE
Add __experimentalSelectControl suffix prop

### DIFF
--- a/packages/js/components/changelog/add-select-control-suffix
+++ b/packages/js/components/changelog/add-select-control-suffix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for custom suffix prop on SelectControl.

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -5,19 +5,25 @@
 	background: $studio-white;
 	position: relative;
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
-	padding: 2px 36px 2px $gap-smaller;
 	margin-bottom: 4px;
 	min-height: 36px;
 	box-sizing: border-box;
 
-	> * {
-		display: inline-flex;
-	}
-
 	&--disabled {
 		opacity: 0.5;
+	}
+}
+
+.woocommerce-experimental-select-control__items-wrapper {
+	display: flex;
+	flex-grow: 1;
+	flex-wrap: wrap;
+	align-items: center;
+	padding: 2px $gap-smaller;
+
+	> * {
+		display: inline-flex;
 	}
 }
 
@@ -35,9 +41,6 @@
 	}
 }
 
-.woocommerce-experimental-select-control__combox-box-icon {
-	position: absolute;
-	right: 6px;
-	top: 50%;
-	transform: translateY( -50% );
+.woocommerce-experimental-select-control__suffix {
+	align-self: stretch;
 }

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { createElement, MouseEvent, useRef } from 'react';
-import { Icon, search } from '@wordpress/icons';
 import classNames from 'classnames';
 
 /**
@@ -14,12 +13,14 @@ type ComboBoxProps = {
 	children?: JSX.Element | JSX.Element[] | null;
 	comboBoxProps: Props;
 	inputProps: Props;
+	suffix?: JSX.Element | null;
 };
 
 export const ComboBox = ( {
 	children,
 	comboBoxProps,
 	inputProps,
+	suffix,
 }: ComboBoxProps ) => {
 	const inputRef = useRef< HTMLInputElement | null >( null );
 
@@ -50,27 +51,30 @@ export const ComboBox = ( {
 			) }
 			onMouseDown={ maybeFocusInput }
 		>
-			{ children }
-			<div
-				{ ...comboBoxProps }
-				className="woocommerce-experimental-select-control__combox-box"
-			>
-				<input
-					{ ...inputProps }
-					ref={ ( node ) => {
-						inputRef.current = node;
-						(
-							inputProps.ref as unknown as (
-								node: HTMLInputElement | null
-							) => void
-						 )( node );
-					} }
-				/>
+			<div className="woocommerce-experimental-select-control__items-wrapper">
+				{ children }
+				<div
+					{ ...comboBoxProps }
+					className="woocommerce-experimental-select-control__combox-box"
+				>
+					<input
+						{ ...inputProps }
+						ref={ ( node ) => {
+							inputRef.current = node;
+							(
+								inputProps.ref as unknown as (
+									node: HTMLInputElement | null
+								) => void
+							 )( node );
+						} }
+					/>
+				</div>
 			</div>
-			<Icon
-				className="woocommerce-experimental-select-control__combox-box-icon"
-				icon={ search }
-			/>
+			{ suffix && (
+				<div className="woocommerce-experimental-select-control__suffix">
+					{ suffix }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/js/components/src/experimental-select-control/select-control.scss
+++ b/packages/js/components/src/experimental-select-control/select-control.scss
@@ -2,6 +2,7 @@
 @import './menu.scss';
 @import './menu-item.scss';
 @import './selected-items.scss';
+@import './suffix-icon.scss';
 
 .woocommerce-experimental-select-control {
 	position: relative;

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -14,6 +14,7 @@ import {
 	createElement,
 	Fragment,
 } from '@wordpress/element';
+import { search } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ import { SelectedItems } from './selected-items';
 import { ComboBox } from './combo-box';
 import { Menu } from './menu';
 import { MenuItem } from './menu-item';
+import { SuffixIcon } from './suffix-icon';
 import {
 	defaultGetItemLabel,
 	defaultGetItemValue,
@@ -63,6 +65,7 @@ type SelectControlProps< ItemType > = {
 	selected: ItemType | ItemType[] | null;
 	className?: string;
 	disabled?: boolean;
+	suffix?: JSX.Element | null;
 	/**
 	 * This is a feature already implemented in downshift@7.0.0 through the
 	 * reducer. In order for us to use it this prop is added temporarily until
@@ -116,6 +119,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 	selected,
 	className,
 	disabled,
+	suffix = <SuffixIcon icon={ search } />,
 	__experimentalOpenMenuOnFocus = false,
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -265,6 +269,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 					placeholder,
 					disabled,
 				} ) }
+				suffix={ suffix }
 			>
 				<>
 					{ children( {

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import React from 'react';
 import { createElement, useState } from '@wordpress/element';
+import { tag } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import { SelectedType, DefaultItemType, getItemLabelType } from '../types';
 import { MenuItem } from '../menu-item';
 import { SelectControl, selectControlStateChangeTypes } from '../';
 import { Menu, MenuSlot } from '../menu';
+import { SuffixIcon } from '../suffix-icon';
 
 const sampleItems = [
 	{ value: 'apple', label: 'Apple' },
@@ -407,6 +409,77 @@ export const SingleWithinModalUsingBodyDropdownPlacement: React.FC = () => {
 			) }
 			<MenuSlot />
 		</SlotFillProvider>
+	);
+};
+
+export const DefaultSuffix: React.FC = () => {
+	const [ selected, setSelected ] = useState<
+		SelectedType< DefaultItemType >
+	>( sampleItems[ 1 ] );
+
+	return (
+		<SelectControl
+			items={ sampleItems }
+			label="Default suffix"
+			selected={ selected }
+			onSelect={ ( item ) => item && setSelected( item ) }
+			onRemove={ () => setSelected( null ) }
+		/>
+	);
+};
+
+export const CustomSuffixIcon: React.FC = () => {
+	const [ selected, setSelected ] = useState<
+		SelectedType< DefaultItemType >
+	>( sampleItems[ 1 ] );
+
+	return (
+		<SelectControl
+			items={ sampleItems }
+			label="Custom suffix icon"
+			selected={ selected }
+			onSelect={ ( item ) => item && setSelected( item ) }
+			onRemove={ () => setSelected( null ) }
+			suffix={ <SuffixIcon icon={ tag } /> }
+		/>
+	);
+};
+
+export const NoSuffix: React.FC = () => {
+	const [ selected, setSelected ] = useState<
+		SelectedType< DefaultItemType >
+	>( sampleItems[ 1 ] );
+
+	return (
+		<SelectControl
+			items={ sampleItems }
+			label="No suffix"
+			selected={ selected }
+			onSelect={ ( item ) => item && setSelected( item ) }
+			onRemove={ () => setSelected( null ) }
+			suffix={ null }
+		/>
+	);
+};
+
+export const CustomSuffix: React.FC = () => {
+	const [ selected, setSelected ] = useState<
+		SelectedType< DefaultItemType >
+	>( sampleItems[ 1 ] );
+
+	return (
+		<SelectControl
+			items={ sampleItems }
+			label="Custom suffix"
+			selected={ selected }
+			onSelect={ ( item ) => item && setSelected( item ) }
+			onRemove={ () => setSelected( null ) }
+			suffix={
+				<div style={ { background: 'red', height: '100%' } }>
+					Suffix!
+				</div>
+			}
+		/>
 	);
 };
 

--- a/packages/js/components/src/experimental-select-control/suffix-icon.scss
+++ b/packages/js/components/src/experimental-select-control/suffix-icon.scss
@@ -1,0 +1,6 @@
+.woocommerce-experimental-select-control__suffix-icon {
+	display: flex;
+	align-items: center;
+	height: 100%;
+	padding-right: $gap-smaller;
+}

--- a/packages/js/components/src/experimental-select-control/suffix-icon.tsx
+++ b/packages/js/components/src/experimental-select-control/suffix-icon.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { createElement } from 'react';
+import { Icon } from '@wordpress/icons';
+
+type SuffixIconProps = {
+	icon: JSX.Element;
+};
+
+export const SuffixIcon = ( { icon }: SuffixIconProps ) => {
+	return (
+		<div className="woocommerce-experimental-select-control__suffix-icon">
+			<Icon icon={ icon } size={ 24 } />
+		</div>
+	);
+};

--- a/packages/js/components/src/experimental-select-control/test/index.tsx
+++ b/packages/js/components/src/experimental-select-control/test/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { SelectControl } from '../';
+
+describe( 'SelectControl', () => {
+	it( 'should render the default suffix if none is specified', () => {
+		const { container } = render(
+			<SelectControl label="Select" items={ [] } selected={ null } />
+		);
+
+		// We can't really determine if the correct suffix icon is being used
+		// without checking against the SVG path, which would be brittle;
+		// so, we just check if any suffix icon has been rendered
+		expect(
+			container.querySelector(
+				'.woocommerce-experimental-select-control__suffix-icon'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render a custom suffix if one is specified', () => {
+		const { getByText } = render(
+			<SelectControl
+				label="Select"
+				items={ [] }
+				selected={ null }
+				suffix={ <div>custom suffix</div> }
+			/>
+		);
+
+		expect( getByText( 'custom suffix' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render no suffix if null is specified', () => {
+		const { container } = render(
+			<SelectControl
+				label="Select"
+				items={ [] }
+				selected={ null }
+				suffix={ null }
+			/>
+		);
+
+		expect(
+			container.querySelector(
+				'.woocommerce-experimental-select-control__suffix'
+			)
+		).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds support for a `suffix` prop on `__experimentalSelectControl`.

New tests and stories were also added. 

According to the acceptance criteria in #35426:

- The suffix is shown on the right hand side of the select control's input field
- If no suffix is set, a search icon is shown as the suffix
- If a suffix is set, it is used instead of the default

Additionally (this wasn't spelled out in the acceptance criteria):

- If `suffix` is set to `null`, no suffix is shown

I decided that a `SelectControlSuffixWrapper` wasn't necessary at this time. We have no immediate need for it, and we are providing a `SuffixIcon` component that can be used to easily set a custom icon while maintaining the correct styling.

If a need for a `SelectControlSuffixWrapper` arises in the future it will be addressed in a separate PR.

Closes #35426.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run unit tests: `pnpm --filter=@woocommerce/components run test -- src/experimental-select-control`
2. Interact with Storybook and make sure experimental > SelectControl stories render correctly. Especially the new, suffix-specific ones:
    - Custom Suffix
    - Custom Suffix icon
    - Default Suffix
    - No Suffix
4. Go to `Products` > `Add new (MVP)`
5. Verify the `Categories` select control renders properly

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
