### PR TITLE
Automatically generate product variations on option changes

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/options/options.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/options/options.tsx
@@ -1,8 +1,13 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { ProductAttribute } from '@woocommerce/data';
+import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	Product,
+	ProductAttribute,
+	PRODUCTS_STORE_NAME,
+} from '@woocommerce/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,11 +25,24 @@ export const Options: React.FC< OptionsProps > = ( {
 	onChange,
 	productId,
 } ) => {
+	const { generateProductVariations, invalidateResolutionForStoreSelector } =
+		useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
+	const { updateProduct } = useDispatch( PRODUCTS_STORE_NAME );
+
+	const handleChange = async ( attributes: ProductAttribute[] ) => {
+		onChange( attributes );
+		await updateProduct( productId, {
+			attributes,
+		} );
+		await generateProductVariations( { product_id: productId } );
+		invalidateResolutionForStoreSelector( 'getProductVariations' );
+	};
+
 	return (
 		<AttributeField
 			attributeType="for-variations"
 			value={ value }
-			onChange={ onChange }
+			onChange={ handleChange }
 			productId={ productId }
 		/>
 	);

--- a/plugins/woocommerce-admin/client/products/fields/options/options.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/options/options.tsx
@@ -1,18 +1,14 @@
 /**
  * External dependencies
  */
-import {
-	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
-	Product,
-	ProductAttribute,
-	PRODUCTS_STORE_NAME,
-} from '@woocommerce/data';
-import { useDispatch } from '@wordpress/data';
+import { Product, ProductAttribute } from '@woocommerce/data';
+import { useFormContext } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import { AttributeField } from '../attribute-field';
+import { useProductVariationsHelper } from '../../hooks/use-product-variations-helper';
 
 type OptionsProps = {
 	value: ProductAttribute[];
@@ -25,17 +21,12 @@ export const Options: React.FC< OptionsProps > = ( {
 	onChange,
 	productId,
 } ) => {
-	const { generateProductVariations, invalidateResolutionForStoreSelector } =
-		useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
-	const { updateProduct } = useDispatch( PRODUCTS_STORE_NAME );
+	const { values } = useFormContext< Product >();
+	const { generateProductVariations } = useProductVariationsHelper();
 
 	const handleChange = async ( attributes: ProductAttribute[] ) => {
 		onChange( attributes );
-		await updateProduct( productId, {
-			attributes,
-		} );
-		await generateProductVariations( { product_id: productId } );
-		invalidateResolutionForStoreSelector( 'getProductVariations' );
+		generateProductVariations( { ...values, attributes } );
 	};
 
 	return (

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -58,6 +58,7 @@ export const Variations: React.FC = () => {
 		{}
 	);
 	const { values } = useFormContext< Product >();
+	const productId = values.id;
 	const context = useContext( CurrencyContext );
 	const { formatAmount, getCurrencyConfig } = context;
 	const { isLoading, variations, totalCount } = useSelect(
@@ -68,7 +69,7 @@ export const Variations: React.FC = () => {
 				getProductVariationsTotalCount,
 			} = select( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
 			const requestParams = {
-				product_id: values.id,
+				product_id: productId,
 				page: currentPage,
 				per_page: perPage,
 				order: 'asc',
@@ -84,7 +85,7 @@ export const Variations: React.FC = () => {
 					getProductVariationsTotalCount< number >( requestParams ),
 			};
 		},
-		[ currentPage, perPage, values.id ]
+		[ currentPage, perPage, productId ]
 	);
 
 	const { updateProductVariation } = useDispatch(

--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, Card, Spinner, Tooltip } from '@wordpress/components';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	Product,
 	ProductVariation,
 } from '@woocommerce/data';
 import {
@@ -13,6 +14,7 @@ import {
 	Pagination,
 	Sortable,
 	Tag,
+	useFormContext,
 } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { useContext, useState } from '@wordpress/element';
@@ -55,7 +57,7 @@ export const Variations: React.FC = () => {
 	const [ isUpdating, setIsUpdating ] = useState< Record< string, boolean > >(
 		{}
 	);
-	const { productId } = useParams();
+	const { values } = useFormContext< Product >();
 	const context = useContext( CurrencyContext );
 	const { formatAmount, getCurrencyConfig } = context;
 	const { isLoading, variations, totalCount } = useSelect(
@@ -66,7 +68,7 @@ export const Variations: React.FC = () => {
 				getProductVariationsTotalCount,
 			} = select( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
 			const requestParams = {
-				product_id: productId,
+				product_id: values.id,
 				page: currentPage,
 				per_page: perPage,
 				order: 'asc',
@@ -82,7 +84,7 @@ export const Variations: React.FC = () => {
 					getProductVariationsTotalCount< number >( requestParams ),
 			};
 		},
-		[ currentPage, perPage ]
+		[ currentPage, perPage, values.id ]
 	);
 
 	const { updateProductVariation } = useDispatch(

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
@@ -10,6 +10,11 @@ import {
 } from '@woocommerce/data';
 import { useFormContext } from '@woocommerce/components';
 
+/**
+ * Internal dependencies
+ */
+import { AUTO_DRAFT_NAME } from '../utils/get-product-title';
+
 export function useProductVariationsHelper() {
 	const {
 		generateProductVariations: _generateProductVariations,
@@ -34,7 +39,7 @@ export function useProductVariationsHelper() {
 						return createProduct< Promise< Product > >( {
 							...product,
 							status: 'auto-draft',
-							name: product.name || 'AUTO-DRAFT',
+							name: product.name || AUTO_DRAFT_NAME,
 						} );
 				  };
 
@@ -43,10 +48,7 @@ export function useProductVariationsHelper() {
 					if ( ! product.id ) {
 						resetForm( {
 							...createdOrUpdatedProduct,
-							name:
-								createdOrUpdatedProduct.name === 'AUTO-DRAFT'
-									? ''
-									: createdOrUpdatedProduct.name,
+							name: product.name || '',
 						} );
 					}
 					return _generateProductVariations( {

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
@@ -8,6 +8,7 @@ import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	PRODUCTS_STORE_NAME,
 } from '@woocommerce/data';
+import { useFormContext } from '@woocommerce/components';
 
 export function useProductVariationsHelper() {
 	const {
@@ -15,6 +16,7 @@ export function useProductVariationsHelper() {
 		invalidateResolutionForStoreSelector,
 	} = useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
 	const { createProduct, updateProduct } = useDispatch( PRODUCTS_STORE_NAME );
+	const { setValue } = useFormContext< Product >();
 
 	const [ isGenerating, setIsGenerating ] = useState( false );
 
@@ -38,6 +40,9 @@ export function useProductVariationsHelper() {
 
 			return createOrUpdateProduct()
 				.then( ( createdOrUpdatedProduct ) => {
+					if ( ! product.id ) {
+						setValue( 'id', createdOrUpdatedProduct.id );
+					}
 					return _generateProductVariations( {
 						product_id: createdOrUpdatedProduct.id,
 					} );

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import {
+	Product,
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	PRODUCTS_STORE_NAME,
+} from '@woocommerce/data';
+
+export function useProductVariationsHelper() {
+	const {
+		generateProductVariations: _generateProductVariations,
+		invalidateResolutionForStoreSelector,
+	} = useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
+	const { updateProduct } = useDispatch( PRODUCTS_STORE_NAME );
+
+	const [ isGenerating, setIsGenerating ] = useState( false );
+
+	const generateProductVariations = useCallback(
+		async ( product: Partial< Product > ) => {
+			setIsGenerating( true );
+			return updateProduct< Promise< Product > >( product.id, product )
+				.then( () => {
+					return _generateProductVariations( {
+						product_id: product.id,
+					} );
+				} )
+				.then( () => {
+					return invalidateResolutionForStoreSelector(
+						'getProductVariations'
+					);
+				} )
+				.finally( () => {
+					setIsGenerating( false );
+				} );
+		},
+		[]
+	);
+
+	return {
+		generateProductVariations,
+		isGenerating,
+	};
+}

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-variations-helper.ts
@@ -16,7 +16,7 @@ export function useProductVariationsHelper() {
 		invalidateResolutionForStoreSelector,
 	} = useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
 	const { createProduct, updateProduct } = useDispatch( PRODUCTS_STORE_NAME );
-	const { setValue } = useFormContext< Product >();
+	const { resetForm } = useFormContext< Product >();
 
 	const [ isGenerating, setIsGenerating ] = useState( false );
 
@@ -41,7 +41,13 @@ export function useProductVariationsHelper() {
 			return createOrUpdateProduct()
 				.then( ( createdOrUpdatedProduct ) => {
 					if ( ! product.id ) {
-						setValue( 'id', createdOrUpdatedProduct.id );
+						resetForm( {
+							...createdOrUpdatedProduct,
+							name:
+								createdOrUpdatedProduct.name === 'AUTO-DRAFT'
+									? ''
+									: createdOrUpdatedProduct.name,
+						} );
 					}
 					return _generateProductVariations( {
 						product_id: createdOrUpdatedProduct.id,

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -20,6 +20,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
+import { AUTO_DRAFT_NAME } from './utils/get-product-title';
 import { CurrencyContext } from '../lib/currency-context';
 import {
 	NUMBERS_AND_DECIMAL_SEPARATOR,
@@ -70,8 +71,8 @@ export function useProductHelper() {
 	/**
 	 * Create product with status.
 	 *
-	 * @param {Product} product the product to be created.
-	 * @param {string}  status the product status.
+	 * @param {Product} product    the product to be created.
+	 * @param {string}  status     the product status.
 	 * @param {boolean} skipNotice if the notice should be skipped (default: false).
 	 * @return {Promise<Product>} Returns a promise with the created product.
 	 */
@@ -163,9 +164,9 @@ export function useProductHelper() {
 	/**
 	 * Update product with status.
 	 *
-	 * @param {number} productId the product id to be updated.
-	 * @param {Product} product the product to be updated.
-	 * @param {string}  status the product status.
+	 * @param {number}  productId  the product id to be updated.
+	 * @param {Product} product    the product to be updated.
+	 * @param {string}  status     the product status.
 	 * @param {boolean} skipNotice if the notice should be skipped (default: false).
 	 * @return {Promise<Product>} Returns a promise with the updated product.
 	 */
@@ -242,7 +243,7 @@ export function useProductHelper() {
 	 * Creates a copy of the given product with the given status.
 	 *
 	 * @param {Product} product the product to be copied.
-	 * @param {string}  status the product status.
+	 * @param {string}  status  the product status.
 	 * @return {Promise<Product>} promise with the newly created and copied product.
 	 */
 	const copyProductWithStatus = useCallback(
@@ -250,7 +251,7 @@ export function useProductHelper() {
 			return createProductWithStatus(
 				removeReadonlyProperties( {
 					...product,
-					name: ( product.name || 'AUTO-DRAFT' ) + ' - Copy',
+					name: ( product.name || AUTO_DRAFT_NAME ) + ' - Copy',
 				} ),
 				status
 			);

--- a/plugins/woocommerce-admin/client/products/utils/get-product-title.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-title.ts
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 
+export const AUTO_DRAFT_NAME = 'AUTO-DRAFT';
+
 /**
  * Get the product title for use in the header.
  *
@@ -20,7 +22,7 @@ export const getProductTitle = (
 		return name;
 	}
 
-	if ( persistedName ) {
+	if ( persistedName && persistedName !== AUTO_DRAFT_NAME ) {
 		return persistedName;
 	}
 

--- a/plugins/woocommerce-admin/client/products/utils/test/get-product-title.test.ts
+++ b/plugins/woocommerce-admin/client/products/utils/test/get-product-title.test.ts
@@ -28,4 +28,9 @@ describe( 'getProductTitle', () => {
 		const title = getProductTitle( '', 'custom-type', undefined );
 		expect( title ).toBe( 'New product' );
 	} );
+
+	it( 'should return the generic add new string when the product title is the auto draft title', () => {
+		const title = getProductTitle( '', 'custom-type', 'AUTO-DRAFT' );
+		expect( title ).toBe( 'New product' );
+	} );
 } );

--- a/plugins/woocommerce/changelog/add-35778
+++ b/plugins/woocommerce/changelog/add-35778
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Auto generate variations on option changes

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -867,7 +867,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					'description' => __( 'Product status (post status).', 'woocommerce' ),
 					'type'        => 'string',
 					'default'     => 'publish',
-					'enum'        => array_merge( array_keys( get_post_statuses() ), array( 'future' ) ),
+					'enum'        => array_merge( array_keys( get_post_statuses() ), array( 'future', 'auto-draft', 'trash' ) ),
 					'context'     => array( 'view', 'edit' ),
 				),
 				'featured'              => array(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Updates the product with the new options automatically whenever any changes occur
* Automatically generate the variations after the options have been saved

The current behavior is a little slow and does not hint at variations being regenerated until after the product has been saved.  I think it would be worthwhile to show a spinner with a minimum fixed height on variations when saving, generating, and when reloading variations.  However, the current data stores do not have a way to detect when an action has been dispatched in another component.  This would be a nice addition to the CRUD data stores.

Another side note: we could reduce the number of synchronous round trips by 1 request if we update the generated variations response to include generated variations, but we might need to limit or paginate the number returned.
<img width="755" alt="Screen Shot 2022-12-26 at 3 04 56 PM" src="https://user-images.githubusercontent.com/10561050/209587809-9d52ab52-b43e-4aa0-b718-09402446327a.png">



Closes #35778  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product management experience (Products -> Add new (MVP))
2. Click the "Options" tab
3. Add or edit an attribute
4. Note that the variations list gets updated with the new properties (deleting does not affect the variations which also appears to be true of the old experience and I think we should be cautious deleting variations without user permission)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
