### PR TITLE
Truncate attribute option name to a max of 32 chars in variations list

### DIFF
--- a/plugins/woocommerce-admin/client/products/constants.ts
+++ b/plugins/woocommerce-admin/client/products/constants.ts
@@ -5,3 +5,4 @@ export const ONLY_ONE_DECIMAL_SEPARATOR = '[%s](?=%s*[%s])';
 export const ADD_NEW_SHIPPING_CLASS_OPTION_VALUE =
 	'__ADD_NEW_SHIPPING_CLASS_OPTION__';
 export const UNCATEGORIZED_CATEGORY_SLUG = 'uncategorized';
+export const PRODUCT_VARIATION_TITLE_LIMIT = 32;

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -17,6 +17,7 @@ import truncate from 'lodash/truncate';
 /**
  * Internal dependencies
  */
+import { PRODUCT_VARIATION_TITLE_LIMIT } from '~/products/constants';
 import useVariationsOrder from '~/products/hooks/use-variations-order';
 import HiddenIcon from '~/products/images/hidden-icon';
 import VisibleIcon from '~/products/images/visible-icon';
@@ -40,8 +41,6 @@ const DEFAULT_PER_PAGE_OPTION = 25;
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 const VISIBLE_TEXT = __( 'Visible to customers', 'woocommerce' );
 const UPDATING_TEXT = __( 'Updating product variation', 'woocommerce' );
-
-const TRUNCATE_LENGTH = 32;
 
 export const Variations: React.FC = () => {
 	const [ currentPage, setCurrentPage ] = useState( 1 );
@@ -142,14 +141,14 @@ export const Variations: React.FC = () => {
 										className="woocommerce-product-variations__attribute"
 										key={ attribute.id }
 										label={ truncate( attribute.option, {
-											length: TRUNCATE_LENGTH,
+											length: PRODUCT_VARIATION_TITLE_LIMIT,
 										} ) }
 										screenReaderLabel={ attribute.option }
 									/>
 								);
 
 								return attribute.option.length <=
-									TRUNCATE_LENGTH ? (
+									PRODUCT_VARIATION_TITLE_LIMIT ? (
 									tag
 								) : (
 									<Tooltip

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -12,6 +12,7 @@ import { useContext, useState } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
+import truncate from 'lodash/truncate';
 
 /**
  * Internal dependencies
@@ -39,6 +40,8 @@ const DEFAULT_PER_PAGE_OPTION = 25;
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 const VISIBLE_TEXT = __( 'Visible to customers', 'woocommerce' );
 const UPDATING_TEXT = __( 'Updating product variation', 'woocommerce' );
+
+const TRUNCATE_LENGTH = 32;
 
 export const Variations: React.FC = () => {
 	const [ currentPage, setCurrentPage ] = useState( 1 );
@@ -130,16 +133,34 @@ export const Variations: React.FC = () => {
 				{ sortedVariations.map( ( variation ) => (
 					<ListItem key={ getVariationKey( variation ) }>
 						<div className="woocommerce-product-variations__attributes">
-							{ variation.attributes.map( ( attribute ) => (
-								/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-								/* @ts-ignore Additional props are not required. */
-								<Tag
-									id={ attribute.id }
-									className="woocommerce-product-variations__attribute"
-									key={ attribute.id }
-									label={ attribute.option }
-								/>
-							) ) }
+							{ variation.attributes.map( ( attribute ) => {
+								const tag = (
+									/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+									/* @ts-ignore Additional props are not required. */
+									<Tag
+										id={ attribute.id }
+										className="woocommerce-product-variations__attribute"
+										key={ attribute.id }
+										label={ truncate( attribute.option, {
+											length: TRUNCATE_LENGTH,
+										} ) }
+										screenReaderLabel={ attribute.option }
+									/>
+								);
+
+								return attribute.option.length <=
+									TRUNCATE_LENGTH ? (
+									tag
+								) : (
+									<Tooltip
+										key={ attribute.id }
+										text={ attribute.option }
+										position="top center"
+									>
+										<span>{ tag }</span>
+									</Tooltip>
+								);
+							} ) }
 						</div>
 						<div
 							className={ classnames(

--- a/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { ProductVariation } from '@woocommerce/data';
-
-export const PRODUCT_VARIATION_TITLE_LIMIT = 32;
+import { PRODUCT_VARIATION_TITLE_LIMIT } from '../constants';
 
 /**
  * Get the product variation title for use in the header.

--- a/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-variation-title.ts
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { ProductVariation } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
 import { PRODUCT_VARIATION_TITLE_LIMIT } from '../constants';
 
 /**

--- a/plugins/woocommerce/changelog/add-36116
+++ b/plugins/woocommerce/changelog/add-36116
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Truncate attribute option name to a max of 32 chars in variations list


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the max `length` of the text to be cut is 32 I decided not to add the `...` at the end of the truncated string because the new length is gonna be `32 + 3`. So instead I cut the string at `length - 3` and then add the `...` so that the final string `length` never be more than `32` chars.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36116

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some attributes using the legacy experience and grab its id.
2. The attributes options names should be more than 32 chars length. 
3. Got to `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}`.
4. Under `Options` tab and `Variations` section a list of variations shown be shown.
5. If an attribute option length is greather than 32 then the text should be cut and `...` should be at the end.
6. When hovering truncated texts a tooltip with the full attribute option text should be shown.

<video src="https://user-images.githubusercontent.com/13334210/208993606-a9cc50b9-eb6b-4700-96af-d2c9d4213ded.mov"></video>

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
