### PR TITLE
Allow use of pathspecs to limit the scope of generating a diff in Code Analyzer

### DIFF
--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -36,7 +36,8 @@ export const scanForChanges = async (
 		tmpRepoPath,
 		base,
 		compareVersion,
-		Logger.error
+		Logger.error,
+		[ 'tools' ]
 	);
 
 	// Only checkout the compare version if we're in CLI mode.

--- a/tools/code-analyzer/src/lib/template-changes.ts
+++ b/tools/code-analyzer/src/lib/template-changes.ts
@@ -23,14 +23,15 @@ export const scanForTemplateChanges = ( content: string, version: string ) => {
 		/\./g,
 		'\\.'
 	) }).*`;
+
 	const versionRegex = new RegExp( matchVersion, 'g' );
 
 	for ( const p in patches ) {
 		const patch = patches[ p ];
 		const lines = patch.split( '\n' );
 		const filePath = getFilename( lines[ 0 ] );
-		let code = 'warning';
 
+		let code = 'warning';
 		let message = 'This template may require a version bump!';
 
 		for ( const l in lines ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes an issue where code analyzer finds template changes inside the `tools` directory. To fix this I have added the ability to filter diffs to exclude paths and then when we call `generateDiff` in the analyzer lint, we pass `tools` to tell it to ignore that directory.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout trunk and run this command from `tools/code-analyzer`: pnpm run analyzer -- lint release/7.2 "7.2.0" -b release/7.1 -ss
2. You should see a list of changes that includes 2 ejs templates we don't care about
3. Checkout this branch and run command from 1.
4. Check the output carefully  you should see the same amount of PHP template changes but no changes from `tools`.

<!-- End testing instructions -->

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
