### PR TITLE
Add product form api functions

### DIFF
--- a/plugins/woocommerce/changelog/add-36021_php_add_product_form_api_functions
+++ b/plugins/woocommerce/changelog/add-36021_php_add_product_form_api_functions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new product form API for extending the new Product Form MVP.

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -88,6 +88,12 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
 		);
 
+		if ( Features::is_enabled( 'new-product-management-experience' ) ) {
+			$product_form_controllers = array(
+				'Automattic\WooCommerce\Admin\API\ProductForm'
+			);
+		}
+
 		if ( Features::is_enabled( 'analytics' ) ) {
 			$analytics_controllers = array(
 				'Automattic\WooCommerce\Admin\API\Customers',
@@ -118,7 +124,7 @@ class Init {
 			// The performance indicators controller must be registered last, after other /stats endpoints have been registered.
 			$analytics_controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
 
-			$controllers = array_merge( $controllers, $analytics_controllers );
+			$controllers = array_merge( $controllers, $analytics_controllers, $product_form_controllers );
 		}
 
 		$controllers = apply_filters( 'woocommerce_admin_rest_controllers', $controllers );

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -90,7 +90,7 @@ class Init {
 
 		if ( Features::is_enabled( 'new-product-management-experience' ) ) {
 			$product_form_controllers = array(
-				'Automattic\WooCommerce\Admin\API\ProductForm'
+				'Automattic\WooCommerce\Admin\API\ProductForm',
 			);
 		}
 
@@ -127,6 +127,12 @@ class Init {
 			$controllers = array_merge( $controllers, $analytics_controllers, $product_form_controllers );
 		}
 
+		/**
+		 * Filter for the WooCommerce Admin REST controllers.
+		 *
+		 * @since 3.5.0
+		 * @param array $controllers List of rest API controllers.
+		 */
 		$controllers = apply_filters( 'woocommerce_admin_rest_controllers', $controllers );
 
 		foreach ( $controllers as $controller ) {

--- a/plugins/woocommerce/src/Admin/API/Init.php
+++ b/plugins/woocommerce/src/Admin/API/Init.php
@@ -88,10 +88,9 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\MobileAppMagicLink',
 		);
 
+		$product_form_controllers = array();
 		if ( Features::is_enabled( 'new-product-management-experience' ) ) {
-			$product_form_controllers = array(
-				'Automattic\WooCommerce\Admin\API\ProductForm',
-			);
+			$product_form_controllers[] = 'Automattic\WooCommerce\Admin\API\ProductForm';
 		}
 
 		if ( Features::is_enabled( 'analytics' ) ) {

--- a/plugins/woocommerce/src/Admin/API/ProductForm.php
+++ b/plugins/woocommerce/src/Admin/API/ProductForm.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * REST API Product Form Controller
+ *
+ * Handles requests to retrieve product form data.
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+use Automattic\WooCommerce\Internal\Admin\ProductForm\Form;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ProductForm Controller.
+ *
+ * @internal
+ * @extends WC_REST_Data_Controller
+ */
+class ProductForm extends \WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-admin';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'product-form';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/fields',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_fields' ),
+					'permission_callback' => array( $this, 'get_product_form_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to manage woocommerce.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_product_form_permission_check( $request ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to retrieve product form data.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the form fields.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_fields( $request ) {
+		$json = Form::get_fields();
+		error_log( print_r( $json, true ) );
+
+		return rest_ensure_response( $json );
+	}
+}

--- a/plugins/woocommerce/src/Admin/API/ProductForm.php
+++ b/plugins/woocommerce/src/Admin/API/ProductForm.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\WooCommerce\Admin\API;
 
-use Automattic\WooCommerce\Internal\Admin\ProductForm\Form;
+use Automattic\WooCommerce\Internal\Admin\ProductForm\FormFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -87,7 +87,7 @@ class ProductForm extends \WC_REST_Data_Controller {
 			function( $field ) {
 				return $field->get_json();
 			},
-			Form::get_fields()
+			FormFactory::get_fields()
 		);
 
 		return rest_ensure_response( $json );
@@ -100,30 +100,30 @@ class ProductForm extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_form_config( $request ) {
-		$fields   = array_map(
+		$fields      = array_map(
 			function( $field ) {
 				return $field->get_json();
 			},
-			Form::get_fields()
+			FormFactory::get_fields()
 		);
-		$cards    = array_map(
+		$subsections = array_map(
 			function( $card ) {
 				return $card->get_json();
 			},
-			Form::get_cards()
+			FormFactory::get_subsections()
 		);
-		$sections = array_map(
+		$sections    = array_map(
 			function( $section ) {
 				return $section->get_json();
 			},
-			Form::get_sections()
+			FormFactory::get_sections()
 		);
 
 		return rest_ensure_response(
 			array(
-				'fields'   => $fields,
-				'cards'    => $cards,
-				'sections' => $sections,
+				'fields'      => $fields,
+				'subsections' => $subsections,
+				'sections'    => $sections,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Admin/API/ProductForm.php
+++ b/plugins/woocommerce/src/Admin/API/ProductForm.php
@@ -94,7 +94,7 @@ class ProductForm extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Get the form fields.
+	 * Get the form config.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error
@@ -107,8 +107,8 @@ class ProductForm extends \WC_REST_Data_Controller {
 			FormFactory::get_fields()
 		);
 		$subsections = array_map(
-			function( $card ) {
-				return $card->get_json();
+			function( $subsection ) {
+				return $subsection->get_json();
 			},
 			FormFactory::get_subsections()
 		);

--- a/plugins/woocommerce/src/Admin/API/ProductForm.php
+++ b/plugins/woocommerce/src/Admin/API/ProductForm.php
@@ -100,13 +100,13 @@ class ProductForm extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_form_config( $request ) {
-		$fields = array_map(
+		$fields   = array_map(
 			function( $field ) {
 				return $field->get_json();
 			},
 			Form::get_fields()
 		);
-		$cards = array_map(
+		$cards    = array_map(
 			function( $card ) {
 				return $card->get_json();
 			},
@@ -119,10 +119,12 @@ class ProductForm extends \WC_REST_Data_Controller {
 			Form::get_sections()
 		);
 
-		return rest_ensure_response( array(
-			'fields'   => $fields,
-			'cards'    => $cards,
-			'sections' => $sections
-		) );
+		return rest_ensure_response(
+			array(
+				'fields'   => $fields,
+				'cards'    => $cards,
+				'sections' => $sections,
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/ProductForm.php
+++ b/plugins/woocommerce/src/Admin/API/ProductForm.php
@@ -38,6 +38,18 @@ class ProductForm extends \WC_REST_Data_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_form_config' ),
+					'permission_callback' => array( $this, 'get_product_form_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/fields',
 			array(
 				array(
@@ -71,9 +83,46 @@ class ProductForm extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_fields( $request ) {
-		$json = Form::get_fields();
-		error_log( print_r( $json, true ) );
+		$json = array_map(
+			function( $field ) {
+				return $field->get_json();
+			},
+			Form::get_fields()
+		);
 
 		return rest_ensure_response( $json );
+	}
+
+	/**
+	 * Get the form fields.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_form_config( $request ) {
+		$fields = array_map(
+			function( $field ) {
+				return $field->get_json();
+			},
+			Form::get_fields()
+		);
+		$cards = array_map(
+			function( $card ) {
+				return $card->get_json();
+			},
+			Form::get_cards()
+		);
+		$sections = array_map(
+			function( $section ) {
+				return $section->get_json();
+			},
+			Form::get_sections()
+		);
+
+		return rest_ensure_response( array(
+			'fields'   => $fields,
+			'cards'    => $cards,
+			'sections' => $sections
+		) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/ProductForm/Component.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductForm/Component.php
@@ -6,7 +6,7 @@
 namespace Automattic\WooCommerce\Internal\Admin\ProductForm;
 
 /**
- * Card class.
+ * Component class.
  */
 abstract class Component {
 	/**
@@ -15,7 +15,7 @@ abstract class Component {
 	use ComponentTrait;
 
 	/**
-	 * Card additional arguments.
+	 * Component additional arguments.
 	 *
 	 * @var array
 	 */
@@ -24,7 +24,7 @@ abstract class Component {
 	/**
 	 * Constructor
 	 *
-	 * @param string $id Card id.
+	 * @param string $id Component id.
 	 * @param string $plugin_id Plugin id.
 	 * @param array  $additional_args Array containing additional arguments.
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/ProductForm/FormFactory.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductForm/FormFactory.php
@@ -169,6 +169,24 @@ class FormFactory {
 	/**
 	 * Returns list of registered items.
 	 *
+	 * @param string $type Form component type.
+	 * @return array List of registered items.
+	 */
+	private static function get_item_list( $type ) {
+		$mapping = array(
+			'field' => self::$form_fields,
+			'subsection' => self::$form_subsections,
+			'section' => self::$form_sections,
+		);
+		if ( array_key_exists( $type, $mapping ) ) {
+			return $mapping[ $type ];
+		}
+		return array();
+	}
+
+	/**
+	 * Returns list of registered items.
+	 *
 	 * @param string       $type Form component type.
 	 * @param class-string $class_name Class of component type.
 	 * @param array        $sort_by key and order to sort by.
@@ -178,7 +196,7 @@ class FormFactory {
 		'key'   => 'order',
 		'order' => 'asc',
 	) ) {
-		$item_list = self::${ 'form_' . $type . 's' };
+		$item_list = self::get_item_list( $type );
 		$class     = 'Automattic\\WooCommerce\\Internal\\Admin\\ProductForm\\' . $class_name;
 		$items     = array_values( $item_list );
 		if ( class_exists( $class ) && method_exists( $class, 'sort' ) ) {
@@ -203,7 +221,7 @@ class FormFactory {
 	 * @return Field|Card|Section|WP_Error New product form item or WP_Error.
 	 */
 	private static function create_item( $type, $class_name, $id, $plugin_id, $args ) {
-		$item_list = self::${ 'form_' . $type . 's' };
+		$item_list = self::get_item_list( $type );
 		$class     = 'Automattic\\WooCommerce\\Internal\\Admin\\ProductForm\\' . $class_name;
 		if ( ! class_exists( $class ) ) {
 			return new WP_Error(

--- a/plugins/woocommerce/src/Internal/Admin/ProductForm/FormFactory.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductForm/FormFactory.php
@@ -174,9 +174,9 @@ class FormFactory {
 	 */
 	private static function get_item_list( $type ) {
 		$mapping = array(
-			'field' => self::$form_fields,
+			'field'      => self::$form_fields,
 			'subsection' => self::$form_subsections,
-			'section' => self::$form_sections,
+			'section'    => self::$form_sections,
 		);
 		if ( array_key_exists( $type, $mapping ) ) {
 			return $mapping[ $type ];

--- a/plugins/woocommerce/src/Internal/Admin/ProductForm/README.md
+++ b/plugins/woocommerce/src/Internal/Admin/ProductForm/README.md
@@ -8,7 +8,7 @@ This will primarily be done through the `Form` class, under the `Automattic\WooC
 ```php
 function add_product_form_field() {
     if (
-        ! method_exists( '\Automattic\WooCommerce\Internal\Admin\ProductForm\Form', 'add_field' )
+        ! method_exists( '\Automattic\WooCommerce\Internal\Admin\ProductForm\FormFactory', 'add_field' )
     ) {
         return;
     }

--- a/plugins/woocommerce/src/Internal/Admin/ProductForm/Section.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductForm/Section.php
@@ -71,7 +71,7 @@ class Section extends Component {
 	public function get_json() {
 		return array(
 			'id'        => $this->get_id(),
-			'plugin_id'	=> $this->get_plugin_id(),
+			'plugin_id' => $this->get_plugin_id(),
 			'arguments' => $this->get_arguments(),
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/ProductForm/Section.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductForm/Section.php
@@ -55,6 +55,28 @@ class Section extends Component {
 	}
 
 	/**
+	 * Field arguments.
+	 *
+	 * @return array
+	 */
+	public function get_arguments() {
+		return $this->additional_args;
+	}
+
+	/**
+	 * Get the section as JSON.
+	 *
+	 * @return array
+	 */
+	public function get_json() {
+		return array(
+			'id'        => $this->get_id(),
+			'plugin_id'	=> $this->get_plugin_id(),
+			'arguments' => $this->get_arguments(),
+		);
+	}
+
+	/**
 	 * Get missing arguments of args array.
 	 *
 	 * @param array $args section arguments.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds two REST api endpoints for retrieving the product form fields and all the form data (fields, cards, sections).

Closes #36021

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

**Note: you may have to run `composer dump-autoload` for the new classes to show.
1. In your `mu-plugin` add this action:
```php
/**
 * Add Example items to WooCommerce Navigation
 */
function add_product_form_field() {
    if (
        ! method_exists( '\Automattic\WooCommerce\Internal\Admin\ProductForm\FormFactory', 'add_field' )
    ) {
        return;
    }

    \Automattic\WooCommerce\Internal\Admin\ProductForm\FormFactory::add_field(
        'test_new_field',
        'woocommerce',
        array(
            'type'       => 'text',
            'section'    => 'product-details',
            'properties' => array(
                'name'       => 'name',
                'label'      => 'label',
            )
        )
    );
}
add_action( 'init', 'add_product_form_field' );
```
2. Enable the `new-product-management-experience` feature flag.
3. Go to **WooCommerce > Home** and open your console.
4. You can test the API endpoints by running: `wp.apiFetch({ path: '/wc-admin/product-form/fields' } ).then( (fields) => console.log(fields) );` to retrieve the fields, check if your registered field is included in this list.
5. And `wp.apiFetch({ path: '/wc-admin/product-form' } ).then( (fields) => console.log(fields) );` to retrieve the config, check if the field is added to the field array.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
