### PR TITLE
Resolve conflict with the JWT Plugin

### DIFF
--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -147,7 +147,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		$endpoints = $response->get_data();
 
 		foreach ( $endpoints as $endpoint ) {
-			if ( '/stats' === substr( $endpoint['slug'], -6 ) ) {
+			if ( is_array( $endpoint ) && ! empty( $endpoint['slug'] ) && '/stats' === substr( $endpoint['slug'], -6 ) ) {
 				$request  = new \WP_REST_Request( 'OPTIONS', $endpoint['path'] );
 				$response = rest_do_request( $request );
 


### PR DESCRIPTION
If JWT is enabled inside the website and you make a request for your endpoint it will generate a fatal error.

So I have added an array check and key check conditions.

Thanks