### PR TITLE
k6: update order requests for HPOS add tidy scenarios

### DIFF
--- a/plugins/woocommerce/changelog/update-k6-order-requests
+++ b/plugins/woocommerce/changelog/update-k6-order-requests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: perf test not included in release package
+
+

--- a/plugins/woocommerce/tests/performance/requests/merchant/add-order.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/add-order.js
@@ -57,10 +57,10 @@ let admin_update_order_assert;
 if ( cot_status === true ) {
 	admin_new_order_base = 'admin.php?page=wc-orders&action=new';
 	admin_update_order_base = 'admin.php?page=wc-orders&action=edit';
-	admin_new_order_assert = 'Edit order		</h1>';
-	admin_open_order_assert = 'Edit order		</h1>';
+	admin_new_order_assert = 'post_status" type="hidden" value="auto-draft';
+	admin_open_order_assert = 'post_status" type="hidden" value="pending';
 	admin_created_order_assert = 'changed from auto-draft to';
-	admin_update_order_assert = 'changed from auto-draft to';
+	admin_update_order_assert = 'changed from Pending payment to Completed';
 } else {
 	admin_new_order_base = 'post-new.php?post_type=shop_order';
 	admin_update_order_base = 'post.php';
@@ -145,7 +145,11 @@ export function addOrder() {
 			.find( 'input[id=post_ID]' )
 			.first()
 			.attr( 'value' );
-		hpos_post_id = findBetween( response.body, 'post_id":"', '",' );
+		hpos_post_id = findBetween(
+			response.body,
+			';id=',
+			'" method="post" id="order"'
+		);
 		heartbeat_nonce = findBetween(
 			response.body,
 			'heartbeatSettings = {"nonce":"',
@@ -299,18 +303,18 @@ export function addOrder() {
 			[ 'order_date_second', '01' ],
 			[ 'order_note', '' ],
 			[ 'order_note_type', '' ],
-			[ 'order_status', 'wc-pending' ], //change
-			[ 'original_post_status', 'auto-draft' ], //wc-pending
-			[ 'original_post_title', '' ], //string
+			[ 'order_status', 'wc-pending' ],
+			[ 'original_post_status', 'auto-draft' ],
+			[ 'original_post_title', '' ],
 			[ 'originalaction', 'editpost' ],
 			[ 'post_ID', `${ post_id }` ],
 			[ 'post_author', '1' ],
-			[ 'post_status', 'auto-draft' ], //pending
-			[ 'post_title', '%2COrder' ], //string
+			[ 'post_status', 'auto-draft' ],
+			[ 'post_title', '%2COrder' ],
 			[ 'post_type', 'shop_order' ],
 			[ 'referredby', '' ],
 			[ 'samplepermalinknonce', `${ sample_permalink_nonce }` ],
-			[ 'save', 'Create' ], //Update
+			[ 'save', 'Create' ],
 			[ 'user_ID', '1' ],
 			[ 'wc_order_action', '' ],
 			[ 'woocommerce_meta_nonce', `${ woocommerce_meta_nonce }` ],
@@ -361,11 +365,11 @@ export function addOrder() {
 			[ 'order_note', '' ],
 			[ 'order_note_type', '' ],
 			[ 'order_status', 'wc-pending' ],
-			[ 'original_order_status', 'auto-draft' ], //pending
-			[ 'post_status', 'auto-draft' ], //pending
+			[ 'original_order_status', 'auto-draft' ],
+			[ 'post_status', 'auto-draft' ],
 			[ 'post_title', 'Order' ],
 			[ 'referredby', '' ],
-			[ 'save', 'Create' ], //Save
+			[ 'save', 'Create' ],
 			[ 'wc_order_action', '' ],
 			[ 'woocommerce_meta_nonce', `${ woocommerce_meta_nonce }` ],
 		] );
@@ -487,12 +491,12 @@ export function addOrder() {
 			[ 'order_note_type', '' ],
 			[ 'order_status', 'wc-completed' ],
 			[ 'original_post_status', 'wc-pending' ],
-			[ 'original_post_title', '' ], //string
+			[ 'original_post_title', '' ],
 			[ 'originalaction', 'editpost' ],
 			[ 'post_ID', `${ post_id }` ],
 			[ 'post_author', '1' ],
 			[ 'post_status', 'pending' ],
-			[ 'post_title', '%2COrder' ], //string
+			[ 'post_title', '%2COrder' ],
 			[ 'post_type', 'shop_order' ],
 			[ 'referredby', '' ],
 			[ 'samplepermalinknonce', `${ sample_permalink_nonce }` ],
@@ -574,8 +578,6 @@ export function addOrder() {
 		);
 		check( response, {
 			'is status 200': ( r ) => r.status === 200,
-			"body contains: 'Edit order' header": ( response ) =>
-				response.body.includes( `${ admin_open_order_assert }` ),
 			"body contains: 'Order updated' confirmation": ( response ) =>
 				response.body.includes( `${ admin_update_order_assert }` ),
 		} );

--- a/plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
@@ -83,165 +83,166 @@ export const options = {
 		},
 	},
 	thresholds: {
-		checks: ['rate==1'],
+		checks: [ 'rate==1' ],
+		// Listing individual metrics due to https://github.com/grafana/k6/issues/1321
 		'http_req_duration{name:Shopper - Site Root}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Shop Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Search Products}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Category Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Product Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=add_to_cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - View Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Remove Item From Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=apply_coupon}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Update Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - View Checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=update_order_review}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Order Received}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=get_refreshed_fragments}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Login to Checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Login Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Login to My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Orders}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Open Order}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WP Login Page}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Login to WP Admin}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WC-Admin}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/orders?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/products/reviews?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/products/low-in-stock?}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - All Orders}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Completed Orders}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - New Order Page}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Create New Order}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Open Order}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Update Existing Order Status}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Customer Email}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Customer Address}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - Filter Orders By Month}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Filter Orders By Customer}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - All Products}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Add New Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - action=sample-permalink}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - action=heartbeat autosave}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Update New Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Coupons}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-admin/onboarding/tasks?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/admin/notes?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-admin/options?options=woocommerce_ces_tracks_queue}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - action=heartbeat}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:API - Create Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Retrieve Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Update Order (Status)}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Delete Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Batch Create Orders}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Batch Update (Status) Orders}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 	},
 };

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -85,6 +85,7 @@ export const options = {
 	},
 	thresholds: {
 		checks: [ 'rate==1' ],
+		// Listing individual metrics due to https://github.com/grafana/k6/issues/1321
 		'http_req_duration{name:Shopper - Site Root}': [
 			`${ shopper_request_threshold }`,
 		],
@@ -140,13 +141,13 @@ export const options = {
 			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Orders}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Open Order}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WP Login Page}': [
 			`${ merchant_request_threshold }`,

--- a/plugins/woocommerce/tests/performance/tests/simple-all-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/simple-all-requests.js
@@ -87,165 +87,166 @@ export const options = {
 		},
 	},
 	thresholds: {
-		checks: ['rate==1'],
+		checks: [ 'rate==1' ],
+		// Listing individual metrics due to https://github.com/grafana/k6/issues/1321
 		'http_req_duration{name:Shopper - Site Root}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Shop Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Search Products}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Category Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Product Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=add_to_cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - View Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Remove Item From Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=apply_coupon}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Update Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - View Checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=update_order_review}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Order Received}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=get_refreshed_fragments}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Login to Checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Login Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Login to My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Orders}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Open Order}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WP Login Page}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Login to WP Admin}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WC-Admin}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/orders?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/products/reviews?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/products/low-in-stock?}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - All Orders}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Completed Orders}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - New Order Page}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Create New Order}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Open Order}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Update Existing Order Status}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Customer Email}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Customer Address}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - Filter Orders By Month}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Filter Orders By Customer}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - All Products}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Add New Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - action=sample-permalink}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - action=heartbeat autosave}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Update New Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Coupons}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-admin/onboarding/tasks?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/admin/notes?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-admin/options?options=woocommerce_ces_tracks_queue}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - action=heartbeat}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:API - Create Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Retrieve Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Update Order (Status)}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Delete Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Batch Create Orders}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Batch Update (Status) Orders}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 	},
 };
@@ -275,7 +276,7 @@ export function cartFlow() {
 }
 
 export function allMerchantFlow() {
-	if (admin_acc_login === true) {
+	if ( admin_acc_login === true ) {
 		myAccountMerchantLogin();
 	} else {
 		wpLogin();

--- a/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js
+++ b/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js
@@ -118,171 +118,172 @@ export const options = {
 		},
 	},
 	thresholds: {
+		// Listing individual metrics due to https://github.com/grafana/k6/issues/1321
 		'http_req_duration{name:Shopper - Site Root}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Shop Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Search Products}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Category Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Product Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=add_to_cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - View Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Remove Item From Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=apply_coupon}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Update Cart}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - View Checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=update_order_review}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Order Received}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - wc-ajax=get_refreshed_fragments}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Login to Checkout}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Login Page}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - Login to My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Orders}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Shopper - My Account Open Order}': [
-			`${shopper_request_threshold}`,
+			`${ shopper_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WP Login Page}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Login to WP Admin}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - WC-Admin}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/orders?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/products/reviews?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/products/low-in-stock?}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - All Orders}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Completed Orders}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - New Order Page}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Create New Order}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Open Order}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Update Existing Order Status}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Customer Email}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Search Orders By Customer Address}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - Filter Orders By Month}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Filter Orders By Customer}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - All Products}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Add New Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - action=sample-permalink}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - action=heartbeat autosave}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Update New Product}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - Coupons}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-admin/onboarding/tasks?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-analytics/admin/notes?}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:Merchant - wc-admin/options?options=woocommerce_ces_tracks_queue}':
-			[`${merchant_request_threshold}`],
+			[ `${ merchant_request_threshold }` ],
 		'http_req_duration{name:Merchant - action=heartbeat}': [
-			`${merchant_request_threshold}`,
+			`${ merchant_request_threshold }`,
 		],
 		'http_req_duration{name:API - Create Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Retrieve Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Update Order (Status)}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Delete Order}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Batch Create Orders}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 		'http_req_duration{name:API - Batch Update (Status) Orders}': [
-			`${api_request_threshold}`,
+			`${ api_request_threshold }`,
 		],
 	},
 };
 
 // Use myAccountMerchantLogin() instead of wpLogin() if having issues with login.
 export function merchantOrderFlows() {
-	if (admin_acc_login === true) {
+	if ( admin_acc_login === true ) {
 		myAccountMerchantLogin();
 	} else {
 		wpLogin();
@@ -295,7 +296,7 @@ export function merchantOrderFlows() {
 
 // Use myAccountMerchantLogin() instead of wpLogin() if having issues with login.
 export function merchantOtherFlows() {
-	if (admin_acc_login === true) {
+	if ( admin_acc_login === true ) {
 		myAccountMerchantLogin();
 	} else {
 		wpLogin();


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the k6 performance tests tweaks the assertions used for merchant order requests to be better suited for when HPOS is authoritative.

It also tidies up the formatting of the scenarios.  

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Setup test environment
[See instructions here for more details
](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/performance#test-environment)
- use wp-env to setup a local environment with `performance/bin/init-sample-products.sh` that will set up a shop with sample products imported and the shop settings (payment method, permalinks, address etc) needed for the tests already set **with the exception of coupon data**.
- OR use an existing test site and update `performance/config.js` to use that site
- For the HPOS change also test on a site with HPOS authoritative  and update `performance/config.js` to use that site and make sure to set `cot_status ` to true in the config.


2. Install k6 and run test
run `brew install k6`
[For other platforms please see the k6 installation guide.](https://k6.io/docs/getting-started/installation/)
change directory to `plugins/woocommerce/tests/performance`
Run all requests with 
`k6 run tests/simple-all-requests.js` (if coupon data is not set up, coupon tests will fail)

3. Check tests pass in CI


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
