### PR TITLE
Fix RegExp used to filter the country list dropdown on the store details step

### DIFF
--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -357,6 +357,9 @@ export function StoreAddress( {
 				label={ __( 'Country / Region', 'woocommerce' ) + ' *' }
 				required
 				autoComplete="new-password" // disable autocomplete and autofill
+				getSearchExpression={ ( query: string ) => {
+					return new RegExp( '^' + query, 'i' );
+				} }
 				options={ countryStateOptions }
 				excludeSelectedOptions={ false }
 				showAllOnFocus

--- a/plugins/woocommerce/changelog/fix-regex-used-to-filter-country-dropdown
+++ b/plugins/woocommerce/changelog/fix-regex-used-to-filter-country-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix regexp used for filtering country dropdown on the store details step #35941


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


Closes #35941 

### How to test the changes in this Pull Request:

1. Checkout this branch and build the assets.
2. Start OBW
3. On the store details step, try to search for a country.
4. Confirm the filtered result doesn't contain any relevant countries.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
