### PR TITLE
Add noDataLabel into Table component allowing to customise No Data Label message.  

### DIFF
--- a/packages/js/components/changelog/enhancement-table-add-no-data-label-property
+++ b/packages/js/components/changelog/enhancement-table-add-no-data-label-property
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add noDataLabel property into table.js component to allow No Data label customization.

--- a/packages/js/components/src/table/README.md
+++ b/packages/js/components/src/table/README.md
@@ -241,7 +241,7 @@ Name | Type | Default | Description
 `rows` | Array | `null` | (required) An array of arrays of display/value object pairs
 `rowHeader` | One of type: number, bool | `0` | Which column should be the row header, defaults to the first item (`0`) (but could be set to `1`, if the first col is checkboxes, for example). Set to false to disable row headers
 `rowKey` | Function(row, index): string | `null` | Function used to get the row key.
-`noDataLabel` | String | `undefined` | Customize the label to show when there are no rows in the table.
+`emptyMessage` | String | `undefined` | Customize the message to show when there are no rows in the table.
 
 ### `headers` structure
 

--- a/packages/js/components/src/table/README.md
+++ b/packages/js/components/src/table/README.md
@@ -241,6 +241,7 @@ Name | Type | Default | Description
 `rows` | Array | `null` | (required) An array of arrays of display/value object pairs
 `rowHeader` | One of type: number, bool | `0` | Which column should be the row header, defaults to the first item (`0`) (but could be set to `1`, if the first col is checkboxes, for example). Set to false to disable row headers
 `rowKey` | Function(row, index): string | `null` | Function used to get the row key.
+`noDataLabel` | String | `undefined` | Customize the label to show when there are no rows in the table.
 
 ### `headers` structure
 

--- a/packages/js/components/src/table/index.js
+++ b/packages/js/components/src/table/index.js
@@ -153,6 +153,7 @@ class TableCard extends Component {
 			title,
 			totalRows,
 			rowKey,
+			noDataLabel,
 		} = this.props;
 		const { showCols } = this.state;
 		const allHeaders = this.props.headers;
@@ -237,6 +238,7 @@ class TableCard extends Component {
 							query={ query }
 							onSort={ onSort || onQueryChange( 'sort' ) }
 							rowKey={ rowKey }
+							noDataLabel={ noDataLabel }
 						/>
 					) }
 				</CardBody>
@@ -361,6 +363,10 @@ TableCard.propTypes = {
 	 * This uses the index if not defined.
 	 */
 	rowKey: PropTypes.func,
+	/**
+	 * Customize the label to show when there are no rows in the table.
+	 */
+	noDataLabel: PropTypes.string,
 };
 
 TableCard.defaultProps = {
@@ -372,6 +378,7 @@ TableCard.defaultProps = {
 	rowHeader: 0,
 	rows: [],
 	showMenu: true,
+	noDataLabel: undefined,
 };
 
 export default TableCard;

--- a/packages/js/components/src/table/index.js
+++ b/packages/js/components/src/table/index.js
@@ -153,7 +153,7 @@ class TableCard extends Component {
 			title,
 			totalRows,
 			rowKey,
-			noDataLabel,
+			emptyMessage,
 		} = this.props;
 		const { showCols } = this.state;
 		const allHeaders = this.props.headers;
@@ -238,7 +238,7 @@ class TableCard extends Component {
 							query={ query }
 							onSort={ onSort || onQueryChange( 'sort' ) }
 							rowKey={ rowKey }
-							noDataLabel={ noDataLabel }
+							emptyMessage={ emptyMessage }
 						/>
 					) }
 				</CardBody>
