### PR TITLE
E2E: Update tests in `create-variable-product.spec.js` to avoid creating variations from all attributes automatically

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-create-variable-product
+++ b/plugins/woocommerce/changelog/e2e-update-create-variable-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update the "can manually add a variation" E2E test to prevent automatic creation of variations from all attributes.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -65,7 +65,14 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 		}
 		await page.click( 'text=Save attributes' );
 
-		// create variations from all attributes
+		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
+		await page.locator( '#save-post' ).click();
+		await expect(
+			page.getByText( 'Product draft updated. ' )
+		).toBeVisible();
+		await page.click( '.updated.notice .notice-dismiss' );
+
+		// manually create variations from all attributes
 		await page.click( 'a[href="#variable_product_options"]' );
 		await page.selectOption( '#field_to_edit', 'link_all_variations', {
 			force: true,
@@ -199,23 +206,20 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				'val1 | val2'
 			);
 			await page.click( `input[name="attribute_variation[${ i }]"]` );
-		}
-		await page.click( 'text=Save attributes' );
-		await page.locator( '#save-post' ).click();
-		await expect(
-			page.getByText( 'Product draft updated. ' )
-		).toBeVisible();
-		await page.click( '.updated.notice .notice-dismiss' );
-
-		// verify that they were saved
-		await page.click( 'a[href="#product_attributes"]' );
-		for ( let i = 0; i < 3; i++ ) {
+			await page.click( 'text=Save attributes' );
 			await expect(
 				page
 					.locator( '.woocommerce_attribute.closed' )
 					.filter( { hasText: `attr #${ i + 1 }` } )
 			).toBeVisible();
 		}
+
+		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
+		await page.locator( '#save-post' ).click();
+		await expect(
+			page.getByText( 'Product draft updated. ' )
+		).toBeVisible();
+		await page.click( '.updated.notice .notice-dismiss' );
 
 		// manually adds a variation
 		await page.click( 'a[href="#variable_product_options"]' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -201,31 +201,51 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			await page.click( `input[name="attribute_variation[${ i }]"]` );
 		}
 		await page.click( 'text=Save attributes' );
-		await page.click( 'a[href="#variable_product_options"]' );
+		await page.locator( '#save-post' ).click();
+		await expect(
+			page.getByText( 'Product draft updated. ' )
+		).toBeVisible();
+		await page.click( '.updated.notice .notice-dismiss' );
+
+		// verify that they were saved
+		await page.click( 'a[href="#product_attributes"]' );
+		for ( let i = 0; i < 3; i++ ) {
+			await expect(
+				page
+					.locator( '.woocommerce_attribute.closed' )
+					.filter( { hasText: `attr #${ i + 1 }` } )
+			).toBeVisible();
+		}
 
 		// manually adds a variation
+		await page.click( 'a[href="#variable_product_options"]' );
 		await page.selectOption( '#field_to_edit', 'add_variation', {
 			force: true,
 		} );
 		await page.click( 'a.do_variation_action' );
+		await expect( page.locator( '.variation-needs-update' ) ).toBeVisible();
 		for ( let i = 0; i < defaultAttributes.length; i++ ) {
 			await page.selectOption(
-				`select[name="attribute_attr-${ i + 1 }[0]"]`,
+				`.variation-needs-update h3 select >> nth=${ i }`,
 				defaultAttributes[ i ]
 			);
 		}
 		await page.click( 'button.save-variation-changes' );
 		for ( let i = 0; i < defaultAttributes.length; i++ ) {
 			await expect(
-				page.locator(
-					`select[name="attribute_attr-${
-						i + 1
-					}[0]"] > option[selected]`
-				)
+				page
+					.locator( '.woocommerce_variation' )
+					.first()
+					.locator( 'select' )
+					.nth( i )
+					.locator( 'option[selected]' )
 			).toHaveText( defaultAttributes[ i ] );
 		}
 
 		await page.locator( '#save-post' ).click();
+		await expect(
+			page.getByText( 'Product draft updated. ' )
+		).toBeVisible();
 	} );
 
 	test( 'can manage stock at variation level', async ( { page } ) => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The E2E test `can manually add a variation` became flaky due to a recent change introduced by https://github.com/woocommerce/woocommerce/pull/35807. This PR updates this test and the `can create product, attributes and variations` test so that:
- The test product will be saved first before moving to the Variations tab to prevent all variations from being created automatically.
- Assertions were added in key steps of the test.
- Locators for the attribute dropdowns were updated to be more accurate, preventing flakiness when the test ends up in the Variations tab with a lot of pre-existing variations.

Closes #36005.

### How to test the changes in this Pull Request:

1. Set up your local E2E environment using the instructions in the [README](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/README.md).
2. Run only the `can manually add a variation` by running this command in `plugins/woocommerce` directory, and make sure that it passes:
    `pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js -g "can manually add a variation"`
1. Run the whole `create-variable-product.spec.js` test file using this command, and make sure that it passes:
    `pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js create-variable-product.spec.js`
4. Run the `Run tests against PR` workflow and make sure the E2E tests pass.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
