### PR TITLE
Typo correction in woocommerce/src/Admin/ReportsSync.php

### DIFF
--- a/plugins/woocommerce/changelog/fix-typo-in-regenerate_report_data-doc
+++ b/plugins/woocommerce/changelog/fix-typo-in-regenerate_report_data-doc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix typo in a function comment.

--- a/plugins/woocommerce/src/Admin/ReportsSync.php
+++ b/plugins/woocommerce/src/Admin/ReportsSync.php
@@ -71,7 +71,7 @@ class ReportsSync {
 	 * Regenerate data for reports.
 	 *
 	 * @param int|bool $days Number of days to import.
-	 * @param bool     $skip_existing Skip exisiting records.
+	 * @param bool     $skip_existing Skip existing records.
 	 * @return string
 	 */
 	public static function regenerate_report_data( $days, $skip_existing ) {


### PR DESCRIPTION
Correcting typo in function documentation

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).
