### PR TITLE
Make `Table` component accept `className` prop

### DIFF
--- a/packages/js/components/changelog/fix-36129-table-className
+++ b/packages/js/components/changelog/fix-36129-table-className
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Make Table component accept className prop.

--- a/packages/js/components/src/table/placeholder.js
+++ b/packages/js/components/src/table/placeholder.js
@@ -25,7 +25,7 @@ class TablePlaceholder extends Component {
 		return (
 			<Table
 				ariaHidden={ true }
-				classNames="is-loading"
+				className="is-loading"
 				rows={ rows }
 				{ ...tableProps }
 			/>

--- a/packages/js/components/src/table/table.js
+++ b/packages/js/components/src/table/table.js
@@ -140,6 +140,7 @@ class Table extends Component {
 		const {
 			ariaHidden,
 			caption,
+			className,
 			classNames,
 			headers,
 			instanceId,
@@ -148,10 +149,15 @@ class Table extends Component {
 			rows,
 		} = this.props;
 		const { isScrollableRight, isScrollableLeft, tabIndex } = this.state;
-		const classes = classnames( 'woocommerce-table__table', classNames, {
-			'is-scrollable-right': isScrollableRight,
-			'is-scrollable-left': isScrollableLeft,
-		} );
+		const classes = classnames(
+			'woocommerce-table__table',
+			classNames,
+			className,
+			{
+				'is-scrollable-right': isScrollableRight,
+				'is-scrollable-left': isScrollableLeft,
+			}
+		);
 		const sortedBy =
 			query.orderby ||
 			get( find( headers, { defaultSort: true } ), 'key', false );

--- a/packages/js/components/src/table/table.js
+++ b/packages/js/components/src/table/table.js
@@ -14,6 +14,7 @@ import { find, get, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
+import deprecated from '@wordpress/deprecated';
 
 const ASC = 'asc';
 const DESC = 'desc';
@@ -149,6 +150,16 @@ class Table extends Component {
 			rows,
 		} = this.props;
 		const { isScrollableRight, isScrollableLeft, tabIndex } = this.state;
+
+		if ( classNames ) {
+			deprecated( `Table component's classNames prop`, {
+				since: '11.1.0',
+				version: '12.0.0',
+				alternative: 'className',
+				plugin: '@woocommerce/components',
+			} );
+		}
+
 		const classes = classnames(
 			'woocommerce-table__table',
 			classNames,

--- a/packages/js/components/src/table/test/index.js
+++ b/packages/js/components/src/table/test/index.js
@@ -10,6 +10,7 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 import TableCard from '../index';
+import Table from '../table';
 import mockHeaders from './data/table-mock-headers';
 import mockData from './data/table-mock-data';
 import mockSummary from './data/table-mock-summary';
@@ -170,5 +171,37 @@ describe( 'TableCard', () => {
 		expect( screen.getAllByRole( 'columnheader' )[ 3 ] ).toHaveClass(
 			'is-left-aligned'
 		);
+	} );
+} );
+
+describe( 'Table', () => {
+	it( 'should accept className prop and renders it in the HTML output', () => {
+		render(
+			<Table
+				className="class-111"
+				caption="Table with className"
+				headers={ mockHeaders }
+				rows={ mockData }
+			/>
+		);
+
+		const el = screen.getByLabelText( 'Table with className' );
+
+		expect( el ).toHaveClass( 'class-111' );
+	} );
+
+	it( 'should still work with classNames prop and renders it in the HTML output, for backward compatibility reason', () => {
+		render(
+			<Table
+				classNames="class-222"
+				caption="Table with classNames"
+				headers={ mockHeaders }
+				rows={ mockData }
+			/>
+		);
+
+		const el = screen.getByLabelText( 'Table with classNames' );
+
+		expect( el ).toHaveClass( 'class-222' );
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/36129.

This PR makes the `Table` component accept `className` props. 

The component will continue to work with the existing `classNames` prop for backward compatibility reason.

I added tests to cover both `className` and `classNames` props usage.

`classNames` prop is used in the `TablePlaceholder` component. I have changed it to `className`.

### How to test the changes in this Pull Request:

Component testing:

1. Run `pnpm --filter=@woocommerce/components run test`. All tests should pass.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
