### PR TITLE
Make quantity selector more specific Only select the primary quantity

### DIFF
--- a/plugins/woocommerce/changelog/issues-36086-more-specific-variation-qty-selector
+++ b/plugins/woocommerce/changelog/issues-36086-more-specific-variation-qty-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+onFoundVariation make $qty selector more specific

--- a/plugins/woocommerce/changelog/issues-36086-more-specific-variation-qty-selector
+++ b/plugins/woocommerce/changelog/issues-36086-more-specific-variation-qty-selector
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-onFoundVariation make $qty selector more specific
+Improves handling of the single product page quantity selector, in relation to variable products.

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -245,7 +245,7 @@
 			$dimensions    = form.$product.find(
 				'.product_dimensions, .woocommerce-product-attributes-item--dimensions .woocommerce-product-attributes-item__value'
 			),
-			$qty           = form.$singleVariationWrap.find( '.woocommerce-variation-add-to-cart .quantity' ),
+			$qty           = form.$singleVariationWrap.find( '.quantity input[name="quantity"]' ),
 			purchasable    = true,
 			variation_id   = '',
 			template       = false,

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -245,7 +245,7 @@
 			$dimensions    = form.$product.find(
 				'.product_dimensions, .woocommerce-product-attributes-item--dimensions .woocommerce-product-attributes-item__value'
 			),
-			$qty           = form.$singleVariationWrap.find( '.quantity' ),
+			$qty           = form.$singleVariationWrap.find( '.woocommerce-variation-add-to-cart .quantity' ),
 			purchasable    = true,
 			variation_id   = '',
 			template       = false,


### PR DESCRIPTION
 buttons inside the .woocommerce-variation-add-to-cart div.
 
 More explanation is available in #36086 36086

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36086 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request (Part 1)

This set of testing instructions is aimed at showing the problem (involving custom code) that this PR solves. Start by adding the following snippet, which adds a new quantity input to the single variation:

```php
function kia_test_single_variation_qty() {
	echo '<div class="quantity"><input class="qty" type="number" name="tacos" /></div>';
}
add_action( 'woocommerce_before_single_variation', 'kia_test_single_variation_qty' );
```

1. Go to a variable product
2. Select a variation by selecting the attributes necessary
3. Increase the rogue quantity input's value
4. change to another variation
5. the main quantity input's value should now match what you entered in the _other_ input.

This will no longer happen with the proposed changes.

Instead, if you increase the primary quantity input's value, then switch variations.. the primary quantity input should stay the same (assuming no stock issues of very specific filters)

### How to test the changes in this Pull Request (Part 2)

This second set of testing instructions aims to confirm that there were no adverse effects to our default plugin behavior following this change.

- Remove any custom snippets you might have added in the previous steps.
- Visit the single product page for a variable product.
- Ensure you can select a variation, and a specific quantity, and add it to the cart successfully.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
