### PR TITLE
Add PR links to release post template output, and allow blog ID to be specified.

### DIFF
--- a/tools/cli-core/src/git.ts
+++ b/tools/cli-core/src/git.ts
@@ -183,7 +183,7 @@ const refIsHash = ( ref: string ) => {
  * @param {string} ref     -    Either a commit hash or a branch name.
  * @return {string} - the commit hash of the ref.
  */
-export const getCommitHash = async ( baseDir: string, ref: string ): string => {
+export const getCommitHash = async ( baseDir: string, ref: string ) => {
 	const isHash = refIsHash( ref );
 
 	// check if its in history, if its not an error will be thrown
@@ -206,7 +206,7 @@ export const getCommitHash = async ( baseDir: string, ref: string ): string => {
 
 /**
  * Get the commit hash for the last change to a line within a specific file.
- * 
+ *
  * @param {string} baseDir    - the dir of the git repo to get the hash from.
  * @param {string} filePath   - the relative path to the file to check the commit hash of.
  * @param {number} lineNumber - the line number from which to get the hash of the last commit.
@@ -216,25 +216,33 @@ export const getLineCommitHash = async (
 	baseDir: string,
 	filePath: string,
 	lineNumber: number
-): number => {
+) => {
 	// Remove leading slash, if it exists.
 	const adjustedFilePath = filePath.replace( /^\//, '' );
 	try {
 		const git = await simpleGit( { baseDir } );
-		const blame = await git.raw( [ 'blame', `-L${ lineNumber },${ lineNumber }`, adjustedFilePath ] );
+		const blame = await git.raw( [
+			'blame',
+			`-L${ lineNumber },${ lineNumber }`,
+			adjustedFilePath,
+		] );
 		const hash = blame.match( /^([a-f0-9]+)\s+/ );
 		if ( ! hash ) {
-			throw new Error( `Unable to git blame ${ adjustedFilePath }:${ lineNumber }` );
+			throw new Error(
+				`Unable to git blame ${ adjustedFilePath }:${ lineNumber }`
+			);
 		}
-		return hash[1];
+		return hash[ 1 ];
 	} catch ( e ) {
-		throw new Error( `Unable to git blame ${ adjustedFilePath }:${ lineNumber }` );
-	} 
+		throw new Error(
+			`Unable to git blame ${ adjustedFilePath }:${ lineNumber }`
+		);
+	}
 };
 
 /**
  * Get the commit hash for the last change to a line within a specific file.
- * 
+ *
  * @param {string} baseDir - the dir of the git repo to get the PR number from.
  * @param {string} hash    - the hash to get the PR number from.
  * @return {number} - the pull request number from the given inputs.
@@ -242,22 +250,31 @@ export const getLineCommitHash = async (
 export const getPullRequestNumberFromHash = async (
 	baseDir: string,
 	hash: string
-): number => {
+) => {
 	try {
 		const git = await simpleGit( { baseDir } );
 		const formerHead = await git.revparse( 'HEAD' );
 		await git.checkout( hash );
-		const cmdOutput = await git.raw( [ 'log', '-1', '--first-parent', '--format=%cI\n%s' ] );
-		const cmdLines = cmdOutput.split( "\n" );
+		const cmdOutput = await git.raw( [
+			'log',
+			'-1',
+			'--first-parent',
+			'--format=%cI\n%s',
+		] );
+		const cmdLines = cmdOutput.split( '\n' );
 		await git.checkout( formerHead );
-		const prNumber = cmdLines[1].trim().match( /(?:^Merge pull request #(\d+))|(?:\(#(\d+)\)$)/ );
+		const prNumber = cmdLines[ 1 ]
+			.trim()
+			.match( /(?:^Merge pull request #(\d+))|(?:\(#(\d+)\)$)/ );
 		if ( prNumber ) {
-			return prNumber[1] ? parseInt( prNumber[1], 10 ) : parseInt( prNumber[2], 10 );
+			return prNumber[ 1 ]
+				? parseInt( prNumber[ 1 ], 10 )
+				: parseInt( prNumber[ 2 ], 10 );
 		}
-		throw new Error( `Unable to get PR number from hash ${hash}.` );
+		throw new Error( `Unable to get PR number from hash ${ hash }.` );
 	} catch ( e ) {
-		throw new Error( `Unable to get PR number from hash ${hash}.` );
-	} 
+		throw new Error( `Unable to get PR number from hash ${ hash }.` );
+	}
 };
 
 /**

--- a/tools/cli-core/src/git.ts
+++ b/tools/cli-core/src/git.ts
@@ -21,6 +21,20 @@ export const getFilename = ( str: string ): string => {
 };
 
 /**
+ * Get starting line number from patch
+ *
+ * @param {string} str String to extract starting line number from.
+ * @return {number} line number.
+ */
+export const getStartingLineNumber = ( str: string ): number => {
+	const lineNumber = str.replace( /^@@ -\d+,\d+ \+(\d+),\d+ @@.*?$/, '$1' );
+	if ( ! lineNumber.match( /^\d+$/ ) ) {
+		throw new Error( 'Unable to parse line number from patch' );
+	}
+	return parseInt( lineNumber, 10 );
+};
+
+/**
  * Get patches
  *
  * @param {string} content Patch content.
@@ -169,7 +183,7 @@ const refIsHash = ( ref: string ) => {
  * @param {string} ref     -    Either a commit hash or a branch name.
  * @return {string} - the commit hash of the ref.
  */
-export const getCommitHash = async ( baseDir: string, ref: string ) => {
+export const getCommitHash = async ( baseDir: string, ref: string ): string => {
 	const isHash = refIsHash( ref );
 
 	// check if its in history, if its not an error will be thrown
@@ -188,6 +202,62 @@ export const getCommitHash = async ( baseDir: string, ref: string ) => {
 
 	// Its a hash already
 	return ref;
+};
+
+/**
+ * Get the commit hash for the last change to a line within a specific file.
+ * 
+ * @param {string} baseDir    - the dir of the git repo to get the hash from.
+ * @param {string} filePath   - the relative path to the file to check the commit hash of.
+ * @param {number} lineNumber - the line number from which to get the hash of the last commit.
+ * @return {string} - the commit hash of the last change to filePath at lineNumber.
+ */
+export const getLineCommitHash = async (
+	baseDir: string,
+	filePath: string,
+	lineNumber: number
+): number => {
+	// Remove leading slash, if it exists.
+	const adjustedFilePath = filePath.replace( /^\//, '' );
+	try {
+		const git = await simpleGit( { baseDir } );
+		const blame = await git.raw( [ 'blame', `-L${ lineNumber },${ lineNumber }`, adjustedFilePath ] );
+		const hash = blame.match( /^([a-f0-9]+)\s+/ );
+		if ( ! hash ) {
+			throw new Error( `Unable to git blame ${ adjustedFilePath }:${ lineNumber }` );
+		}
+		return hash[1];
+	} catch ( e ) {
+		throw new Error( `Unable to git blame ${ adjustedFilePath }:${ lineNumber }` );
+	} 
+};
+
+/**
+ * Get the commit hash for the last change to a line within a specific file.
+ * 
+ * @param {string} baseDir - the dir of the git repo to get the PR number from.
+ * @param {string} hash    - the hash to get the PR number from.
+ * @return {number} - the pull request number from the given inputs.
+ */
+export const getPullRequestNumberFromHash = async (
+	baseDir: string,
+	hash: string
+): number => {
+	try {
+		const git = await simpleGit( { baseDir } );
+		const formerHead = await git.revparse( 'HEAD' );
+		await git.checkout( hash );
+		const cmdOutput = await git.raw( [ 'log', '-1', '--first-parent', '--format=%cI\n%s' ] );
+		const cmdLines = cmdOutput.split( "\n" );
+		await git.checkout( formerHead );
+		const prNumber = cmdLines[1].trim().match( /(?:^Merge pull request #(\d+))|(?:\(#(\d+)\)$)/ );
+		if ( prNumber ) {
+			return prNumber[1] ? parseInt( prNumber[1], 10 ) : parseInt( prNumber[2], 10 );
+		}
+		throw new Error( `Unable to get PR number from hash ${hash}.` );
+	} catch ( e ) {
+		throw new Error( `Unable to get PR number from hash ${hash}.` );
+	} 
 };
 
 /**

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -66,7 +66,11 @@ export const scanForChanges = async (
 	Logger.endTask();
 
 	Logger.startTask( 'Detecting template changes...' );
-	const templateChanges = await scanForTemplateChanges( diff, sinceVersion, tmpRepoPath );
+	const templateChanges = await scanForTemplateChanges(
+		diff,
+		sinceVersion,
+		tmpRepoPath
+	);
 	Logger.endTask();
 
 	Logger.startTask( 'Detecting DB changes...' );

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -22,11 +22,15 @@ export const scanForChanges = async (
 	skipSchemaCheck: boolean,
 	source: string,
 	base: string,
-	outputStyle: string
+	outputStyle: string,
+	clonedPath?: string
 ) => {
-	Logger.startTask( `Making temporary clone of ${ source }...` );
-	const tmpRepoPath = await cloneRepo( source );
-	Logger.endTask();
+	let tmpRepoPath = clonedPath;
+	if ( ! clonedPath ) {
+		Logger.startTask( `Making temporary clone of ${ source }...` );
+		tmpRepoPath = typeof clonedPath !== 'undefined' ? clonedPath : await cloneRepo( source );
+		Logger.endTask();
+	}
 
 	Logger.notice(
 		`Temporary clone of ${ source } created at ${ tmpRepoPath }`

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -25,12 +25,16 @@ export const scanForChanges = async (
 	outputStyle: string,
 	clonedPath?: string
 ) => {
-	let tmpRepoPath = clonedPath;
-	if ( ! clonedPath ) {
-		Logger.startTask( `Making temporary clone of ${ source }...` );
-		tmpRepoPath = typeof clonedPath !== 'undefined' ? clonedPath : await cloneRepo( source );
-		Logger.endTask();
-	}
+	Logger.startTask( `Making temporary clone of ${ source }...` );
+
+	const tmpRepoPath =
+		typeof clonedPath !== 'undefined'
+			? clonedPath
+			: await cloneRepo( source );
+
+	Logger.notice(
+		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
+	);
 
 	Logger.notice(
 		`Temporary clone of ${ source } created at ${ tmpRepoPath }`

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -62,7 +62,7 @@ export const scanForChanges = async (
 	Logger.endTask();
 
 	Logger.startTask( 'Detecting template changes...' );
-	const templateChanges = scanForTemplateChanges( diff, sinceVersion );
+	const templateChanges = await scanForTemplateChanges( diff, sinceVersion, tmpRepoPath );
 	Logger.endTask();
 
 	Logger.startTask( 'Detecting DB changes...' );

--- a/tools/release-posts/README.md
+++ b/tools/release-posts/README.md
@@ -4,7 +4,7 @@ This is a cli tool designed to generate draft release posts for WooCommerce.
 Posts generated via the tool will be draft posted to https://developer.woocommerce.com.
 
 You can also generate an HTML representation of the post if you
-don't have access to a wc.com auth token.
+don't have access to a WordPress.com auth token.
 
 ### Setup
 
@@ -18,7 +18,7 @@ the `GITHUB_ACCESS_TOKEN` is required. If you need help generating a token see [
 
 This tool will publish draft posts to `https://developer.woocommerce.com` for you if you omit the `--outputOnly` flag. There is some minimal first time setup for this though:
 
-1. Create an app on Wordpress.com [here](https://developer.wordpress.com/apps/).
+1. Create an app on WordPress.com [here](https://developer.wordpress.com/apps/).
 2. Recommended settings:
 
 * Name can be anything
@@ -48,7 +48,7 @@ If you can't run anything on your localhost port 3000 you may want to override t
 Steps:
 
 1. Add your preferred redirect URI to the `WPCOM_OAUTH_REDIRECT_URI` variable in `.env`. e.g. `http://localhost:4321/oauth`
-2. When creating your app on [Wordpress.com](https://developer.wordpress.com/apps/) make sure the redirect URL you set matches the one set in `.env`
+2. When creating your app on [WordPress.com](https://developer.wordpress.com/apps/) make sure the redirect URL you set matches the one set in `.env`
 
 
 

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -110,6 +110,9 @@ const program = new Command()
 		let previousVersionRef;
 
 		try {
+			if ( ! currentParsed ) {
+				throw new Error( 'Unable to parse current version' );
+			}
 			currentBranch = `release/${ currentParsed.major }.${ currentParsed.minor }`;
 			currentVersionRef = await getCommitHash(
 				tmpRepoPath,
@@ -127,6 +130,9 @@ const program = new Command()
 		}
 
 		try {
+			if ( ! previousParsed ) {
+				throw new Error( 'Unable to parse previous version' );
+			}
 			previousBranch = `release/${ previousParsed.major }.${ previousParsed.minor }`;
 			previousVersionRef = await getCommitHash(
 				tmpRepoPath,

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -24,7 +24,6 @@ import { editPostHTML } from '../../lib/edit-post.ts';
 const DEVELOPER_WOOCOMMERCE_SITE_ID = '96396764';
 
 const SOURCE_REPO = 'https://github.com/woocommerce/woocommerce.git';
-//const SOURCE_REPO = '/Users/jonathan/woo/woocommerce';
 
 const VERSION_VALIDATION_REGEX =
 	/^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -23,8 +23,8 @@ import { editPostHTML } from '../../lib/edit-post.ts';
 
 const DEVELOPER_WOOCOMMERCE_SITE_ID = '96396764';
 
-//const SOURCE_REPO = 'https://github.com/woocommerce/woocommerce.git';
-const SOURCE_REPO = '/Users/jonathan/woo/woocommerce';
+const SOURCE_REPO = 'https://github.com/woocommerce/woocommerce.git';
+//const SOURCE_REPO = '/Users/jonathan/woo/woocommerce';
 
 const VERSION_VALIDATION_REGEX =
 	/^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
@@ -88,8 +88,7 @@ const program = new Command()
 		Logger.startTask( `Making temporary clone of ${ SOURCE_REPO }...` );
 		const currentParsed = semver.parse( currentVersion );
 		const previousParsed = semver.parse( previousVersion );
-		//const tmpRepoPath = await cloneRepo( SOURCE_REPO );
-		const tmpRepoPath = '/var/folders/hs/01mlh7d15495b666jjdj7ly80000gn/T/code-analyzer-tmp/2b527a2a-8980-4f40-8e0a-e160867f679a';
+		const tmpRepoPath = await cloneRepo( SOURCE_REPO );
 		Logger.endTask();
 		let currentBranch;
 		let previousBranch;
@@ -148,11 +147,10 @@ const program = new Command()
 		Logger.startTask( 'Finding contributors' );
 		const title = `WooCommerce ${ currentVersion } Released`;
 
-		/*const contributors = await generateContributors(
+		const contributors = await generateContributors(
 			currentVersion,
 			previousVersion.toString()
-		);*/
-		const contributors = {};
+		);
 
 		const postVariables = {
 			contributors,

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -6,6 +6,7 @@ import semver from 'semver';
 import { writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { cloneRepo, getCommitHash } from 'cli-core/src/git';
 import { Logger } from 'cli-core/src/logger';
 import { Command } from '@commander-js/extra-typings';
 import dotenv from 'dotenv';
@@ -14,10 +15,16 @@ import dotenv from 'dotenv';
  * Internal dependencies
  */
 import { renderTemplate } from '../../lib/render-template';
-import { createWpComDraftPost } from '../../lib/draft-post';
+import { createWpComDraftPost, fetchWpComPost, editWpComPostContent } from '../../lib/draft-post';
+import { getWordpressComAuthToken } from '../../lib/oauth-helper';
+import { getEnvVar } from '../../lib/environment';
 import { generateContributors } from '../../lib/contributors';
+import { editPostHTML } from '../../lib/edit-post.ts';
 
 const DEVELOPER_WOOCOMMERCE_SITE_ID = '96396764';
+
+//const SOURCE_REPO = 'https://github.com/woocommerce/woocommerce.git';
+const SOURCE_REPO = '/Users/jonathan/woo/woocommerce';
 
 const VERSION_VALIDATION_REGEX =
 	/^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
@@ -30,118 +37,181 @@ const program = new Command()
 	.description( 'CLI to automate generation of a release post.' )
 	.argument(
 		'<currentVersion>',
-		'The version of the plugin to generate a post for, please use the tag version from Github.'
+		'The current version in x.y.z or x.y.z-stage.n format. Ex: 7.1.0, 7.1.0-rc.1'
+	)
+	.argument(
+		'<previousVersion>',
+		'The previous version in x.y.z format. Ex: 7.0.0'
 	)
 	.option( '--outputOnly', 'Only output the post, do not publish it' )
-	.option(
-		'--previousVersion <previousVersion>',
-		'If you would like to compare against a version other than last minor you can provide a tag version from Github.'
-	)
-	.option(
-		'--tags <tags>',
-		'Comma separated list of tags to add to the post.',
-		'Releases,WooCommerce Core'
-	)
-	.action( async ( currentVersion, options ) => {
-		const tags = options.tags.split( ',' ).map( ( tag ) => tag.trim() );
+	.option( '--editPost <postId>', 'Updates an existing post' )
+	.option( '--siteId <siteId>', 'For posting to a non-default site (for testing)')
+	.action( async ( currentVersion, previousVersion, options ) => {
 
-		const previousVersion = options.previousVersion
-			? semver.parse( options.previousVersion )
-			: semver.parse( currentVersion );
+		const siteId = options.siteId || DEVELOPER_WOOCOMMERCE_SITE_ID;
+		const tags = ( options.tags && options.tags.split( ',' ).map( ( tag ) => tag.trim() ) ) || [ 'WooCommerce Core','Releases' ];
+		const isOutputOnly = !! options.outputOnly;
+		const isEditPost = !! options.editPost;
 
-		if ( ! options.previousVersion && previousVersion ) {
-			// e.g 6.8.0 -> 6.7.0
-			previousVersion.major =
-				previousVersion.minor === 0
-					? previousVersion.major - 1
-					: previousVersion.major;
-
-			previousVersion.minor =
-				previousVersion.minor === 0 ? 9 : previousVersion.minor - 1;
-
-			previousVersion.format();
+		if ( ! VERSION_VALIDATION_REGEX.test( currentVersion ) ) {
+			throw new Error(
+				`Invalid current version: ${ currentVersion }. Provide current version in x.y.z or x.y.z-stage.n format.`
+			);
 		}
 
-		if ( previousVersion && previousVersion.major ) {
-			const isOutputOnly = !! options.outputOnly;
+		if ( ! VERSION_VALIDATION_REGEX.test( previousVersion ) ) {
+			throw new Error(
+				`Invalid previous version: ${ previousVersion }. Provide previous version in x.y.z format.`
+			);
+		}
 
-			if ( ! VERSION_VALIDATION_REGEX.test( previousVersion.raw ) ) {
+		const clientId = getEnvVar( 'WPCOM_OAUTH_CLIENT_ID', true );
+		const clientSecret = getEnvVar( 'WPCOM_OAUTH_CLIENT_SECRET', true );
+		const redirectUri =
+			getEnvVar( 'WPCOM_OAUTH_REDIRECT_URI' ) ||
+			'http://localhost:3000/oauth';
+		const authToken = isOutputOnly || await getWordpressComAuthToken(
+			clientId,
+			clientSecret,
+			siteId,
+			redirectUri,
+			'posts'
+		);
+
+		if ( ! authToken ) {
+			throw new Error(
+				'Error getting auth token, check your env settings are correct.'
+			);
+		}
+
+
+		Logger.startTask( `Making temporary clone of ${ SOURCE_REPO }...` );
+		const currentParsed = semver.parse( currentVersion );
+		const previousParsed = semver.parse( previousVersion );
+		//const tmpRepoPath = await cloneRepo( SOURCE_REPO );
+		const tmpRepoPath = '/var/folders/hs/01mlh7d15495b666jjdj7ly80000gn/T/code-analyzer-tmp/2b527a2a-8980-4f40-8e0a-e160867f679a';
+		Logger.endTask();
+		let currentBranch;
+		let previousBranch;
+		let currentVersionRef;
+		let previousVersionRef;
+
+		try {
+			currentBranch = `release/${ currentParsed.major }.${ currentParsed.minor }`;
+			currentVersionRef = await getCommitHash( tmpRepoPath, `remotes/origin/${ currentBranch }` );
+		} catch( error: unknown ) {
+			Logger.notice( `Unable to find '${ currentBranch }', using 'trunk'.` );
+			currentBranch = 'trunk';
+			currentVersionRef = await getCommitHash( tmpRepoPath, 'remotes/origin/trunk' );
+		}
+
+		try {
+			previousBranch = `release/${ previousParsed.major }.${ previousParsed.minor }`;
+			previousVersionRef = await getCommitHash( tmpRepoPath, `remotes/origin/${ previousBranch }` );
+		} catch( error: unknown ) {
+			throw new Error(
+				`Unable to find '${ previousBranch }'. Branch for previous version must exist.`
+			);
+		}
+
+
+		Logger.notice( `Using ${ currentBranch }(${ currentVersionRef }) for current and ${ previousBranch }(${ previousVersionRef }) for previous.` );
+
+		let postContent;
+
+		if ( isEditPost ) {
+			try {
+				const prevPost = await fetchWpComPost( siteId, options.editPost, authToken );
+				postContent = prevPost.content;
+			} catch( error: unknown ) {
 				throw new Error(
-					`Invalid previous version: ${ previousVersion.raw }`
+					`Unable to fetch existing post with ID: ${ options.editPost }`
 				);
 			}
-			if ( ! VERSION_VALIDATION_REGEX.test( currentVersion ) ) {
-				throw new Error(
-					`Invalid current version: ${ currentVersion }`
-				);
-			}
+		}
 
-			const changes = await scanForChanges(
-				currentVersion,
-				currentVersion,
-				false,
-				'https://github.com/woocommerce/woocommerce.git',
-				previousVersion.toString(),
-				'cli'
+		const changes = await scanForChanges(
+			currentVersionRef,
+			`${ previousParsed.major }.${ previousParsed.minor }.${ previousParsed.patch }`,
+			//false,
+			true,
+			SOURCE_REPO,
+			previousVersionRef,
+			'cli',
+			tmpRepoPath
+		);
+
+		const schemaChanges = changes.schema.filter(
+			( s ) => ! s.areEqual
+		);
+
+		Logger.startTask( 'Finding contributors' );
+		const title = `WooCommerce ${ currentVersion } Released`;
+
+		/*const contributors = await generateContributors(
+			currentVersion,
+			previousVersion.toString()
+		);*/
+		const contributors = {};
+
+		const postVariables = {
+			contributors,
+			title,
+			changes: {
+				...changes,
+				schema: schemaChanges,
+			},
+			displayVersion: currentVersion,
+		};
+
+		const html = isEditPost ?
+			editPostHTML( postContent, {
+				hooks: await renderTemplate( 'hooks.ejs', postVariables ),
+				database: await renderTemplate( 'database.ejs', postVariables ),
+				templates: await renderTemplate( 'templates.ejs', postVariables ),
+				contributors: await renderTemplate( 'contributors.ejs', postVariables ),
+			} ) :
+			await renderTemplate( 'release.ejs', postVariables );
+
+		Logger.endTask();
+
+		if ( isOutputOnly ) {
+			const tmpFile = join(
+				tmpdir(),
+				`release-${ currentVersion }.html`
 			);
 
-			const schemaChanges = changes.schema.filter(
-				( s ) => ! s.areEqual
-			);
+			await writeFile( tmpFile, html );
 
-			Logger.startTask( 'Finding contributors' );
-			const title = `WooCommerce ${ currentVersion } Released`;
+			Logger.notice( `Output written to ${ tmpFile }` );
+		} else {
+			Logger.startTask( 'Publishing draft release post' );
 
-			const contributors = await generateContributors(
-				currentVersion,
-				previousVersion.toString()
-			);
-
-			const html = await renderTemplate( 'release.ejs', {
-				contributors,
-				title,
-				changes: {
-					...changes,
-					schema: schemaChanges,
-				},
-				displayVersion: currentVersion,
-			} );
-
-			Logger.endTask();
-
-			if ( isOutputOnly ) {
-				const tmpFile = join(
-					tmpdir(),
-					`release-${ currentVersion }.html`
-				);
-
-				await writeFile( tmpFile, html );
-
-				Logger.notice( `Output written to ${ tmpFile }` );
-			} else {
-				Logger.startTask( 'Publishing draft release post' );
-
-				try {
-					const { URL } = await createWpComDraftPost(
-						DEVELOPER_WOOCOMMERCE_SITE_ID,
+			try {
+				const { URL } = isEditPost ?
+					await editWpComPostContent(
+						siteId,
+						options.editPost,
+						html,
+						authToken
+					) :
+					await createWpComDraftPost(
+						siteId,
 						title,
 						html,
-						tags
+						tags,
+						authToken
 					);
 
-					Logger.notice( `Published draft release post at ${ URL }` );
-					Logger.endTask();
-				} catch ( error: unknown ) {
-					if ( error instanceof Error ) {
-						Logger.error( error.message );
-					}
+				Logger.notice( `Published draft release post at ${ URL }` );
+				Logger.endTask();
+			} catch ( error: unknown ) {
+				if ( error instanceof Error ) {
+					Logger.error( error.message );
 				}
 			}
-		} else {
-			throw new Error(
-				`Could not find previous version for ${ currentVersion }`
-			);
 		}
+
 	} );
 
 program.parse( process.argv );

--- a/tools/release-posts/lib/draft-post.ts
+++ b/tools/release-posts/lib/draft-post.ts
@@ -15,7 +15,7 @@ import { Logger } from 'cli-core/src/logger';
 export const fetchWpComPost = async (
 	siteId: string,
 	postId: string,
-	authToken: string,
+	authToken: string
 ) => {
 	try {
 		const post = await fetch(

--- a/tools/release-posts/lib/draft-post.ts
+++ b/tools/release-posts/lib/draft-post.ts
@@ -5,10 +5,84 @@ import fetch from 'node-fetch';
 import { Logger } from 'cli-core/src/logger';
 
 /**
- * Internal dependencies
+ * Fetch a post from WordPress.com
+ *
+ * @param {string} siteId    - The site to fetch from.
+ * @param {string} postId    - The id of the post to fetch.
+ * @param {string} authToken - WordPress.com auth token.
+ * @return {Promise}      - A promise that resolves to the JSON API response.
  */
-import { getWordpressComAuthToken } from './oauth-helper';
-import { getEnvVar } from './environment';
+export const fetchWpComPost = async (
+	siteId: string,
+	postId: string,
+	authToken: string,
+) => {
+	try {
+		const post = await fetch(
+			`https://public-api.wordpress.com/rest/v1.1/sites/${ siteId }/posts/${ postId }`,
+			{
+				headers: {
+					Authorization: `Bearer ${ authToken }`,
+					'Content-Type': 'application/json',
+				},
+			}
+		);
+
+		if ( post.status !== 200 ) {
+			const text = await post.text();
+			throw new Error( `Error creating draft post: ${ text }` );
+		}
+
+		return post.json();
+	} catch ( e: unknown ) {
+		if ( e instanceof Error ) {
+			Logger.error( e.message );
+		}
+	}
+};
+
+/**
+ * Edit a post on wordpress.com
+ *
+ * @param {string} siteId      - The site to post to.
+ * @param {string} postId      - The post to edit.
+ * @param {string} postContent - Post content.
+ * @param {string} authToken   - WordPress.com auth token.
+ * @return {Promise}           - A promise that resolves to the JSON API response.
+ */
+export const editWpComPostContent = async (
+	siteId: string,
+	postId: string,
+	postContent: string,
+	authToken: string
+) => {
+	try {
+		const post = await fetch(
+			`https://public-api.wordpress.com/rest/v1.2/sites/${ siteId }/posts/${ postId }`,
+			{
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${ authToken }`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify( {
+					content: postContent,
+				} ),
+			}
+		);
+
+		if ( post.status !== 200 ) {
+			const text = await post.text();
+			throw new Error( `Error creating draft post: ${ text }` );
+		}
+
+		return post.json();
+	} catch ( e: unknown ) {
+		if ( e instanceof Error ) {
+			Logger.error( e.message );
+		}
+	}
+};
 
 /**
  * Create a draft of a post on wordpress.com
@@ -16,35 +90,17 @@ import { getEnvVar } from './environment';
  * @param {string} siteId      - The site to post to.
  * @param {string} postTitle   - Post title.
  * @param {string} postContent - Post content.
+ * @param {string} authToken   - WordPress.com auth token.
  * @return {Promise}           - A promise that resolves to the JSON API response.
  */
 export const createWpComDraftPost = async (
 	siteId: string,
 	postTitle: string,
 	postContent: string,
-	tags: string[]
+	tags: string[],
+	authToken: string
 ) => {
-	const clientId = getEnvVar( 'WPCOM_OAUTH_CLIENT_ID', true );
-	const clientSecret = getEnvVar( 'WPCOM_OAUTH_CLIENT_SECRET', true );
-	const redirectUri =
-		getEnvVar( 'WPCOM_OAUTH_REDIRECT_URI' ) ||
-		'http://localhost:3000/oauth';
-
 	try {
-		const authToken = await getWordpressComAuthToken(
-			clientId,
-			clientSecret,
-			siteId,
-			redirectUri,
-			'posts'
-		);
-
-		if ( ! authToken ) {
-			throw new Error(
-				'Error getting auth token, check your env settings are correct.'
-			);
-		}
-
 		const post = await fetch(
 			`https://public-api.wordpress.com/rest/v1.2/sites/${ siteId }/posts/new`,
 			{

--- a/tools/release-posts/lib/edit-post.ts
+++ b/tools/release-posts/lib/edit-post.ts
@@ -1,6 +1,13 @@
-
-export const editPostHTML = ( postContent, postVariables ) => {
-	return postContent.replaceAll( /<!-- release:([a-z]+) -->.*?<!-- \/release:\1 -->/gm, ( match, key ) => {
-		return `<!-- release:${ key } -->${ postVariables[ key ] || '' }<!-- /release:${ key } -->`;
-	} );
+export const editPostHTML = (
+	postContent: string,
+	postVariables: string[]
+) => {
+	return postContent.replaceAll(
+		/<!-- release:([a-z]+) -->.*?<!-- \/release:\1 -->/gm,
+		( match, key ) => {
+			return `<!-- release:${ key } -->${
+				postVariables[ key ] || ''
+			}<!-- /release:${ key } -->`;
+		}
+	);
 };

--- a/tools/release-posts/lib/edit-post.ts
+++ b/tools/release-posts/lib/edit-post.ts
@@ -1,13 +1,13 @@
-export const editPostHTML = (
-	postContent: string,
-	postVariables: string[]
-) => {
-	return postContent.replaceAll(
-		/<!-- release:([a-z]+) -->.*?<!-- \/release:\1 -->/gm,
-		( match, key ) => {
-			return `<!-- release:${ key } -->${
-				postVariables[ key ] || ''
-			}<!-- /release:${ key } -->`;
-		}
-	);
+
+export type EditPostVariables = {
+	hooks?: string;
+	database?: string;
+	templates?: string;
+	contributors?: string;
+};
+
+export const editPostHTML = ( postContent: string, postVariables: EditPostVariables ) => {
+	return postContent.replaceAll( /<!-- release:([a-z]+) -->.*?<!-- \/release:\1 -->/gm, ( match, key: string ) => {
+		return `<!-- release:${ key } -->${ postVariables[ key as keyof EditPostVariables ] || '' }<!-- /release:${ key } -->`;
+	} );
 };

--- a/tools/release-posts/lib/edit-post.ts
+++ b/tools/release-posts/lib/edit-post.ts
@@ -1,0 +1,6 @@
+
+export const editPostHTML = ( postContent, postVariables ) => {
+	return postContent.replaceAll( /<!-- release:([a-z]+) -->.*?<!-- \/release:\1 -->/gm, ( match, key ) => {
+		return `<!-- release:${ key } -->${ postVariables[ key ] || '' }<!-- /release:${ key } -->`;
+	} );
+};

--- a/tools/release-posts/templates/release.ejs
+++ b/tools/release-posts/templates/release.ejs
@@ -49,9 +49,9 @@
 <!-- /wp:paragraph -->
 
 
-<%- include( 'hooks' ) %>
-<%- include( 'database') %>
-<%- include( 'templates' ) %>
+<!-- release:hooks --><%- include( 'hooks' ) %><!-- /release:hooks -->
+<!-- release:database --><%- include( 'database') %><!-- /release:database -->
+<!-- release:templates --><%- include( 'templates' ) %><!-- /release:templates -->
 
 <!-- wp:heading -->
 <h2 id="deprecations">Deprecations</h2>
@@ -60,5 +60,5 @@
 <p>There are no deprecations in this release.</p>
 <!-- /wp:paragraph -->
 
-<%- include('contributors') %>
+<!-- release:contributors--><%- include('contributors') %><!-- /release:contributors -->
 

--- a/tools/release-posts/templates/release.ejs
+++ b/tools/release-posts/templates/release.ejs
@@ -50,7 +50,7 @@
 
 
 <!-- release:hooks --><%- include( 'hooks' ) %><!-- /release:hooks -->
-<!-- release:database --><%- include( 'database') %><!-- /release:database -->
+<!-- release:database --><%- include( 'database' ) %><!-- /release:database -->
 <!-- release:templates --><%- include( 'templates' ) %><!-- /release:templates -->
 
 <!-- wp:heading -->

--- a/tools/release-posts/templates/templates.ejs
+++ b/tools/release-posts/templates/templates.ejs
@@ -10,6 +10,9 @@
         <th>
           <strong>Template</strong>
         </th>
+        <th>
+          <strong>GitHub Link</strong>
+        </th>
       </thead>
       <tbody>
 
@@ -17,6 +20,11 @@
         <% changes.templates.forEach((change) => { %>
           <tr>
             <td><%= change.filePath %></td>
+            <td>
+              <% change.pullRequests.forEach( ( pullRequest ) => { %>
+                <a href="https://github.com/woocommerce/woocommerce/pull/<%= pullRequest %>">#<%= pullRequest %></a>
+              <% }) %>
+            </td>
           </tr>
         <% }) %>
       </tbody>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the release post tool such that it's possible to edit previous release posts. It also adds support for specifying a blog ID, if you'd like to test the tool with a different blog. Finally, it links to the PRs that introduced the changes in the templates section.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34248.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Make sure Docker is running and in a state to run `wp-env`
1. Checkout this branch
1. `cd` to the `tools/release-posts` directory
1. Follow the [instructions in the readme](https://github.com/woocommerce/woocommerce/blob/trunk/tools/release-posts/README.md#publishing-draft-posts) to setup for publishing release posts. If you're doing this with a test blog, use that site ID when granting access.
1. The tool will open a browser window, so be sure before running that your focused browser is logged in with access to the blog you'll use for testing.
1. Run the following: `GITHUB_ACCESS_TOKEN="..." WPCOM_OAUTH_CLIENT_ID="..." WPCOM_OAUTH_CLIENT_SECRET="..." pnpm run release-post 7.2.0 7.1.0 --siteId=...`  Be sure to provide th values for the missing variables (...). You may also choose to specify the values via your `.env` file.
1. Follow the prompts in the open browser tool to grant permissions to the site corresponding to the `siteId` that you specified.
1. Verify that the post that is created contains a link to the PR(s) that introduced the template changes.
1. Create a new post on your test site manually, add `<!-- release:templates --> This will be replaced <!-- /release:templates -->` to the source of the post you created. Note the post id.
1. Re-run the previous command with `--editPost=...`, specifying the ID of the post you just created.
1. Verify that that section of the post gets updated properly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
