### PR TITLE
Remove redundant Pinterest listing from marketing task

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-redundant-pinterest-from-marketing-task
+++ b/plugins/woocommerce/changelog/fix-remove-redundant-pinterest-from-marketing-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove redundant Pinterest plugin from marketing task

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -61,7 +61,6 @@ class DefaultFreeExtensions {
 					self::get_plugin( 'tiktok-for-business' ),
 					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
 					self::get_plugin( 'facebook-for-woocommerce:alt' ),
-					self::get_plugin( 'pinterest-for-woocommerce' ),
 					self::get_plugin( 'codistoconnect:alt' ),
 				],
 			],


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix to https://github.com/woocommerce/woocommerce/pull/36003

Remove a redundant Pinterest plugin shown in the marketing task.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/3747241/209261554-e10a7335-b4ac-401f-9738-94c0a227cd75.png">


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

With a new site,

1. Disable `Display suggestions within WooCommerce` in WooCommerce > Settings > Advanced > WooCommerce.com
1. Go to WooCommerce > Home > Get more sales
2. Observe Pinterest plugin is only shown once

<img width="693" alt="image" src="https://user-images.githubusercontent.com/3747241/209261850-5da138e2-4b5c-4b65-8429-49d7f07b9da8.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
