### PR TITLE
Fix product table dropdown on mobile

### DIFF
--- a/plugins/woocommerce/changelog/fix-34534_product_dropdown_on_mobile
+++ b/plugins/woocommerce/changelog/fix-34534_product_dropdown_on_mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product table dropdown issue on mobile.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -6741,7 +6741,7 @@ table.bar_chart {
 				overflow: visible;
 			}
 
-			.toggle-row {
+			.is-expanded .toggle-row {
 				top: -28px;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This makes sure we only add the `top` when the row is expanded to account for the product image.
This fixes an issue were the dropdown arrow shows up on the previous row (see picture in original issue).

Closes #34534  .

<img width="297" alt="Screen Shot 2022-12-16 at 11 04 05 AM" src="https://user-images.githubusercontent.com/2240960/208074404-0b3f0e81-eade-42e3-bf71-658513072afa.png">

<img width="305" alt="Screen Shot 2022-12-16 at 11 04 38 AM" src="https://user-images.githubusercontent.com/2240960/208074421-78d2874a-bd59-41a2-8d47-a37ff051bb5f.png">

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, make sure you have some products and go to **Products > All Products** on a phone or changing your browser viewport to a mobile viewport.
2. The dropdown arrow should show in the top right and open the same row it's in.
3. Upon expansion the arrow should still show in the top right.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
