### PR TITLE
Skip invalid child product for `get_download_files_and_permissions()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-35916
+++ b/plugins/woocommerce/changelog/fix-35916
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Skip invalid child product to avoid calling get_download_files_and_permissions() with `false` value.

--- a/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
+++ b/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
@@ -99,7 +99,10 @@ class DownloadPermissionsAdjuster {
 
 		$children_with_downloads = array();
 		foreach ( $children_ids as $child_id ) {
-			$child                                = wc_get_product( $child_id );
+			$child = wc_get_product( $child_id );
+			if ( ! $child ) {
+				continue;
+			}
 			$children_with_downloads[ $child_id ] = $this->get_download_files_and_permissions( $child );
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Skip invalid child product. This can happen when saving a variable product and wp-cron is running at the same time.

Closes #35916.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