@@ -364,9 +364,9 @@ TableCard.propTypes = {
 	 */
 	rowKey: PropTypes.func,
 	/**
-	 * Customize the label to show when there are no rows in the table.
+	 * Customize the message to show when there are no rows in the table.
 	 */
-	noDataLabel: PropTypes.string,
+	emptyMessage: PropTypes.string,
 };
 
 TableCard.defaultProps = {
@@ -378,7 +378,7 @@ TableCard.defaultProps = {
 	rowHeader: 0,
 	rows: [],
 	showMenu: true,
-	noDataLabel: undefined,
+	emptyMessage: undefined,
 };
 
 export default TableCard;

--- a/packages/js/components/src/table/stories/table.js
+++ b/packages/js/components/src/table/stories/table.js
@@ -20,6 +20,18 @@ export const Basic = () => (
 	</Card>
 );
 
+export const NoDataCustomMessage = () => (
+	<Card size={ null }>
+		<Table
+			caption="Revenue last week"
+			rows={ [] }
+			headers={ headers }
+			rowKey={ ( row ) => row[ 0 ].value }
+			emptyMessage="Custom empty message"
+		/>
+	</Card>
+);
+
 export default {
 	title: 'WooCommerce Admin/components/Table',
 	component: Table,

--- a/packages/js/components/src/table/table.js
+++ b/packages/js/components/src/table/table.js
@@ -146,7 +146,7 @@ class Table extends Component {
 			query,
 			rowHeader,
 			rows,
-			noDataLabel,
+			emptyMessage,
 		} = this.props;
 		const { isScrollableRight, isScrollableLeft, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames, {
@@ -345,7 +345,7 @@ class Table extends Component {
 									className="woocommerce-table__empty-item"
 									colSpan={ headers.length }
 								>
-									{ noDataLabel ??
+									{ emptyMessage ??
 										__(
 											'No data to display',
 											'woocommerce'
@@ -457,9 +457,9 @@ Table.propTypes = {
 	 */
 	rowKey: PropTypes.func,
 	/**
-	 * Customize the label to show when there are no rows in the table.
+	 * Customize the message to show when there are no rows in the table.
 	 */
-	noDataLabel: PropTypes.string,
+	emptyMessage: PropTypes.string,
 };
 
 Table.defaultProps = {
@@ -468,7 +468,7 @@ Table.defaultProps = {
 	onSort: noop,
 	query: {},
 	rowHeader: 0,
-	noDataLabel: undefined,
+	emptyMessage: undefined,
 };
 
 export default withInstanceId( Table );

--- a/packages/js/components/src/table/table.js
+++ b/packages/js/components/src/table/table.js
@@ -146,6 +146,7 @@ class Table extends Component {
 			query,
 			rowHeader,
 			rows,
+			noDataLabel,
 		} = this.props;
 		const { isScrollableRight, isScrollableLeft, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames, {
@@ -344,10 +345,11 @@ class Table extends Component {
 									className="woocommerce-table__empty-item"
 									colSpan={ headers.length }
 								>
-									{ __(
-										'No data to display',
-										'woocommerce'
-									) }
+									{ noDataLabel ??
+										__(
+											'No data to display',
+											'woocommerce'
+										) }
 								</td>
 							</tr>
 						) }
@@ -454,6 +456,10 @@ Table.propTypes = {
 	 * Defaults to index.
 	 */
 	rowKey: PropTypes.func,
+	/**
+	 * Customize the label to show when there are no rows in the table.
+	 */
+	noDataLabel: PropTypes.string,
 };
 
 Table.defaultProps = {
@@ -462,6 +468,7 @@ Table.defaultProps = {
 	onSort: noop,
 	query: {},
 	rowHeader: 0,
+	noDataLabel: undefined,
 };
 
 export default withInstanceId( Table );

--- a/packages/js/components/src/table/test/index.js
+++ b/packages/js/components/src/table/test/index.js
@@ -172,7 +172,7 @@ describe( 'TableCard', () => {
 		);
 	} );
 
-	it( 'should render the default "No data to display" when there are no data and noDataLabel is unset', () => {
+	it( 'should render the default "No data to display" when there are no data and emptyMessage is unset', () => {
 		render(
 			<TableCard
 				title="My table"
@@ -188,8 +188,8 @@ describe( 'TableCard', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should render the custom label set in noDataLabel when there are no data.', () => {
-		const noDataLabel = 'My no data label';
+	it( 'should render the custom label set in emptyMessage when there are no data.', () => {
+		const emptyMessage = 'My no data label';
 
 		render(
 			<TableCard
@@ -198,10 +198,10 @@ describe( 'TableCard', () => {
 				isLoading={ false }
 				rows={ [] }
 				rowsPerPage={ 5 }
-				noDataLabel={ noDataLabel }
+				emptyMessage={ emptyMessage }
 			/>
 		);
 
-		expect( screen.queryByText( noDataLabel ) ).toBeInTheDocument();
+		expect( screen.queryByText( emptyMessage ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/js/components/src/table/test/index.js
+++ b/packages/js/components/src/table/test/index.js
@@ -171,4 +171,37 @@ describe( 'TableCard', () => {
 			'is-left-aligned'
 		);
 	} );
+
+	it( 'should render the default "No data to display" when there are no data and noDataLabel is unset', () => {
+		render(
+			<TableCard
+				title="My table"
+				headers={ mockHeaders }
+				isLoading={ false }
+				rows={ [] }
+				rowsPerPage={ 5 }
+			/>
+		);
+
+		expect(
+			screen.queryByText( 'No data to display' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the custom label set in noDataLabel when there are no data.', () => {
+		const noDataLabel = 'My no data label';
+
+		render(
+			<TableCard
+				title="My table"
+				headers={ mockHeaders }
+				isLoading={ false }
+				rows={ [] }
+				rowsPerPage={ 5 }
+				noDataLabel={ noDataLabel }
+			/>
+		);
+
+		expect( screen.queryByText( noDataLabel ) ).toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a new property into Table component. The property is noDataLabel and it's a type String  property allowing us to customise the default "No data to display" label when there are no data in the table. 

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- See the two new unit tests working fine.
- Compile the components and try to load the Table component:
- When  `noDataLabel` is unset. It shows the default "No data to display" when there is no rows.
- Set your own  `noDataLabel` using `__()` to see if it works.
- Check code quality

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
