### PR TITLE
Add Options section to new product experience

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -12,8 +12,11 @@ import { resolveSelect } from '@wordpress/data';
 import {
 	Sortable,
 	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
+	Link,
 } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
+import interpolateComponents from '@automattic/interpolate-components';
+import { getAdminLink } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -255,6 +258,16 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 		( attr ) => fetchAttributeId( attr ) === editingAttributeId
 	) as HydratedAttributeType;
 
+	const editAttributeCopy = isOnlyForVariations
+		? __(
+				`You can change the option's name in {{link}}Attributes{{/link}}.`,
+				'woocommerce'
+		  )
+		: __(
+				`You can change the attribute's name in {{link}}Attributes{{/link}}.`,
+				'woocommerce'
+		  );
+
 	return (
 		<div className="woocommerce-attribute-field">
 			<Sortable
@@ -318,6 +331,22 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 							attribute.name
 						)
 					}
+					globalAttributeHelperMessage={ interpolateComponents( {
+						mixedString: editAttributeCopy,
+						components: {
+							link: (
+								<Link
+									href={ getAdminLink(
+										'edit.php?post_type=product&page=product_attributes'
+									) }
+									target="_blank"
+									type="wp-admin"
+								>
+									<></>
+								</Link>
+							),
+						},
+					} ) }
 					onCancel={ () => setEditingAttributeId( null ) }
 					onEdit={ ( changedAttribute ) => {
 						const newAttributesSet = [ ...hydratedAttributes ];

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -218,6 +218,11 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 						);
 						setShowAddAttributeModal( true );
 					} }
+					subtitle={
+						isOnlyForVariations
+							? __( 'No options yet', 'woocommerce' )
+							: undefined
+					}
 				/>
 				{ showAddAttributeModal && (
 					<AddAttributeModal

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -35,6 +35,7 @@ type AttributeFieldProps = {
 	productId?: number;
 	filter?: ( attribute: ProductAttribute ) => boolean;
 	newAttributeProps?: Partial< ProductAttribute >;
+	addButtonLabel?: string;
 };
 
 export type HydratedAttributeType = Omit< ProductAttribute, 'options' > & {
@@ -48,6 +49,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	productId,
 	filter,
 	newAttributeProps,
+	addButtonLabel = __( 'Add attribute', 'woocommerce' ),
 } ) => {
 	const [ showAddAttributeModal, setShowAddAttributeModal ] =
 		useState( false );
@@ -265,6 +267,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 				) ) }
 			</Sortable>
 			<AddAttributeListItem
+				label={ addButtonLabel }
 				onAddClick={ () => {
 					recordEvent( 'product_add_attribute_button' );
 					setShowAddAttributeModal( true );

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -54,9 +54,6 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 } ) => {
 	const [ showAddAttributeModal, setShowAddAttributeModal ] =
 		useState( false );
-	// const [ hydrationComplete, setHydrationComplete ] = useState< boolean >(
-	// 	value ? false : true
-	// );
 	const [ hydratedAttributes, setHydratedAttributes ] = useState<
 		HydratedAttributeType[]
 	>( [] );
@@ -106,7 +103,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 		// somewhere so that a single hydration source can be shared between multiple
 		// instances? Something like a simple key-value store in the form context
 		// would be handy.
-		if ( ! value /*|| hydrationComplete*/ ) {
+		if ( ! value ) {
 			return;
 		}
 
@@ -137,8 +134,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 				...customAttributes,
 			] );
 		} );
