### PR TITLE
Reset variation form if a new variation is given

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-variation-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Form } from '@woocommerce/components';
+import { useEffect, useRef } from '@wordpress/element';
+import { Form, FormRef } from '@woocommerce/components';
 import { PartialProduct, ProductVariation } from '@woocommerce/data';
 
 /**
@@ -24,15 +25,29 @@ export const ProductVariationForm: React.FC< {
 	product: PartialProduct;
 	productVariation: Partial< ProductVariation >;
 } > = ( { product, productVariation } ) => {
+	const previousVariationIdRef = useRef< number >();
+	const formRef = useRef< FormRef< Partial< ProductVariation > > >( null );
+
 	const navigationProps = useProductVariationNavigation( {
 		product,
 		productVariation,
 	} );
 
+	useEffect( () => {
+		if (
+			productVariation &&
+			previousVariationIdRef.current !== productVariation.id
+		) {
+			formRef.current?.resetForm( productVariation );
+			previousVariationIdRef.current = productVariation.id;
+		}
+	}, [ productVariation ] );
+
 	return (
 		<Form< Partial< ProductVariation > >
 			initialValues={ productVariation }
 			errors={ {} }
+			ref={ formRef }
 		>
 			<ProductFormHeader />
 			<ProductFormLayout>

--- a/plugins/woocommerce/changelog/fix-36077
+++ b/plugins/woocommerce/changelog/fix-36077
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reset variation form if a new variation is given


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36077

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Check that after navigating between variations the form values get updated with the new variation's properties.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
