### PR TITLE
Add product variations data store

### DIFF
--- a/packages/js/data/changelog/add-35771
+++ b/packages/js/data/changelog/add-35771
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product variations data store

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -24,6 +24,7 @@ export { EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME } from './shipping-zones';
 export { EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME } from './product-tags';
 export { EXPERIMENTAL_PRODUCT_CATEGORIES_STORE_NAME } from './product-categories';
 export { EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME } from './product-attribute-terms';
+export { EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME } from './product-variations';
 export { PaymentGateway } from './payment-gateways/types';
 
 // Export hooks
@@ -115,6 +116,7 @@ import type { EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME } from './shipping-zones';
 import type { EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME } from './product-tags';
 import type { EXPERIMENTAL_PRODUCT_CATEGORIES_STORE_NAME } from './product-categories';
 import type { EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME } from './product-attribute-terms';
+import type { EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME } from './product-variations';
 
 export type WCDataStoreName =
 	| typeof REVIEWS_STORE_NAME
@@ -136,7 +138,8 @@ export type WCDataStoreName =
 	| typeof EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME
 	| typeof EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME
 	| typeof EXPERIMENTAL_PRODUCT_TAGS_STORE_NAME
-	| typeof EXPERIMENTAL_PRODUCT_CATEGORIES_STORE_NAME;
+	| typeof EXPERIMENTAL_PRODUCT_CATEGORIES_STORE_NAME
+	| typeof EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME;
 
 /**
  * Internal dependencies
@@ -154,6 +157,7 @@ import { ShippingZonesSelectors } from './shipping-zones/types';
 import { ProductTagSelectors } from './product-tags/types';
 import { ProductCategorySelectors } from './product-categories/types';
 import { ProductAttributeTermsSelectors } from './product-attribute-terms/types';
+import { ProductVariationSelectors } from './product-variations/types';
 
 // As we add types to all the package selectors we can fill out these unknown types with real ones. See one
 // of the already typed selectors for an example of how you can do this.
@@ -193,6 +197,8 @@ export type WCSelectorType< T > = T extends typeof REVIEWS_STORE_NAME
 	? ProductCategorySelectors
 	: T extends typeof EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME
 	? ProductAttributeTermsSelectors
+	: T extends typeof EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+	? ProductVariationSelectors
 	: T extends typeof ORDERS_STORE_NAME
 	? OrdersSelectors
 	: T extends typeof EXPERIMENTAL_SHIPPING_ZONES_STORE_NAME
@@ -209,6 +215,7 @@ export { ActionDispatchers as ProductAttributesActions } from './product-attribu
 export { ActionDispatchers as ProductTagsActions } from './product-tags/types';
 export { ActionDispatchers as ProductCategoryActions } from './product-categories/types';
 export { ActionDispatchers as ProductAttributeTermsActions } from './product-attribute-terms/types';
+export { ActionDispatchers as ProductVariationsActions } from './product-variations/types';
 export { ActionDispatchers as ProductsStoreActions } from './products/actions';
 export { ActionDispatchers as ProductShippingClassesActions } from './product-shipping-classes/types';
 export { ActionDispatchers as ShippingZonesActions } from './shipping-zones/types';

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -77,6 +77,7 @@ export * from './countries/types';
 export * from './onboarding/types';
 export * from './plugins/types';
 export * from './products/types';
+export { ProductVariation } from './product-variations/types';
 export {
 	QueryProductAttribute,
 	ProductAttributeSelectors,

--- a/packages/js/data/src/product-variations/constants.ts
+++ b/packages/js/data/src/product-variations/constants.ts
@@ -1,3 +1,4 @@
 export const STORE_NAME = 'wc/admin/products/variations';
 
-export const WC_PRODUCT_VARIATIONS_NAMESPACE = '/wc/v3/products/{product_id}/variations';
+export const WC_PRODUCT_VARIATIONS_NAMESPACE =
+	'/wc/v3/products/{product_id}/variations';

--- a/packages/js/data/src/product-variations/constants.ts
+++ b/packages/js/data/src/product-variations/constants.ts
@@ -1,0 +1,3 @@
+export const STORE_NAME = 'wc/admin/products/variations';
+
+export const WC_PRODUCT_VARIATIONS_NAMESPACE = '/wc/v3/products/{product_id}/variations';

--- a/packages/js/data/src/product-variations/index.ts
+++ b/packages/js/data/src/product-variations/index.ts
@@ -4,8 +4,6 @@
 import { STORE_NAME, WC_PRODUCT_VARIATIONS_NAMESPACE } from './constants';
 import { createCrudDataStore } from '../crud';
 
-console.log('creating');
-
 createCrudDataStore( {
 	storeName: STORE_NAME,
 	resourceName: 'ProductVariation',

--- a/packages/js/data/src/product-variations/index.ts
+++ b/packages/js/data/src/product-variations/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME, WC_PRODUCT_VARIATIONS_NAMESPACE } from './constants';
+import { createCrudDataStore } from '../crud';
+
+console.log('creating');
+
+createCrudDataStore( {
+	storeName: STORE_NAME,
+	resourceName: 'ProductVariation',
+	pluralResourceName: 'ProductVariations',
+	namespace: WC_PRODUCT_VARIATIONS_NAMESPACE,
+} );
+
+export const EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME = STORE_NAME;

--- a/packages/js/data/src/product-variations/types.ts
+++ b/packages/js/data/src/product-variations/types.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { DispatchFromMap } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import { CrudActions, CrudSelectors } from '../crud/types';
+import { Product, ProductQuery, ReadOnlyProperties } from '../products/types';
+
+type ProductVariation = Omit< Product, 'name' | 'slug' >;
+
+type Query = Omit< ProductQuery, 'name' >;
+
+type MutableProperties = Partial<
+	Omit< ProductVariation, ReadOnlyProperties >
+>;
+
+type ProductVariationActions = CrudActions<
+	'ProductVariation',
+	ProductVariation,
+	MutableProperties
+>;
+
+export type ProductVariationSelectors = CrudSelectors<
+	'ProductVariation',
+	'ProductVariations',
+	ProductVariation,
+	Query,
+	MutableProperties
+>;
+
+export type ActionDispatchers = DispatchFromMap< ProductVariationActions >;

--- a/packages/js/data/src/product-variations/types.ts
+++ b/packages/js/data/src/product-variations/types.ts
@@ -9,7 +9,7 @@ import { DispatchFromMap } from '@automattic/data-stores';
 import { CrudActions, CrudSelectors } from '../crud/types';
 import { Product, ProductQuery, ReadOnlyProperties } from '../products/types';
 
-type ProductVariation = Omit< Product, 'name' | 'slug' >;
+export type ProductVariation = Omit< Product, 'name' | 'slug' >;
 
 type Query = Omit< ProductQuery, 'name' >;
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the product variations data store in preparation for use in the new product management experience.

Closes #35771 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create some product variations under a product
1. Attempt to get product variations `wp.data.select('wc/admin/products/variations').getProductVariations({ product_id: 123 });`. Note that you. may have to run this again after the fetch has finished resolving.  Replace `123` with your respective product ID.
2. Optionally, pass some query parameters found in https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-product-variations
`wp.data.select('wc/admin/products/variations').getProductVariations({product_id: 123, page: 2});`
3. Using one of the variations IDs, update some variations properties - `wp.data.dispatch('wc/admin/products/variations').updateProductVariation({id: 456, product_id: 123}, { regular_price: '10.00'  } );`
4. Check that the variation was updated
5. Attempt to create a new variation - `wp.data.dispatch('wc/admin/products/variations').createProductVariation({ product_id: 123, regular_price: '20.00'  } );`
6. Check that the variation was added
7. Attempt to delete a variation- `wp.data.dispatch('wc/admin/products/variations').deleteProductVariation({ id: 456, product_id: 123});`
8. Check that the variation was deleted

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
