### PR TITLE
Adding delayed spotlight to feedback button on current product page

### DIFF
--- a/packages/js/components/changelog/add-35301-delayed-ces-prompt
+++ b/packages/js/components/changelog/add-35301-delayed-ces-prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding isHidden option for primary button in TourKit component.

--- a/packages/js/components/src/tour-kit/components/step-navigation.tsx
+++ b/packages/js/components/src/tour-kit/components/step-navigation.tsx
@@ -25,7 +25,7 @@ const StepNavigation: React.FunctionComponent< Props > = ( {
 	const isFirstStep = currentStepIndex === 0;
 	const isLastStep = currentStepIndex === steps.length - 1;
 
-	const { primaryButton = { text: '', isDisabled: false } } =
+	const { primaryButton = { text: '', isDisabled: false, isHidden: false } } =
 		steps[ currentStepIndex ].meta;
 
 	const NextButton = (
@@ -79,6 +79,10 @@ const StepNavigation: React.FunctionComponent< Props > = ( {
 			</div>
 		);
 	};
+
+	if ( primaryButton.isHidden ) {
+		return null;
+	}
 
 	return (
 		<div className="woocommerce-tour-kit-step-navigation">

--- a/packages/js/components/src/tour-kit/types.ts
+++ b/packages/js/components/src/tour-kit/types.ts
@@ -22,6 +22,7 @@ export interface WooStep extends Step {
 			text?: string;
 			/** Disable the button or not. Default to False */
 			isDisabled?: boolean;
+			isHidden?: boolean;
 		};
 	};
 	/** Auto apply the focus state for the element. Default to null */

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -49,6 +49,7 @@ import { LayoutContext } from '~/layout';
 import { getSegmentsFromPath } from '~/utils/url-helpers';
 import { FeedbackIcon } from '~/products/images/feedback-icon';
 import { STORE_KEY as CES_STORE_KEY } from '~/customer-effort-score-tracks/data/constants';
+import { ProductFeedbackTour } from '~/guided-tours/add-product-feedback-tour';
 
 const HelpPanel = lazy( () =>
 	import( /* webpackChunkName: "activity-panels-help" */ './panels/help' )
@@ -80,12 +81,21 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		() => layoutContext.getExtendedContext( 'activity-panel' ),
 		[ layoutContext ]
 	);
+	const [ displayFeedbackTour, setDisplayFeedbackTour ] = useState( false );
 
 	useEffect( () => {
 		return addHistoryListener( () => {
 			closePanel();
 			clearPanel();
 		} );
+	}, [] );
+
+	useEffect( () => {
+		const tourTimeout = setTimeout( () => {
+			setDisplayFeedbackTour( true );
+		}, 5 * 1000 );
+
+		return () => clearTimeout( tourTimeout );
 	}, [] );
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
@@ -485,6 +495,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 						clearPanel={ () => clearPanel() }
 					/>
 				</Section>
+				{ displayFeedbackTour && <ProductFeedbackTour /> }
 				{ showHelpHighlightTooltip ? (
 					<HighlightTooltip
 						delay={ 1000 }

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -81,21 +81,12 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		() => layoutContext.getExtendedContext( 'activity-panel' ),
 		[ layoutContext ]
 	);
-	const [ displayFeedbackTour, setDisplayFeedbackTour ] = useState( false );
 
 	useEffect( () => {
 		return addHistoryListener( () => {
 			closePanel();
 			clearPanel();
 		} );
-	}, [] );
-
-	useEffect( () => {
-		const tourTimeout = setTimeout( () => {
-			setDisplayFeedbackTour( true );
-		}, 5 * 1000 );
-
-		return () => clearTimeout( tourTimeout );
 	}, [] );
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
@@ -495,7 +486,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 						clearPanel={ () => clearPanel() }
 					/>
 				</Section>
-				{ displayFeedbackTour && <ProductFeedbackTour /> }
+				<ProductFeedbackTour currentTab={ currentTab } />
 				{ showHelpHighlightTooltip ? (
 					<HighlightTooltip
 						delay={ 1000 }

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -251,6 +251,16 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		);
 	};
 
+	const isAddProductPage = () => {
+		const urlParams = getUrlParams( window.location.search );
+
+		return (
+			isEmbedded &&
+			/post-new\.php$/.test( window.location.pathname ) &&
+			urlParams?.post_type === 'product'
+		);
+	};
+
 	const isPerformingSetupTask = () => {
 		return (
 			query.task &&
@@ -263,8 +273,6 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 	// @todo Pull in dynamic unread status/count
 	const getTabs = () => {
-		const urlParams = getUrlParams( window.location.search );
-
 		const activity = {
 			name: 'activity',
 			title: __( 'Activity', 'woocommerce' ),
@@ -315,10 +323,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 					}
 				);
 			},
-			visible:
-				isEmbedded &&
-				urlParams?.post_type === 'product' &&
-				! urlParams?.taxonomy,
+			visible: isAddProductPage(),
 		};
 
 		const setup = {
@@ -486,7 +491,9 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 						clearPanel={ () => clearPanel() }
 					/>
 				</Section>
-				<ProductFeedbackTour currentTab={ currentTab } />
+				{ isAddProductPage() && (
+					<ProductFeedbackTour currentTab={ currentTab } />
+				) }
 				{ showHelpHighlightTooltip ? (
 					<HighlightTooltip
 						delay={ 1000 }

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { TourKit, TourKitTypes } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { EmbeddedBodyProps } from '../embedded-body-layout/embedded-body-props';
+
+const STORE_ADDRESS_SETTINGS_OPTION = 'woocommerce_store_address';
+const STORE_CITY_SETTINGS_OPTION = 'woocommerce_store_city';
+const STORE_POSTCODE_SETTINGS_OPTION = 'woocommerce_store_postcode';
+
+// const useShowStoreLocationTour = () => {
+// 	const { hasFilledStoreAddress, isLoading } = useSelect( ( select ) => {
+// 		const { hasFinishedResolution, getOption } =
+// 			select( OPTIONS_STORE_NAME );
+
+// 		return {
+// 			isLoading:
+// 				! hasFinishedResolution( 'getOption', [
+// 					STORE_ADDRESS_SETTINGS_OPTION,
+// 				] ) ||
+// 				! hasFinishedResolution( 'getOption', [
+// 					STORE_CITY_SETTINGS_OPTION,
+// 				] ) ||
+// 				! hasFinishedResolution( 'getOption', [
+// 					STORE_POSTCODE_SETTINGS_OPTION,
+// 				] ),
+// 			hasFilledStoreAddress:
+// 				getOption( STORE_ADDRESS_SETTINGS_OPTION ) !== '' &&
+// 				getOption( STORE_CITY_SETTINGS_OPTION ) !== '' &&
+// 				getOption( STORE_POSTCODE_SETTINGS_OPTION ) !== '',
+// 		};
+// 	} );
+
+// 	return {
+// 		isLoading,
+// 		show: ! isLoading && ! hasFilledStoreAddress,
+// 	};
+// };
+
+export const ProductFeedbackTour: React.FC = () => {
+	const { isLoading, show } = { isLoading: false, show: true }; //useShowStoreLocationTour();
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	const config: TourKitTypes.WooConfig = {
+		steps: [
+			{
+				referenceElements: {
+					desktop: '#activity-panel-tab-feedback',
+				},
+				meta: {
+					name: 'product-feedback-tour-1',
+					heading: __( '🫣 Feeling stuck?', 'woocommerce' ),
+					descriptions: {
+						desktop: __(
+							'You have been working on this product for a few minutes now. Is there something you’re struggling with? Share your feedback.',
+							'woocommerce'
+						),
+					},
+					primaryButton: {
+						isHidden: true,
+					},
+				},
+			},
+		],
+		placement: 'bottom-start',
+		options: {
+			effects: {
+				liveResize: { mutation: true, resize: true },
+			},
+		},
+		closeHandler: ( _steps ) => {
+			// recordEvent( 'settings_store_address_tour_dismiss', {
+			// 	source,
+			// } );
+
+			setIsDismissed( true );
+		},
+	};
+
+	if ( isDismissed || isLoading || ! show ) {
+		return null;
+	}
+	return <TourKit config={ config }></TourKit>;
+};

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
@@ -4,51 +4,68 @@
 import { TourKit, TourKitTypes } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
-import { EmbeddedBodyProps } from '../embedded-body-layout/embedded-body-props';
 
-const STORE_ADDRESS_SETTINGS_OPTION = 'woocommerce_store_address';
-const STORE_CITY_SETTINGS_OPTION = 'woocommerce_store_city';
-const STORE_POSTCODE_SETTINGS_OPTION = 'woocommerce_store_postcode';
+const FEEDBACK_TOUR_OPTION = 'woocommerce_ces_product_feedback_shown';
 
-// const useShowStoreLocationTour = () => {
-// 	const { hasFilledStoreAddress, isLoading } = useSelect( ( select ) => {
-// 		const { hasFinishedResolution, getOption } =
-// 			select( OPTIONS_STORE_NAME );
+const useShowProductFeedbackTour = () => {
+	const { tourOptionValue, isLoading } = useSelect( ( select ) => {
+		const { hasFinishedResolution, getOption } =
+			select( OPTIONS_STORE_NAME );
 
-// 		return {
-// 			isLoading:
-// 				! hasFinishedResolution( 'getOption', [
-// 					STORE_ADDRESS_SETTINGS_OPTION,
-// 				] ) ||
-// 				! hasFinishedResolution( 'getOption', [
-// 					STORE_CITY_SETTINGS_OPTION,
-// 				] ) ||
-// 				! hasFinishedResolution( 'getOption', [
-// 					STORE_POSTCODE_SETTINGS_OPTION,
-// 				] ),
-// 			hasFilledStoreAddress:
-// 				getOption( STORE_ADDRESS_SETTINGS_OPTION ) !== '' &&
-// 				getOption( STORE_CITY_SETTINGS_OPTION ) !== '' &&
-// 				getOption( STORE_POSTCODE_SETTINGS_OPTION ) !== '',
-// 		};
-// 	} );
+		return {
+			isLoading: ! hasFinishedResolution( 'getOption', [
+				FEEDBACK_TOUR_OPTION,
+			] ),
+			tourOptionValue: getOption( FEEDBACK_TOUR_OPTION ),
+		};
+	} );
 
-// 	return {
-// 		isLoading,
-// 		show: ! isLoading && ! hasFilledStoreAddress,
-// 	};
-// };
+	return {
+		isLoading,
+		tourOptionValue,
+	};
+};
 
-export const ProductFeedbackTour: React.FC = () => {
-	const { isLoading, show } = { isLoading: false, show: true }; //useShowStoreLocationTour();
-	const [ isDismissed, setIsDismissed ] = useState( false );
+type ProductFeedbackTour = {
+	currentTab: string;
+};
+
+export const ProductFeedbackTour: React.FC< ProductFeedbackTour > = ( {
+	currentTab,
+} ) => {
+	const { isLoading, tourOptionValue } = useShowProductFeedbackTour();
+	const [ isTourVisible, setIsTourVisible ] = useState( false );
+	const tourTimeout = useRef< ReturnType< typeof setTimeout > | null >(
+		null
+	);
+
+	const clearTourTimeout = () => {
+		clearTimeout( tourTimeout.current as ReturnType< typeof setTimeout > );
+	};
+
+	console.debug( 'render', isLoading, tourOptionValue );
+
+	useEffect( () => {
+		tourTimeout.current = setTimeout( () => {
+			setIsTourVisible( true );
+		}, 5 * 1000 );
+
+		return () => clearTourTimeout();
+	}, [] );
+
+	useEffect( () => {
+		if ( currentTab === 'feedback' ) {
+			setIsTourVisible( false );
+			clearTourTimeout();
+		}
+	}, [ currentTab ] );
 
 	const config: TourKitTypes.WooConfig = {
 		steps: [
@@ -81,12 +98,10 @@ export const ProductFeedbackTour: React.FC = () => {
 			// recordEvent( 'settings_store_address_tour_dismiss', {
 			// 	source,
 			// } );
-
-			setIsDismissed( true );
 		},
 	};
 
-	if ( isDismissed || isLoading || ! show ) {
+	if ( ! isTourVisible ) {
 		return null;
 	}
 	return <TourKit config={ config }></TourKit>;

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
@@ -40,6 +40,7 @@ export const ProductFeedbackTour: React.FC< ProductFeedbackTour > = ( {
 
 	const clearTourTimeout = () => {
 		clearTimeout( tourTimeout.current as ReturnType< typeof setTimeout > );
+		tourTimeout.current = null;
 	};
 
 	useEffect( () => {
@@ -63,7 +64,10 @@ export const ProductFeedbackTour: React.FC< ProductFeedbackTour > = ( {
 		} );
 	}, [ isTourVisible ] );
 
-	if ( currentTab === 'feedback' && isTourVisible ) {
+	if (
+		currentTab === 'feedback' &&
+		( isTourVisible || tourTimeout.current )
+	) {
 		setIsTourVisible( false );
 		clearTourTimeout();
 	}

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
@@ -1,18 +1,14 @@
 /**
  * External dependencies
  */
-import { TourKit, TourKitTypes } from '@woocommerce/components';
+import { TourKit } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { recordEvent } from '@woocommerce/tracks';
-
-/**
- * Internal dependencies
- */
 
 const FEEDBACK_TOUR_OPTION = 'woocommerce_ces_product_feedback_shown';
+const FEEDBACK_TIMEOUT_MS = 7 * 60 * 1000;
 
 const useShowProductFeedbackTour = (): undefined | boolean => {
 	const { tourOptionValue } = useSelect( ( select ) => {
@@ -53,17 +49,10 @@ export const ProductFeedbackTour: React.FC< ProductFeedbackTour > = ( {
 
 		tourTimeout.current = setTimeout( () => {
 			setIsTourVisible( true );
-		}, 5 * 1000 );
+		}, FEEDBACK_TIMEOUT_MS );
 
 		return () => clearTourTimeout();
 	}, [ tourOptionValue ] );
-
-	useEffect( () => {
-		if ( currentTab === 'feedback' ) {
-			setIsTourVisible( false );
-			clearTourTimeout();
-		}
-	}, [ currentTab ] );
 
 	useEffect( () => {
 		if ( ! isTourVisible ) {
@@ -74,44 +63,48 @@ export const ProductFeedbackTour: React.FC< ProductFeedbackTour > = ( {
 		} );
 	}, [ isTourVisible ] );
 
-	const config: TourKitTypes.WooConfig = {
-		steps: [
-			{
-				referenceElements: {
-					desktop: '#activity-panel-tab-feedback',
-				},
-				meta: {
-					name: 'product-feedback-tour-1',
-					heading: __( '🫣 Feeling stuck?', 'woocommerce' ),
-					descriptions: {
-						desktop: __(
-							"You have been working on this product for a few minutes now. Is there something you're struggling with? Share your feedback.",
-							'woocommerce'
-						),
-					},
-					primaryButton: {
-						isHidden: true,
-					},
-				},
-			},
-		],
-		placement: 'bottom-start',
-		options: {
-			effects: {
-				liveResize: { mutation: true, resize: true },
-			},
-		},
-		closeHandler: () => {
-			setIsTourVisible( false );
-			// Add tracks?
-			// recordEvent( 'settings_store_address_tour_dismiss', {
-			// 	source,
-			// } );
-		},
-	};
+	if ( currentTab === 'feedback' && isTourVisible ) {
+		setIsTourVisible( false );
+		clearTourTimeout();
+	}
 
 	if ( ! isTourVisible ) {
 		return null;
 	}
-	return <TourKit config={ config }></TourKit>;
+
+	return (
+		<TourKit
+			config={ {
+				steps: [
+					{
+						referenceElements: {
+							desktop: '#activity-panel-tab-feedback',
+						},
+						meta: {
+							name: 'product-feedback-tour-1',
+							heading: __( '🫣 Feeling stuck?', 'woocommerce' ),
+							descriptions: {
+								desktop: __(
+									"You have been working on this product for a few minutes now. Is there something you're struggling with? Share your feedback.",
+									'woocommerce'
+								),
+							},
+							primaryButton: {
+								isHidden: true,
+							},
+						},
+					},
+				],
+				placement: 'bottom-start',
+				options: {
+					effects: {
+						liveResize: { mutation: true, resize: true },
+					},
+				},
+				closeHandler: () => {
+					setIsTourVisible( false );
+				},
+			} }
+		/>
+	);
 };

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
@@ -24,11 +24,11 @@ const useShowProductFeedbackTour = (): undefined | boolean => {
 	return tourOptionValue;
 };
 
-type ProductFeedbackTour = {
+type ProductFeedbackTourProps = {
 	currentTab: string;
 };
 
-export const ProductFeedbackTour: React.FC< ProductFeedbackTour > = ( {
+export const ProductFeedbackTour: React.FC< ProductFeedbackTourProps > = ( {
 	currentTab,
 } ) => {
 	const tourOptionValue = useShowProductFeedbackTour();

--- a/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx
@@ -11,17 +11,17 @@ const FEEDBACK_TOUR_OPTION = 'woocommerce_ces_product_feedback_shown';
 const FEEDBACK_TIMEOUT_MS = 7 * 60 * 1000;
 
 const useShowProductFeedbackTour = (): undefined | boolean => {
-	const { tourOptionValue } = useSelect( ( select ) => {
+	const { hasShownTour } = useSelect( ( select ) => {
 		const { getOption } = select( OPTIONS_STORE_NAME );
 
 		return {
-			tourOptionValue: getOption( FEEDBACK_TOUR_OPTION ) as
+			hasShownTour: getOption( FEEDBACK_TOUR_OPTION ) as
 				| boolean
 				| undefined,
 		};
 	} );
 
-	return tourOptionValue;
+	return hasShownTour;
 };
 
 type ProductFeedbackTourProps = {
@@ -31,7 +31,7 @@ type ProductFeedbackTourProps = {
 export const ProductFeedbackTour: React.FC< ProductFeedbackTourProps > = ( {
 	currentTab,
 } ) => {
-	const tourOptionValue = useShowProductFeedbackTour();
+	const hasShownTour = useShowProductFeedbackTour();
 	const [ isTourVisible, setIsTourVisible ] = useState( false );
 	const tourTimeout = useRef< ReturnType< typeof setTimeout > | null >(
 		null
@@ -44,7 +44,7 @@ export const ProductFeedbackTour: React.FC< ProductFeedbackTourProps > = ( {
 	};
 
 	useEffect( () => {
-		if ( tourOptionValue !== false ) {
+		if ( hasShownTour !== false ) {
 			return;
 		}
 
@@ -53,7 +53,7 @@ export const ProductFeedbackTour: React.FC< ProductFeedbackTourProps > = ( {
 		}, FEEDBACK_TIMEOUT_MS );
 
 		return () => clearTourTimeout();
-	}, [ tourOptionValue ] );
+	}, [ hasShownTour ] );
 
 	useEffect( () => {
 		if ( ! isTourVisible ) {

--- a/plugins/woocommerce/changelog/add-35301-delayed-ces-prompt
+++ b/plugins/woocommerce/changelog/add-35301-delayed-ces-prompt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding delayed spotlight to feedback button on current product page.


### PR DESCRIPTION
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This will create a spotlight component to highlight the feedback button on the current product UI, only after 7 minutes. 

- User interaction doesn't matter--if they're still on the page it will be displayed. 
- It will only be displayed once.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/206032562-f3d58575-556e-46d2-bd73-6c562c1df158.png)


Closes #35301 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch on fresh store.
2. The timeout is set to 7 minutes. You can either wait that amount of time, or [alter this line](https://github.com/woocommerce/woocommerce/blob/d9a577859cedf651efa67ed233dac0887a2f38b9/plugins/woocommerce-admin/client/guided-tours/add-product-feedback-tour.tsx#L11) to a more reasonable timeout for testing.
3. Navigate to current product UI (Products -> Add new)
4. Notice Feedback button on Activity bar at top right. After the timeout elapses you should see the spotlight popover appear as pictured above.
5. Refresh, and wait. It should not appear again.
6. Delete the `woocommerce_ces_product_feedback_shown` option on your store, and refresh. It should appear again as it did originally.
7. Click the "Feedback" button and either close the modal or fill it out and submit. The popover should close at the same time.
8. Delete the option and refresh. Immediately hit the "Feedback" button (before popover displays), and close. The popover should not display.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
