### PR TITLE
Add a set_output function to script that uses the new GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/scripts/release-code-freeze.php
+++ b/.github/workflows/scripts/release-code-freeze.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Script to automatically enforce the release code freeze.
  *
@@ -10,6 +11,16 @@ require_once __DIR__ . '/post-request-shared.php';
 $now = time();
 if ( getenv( 'TIME_OVERRIDE' ) ) {
 	$now = strtotime( getenv( 'TIME_OVERRIDE' ) );
+}
+
+/**
+ * Set an output for the GitHub action.
+ *
+ * @param string $name The name of the output.
+ * @param string $value The value of the output.
+ */
+function set_output( $name, $value ) {
+	file_put_contents( getenv( 'GITHUB_OUTPUT' ), "{$name}={$value}" . PHP_EOL, FILE_APPEND );
 }
 
 // Code freeze comes 26 days prior to release day.
@@ -41,10 +52,11 @@ $milestone_to_create      = "{$milestone_major_minor}.0";
 
 if ( getenv( 'GITHUB_OUTPUTS' ) ) {
 	echo 'Including GitHub Outputs...' . PHP_EOL;
-	echo '::set-output name=next_version::' . $milestone_major_minor . PHP_EOL;
-	echo '::set-output name=release_version::' . $branch_major_minor . PHP_EOL;
-	echo '::set-output name=branch::' . $release_branch_to_create . PHP_EOL;
-	echo '::set-output name=milestone::' . $milestone_to_create . PHP_EOL;
+	
+	set_output( 'next_version', $milestone_major_minor );
+	set_output( 'release_version', $branch_major_minor );
+	set_output( 'branch', $release_branch_to_create );
+	set_output( 'milestone', $milestone_to_create );
 }
 
 if ( getenv( 'DRY_RUN' ) ) {
@@ -56,7 +68,7 @@ if ( getenv( 'DRY_RUN' ) ) {
 
 if ( create_github_milestone( $milestone_to_create ) ) {
 	echo "Created milestone {$milestone_to_create}" . PHP_EOL;
-} else if ( '422' === $github_api_response_code ) {
+} elseif ( '422' === $github_api_response_code ) {
 	// The milestone already existed when GitHub returns a 422 status.
 	echo "Notice: Unable to create {$milestone_to_create} milestone. Maybe it already exists? Skipping..." . PHP_EOL;
 } else {
@@ -65,7 +77,7 @@ if ( create_github_milestone( $milestone_to_create ) ) {
 
 if ( create_github_branch_from_branch( 'trunk', $release_branch_to_create ) ) {
 	echo "Created branch {$release_branch_to_create}" . PHP_EOL;
-} else if ( '422' === $github_api_response_code ) {
+} elseif ( '422' === $github_api_response_code ) {
 	// The release branch already existed when GitHub returns a 422 status.
 	echo "Notice: Unable to create {$release_branch_to_create} branch. Maybe it already exists? Skipping..." . PHP_EOL;
 	exit( 1 );


### PR DESCRIPTION

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since `set-output` is deprecated in Github Actions, we are migrating usages of `set-output` to write to the new `GITHUB_OUTPUT` file. I've broken the work up into several PRs to make the testing/review easier and to try limit risk.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Follow the release code freeze test instructions from https://github.com/woocommerce/woocommerce/pull/35799

<!-- End testing instructions -->

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
