### PR TITLE
Extend product variations data store with generate variations actions

### DIFF
--- a/packages/js/data/changelog/add-35778-data-store
+++ b/packages/js/data/changelog/add-35778-data-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Extend product variations data store with generate variations actions

--- a/packages/js/data/src/crud/README.md
+++ b/packages/js/data/src/crud/README.md
@@ -18,6 +18,12 @@ createCrudDataStore( {
 	resourceName: 'MyThing',
 	pluralResourceName: 'MyThings',
 	namespace: '/my/rest/namespace',
+    storeConfig: {
+        actions: additionalActions,
+        selectors: additionalSelectors,
+        resolvers: additionalResolvers,
+        controls: additionalControls,
+    }
 } );
 ```
 
@@ -55,7 +61,7 @@ If the default settings are not adequate for your needs, you can always create y
 
 ```js
 import { createSelectors } from '../crud/selectors';
-import { createResolvers } from '../crud/selectors';
+import { createResolvers } from '../crud/resolvers';
 import { createActions } from '../crud/actions';
 import { registerStore, combineReducers } from '@wordpress/data';
 

--- a/packages/js/data/src/crud/index.ts
+++ b/packages/js/data/src/crud/index.ts
@@ -9,7 +9,7 @@ import { Reducer } from 'redux';
  */
 import { createSelectors } from './selectors';
 import { createDispatchActions } from './actions';
-import controls from '../controls';
+import defaultControls from '../controls';
 import { createResolvers } from './resolvers';
 import { createReducer, ResourceState } from './reducer';
 
@@ -51,6 +51,7 @@ export const createCrudDataStore = ( {
 		actions = {},
 		selectors = {},
 		resolvers = {},
+		controls = {},
 	} = storeConfig;
 
 	registerStore( storeName, {
@@ -63,6 +64,6 @@ export const createCrudDataStore = ( {
 		actions: { ...crudActions, ...actions },
 		selectors: { ...crudSelectors, ...selectors },
 		resolvers: { ...crudResolvers, ...resolvers },
-		controls,
+		controls: { ...defaultControls, ...controls },
 	} );
 };

--- a/packages/js/data/src/crud/index.ts
+++ b/packages/js/data/src/crud/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerStore } from '@wordpress/data';
+import { combineReducers, registerStore, StoreConfig } from '@wordpress/data';
 import { Reducer } from 'redux';
 
 /**
@@ -18,6 +18,7 @@ type CrudDataStore = {
 	resourceName: string;
 	pluralResourceName: string;
 	namespace: string;
+	storeConfig?: Partial< StoreConfig< ResourceState > >;
 };
 
 export const createCrudDataStore = ( {
@@ -25,29 +26,43 @@ export const createCrudDataStore = ( {
 	resourceName,
 	namespace,
 	pluralResourceName,
+	storeConfig = {},
 }: CrudDataStore ) => {
-	const reducer = createReducer();
-	const actions = createDispatchActions( {
+	const crudReducer = createReducer();
+
+	const crudActions = createDispatchActions( {
 		resourceName,
 		namespace,
 	} );
-	const resolvers = createResolvers( {
+	const crudResolvers = createResolvers( {
 		storeName,
 		resourceName,
 		pluralResourceName,
 		namespace,
 	} );
-	const selectors = createSelectors( {
+	const crudSelectors = createSelectors( {
 		resourceName,
 		pluralResourceName,
 		namespace,
 	} );
 
+	const {
+		reducer,
+		actions = {},
+		selectors = {},
+		resolvers = {},
+	} = storeConfig;
+
 	registerStore( storeName, {
-		reducer: reducer as Reducer< ResourceState >,
-		actions,
-		selectors,
-		resolvers,
+		reducer: reducer
+			? ( combineReducers( {
+					crudReducer,
+					reducer,
+			  } ) as Reducer )
+			: ( crudReducer as Reducer< ResourceState > ),
+		actions: { ...crudActions, ...actions },
+		selectors: { ...crudSelectors, ...selectors },
+		resolvers: { ...crudResolvers, ...resolvers },
 		controls,
 	} );
 };

--- a/packages/js/data/src/product-variations/action-types.ts
+++ b/packages/js/data/src/product-variations/action-types.ts
@@ -1,0 +1,5 @@
+export enum TYPES {
+	GENERATE_VARIATIONS_ERROR = 'GENERATE_VARIATIONS_ERROR',
+}
+
+export default TYPES;

--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import { getUrlParameters, getRestPath, parseId } from '../crud/utils';
+import TYPES from './action-types';
+import { IdQuery, IdType, Item } from '../crud/types';
+import { WC_PRODUCT_VARIATIONS_NAMESPACE } from './constants';
+
+export function generateProductVariationsError( key: IdType, error: unknown ) {
+	return {
+		type: TYPES.GENERATE_VARIATIONS_ERROR as const,
+		key,
+		error,
+		errorType: 'GENERATE_VARIATIONS',
+	};
+}
+
+export const generateProductVariations = function* ( idQuery: IdQuery ) {
+	const urlParameters = getUrlParameters(
+		WC_PRODUCT_VARIATIONS_NAMESPACE,
+		idQuery
+	);
+
+	try {
+		const result: Item = yield apiFetch( {
+			path: getRestPath(
+				`${ WC_PRODUCT_VARIATIONS_NAMESPACE }/generate`,
+				{},
+				urlParameters
+			),
+			method: 'POST',
+		} );
+
+		return result;
+	} catch ( error ) {
+		yield generateProductVariationsError( key, error );
+		throw error;
+	}
+};

--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -38,6 +38,8 @@ export const generateProductVariations = function* ( idQuery: IdQuery ) {
 
 		return result;
 	} catch ( error ) {
+		const { key } = parseId( idQuery, urlParameters );
+
 		yield generateProductVariationsError( key, error );
 		throw error;
 	}

--- a/packages/js/data/src/product-variations/index.ts
+++ b/packages/js/data/src/product-variations/index.ts
@@ -3,12 +3,16 @@
  */
 import { STORE_NAME, WC_PRODUCT_VARIATIONS_NAMESPACE } from './constants';
 import { createCrudDataStore } from '../crud';
+import * as actions from './actions';
 
 createCrudDataStore( {
 	storeName: STORE_NAME,
 	resourceName: 'ProductVariation',
 	pluralResourceName: 'ProductVariations',
 	namespace: WC_PRODUCT_VARIATIONS_NAMESPACE,
+	storeConfig: {
+		actions,
+	},
 } );
 
 export const EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME = STORE_NAME;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Adds a `storeConfig` to make extending crud data stores easier
* Adds the generate action to product variations data store

Part of #35778 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a product with some variations using the legacy experience
2. On a WooCommerce Admin page, run `wp.data.dispatch('wc/admin/products/variations').generateProductVariations({product_id: 123});` replacing `123` with the product ID
3. Note that the `generate` endpoint is called in the Network tab
4. Check the product to make sure all variations have been generated

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
