### PR TITLE
Update TaskLists::add_task() to reflect changes in TaskList::add_task()

### DIFF
--- a/plugins/woocommerce/changelog/update-tasklists-addtask
+++ b/plugins/woocommerce/changelog/update-tasklists-addtask
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update TaskLists::add_task() to reflect changes in TaskList::add_task()

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -288,10 +288,11 @@ class TaskLists {
 	 * Add task to a given task list.
 	 *
 	 * @param string $list_id List ID to add the task to.
-	 * @param array  $args Task properties.
+	 * @param Task   $task Task object.
+	 *
 	 * @return \WP_Error|Task
 	 */
-	public static function add_task( $list_id, $args ) {
+	public static function add_task( $list_id, $task ) {
 		if ( ! isset( self::$lists[ $list_id ] ) ) {
 			return new \WP_Error(
 				'woocommerce_task_list_invalid_list',
@@ -299,7 +300,7 @@ class TaskLists {
 			);
 		}
 
-		self::$lists[ $list_id ]->add_task( $args );
+		self::$lists[ $list_id ]->add_task( $task );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/commit/8ff08ea0c96833e58564590bdb5ca4584f1d49c2#diff-061f664bd417ad78d47c53ad5e6cc7e2eb1243af4e55b6fbf68750225acb06a3R173 `TaskList::add_task()` was refactored to receive an instance of `Task` instead of an `array` as its first parameter.

This PR updates `TaskLists::add_task()` (easy to miss that it is a different method as the only difference is the plural in the class name) to reflect the changes from the commit mentioned above. It updates the type of the second parameter from `array` to `Task` and renames the parameter from `$args` to `$task`.

I found this while using `TaskLists::add_task()` to add a MailPoet task as our PHPStan checks complained that I was passing the wrong parameter to this WooCommerce method.

Somewhat related to https://github.com/woocommerce/woocommerce/issues/35234

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [X] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
