### PR TITLE
Bump "tested up to" field (WP is now at 6.1.1).

### DIFF
--- a/plugins/woocommerce/changelog/spotfix-tested-up-to-61
+++ b/plugins/woocommerce/changelog/spotfix-tested-up-to-61
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+WooCommerce has now been tested up to WordPress 6.1.x.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
 Requires at least: 5.8
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 7.2
 Stable tag: 7.1.1
 License: GPLv3


### PR DESCRIPTION
Bumps the "tested up to" field to 6.1—noting the stable version of WP has been 6.1.1 for one month now.

Internal conversation: p1671050983091469-slack-C01DT6U03HC

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Should be no need to test manually, code review will suffice.

<!-- End testing instructions -->


<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.