### PR TITLE
Fix ellipsis dropdown is hidden in task list

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/task-list.scss
+++ b/plugins/woocommerce-admin/client/tasks/task-list.scss
@@ -1,5 +1,4 @@
 .woocommerce-task-list__item {
-	overflow: hidden;
 	&.woocommerce-list__item-enter {
 		opacity: 0;
 		max-height: 0;

--- a/plugins/woocommerce/changelog/fix-35505-ellipsis-dropdown-is-hidden
+++ b/plugins/woocommerce/changelog/fix-35505-ellipsis-dropdown-is-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix ellipsis dropdown menu is mostly hidden within the task list


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35505 #34780.

Fixes Dismiss" button overlaps with task list "Add (Paid Theme) to my store"


Before

<img width="1048" alt="Screen Shot 2022-12-13 at 14 26 35" src="https://user-images.githubusercontent.com/4344253/207242547-dee3ccea-287d-4b20-a225-1cae33d6006a.png">


After

<img width="896" alt="Screen Shot 2022-12-13 at 14 25 55" src="https://user-images.githubusercontent.com/4344253/207242439-09edad5d-e520-4e6d-b54a-26601a172093.png">



<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Complete the OBW till Themes tab.
2. Select any Paid theme and complete the OBW.
3. Go to Woocommerce > Home.
4. Select ellipsis menu of "Add (Paid Theme) to my store" task from Set up tasklist.
5. Observe that, "Dismiss" button is shown properly with task list "Add (Paid Theme) to my store".

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
