### PR TITLE
Update country select control regex

### DIFF
--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -358,7 +358,10 @@ export function StoreAddress( {
 				required
 				autoComplete="new-password" // disable autocomplete and autofill
 				getSearchExpression={ ( query: string ) => {
-					return new RegExp( '(^' + query + '| \— (' + query + '))', 'i' );
+					return new RegExp(
+						'(^' + query + '| — (' + query + '))',
+						'i'
+					);
 				} }
 				options={ countryStateOptions }
 				excludeSelectedOptions={ false }

--- a/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
+++ b/plugins/woocommerce-admin/client/dashboard/components/settings/general/store-address.tsx
@@ -358,7 +358,7 @@ export function StoreAddress( {
 				required
 				autoComplete="new-password" // disable autocomplete and autofill
 				getSearchExpression={ ( query: string ) => {
-					return new RegExp( '^' + query, 'i' );
+					return new RegExp( '(^' + query + '| \— (' + query + '))', 'i' );
 				} }
 				options={ countryStateOptions }
 				excludeSelectedOptions={ false }

--- a/plugins/woocommerce/changelog/update-fix-country-select-control-match
+++ b/plugins/woocommerce/changelog/update-fix-country-select-control-match
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Match country name or ' - region' when filtering country select control #36120


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


Closes #36120  

This PR updates regex used in the country select control to match a country name or ` - state`. The previous change only matched a country name

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Start OBW
2. Type a country name and confirm it matches a country
3. Type a state name and confirm it matches a state

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
