### PR TITLE
Add product variation title to page header

### DIFF
--- a/packages/js/data/changelog/add-35990
+++ b/packages/js/data/changelog/add-35990
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update IdQuery type on get item selectors

--- a/packages/js/data/src/crud/types.ts
+++ b/packages/js/data/src/crud/types.ts
@@ -86,7 +86,7 @@ export type CrudSelectors<
 			UpdateError: WPDataSelector< typeof getItemUpdateError >;
 		},
 		ResourceName,
-		IdType,
+		IdQuery,
 		unknown
 	> &
 	MapSelectors<

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -56,7 +56,7 @@ const EditProductPage: React.FC = () => {
 						isProductVariation &&
 						getProductVariation( {
 							id: parseInt( variationId, 10 ),
-							product_id: productId,
+							product_id: parseInt( productId, 10 ),
 						} ),
 					isLoading:
 						! hasProductFinishedResolution( 'getProduct', [

--- a/plugins/woocommerce-admin/client/products/product-title.tsx
+++ b/plugins/woocommerce-admin/client/products/product-title.tsx
@@ -90,6 +90,7 @@ export const ProductTitle: React.FC = () => {
 		},
 		{
 			href: getNewPath( {}, '/product/' + productId ),
+			type: 'wc-admin',
 			title: (
 				<>
 					{ productTitle }

--- a/plugins/woocommerce-admin/client/products/product-title.tsx
+++ b/plugins/woocommerce-admin/client/products/product-title.tsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getAdminLink } from '@woocommerce/settings';
 import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	Product,
 	PRODUCTS_STORE_NAME,
 	WCDataSelector,
 } from '@woocommerce/data';
+import { getAdminLink } from '@woocommerce/settings';
+import { getNewPath } from '@woocommerce/navigation';
 import { useFormContext } from '@woocommerce/components';
 import { useParams } from 'react-router-dom';
 import { useSelect } from '@wordpress/data';
@@ -16,6 +18,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getProductTitle } from './utils/get-product-title';
+import { getProductVariationTitle } from './utils/get-product-variation-title';
 import { ProductBreadcrumbs } from './product-breadcrumbs';
 import { ProductStatusBadge } from './product-status-badge';
 import { WooHeaderPageTitle } from '~/header/utils';
@@ -23,35 +26,103 @@ import './product-title.scss';
 
 export const ProductTitle: React.FC = () => {
 	const { values } = useFormContext< Product >();
-	const { productId } = useParams();
-	const { persistedName } = useSelect( ( select: WCDataSelector ) => {
-		const product = productId
-			? select( PRODUCTS_STORE_NAME ).getProduct(
+	const { productId, variationId } = useParams();
+	const { isLoading, persistedName, productVariation } = useSelect(
+		( select: WCDataSelector ) => {
+			const {
+				getProduct,
+				hasFinishedResolution: hasProductFinishedResolution,
+			} = select( PRODUCTS_STORE_NAME );
+			const {
+				getProductVariation,
+				hasFinishedResolution: hasProductVariationFinishedResolution,
+			} = select( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
+			const product = productId
+				? getProduct( parseInt( productId, 10 ) )
+				: null;
+			const variation =
+				variationId && productId
+					? getProductVariation( {
+							id: parseInt( variationId, 10 ),
+							product_id: parseInt( productId, 10 ),
+					  } )
+					: null;
+
+			const isProductLoading =
+				productId &&
+				! hasProductFinishedResolution( 'getProduct', [
 					parseInt( productId, 10 ),
-					undefined
-			  )
-			: null;
+				] );
 
-		return {
-			persistedName: product?.name,
-		};
-	} );
+			const isVariationLoading =
+				variationId &&
+				productId &&
+				! hasProductVariationFinishedResolution(
+					'getProductVariation',
+					[
+						{
+							id: parseInt( variationId, 10 ),
+							product_id: parseInt( productId, 10 ),
+						},
+					]
+				);
 
-	const breadcrumbs = [
+			return {
+				persistedName: product?.name,
+				productVariation: variation,
+				isLoading: isProductLoading || isVariationLoading,
+			};
+		}
+	);
+
+	const productTitle = getProductTitle(
+		values.name,
+		values.type,
+		persistedName
+	);
+	const productVariationTitle =
+		productVariation && getProductVariationTitle( productVariation );
+
+	const pageHierarchy = [
 		{
 			href: getAdminLink( 'edit.php?post_type=product' ),
 			title: __( 'Products', 'woocommerce' ),
 		},
-	];
-	const title = getProductTitle( values.name, values.type, persistedName );
+		{
+			href: getNewPath( {}, '/product/' + productId ),
+			title: (
+				<>
+					{ productTitle }
+					<ProductStatusBadge />
+				</>
+			),
+		},
+		productVariationTitle && {
+			title: (
+				<span title={ productVariationTitle }>
+					{ productVariationTitle.length > 50
+						? productVariationTitle.substring( 0, 50 ) + '…'
+						: productVariationTitle }
+				</span>
+			),
+		},
+	].filter( ( page ) => !! page ) as {
+		href: string;
+		title: string | JSX.Element;
+	}[];
+
+	const current = pageHierarchy.pop();
+
+	if ( isLoading ) {
+		return null;
+	}
 
 	return (
 		<WooHeaderPageTitle>
 			<span className="woocommerce-product-title">
-				<ProductBreadcrumbs breadcrumbs={ breadcrumbs } />
+				<ProductBreadcrumbs breadcrumbs={ pageHierarchy } />
 				<span className="woocommerce-product-title__wrapper">
-					{ title }
-					<ProductStatusBadge />
+					{ current?.title }
 				</span>
 			</span>
 		</WooHeaderPageTitle>

--- a/plugins/woocommerce-admin/client/products/product-title.tsx
+++ b/plugins/woocommerce-admin/client/products/product-title.tsx
@@ -18,7 +18,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getProductTitle } from './utils/get-product-title';
-import { getProductVariationTitle } from './utils/get-product-variation-title';
+import {
+	getProductVariationTitle,
+	getTruncatedProductVariationTitle,
+} from './utils/get-product-variation-title';
 import { ProductBreadcrumbs } from './product-breadcrumbs';
 import { ProductStatusBadge } from './product-status-badge';
 import { WooHeaderPageTitle } from '~/header/utils';
@@ -101,9 +104,7 @@ export const ProductTitle: React.FC = () => {
 		productVariationTitle && {
 			title: (
 				<span title={ productVariationTitle }>
-					{ productVariationTitle.length > 50
-						? productVariationTitle.substring( 0, 50 ) + '…'
-						: productVariationTitle }
+					{ getTruncatedProductVariationTitle( productVariation ) }
 				</span>
 			),
 		},

--- a/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
@@ -3,6 +3,8 @@
  */
 import { ProductVariation } from '@woocommerce/data';
 
+export const PRODUCT_VARIATION_TITLE_LIMIT = 32;
+
 /**
  * Get the product variation title for use in the header.
  *
@@ -21,4 +23,22 @@ export const getProductVariationTitle = (
 			return attribute.option;
 		} )
 		.join( ', ' );
+};
+
+/**
+ * Get the truncated product variation title.
+ *
+ * @param  productVariation The product variation.
+ * @return string
+ */
+export const getTruncatedProductVariationTitle = (
+	productVariation: Partial< ProductVariation >
+) => {
+	const title = getProductVariationTitle( productVariation );
+
+	if ( title.length > PRODUCT_VARIATION_TITLE_LIMIT ) {
+		return title.substring( 0, PRODUCT_VARIATION_TITLE_LIMIT ) + '…';
+	}
+
+	return title;
 };

--- a/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { ProductVariation } from '@woocommerce/data';
+
+/**
+ * Get the product variation title for use in the header.
+ *
+ * @param  productVariation The product variation.
+ * @return string
+ */
+export const getProductVariationTitle = (
+	productVariation: Partial< ProductVariation >
+) => {
+	if ( ! productVariation?.attributes?.length ) {
+		return '#' + productVariation.id;
+	}
+
+	return productVariation.attributes
+		.map( ( attribute ) => {
+			return attribute.option;
+		} )
+		.join( ', ' );
+};

--- a/plugins/woocommerce-admin/client/products/utils/test/get-product-variation-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/test/get-product-variation-title.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { getProductVariationTitle } from '../get-product-variation-title';
+
+describe( 'getProductVariationTitle', () => {
+	it( 'should return the product variation options in a comma separated list', () => {
+		const title = getProductVariationTitle( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Color',
+					option: 'Red',
+				},
+				{
+					id: 0,
+					name: 'Size',
+					option: 'Medium',
+				},
+			],
+		} );
+		expect( title ).toBe( 'Red, Medium' );
+	} );
+
+	it( 'should return the only product variation attribute option name', () => {
+		const title = getProductVariationTitle( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Color',
+					option: 'Blue',
+				},
+			],
+		} );
+		expect( title ).toBe( 'Blue' );
+	} );
+
+	it( 'should return the product variation id when no attributes exist', () => {
+		const title = getProductVariationTitle( {
+			id: 123,
+			attributes: [],
+		} );
+		expect( title ).toBe( '#123' );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/products/utils/test/get-product-variation-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/test/get-product-variation-title.ts
@@ -1,7 +1,10 @@
 /**
  * Internal dependencies
  */
-import { getProductVariationTitle } from '../get-product-variation-title';
+import {
+	getProductVariationTitle,
+	getTruncatedProductVariationTitle,
+} from '../get-product-variation-title';
 
 describe( 'getProductVariationTitle', () => {
 	it( 'should return the product variation options in a comma separated list', () => {
@@ -43,5 +46,45 @@ describe( 'getProductVariationTitle', () => {
 			attributes: [],
 		} );
 		expect( title ).toBe( '#123' );
+	} );
+} );
+
+describe( 'getTruncatedProductVariationTitle', () => {
+	it( 'should return the default product variation title when the limit is not met', () => {
+		const truncatedTitle = getTruncatedProductVariationTitle( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Color',
+					option: 'Red',
+				},
+				{
+					id: 0,
+					name: 'Size',
+					option: 'Medium',
+				},
+			],
+		} );
+		expect( truncatedTitle ).toBe( 'Red, Medium' );
+	} );
+
+	it( 'should return the truncated product title when the limit is reached', () => {
+		const truncatedTitle = getTruncatedProductVariationTitle( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Color',
+					option: 'Reddish',
+				},
+				{
+					id: 0,
+					name: 'Size',
+					option: 'MediumLargeSmallishTypeOfSize',
+				},
+			],
+		} );
+		expect( truncatedTitle ).toBe( 'Reddish, MediumLargeSmallishType…' );
 	} );
 } );

