### PR TITLE
Fix wrong query param in onboarding product api call

### DIFF
--- a/plugins/woocommerce/changelog/fix-onboarding-api-qurey
+++ b/plugins/woocommerce/changelog/fix-onboarding-api-qurey
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong query param in onboarding product api call

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -94,7 +94,7 @@ class OnboardingProducts {
 				),
 				array(
 					'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
-				),
+				)
 			);
 			if ( is_wp_error( $woocommerce_products ) ) {
 				return $product_types;

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -88,11 +88,13 @@ class OnboardingProducts {
 			$woocommerce_products = wp_remote_get(
 				add_query_arg(
 					array(
-						'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
-						'locale'     => $locale,
+						'locale' => $locale,
 					),
 					'https://woocommerce.com/wp-json/wccom-extensions/1.0/search'
-				)
+				),
+				array(
+					'user-agent' => 'WooCommerce/' . WC()->version . '; ' . get_bloginfo( 'url' ),
+				),
 			);
 			if ( is_wp_error( $woocommerce_products ) ) {
 				return $product_types;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35846.

I mistakenly added the user-agent to the query in https://github.com/woocommerce/woocommerce/pull/34461/files#diff-c4dd3352cdd52db33131d66f0f88be1de6ff47c00b9e5951462da52f5da8b0d5L85-L86. The `user-agent` needs to be passed as args to wp_remote_get instead. It's causing a performance issue on WCCOM.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to OBW
2. Go to the Product types step
3. Click on an info icon (i)
4. Observe that tooltip shows contents properly.

<img width="670" alt="Screen Shot 2022-12-12 at 16 42 01" src="https://user-images.githubusercontent.com/4344253/207000068-05409a7a-95bd-4292-9959-ab9199f71657.png">


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
