### PR TITLE
Make order number customizable during creation of new orders through …

### DIFF
--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
@@ -426,6 +426,11 @@ class WC_API_Orders extends WC_API_Resource {
 				$default_order_args['customer_id'] = $data['customer_id'];
 			}
 
+			// if custom order id is set
+			if ( isset( $data['number'] ) ) {
+				$default_order_args['number'] = $data['number'];
+			}
+
 			// create the pending order
 			$order = $this->create_base_order( $default_order_args, $data );
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1049,7 +1049,6 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					'description' => __( 'Order number.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
 				),
 				'order_key'            => array(
 					'description' => __( 'Order key.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -82,6 +82,7 @@ function wc_maybe_define_constant( $name, $value ) {
  * @return WC_Order|WP_Error
  */
 function wc_create_order( $args = array() ) {
+	$custom_order_number_set = isset( $args['number'] ) ? true : null;
 	$default_args = array(
 		'status'        => null,
 		'customer_id'   => null,
@@ -89,7 +90,7 @@ function wc_create_order( $args = array() ) {
 		'parent'        => null,
 		'created_via'   => null,
 		'cart_hash'     => null,
-		'order_id'      => 0,
+		'order_id'      => isset( $custom_order_number_set ) ? $args['number'] : 0,
 	);
 
 	try {
@@ -122,7 +123,8 @@ function wc_create_order( $args = array() ) {
 		}
 
 		// Set these fields when creating a new order but not when updating an existing order.
-		if ( ! $args['order_id'] ) {
+		// custom order number is always a new order
+		if ( ! $args['order_id'] || ! is_null($custom_order_number_set) ) {
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );


### PR DESCRIPTION
Explanation:

Change to the REST API to https://woocommerce.github.io/woocommerce-rest-api-docs/?ruby#create-an-order

Make it possible to use a custom order number for example "128231923123" instead of the standard creating an unused id.

This should make it possible to use an external order id for new orders created through the API. This in turn makes it more compatible with third parties needing the external order id.

Also people ordering from marketplaces only know their marketplace order number and it should be the same as the woocommerce order number.



### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a new order through the REST API
2. Use a custom order number for the order property "number"
3. Check to see a new order has been created with the custom order number

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.


Not sure what i'm missing in the bigger picture since this is the first commit to Woocommerce.