### PR TITLE
Fix react chunk build warnings

### DIFF
--- a/plugins/woocommerce-admin/client/products/add-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/add-product-page.tsx
@@ -7,8 +7,6 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-
-import './product-page.scss';
 import { ProductForm } from './product-form';
 
 const AddProductPage: React.FC = () => {

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -16,9 +16,8 @@ import { useParams } from 'react-router-dom';
 /**
  * Internal dependencies
  */
-import { ProductFormLayout } from './layout/product-form-layout';
-import './product-page.scss';
 import { ProductForm } from './product-form';
+import { ProductFormLayout } from './layout/product-form-layout';
 
 const EditProductPage: React.FC = () => {
 	const { productId } = useParams();

--- a/plugins/woocommerce/changelog/fix-chunk_build_warnings
+++ b/plugins/woocommerce/changelog/fix-chunk_build_warnings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix WooCommerce Admin client React build warnings.

--- a/plugins/woocommerce/changelog/fix-chunk_build_warnings
+++ b/plugins/woocommerce/changelog/fix-chunk_build_warnings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix WooCommerce Admin client React build warnings.
+Fix WooCommerce Admin client React build warnings and remove unnecessary scss imports.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run `pnpm --filter=woocommerce/client/admin run start`
2. Make sure it **doesn't** output any warnings related to `Couldn't fill desired order of chunk` there were around 7 of them (should be able to see them on `trunk`)
<img width="1040" alt="Screenshot 2022-12-12 at 09 11 08" src="https://user-images.githubusercontent.com/2240960/207053100-aa78cb36-4cdf-478c-8fd3-916710e39b45.png">


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
