### PR TITLE
Adding ces exit prompt when filtering analytics.

### DIFF
--- a/plugins/woocommerce-admin/client/analytics/components/report-filters/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-filters/index.js
@@ -21,6 +21,9 @@ import { recordEvent } from '@woocommerce/tracks';
 import { CurrencyContext } from '../../../lib/currency-context';
 import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 import { LOCALE } from '~/utils/admin-settings';
+import { addExitPage } from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
+
+const queueExitPageSurvey = () => addExitPage( 'analytics_filtered' );
 
 class ReportFilters extends Component {
 	constructor() {
@@ -32,6 +35,8 @@ class ReportFilters extends Component {
 
 	onDateSelect( data ) {
 		const { report, addCesSurveyForAnalytics } = this.props;
+
+		queueExitPageSurvey();
 		addCesSurveyForAnalytics();
 		recordEvent( 'datepicker_update', {
 			report,
@@ -41,6 +46,8 @@ class ReportFilters extends Component {
 
 	onFilterSelect( data ) {
 		const { report, addCesSurveyForAnalytics } = this.props;
+
+		queueExitPageSurvey();
 
 		// This event gets triggered in the following cases.
 		// 1. Select "Single product" and choose a product.

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -205,6 +205,31 @@ function getExitPageCESCopy( pageId: string ): {
 					'woocommerce'
 				),
 			};
+		case 'analytics_filtered':
+			return {
+				action: pageId,
+				icon: '📊',
+				noticeLabel: __(
+					'Did you find the data you were looking for?',
+					'woocommerce'
+				),
+				title: __(
+					`How's your experience with analytics?`,
+					'woocommerce'
+				),
+				description: __(
+					'We noticed you started filtering store data, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
+					'woocommerce'
+				),
+				firstQuestion: __(
+					'The store analytics screen is easy to use',
+					'woocommerce'
+				),
+				secondQuestion: __(
+					"The store analytics screen's functionality meets my needs",
+					'woocommerce'
+				),
+			};
 		default:
 			return null;
 	}

--- a/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_analytics
+++ b/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding ces exit prompt when filtering analytics.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Adding a CES exit prompt and notice _after_ leaving the analytics page when some kind of filtering/etc was done.

Closes # part of https://github.com/woocommerce/woocommerce/issues/35126

### Screenshots

![image](https://user-images.githubusercontent.com/444632/207725414-a666a1a5-154a-4e72-a22f-ece5a3903e92.png)


![image](https://user-images.githubusercontent.com/444632/207725453-124a23f8-7ea0-476d-a5fc-da7e1071f83e.png)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Load this branch, build it.
2. Make sure you have tracks enabled and also outputted in the console: `localStorage.setItem( 'debug', 'wc-admin:*' );`
3. Go to Analytics -> (any report)
4. Change the date period or apply any random filter. You'll likely see the standard CES notice in the lower left-hand corner. **Do not respond to or dismiss this.**
5. Navigate to another page, such as "All products." If you go to another React page without dismissing the other notice, it won't display the new one, so you may want to pick a page that require a page refresh.
6. Observe the notice appear as seen in the screenshots above.
7. Click the share feedback and submit feedback, notice how the `wcadmin_ces_snackbar_view`, `wcadmin_ces_view`, and `wcadmin_ces_feedback` include the `ces_location` prop with the  `outside` value.
8. For the CES modal check if the copy matches that listed in this document for the filter analytics action: [copy](https://docs.google.com/spreadsheets/d/1t0JplRZL3cC3vNCATmMy95surJzYH_uhsitznelYcRI/edit?usp=sharing).
You may also want to try dismissing the notice and see if the prop has been added to `wcadmin_ces_snackbar_dismiss`
9. Now delete the `woocommerce_ces_shown_for_actions` option and disable tracking under **WooCommerce > Settings > Advanced > Woocommerce.com**
10. Make sure the notice doesn't show up for the above anymore and that `customer-effort-score-exit-page` in local storage does not get updated, but stays empty.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
