### PR TITLE
Persist active tab on refresh

### DIFF
--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Children, useEffect } from '@wordpress/element';
 import { TabPanel, Tooltip } from '@wordpress/components';
+import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -14,6 +15,8 @@ import { ProductFormTab } from '../product-form-tab';
 export const ProductFormLayout: React.FC< {
 	children: JSX.Element | JSX.Element[];
 } > = ( { children } ) => {
+	const query = getQuery() as Record< string, string >;
+
 	useEffect( () => {
 		window.document.body.classList.add(
 			'woocommerce-admin-product-layout'
@@ -63,7 +66,13 @@ export const ProductFormLayout: React.FC< {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore Disabled properties will be included in newer versions of Gutenberg.
 			tabs={ tabs }
-			onSelect={ () => ( window.document.documentElement.scrollTop = 0 ) }
+			initialTabName={ query.tab ?? tabs[ 0 ].name }
+			onSelect={ ( tabName: string ) => {
+				window.document.documentElement.scrollTop = 0;
+				navigateTo( {
+					url: getNewPath( { tab: tabName } ),
+				} );
+			} }
 		>
 			{ ( tab ) => (
 				<>

--- a/plugins/woocommerce/changelog/add-36061
+++ b/plugins/woocommerce/changelog/add-36061
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Persist active tab on refresh


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36061

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products -> Add New (MVP)` page
2. If you click on any tab and then refresh the page the active tab should persist selected.

<video src="https://user-images.githubusercontent.com/13334210/208777580-97b31bf7-ce5f-40a0-b9f1-0e879eb5bf4b.mov"></video>

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
