### PR TITLE
Fix no email report on product filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-32220_no_email_report_on_product_filter
+++ b/plugins/woocommerce/changelog/fix-32220_no_email_report_on_product_filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix total count query of orders within Analytics reports data store.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -256,7 +256,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$this->add_sql_query_params( $query_args );
 			/* phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared */
 			$db_records_count = (int) $wpdb->get_var(
-				"SELECT COUNT(*) FROM (
+				"SELECT COUNT( DISTINCT tt.order_id ) FROM (
 					{$this->subquery->get_query_statement()}
 				) AS tt"
 			);

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -262,7 +262,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			'after'            => $start_time,
 			'before'           => $end_time,
 			'extended_info'    => 1,
-			'product_includes' => array( $parent_product->get_id() )
+			'product_includes' => array( $parent_product->get_id() ),
 		);
 		// Test retrieving the stats through the data store.
 		$data     = $data_store->get_data( $args );
@@ -271,7 +271,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$args_variation = array(
 			'after'              => $start_time,
 			'before'             => $end_time,
-			'variation_includes' => array( $variation->get_id() )
+			'variation_includes' => array( $variation->get_id() ),
 		);
 		// Test retrieving the stats through the data store.
 		$data_variation     = $data_store->get_data( $args_variation );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -176,6 +176,109 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that product includes count returns correctly when multiple variations of the same product is added.
