### PR TITLE
Additional order list table actions

### DIFF
--- a/plugins/woocommerce/changelog/fix-35467-hpos-order-list-table-actions
+++ b/plugins/woocommerce/changelog/fix-35467-hpos-order-list-table-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Introduces action `woocommerce_order_list_table_restrict_manage_orders` as an equivalent of the legacy `restrict_manage_posts` hook.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -593,7 +593,7 @@ class ListTable extends WP_List_Table {
 			/**
 			 * Fires before the "Filter" button on the list table for orders and other order types.
 			 *
-			 * @since x.x.x
+			 * @since 7.3.0
 			 *
 			 * @param string $order_type  The order type.
 			 * @param string $which       The location of the extra table nav: 'top' or 'bottom'.
@@ -616,7 +616,7 @@ class ListTable extends WP_List_Table {
 		 * Fires immediately following the closing "actions" div in the tablenav for the order
 		 * list table.
 		 *
-		 * @since x.x.x
+		 * @since 7.3.0
 		 *
 		 * @param string $order_type  The order type.
 		 * @param string $which       The location of the extra table nav: 'top' or 'bottom'.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -594,10 +594,11 @@ class ListTable extends WP_List_Table {
 			 * Fires before the "Filter" button on the list table for orders and other order types.
 			 *
 			 * @since x.x.x
+			 *
 			 * @param string $order_type  The order type.
 			 * @param string $which       The location of the extra table nav: 'top' or 'bottom'.
 			 */
-			do_action( 'woocommerce_order_list_table_extra_tablenav', $this->order_type, $which );
+			do_action( 'woocommerce_order_list_table_restrict_manage_orders', $this->order_type, $which );
 
 			$output = ob_get_clean();
 
@@ -610,6 +611,17 @@ class ListTable extends WP_List_Table {
 		if ( $this->is_trash && $this->has_items() && current_user_can( 'edit_others_shop_orders' ) ) {
 			submit_button( __( 'Empty Trash', 'woocommerce' ), 'apply', 'delete_all', false );
 		}
+
+		/**
+		 * Fires immediately following the closing "actions" div in the tablenav for the order
+		 * list table.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $order_type  The order type.
+		 * @param string $which       The location of the extra table nav: 'top' or 'bottom'.
+		 */
+		do_action( 'woocommerce_order_list_table_extra_tablenav', $this->order_type, $which );
 
 		echo '</div>';
 	}


### PR DESCRIPTION
Introduces new hooks to the HPOS Order List Table, to parallel existing legacy/CPT order list hooks:

- `manage_posts_extra_tablenav`→ `woocommerce_order_list_table_extra_tablenav`
- `restrict_manage_posts` → `woocommerce_order_list_table_restrict_manage_orders`

† Actually, to be a little more accurate, the first of those was already recently added via #35658. However, it was part of the scope of the parent issue for this PR and I also propose we change when it executes.

Closes #35467.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Code review should suffice, here. There are no functional changes that can be easily observed within the HPOS order editor, since we don't actually use these hooks ourselves (they chiefly exist for the benefit of extension developers).

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
