### PR TITLE
Make sure attribute term dropdown adheres to sort order setting

### DIFF
--- a/plugins/woocommerce/changelog/fix-35639_attribute_term_sort_order
+++ b/plugins/woocommerce/changelog/fix-35639_attribute_term_sort_order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue where attribute term dropdown was not adhering to sort order setting.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -324,6 +324,7 @@ jQuery( function( $ ) {
 								return {
 									taxonomy: $( this ).data( 'taxonomy' ),
 									limit:    $( this ).data( 'limit' ),
+									orderby:  $( this ).data( 'orderby'),
 									term:     params.term,
 									action:   'woocommerce_json_search_taxonomy_terms',
 									security: wc_enhanced_select_params.search_taxonomy_terms_nonce

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -38,12 +38,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							if ( 'select' === $attribute_taxonomy->attribute_type ) {
 								?>
-								<select multiple="multiple" data-minimum_input_length="0" data-limit="50" data-return_id="id" data-placeholder="<?php esc_attr_e( 'Select terms', 'woocommerce' ); ?>" class="multiselect attribute_values wc-taxonomy-term-search" name="attribute_values[<?php echo esc_attr( $i ); ?>][]" data-taxonomy="<?php echo esc_attr( $attribute->get_taxonomy() ); ?>">
+								<select multiple="multiple"
+										data-minimum_input_length="0"
+										data-limit="50" data-return_id="id"
+										data-placeholder="<?php esc_attr_e( 'Select terms', 'woocommerce' ); ?>"
+										data-orderby="<?php echo ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name'; ?>"
+										class="multiselect attribute_values wc-taxonomy-term-search"
+										name="attribute_values[<?php echo esc_attr( $i ); ?>][]"
+										data-taxonomy="<?php echo esc_attr( $attribute->get_taxonomy() ); ?>">
 									<?php
-									$args           = array(
-										'orderby'    => ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name',
-										'hide_empty' => 0,
-									);
 									$selected_terms = $attribute->get_terms();
 									if ( $selected_terms ) {
 										foreach ( $selected_terms as $selected_term ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -37,12 +37,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 							}
 
 							if ( 'select' === $attribute_taxonomy->attribute_type ) {
+								$attribute_orderby = ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name';
 								?>
 								<select multiple="multiple"
 										data-minimum_input_length="0"
 										data-limit="50" data-return_id="id"
 										data-placeholder="<?php esc_attr_e( 'Select terms', 'woocommerce' ); ?>"
-										data-orderby="<?php echo ! empty( $attribute_taxonomy->attribute_orderby ) ? $attribute_taxonomy->attribute_orderby : 'name'; ?>"
+										data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"
 										class="multiselect attribute_values wc-taxonomy-term-search"
 										name="attribute_values[<?php echo esc_attr( $i ); ?>][]"
 										data-taxonomy="<?php echo esc_attr( $attribute->get_taxonomy() ); ?>">

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1745,10 +1745,11 @@ class WC_AJAX {
 		$search_text = isset( $_GET['term'] ) ? wc_clean( wp_unslash( $_GET['term'] ) ) : '';
 		$limit       = isset( $_GET['limit'] ) ? absint( wp_unslash( $_GET['limit'] ) ) : null;
 		$taxonomy    = isset( $_GET['taxonomy'] ) ? wc_clean( wp_unslash( $_GET['taxonomy'] ) ) : '';
+		$orderby    = isset( $_GET['orderby'] ) ? wc_clean( wp_unslash( $_GET['orderby'] ) ) : 'name';
 
 		$args = array(
 			'taxonomy'        => $taxonomy,
-			'orderby'         => 'id',
+			'orderby'         => $orderby,
 			'order'           => 'ASC',
 			'hide_empty'      => false,
 			'fields'          => 'all',

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1745,7 +1745,7 @@ class WC_AJAX {
 		$search_text = isset( $_GET['term'] ) ? wc_clean( wp_unslash( $_GET['term'] ) ) : '';
 		$limit       = isset( $_GET['limit'] ) ? absint( wp_unslash( $_GET['limit'] ) ) : null;
 		$taxonomy    = isset( $_GET['taxonomy'] ) ? wc_clean( wp_unslash( $_GET['taxonomy'] ) ) : '';
-		$orderby    = isset( $_GET['orderby'] ) ? wc_clean( wp_unslash( $_GET['orderby'] ) ) : 'name';
+		$orderby     = isset( $_GET['orderby'] ) ? wc_clean( wp_unslash( $_GET['orderby'] ) ) : 'name';
 
 		$args = array(
 			'taxonomy'        => $taxonomy,


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes a bug introduced in https://github.com/woocommerce/woocommerce/pull/34744 where we default the sort order to `id`. This change makes use of the `orderby` setting in attributes and defaults to `name` if it is not set.

Closes #35639  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Load this branch, create an attribute with several terms under **Products > Attributes** and set the **Default sort order** to `name`
2. Create a new product (or edit an existing) and go to the attributes tab
3. Add the newly created attribute and click on the attribute term search field, the dropdown should show the existing terms in the order set above.
4. Now change the order of the attribute to `Custom ordering` or `Term ID` and see if the order within the product edit screen matches what is set.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
