### PR TITLE
Drop use of WP 5.9 function in `quantity-input.php`

### DIFF
--- a/plugins/woocommerce/changelog/fix-36039
+++ b/plugins/woocommerce/changelog/fix-36039
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Drop usage of WP 5.9 function in the product quantity selector template.

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.2.0
+ * @version 7.2.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -40,7 +40,7 @@ if ( $max_value && $min_value === $max_value ) {
 	<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
 	<input
 		type="<?php echo $is_readonly ? 'text' : 'number'; ?>"
-		<?php wp_readonly( $is_readonly ); ?>
+		<?php echo $is_readonly ? 'readonly="readonly"' : ''; ?>
 		id="<?php echo esc_attr( $input_id ); ?>"
 		class="<?php echo esc_attr( join( ' ', (array) $classes ) ); ?>"
 		name="<?php echo esc_attr( $input_name ); ?>"


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The `quantity-input.php` template, which is used to render the quantity selector on a product page, is using function `wp_readonly()`, which [was introduced in WordPress 5.9](https://developer.wordpress.org/reference/functions/wp_readonly/#changelog). This produces fatal errors when running the latest version of WC on top of WP 5.8.x.

This PR adds a workaround that is compatible with WP >= 5.8.

Please note that WooCommerce currently requires WP 5.8, so until this minimum requirement is bumped, we shouldn't be relying on anything in WP 5.9. In any case, WC 7.2.x should remain compatible with WP 5.8.x.

Closes #36039.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install or downgrade WP to 5.8.x.
   This can be done with WP-CLI by executing `wp core update --version=5.8.3 --force`.
2. Go to a product's page.
3. On trunk, you get a fatal error:
   > PHP Fatal error:  Uncaught Error: Call to undefined function wp_readonly() in […]global/quantity-input.php:43
4. Check out this branch, and confirm no fatal error appears.
5. Confirm that the "readonly" attribute on the quantity selector still works correctly:
   1. Add and enable the following snippet (via `functions.php` or as a `mu-plugin`) on your site:
      ```php
      foreach ( array( 'min', 'max' ) as $k ) {
	      add_filter( "woocommerce_quantity_input_${k}", function() { return 2; } );
      }
	  ```
   2. Go to a product's page and confirm that the quantity can't be changed and the selector has the "readonly" attribute.
6. Add the product to the cart and complete the checkout.

<!-- End testing instructions —>

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] —>

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