-	}, [ productId, value ] );
-	// }, [ productId, value, hydrationComplete ] );
+	}, [ fetchTerms, productId, value ] );
 
 	const fetchAttributeId = ( attribute: { id: number; name: string } ) =>
 		`${ attribute.id }-${ attribute.name }`;

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -212,6 +212,11 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 		return (
 			<>
 				<AttributeEmptyState
+					addNewLabel={
+						isOnlyForVariations
+							? __( 'Add options', 'woocommerce' )
+							: undefined
+					}
 					onNewClick={ () => {
 						recordEvent(
 							'product_add_first_attribute_button_click'

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -33,9 +33,8 @@ type AttributeFieldProps = {
 	value: ProductAttribute[];
 	onChange: ( value: ProductAttribute[] ) => void;
 	productId?: number;
-	filter?: ( attribute: ProductAttribute ) => boolean;
-	newAttributeProps?: Partial< ProductAttribute >;
-	addButtonLabel?: string;
+	// TODO: should we support an 'any' option to show all attributes?
+	attributeType?: 'regular' | 'for-variations';
 };
 
 export type HydratedAttributeType = Omit< ProductAttribute, 'options' > & {
@@ -47,9 +46,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	value,
 	onChange,
 	productId,
-	filter,
-	newAttributeProps,
-	addButtonLabel = __( 'Add attribute', 'woocommerce' ),
+	attributeType = 'regular',
 } ) => {
 	const [ showAddAttributeModal, setShowAddAttributeModal ] =
 		useState( false );
@@ -63,8 +60,17 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 		null | string
 	>( null );
 
-	const CANCEL_BUTTON_EVENT_NAME =
-		'product_add_attributes_modal_cancel_button_click';
+	const isOnlyForVariations = attributeType === 'for-variations';
+
+	const filter = ( attribute: ProductAttribute ) => {
+		return attribute.variation === isOnlyForVariations;
+	};
+
+	const newAttributeProps = { variation: isOnlyForVariations };
+
+	const CANCEL_BUTTON_EVENT_NAME = isOnlyForVariations
+		? 'product_add_options_modal_cancel_button_click'
+		: 'product_add_attributes_modal_cancel_button_click';
 
 	const fetchTerms = useCallback(
 		( attributeId: number ) => {
@@ -267,14 +273,27 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 				) ) }
 			</Sortable>
 			<AddAttributeListItem
-				label={ addButtonLabel }
+				label={
+					isOnlyForVariations
+						? __( 'Add option', 'woocommerce' )
+						: undefined
+				}
 				onAddClick={ () => {
-					recordEvent( 'product_add_attribute_button' );
+					recordEvent(
+						isOnlyForVariations
+							? 'product_add_option_button'
+							: 'product_add_attribute_button'
+					);
 					setShowAddAttributeModal( true );
 				} }
 			/>
 			{ showAddAttributeModal && (
 				<AddAttributeModal
+					title={
+						isOnlyForVariations
+							? __( 'Add options', 'woocommerce' )
+							: undefined
+					}
 					onCancel={ () => {
 						recordEvent( CANCEL_BUTTON_EVENT_NAME );
 						setShowAddAttributeModal( false );

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/edit-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/edit-attribute-modal.tsx
@@ -9,12 +9,7 @@ import {
 	TextControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import {
-	__experimentalTooltip as Tooltip,
-	Link,
-} from '@woocommerce/components';
-import interpolateComponents from '@automattic/interpolate-components';
-import { getAdminLink } from '@woocommerce/settings';
+import { __experimentalTooltip as Tooltip } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -30,7 +25,7 @@ import './edit-attribute-modal.scss';
 type EditAttributeModalProps = {
 	title?: string;
 	nameLabel?: string;
-	globalAttributeHelperMessage?: string;
+	globalAttributeHelperMessage?: JSX.Element;
 	customAttributeHelperMessage?: string;
 	termsLabel?: string;
 	termsPlaceholder?: string;
@@ -50,25 +45,7 @@ type EditAttributeModalProps = {
 export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 	title = __( 'Edit attribute', 'woocommerce' ),
 	nameLabel = __( 'Name', 'woocommerce' ),
-	globalAttributeHelperMessage = interpolateComponents( {
-		mixedString: __(
-			`You can change the attribute's name in {{link}}Attributes{{/link}}.`,
-			'woocommerce'
-		),
-		components: {
-			link: (
-				<Link
-					href={ getAdminLink(
-						'edit.php?post_type=product&page=product_attributes'
-					) }
-					target="_blank"
-					type="wp-admin"
-				>
-					<></>
-				</Link>
-			),
-		},
-	} ),
+	globalAttributeHelperMessage,
 	customAttributeHelperMessage = __(
 		'Your customers will see this on the product page',
 		'woocommerce'

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/edit-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/edit-attribute-modal.tsx
@@ -170,10 +170,10 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 						onChange={ ( val ) =>
 							setEditableAttribute( {
 								...( editableAttribute as HydratedAttributeType ),
-								variation: val,
+								variation: ! val,
 							} )
 						}
-						checked={ editableAttribute?.variation }
+						checked={ ! editableAttribute?.variation }
 						label={ filtersLabel }
 					/>
 					<Tooltip text={ filtersTooltip } />

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/edit-attribute-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/edit-attribute-modal.tsx
@@ -31,8 +31,6 @@ type EditAttributeModalProps = {
 	termsPlaceholder?: string;
 	visibleLabel?: string;
 	visibleTooltip?: string;
-	filtersLabel?: string;
-	filtersTooltip?: string;
 	cancelAccessibleLabel?: string;
 	cancelLabel?: string;
 	updateAccessibleLabel?: string;
@@ -55,11 +53,6 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 	visibleLabel = __( 'Visible to customers', 'woocommerce' ),
 	visibleTooltip = __(
 		'Show or hide this attribute on the product page',
-		'woocommerce'
-	),
-	filtersLabel = __( 'Used for filters', 'woocommerce' ),
-	filtersTooltip = __(
-		`Show or hide this attribute in the filters section on your store's category and shop pages`,
 		'woocommerce'
 	),
 	cancelAccessibleLabel = __( 'Cancel', 'woocommerce' ),
@@ -141,19 +134,6 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 						label={ visibleLabel }
 					/>
 					<Tooltip text={ visibleTooltip } />
-				</div>
-				<div className="woocommerce-edit-attribute-modal__option-container">
-					<CheckboxControl
-						onChange={ ( val ) =>
-							setEditableAttribute( {
-								...( editableAttribute as HydratedAttributeType ),
-								variation: ! val,
-							} )
-						}
-						checked={ ! editableAttribute?.variation }
-						label={ filtersLabel }
-					/>
-					<Tooltip text={ filtersTooltip } />
 				</div>
 			</div>
 			<div className="woocommerce-add-attribute-modal__buttons">

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/attribute-field.spec.tsx
@@ -26,7 +26,7 @@ const attributeList: ProductAttribute[] = [
 		visible: true,
 		variation: true,
 		options: [
-			'Beige',
+			'beige',
 			'black',
 			'Blue',
 			'brown',
@@ -134,23 +134,24 @@ describe( 'AttributeField', () => {
 			await screen.findByText( attributeList[ 0 ].name )
 		).toBeInTheDocument();
 		expect(
-			await screen.findByText( attributeList[ 1 ].name )
-		).toBeInTheDocument();
+			await screen.queryByText( attributeList[ 1 ].name )
+		).not.toBeInTheDocument();
 	} );
 
-	it( 'should render the first two terms of each attribute, and show "+ n more" for the rest', async () => {
+	it( 'should render the first two terms of each option, and show "+ n more" for the rest', async () => {
 		act( () => {
 			render(
 				<AttributeField
 					value={ [ ...attributeList ] }
 					onChange={ () => {} }
+					attributeType="for-variations"
 				/>
 			);
 		} );
 
 		expect(
-			await screen.findByText( attributeList[ 0 ].options[ 0 ] )
-		).toBeInTheDocument();
+			await screen.queryByText( attributeList[ 0 ].options[ 0 ] )
+		).not.toBeInTheDocument();
 		expect(
 			await screen.findByText( attributeList[ 1 ].options[ 0 ] )
 		).toBeInTheDocument();

--- a/plugins/woocommerce-admin/client/products/fields/attributes/attributes.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attributes/attributes.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { ProductAttribute } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { AttributeField } from '../attribute-field';
+
+type AttributesProps = {
+	value: ProductAttribute[];
+	onChange: ( value: ProductAttribute[] ) => void;
+	productId?: number;
+};
+
+export const Attributes: React.FC< AttributesProps > = ( {
+	value,
+	onChange,
+	productId,
+} ) => {
+	return (
+		<AttributeField
+			attributeType="regular"
+			value={ value }
+			onChange={ onChange }
+			productId={ productId }
+		/>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/fields/attributes/index.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attributes/index.ts
@@ -1,0 +1,1 @@
+export * from './attributes';

--- a/plugins/woocommerce-admin/client/products/fields/options/index.ts
+++ b/plugins/woocommerce-admin/client/products/fields/options/index.ts
@@ -1,0 +1,1 @@
+export * from './options';

--- a/plugins/woocommerce-admin/client/products/fields/options/options.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/options/options.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ProductAttribute } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { AttributeField } from '../attribute-field';
+
+type OptionsProps = {
+	value: ProductAttribute[];
+	onChange: ( value: ProductAttribute[] ) => void;
+	productId?: number;
+};
+
+export const Options: React.FC< OptionsProps > = ( {
+	value,
+	onChange,
+	productId,
+} ) => {
+	return (
+		<AttributeField
+			attributeType="for-variations"
+			value={ value }
+			onChange={ onChange }
+			productId={ productId }
+		/>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -70,6 +70,7 @@ export const ProductForm: React.FC< {
 					<ProductShippingSection product={ product } />
 				</ProductFormTab>
 				<ProductFormTab name="options" title="Options">
+					<OptionsSection />
 					<ProductVariationsSection />
 				</ProductFormTab>
 			</ProductFormLayout>

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -18,6 +18,7 @@ import { ProductVariationsSection } from './sections/product-variations-section'
 import { ImagesSection } from './sections/images-section';
 import { validate } from './product-validation';
 import { AttributesSection } from './sections/attributes-section';
+import { OptionsSection } from './sections/options-section';
 import { ProductFormFooter } from './layout/product-form-footer';
 import { ProductFormTab } from './product-form-tab';
 

--- a/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/attributes-section.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Link, useFormContext } from '@woocommerce/components';
-import { Product, ProductAttribute } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -11,19 +11,13 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import './attributes-section.scss';
 import { ProductSectionLayout } from '../layout/product-section-layout';
-import { AttributeField } from '../fields/attribute-field';
+import { Attributes } from '../fields/attributes';
 
 export const AttributesSection: React.FC = () => {
 	const {
 		getInputProps,
 		values: { id: productId },
 	} = useFormContext< Product >();
-
-	const filter = ( attribute: ProductAttribute ) => {
-		return attribute.variation === false;
-	};
-
-	const newAttributeProps = { variation: false };
 
 	return (
 		<ProductSectionLayout
@@ -51,11 +45,9 @@ export const AttributesSection: React.FC = () => {
 				</>
 			}
 		>
-			<AttributeField
+			<Attributes
 				{ ...getInputProps( 'attributes', {
 					productId,
-					filter,
-					newAttributeProps,
 				} ) }
 			/>
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/options-section.scss
+++ b/plugins/woocommerce-admin/client/products/sections/options-section.scss
@@ -1,0 +1,6 @@
+.woocommerce-product-options-section.woocommerce-form-section {
+	.woocommerce-form-section__content {
+		padding: 0;
+		border: 0;
+	}
+}

--- a/plugins/woocommerce-admin/client/products/sections/options-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/options-section.tsx
@@ -9,31 +9,31 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import './attributes-section.scss';
+import './options-section.scss';
 import { ProductSectionLayout } from '../layout/product-section-layout';
 import { AttributeField } from '../fields/attribute-field';
 
-export const AttributesSection: React.FC = () => {
+export const OptionsSection: React.FC = () => {
 	const {
 		getInputProps,
 		values: { id: productId },
 	} = useFormContext< Product >();
 
 	const filter = ( attribute: ProductAttribute ) => {
-		return attribute.variation === false;
+		return attribute.variation === true;
 	};
 
-	const newAttributeProps = { variation: false };
+	const newAttributeProps = { variation: true };
 
 	return (
 		<ProductSectionLayout
-			title={ __( 'Attributes', 'woocommerce' ) }
-			className="woocommerce-product-attributes-section"
+			title={ __( 'Options', 'woocommerce' ) }
+			className="woocommerce-product-options-section"
 			description={
 				<>
 					<span>
 						{ __(
-							'Add descriptive pieces of information that customers can use to filter and search for this product.',
+							'Add and manage options, such as size and color, for customers to choose on the product page.',
 							'woocommerce'
 						) }
 					</span>
@@ -43,10 +43,10 @@ export const AttributesSection: React.FC = () => {
 						target="_blank"
 						type="external"
 						onClick={ () => {
-							recordEvent( 'learn_more_about_attributes_help' );
+							recordEvent( 'learn_more_about_options_help' );
 						} }
 					>
-						{ __( 'Learn more about attributes', 'woocommerce' ) }
+						{ __( 'Learn more about options', 'woocommerce' ) }
 					</Link>
 				</>
 			}

--- a/plugins/woocommerce-admin/client/products/sections/options-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/options-section.tsx
@@ -56,6 +56,7 @@ export const OptionsSection: React.FC = () => {
 					productId,
 					filter,
 					newAttributeProps,
+					addButtonLabel: __( 'Add option', 'woocommerce' ),
 				} ) }
 			/>
 		</ProductSectionLayout>

--- a/plugins/woocommerce-admin/client/products/sections/options-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/options-section.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Link, useFormContext } from '@woocommerce/components';
-import { Product, ProductAttribute } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -11,19 +11,13 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import './options-section.scss';
 import { ProductSectionLayout } from '../layout/product-section-layout';
-import { AttributeField } from '../fields/attribute-field';
+import { Options } from '../fields/options';
 
 export const OptionsSection: React.FC = () => {
 	const {
 		getInputProps,
 		values: { id: productId },
 	} = useFormContext< Product >();
-
-	const filter = ( attribute: ProductAttribute ) => {
-		return attribute.variation === true;
-	};
-
-	const newAttributeProps = { variation: true };
 
 	return (
 		<ProductSectionLayout
@@ -51,12 +45,9 @@ export const OptionsSection: React.FC = () => {
 				</>
 			}
 		>
-			<AttributeField
+			<Options
 				{ ...getInputProps( 'attributes', {
 					productId,
-					filter,
-					newAttributeProps,
-					addButtonLabel: __( 'Add option', 'woocommerce' ),
 				} ) }
 			/>
 		</ProductSectionLayout>

--- a/plugins/woocommerce/changelog/add-new-product-experience-options
+++ b/plugins/woocommerce/changelog/add-new-product-experience-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Options section to new product experience form.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds an Options section to the new product experience and modifies the attribute component to allow us to reuse it.

Here are a few things that we should handle in follow-up PRs:

- [x] Variations section. Now we are showing the `Variations` section even when we don't have any to list. That shows the Variations section with an infinite spinner. [36181](https://github.com/woocommerce/woocommerce/issues/36181)
- [ ] Components' hydration. Handle the components' hydration. [36185](https://github.com/woocommerce/woocommerce/issues/36185)
- [x] There is a minor bug when editing an attribute already added. It's saving correctly, but it's not refreshing the terms list after closing it and reopening it. Maybe this fix could be addressed in the components hydration PR. [36183](https://github.com/woocommerce/woocommerce/issues/36183)
- [ ] Add a tooltip for local attributes and options. [36187](https://github.com/woocommerce/woocommerce/issues/36187)
- [ ] Add a dropdown menu to set a `Default` value for options.
- [ ] How should we handle the variations creation without a product ID?


Closes #35770 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout this branch.
2. Go to `Products` > `Attributes` and create a couple of attributes with a few terms.
3. Create a product.
4. Add one of the attributes you created to that product under `General` > `Attributes`.
5. Go to `Options` > `Options` and press `Add options`.
6. Verify that the attribute you added as an `Attribute` is not available as an `Option`.
7. Remove the attribute from `General` > `Attributes` and add it as an option (step 5)
8. Verify that the attribute you added as an `Option` is not available as an `Attribute`.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
