### PR TITLE
Add Missing Tracks Events to Tax Settings Conflict Warning

### DIFF
--- a/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
+++ b/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
@@ -71,6 +71,8 @@ const SettingsErrorFill = () => {
 			'success',
 			__( 'Recommended settings applied.', 'woocommerce' )
 		);
+
+		recordEvent( 'tax_settings_conflict_recommended_settings_clicked' );
 	};
 
 	const ApplyRecommendedSettingsButton = () => (

--- a/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
+++ b/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
@@ -15,6 +15,7 @@ import { Icon, closeSmall } from '@wordpress/icons';
 import { useEffect, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
+++ b/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
@@ -128,6 +128,12 @@ const SettingsErrorFill = () => {
 			setIsConflict( false );
 		} else {
 			setIsConflict( true );
+
+			recordEvent( 'tax_settings_conflict', {
+				main: pricesEnteredWithTaxSetting,
+				shop: displayPricesInShopWithTaxSetting,
+				cart: displayPricesInCartWithTaxSetting,
+			} );
 		}
 	}, [
 		displayPricesInCartWithTaxSetting,

--- a/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
+++ b/plugins/woocommerce-admin/client/settings/conflict-error-slotfill.js
@@ -178,9 +178,13 @@ const SettingsErrorFill = () => {
 						<div>
 							<Button
 								className="woocommerce_tax_settings_conflict_error_card_body__close_icon"
-								onClick={ () =>
-									setDismissedConflictWarning( true )
-								}
+								onClick={ () => {
+									setDismissedConflictWarning( true );
+
+									recordEvent(
+										'tax_settings_conflict_dismissed'
+									);
+								} }
 							>
 								<Icon icon={ closeSmall } />
 							</Button>

--- a/plugins/woocommerce/changelog/add-tax-settings-conflict-tracks
+++ b/plugins/woocommerce/changelog/add-tax-settings-conflict-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add missing Tracks events to tax settings conflict banner.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up to https://github.com/woocommerce/woocommerce/pull/36010, adding Tracks events when:

* A conflict is detected
* The conflict is fixed with the recommended settings button
* The warning is dismissed

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

0. Enable Tracks debugging  in browser developer console with `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Set up woocommerce and enable tax settings in general woocommerce settings
2. Go to tax settings tab
3. If any of the 3 tax display settings (Prices entered with tax , Display prices in the shop, Display prices during cart and checkout) differ, there should be a warning banner.
4. See that the `tax_settings_conflict` Tracks event is sent. The props should match the corresponding field values in the form.

Additionally: 

4. Clicking on "Use recommended settings" should trigger the `tax_settings_conflict_recommended_settings_clicked` Tracks event.
6. Closing the warning messge with the X button should trigger the `tax_settings_conflict_dismissed` Tracks event.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
