### PR TITLE
Add endpoint to create all product variations

### DIFF
--- a/plugins/woocommerce/changelog/add-35778-endpoint
+++ b/plugins/woocommerce/changelog/add-35778-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add endpoint to create all product variations

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -34,7 +34,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		parent::register_routes();
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/create_all', array(
+			$this->namespace, '/' . $this->rest_base . '/generate', array(
 				'args'   => array(
 					'product_id' => array(
 						'description' => __( 'Unique identifier for the variable product.', 'woocommerce' ),
@@ -43,7 +43,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'create_all' ),
+					'callback'            => array( $this, 'generate' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
@@ -906,12 +906,12 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	}
 
 	/**
-	 * Create all variations for a given product.
+	 * Generate all variations for a given product.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|WP_REST_Response
 	 */
-	public function create_all( $request ) {
+	public function generate( $request ) {
 		$product_id = (int) $request['product_id'];
 
 		if ( 'product' !== get_post_type( $product_id ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -10,6 +10,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * REST API variations controller class.
  *
@@ -24,6 +26,31 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/create_all', array(
+				'args'   => array(
+					'product_id' => array(
+						'description' => __( 'Unique identifier for the variable product.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_all' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
 
 	/**
 	 * Prepare a single variation output for response.
@@ -876,5 +903,31 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Create all variations for a given product.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_all( $request ) {
+		$product_id = (int) $request['product_id'];
+
+		if ( 'product' !== get_post_type( $product_id ) ) {
+			return new WP_Error( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		wc_maybe_define_constant( 'WC_MAX_LINKED_VARIATIONS', 50 );
+		wc_set_time_limit( 0 );
+
+		$response          = array();
+		$product           = wc_get_product( $product_id );
+		$data_store        = $product->get_data_store();
+		$response['count'] = $data_store->create_all_product_variations( $product, Constants::get_constant( 'WC_MAX_LINKED_VARIATIONS' ) );
+
+		$data_store->sort_all_product_variations( $product->get_id() );
+
+		return rest_ensure_response( $response );
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -34,7 +34,9 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		parent::register_routes();
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/generate', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/generate',
+			array(
 				'args'   => array(
 					'product_id' => array(
 						'description' => __( 'Unique identifier for the variable product.', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds an endpoint to create all product variations.   This function already exists and is usable via AJAX but requires a nonce in order to do so.  This PR adds this utility to the REST endpoint on variations.

<img width="320" alt="Screen Shot 2022-12-14 at 11 12 33 AM" src="https://user-images.githubusercontent.com/10561050/207692508-c44b97ed-7f6c-43a2-8d66-7c886bf6c2d0.png">


Part of #35778 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some attributes and check "Used for variations".
2. Using Postman or a similar app, make a POST request to `/wp-json/wc/v3/products/{product_id}/variations/generate` replacing `{product_id}` with your product ID.
3. Check that the number of variations is returned in the `count` parameter (this will be `0` if variations already exist).
4. Visit the old product experience for that product `wp-admin/post.php?post={product_id}&action=edit`
5. Navigate to the "Variations" tab to confirm the variations were added.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
