### PR TITLE
Adding ces exit prompt when product importer abandoned

### DIFF
--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { dispatch, resolveSelect } from '@wordpress/data';
+import { getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -93,7 +94,7 @@ export const addCustomerEffortScoreExitPageListener = (
 	pageId: string,
 	hasUnsavedChanges: () => boolean
 ) => {
-	eventListeners[ pageId ] = ( event ) => {
+	eventListeners[ pageId ] = () => {
 		if ( hasUnsavedChanges() && allowTracking ) {
 			addExitPage( pageId );
 		}
@@ -230,9 +231,48 @@ function getExitPageCESCopy( pageId: string ): {
 					'woocommerce'
 				),
 			};
+		case 'import_products':
+			return {
+				action: pageId,
+				icon: '🔄',
+				noticeLabel: __(
+					'How is your experience with importing products?',
+					'woocommerce'
+				),
+				title: __(
+					`How's your experience with importing products?`,
+					'woocommerce'
+				),
+				description: __(
+					'We noticed you started importing products, then left. How was it? Your feedback will help create a better experience for thousands of merchants like you.',
+					'woocommerce'
+				),
+				firstQuestion: __(
+					'The product import screen is easy to use',
+					'woocommerce'
+				),
+				secondQuestion: __(
+					"The product import screen's functionality meets my needs",
+					'woocommerce'
+				),
+			};
 		default:
 			return null;
 	}
+}
+
+/**
+ * Stores trigger conditions for exit page actions.
+ *
+ * @param {string} pageId page id.
+ */
+function getShouldExitPageFire( pageId: string ) {
+	const conditionPageMap: Record< string, () => boolean > = {
+		import_products: () =>
+			( getQuery() as { page: string } ).page !== 'product_importer',
+	};
+
+	return conditionPageMap[ pageId ] ? conditionPageMap[ pageId ]() : true;
 }
 
 /**
@@ -240,9 +280,14 @@ function getExitPageCESCopy( pageId: string ): {
  */
 export function triggerExitPageCesSurvey() {
 	const exitPageItems: string[] = getExitPageData();
-	if ( exitPageItems && exitPageItems.length > 0 ) {
+	if ( exitPageItems?.length ) {
+		if ( ! getShouldExitPageFire( exitPageItems[ 0 ] ) ) {
+			return;
+		}
+
 		const copy = getExitPageCESCopy( exitPageItems[ 0 ] );
-		if ( copy && copy.title.length > 0 ) {
+
+		if ( copy?.title?.length ) {
 			dispatch( 'wc/customer-effort-score' ).addCesSurvey( {
 				...copy,
 				pageNow: window.pagenow,

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -43,7 +43,7 @@ export const getExitPageData = () => {
  * @param {string} pageId of page exited early.
  */
 export const addExitPage = ( pageId: string ) => {
-	if ( ! window.localStorage ) {
+	if ( ! ( window.localStorage && allowTracking ) ) {
 		return;
 	}
 
@@ -95,7 +95,7 @@ export const addCustomerEffortScoreExitPageListener = (
 	hasUnsavedChanges: () => boolean
 ) => {
 	eventListeners[ pageId ] = () => {
-		if ( hasUnsavedChanges() && allowTracking ) {
+		if ( hasUnsavedChanges() ) {
 			addExitPage( pageId );
 		}
 	};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-import-tracking/index.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-import-tracking/index.ts
@@ -1,0 +1,1 @@
+export * from './product-import-tracking';

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-import-tracking/product-import-tracking.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-import-tracking/product-import-tracking.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { getQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import {
+	addExitPage,
+	removeExitPage,
+} from '~/customer-effort-score-tracks/customer-effort-score-exit-page';
+
+const ACTION_NAME = 'import_products';
+
+( () => {
+	const query: { step?: string; page?: string } = getQuery();
+
+	if ( query.page !== 'product_importer' ) {
+		return;
+	}
+
+	if ( query.step === 'done' ) {
+		removeExitPage( ACTION_NAME );
+		return;
+	}
+
+	addExitPage( ACTION_NAME );
+} )();

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -59,6 +59,7 @@ const wpAdminScripts = [
 	'wc-addons-tour',
 	'settings-tracking',
 	'order-tracking',
+	'product-import-tracking',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_import
+++ b/plugins/woocommerce/changelog/add-35126_ces_exit_prompt_import
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Run ces exit prompt when product import abandoned.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -332,9 +332,7 @@ class WC_Products_Tracking {
 			return 'edit';
 		}
 
-		if(
-			'product_page_product_importer' === $hook
-		) {
+		if ( 'product_page_product_importer' === $hook ) {
 			return 'import';
 		}
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -26,6 +26,7 @@ class WC_Products_Tracking {
 		add_action( 'edited_product_cat', array( $this, 'track_product_category_updated' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_product_tracking_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_product_import_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_attribute_tracking_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_tag_tracking_scripts' ) );
 	}
@@ -330,6 +331,13 @@ class WC_Products_Tracking {
 		) {
 			return 'edit';
 		}
+
+		if(
+			'product_page_product_importer' === $hook
+		) {
+			return 'import';
+		}
+
 		// phpcs:enable
 
 		return false;
@@ -354,6 +362,22 @@ class WC_Products_Tracking {
 				'name' => $product_screen,
 			)
 		);
+	}
+
+	/**
+	 * Adds the tracking scripts for product setting pages.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function possibly_add_product_import_scripts( $hook ) {
+		$product_screen = $this->get_product_screen( $hook );
+
+		if ( 'import' !== $product_screen ) {
+			return;
+		}
+
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'product-import-tracking', false );
+
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Adding a CES exit prompt and notice _after_ leaving the product  importer when it wasn't completed.

Closes # part of https://github.com/woocommerce/woocommerce/issues/35126

### Screenshots

![image](https://user-images.githubusercontent.com/444632/207752922-33d21744-f88f-409f-8d48-51d888858672.png)

![image](https://user-images.githubusercontent.com/444632/207752954-ed8d592e-f35f-42f9-9544-81fe492669a8.png)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Load this branch, build it.
2. Make sure you have tracks enabled and also outputted in the console: `localStorage.setItem( 'debug', 'wc-admin:*' );`
3. Add a product (or multiple) via smooth generator or manually.
4. Go to Products -> All Products
5. Export your product to a csv file.
6. Go back to Products -> All Products
7. Click "Import" button.
8. Without continuing the import, click back to Products -> All Products (or another page).
9. Observe the notice appear as seen in the screenshots above.
10. Click the share feedback and submit feedback, notice how the `wcadmin_ces_snackbar_view`, `wcadmin_ces_view`, and `wcadmin_ces_feedback` include the `ces_location` prop with the  `outside` value.
11. For the CES modal check if the copy matches that listed in this document for the import products action: [copy](https://docs.google.com/spreadsheets/d/1t0JplRZL3cC3vNCATmMy95surJzYH_uhsitznelYcRI/edit?usp=sharing).
You may also want to try dismissing the notice and see if the prop has been added to `wcadmin_ces_snackbar_dismiss`
12. Delete the `woocommerce_ces_shown_for_actions` option.
13. Go back to the product importer, and complete the product import for the csv you exported.
14. After complete, navigate to another page again.
15. You should _not_ see the notice after navigating.
16. Now delete the `woocommerce_ces_shown_for_actions` option and disable tracking under **WooCommerce > Settings > Advanced > Woocommerce.com**
17. Make sure the notice doesn't show up for the above anymore and that `customer-effort-score-exit-page` in local storage does not get updated, but stays empty.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
