### PR TITLE
Fix REST API orders query when HPOS is used

### DIFF
--- a/plugins/woocommerce/changelog/fix-get-orders-rest-api-endpoint-with-hpos
+++ b/plugins/woocommerce/changelog/fix-get-orders-rest-api-endpoint-with-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix get orders REST API endpoint when using 'search' or 'parent' and HPOS is enabled

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -889,7 +889,12 @@ WHERE
 	 * @return int[] Array of order IDs.
 	 */
 	public function search_orders( $term ) {
-		$order_ids = wc_get_orders( array( 's' => $term, 'return' => 'ids' ) );
+		$order_ids = wc_get_orders(
+			array(
+				's'      => $term,
+				'return' => 'ids',
+			)
+		);
 
 		/**
 		 * Provides an opportunity to modify the list of order IDs obtained during an order search.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -889,7 +889,7 @@ WHERE
 	 * @return int[] Array of order IDs.
 	 */
 	public function search_orders( $term ) {
-		$order_ids = wc_get_orders( array( 's' => $term ) );
+		$order_ids = wc_get_orders( array( 's' => $term, 'return' => 'ids' ) );
 
 		/**
 		 * Provides an opportunity to modify the list of order IDs obtained during an order search.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -242,7 +242,7 @@ class OrdersTableQuery {
 		);
 
 		foreach ( $mapping as $query_key => $table_field ) {
-			if ( isset( $this->args[ $query_key ]) && '' !== $this->args[ $query_key ] ) {
+			if ( isset( $this->args[ $query_key ] ) && '' !== $this->args[ $query_key ] ) {
 				$this->args[ $table_field ] = $this->args[ $query_key ];
 				unset( $this->args[ $query_key ] );
 			}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -242,7 +242,7 @@ class OrdersTableQuery {
 		);
 
 		foreach ( $mapping as $query_key => $table_field ) {
-			if ( isset( $this->args[ $query_key ] ) ) {
+			if ( isset( $this->args[ $query_key ]) && '' !== $this->args[ $query_key ] ) {
 				$this->args[ $table_field ] = $this->args[ $query_key ];
 				unset( $this->args[ $query_key ] );
 			}


### PR DESCRIPTION
The query wasn't working properly when 'search' or 'parent'
query string arguments were used and HPOS was enabled.### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request fixes two issues that manifest in the orders retrieval REST API endpoint (`/wp-json/wc/v3/orders`) when HPOS is active:

1. The `search` parameter doesn't work: an empty orders list is always returned.
2. The `parent` parameter doesn't work: the parameter is ignored.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Enable HPOS and make the orders table authoritative.
2. Create a few orders and make sure that some are parents of other existing orders (the easiest way is to directly alter the `parent_order_id` field of the order records in the `wp_wc_orders` table).
3. Verify that the search by parent order id works as expected: `http://localhost/wp-json/wc/v3/orders?parent=<parent order id>`
4. Verify that the search by search term works as expected, e.g. `http://localhost/wp-json/wc/v3/orders?search=<customer name>` 

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
