### PR TITLE
Re-run the 7.2.1 state migrations when merchants update to 7.2.2.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36096-nz-ua-states-migration
+++ b/plugins/woocommerce/changelog/fix-36096-nz-ua-states-migration
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: A changelog entry was added via https://github.com/woocommerce/woocommerce/pull/36100. This is an amendment to that change, and an additional changelog entry is therefore not required.
+
+

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -221,6 +221,10 @@ class WC_Install {
 			'wc_update_721_adjust_new_zealand_states',
 			'wc_update_721_adjust_ukraine_states',
 		),
+		'7.2.2' => array(
+			'wc_update_722_adjust_new_zealand_states',
+			'wc_update_722_adjust_ukraine_states',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2537,3 +2537,24 @@ function wc_update_721_adjust_ukraine_states() {
 	);
 }
 
+/**
+ * Update the New Zealand state codes in the database after they were updated in code to the CLDR standard.
+ *
+ * This is a simple wrapper for the corresponding 7.2.1 update function. The reason we do this (instead of
+ * reusing the original function directly) is for better traceability in the Action Scheduler log, in case
+ * of problems.
+ */
+function wc_update_722_adjust_new_zealand_states() {
+	return wc_update_721_adjust_new_zealand_states();
+}
+
+/**
+ * Update the Ukraine state codes in the database after they were updated in code to the CLDR standard.
+ *
+ * This is a simple wrapper for the corresponding 7.2.1 update function. The reason we do this (instead of
+ * reusing the original function directly) is for better traceability in the Action Scheduler log, in case
+ * of problems.
+ */
+function wc_update_722_adjust_ukraine_states() {
+	return wc_update_721_adjust_ukraine_states();
+}


### PR DESCRIPTION
This PR compliments the fix made in https://github.com/woocommerce/woocommerce/pull/36100. If you are unfamiliar with that PR, please read through it as well as the following PRs before reviewing this change:

- https://github.com/woocommerce/woocommerce/pull/35967
- https://github.com/woocommerce/woocommerce/pull/35669

### Background

Building on the above PRs, our theory (and, initially, testing seemed to bear this out) was that for sites experiencing the database error, the migration would not complete and would therefore would stay active through rescheduling of the relevant scheduled actions—thanks to [these update mechanics](https://github.com/woocommerce/woocommerce/blob/7.2.1/plugins/woocommerce/includes/class-wc-install.php#L342-L350). For that reason, we did not create a fresh set of update callbacks for 7.2.2. 

What we found via further testing was that this was not guaranteed to be the case. The active queue runner may pick up the waiting migration in its first batch, and process it. Since the migration does not complete, it will be rescheduled and in fact the same queue runner may also pick up the replacement in its next batch, and so on. In the context of the async queue runner, that led to the potential for a timeout in which the migration task is placed in-progress but does not complete. 

In these cases, since the task doesn't actually complete, it also doesn't hand back control to `WC_Install::run_update_callback()` and a replacement will not be rescheduled. The incomplete action will eventually be set to *failed* by the queue cleaner.

### This change

To mitigate the above problem, we should trigger a fresh migration in 7.2.2. In some cases, where the migration already worked successfully, it will quickly stand down. Otherwise, it will run and make the expected changes to relevant billing/shipping states, etc.

Note that I introduced two new `wc_update_722_*` functions. Of course, I could have reused the existing `wc_update_721_*` functions, however a different set of callback names will provide better traceability should there be any other unexpected problems.

Closes https://github.com/woocommerce/woocommerce/issues/36096.

### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

In these testing instructions, I'll focus on checking the shipping zone and will use New Zealand/Northland as my country/state. You could however pick some other state (including a Ukrainian state) and you could also test against a tax rate. If you wish to do that, please refer to the other PRs linked above for details on what to expect.

1. Setup a new WordPress site using a non-standard database prefix.
2. Install WooCommerce 7.0.0 and set up your store as if it is in New Zealand/Northland.
3. Also setup a shipping zone for New Zealand/Northland.
4. Place an order in which the New Zealand/Northland shipping fee is applied.
5. If you run a query like `SELECT * FROM wp_postmeta WHERE ID = <order_id> AND meta_key = '_billing_state'` (adjust the order ID and the table prefix as needed!) you should see that the billing state code is `NL`.
6. Update to WooCommerce 7.2.1 and trigger the database update.
7. Allow some time for the update tasks to complete (this generally happens asynchronously, and for our purposes here I would advise against hurrying things along with `wp action-scheduler run`, though you *might* have success testing that way). There are two possible outcomes at this point:
    - In one case, everything will have worked successfully. If you retest step 5 you will see the billing state code is now `NTL`. Should this have happened, huzzah. Celebrate. Then, manually change it back to `NL` to simulate the next scenario where things didn't work out so well.
    - In a different case, the billing state code will not have succeeded. I'm going to proceed as if that is the case.
8. Now checkout this branch (or switch to the 7.2.2 build, if available at time of testing). 
9. If you visit the **WooCommerce ▸ Settings** screen you should be prompted to run another database update. Do so.
10. Give some time for the updates to run ...
    - Re-test step 5, the billing code should now be `NTL`.
    - Visit **Tools ▸ Scheduled Actions** (or inspect the scheduled actions database table directly) and search for `wc_update_722` ... you should only find completed actions and no failed actions.
 
<!-- End testing instructions -->

<!-- Mark completed items with an [x] -->

### Other information

Separately, I think we should consider tweaking `WC_Install::run_update_callback_end()` and scheduling the follow-up action (when needed) a little further in the future, or have some other way to prevent the problem described above.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
