### PR TITLE
Fix installation error in Onboarding Wizard when plugin generates unexpected output

### DIFF
--- a/plugins/woocommerce/changelog/fix-activate-plugin
+++ b/plugins/woocommerce/changelog/fix-activate-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix error in onboarding wizard when plugin is activated but includes unexpected output.

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -332,7 +332,7 @@ class PluginsHelper {
 			}
 
 			$result = activate_plugin( $path );
-			if ( ! is_null( $result ) ) {
+			if ( ! is_plugin_active( $path ) ) {
 				/**
 				 * Action triggered when a plugin activation fails.
 				 *

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php
@@ -137,4 +137,34 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 		$actual_data = PluginsHelper::get_plugin_data( 'my-plugin' );
 		$this->assertEquals( false, $actual_data, 'Should return false if plugin is not found.' );
 	}
+
+	public function test_activate_akismet() {
+		// Prepare Akismet plugin in the "installed" state.
+		deactivate_plugins( 'akismet/akismet.php' );
+		$this->assertTrue( PluginsHelper::is_plugin_installed( 'akismet' ) );
+
+		// Activate the plugin.
+		$test = PluginsHelper::activate_plugins( [ 'akismet' ] );
+
+		// Assert plugin activated.
+		$this->assertSame( 'akismet', $test['activated'][0] );
+
+		// Assert no errors return.
+		$this->assertFalse( $test['errors']->has_errors() );
+
+		// Clean up
+		deactivate_plugins( 'akismet/akismet.php' );
+	}
+
+	public function test_activate_plugins_with_error() {
+		// Try to activate a plugin that has not been installed.
+		$this->assertFalse( PluginsHelper::is_plugin_installed( 'foo-bar' ) );
+		$test = PluginsHelper::activate_plugins( [ 'foo-bar' ] );
+
+		// Assert plugin is NOT activated.
+		$this->assertFalse( PluginsHelper::is_plugin_active( 'foo-bar' ) );
+
+		// Assert that errors return.
+		$this->assertTrue( $test['errors']->has_errors() );
+	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/plugins-helper.php
@@ -138,13 +138,16 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 		$this->assertEquals( false, $actual_data, 'Should return false if plugin is not found.' );
 	}
 
+	/**
+	 * Test activate_plugins() by using Akismet.
+	 */
 	public function test_activate_akismet() {
 		// Prepare Akismet plugin in the "installed" state.
 		deactivate_plugins( 'akismet/akismet.php' );
 		$this->assertTrue( PluginsHelper::is_plugin_installed( 'akismet' ) );
 
 		// Activate the plugin.
-		$test = PluginsHelper::activate_plugins( [ 'akismet' ] );
+		$test = PluginsHelper::activate_plugins( array( 'akismet' ) );
 
 		// Assert plugin activated.
 		$this->assertSame( 'akismet', $test['activated'][0] );
@@ -152,14 +155,17 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 		// Assert no errors return.
 		$this->assertFalse( $test['errors']->has_errors() );
 
-		// Clean up
+		// Clean up.
 		deactivate_plugins( 'akismet/akismet.php' );
 	}
 
+	/**
+	 * Test error handling in activate_plugins().
+	 */
 	public function test_activate_plugins_with_error() {
 		// Try to activate a plugin that has not been installed.
 		$this->assertFalse( PluginsHelper::is_plugin_installed( 'foo-bar' ) );
-		$test = PluginsHelper::activate_plugins( [ 'foo-bar' ] );
+		$test = PluginsHelper::activate_plugins( array( 'foo-bar' ) );
 
 		// Assert plugin is NOT activated.
 		$this->assertFalse( PluginsHelper::is_plugin_active( 'foo-bar' ) );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35836.

In WordPress 6.1, when a plugin is activated and generates unexpected output, the `activate_plugins` function returns a `WP_Error`, no matter whether the plugin actually activated successfully.

This triggers a bug in the `PluginsHelper` class, as it had an expectation that a returned `WP_Error` means the plugin did not activate at all. To address this, a check is made on the plugin state directly using the native WordPress `is_plugin_active` function.

New tests have been added for `activate_plugins`. Unfortunately, the unexpected output error can't be tested for because [output buffering is always Off in PHP-CLI](https://www.php.net/manual/en/outcontrol.configuration.php).

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

On a new install of WooCommerce, under WordPress 6.1

1. Start the onboarding wizard
2. Proceed to the Business Details (Free Features) section
3. Install Jetpack and TikTok plugins. Note: at time of writing the latest TikTok version (1.0.12) generates unexpected output.
4. Continue and complete the onboarding wizard.
5. Navigate to the WordPress plugins screen.
6. See that Jetpack and TikTok plugins are installed and activated.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
