### PR TITLE
Update In-App Marketplace tour wording

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
@@ -24,7 +24,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 				descriptions: {
 					desktop: createInterpolateElement(
 						__(
-							'This is the place to find extensions, themes, and services for your store - all reviewed and approved by the WooCommerce team.<br/><br/>Whether you’re looking to improve your store or grow your business, you can find a solution here. There are hundreds of options available, and new products are added regularly.<br/><br/>The WooCommerce Marketplace is also available at WooCommerce.com.',
+							'Power up your store by adding extra functionality using extensions, find a fresh new look with themes, or integrate your store with other software and services.<br/><br/>The WooCommerce Marketplace is your go-to for all of the above, and the only place you’ll find products that have been reviewed and approved by the WooCommerce team.<br/><br/>Whether you’re looking to improve your store or grow your business, you can find a solution here. There are hundreds of options available, and new products are added regularly.<br/><br/>The WooCommerce Marketplace is also available at WooCommerce.com.',
 							'woocommerce'
 						),
 						{
@@ -46,7 +46,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 				heading: __( 'Find exactly what you need', 'woocommerce' ),
 				descriptions: {
 					desktop: __(
-						'Use the search box to find specific products.',
+						'Use the search box to find specific products or solutions.',
 						'woocommerce'
 					),
 				},
@@ -111,7 +111,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 				descriptions: {
 					desktop: createInterpolateElement(
 						__(
-							"Products purchased from the WooCommerce Marketplace can be managed in My Subscriptions, either here or on WooCommerce.com.<br/><br/>Every purchase is backed by our <a1>30-day money-back guarantee</a1>, and includes <a2>email and live chat support</a2>.<br/><br/>That's it! We hope the Marketplace helps you build the business of your dreams.",
+							"Products purchased from the WooCommerce Marketplace can be managed in My Subscriptions, either here or on WooCommerce.com.<br/><br/>Every purchase is backed by our <a1>30-day money-back guarantee</a1>, and includes <a2>email and live chat support</a2>.<br/><br/>That's it! We hope the WooCommerce Marketplace helps you build the business of your dreams.",
 							'woocommerce'
 						),
 						{

--- a/plugins/woocommerce/changelog/update-in-app-marketplace-tour
+++ b/plugins/woocommerce/changelog/update-in-app-marketplace-tour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update wording for In-App Marketplace tour.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
@@ -23,7 +23,10 @@ class TourInAppMarketplace extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		return __( 'Tour the WooCommerce Marketplace', 'woocommerce' );
+		return __(
+			'Discover where to find powerful store add-ons and integrations, with a WooCommerce Marketplace tour',
+			'woocommerce'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We want to update wording for In-App Marketplace according to the latest copy update.

Closes https://github.com/Automattic/woocommerce.com/issues/15255 and related to changes initially added in https://github.com/woocommerce/woocommerce/pull/35278.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
Despite changes contain wording change, I'll jot down how to test it.

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout related branch in your local dev environment
2. Make sure your sources are properly built: `pnpm install && pnpm run build`
3. Start dev. env (if needed):  `cd plugins/woocommerce && npm run env:dev`, then I'll assume we use http://localhost:8888/ for testing
4. Open WP Admin by [this link](http://localhost:8888/wp-admin/) (usename: `admin` / `password`)
5. Open [`WooCommerce > Home`](http://localhost:8888/wp-admin/admin.php?page=wc-admin)
6. You should see a new Things-to-do task with the following title: `Discover where to find powerful store add-ons and integrations, with a WooCommerce Marketplace tour`
<img width="1114" alt="01-Things-to-do" src="https://user-images.githubusercontent.com/115007291/207048278-b0537fd6-9c2f-452b-a10e-5b622c2c692f.png">

7. Click by the task, you'll be redirected to [WooCommerce In-App Marketplace page](http://localhost:8888/wp-admin/admin.php?page=wc-addons&tutorial=true)
8. You should see a guided tour UI, step 1 should contain the updated wording:
> Power up your store by adding extra functionality using extensions, find a fresh new look with themes, or integrate your store with other software and services.
> 
> The WooCommerce Marketplace is your go-to for all of the above, and the only place you’ll find products that have been reviewed and approved by the WooCommerce team.
> 
> Whether you’re looking to improve your store or grow your business, you can find a solution here. There are hundreds of options available, and new products are added regularly.
> 
> The WooCommerce Marketplace is also available at WooCommerce.com.
<img width="821" alt="02-Step-1-Welcome" src="https://user-images.githubusercontent.com/115007291/207048273-df64f7b0-e964-4a61-9ec9-51ebb1fd3316.png">

9. Click next, content of step 2 was appended by `or solutions` part and should sum up to:
> Use the search box to find specific products or solutions.
<img width="861" alt="03-Step-2-Find-what-you-need" src="https://user-images.githubusercontent.com/115007291/207048268-2e50cd1f-092c-44ee-aa7e-9f4883e4e2b4.png">

10. Steps `3` and `4` remain the same, so go to step `5`
<img width="1114" alt="04-Step-3-Browse-for-new-ideas" src="https://user-images.githubusercontent.com/115007291/207048263-9c511c89-2cc5-4d18-9a5b-eddaf4df0acb.png">

<img width="1284" alt="05-Step-4-Learn-more" src="https://user-images.githubusercontent.com/115007291/207048253-0b43f82e-0d13-4691-a0cf-d710f4f0d557.png">

11. The step `5` was updated to have `WooCommerce` before `Marketplace` in the last sentence (it's the only change there), as a whole it's:
> Products purchased from the WooCommerce Marketplace can be managed in My Subscriptions, either here or on WooCommerce.com. 
> 
> Every purchase is backed by our [30-day money-back guarantee](https://woocommerce.com/refund-policy/) and includes [email and live chat support](https://woocommerce.com/my-account/create-a-ticket/).
> 
> That’s it! We hope the WooCommerce Marketplace helps you build the business of your dreams.
<img width="1102" alt="06-Step-5-Manage-purchases" src="https://user-images.githubusercontent.com/115007291/207048241-a0951da6-db49-47e9-bf4f-657490fa3785.png">

12. Finish the tour by clicking "Done"
13. Open Things-to-do tasks in [WooCommerce Home](http://localhost:8888/wp-admin/admin.php?page=wc-admin), the In-App Marketplace tour task should be done
<img width="1123" alt="07-Tour-completed" src="https://user-images.githubusercontent.com/115007291/207048228-2d08ccbb-9667-4e42-a2d4-71959d1b82df.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.




