### PR TITLE
Move CSS about notice outside of .woocommerce class scope

### DIFF
--- a/plugins/woocommerce/changelog/fix-notice-css-mini-cart
+++ b/plugins/woocommerce/changelog/fix-notice-css-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Move CSS about notice outside of .woocommerce class scope

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -130,73 +130,6 @@ a.button {
 	}
 }
 
-.woocommerce-message,
-.woocommerce-error,
-.woocommerce-info {
-	margin-bottom: 1.5rem;
-	padding: 1rem;
-	background: #eee;
-	font-size: 0.88889em;
-	font-family: $headings;
-	list-style: none;
-	overflow: hidden;
-}
-
-.woocommerce-message {
-	background: #eee;
-	color: $body-color;
-}
-
-.woocommerce-error,
-.woocommerce-info {
-	color: #fff;
-
-	a {
-		color: #fff;
-
-		&:hover {
-			color: #fff;
-		}
-
-		&.button {
-			background: #111;
-		}
-	}
-}
-
-.woocommerce-error {
-	background: firebrick;
-}
-
-.woocommerce-info {
-	background: $highlights-color;
-}
-
-.woocommerce-store-notice {
-	background: $highlights-color;
-	color: #fff;
-	padding: 1rem;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	z-index: 999;
-}
-
-.admin-bar .woocommerce-store-notice {
-	top: 32px;
-}
-
-.woocommerce-store-notice__dismiss-link {
-	float: right;
-	color: #fff;
-
-	&:hover {
-		text-decoration: underline;
-		color: #fff;
-	}
-}
-
 /**
 * Tables
 */
@@ -1371,5 +1304,72 @@ table.variations {
 				max-width: calc(6 * (100vw / 12) - 28px);
 			}
 		}
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+	margin-bottom: 1.5rem;
+	padding: 1rem;
+	background: #eee;
+	font-size: 0.88889em;
+	font-family: $headings;
+	list-style: none;
+	overflow: hidden;
+}
+
+.woocommerce-message {
+	background: #eee;
+	color: $body-color;
+}
+
+.woocommerce-error,
+.woocommerce-info {
+	color: #fff;
+
+	a {
+		color: #fff;
+
+		&:hover {
+			color: #fff;
+		}
+
+		&.button {
+			background: #111;
+		}
+	}
+}
+
+.woocommerce-error {
+	background: firebrick;
+}
+
+.woocommerce-info {
+	background: $highlights-color;
+}
+
+.woocommerce-store-notice {
+	background: $highlights-color;
+	color: #fff;
+	padding: 1rem;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+	top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+	float: right;
+	color: #fff;
+
+	&:hover {
+		text-decoration: underline;
+		color: #fff;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
@@ -176,64 +176,6 @@
 	}
 }
 
-.woocommerce-message,
-.woocommerce-error,
-.woocommerce-info {
-	margin-bottom: 1.5em;
-	padding: 2em;
-	background: #eee;
-}
-
-.woocommerce-message {
-	background: teal;
-	color: #fff;
-}
-
-.woocommerce-error {
-	background: firebrick;
-	color: #fff;
-}
-
-.woocommerce-info {
-	background: royalblue;
-	color: #fff;
-}
-
-.woocommerce-message,
-.woocommerce-error,
-.woocommerce-info {
-
-	a {
-
-		@include link_white();
-	}
-}
-
-.woocommerce-store-notice {
-	background: royalblue;
-	color: #fff;
-	padding: 1em;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	z-index: 999;
-}
-
-.admin-bar .woocommerce-store-notice {
-	top: 32px;
-}
-
-.woocommerce-store-notice__dismiss-link {
-	float: right;
-	color: #fff;
-
-	&:hover {
-		text-decoration: underline;
-		color: #fff;
-	}
-}
-
 /**
  * Shop page
  */