+	 */
+	public function test_product_and_variation_includes_count() {
+		global $wpdb;
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$parent_product = new WC_Product_Variable();
+		$parent_product->set_name( 'Variable Product' );
+		$parent_product->set_regular_price( 25 );
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( 0 );
+		$attribute->set_name( 'pa_color' );
+		$attribute->set_options( explode( WC_DELIMITER, 'green | red' ) );
+		$attribute->set_visible( false );
+		$attribute->set_variation( true );
+		$parent_product->set_attributes( array( $attribute ) );
+		$parent_product->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_name( 'Test Variation - Green' );
+		$variation->set_parent_id( $parent_product->get_id() );
+		$variation->set_regular_price( 10 );
+		$variation->set_attributes( array( 'pa_color' => 'green' ) );
+		$variation->set_manage_stock( true );
+		$variation->set_stock_quantity( 25 );
+		$variation->save();
+
+		$variation2 = new WC_Product_Variation();
+		$variation2->set_name( 'Test Variation - Red' );
+		$variation2->set_parent_id( $parent_product->get_id() );
+		$variation2->set_regular_price( 10 );
+		$variation2->set_attributes( array( 'pa_color' => 'red' ) );
+		$variation2->set_manage_stock( true );
+		$variation2->set_stock_quantity( 25 );
+		$variation2->save();
+
+		$simple_product = new WC_Product_Simple();
+		$simple_product->set_name( 'Simple Product' );
+		$simple_product->set_regular_price( 25 );
+		$simple_product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $variation );
+		$order2 = WC_Helper_Order::create_order( 1, $simple_product );
+		// Add simple product.
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $simple_product,
+				'quantity' => 1,
+				'subtotal' => wc_get_price_excluding_tax( $simple_product, array( 'qty' => 1 ) ),
+				'total'    => wc_get_price_excluding_tax( $simple_product, array( 'qty' => 1 ) ),
+			)
+		);
+		$item->save();
+		$order->add_item( $item );
+		$item2 = new WC_Order_Item_Product();
+		$item2->set_props(
+			array(
+				'product'  => $variation2,
+				'quantity' => 2,
+				'subtotal' => wc_get_price_excluding_tax( $variation2, array( 'qty' => 1 ) ),
+				'total'    => wc_get_price_excluding_tax( $variation2, array( 'qty' => 1 ) ),
+			)
+		);
+		$item2->save();
+		$order->add_item( $item2 );
+		// Fix totals.
+		$order->set_total( 95 ); // ( 6 * 10 ) + 25 + 10 shipping (in helper).
+		$order->set_status( 'completed' );
+		$order->save();
+
+		$order2->set_total( 45 ); // ( 1 * 10 ) + 25 + 10 shipping (in helper).
+		$order2->set_status( 'completed' );
+		$order2->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$data_store = new OrdersDataStore();
+		$start_time = gmdate( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time   = gmdate( 'Y-m-d H:59:59', $order2->get_date_created()->getOffsetTimestamp() );
+		$args       = array(
+			'after'            => $start_time,
+			'before'           => $end_time,
+			'extended_info'    => 1,
+			'product_includes' => array( $parent_product->get_id() )
+		);
+		// Test retrieving the stats through the data store.
+		$data     = $data_store->get_data( $args );
+		$this->assertEquals( 1, $data->total );
+
+		$args_variation = array(
+			'after'              => $start_time,
+			'before'             => $end_time,
+			'variation_includes' => array( $variation->get_id() )
+		);
+		// Test retrieving the stats through the data store.
+		$data_variation     = $data_store->get_data( $args_variation );
+		$this->assertEquals( 1, $data_variation->total );
+	}
+
+	/**
 	 * Test that excluding specific coupons doesn't exclude orders without coupons.
 	 * See: https://github.com/woocommerce/woocommerce-admin/issues/6824.
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -219,7 +219,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$simple_product->set_regular_price( 25 );
 		$simple_product->save();
 
-		$order = WC_Helper_Order::create_order( 1, $variation );
+		$order  = WC_Helper_Order::create_order( 1, $variation );
 		$order2 = WC_Helper_Order::create_order( 1, $simple_product );
 		// Add simple product.
 		$item = new WC_Order_Item_Product();
@@ -265,7 +265,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			'product_includes' => array( $parent_product->get_id() ),
 		);
 		// Test retrieving the stats through the data store.
-		$data     = $data_store->get_data( $args );
+		$data = $data_store->get_data( $args );
 		$this->assertEquals( 1, $data->total );
 
 		$args_variation = array(
@@ -274,7 +274,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			'variation_includes' => array( $variation->get_id() ),
 		);
 		// Test retrieving the stats through the data store.
-		$data_variation     = $data_store->get_data( $args_variation );
+		$data_variation = $data_store->get_data( $args_variation );
 		$this->assertEquals( 1, $data_variation->total );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure we add a `distinct` to the totals query so duplicate order id's are not included.
This is possible because of the left join used for the included product filter.

Closes #32220 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Before loading this branch, build latest of `trunk`
2. Start a new store, finish the onboarding, and load the sample products in Step 7 (personalize your store) or import these products -> https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/sample-data/sample_products.csv
3. Set up payments ( I usually select cash on delivery )
4. Create a new order through the store, adding two different variable products of the same product (ex: Hoodie - Red, Hoodie - Green ) and checkout.
5. Go to **WooCommerce > Status > Scheduled Actions** and make sure there are no outstanding actions left (there is usually one daily one), if there is more then one, you can click `run` on each item to finish it.
6. Go to **Analytics > Orders** a single order should be displayed
7. Now select an advanced filter and select the Products filter. Search for your variable product (in my case: Hoodie) and select that.
8. The order should still be displayed, now click `Download` within the table. Notice how it shows a notice that the report will be emailed to you (but if you install the Email log plugin you will notice that won't happen). Technically it should only email reports if the order size is larger then the page size, so in this case you can see it's a bug.
9. Remove the advanced filter and click `Download` again, notice how it does allow you to download it right away.
10. Now load and build this branch
11. Add the advanced filter for the specific product again (Hoodie)
12. Click `Download` and notice how it shows the popup to immediately download the reports.
13. You can also check the network panel and look for the `wc-analytics/reports/orders?` request and check if the `X-WP-Total` response header returns the correct order number ( it will return a bigger number on `trunk` )

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
