### PR TITLE
Add WC active validation

### DIFF
--- a/packages/js/create-extension/$slug.php.mustache
+++ b/packages/js/create-extension/$slug.php.mustache
@@ -4,7 +4,7 @@
 {{#description}}
  * Description: {{description}}
 {{/description}}
-  * Version: {{version}}
+ * Version: {{version}}
 {{#author}}
  * Author: {{author}}
 {{/author}}
@@ -28,57 +28,102 @@ require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
 
 use {{slugPascalCase}}\Admin\Setup;
 
+// phpcs:disable WordPress.Files.FileName
+
 /**
- * {{slugPascalCase}} class.
+ * WooCommerce fallback notice.
+ *
+ * @since {{version}}
  */
-class {{slugPascalCase}} {
-	/**
-	 * This class instance.
-	 *
-	 * @var \{{slugPascalCase}} single instance of this class.
-	 */
-	private static $instance;
+function {{slugSnakeCase}}_missing_wc_notice() {
+	/* translators: %s WC download URL link. */
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__( '{{title}} requires WooCommerce to be installed and active. You can download %s here.', '{{slugSnakeCase}}' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
+}
 
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'init' ) );
-	}
+register_activation_hook( __FILE__, '{{slugSnakeCase}}_activate' );
 
-	/**
-	 * Init the plugin once WP is loaded.
-	 */
-	public function init() {
-		// If WooCommerce does not exist, deactivate plugin.
-		if ( ! class_exists( 'WooCommerce' ) ) {
-			deactivate_plugins( plugin_basename( __FILE__ ) );
-		}
-
-		if ( is_admin() ) {
-			// Load plugin translations.
-			$plugin_rel_path = basename( dirname( __FILE__ ) ) . '/languages'; /* Relative to WP_PLUGIN_DIR */
-			load_plugin_textdomain( '{{slug}}', false, $plugin_rel_path );
-
-			new Setup();
-		}
-	}
-
-	/**
-	 * Gets the main instance.
-	 *
-	 * Ensures only one instance can be loaded.
-	 *
-	 * @return \{{slugPascalCase}}
-	 */
-	public static function instance() {
-
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-
-		return self::$instance;
+/**
+ * Activation hook.
+ *
+ * @since {{version}}
+ */
+function {{slugSnakeCase}}_activate() {
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		add_action( 'admin_notices', '{{slugSnakeCase}}_missing_wc_notice' );
+		return;
 	}
 }
 
-{{slugPascalCase}}::instance();
+if ( ! class_exists( '{{slugSnakeCase}}' ) ) :
+	/**
+	 * The {{slugSnakeCase}} class.
+	 */
+	class {{slugSnakeCase}} {
+		/**
+		 * This class instance.
+		 *
+		 * @var \{{slugSnakeCase}} single instance of this class.
+		 */
+		private static $instance;
+
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			if ( is_admin() ) {
+				new Setup();
+			}
+		}
+
+		/**
+		 * Cloning is forbidden.
+		 *
+		 */
+		public function __clone() {
+			wc_doing_it_wrong( __FUNCTION__, __( 'Cloning is forbidden.', '{{slugSnakeCase}}' ), $this->version );
+		}
+
+		/**
+		 * Unserializing instances of this class is forbidden.
+		 *
+		 */
+		public function __wakeup() {
+			wc_doing_it_wrong( __FUNCTION__, __( 'Unserializing instances of this class is forbidden.', '{{slugSnakeCase}}' ), $this->version );
+		}
+
+		/**
+		 * Gets the main instance.
+		 *
+		 * Ensures only one instance can be loaded.
+		 *
+		 * @return \{{slugSnakeCase}}
+		 */
+		public static function instance() {
+
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+	}
+endif;
+
+add_action( 'plugins_loaded', '{{slugSnakeCase}}_init', 10 );
+
+/**
+ * Initialize the plugin.
+ *
+ * @since {{version}}
+ */
+function {{slugSnakeCase}}_init() {
+	load_plugin_textdomain( '{{slugSnakeCase}}', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
+
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		add_action( 'admin_notices', '{{slugSnakeCase}}_missing_wc_notice' );
+		return;
+	}
+
+	{{slugSnakeCase}}::instance();
+
+}

--- a/packages/js/create-extension/changelog/add-wc-validation
+++ b/packages/js/create-extension/changelog/add-wc-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add WC validation


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/platform-private/issues/125

This PR adds validation to make sure WC is active before trying to run the extension.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Pull down this branch locally
2. `cd` to a new directory and run the scaffold command
```
npx @wordpress/create-block -t ../path/to/woocommerce/packages/js/create-extension my-extension-name
```
3. Install and build your new extension
```
cd my-extension-name
npm install
composer install
npm run build
``` 
4. `wp-env start` and navigate to plugins page.
5. Deactivate WooCommerce plugin and you should see a notice at the top stating WooCommerce needs to be active.
6. Now deactivate your extension plugin and activate it again, you should also see a notice at the top stating WooCommerce needs to be active.

Note: I didn't opt to deactivate the extension plugin as it doesn't really matter at this point as it won't run anything.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
