### PR TITLE
Add product variations list to new product management experience

### DIFF
--- a/packages/js/data/changelog/add-35772
+++ b/packages/js/data/changelog/add-35772
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update attributes type for product variations data store

--- a/packages/js/data/src/product-variations/types.ts
+++ b/packages/js/data/src/product-variations/types.ts
@@ -9,7 +9,18 @@ import { DispatchFromMap } from '@automattic/data-stores';
 import { CrudActions, CrudSelectors } from '../crud/types';
 import { Product, ProductQuery, ReadOnlyProperties } from '../products/types';
 
-export type ProductVariation = Omit< Product, 'name' | 'slug' >;
+export type ProductVariationAttribute = {
+	id: number;
+	name: string;
+	option: string;
+};
+
+export type ProductVariation = Omit<
+	Product,
+	'name' | 'slug' | 'attributes'
+> & {
+	attributes: ProductVariationAttribute[];
+};
 
 type Query = Omit< ProductQuery, 'name' >;
 

--- a/plugins/woocommerce-admin/client/products/fields/variations/index.ts
+++ b/plugins/woocommerce-admin/client/products/fields/variations/index.ts
@@ -1,0 +1,1 @@
+export * from './variations';

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -1,39 +1,39 @@
 .woocommerce-product-variations {
-    min-height: 300px;
+	min-height: 300px;
 
-    &__header {
-        display: grid;
-        grid-template-columns: calc(38px + 25%) 25% 25%;
-        padding: $gap-small $gap;
+	&__header {
+		display: grid;
+		grid-template-columns: calc(38px + 25%) 25% 25%;
+		padding: $gap-small $gap;
 
-        h4 {
-            color: $gray-700;
-            font-size: 11px;
-            text-transform: uppercase;
-            margin: 0;
-            font-weight: 500;
-        }
-    }
+		h4 {
+			color: $gray-700;
+			font-size: 11px;
+			text-transform: uppercase;
+			margin: 0;
+			font-weight: 500;
+		}
+	}
 
-    .woocommerce-list-item {
-        display: grid;
-        grid-template-columns: 38px 25% 25% 25%;
-        margin-left: -1px;
-        margin-right: -1px;
-        margin-bottom: -1px;
-    }
+	.woocommerce-list-item {
+		display: grid;
+		grid-template-columns: 38px 25% 25% 25%;
+		margin-left: -1px;
+		margin-right: -1px;
+		margin-bottom: -1px;
+	}
 
-    .woocommerce-sortable {
-        margin: 0;
-    }
+	.woocommerce-sortable {
+		margin: 0;
+	}
 
-    .components-spinner {
-        width: 34px;
-        height: 34px;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        position: absolute;
-        margin: 0;
-    }
+	.components-spinner {
+		width: 34px;
+		height: 34px;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		position: absolute;
+		margin: 0;
+	}
 }

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -1,4 +1,6 @@
 .woocommerce-product-variations {
+    min-height: 300px;
+
     &__header {
         display: grid;
         grid-template-columns: calc(38px + 25%) 25% 25%;
@@ -22,6 +24,16 @@
     }
 
     .woocommerce-sortable {
+        margin: 0;
+    }
+
+    .components-spinner {
+        width: 34px;
+        height: 34px;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        position: absolute;
         margin: 0;
     }
 }

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -1,0 +1,28 @@
+.woocommerce-product-variations {
+
+    &__header {
+        display: grid;
+        grid-template-columns: 38px 25% 25% 25%;
+        padding: $gap-small $gap;
+
+        h4 {
+            color: $gray-700;
+            font-size: 11px;
+            text-transform: uppercase;
+            margin: 0;
+            font-weight: 500;
+        }
+    }
+
+    .woocommerce-list-item {
+        display: grid;
+        grid-template-columns: 38px 25% 25% 25%;
+        margin-left: -1px;
+        margin-right: -1px;
+        margin-bottom: -1px;
+    }
+
+    .woocommerce-sortable {
+        margin: 0;
+    }
+}

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -1,8 +1,7 @@
 .woocommerce-product-variations {
-
     &__header {
         display: grid;
-        grid-template-columns: 38px 25% 25% 25%;
+        grid-template-columns: calc(38px + 25%) 25% 25%;
         padding: $gap-small $gap;
 
         h4 {

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	ProductVariation,
+} from '@woocommerce/data';
+import { ListItem, Sortable, Tag } from '@woocommerce/components';
+import { useContext } from '@wordpress/element';
+import { useParams } from 'react-router-dom';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { CurrencyContext } from '../../../lib/currency-context';
+import './variations.scss';
+
+export const Variations: React.FC = () => {
+	const { productId } = useParams();
+	const context = useContext( CurrencyContext );
+	const { formatAmount } = context;
+	const { variations } = useSelect( ( select ) => {
+		const { getProductVariations } = select(
+			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+		);
+		return {
+			variations: getProductVariations< ProductVariation[] >( {
+				product_id: productId,
+			} ),
+		};
+	} );
+
+	if ( ! variations ) {
+		return null;
+	}
+
+	return (
+		<div className="woocommerce-product-variations">
+			<div className="woocommerce-product-variations__header">
+				<span />
+				<h4>{ __( 'Variation', 'woocommerce' ) }</h4>
+				<h4>{ __( 'Price', 'woocommerce' ) }</h4>
+				<h4>{ __( 'Quantity', 'woocommerce' ) }</h4>
+			</div>
+			<Sortable>
+				{ variations.map( ( variation ) => (
+					<ListItem key={ variation.id }>
+						<div className="woocommerce-product-variations__attributes">
+							{ variation.attributes.map( ( attribute ) => (
+								/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+								/* @ts-ignore Additional props are not required. */
+								<Tag
+									id={ attribute.id }
+									className="woocommerce-product-variations__attribute"
+									key={ attribute.id }
+									label={ attribute.option }
+								/>
+							) ) }
+						</div>
+						<div className="woocommerce-product-variations__price">
+							{ formatAmount( variation.price ) }
+						</div>
+						<div className="woocommerce-product-variations__quantity">
+							{ variation.stock_quantity }
+						</div>
+					</ListItem>
+				) ) }
+			</Sortable>
+		</div>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { Card, Spinner } from '@wordpress/components';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	ProductVariation,
@@ -22,24 +23,34 @@ export const Variations: React.FC = () => {
 	const { productId } = useParams();
 	const context = useContext( CurrencyContext );
 	const { formatAmount, getCurrencyConfig } = context;
-	const currencyConfig = getCurrencyConfig();
-	const { variations } = useSelect( ( select ) => {
-		const { getProductVariations } = select(
+	const { isLoading, variations } = useSelect( ( select ) => {
+		const { getProductVariations, hasFinishedResolution } = select(
 			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 		);
 		return {
+			isLoading: ! hasFinishedResolution( 'getProductVariations', [
+				{
+					product_id: productId,
+				},
+			] ),
 			variations: getProductVariations< ProductVariation[] >( {
 				product_id: productId,
 			} ),
 		};
 	} );
 
-	if ( ! variations ) {
-		return null;
+	if ( ! variations || isLoading ) {
+		return (
+			<Card className="woocommerce-product-variations is-loading">
+				<Spinner />
+			</Card>
+		);
 	}
 
+	const currencyConfig = getCurrencyConfig();
+
 	return (
-		<div className="woocommerce-product-variations">
+		<Card className="woocommerce-product-variations">
 			<div className="woocommerce-product-variations__header">
 				<h4>{ __( 'Variation', 'woocommerce' ) }</h4>
 				<h4>
@@ -75,6 +86,6 @@ export const Variations: React.FC = () => {
 					</ListItem>
 				) ) }
 			</Sortable>
-		</div>
+		</Card>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -41,7 +41,6 @@ export const Variations: React.FC = () => {
 	return (
 		<div className="woocommerce-product-variations">
 			<div className="woocommerce-product-variations__header">
-				<span />
 				<h4>{ __( 'Variation', 'woocommerce' ) }</h4>
 				<h4>
 					{ sprintf(

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -15,6 +15,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { CurrencyContext } from '../../../lib/currency-context';
+import { getProductStockStatus } from '../../utils/get-product-stock-status';
 import './variations.scss';
 
 export const Variations: React.FC = () => {
@@ -63,7 +64,7 @@ export const Variations: React.FC = () => {
 							{ formatAmount( variation.price ) }
 						</div>
 						<div className="woocommerce-product-variations__quantity">
-							{ variation.stock_quantity }
+							{ getProductStockStatus( variation ) }
 						</div>
 					</ListItem>
 				) ) }

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	ProductVariation,
@@ -21,7 +21,8 @@ import './variations.scss';
 export const Variations: React.FC = () => {
 	const { productId } = useParams();
 	const context = useContext( CurrencyContext );
-	const { formatAmount } = context;
+	const { formatAmount, getCurrencyConfig } = context;
+	const currencyConfig = getCurrencyConfig();
 	const { variations } = useSelect( ( select ) => {
 		const { getProductVariations } = select(
 			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
@@ -42,7 +43,13 @@ export const Variations: React.FC = () => {
 			<div className="woocommerce-product-variations__header">
 				<span />
 				<h4>{ __( 'Variation', 'woocommerce' ) }</h4>
-				<h4>{ __( 'Price', 'woocommerce' ) }</h4>
+				<h4>
+					{ sprintf(
+						/** Translators: The 3 letter currency code for the store. */
+						__( 'Price (%s)', 'woocommerce' ),
+						currencyConfig.code
+					) }
+				</h4>
 				<h4>{ __( 'Quantity', 'woocommerce' ) }</h4>
 			</div>
 			<Sortable>

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -14,6 +14,7 @@ import { ProductDetailsSection } from './sections/product-details-section';
 import { ProductInventorySection } from './sections/product-inventory-section';
 import { PricingSection } from './sections/pricing-section';
 import { ProductShippingSection } from './sections/product-shipping-section';
+import { ProductVariationsSection } from './sections/product-variations-section';
 import { ImagesSection } from './sections/images-section';
 import './product-page.scss';
 import { validate } from './product-validation';
@@ -55,6 +56,9 @@ export const ProductForm: React.FC< {
 				</ProductFormTab>
 				<ProductFormTab name="shipping" title="Shipping">
 					<ProductShippingSection product={ product } />
+				</ProductFormTab>
+				<ProductFormTab name="options" title="Options">
+					<ProductVariationsSection />
 				</ProductFormTab>
 			</ProductFormLayout>
 			<ProductFormFooter />

--- a/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
@@ -10,6 +10,7 @@ import { Link } from '@woocommerce/components';
  * Internal dependencies
  */
 import { ProductSectionLayout } from '../layout/product-section-layout';
+import { Variations } from '../fields/variations';
 
 export const ProductVariationsSection: React.FC = () => {
 	return (
@@ -40,7 +41,9 @@ export const ProductVariationsSection: React.FC = () => {
 				</>
 			}
 		>
-			<Card></Card>
+			<Card>
+				<Variations />
+			</Card>
 		</ProductSectionLayout>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Card } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { Link } from '@woocommerce/components';
 
@@ -41,9 +40,7 @@ export const ProductVariationsSection: React.FC = () => {
 				</>
 			}
 		>
-			<Card>
-				<Variations />
-			</Card>
+			<Variations />
 		</ProductSectionLayout>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-variations-section.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Card } from '@wordpress/components';
+import { recordEvent } from '@woocommerce/tracks';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { ProductSectionLayout } from '../layout/product-section-layout';
+
+export const ProductVariationsSection: React.FC = () => {
+	return (
+		<ProductSectionLayout
+			title={ __( 'Variations', 'woocommerce' ) }
+			description={
+				<>
+					<span>
+						{ __(
+							'Manage individual product combinations created from options.',
+							'woocommerce'
+						) }
+					</span>
+					<Link
+						className="woocommerce-form-section__header-link"
+						href="https://woocommerce.com/posts/product-variations-display/"
+						target="_blank"
+						type="external"
+						onClick={ () => {
+							recordEvent( 'add_product_variation_help' );
+						} }
+					>
+						{ __(
+							'How to make variations work for you',
+							'woocommerce'
+						) }
+					</Link>
+				</>
+			}
+		>
+			<Card></Card>
+		</ProductSectionLayout>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/utils/get-product-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-status.ts
@@ -28,7 +28,7 @@ export const PRODUCT_STATUS_LABELS = {
  * Get the product status for use in the header.
  *
  * @param  product Product instance.
- * @return {PRODUCT_STATUS_KEYS} Product staus key.
+ * @return {PRODUCT_STATUS_KEYS} Product status key.
  */
 export const getProductStatus = (
 	product: PartialProduct | undefined

--- a/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
@@ -32,7 +32,7 @@ export const PRODUCT_STOCK_STATUS_LABELS = {
  * Get the product stock quantity or stock status label.
  *
  * @param  product Product instance.
- * @return {PRODUCT_STOCK_STATUS_KEYS} Product staus key.
+ * @return {PRODUCT_STOCK_STATUS_KEYS} Product status key.
  */
 export const getProductStockStatus = (
 	product: PartialProduct | Partial< ProductVariation >

--- a/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
@@ -32,7 +32,7 @@ export const PRODUCT_STOCK_STATUS_LABELS = {
  * Get the product stock quantity or stock status label.
  *
  * @param  product Product instance.
- * @return {PRODUCT_STOCK_STATUS_KEYS} Product status key.
+ * @return {PRODUCT_STOCK_STATUS_KEYS|number} Product stock quantity or product status key.
  */
 export const getProductStockStatus = (
 	product: PartialProduct | Partial< ProductVariation >

--- a/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PartialProduct } from '@woocommerce/data';
+import { PartialProduct, ProductVariation } from '@woocommerce/data';
 
 /**
  * Labels for product stock statuses.
@@ -35,7 +35,7 @@ export const PRODUCT_STOCK_STATUS_LABELS = {
  * @return {PRODUCT_STOCK_STATUS_KEYS} Product staus key.
  */
 export const getProductStockStatus = (
-	product: PartialProduct
+	product: PartialProduct | Partial< ProductVariation >
 ): string | number => {
 	if ( product.manage_stock ) {
 		return product.stock_quantity || 0;

--- a/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PartialProduct } from '@woocommerce/data';
+
+/**
+ * Labels for product stock statuses.
+ */
+export enum PRODUCT_STOCK_STATUS_KEYS {
+	instock = 'instock',
+	onbackorder = 'onbackorder',
+	outofstock = 'outofstock',
+}
+
+/**
+ * Labels for product stock statuses.
+ */
+export const PRODUCT_STOCK_STATUS_LABELS = {
+	[ PRODUCT_STOCK_STATUS_KEYS.instock ]: __( 'In stock', 'woocommerce' ),
+	[ PRODUCT_STOCK_STATUS_KEYS.onbackorder ]: __(
+		'On backorder',
+		'woocommerce'
+	),
+	[ PRODUCT_STOCK_STATUS_KEYS.outofstock ]: __(
+		'Out of stock',
+		'woocommerce'
+	),
+};
+
+/**
+ * Get the product stock quantity or stock status label.
+ *
+ * @param  product Product instance.
+ * @return {PRODUCT_STOCK_STATUS_KEYS} Product staus key.
+ */
+export const getProductStockStatus = (
+	product: PartialProduct
+): string | number => {
+	if ( product.manage_stock ) {
+		return product.stock_quantity || 0;
+	}
+
+	if ( product.stock_status ) {
+		return PRODUCT_STOCK_STATUS_LABELS[ product.stock_status ];
+	}
+
+	return PRODUCT_STOCK_STATUS_LABELS.instock;
+};

--- a/plugins/woocommerce/changelog/add-35772
+++ b/plugins/woocommerce/changelog/add-35772
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product variations list to new product management experience


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the variations list to the new product experience.

Note that this PR does not address persistence of ordering for variations or any other updates.  Those will be handled in a follow-up.

<img width="776" alt="Screen Shot 2022-12-07 at 11 50 36 AM" src="https://user-images.githubusercontent.com/10561050/206282104-30d27fb2-c4be-4e61-a8ee-ee3c197e2f6d.png">

Closes #35772 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Add a product with variations using the old product experience
2. Navigate to that product in the new experience.  E.g., `wp-admin/admin.php?page=wc-admin&path=/product/{product_id}`
3. Click on "Options"
4. Note that the variations section exists with the correct text and a working link
5. Note that variations show a spinner until variations are loaded
6. Note that variations appear with their attributes, price, and stock status listed

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