--- a/plugins/woocommerce/changelog/add-35990
+++ b/plugins/woocommerce/changelog/add-35990
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product variation title to page header


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the product variation title to the page header.

<img width="477" alt="Screen Shot 2022-12-19 at 4 07 19 PM" src="https://user-images.githubusercontent.com/10561050/208563125-c44e3ee7-8e74-4102-abf5-7a3e25ad902c.png">
<img width="1007" alt="Screen Shot 2022-12-19 at 5 36 21 PM" src="https://user-images.githubusercontent.com/10561050/208563127-25407497-2129-4681-971f-c4a8090d68ce.png">


Closes #35990  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some variations and multiple options in the legacy product experience
2.Navigate to the new product variation screen `wp-admin/admin.php?page=wc-admin&path=/product/{product_id}/variation/{variation_id}` replacing `{product_id}` and `{variation_id}` with your respective IDs.
3. Check the page header and make sure the variation options are shown in a comma separated list
4. Create a variation without any attributes in the legacy product experience
5. Navigate to the new product variation screen
6. Check that the page header includes the variation ID
7. Create a very long (> 50 characters) option for a variation in the legacy product experience
8. Navigate to the new product variation screen and note that the variation title is truncated with an ellipsis at the end
9. Hover the variation title to see the full title
10. Click the parent product name (not the variation) to check that you are navigated back to the product page

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
