### PR TITLE
Adds `add_meta_boxes_<SCREEN_ID>` hook to the HPOS order editor.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35647-hpos-meta-boxes
+++ b/plugins/woocommerce/changelog/fix-35647-hpos-meta-boxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Makes it possible to use an `add_meta_boxes_<SCREEN_ID>` style hook in the HPOS editor, for parity with the traditional post editor.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -114,7 +114,7 @@ class Edit {
 		 * Provides an opportunity to inject custom meta boxes into the order editor screen. This
 		 * hook is an analog of `add_meta_boxes_<POST_TYPE>` as provided by WordPress core.
 		 *
-		 * @since 7.3.0
+		 * @since 7.4.0
 		 *
 		 * @oaram WC_Order $order The order being edited.
 		 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -89,6 +89,7 @@ class Edit {
 	 */
 	public function setup( \WC_Order $order ) {
 		$this->order    = $order;
+		$wc_screen_id   = wc_get_page_screen_id( 'shop-order' );
 		$current_screen = get_current_screen();
 		$current_screen->is_block_editor( false );
 		$this->screen_id = $current_screen->id;
@@ -107,7 +108,18 @@ class Edit {
 		 *
 		 * @since 3.8.0.
 		 */
-		do_action( 'add_meta_boxes', wc_get_page_screen_id( 'shop-order' ), $this->order );
+		do_action( 'add_meta_boxes', $wc_screen_id, $this->order );
+
+		/**
+		 * Provides an opportunity to inject custom meta boxes into the order editor screen. This
+		 * hook is an analog of `add_meta_boxes_<POST_TYPE>` as provided by WordPress core.
+		 *
+		 * @since 7.3.0
+		 *
+		 * @oaram WC_Order $order The order being edited.
+		 */
+		do_action( 'add_meta_boxes_' . $wc_screen_id, $this->order );
+
 		$this->enqueue_scripts();
 	}
 


### PR DESCRIPTION
For parity with core WordPress screens and the traditional CPT-based order editor, this PR adds a new action (that will be fired in the context of the new HPOS order editor):

`add_meta_boxes_<SCREEN_ID>`

Which, in practice, will resolve to:

`add_meta_boxes_woocommerce_page_wc-orders`

This also makes it easier to support adding the same meta box to both forms of order editor (less need for conditionals, at least in the simplest cases).

Closes #35647.

---

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Code review is probably sufficient for this change, however you can also test manually by adding a snippet like the following to a suitable location (I would suggest `wp-content/mu-plugins/test-35647.php`):

```php
<?php

add_action( 'add_meta_boxes_shop_order', 'register_custom_woo_order_meta_box' );
add_action( 'add_meta_boxes_woocommerce_page_wc-orders', 'register_custom_woo_order_meta_box' );

function register_custom_woo_order_meta_box() {
	add_meta_box( 'custom_woo_order_meta_box', 'Custom Meta Box', 'render_custom_woo_order_meta_box' );
}

function render_custom_woo_order_meta_box() {
	print 'MY CUSTOM META BOX';
}
```

1. With the above in place, enable HPOS (if you are unsure how to do this, see subsequent set of instructions).
2. Visit **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** then select **Use the WooCommerce orders tables** and save.
3. Visit the order editor for any order, and you should see the custom meta box (probably toward the bottom of the screen).
4. Return to **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** then select **Use the WordPress posts table** and save.
5. Again visit the order editor for any order (for the avoidance of any confusion, if the previous editor is still open in a tab ... do not reuse it: return to the order list and select an order from there) and confirm you still see the custom meta box.
6. Then, visit any other post editor—that is, one that is unrelated to WooCommerce such as the page or post editor—and confirm you do **not** see the custom meta box there.

You can expect the custom meta box to look like this:

<img width="933" alt="custom-order-meta-box" src="https://user-images.githubusercontent.com/3594411/207761011-74e582f0-545c-4eb8-962e-b4aeb8c86133.png">

---

💡 ***Need a reminder on how to enable HPOS?***

- If necessary (that is, if you haven't enabled HPOS on your test site before now) start by running the **WooCommerce ▸ Status ▸ Tools ▸ Create Custom Order Tables** tool.
- Then, visit **WooCommerce ▸ Settings ▸ Advanced ▸ Features** and enable the **High-Performance Order Storage** feature.

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
