### PR TITLE
Adds 2 new order status filters for bacs and cheque email instructions

### DIFF
--- a/plugins/woocommerce/changelog/2023-01-05-09-16-47-168455
+++ b/plugins/woocommerce/changelog/2023-01-05-09-16-47-168455
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Adds new order status filters for bacs and cheque email instructions.

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -259,7 +259,13 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 	 * @param bool     $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-
+		/**
+		 * Filter the email instructions order status.
+		 *
+		 * @since 7.3
+		 * @param string $terms The order status.
+		 * @param object $order The order object.
+		 */
 		if ( ! $sent_to_admin && 'bacs' === $order->get_payment_method() && $order->has_status( apply_filters( 'woocommerce_bacs_email_instructions_order_status', 'on-hold', $order ) ) ) {
 			if ( $this->instructions ) {
 				echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -262,7 +262,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 		/**
 		 * Filter the email instructions order status.
 		 *
-		 * @since 7.3
+		 * @since 7.4
 		 * @param string $terms The order status.
 		 * @param object $order The order object.
 		 */

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -260,7 +260,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
 
-		if ( ! $sent_to_admin && 'bacs' === $order->get_payment_method() && $order->has_status( 'on-hold' ) ) {
+		if ( ! $sent_to_admin && 'bacs' === $order->get_payment_method() && $order->has_status( apply_filters( 'woocommerce_bacs_email_instructions_order_status', 'on-hold', $order ) ) ) {
 			if ( $this->instructions ) {
 				echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 			}

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -102,6 +102,13 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 	 * @param bool     $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
+		/**
+		 * Filter the email instructions order status.
+		 *
+		 * @since 7.3
+		 * @param string $terms The order status.
+		 * @param object $order The order object.
+		 */
 		if ( $this->instructions && ! $sent_to_admin && 'cheque' === $order->get_payment_method() && $order->has_status( apply_filters( 'woocommerce_cheque_email_instructions_order_status', 'on-hold', $order ) ) ) {
 			echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 		}

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -102,7 +102,7 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 	 * @param bool     $plain_text Email format: plain text or HTML.
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-		if ( $this->instructions && ! $sent_to_admin && 'cheque' === $order->get_payment_method() && $order->has_status( 'on-hold' ) ) {
+		if ( $this->instructions && ! $sent_to_admin && 'cheque' === $order->get_payment_method() && $order->has_status( apply_filters( 'woocommerce_cheque_email_instructions_order_status', 'on-hold', $order ) ) ) {
 			echo wp_kses_post( wpautop( wptexturize( $this->instructions ) ) . PHP_EOL );
 		}
 	}

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -105,7 +105,7 @@ class WC_Gateway_Cheque extends WC_Payment_Gateway {
 		/**
 		 * Filter the email instructions order status.
 		 *
-		 * @since 7.3
+		 * @since 7.4
 		 * @param string $terms The order status.
 		 * @param object $order The order object.
 		 */


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR purposes 2 new filters to the `bacs` and `cheque` payment gateways email instructions to allow displaying those instructions on custom email templates using custom status.

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

Email instructions are currently being injected with the following hook `woocommerce_email_before_order_table` in the email templates, but this is restricted to `on-hold` order status here: 

https://github.com/woocommerce/woocommerce/blob/2a56407ba125ab281f901817af2485438c18a9b0/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php#L263

https://github.com/woocommerce/woocommerce/blob/2a56407ba125ab281f901817af2485438c18a9b0/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php#L105

We have a plugin with a custom order status and also a custom email template, and instead of duplicating the WooCommerce code in our plugin, having this filter would make this a lot easier, and we could display the payment instructions.

eg.
```php
add_filter( 'woocommerce_bacs_email_instructions_order_status', function ( $status, $order ) {
	if ( ! empty( $order ) && $order->get_status() == 'order-proposal' ) {
		$status = $order->get_status();
	}
	return $status;
} );
```

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
