### PR TITLE
Include WC Cart functions for REST API calls

### DIFF
--- a/plugins/woocommerce/changelog/fix-missed-wc-empty-cart
+++ b/plugins/woocommerce/changelog/fix-missed-wc-empty-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Load wc_empty_cart function for REST API calls.

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -369,7 +369,11 @@ class WC_Session_Handler extends WC_Session {
 	public function forget_session() {
 		wc_setcookie( $this->_cookie, '', time() - YEAR_IN_SECONDS, $this->use_secure_cookie(), true );
 
-		wc_empty_cart();
+		if( ! is_admin() ) {
+			include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
+
+			wc_empty_cart();
+		}
 
 		$this->_data        = array();
 		$this->_dirty       = false;

--- a/plugins/woocommerce/includes/class-wc-session-handler.php
+++ b/plugins/woocommerce/includes/class-wc-session-handler.php
@@ -369,7 +369,7 @@ class WC_Session_Handler extends WC_Session {
 	public function forget_session() {
 		wc_setcookie( $this->_cookie, '', time() - YEAR_IN_SECONDS, $this->use_secure_cookie(), true );
 
-		if( ! is_admin() ) {
+		if ( ! is_admin() ) {
 			include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
 
 			wc_empty_cart();


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to https://github.com/Automattic/woocommerce.com/pull/15503.

Using `WC()->initialize_session();` in REST API endpoints turns out into an error:
```php
Error message:
Uncaught exception 'Error' with message 'Call to undefined function wc_empty_cart()'
in plugins/woocommerce/includes/class-wc-session-handler.php:372
```

To make sure this error won't be produced we need to include `includes/wc-cart-functions.php` before calling `wc_empty_cart();`.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Use the `trunk` branch to reproduce an error first
2. Add a mu-plugin with the following content (we need to initialize WC Session even for REST API call):
```php
add_action( 'plugins_loaded', function () {
        WC()->initialize_session();
} );
```
3. Open [`class-wc-session-handler.php`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-session-handler.php#L88) and put the following after the line `88` (pretending that WC cookie is set):
```php
if ( ! $cookie ) {
	$cookie = [
		$this->generate_customer_id(),
		0,
		0,
	];
}
```

4. And modify the line `104` (originally it's the line [`98`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-session-handler.php#L98)) to looks like this (pretending our cookie is valid but outdated:
```php
if ( true || ! $this->is_session_cookie_valid() ) {
```

5. And finally, add this debug `die` call right before `wc_empty_cart();` call in the line `379`:
```php
die (
	'function exists: ' .
	( function_exists( 'wc_empty_cart' ) ? 'yes' : 'no' )
);
```

6. Call any REST API method, e.g. I opened the link http://localhost:8888/wp-json/wc/v3/products (to run a local dev environment I run `cd plugins/woocommerce && pnpm -- wp-env start`)

7. You should see (that means frontend functions wasn't included for a REST API call): 
<img width="408" alt="image" src="https://user-images.githubusercontent.com/115007291/209553492-c69a1593-9a5b-44bf-bf84-34b3e0ad06dc.png">

8. Switch to this PR's branch (`git reset --hard && git checkout fix/missed-wc-empty-cart`)
9. Apply changes from steps `3`, `4`, and `5` once again
10. Call the same REST API method, e.g. http://localhost:8888/wp-json/wc/v3/products
11. Now you should see that the function exists:
<img width="409" alt="image" src="https://user-images.githubusercontent.com/115007291/209553877-9fded6e8-df06-46bb-b846-d801df0a3c8c.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
