### PR TITLE
Update code-freeze actions to Monday 22 days before release

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -1,7 +1,7 @@
 name: 'Release: Code freeze'
 on:
     schedule:
-        - cron: '0 16 * * 4' # Run at 1600 UTC on Thursdays.
+        - cron: '0 23 * * 1' # Run at 2300 UTC on Mondays.
     workflow_dispatch:
         inputs:
             timeOverride:
@@ -42,12 +42,12 @@ jobs:
                     $now = strtotime( getenv( 'TIME_OVERRIDE' ) );
                   }
 
-                  // Code freeze comes 26 days prior to release day.
-                  $release_time         = strtotime( '+26 days', $now );
+                  // Code freeze comes 22 days prior to release day.
+                  $release_time         = strtotime( '+22 days', $now );
                   $release_day_of_week  = date( 'l', $release_time );
                   $release_day_of_month = (int) date( 'j', $release_time );
 
-                  // If 26 days from now isn't the second Tuesday, then it's not code freeze day.
+                  // If 22 days from now isn't the second Tuesday, then it's not code freeze day.
                   if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
                     file_put_contents( getenv( 'GITHUB_OUTPUT' ), "freeze=1\n", FILE_APPEND );
                   } else {

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -163,7 +163,7 @@ jobs:
                         workflow_id: 'release-changelog.yml',
                         ref: 'trunk',
                         inputs: {
-                          releaseVersion: "release/${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}",
-                          releaseBranch: "${{ needs.maybe-create-next-milestone-and-release-branch.outputs.next_version }}"
+                          releaseVersion: "${{ needs.maybe-create-next-milestone-and-release-branch.outputs.release_version }}",
+                          releaseBranch: "${{ needs.maybe-create-next-milestone-and-release-branch.outputs.branch }}"
                         }
                       })

--- a/.github/workflows/scripts/release-code-freeze.php
+++ b/.github/workflows/scripts/release-code-freeze.php
@@ -23,14 +23,14 @@ function set_output( $name, $value ) {
 	file_put_contents( getenv( 'GITHUB_OUTPUT' ), "{$name}={$value}" . PHP_EOL, FILE_APPEND );
 }
 
-// Code freeze comes 26 days prior to release day.
-$release_time         = strtotime( '+26 days', $now );
+// Code freeze comes 22 days prior to release day.
+$release_time         = strtotime( '+22 days', $now );
 $release_day_of_week  = date( 'l', $release_time );
 $release_day_of_month = (int) date( 'j', $release_time );
 
-// If 26 days from now isn't the second Tuesday, then it's not code freeze day.
+// If 22 days from now isn't the second Tuesday, then it's not code freeze day.
 if ( 'Tuesday' !== $release_day_of_week || $release_day_of_month < 8 || $release_day_of_month > 14 ) {
-	echo 'Info: Today is not the Thursday of the code freeze.' . PHP_EOL;
+	echo 'Info: Today is not the Monday of the code freeze.' . PHP_EOL;
 	exit( 1 );
 }
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the code freeze for WooCommerce Core from the Thursday that falls 26 days before the release date (2nd Tuesday of each month) to the Monday that falls 22 days before the release date. For context, see pdV5qK-76-p2.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Fork this repository.
1. Enable issues in your fork from `https://github.com/YOURORG/woocommerce/settings`
1. Enable actions in your fork from `https://github.com/YOURORG/woocommerce/settings/actions`. Also, make sure workflows have read and write permissions and the ability to create and approve PRs.
1. Enable the scheduled workflow from `https://github.com/YOURORG/woocommerce/actions/workflows/release-code-freeze.yml`.
1. Merge this PR into trunk of your new fork.
1. Run the action manually from `https://github.com/YOURORG/woocommerce/actions/workflows/release-code-freeze.yml` with "2023-01-19" as the value for time override. While previously this would've caused the code freeze to run, it should no longer run, as Thursdays are no longer the date of code freeze.
1.  If you want to verify that the rest of the job runs, make sure that you've first created an existing release in your fork. But if you just want to verify that it runs correctly, this isn't necessary and you can cancel the next job as soon as the action gets past the date check
1. Run the action manually from `https://github.com/YOURORG/woocommerce/actions/workflows/release-code-freeze.yml` with "2023-01-23" as the value for time override. This is the Monday that comes 22 days prior to 2023-02-14 (the 7.4 release date). The code freeze action should now run.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.


**NOTE: Since the code freeze has already run for 7.3, this PR shouldn't be merged until after December 19, as running it again would prematurely freeze 7.4**
