### PR TITLE
Add product variation General section

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-variation-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.tsx
@@ -14,6 +14,7 @@ import { ProductFormTab } from './product-form-tab';
 import { PricingSection } from './sections/pricing-section';
 import { ProductInventorySection } from './sections/product-inventory-section';
 import { ProductShippingSection } from './sections/product-shipping-section';
+import { ProductVariationDetailsSection } from './sections/product-variation-details-section';
 
 export const ProductVariationForm: React.FC< {
 	product: PartialProduct;
@@ -27,7 +28,7 @@ export const ProductVariationForm: React.FC< {
 			<ProductFormHeader />
 			<ProductFormLayout>
 				<ProductFormTab name="general" title="General">
-					<>General</>
+					<ProductVariationDetailsSection />
 				</ProductFormTab>
 				<ProductFormTab name="pricing" title="Pricing">
 					<PricingSection />

--- a/plugins/woocommerce-admin/client/products/sections/product-variation-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-variation-details-section.tsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { BlockInstance, serialize, parse } from '@wordpress/blocks';
+import { CheckboxControl, Card, CardBody } from '@wordpress/components';
+import {
+	useFormContext,
+	__experimentalRichTextEditor as RichTextEditor,
+	__experimentalTooltip as Tooltip,
+} from '@woocommerce/components';
+import { ProductVariation } from '@woocommerce/data';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getCheckboxTracks } from './utils';
+import { ProductSectionLayout } from '../layout/product-section-layout';
+
+export const ProductVariationDetailsSection: React.FC = () => {
+	const { getCheckboxControlProps, values, setValue } =
+		useFormContext< ProductVariation >();
+
+	const [ descriptionBlocks, setDescriptionBlocks ] = useState<
+		BlockInstance[]
+	>( parse( values.description || '' ) );
+
+	return (
+		<ProductSectionLayout
+			title={ __( 'Variant details', 'woocommerce' ) }
+			description={ __(
+				'This info will be displayed on the product page, category pages, social media, and search results.',
+				'woocommerce'
+			) }
+		>
+			<Card>
+				<CardBody>
+					<CheckboxControl
+						label={
+							<>
+								{ __( 'Visible to customers', 'woocommerce' ) }
+								<Tooltip
+									text={ __(
+										'When enabled, customers will be able to select and purchase this variation from the product page.',
+										'woocommerce'
+									) }
+								/>
+							</>
+						}
+						{ ...getCheckboxControlProps(
+							'status',
+							getCheckboxTracks( 'status' )
+						) }
+						checked={ values.status === 'publish' }
+						onChange={ () =>
+							setValue(
+								'status',
+								values.status !== 'publish'
+									? 'publish'
+									: 'private'
+							)
+						}
+					/>
+					<RichTextEditor
+						label={ __( 'Description', 'woocommerce' ) }
+						blocks={ descriptionBlocks }
+						onChange={ ( blocks ) => {
+							setDescriptionBlocks( blocks );
+							if ( ! descriptionBlocks.length ) {
+								return;
+							}
+							setValue( 'description', serialize( blocks ) );
+						} }
+						placeholder={ __(
+							'Describe this product. What makes it unique? What are its most important features?',
+							'woocommerce'
+						) }
+					/>
+				</CardBody>
+			</Card>
+		</ProductSectionLayout>
+	);
+};

--- a/plugins/woocommerce/changelog/add-35987
+++ b/plugins/woocommerce/changelog/add-35987
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product variation General section


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a general section for product variations.  Note that the design for images is changing as variations currently on support a single image and not a gallery so that will be included a follow-up PR.

<img width="912" alt="Screen Shot 2022-12-19 at 12 56 55 PM" src="https://user-images.githubusercontent.com/10561050/208522902-048cd98f-ddbd-4e2f-bbe0-6bb2596c9af3.png">


Closes #35987  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some variations
2. Navigate to the new product variation screen `wp-admin/admin.php?page=wc-admin&path=/product/{product_id}/variation/{variation_id}` replacing `{product_id}` and `{variation_id}` with your respective IDs.
3. Note that the general section exists with a "Description" rich text editor and a toggle for visibility.
4. This information will not yet persist on save, but you can optionally verify that the form values are updated for `description` and `status` using React dev tools

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
