### PR TITLE
Include taxes migration in the states migrator helper method

### DIFF
--- a/plugins/woocommerce/changelog/fix-include-taxes-in-states-migrator
+++ b/plugins/woocommerce/changelog/fix-include-taxes-in-states-migrator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Include taxes migration in MigrationHelper::migrate_country_states

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -217,9 +217,9 @@ class WC_Install {
 			'wc_update_700_remove_download_log_fk',
 			'wc_update_700_remove_recommended_marketing_plugins_transient',
 		),
-		'7.2.0' => array(
-			'wc_update_720_adjust_new_zealand_states',
-			'wc_update_720_adjust_ukraine_states',
+		'7.3.0' => array(
+			'wc_update_730_adjust_new_zealand_states',
+			'wc_update_730_adjust_ukraine_states',
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -217,9 +217,9 @@ class WC_Install {
 			'wc_update_700_remove_download_log_fk',
 			'wc_update_700_remove_recommended_marketing_plugins_transient',
 		),
-		'7.3.0' => array(
-			'wc_update_730_adjust_new_zealand_states',
-			'wc_update_730_adjust_ukraine_states',
+		'7.2.1' => array(
+			'wc_update_721_adjust_new_zealand_states',
+			'wc_update_721_adjust_ukraine_states',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2477,7 +2477,7 @@ function wc_update_700_remove_recommended_marketing_plugins_transient() {
  * Update the New Zealand state codes in the database
  * after they were updated in code to the CLDR standard.
  */
-function wc_update_730_adjust_new_zealand_states() {
+function wc_update_721_adjust_new_zealand_states() {
 		return MigrationHelper::migrate_country_states(
 		'NZ',
 		array(
@@ -2505,7 +2505,7 @@ function wc_update_730_adjust_new_zealand_states() {
  * Update the Ukraine state codes in the database
  * after they were updated in code to the CLDR standard.
  */
-function wc_update_730_adjust_ukraine_states() {
+function wc_update_721_adjust_ukraine_states() {
 	return MigrationHelper::migrate_country_states(
 		'UA',
 		array(

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2478,7 +2478,7 @@ function wc_update_700_remove_recommended_marketing_plugins_transient() {
  * after they were updated in code to the CLDR standard.
  */
 function wc_update_721_adjust_new_zealand_states() {
-		return MigrationHelper::migrate_country_states(
+	return MigrationHelper::migrate_country_states(
 		'NZ',
 		array(
 			'NL' => 'NTL',

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2477,8 +2477,8 @@ function wc_update_700_remove_recommended_marketing_plugins_transient() {
  * Update the New Zealand state codes in the database
  * after they were updated in code to the CLDR standard.
  */
-function wc_update_720_adjust_new_zealand_states() {
-	return MigrationHelper::migrate_country_states(
+function wc_update_730_adjust_new_zealand_states() {
+		return MigrationHelper::migrate_country_states(
 		'NZ',
 		array(
 			'NL' => 'NTL',
@@ -2505,7 +2505,7 @@ function wc_update_720_adjust_new_zealand_states() {
  * Update the Ukraine state codes in the database
  * after they were updated in code to the CLDR standard.
  */
-function wc_update_720_adjust_ukraine_states() {
+function wc_update_730_adjust_ukraine_states() {
 	return MigrationHelper::migrate_country_states(
 		'UA',
 		array(

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -274,18 +274,15 @@ class MigrationHelper {
 	private static function migrate_country_states_for_tax_rates( string $country_code, array $old_to_new_states_mapping ): void {
 		global $wpdb;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-
 		foreach ( $old_to_new_states_mapping as $old_state_code => $new_state_code ) {
-			$update_query = $wpdb->prepare(
-				"UPDATE {$wpdb->prefix}woocommerce_tax_rates SET tax_rate_state=%s WHERE tax_rate_country=%s AND tax_rate_state=%s",
-				$new_state_code,
-				$country_code,
-				$old_state_code
+			$wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->prefix}woocommerce_tax_rates SET tax_rate_state=%s WHERE tax_rate_country=%s AND tax_rate_state=%s",
+					$new_state_code,
+					$country_code,
+					$old_state_code
+				)
 			);
-			$wpdb->query( $update_query );
 		}
-
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 }

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -102,6 +102,7 @@ class MigrationHelper {
 	 */
 	private static function migrate_country_states_for_misc_data( string $country_code, array $old_to_new_states_mapping ): void {
 		self::migrate_country_states_for_shipping_locations( $country_code, $old_to_new_states_mapping );
+		self::migrate_country_states_for_tax_rates( $country_code, $old_to_new_states_mapping );
 		self::migrate_country_states_for_store_location( $country_code, $old_to_new_states_mapping );
 	}
 
@@ -261,5 +262,30 @@ class MigrationHelper {
 		return (int) ( $wpdb->get_var( $more_exist_query ) ) !== 0;
 
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Migrate state codes in the tax rates table.
+	 *
+	 * @param string $country_code The country that has the states for which the migration is needed.
+	 * @param array  $old_to_new_states_mapping An associative array where keys are the old state codes and values are the new state codes.
+	 * @return void
+	 */
+	private static function migrate_country_states_for_tax_rates( string $country_code, array $old_to_new_states_mapping ): void {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+
+		foreach ( $old_to_new_states_mapping as $old_state_code => $new_state_code ) {
+			$update_query = $wpdb->prepare(
+				"UPDATE {$wpdb->prefix}woocommerce_tax_rates SET tax_rate_state=%s WHERE tax_rate_country=%s AND tax_rate_state=%s",
+				$new_state_code,
+				$country_code,
+				$old_state_code
+			);
+			$wpdb->query( $update_query );
+		}
+
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/35669 introduced a helper method to migrate state codes in various places of the database (shipping locations, orders, store address) but one placed that was missing is the tax rates table. This pull request fixes that.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Same testing instructions of https://github.com/woocommerce/woocommerce/pull/35669 but this time testing that the state codes in the tax rates (WooCommerce - Settings - Tax - Standard, Reduced and Zero taxes) are properly updated.

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
