### PR TITLE
Add cherry-pick support for git merge strategy.

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -154,7 +154,7 @@ jobs:
 
             - name: Cherry pick
               run: |
-                  git cherry-pick ${{ steps.commit-sha.outputs.sha }}
+                  git cherry-pick ${{ steps.commit-sha.outputs.sha }} -m1
 
             - name: Generate changelog
               id: changelog

--- a/plugins/woocommerce/changelog/git-add-cherry-pick-merge
+++ b/plugins/woocommerce/changelog/git-add-cherry-pick-merge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Update the build tool, no code will be shipped to production.
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds support to cherry-pick tool for git merge strategy. It adds a -m1 option, which tells git to consider the first branch as parent when a merge commit is encountered (and has no effect when the commit is not a merge commit).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Tested here: https://github.com/vedanshujain/woocommerce/actions/runs/3674751108 on fork, since it would need to change GH setting just to test. Otherwise, on a fork
2. [On a fork] Enable the merge strategy from GH settings, create a branch release/x.y and push it.
3. Create a PR with any changes and merge it to trunk using the merge strategy.
4. Run the cherry-picker tool, giving the PR as a target. It should work as expected.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
