### PR TITLE
[HPOS] Avoid error noise during plugin activation

### DIFF
--- a/plugins/woocommerce/changelog/fix-35773-order-counts
+++ b/plugins/woocommerce/changelog/fix-35773-order-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+If order types have not been registered, do not attempt to count orders.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -167,8 +167,21 @@ class DataSynchronizer implements BatchProcessorInterface {
 				return (int) $pending_count;
 			}
 		}
-		$orders_table                = $this->data_store::get_orders_table_name();
-		$order_post_types            = wc_get_order_types( 'cot-migration' );
+		$orders_table     = $this->data_store::get_orders_table_name();
+		$order_post_types = wc_get_order_types( 'cot-migration' );
+
+		if ( empty( $order_post_types ) ) {
+			$this->error_logger->debug(
+				sprintf(
+					/* translators: 1: method name. */
+					esc_html__( '%1$s was called but no order types were registered: it may have been called too early.', 'woocommerce' ),
+					__METHOD__
+				)
+			);
+
+			return 0;
+		}
+
 		$order_post_type_placeholder = implode( ', ', array_fill( 0, count( $order_post_types ), '%s' ) );
 
 		if ( $this->custom_orders_table_is_authoritative() ) {


### PR DESCRIPTION
If HPOS is enabled, and WooCommerce is subsequently deactivated and then re-activated, some error noise relating to a bad query is created. Though mostly harmless, it could reduce confidence in HPOS (and could clutter logs with distracting information).

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
During plugin activation, `WP_Install::create_options()` will be invoked which in turn attempts to load the options rendered in each settings page (ie, via `WP_Settings_Page::get_settings( $section )`).

When the Custom Order Table settings array is composed, a call is made to `DataSynchronizer::get_current_orders_pending_sync_count()` and, just as the method name suggests, this method tries to count the number of orders pending synchronization. However, it cannot form a valid query (though it tries) at this early stage (plugin activation) because no order types have yet been registered. 

<details>
<summary><strong>Error example</strong> (slightly edited for clarity)</summary><br/>
<div class="snippet-clipboard-content notranslate position-relative overflow-auto"><pre class="notranslate"><code class="notranslate">
WordPress database error 

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use

	(SELECT COUNT(1) FROM (
		SELECT orders.id FROM mywc_wc_orders orders
		JOIN mywc_posts posts on posts.ID = orders.id
		WHERE
			posts.post_type IN ()
			AND orders.date_updated_gmt > posts.post_modified_gmt
		) x)
	) count 

made by do_action('activate_woocommerce/woocommerce.php'), 
        WC_Install::install, 
        WC_Install::create_options, 
        WC_Settings_Page->get_settings, 
        WC_Settings_Page->get_settings_for_section, 
        apply_filters('woocommerce_get_settings_advanced'), 
        Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController->get_settings, 
        Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer->get_sync_status, 
        Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer->get_total_pending_count, 
        Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer->get_current_orders_pending_sync_count
</code></pre></div>
</details>

As a matter of defensive coding, therefore, we guard against this—returning zero and logging a debug message.

Closes #35773.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Activate HPOS and enable sync.
2. Via WP CLI, deactivate WooCommerce: `wp plugin deactivate woocommerce`.
3. Via WP CLI, reactivate WooCommerce: `wp plugin activate woocommerce`.
    - At this point, *without* this change, you should see a database error.
    - With this change, there should be no error.
    - Additionally, with this change, a debug level notice should have been logged (visible via **WooCommerce ▸ Status ▸ Logs**):

<img width="991" alt="debug-log-no-order-types" src="https://user-images.githubusercontent.com/3594411/205399837-43a1b416-4f34-4bb4-818e-1b85b211bbfd.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
