### PR TITLE
Add product variation header actions and persistence

### DIFF
--- a/packages/js/data/changelog/add-36059
+++ b/packages/js/data/changelog/add-36059
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix up updateItem query in CRUD data store

--- a/packages/js/data/src/crud/actions.ts
+++ b/packages/js/data/src/crud/actions.ts
@@ -192,10 +192,11 @@ export const createDispatchActions = ( {
 			const item: Item = yield apiFetch( {
 				path: getRestPath(
 					`${ namespace }/${ id }`,
-					cleanQuery( query, namespace ),
+					{},
 					urlParameters
 				),
 				method: 'PUT',
+				data: query,
 			} );
 
 			yield updateItemSuccess( key, item );

--- a/plugins/woocommerce-admin/client/products/layout/product-variation-form-header.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-variation-form-header.tsx
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { ProductVariationFormActions } from '../product-variation-form-actions';
+import { ProductTitle } from '../product-title';
+
+export const ProductVariationFormHeader: React.FC = () => {
+	return (
+		<>
+			<ProductTitle />
+			<ProductVariationFormActions />
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/product-form-actions.scss
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.scss
@@ -58,4 +58,8 @@ $gutenberg-blue-darker: var(--wp-admin-theme-color-darker-20);
 	.woocommerce-layout {
 		margin-bottom: calc(70px + $gap); // Product actions height + gap.
 	}
+
+	.is-variation .woocommerce-product-form-actions__preview {
+		display: none;
+	}
 }

--- a/plugins/woocommerce-admin/client/products/product-form-actions.scss
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.scss
@@ -6,7 +6,7 @@ $gutenberg-blue-darker: var(--wp-admin-theme-color-darker-20);
 	flex-direction: row;
 	align-items: center;
 	justify-content: flex-end;
-	padding-right: $gap-smaller;
+	padding-right: $gap-large;
 
 	@include breakpoint( '<782px' ) {
 		position: fixed;

--- a/plugins/woocommerce-admin/client/products/product-settings/product-settings.scss
+++ b/plugins/woocommerce-admin/client/products/product-settings/product-settings.scss
@@ -28,6 +28,10 @@
 	}
 }
 
+.woocommerce-product-settings__toggle {
+	margin-left: -$gap;
+}
+
 @include breakpoint( '<782px' ) {
 	.woocommerce-product-settings__toggle,
 	.woocommerce-product-settings__panel {

--- a/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
@@ -61,13 +61,14 @@ export const ProductVariationFormActions: React.FC = () => {
 	return (
 		<WooHeaderItem>
 			{ () => (
-				<div className="woocommerce-product-form-actions">
+				<div className="woocommerce-product-form-actions is-variation">
 					<Button
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 						//@ts-ignore The `href` prop works for both Buttons and MenuItem's.
 						href={ values.permalink + '?preview=true' }
 						disabled={ ! isValidForm || ! values.permalink }
 						target="_blank"
+                        className='woocommerce-product-form-actions__preview'
 					>
 						{ __( 'Preview', 'woocommerce' ) }
 					</Button>

--- a/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
@@ -68,7 +68,7 @@ export const ProductVariationFormActions: React.FC = () => {
 						href={ values.permalink + '?preview=true' }
 						disabled={ ! isValidForm || ! values.permalink }
 						target="_blank"
-                        className='woocommerce-product-form-actions__preview'
+						className="woocommerce-product-form-actions__preview"
 					>
 						{ __( 'Preview', 'woocommerce' ) }
 					</Button>

--- a/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, ButtonGroup } from '@wordpress/components';
+import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	ProductVariation,
+} from '@woocommerce/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { useDispatch } from '@wordpress/data';
+import { useFormContext } from '@woocommerce/components';
+import { useParams } from 'react-router-dom';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import usePreventLeavingPage from '~/hooks/usePreventLeavingPage';
+import { WooHeaderItem } from '~/header/utils';
+import './product-form-actions.scss';
+
+export const ProductVariationFormActions: React.FC = () => {
+	const { productId, variationId } = useParams();
+	const { isDirty, isValidForm, values } =
+		useFormContext< ProductVariation >();
+	const { updateProductVariation } = useDispatch(
+		EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+	);
+	const { createNotice } = useDispatch( 'core/notices' );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	usePreventLeavingPage( isDirty );
+
+	const onSave = async () => {
+		setIsSaving( true );
+		updateProductVariation< Promise< ProductVariation > >(
+			{ id: variationId, product_id: productId },
+			values
+		)
+			.then( () => {
+				createNotice(
+					'success',
+					`🎉‎ ${ __(
+						'Product variation successfully updated.',
+						'woocommerce'
+					) }`
+				);
+			} )
+			.catch( () => {
+				createNotice(
+					'error',
+					__( 'Failed to updated product variation.', 'woocommerce' )
+				);
+			} )
+			.finally( () => {
+				setIsSaving( false );
+			} );
+	};
+
+	return (
+		<WooHeaderItem>
+			{ () => (
+				<div className="woocommerce-product-form-actions">
+					<Button
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						//@ts-ignore The `href` prop works for both Buttons and MenuItem's.
+						href={ values.permalink + '?preview=true' }
+						disabled={ ! isValidForm || ! values.permalink }
+						target="_blank"
+					>
+						{ __( 'Preview', 'woocommerce' ) }
+					</Button>
+					<ButtonGroup className="woocommerce-product-form-actions__publish-button-group">
+						<Button
+							onClick={ onSave }
+							variant="primary"
+							isBusy={ isSaving }
+							disabled={ ! isValidForm || ! isDirty }
+						>
+							{ __( 'Save', 'woocommerce' ) }
+						</Button>
+					</ButtonGroup>
+				</div>
+			) }
+		</WooHeaderItem>
+	);
+};
+
+registerPlugin( 'product-variation-action-buttons-header-item', {
+	render: ProductVariationFormActions,
+	icon: 'admin-generic',
+} );

--- a/plugins/woocommerce-admin/client/products/product-variation-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.tsx
@@ -9,7 +9,6 @@ import { PartialProduct, ProductVariation } from '@woocommerce/data';
  * Internal dependencies
  */
 import PostsNavigation from './shared/posts-navigation';
-import { ProductFormHeader } from './layout/product-form-header';
 import { ProductFormLayout } from './layout/product-form-layout';
 import { ProductFormFooter } from './layout/product-form-footer';
 import { ProductFormTab } from './product-form-tab';
@@ -17,6 +16,7 @@ import { PricingSection } from './sections/pricing-section';
 import { ProductInventorySection } from './sections/product-inventory-section';
 import { ProductShippingSection } from './sections/product-shipping-section';
 import { ProductVariationDetailsSection } from './sections/product-variation-details-section';
+import { ProductVariationFormHeader } from './layout/product-variation-form-header';
 import useProductVariationNavigation from './hooks/use-product-variation-navigation';
 import './product-variation-form.scss';
 
@@ -34,7 +34,7 @@ export const ProductVariationForm: React.FC< {
 			initialValues={ productVariation }
 			errors={ {} }
 		>
-			<ProductFormHeader />
+			<ProductVariationFormHeader />
 			<ProductFormLayout>
 				<ProductFormTab name="general" title="General">
 					<ProductVariationDetailsSection />

--- a/plugins/woocommerce/changelog/add-36059
+++ b/plugins/woocommerce/changelog/add-36059
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product variation header actions and persistence


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Create header actions for product variations and persist any data around the variation.

There are some conflicts with saving parent attributes, but these will be followed up on in https://github.com/woocommerce/woocommerce/issues/35989.

<img width="275" alt="Screen Shot 2022-12-22 at 11 27 40 AM" src="https://user-images.githubusercontent.com/10561050/209213473-0d2e9843-9e0a-4393-8c69-e563479e6b75.png">


Closes #36059  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a product with some variations
2. Navigate to the new product variation screen `wp-admin/admin.php?page=wc-admin&path=/product/{product_id}/variation/{variation_id}` replacing `{product_id}` and `{variation_id}` with your respective IDs.
3. Change the SKU so it does not conflict with the parent product
4. Toggle the stock management toggle (so that it's value does not equal `parent`).
5. Change some data in the form
6. Click "Save"
7. Make sure data is persisted
8. Make sure no styling regressions have occurred on the parent product page

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