@@ -1277,5 +1219,63 @@ table.variations {
 	body.page-two-column.woocommerce-checkout:not(.archive) #primary .entry-content,
 	body.page-two-column.woocommerce-account:not(.archive) #primary .entry-content {
 		width: 78%;
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+	margin-bottom: 1.5em;
+	padding: 2em;
+	background: #eee;
+}
+
+.woocommerce-message {
+	background: teal;
+	color: #fff;
+}
+
+.woocommerce-error {
+	background: firebrick;
+	color: #fff;
+}
+
+.woocommerce-info {
+	background: royalblue;
+	color: #fff;
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+
+	a {
+
+		@include link_white();
+	}
+}
+
+.woocommerce-store-notice {
+	background: royalblue;
+	color: #fff;
+	padding: 1em;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+	top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+	float: right;
+	color: #fff;
+
+	&:hover {
+		text-decoration: underline;
+		color: #fff;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -239,47 +239,6 @@ a.button {
 
 }
 
-.woocommerce-message,
-.woocommerce-error li,
-.woocommerce-info {
-	padding: 1.5rem 3rem;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-
-	.button {
-		order: 2;
-	}
-}
-
-.woocommerce-info {
-	border-top-color: var( --wc-blue );
-}
-
-.woocommerce-error {
-	border-top-color: #b22222;
-
-	> li {
-		margin: 0;
-	}
-}
-
-.woocommerce-store-notice {
-	background: #eee;
-	color: #000;
-	border-top: 2px solid $highlights-color;
-	padding: 2rem;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	z-index: 999;
-}
-
-.admin-bar .woocommerce-store-notice {
-	top: 32px;
-}
-
 .woocommerce-store-notice__dismiss-link {
 	float: right;
 	color: #000;
@@ -3065,5 +3024,56 @@ a.reset_variations {
 
 			@include inversebuttoncolors();
 		}
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error li,
+.woocommerce-info {
+	padding: 1.5rem 3rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	.button {
+		order: 2;
+	}
+}
+
+.woocommerce-info {
+	border-top-color: var( --wc-blue );
+}
+
+.woocommerce-error {
+	border-top-color: #b22222;
+
+	> li {
+		margin: 0;
+	}
+}
+
+.woocommerce-store-notice {
+	background: #eee;
+	color: #000;
+	border-top: 2px solid $highlights-color;
+	padding: 2rem;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+	top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+	float: right;
+	color: #000;
+
+	&:hover {
+		text-decoration: none;
+		color: #000;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -110,65 +110,6 @@
 	.woocommerce-breadcrumb {
 		margin-bottom: 1rem;
 	}
-
-	/*
-		Notice messages (like 'Added to cart', 'Billing address needs to be filled in', etc.
-	 */
-	.woocommerce-message,
-	.woocommerce-error,
-	.woocommerce-info {
-		background-color: rgba(176, 176, 176, 0.6);
-		color: #222;
-		border-top-color: var(--wp--preset--color--primary);
-		border-top-style: solid;
-		border-top-width: 2px;
-		padding: 1rem 1.5rem;
-		margin-bottom: 2rem;
-		list-style: none;
-		font-size: var(--wp--preset--font-size--small);
-		display: flow-root;
-
-		&[role="alert"]::before {
-			background: #d5d5d5;
-			color: black;
-			border-radius: 5rem;
-			font-size: 1rem;
-			padding-left: 3px;
-			padding-right: 3px;
-			margin-right: 1rem;
-		}
-
-		a {
-			color: var(--wp--preset--color--contrast);
-
-			.button {
-				margin-top: -0.5rem;
-				border: none;
-				padding: 0.5rem 1rem;
-			}
-		}
-	}
-
-	.woocommerce-error[role="alert"] {
-		margin: 0;
-
-		&::before {
-			content: "X";
-			padding-right: 4px;
-			padding-left: 4px;
-		}
-
-		li {
-			display: inline-block;
-		}
-	}
-
-	.woocommerce-message {
-		&[role="alert"]::before {
-			content: "\2713";
-		}
-	}
-
 	// Checkout notice group styling.
 	.woocommerce-NoticeGroup-checkout {
 		ul.woocommerce-error[role="alert"] {
@@ -1172,3 +1113,62 @@
 		color: inherit;
 	}
 }
+
+/*
+		Notice messages (like 'Added to cart', 'Billing address needs to be filled in', etc.
+	 */
+	 .woocommerce-message,
+	 .woocommerce-error,
+	 .woocommerce-info {
+		 background-color: rgba( 176, 176, 176, 0.6 );
+		 color: #222;
+		 border-top-color: var( --wp--preset--color--primary );
+		 border-top-style: solid;
+		 border-top-width: 2px;
+		 padding: 1rem 1.5rem;
+		 margin-bottom: 2rem;
+		 list-style: none;
+		 font-size: var( --wp--preset--font-size--small );
+		 display: flow-root;
+	 
+		 &[role='alert']::before {
+			 background: #d5d5d5;
+			 color: black;
+			 border-radius: 5rem;
+			 font-size: 1rem;
+			 padding-left: 3px;
+			 padding-right: 3px;
+			 margin-right: 1rem;
+		 }
+	 
+		 a {
+			 color: var( --wp--preset--color--contrast );
+	 
+			 .button {
+				 margin-top: -0.5rem;
+				 border: none;
+				 padding: 0.5rem 1rem;
+			 }
+		 }
+	 }
+	 
+	 .woocommerce-error[role='alert'] {
+		 margin: 0;
+	 
+		 &::before {
+			 content: 'X';
+			 padding-right: 4px;
+			 padding-left: 4px;
+		 }
+	 
+		 li {
+			 display: inline-block;
+		 }
+	 }
+	 
+	 .woocommerce-message {
+		 &[role='alert']::before {
+			 content: '\2713';
+		 }
+	 }
+	 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -97,61 +97,6 @@ $tt2-gray: #f7f7f7;
 		margin-bottom: 1rem;
 	}
 
-	.woocommerce-message,
-	.woocommerce-error,
-	.woocommerce-info {
-		background: $tt2-gray;
-		border-top-color: var(--wp--preset--color--primary);
-		border-top-style: solid;
-		padding: 1rem 1.5rem;
-		margin-bottom: 2rem;
-		list-style: none;
-		font-size: var(--wp--preset--font-size--small);
-
-		&[role="alert"]::before {
-			color: var(--wp--preset--color--background);
-			background: var(--wp--preset--color--primary);
-			border-radius: 5rem;
-			font-size: 1rem;
-			padding-left: 3px;
-			padding-right: 3px;
-			margin-right: 1rem;
-		}
-
-		a.button {
-			margin-top: -0.5rem;
-			border: none;
-			background: #ebe9eb;
-			color: var(--wp--preset--color--black);
-			padding: 0.5rem 1rem;
-
-			&:hover,
-			&:visited {
-				color: var(--wp--preset--color--black);
-			}
-		}
-	}
-
-	.woocommerce-error[role="alert"] {
-		margin: 0;
-
-		&::before {
-			content: "X";
-			padding-right: 4px;
-			padding-left: 4px;
-		}
-
-		li {
-			display: inline-block;
-		}
-	}
-
-	.woocommerce-message {
-		&[role="alert"]::before {
-			content: "\2713";
-		}
-	}
-
 	.woocommerce-NoticeGroup-checkout {
 		ul.woocommerce-error[role="alert"] {
 			&::before {
@@ -1211,5 +1156,60 @@ $tt2-gray: #f7f7f7;
 		float: right;
 		margin-right: 4rem;
 		color: inherit;
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+	background: $tt2-gray;
+	border-top-color: var(--wp--preset--color--primary);
+	border-top-style: solid;
+	padding: 1rem 1.5rem;
+	margin-bottom: 2rem;
+	list-style: none;
+	font-size: var(--wp--preset--font-size--small);
+
+	&[role="alert"]::before {
+		color: var(--wp--preset--color--background);
+		background: var(--wp--preset--color--primary);
+		border-radius: 5rem;
+		font-size: 1rem;
+		padding-left: 3px;
+		padding-right: 3px;
+		margin-right: 1rem;
+	}
+
+	a.button {
+		margin-top: -0.5rem;
+		border: none;
+		background: #ebe9eb;
+		color: var(--wp--preset--color--black);
+		padding: 0.5rem 1rem;
+
+		&:hover,
+		&:visited {
+			color: var(--wp--preset--color--black);
+		}
+	}
+}
+
+.woocommerce-error[role="alert"] {
+	margin: 0;
+
+	&::before {
+		content: "X";
+		padding-right: 4px;
+		padding-left: 4px;
+	}
+
+	li {
+		display: inline-block;
+	}
+}
+
+.woocommerce-message {
+	&[role="alert"]::before {
+		content: "\2713";
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -183,83 +183,6 @@ a.button {
 	}
 }
 
-.woocommerce-message,
-.woocommerce-error,
-.woocommerce-info {
-	margin-bottom: 5rem;
-	margin-left: 0;
-	background: #eee;
-	color: $body-color;
-	border-top: 3px solid var( --wc-green );
-
-	font-size: 0.88889em;
-	font-family: $headings;
-	list-style: none;
-	overflow: hidden;
-	width: 100%;
-
-	a {
-		color: #fff;
-
-		&:hover {
-			color: #fff;
-		}
-
-		&.button {
-			background: #000000;
-		}
-	}
-}
-
-.woocommerce-message,
-.woocommerce-error li,
-.woocommerce-info {
-	padding: 1.5rem 3rem;
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-
-	.button {
-		order: 2;
-	}
-}
-
-.woocommerce-info {
-	border-color: var( --wc-blue );
-}
-
-.woocommerce-error {
-	border-color: $highlights-color;
-
-	> li {
-		margin: 0;
-	}
-}
-
-#site-content {
-
-	.woocommerce-error,
-	.woocommerce-info {
-		font-family: $headings;
-	}
-}
-
-.woocommerce-store-notice {
-	background: #eee;
-	color: #000;
-	border-top: 2px solid $highlights-color;
-	padding: 2rem;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	z-index: 999;
-}
-
-.admin-bar .woocommerce-store-notice {
-	top: 32px;
-}
-
 .woocommerce-store-notice__dismiss-link {
 	float: right;
 	color: #000;
@@ -2556,5 +2479,92 @@ a.reset_variations {
 				padding-left: 1.5rem;
 			}
 		}
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+	margin-bottom: 5rem;
+	margin-left: 0;
+	background: #eee;
+	color: $body-color;
+	border-top: 3px solid var( --wc-green );
+
+	font-size: 0.88889em;
+	font-family: $headings;
+	list-style: none;
+	overflow: hidden;
+	width: 100%;
+
+	a {
+		color: #fff;
+
+		&:hover {
+			color: #fff;
+		}
+
+		&.button {
+			background: #000000;
+		}
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error li,
+.woocommerce-info {
+	padding: 1.5rem 3rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	.button {
+		order: 2;
+	}
+}
+
+.woocommerce-info {
+	border-color: var( --wc-blue );
+}
+
+.woocommerce-error {
+	border-color: $highlights-color;
+
+	> li {
+		margin: 0;
+	}
+}
+
+#site-content {
+
+	.woocommerce-error,
+	.woocommerce-info {
+		font-family: $headings;
+	}
+}
+
+.woocommerce-store-notice {
+	background: #eee;
+	color: #000;
+	border-top: 2px solid $highlights-color;
+	padding: 2rem;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+	top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+	float: right;
+	color: #000;
+
+	&:hover {
+		text-decoration: none;
+		color: #000;
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With https://github.com/woocommerce/woocommerce-blocks/pull/7234, we are adding support to the errors to the Mini Cart Block, adding the notice support. The Mini Cart block can be loaded on all the pages, so we have to move the CSS about the notice outside the `.woocommerce` class scope.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce/files/10323915/woocommerce-gutenberg-products-block.zip) that contains the change of [this PR](https://github.com/woocommerce/woocommerce-blocks/pull/7234).
2. If you are testing a block theme, open the FSE editor and add the Mini Cart Block in the header, otherwise, open the widget area and put the Mini Cart in the footer. Save.
3. Go to the frontend and add the product to the Cart. Be sure that on Mini Cart Block, any "notice" is visible on top.
4. On the editor side, edit the product that you added and set it as out of stock. Save.
5. On the frontend side, refresh the page. Go to the Cart page and see the notice.
6. Open the Mini Cart block and be sure that the notice is visible. Please check on a WooCommerce page (`/shop`) and a WordPress page (in case of a default installation, the homepage is fine).


| Theme | WooCommerce Page | WordPress Page |
|-------|------------------|----------------|
| TT3   |![image](https://user-images.githubusercontent.com/4463174/206734544-debebbdc-c015-4157-a5b3-b8280fc93ead.png)|![image](https://user-images.githubusercontent.com/4463174/206734628-77119b3d-b246-47ee-8c67-fa90092fa0d8.png)|
|TT2    |![image](https://user-images.githubusercontent.com/4463174/206735084-1dccd57b-9e25-42cc-9302-525044104432.png)|![image](https://user-images.githubusercontent.com/4463174/206734916-3ca6eb5e-0f09-45f8-8e64-4ae1fefeaf85.png)|
|TT1       |![image](https://user-images.githubusercontent.com/4463174/206735253-f8eb04f0-7cc4-4f15-88b0-2f36ff5afaf3.png)|![image](https://user-images.githubusercontent.com/4463174/206737233-ee84a3c5-db1f-4b90-b281-e0d237c9c77f.png)|
|Twenty Twenty Ninteen      |![image](https://user-images.githubusercontent.com/4463174/206735741-8975f569-ca49-42d2-aa82-c3f79687bcc8.png)|![image](https://user-images.githubusercontent.com/4463174/206735654-045d9587-1dcb-486e-aad3-2e1e8273ca9a.png)|
|Twenty Twenty Seventeen       |![image](https://user-images.githubusercontent.com/4463174/206735991-2e92803c-f593-4d31-8848-8986498870e6.png)|![image](https://user-images.githubusercontent.com/4463174/206736165-562209c3-f056-440c-ab73-d79809722406.png)|


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
