### PR TITLE
Update requires at least 5.9 in readme to same as woocommerce.php

### DIFF
--- a/plugins/woocommerce/changelog/update-requires-at-least-5.9
+++ b/plugins/woocommerce/changelog/update-requires-at-least-5.9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: update requires at least to same 5.9
+
+

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 5.8
+Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.2
 Stable tag: 7.1.1


### PR DESCRIPTION
`woocommerce.php` has requires at least of 5.9. this PR updates to the same version in `readme.txt`

To test:

See the version in `woocommerce.php` and make sure they are the same.