### PR TITLE
Replace hardcoded table prefix.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36099-migration-query
+++ b/plugins/woocommerce/changelog/fix-36099-migration-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects a hard-coded reference to the WP post meta table within the HPOS Migration Helper, that would fail on some sites.

--- a/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
+++ b/plugins/woocommerce/src/Database/Migrations/MigrationHelper.php
@@ -205,7 +205,7 @@ class MigrationHelper {
 					AS states_in_country
 				WHERE (meta_key='_billing_state' OR meta_key='_shipping_state')
 				AND meta_value=%s
-				AND wp_postmeta.post_id = states_in_country.post_id
+				AND {$wpdb->postmeta}.post_id = states_in_country.post_id
 				LIMIT %d",
 				$country_code,
 				$old_state,


### PR DESCRIPTION
Fixes a hard-coded table reference in the MigrationHelper.

Closes #36096.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Code-review is probably sufficient in this case. 

However, it should be possible to test manually by creating a new site, setting the table prefix to something other than `wp_` and re-testing per instructions for https://github.com/woocommerce/woocommerce/pull/35967 (and https://github.com/woocommerce/woocommerce/pull/35669). Noting that, where those instructions indicate that you should `"Switch to the branch of this pull request"` you should instead checkout `7.2.1`.

Allow the updates to happen; you may observe the following error:

> WordPress database error Unknown column 'wp_postmeta.post_id' in 'where clause'

Now update to *this* branch and again trigger the updates. Via WP CLI, you can simply do:

```
wp eval 'WC_Install::run_manual_database_update();'
wp action-scheduler run
```

As in the earlier PR, it may take some time for all the scheduled actions to complete. Eventually, all updates to New Zealand/Ukraine states should be correctly fixed.


<!-- End testing instructions -->

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
