### PR TITLE
Product variation quantity status indicator

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -3,7 +3,7 @@
 
 	&__header {
 		display: grid;
-		grid-template-columns: calc(38px + 25%) 25% 25%;
+		grid-template-columns: calc( 38px + 25% ) 25% 25%;
 		padding: $gap-small $gap;
 
 		h4 {
@@ -12,6 +12,19 @@
 			text-transform: uppercase;
 			margin: 0;
 			font-weight: 500;
+		}
+	}
+
+	&__status-dot {
+		margin-right: $gap-small;
+		&.green {
+			color: $alert-green;
+		}
+		&.yellow {
+			color: $alert-yellow;
+		}
+		&.red {
+			color: $alert-red;
 		}
 	}
 
@@ -32,7 +45,7 @@
 		height: 34px;
 		left: 50%;
 		top: 50%;
-		transform: translate(-50%, -50%);
+		transform: translate( -50%, -50% );
 		position: absolute;
 		margin: 0;
 	}

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -16,7 +16,7 @@
 	}
 
 	&__status-dot {
-		margin-right: $gap-small;
+		margin-right: $gap-smaller;
 		&.green {
 			color: $alert-green;
 		}

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -3,7 +3,7 @@
 
 	&__header {
 		display: grid;
-		grid-template-columns: calc( 38px + 25% ) 25% 25%;
+		grid-template-columns: calc(38px + 25%) 25% 25%;
 		padding: $gap-small $gap;
 
 		h4 {
@@ -45,7 +45,7 @@
 		height: 34px;
 		left: 50%;
 		top: 50%;
-		transform: translate( -50%, -50% );
+		transform: translate(-50%, -50%);
 		position: absolute;
 		margin: 0;
 	}

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -11,12 +11,16 @@ import { ListItem, Sortable, Tag } from '@woocommerce/components';
 import { useContext } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
 import { useSelect } from '@wordpress/data';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { CurrencyContext } from '../../../lib/currency-context';
-import { getProductStockStatus } from '../../utils/get-product-stock-status';
+import {
+	getProductStockStatus,
+	getProductStockStatusClass,
+} from '../../utils/get-product-stock-status';
 import './variations.scss';
 
 export const Variations: React.FC = () => {
@@ -81,6 +85,14 @@ export const Variations: React.FC = () => {
 							{ formatAmount( variation.price ) }
 						</div>
 						<div className="woocommerce-product-variations__quantity">
+							<span
+								className={ classnames(
+									'woocommerce-product-variations__status-dot',
+									getProductStockStatusClass( variation )
+								) }
+							>
+								●
+							</span>
 							{ getProductStockStatus( variation ) }
 						</div>
 					</ListItem>

--- a/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
@@ -14,6 +14,15 @@ export enum PRODUCT_STOCK_STATUS_KEYS {
 }
 
 /**
+ * Product stock status colors.
+ */
+export enum PRODUCT_STOCK_STATUS_COLORS {
+	instock = 'green',
+	onbackorder = 'yellow',
+	outofstock = 'red',
+}
+
+/**
  * Labels for product stock statuses.
  */
 export const PRODUCT_STOCK_STATUS_LABELS = {
@@ -46,4 +55,28 @@ export const getProductStockStatus = (
 	}
 
 	return PRODUCT_STOCK_STATUS_LABELS.instock;
+};
+
+/**
+ * Get the product stock status class.
+ *
+ * @param  product Product instance.
+ * @return {PRODUCT_STOCK_STATUS_COLORS} Product stock status class.
+ */
+export const getProductStockStatusClass = (
+	product: PartialProduct | Partial< ProductVariation >
+): string => {
+	if ( product.manage_stock ) {
+		const stockQuantity: number = product.stock_quantity || 0;
+		if ( stockQuantity >= 10 ) {
+			return PRODUCT_STOCK_STATUS_COLORS.instock;
+		}
+		if ( stockQuantity < 10 && stockQuantity > 2 ) {
+			return PRODUCT_STOCK_STATUS_COLORS.onbackorder;
+		}
+		return PRODUCT_STOCK_STATUS_COLORS.outofstock;
+	}
+	return product.stock_status
+		? PRODUCT_STOCK_STATUS_COLORS[ product.stock_status ]
+		: '';
 };

--- a/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-stock-status.ts
@@ -16,7 +16,7 @@ export enum PRODUCT_STOCK_STATUS_KEYS {
 /**
  * Product stock status colors.
  */
-export enum PRODUCT_STOCK_STATUS_COLORS {
+export enum PRODUCT_STOCK_STATUS_CLASSES {
 	instock = 'green',
 	onbackorder = 'yellow',
 	outofstock = 'red',
@@ -61,7 +61,7 @@ export const getProductStockStatus = (
  * Get the product stock status class.
  *
  * @param  product Product instance.
- * @return {PRODUCT_STOCK_STATUS_COLORS} Product stock status class.
+ * @return {PRODUCT_STOCK_STATUS_CLASSES} Product stock status class.
  */
 export const getProductStockStatusClass = (
 	product: PartialProduct | Partial< ProductVariation >
@@ -69,14 +69,14 @@ export const getProductStockStatusClass = (
 	if ( product.manage_stock ) {
 		const stockQuantity: number = product.stock_quantity || 0;
 		if ( stockQuantity >= 10 ) {
-			return PRODUCT_STOCK_STATUS_COLORS.instock;
+			return PRODUCT_STOCK_STATUS_CLASSES.instock;
 		}
 		if ( stockQuantity < 10 && stockQuantity > 2 ) {
-			return PRODUCT_STOCK_STATUS_COLORS.onbackorder;
+			return PRODUCT_STOCK_STATUS_CLASSES.onbackorder;
 		}
-		return PRODUCT_STOCK_STATUS_COLORS.outofstock;
+		return PRODUCT_STOCK_STATUS_CLASSES.outofstock;
 	}
 	return product.stock_status
-		? PRODUCT_STOCK_STATUS_COLORS[ product.stock_status ]
+		? PRODUCT_STOCK_STATUS_CLASSES[ product.stock_status ]
 		: '';
 };

--- a/plugins/woocommerce-admin/client/products/utils/test/get-product-stock-status.test.ts
+++ b/plugins/woocommerce-admin/client/products/utils/test/get-product-stock-status.test.ts
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { PartialProduct } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getProductStockStatus,
+	getProductStockStatusClass,
+} from '../get-product-stock-status';
+
+const products = [
+	{
+		status: 'publish',
+	} as PartialProduct,
+	{
+		status: 'publish',
+		stock_status: 'outofstock',
+	} as PartialProduct,
+	{
+		manage_stock: true,
+		stock_quantity: 15,
+		status: 'publish',
+		stock_status: 'instock',
+	} as PartialProduct,
+	{
+		manage_stock: true,
+		status: 'publish',
+		stock_status: 'instock',
+	} as PartialProduct,
+	{
+		manage_stock: true,
+		stock_quantity: 5,
+		status: 'publish',
+		stock_status: 'instock',
+	} as PartialProduct,
+	{
+		manage_stock: true,
+		stock_quantity: 1,
+		status: 'publish',
+		stock_status: 'instock',
+	} as PartialProduct,
+	{
+		manage_stock: false,
+		status: 'publish',
+		stock_status: 'instock',
+	} as PartialProduct,
+	{
+		manage_stock: false,
+		status: 'publish',
+		stock_status: 'onbackorder',
+	} as PartialProduct,
+	{
+		manage_stock: false,
+		status: 'publish',
+		stock_status: 'outofstock',
+	} as PartialProduct,
+];
+
+describe( 'getProductStockStatus', () => {
+	it( 'should return `In stock` status when the stock is not being managed and there is no stock status', () => {
+		const status = getProductStockStatus( products[ 0 ] );
+		expect( status ).toBe( 'In stock' );
+	} );
+
+	it( 'should return the stock status when there is a stock status and the stock is not being managed', () => {
+		const status = getProductStockStatus( products[ 1 ] );
+		expect( status ).toBe( 'Out of stock' );
+	} );
+
+	it( 'should return the stock quantity when the stock is being managed', () => {
+		const status = getProductStockStatus( products[ 2 ] );
+		expect( status ).toBe( 15 );
+	} );
+
+	it( 'should return stock quantity = 0 when the stock is being managed but there is no a stock quantity', () => {
+		const status = getProductStockStatus( products[ 3 ] );
+		expect( status ).toBe( 0 );
+	} );
+} );
+
+describe( 'getProductStockStatusClass', () => {
+	it( 'should return an emtpy string when the stock is not being managed and there is no stock status', () => {
+		const status = getProductStockStatusClass( products[ 0 ] );
+		expect( status ).toBe( '' );
+	} );
+
+	it( 'should return `green` when the stock is being managed and the stock quantity is higher or equal than 10', () => {
+		const status = getProductStockStatusClass( products[ 2 ] );
+		expect( status ).toBe( 'green' );
+	} );
+
+	it( 'should return `yellow` when the stock is being managed and the stock quantity is lower than 10 but higher than 2', () => {
+		const status = getProductStockStatusClass( products[ 4 ] );
+		expect( status ).toBe( 'yellow' );
+	} );
+
+	it( 'should return `red` when the stock is being managed and the stock quantity is lower or equal than 2', () => {
+		const status = getProductStockStatusClass( products[ 5 ] );
+		expect( status ).toBe( 'red' );
+	} );
+
+	it( 'should return `red` when the stock is being managed but there is no a stock quantity', () => {
+		const status = getProductStockStatusClass( products[ 3 ] );
+		expect( status ).toBe( 'red' );
+	} );
+
+	it( 'should return `green` when the stock is not being managed and the stock status is `instock`', () => {
+		const status = getProductStockStatusClass( products[ 6 ] );
+		expect( status ).toBe( 'green' );
+	} );
+
+	it( 'should return `yellow` when the stock is not being managed and the stock status is `onbackorder`', () => {
+		const status = getProductStockStatusClass( products[ 7 ] );
+		expect( status ).toBe( 'yellow' );
+	} );
+
+	it( 'should return `red` when the stock is not being managed and the stock status is `outofstock`', () => {
+		const status = getProductStockStatusClass( products[ 8 ] );
+		expect( status ).toBe( 'red' );
+	} );
+} );

--- a/plugins/woocommerce/changelog/add-35791_variation_quantity_status_indicator
+++ b/plugins/woocommerce/changelog/add-35791_variation_quantity_status_indicator
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product variation quantity status indicator


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to show a color indicator for the product variation status.

**Design**

BaoQ3PGPnhAiJCsJtxgej3-fi-106%3A1922&t=Jsh233onKmJpJYtN-0


![Image](https://user-images.githubusercontent.com/10561050/204896398-5d5baaa9-9a0d-4f11-8bac-e77c3794a9f7.png)

Closes #35791.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Add a variation to any product using the old product experience. You will need to add a few of them.
2. Navigate to the edit screen for that product in the new experience.  `/wp-admin/admin.php?page=wc-admin&path=/product/{product_id}`.
3. Go to the `Options` tab.
4. You should see the following:
- A `green` dot
      - Stock is being managed and `quantity >= 10`
      - Stock is not being managed and stock status is: `instock`. In this case, it should show the text `In stock` next to the green dot.
- A `yellow` dot
      - Stock is being managed and `10 < quantity > 2`
      - Stock is not being managed and stock status is: `onbackorder`. In this case, it should show the text `On backorder` next to the yellow dot.
- A `red` dot
      - Stock is being managed and `quantity <= 2`
      - Stock is not being managed and stock status is: `outofstock`. In this case, it should show the text `Out of stock` next to the red dot.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
