### PR TITLE
Make set_order_props_from_data() protected rather than private

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcs-core-issue-268
+++ b/plugins/woocommerce/changelog/fix-wcs-core-issue-268
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Make the OrdersTableDataStore::set_order_props_from_data() function protected rather than private
+Make the OrdersTableDataStore init_order_record() and get_order_data_for_ids() functions protected rather than private

--- a/plugins/woocommerce/changelog/fix-wcs-core-issue-268
+++ b/plugins/woocommerce/changelog/fix-wcs-core-issue-268
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make the OrdersTableDataStore::set_order_props_from_data() function protected rather than private

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1027,7 +1027,7 @@ WHERE
 	 *
 	 * @return void
 	 */
-	private function init_order_record( \WC_Abstract_Order &$order, int $order_id, \stdClass $order_data ) {
+	protected function init_order_record( \WC_Abstract_Order &$order, int $order_id, \stdClass $order_data ) {
 		$order->set_defaults();
 		$order->set_id( $order_id );
 		$filtered_meta_data = $this->filter_raw_meta_data( $order, $order_data->meta_data );
@@ -1347,7 +1347,7 @@ WHERE
 	 *
 	 * @return \stdClass[]|object|null DB Order objects or error.
 	 */
-	private function get_order_data_for_ids( $ids ) {
+	protected function get_order_data_for_ids( $ids ) {
 		if ( ! $ids ) {
 			return array();
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1288,7 +1288,7 @@ WHERE
 	 * @param \WC_Abstract_Order $order      The order object.
 	 * @param object             $order_data A row of order data from the database.
 	 */
-	protected function set_order_props_from_data( &$order, $order_data ) {
+	private function set_order_props_from_data( &$order, $order_data ) {
 		foreach ( $this->get_all_order_column_mappings() as $table_name => $column_mapping ) {
 			foreach ( $column_mapping as $column_name => $prop_details ) {
 				if ( ! isset( $prop_details['name'] ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1288,7 +1288,7 @@ WHERE
 	 * @param \WC_Abstract_Order $order      The order object.
 	 * @param object             $order_data A row of order data from the database.
 	 */
-	private function set_order_props_from_data( &$order, $order_data ) {
+	protected function set_order_props_from_data( &$order, $order_data ) {
 		foreach ( $this->get_all_order_column_mappings() as $table_name => $column_mapping ) {
 			foreach ( $column_mapping as $column_name => $prop_details ) {
 				if ( ! isset( $prop_details['name'] ) ) {


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This changes the `set_order_props_from_data()` function to be protected rather than private. 

This fairly simple change, enables us in WC Subscriptions to override this function so we can set our own subscription specific properties while the subscription object is being read. This fixes issues where loading a subscription was incorrectly causing it to resync because WC would determine that the HPOS loaded object was different from the post record because the post object is completely loaded but the HPOS subscription object hasn't finished loading because we need to set subscription specific properties and that was only possible to run after `read_multiple()` and so after the WC comparison was done.

Because all the `read_multiple()` functions are private, there is no opportunity for us to set our own subscription properties without reimplementing large parts of the order datastore. 

This PR enables us to:

1. Override the `set_order_props_from_data()` function in the Subscription datastore. 
2. Inside that function populate our custom properties from the given data fetched from the database. 

All while the subscription is being read and before WC compares the order/subscription to see if it needs a resync. 

I've submitted the required changes to WC Subscriptions here: https://github.com/Automattic/woocommerce-subscriptions-core/pull/336

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
