### PR TITLE
Product import: Remove line breaks in keys

### DIFF
--- a/plugins/woocommerce/changelog/fix-csv-import-header-handling
+++ b/plugins/woocommerce/changelog/fix-csv-import-header-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When importing product CSV, ensure line breaks within header columns do not break the import process.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -79,6 +79,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		if ( false !== $handle ) {
 			$this->raw_keys = version_compare( PHP_VERSION, '5.3', '>=' ) ? array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ) ) : array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'] ) ); // @codingStandardsIgnoreLine
 
+			// Remove line breaks in keys, to avoid mismatch mapping of keys
+			$this->raw_keys = wc_clean( wp_unslash( $this->raw_keys ) );
+			
 			// Remove BOM signature from the first item.
 			if ( isset( $this->raw_keys[0] ) ) {
 				$this->raw_keys[0] = $this->remove_utf8_bom( $this->raw_keys[0] );

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -79,7 +79,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		if ( false !== $handle ) {
 			$this->raw_keys = version_compare( PHP_VERSION, '5.3', '>=' ) ? array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'], $this->params['escape'] ) ) : array_map( 'trim', fgetcsv( $handle, 0, $this->params['delimiter'], $this->params['enclosure'] ) ); // @codingStandardsIgnoreLine
 
-			// Remove line breaks in keys, to avoid mismatch mapping of keys
+			// Remove line breaks in keys, to avoid mismatch mapping of keys.
 			$this->raw_keys = wc_clean( wp_unslash( $this->raw_keys ) );
 
 			// Remove BOM signature from the first item.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -81,7 +81,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 			// Remove line breaks in keys, to avoid mismatch mapping of keys
 			$this->raw_keys = wc_clean( wp_unslash( $this->raw_keys ) );
-			
+
 			// Remove BOM signature from the first item.
 			if ( isset( $this->raw_keys[0] ) ) {
 				$this->raw_keys[0] = $this->remove_utf8_bom( $this->raw_keys[0] );


### PR DESCRIPTION
Hello

I had problems with product import.
After some time, I managed to identify that CSV keys with line breaks cause the import to skip the column, while the mapping looks like it should have worked.
The PR remove line breaks in the keys of the CSV imported file, to avoid mismatch mapping of keys.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes product import when the CSV imported file has a line break in a key name.
If a key has a line break, mapping fields will look OK, but the import will simply skip the values of this key.

Example of a CSV file with line break below:
```csv
ID,Published,"Regular 
price"
3011,1,168
```

With a line break, the mapping looks like it will work (image below):
![image](https://user-images.githubusercontent.com/108828/206227666-1d0aff2d-8276-4b46-a4e5-c087c0aa2669.png)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The PR removes line breaks in all the CSV keys.
`Regular\nprice` becomes `Regular price`.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Export the products using WC core tool
2. In the CSV file, add a line break inside the key `Regular price`
3. Change the price of some products
4. Keep the columns: ID, Published, Regular price, and remove the others
5. Use the product import tool and map the 3 fields
6. After it is done, the price should be be updated thanks to the PR. Without the PR, prices won't be updated

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
