### PR TITLE
Add a default placeholder title for newly added attributes and always show remove button for attributes

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-35116
+++ b/plugins/woocommerce/changelog/enhancement-35116
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add a default placeholder title for newly added attributes and always show remove button for attributes

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -962,7 +962,7 @@
 #variable_product_options .notice {
 	display: flex;
 	margin: 10px;
-	background-color: #FCFAE8;
+	background-color: #fcfae8;
 	> p {
 		width: 85%;
 	}
@@ -977,7 +977,7 @@
 }
 
 .woocommerce-set-price-variations {
-	.woocommerce-usage-modal__wrapper{
+	.woocommerce-usage-modal__wrapper {
 		.woocommerce-usage-modal__message {
 			height: 60px;
 			flex-wrap: wrap;
@@ -990,7 +990,7 @@
 			display: flex;
 			justify-content: flex-end;
 			margin-top: 20px;
-			> button{
+			> button {
 				margin-left: 16px;
 				width: 88px;
 				display: unset;
@@ -1013,7 +1013,8 @@
 
 #product_attributes {
 	.toolbar-top {
-		.button, .select2-container {
+		.button,
+		.select2-container {
 			margin: 1px;
 		}
 	}
@@ -5169,7 +5170,6 @@ img.help_tip {
 	}
 }
 
-
 .woocommerce_options_panel {
 	min-height: 175px;
 	box-sizing: border-box;
@@ -5636,6 +5636,9 @@ img.help_tip {
 			.fr {
 				float: right;
 			}
+		}
+		.placeholder {
+			opacity: 0.4;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5169,13 +5169,6 @@ img.help_tip {
 	}
 }
 
-.woocommerce_attribute {
-	h3 {
-		.sort, a.delete {
-			visibility: hidden;
-		}
-	}
-}
 
 .woocommerce_options_panel {
 	min-height: 175px;
@@ -7861,7 +7854,7 @@ table.bar_chart {
 #postdivrich.woocommerce-product-description {
 	margin-top: 20px;
 	margin-bottom: 0px;
-	
+
 	.wp-editor-tools {
 		background: none;
 		padding-top: 0px;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -520,10 +520,14 @@ jQuery( function ( $ ) {
 	} );
 
 	$( '.product_attributes' ).on( 'blur', 'input.attribute_name', function () {
-		$( this )
+		var text = $( this ).val();
+		var attributeName = $( this )
 			.closest( '.woocommerce_attribute' )
-			.find( 'strong.attribute_name' )
-			.text( $( this ).val() );
+			.find( 'strong.attribute_name' );
+		var isPlaceholder = attributeName.hasClass( 'placeholder' );
+		if ( ( isPlaceholder && text ) || ! isPlaceholder ) {
+			attributeName.removeClass( 'placeholder' ).text( text );
+		}
 	} );
 
 	$( '.product_attributes' ).on(
@@ -1034,7 +1038,6 @@ jQuery( function ( $ ) {
 			delay: 200,
 			keepAlive: true,
 		} );
-
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'Custom attribute', 'woocommerce' ) ); ?></strong>
+		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'e.g. Fabric or Brand', 'woocommerce' ) ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">
 		<table cellpadding="0" cellspacing="0">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name"><?php echo wc_attribute_label( $attribute->get_name() ); ?></strong>
+		<strong class="attribute_name"><?php echo $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : esc_html_e( 'Custom attribute', 'woocommerce' ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">
 		<table cellpadding="0" cellspacing="0">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name"><?php echo $attribute->get_name() !== '' ? esc_html_e( wc_attribute_label( $attribute->get_name() ) ) : esc_html_e( 'Custom attribute', 'woocommerce' ); ?></strong>
+		<strong class="attribute_name"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'Custom attribute', 'woocommerce' ) ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">
 		<table cellpadding="0" cellspacing="0">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'e.g. Fabric or Brand', 'woocommerce' ) ); ?></strong>
+		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'Custom attribute', 'woocommerce' ) ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">
 		<table cellpadding="0" cellspacing="0">
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<strong><?php echo wc_attribute_label( $attribute->get_name() ); ?></strong>
 							<input type="hidden" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" />
 						<?php else : ?>
-							<input type="text" class="attribute_name" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" placeholder="<?php esc_attr_e( 'New attribute', 'woocommerce' ); ?>" />
+							<input type="text" class="attribute_name" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" placeholder="<?php esc_attr_e( 'e.g. Fabric or Brand', 'woocommerce' ); ?>" />
 						<?php endif; ?>
 
 						<input type="hidden" name="attribute_position[<?php echo esc_attr( $i ); ?>]" class="attribute_position" value="<?php echo esc_attr( $attribute->get_position() ); ?>" />

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<strong><?php echo wc_attribute_label( $attribute->get_name() ); ?></strong>
 							<input type="hidden" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" />
 						<?php else : ?>
-							<input type="text" class="attribute_name" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" />
+							<input type="text" class="attribute_name" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" placeholder="<?php esc_attr_e( 'New attribute', 'woocommerce' ); ?>" />
 						<?php endif; ?>
 
 						<input type="hidden" name="attribute_position[<?php echo esc_attr( $i ); ?>]" class="attribute_position" value="<?php echo esc_attr( $attribute->get_position() ); ?>" />

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'Custom attribute', 'woocommerce' ) ); ?></strong>
+		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'Custom attribute', 'woocommerce' ) ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">
 		<table cellpadding="0" cellspacing="0">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name"><?php echo $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : esc_html_e( 'Custom attribute', 'woocommerce' ); ?></strong>
+		<strong class="attribute_name"><?php echo $attribute->get_name() !== '' ? esc_html_e( wc_attribute_label( $attribute->get_name() ) ) : esc_html_e( 'Custom attribute', 'woocommerce' ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">
 		<table cellpadding="0" cellspacing="0">


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add a default placeholder title for newly added attributes and always show remove button for attributes

https://user-images.githubusercontent.com/13437655/206710598-0702659b-f37b-4f5b-8a27-357260aab835.mov

Closes #35116.



<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a new product or edit an existing one.
2. Add at least two attributes.
3. Verify that the Remove button is always visible.
4. Verify that there's a placeholder title "Custom attribute"
5. Fill in the titles and verify that the placeholder gets updated
6. Test to see if no regressions occur in saving and re-ordering

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
