### PR TITLE
Fix wcpay benefits UI padding

### DIFF
--- a/packages/js/onboarding/changelog/fix-35704-wcpay-benefit-padding
+++ b/packages/js/onboarding/changelog/fix-35704-wcpay-benefit-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wcpay benefits padding

--- a/packages/js/onboarding/src/components/WCPayBenefits/WCPayBenefits.tsx
+++ b/packages/js/onboarding/src/components/WCPayBenefits/WCPayBenefits.tsx
@@ -17,7 +17,7 @@ import {
 
 export const WCPayBenefits: React.VFC = () => {
 	return (
-		<Flex className="woocommerce-wcpay-benefits" gap={ 30 } align="top">
+		<Flex className="woocommerce-wcpay-benefits" align="top">
 			<Flex className="woocommerce-wcpay-benefits-benefit">
 				<PaymentCardIcon />
 				<Text as="p">


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35704.

This PR fixes the padding bug caused by WP 6.1.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->
 
1. Go to OBW
2. Continue with a WCPay eligible country such as US 
3. Uncheck WCPay in the **business details** step
4. Complete OBW
5. Go to `WooCommerce > Home > Set up payments` task
6. Observe that the benefit UI is displayed properly.

before:

<img width="1352" alt="Screen Shot 2022-12-13 at 11 32 12" src="https://user-images.githubusercontent.com/4344253/207220455-5cddfe13-4f9d-4ebc-ad11-15c99e6c41f9.png">

after:

<img width="1349" alt="Screen Shot 2022-12-13 at 11 32 21" src="https://user-images.githubusercontent.com/4344253/207220469-d14da05d-f888-4a3a-9114-cc3a31e4459e.png">



<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
