### PR TITLE
Speed up search query by using GROUP BY instead of DISTINCT for HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-35831
+++ b/plugins/woocommerce/changelog/fix-35831
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Speed up HPOS search query by using group by instead of distinct.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -365,6 +365,8 @@ class ListTable extends WP_List_Table {
 		$direction = strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ?? '' ) ) );
 
 		if ( ! in_array( $field, $sortable, true ) ) {
+			$this->order_query_args['orderby'] = 'id';
+			$this->order_query_args['order']   = 'DESC';
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -911,8 +911,6 @@ WHERE
 		return array_map( 'intval', (array) apply_filters( 'woocommerce_cot_shop_order_search_results', $order_ids, $term ) );
 	}
 
-	//phpcs:enable Squiz.Commenting, Generic.Commenting
-
 	/**
 	 * Fetch order type for orders in bulk.
 	 *
@@ -1736,9 +1734,6 @@ FROM $order_meta_table
 		);
 	}
 
-
-	//phpcs:disable Squiz.Commenting, Generic.Commenting
-
 	/**
 	 * Method to delete an order from the database.
 	 *
@@ -1799,7 +1794,8 @@ FROM $order_meta_table
 	/**
 	 * Trashes an order.
 	 *
-	 * @param WC_Order $order The order object
+	 * @param  WC_Order $order The order object.
+	 *
 	 * @return void
 	 */
 	public function trash_order( $order ) {
@@ -1919,9 +1915,9 @@ FROM $order_meta_table
 
 			$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
 			if ( $data_synchronizer->data_sync_is_enabled() ) {
-				//The previous $order->save() will have forced a sync to the posts table,
-				//this implies that the post status is not "trash" anymore, and thus
-				//wp_untrash_post would do nothing.
+				// The previous $order->save() will have forced a sync to the posts table,
+				// this implies that the post status is not "trash" anymore, and thus
+				// wp_untrash_post would do nothing.
 				wp_update_post(
 					array(
 						'ID'          => $id,
@@ -1998,6 +1994,8 @@ FROM $order_meta_table
 	 * This should not contain and specific meta or actions, so that it can be used other order types safely.
 	 *
 	 * @param \WC_Order $order Order object.
+	 * @param bool      $force_all_fields Force update all fields, instead of calculating and updating only changed fields.
+	 * @param bool      $backfill Whether to backfill data to post datastore.
 	 *
 	 * @return void
 	 *
@@ -2027,7 +2025,7 @@ FROM $order_meta_table
 	/**
 	 * Method to update an order in the database.
 	 *
-	 * @param \WC_Order $order
+	 * @param \WC_Order $order Order object.
 	 */
 	public function update( &$order ) {
 		// Before updating, ensure date paid is set if missing.
@@ -2083,6 +2081,7 @@ FROM $order_meta_table
 	 * This is expected to be reused by other order types, and should not contain any specific metadata updates or actions.
 	 *
 	 * @param \WC_Order $order Order object.
+	 * @param bool      $backfill Whether to backfill data to post tables.
 	 *
 	 * @return array $changes Array of changes.
 	 *
@@ -2135,7 +2134,8 @@ FROM $order_meta_table
 
 	/**
 	 * Helper function to update billing and shipping address metadata.
-	 * @param \WC_Abstract_Order $order Order Object
+	 *
+	 * @param \WC_Abstract_Order $order Order Object.
 	 * @param array              $changes Array of changes.
 	 *
 	 * @return void
@@ -2234,6 +2234,13 @@ FROM $order_meta_table
 
 	}
 
+	/**
+	 * Performs actual query to get orders. Uses `OrdersTableQuery` to build and generate the query.
+	 *
+	 * @param array $query_vars Query variables.
+	 *
+	 * @return array|object List of orders and count of orders.
+	 */
 	public function query( $query_vars ) {
 		if ( ! isset( $query_vars['paginate'] ) || ! $query_vars['paginate'] ) {
 			$query_vars['no_found_rows'] = true;
@@ -2280,10 +2287,6 @@ FROM $order_meta_table
 		}
 
 		return $orders;
-	}
-
-	public function get_order_item_type( $order, $order_item_id ) {
-		return 'line_item';
 	}
 
 	//phpcs:enable Squiz.Commenting, Generic.Commenting

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -572,9 +572,6 @@ class OrdersTableQuery {
 			$this->join  = $sql['join'] ? array_merge( $this->join, $sql['join'] ) : $this->join;
 			$this->where = $sql['where'] ? array_merge( $this->where, array( $sql['where'] ) ) : $this->where;
 
-			if ( $sql['join'] ) {
-				$this->groupby[] = "{$this->tables['orders']}.id";
-			}
 		}
 
 		// Date queries.
@@ -588,12 +585,10 @@ class OrdersTableQuery {
 
 		$orders_table = $this->tables['orders'];
 
-		// SELECT [fields].
-		$this->fields = "{$orders_table}.id";
-		$fields       = $this->fields;
-
-		// SQL_CALC_FOUND_ROWS.
-		$found_rows = '';
+		// Group by is a faster substitute for DISTINCT, as long as we are only selecting IDs. MySQL don't like it when we join tables and use DISTINCT.
+		$this->groupby[] = "{$this->tables['orders']}.id";
+		$this->fields    = "{$orders_table}.id";
+		$fields          = $this->fields;
 
 		// JOIN.
 		$join = implode( ' ', array_unique( array_filter( array_map( 'trim', $this->join ) ) ) );
@@ -619,7 +614,7 @@ class OrdersTableQuery {
 		// GROUP BY.
 		$groupby = $this->groupby ? 'GROUP BY ' . implode( ', ', (array) $this->groupby ) : '';
 
-		$this->sql = "SELECT $found_rows DISTINCT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
+		$this->sql = "SELECT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
 		$this->build_count_query( $fields, $join, $where, $groupby );
 	}
 
@@ -636,7 +631,7 @@ class OrdersTableQuery {
 			wc_doing_it_wrong( __FUNCTION__, 'Count query can only be build after main query is built.', '7.3.0' );
 		}
 		$orders_table    = $this->tables['orders'];
-		$this->count_sql = "SELECT COUNT(DISTINCT $fields) FROM  $orders_table $join WHERE $where $groupby";
+		$this->count_sql = "SELECT COUNT(DISTINCT $fields) FROM  $orders_table $join WHERE $where";
 	}
 
 	/**
@@ -1034,7 +1029,10 @@ class OrdersTableQuery {
 		}
 
 		if ( $this->limits ) {
-			$this->found_orders  = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			if ( ! isset( $this->found_orders ) ) {
+				$this->found_orders = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			}
+
 			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
 		} else {
 			$this->found_orders = count( $this->orders );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1029,7 +1029,7 @@ class OrdersTableQuery {
 		}
 
 		if ( $this->limits ) {
-			$this->found_orders = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$this->found_orders  = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
 		} else {
 			$this->found_orders = count( $this->orders );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -1029,10 +1029,7 @@ class OrdersTableQuery {
 		}
 
 		if ( $this->limits ) {
-			if ( ! isset( $this->found_orders ) ) {
-				$this->found_orders = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			}
-
+			$this->found_orders = absint( $wpdb->get_var( $this->count_sql ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
 		} else {
 			$this->found_orders = count( $this->orders );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves the search query performance by using GROUP BY instead of DISTINCT so that mysql can use the order_id index. From my tests on a site with 8M orders, this brings up the performance of worst-case query from 32s to 9s.

On  the performance testing site:

Before:
<img width="1242" alt="Screenshot 2022-12-30 at 3 37 09 PM" src="https://user-images.githubusercontent.com/7571618/210058698-9bd27fe6-9b55-42d3-8c89-1f60e7fe6ecf.png">


After:
<img width="1223" alt="Screenshot 2022-12-30 at 3 36 20 PM" src="https://user-images.githubusercontent.com/7571618/210058599-2047b4e5-2ee7-4dd6-9c7a-bce0d6b195bd.png">

Closes #35831 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create an order, with a particular term in any of the billing/shipping fields. Add a product to the order.
2. Search for the order by address term, it should show up.
4. Search again by product name, it should show up.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
