### PR TITLE
Fix product tab to be shown on production build

### DIFF
--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -9,6 +9,7 @@ import { TabPanel } from '@wordpress/components';
  * Internal dependencies
  */
 import './product-form-layout.scss';
+import { ProductFormTab } from '../product-form-tab';
 
 export const ProductFormLayout: React.FC< {
 	children: JSX.Element | JSX.Element[];
@@ -26,7 +27,7 @@ export const ProductFormLayout: React.FC< {
 	}, [] );
 
 	const tabs = Children.map( children, ( child: JSX.Element ) => {
-		if ( child.type.name !== 'ProductFormTab' ) {
+		if ( child.type !== ProductFormTab ) {
 			return null;
 		}
 		return {
@@ -46,7 +47,7 @@ export const ProductFormLayout: React.FC< {
 				<>
 					{ Children.map( children, ( child: JSX.Element ) => {
 						if (
-							child.type.name !== 'ProductFormTab' ||
+							child.type !== ProductFormTab ||
 							child.props.name !== tab.name
 						) {
 							return null;

--- a/plugins/woocommerce/changelog/fix-35706
+++ b/plugins/woocommerce/changelog/fix-35706
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product tab to be shown on production build


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce/issues/35706

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product management experience (Products -> Add new (MVP))
2. Click the various tabs in the header to navigate between product sections (General/Pricing/etc)
3. Make sure that all content is shown and works as expected
4. Narrow your viewport to make sure that the header placement works with various screen sizes
5. Scroll down inside a given tab and then click another tab to make sure you're scrolled back to the top

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
