### PR TITLE
Disable irrelevant product tabs when variations exist

### DIFF
--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
@@ -63,13 +63,14 @@ $product-form-tabs-height: 56px;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 -3px 0 0 var(--wp-admin-theme-color);
 		}
 
-		&:disabled {
+		&:disabled,
+		&[aria-disabled='true'] {
 			// We need tooltips at full opacity so only child elements have reduced opacity.
 			opacity: 1;
-		}
 
-		&:disabled .woocommerce-product-form-tab__item-inner-text {
-			opacity: 0.3;
+			.woocommerce-product-form-tab__item-inner-text {
+				opacity: 0.3;
+			}
 		}
 
 		.woocommerce-product-form-tab__item-inner {

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
@@ -62,6 +62,21 @@ $product-form-tabs-height: 56px;
 			font-weight: 600;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) transparent, inset 0 -3px 0 0 var(--wp-admin-theme-color);
 		}
+
+		&:disabled {
+			// We need tooltips at full opacity so only child elements have reduced opacity.
+			opacity: 1;
+		}
+
+		&:disabled .woocommerce-product-form-tab__item-inner-text {
+			opacity: 0.3;
+		}
+
+		.woocommerce-product-form-tab__item-inner {
+			min-height: $product-form-tabs-height;
+			display: flex;
+			align-items: center;
+		}
 	}
 }
 

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -32,6 +32,7 @@ export const ProductFormLayout: React.FC< {
 		return {
 			name: child.props.name,
 			title: child.props.title,
+			disabled: child.props.disabled,
 		};
 	} );
 

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Children, useEffect } from '@wordpress/element';
-import { TabPanel } from '@wordpress/components';
+import { TabPanel, Tooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -31,7 +31,26 @@ export const ProductFormLayout: React.FC< {
 		}
 		return {
 			name: child.props.name,
-			title: child.props.title,
+			title: child.props.disabled ? (
+				<Tooltip
+					text={ __(
+						'Manage individual variation details in the Options tab.',
+						'woocommerce'
+					) }
+				>
+					<span className="woocommerce-product-form-tab__item-inner">
+						<span className="woocommerce-product-form-tab__item-inner-text">
+							{ child.props.title }
+						</span>
+					</span>
+				</Tooltip>
+			) : (
+				<span className="woocommerce-product-form-tab__item-inner">
+					<span className="woocommerce-product-form-tab__item-inner-text">
+						{ child.props.title }
+					</span>
+				</span>
+			),
 			disabled: child.props.disabled,
 		};
 	} );
@@ -40,6 +59,8 @@ export const ProductFormLayout: React.FC< {
 		<TabPanel
 			className="product-form-layout"
 			activeClass="is-active"
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Disabled properties will be included in newer versions of Gutenberg.
 			tabs={ tabs }
 			onSelect={ () => ( window.document.documentElement.scrollTop = 0 ) }
 		>

--- a/plugins/woocommerce-admin/client/products/product-form-tab.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-tab.tsx
@@ -4,6 +4,7 @@
 import classnames from 'classnames';
 
 export const ProductFormTab: React.FC< {
+	disabled?: boolean;
 	name: string;
 	title: string;
 	children: JSX.Element | JSX.Element[] | string;

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -48,13 +48,25 @@ export const ProductForm: React.FC< {
 					<ImagesSection />
 					<AttributesSection />
 				</ProductFormTab>
-				<ProductFormTab name="pricing" title="Pricing">
+				<ProductFormTab
+					name="pricing"
+					title="Pricing"
+					disabled={ !! product?.variations?.length }
+				>
 					<PricingSection />
 				</ProductFormTab>
-				<ProductFormTab name="inventory" title="Inventory">
+				<ProductFormTab
+					name="inventory"
+					title="Inventory"
+					disabled={ !! product?.variations?.length }
+				>
 					<ProductInventorySection />
 				</ProductFormTab>
-				<ProductFormTab name="shipping" title="Shipping">
+				<ProductFormTab
+					name="shipping"
+					title="Shipping"
+					disabled={ !! product?.variations?.length }
+				>
 					<ProductShippingSection product={ product } />
 				</ProductFormTab>
 				<ProductFormTab name="options" title="Options">

--- a/plugins/woocommerce/changelog/update-35779
+++ b/plugins/woocommerce/changelog/update-35779
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disable irrelevant product tabs when variations exist


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Disable Pricing, Inventory, and Shipping product tabs when at least one variation exists.

<img width="400" alt="Screen Shot 2022-12-12 at 9 45 18 AM" src="https://user-images.githubusercontent.com/10561050/207116545-b7e67335-8cf2-426c-8cfc-28ea8beab1f3.png">

Closes #35779  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install this branch of Gutenberg - https://github.com/WordPress/gutenberg/pull/46471
2. Add a variation to any product using the old product experience
3. Navigate to the edit screen for that product in the new experience.  `/wp-admin/admin.php?page=wc-admin&path=/product/{product_id}`
4. Check that the Pricing, Inventory, and Shipping product tabs are disabled
5. Hover the disabled product tabs and make sure a tooltip appears
<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
