### PR TITLE
Avoid a fatal error (attempt to call method on bool) when forming order edit URLs

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-edit-url
+++ b/plugins/woocommerce/changelog/fix-order-edit-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid a potential fatal error when forming edit-order URLs.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -323,12 +323,29 @@ class PageController {
 			return admin_url( 'post.php?post=' . absint( $order_id ) ) . '&action=edit';
 		}
 
+		$order = wc_get_order( $order_id );
+
+		// Confirm we could obtain the order object (since it's possible it will not exist, due to a sync issue, or may
+		// have been deleted in a separate concurrent request).
+		if ( false === $order ) {
+			wc_get_logger()->debug(
+				sprintf(
+					/* translators: %d order ID. */
+					__( 'Attempted to determine the edit URL for order %d, however the order does not exist.', 'woocommerce' ),
+					$order_id
+				)
+			);
+			$order_type = 'shop_order';
+		} else {
+			$order_type = $order->get_type();
+		}
+
 		return add_query_arg(
 			array(
 				'action' => 'edit',
 				'id'     => absint( $order_id ),
 			),
-			$this->get_base_page_url( wc_get_order( $order_id )->get_type() )
+			$this->get_base_page_url( $order_type )
 		);
 	}
 


### PR DESCRIPTION
When HPOS is active and custom order tables are authoritative, we try to redirect any requests to the legacy (CPT) order editor to the new HPOS order editor. 

However, there is a possibility that the order in question does not yet exist in the custom order table, or has been removed (could be the result of an unidentified glitch in order sync, or accidental database intervention, etc).

As of a [recent change](https://github.com/woocommerce/woocommerce/pull/35658/files#diff-910ced1fc605c1a86a867a949b958aaf8b9a1cbb3042a833bc16ad153f7e2dd6R331), this situation can lead to a fatal error which we want to avoid.

---

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable High-Performance Order Storage. The steps for doing so are:
    - If necessary (that is, if you haven't enabled HPOS on your test site before now) start by running the **WooCommerce ▸ Status ▸ Tools ▸ Create Custom Order Tables** tool.
    - Then, visit **WooCommerce ▸ Settings ▸ Advanced ▸ Features** and enable **High-Performance Order Storage**.
2. Now configure things via **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** such that:
    - You are using the WordPress posts table.
    - Sync is enabled.
3. Capture the edit URLs for a couple of orders (create new orders if you don't have any existing ones).
    - As a reminder, these URLs should take the form `/wp-admin/post.php?post=12345&action=edit`.
    - The order ID in the above example is `12345` but will of course be different in your case.
4. For **one** of those orders, we now need to manually delete the corresponding entry from the `wp_wc_orders` table.
    - You can use a graphical tool such as phpMyAdmin for this. 
    - Or, if available, you can use WP CLI: `wp db query "DELETE FROM $(wp db prefix)wc_orders WHERE id=12345"` (updating the ID accordingly).
5. That done, return to **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** and enable Custom Order Tables.
6. Try accessing each of the order editor URLs. In the case of the order you manually deleted from `wp_wc_orders`:
    - Without this change, you will experience a fatal error (attempted method call on a boolean).
    - With this change, you should simply see a message explaining the item you are trying to edit does not exist.
    - With or without this change, the redirection should work successfully for the other URL.


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
