### PR TITLE
Fix "Save changes?" modal saves the options after selecting the 'Discard' option

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -45,8 +45,9 @@ const Loader = ( props ) => {
 class Industry extends Component {
 	constructor( props ) {
 		const profileItems = get( props, 'profileItems', {} );
-		let selected = profileItems.industry || [];
-
+		let selected = Array.isArray( profileItems.industry )
+			? [ ...profileItems.industry ]
+			: [];
 		/**
 		 * @todo Remove block on `updateProfileItems` refactor to wp.data dataStores.
 		 *

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/index.js
@@ -77,7 +77,9 @@ export class ProductTypes extends Component {
 			);
 			this.setState(
 				{
-					selected: profileItems.product_types || defaultProductTypes,
+					selected: Array.isArray( profileItems.product_types )
+						? [ ...profileItems.product_types ]
+						: defaultProductTypes,
 				},
 				() => {
 					this.props.trackStepValueChanges(

--- a/plugins/woocommerce-admin/client/profile-wizard/style.scss
+++ b/plugins/woocommerce-admin/client/profile-wizard/style.scss
@@ -417,10 +417,10 @@
 		align-items: center;
 		height: 60px;
 		z-index: 10;
-		position: relative;
 		position: sticky;
 		top: 0;
-		margin: 0 -32px 24px;
+		margin: 0 -32px;
+		display: flex;
 	}
 
 	.woocommerce-usage-modal__actions {

--- a/plugins/woocommerce/changelog/fix-obw-save-changes
+++ b/plugins/woocommerce/changelog/fix-obw-save-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Save changes?" modal saves the options after selecting the 'Discard' option

--- a/plugins/woocommerce/tests/e2e-pw/test-data/data.js
+++ b/plugins/woocommerce/tests/e2e-pw/test-data/data.js
@@ -62,6 +62,12 @@ const storeDetails = {
 			fashion: 'Fashion, apparel, and accessories',
 			health: 'Health and beauty',
 		},
+		// For testing "Save Changes" feature, need to be different from the above
+		industries2: {
+			fashion: 'Fashion, apparel, and accessories',
+			health: 'Health and beauty',
+			foodAndDrinks: 'Food and drink',
+		},
 		products: {
 			physical: 'Physical products',
 			downloadable: 'Downloads',

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -30,6 +30,52 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 	} );
 
 	// eslint-disable-next-line jest/expect-expect
+	test( 'can save industry changes when navigating back to "Store Details"', async ( {
+		page,
+	} ) => {
+		await onboarding.completeIndustrySection(
+			page,
+			storeDetails.us.industries2,
+			storeDetails.us.expectedIndustries
+		);
+
+		// Navigate back to "Store Details" section
+		await page.click( 'button >> text=Store Details' );
+
+		await onboarding.handleSaveChangesModal( page, { saveChanges: true } );
+
+		// Navigate back to "Industry" section
+		await page.click( 'button >> text=Industry' );
+		await page.textContent( '.components-checkbox-control__input' );
+		for ( let industry of Object.values( storeDetails.us.industries2 ) ) {
+			await expect( page.getByLabel( industry ) ).toBeChecked();
+		}
+	} );
+
+	// eslint-disable-next-line jest/expect-expect
+	test( 'can discard industry changes when navigating back to "Store Details"', async ( {
+		page,
+	} ) => {
+		await onboarding.completeIndustrySection(
+			page,
+			storeDetails.us.industries,
+			storeDetails.us.expectedIndustries
+		);
+
+		// Navigate back to "Store Details" section
+		await page.click( 'button >> text=Store Details' );
+
+		await onboarding.handleSaveChangesModal( page, { saveChanges: false } );
+
+		// Navigate back to "Industry" section
+		await page.click( 'button >> text=Industry' );
+		await page.textContent( '.components-checkbox-control__input' );
+		for ( let industry of Object.values( storeDetails.us.industries2 ) ) {
+			await expect( page.getByLabel( industry ) ).toBeChecked();
+		}
+	} );
+
+	// eslint-disable-next-line jest/expect-expect
 	test( 'can complete the product types section', async ( { page } ) => {
 		await onboarding.completeProductTypesSection(
 			page,

--- a/plugins/woocommerce/tests/e2e-pw/utils/onboarding.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/onboarding.js
@@ -56,9 +56,21 @@ const onboarding = {
 			await page.uncheck( currentCheck );
 		}
 
-		Object.keys( industries ).forEach( async ( industry ) => {
-			await page.click( `label >> text=${ industries[ industry ] }` );
-		} );
+		for ( let industry of Object.values( industries ) ) {
+			await page.click( `label >> text=${ industry }` );
+		}
+	},
+
+	handleSaveChangesModal: async ( page, { saveChanges } ) => {
+		// Save changes? Modal
+		await page.textContent( '.components-modal__header-heading' );
+
+		if ( saveChanges ) {
+			await page.click( 'button >> text=Save' );
+		} else {
+			await page.click( 'button >> text=Discard' );
+		}
+		await page.waitForLoadState( 'networkidle' );
 	},
 
 	completeProductTypesSection: async ( page, products ) => {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes  #35934

 "Save changes?" modal saves the options after selecting the 'Discard' option because we mutate the value of the profiler items prop.

Changes in this PR:
- Fixes the bug
- Adds e2e tests.
- Tweaks the save changes modal UI

Before:

![Screen Shot 2022-12-23 at 18 00 57](https://user-images.githubusercontent.com/4344253/209315464-6ee6006e-a9fd-468a-9263-42745c1df58c.png)

After:

![Screen Shot 2022-12-23 at 17 59 49](https://user-images.githubusercontent.com/4344253/209315451-83e8e0a6-821c-4dbc-82ed-bf0f72bf0208.png)


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Start with OBW.
2. Go to Industry Page.
3. Select some options
4. Click on the next page for 'Product Types'
5. When prompted by 'Save changes?' modal, click 'Discard'
6. Navigate back to Industry page observe the selected options are NOT saved.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
