### PR TITLE
Add minimum required permissions for workflow token

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -1,5 +1,6 @@
 name: Setup WooCommerce Monorepo
 description: Handles the installation, building, and caching of the projects within the monorepo.
+permissions: {}
 
 inputs:
     install-filters:

--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -6,10 +6,15 @@ on:
         description: 'By default the zip file is generated from the branch the workflow runs from, but you can specify an explicit reference to use instead here (e.g. refs/tags/tag_name or refs/heads/release/x.x). The resulting file will be available as an artifact on the workflow run.'
         required: false
         default: ''
+
+permissions: {}
+
 jobs:
   build:
     name: Build release zip file
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,10 +2,15 @@ name: Build release asset
 on: 
   release:
     types: [published]
+
+permissions: {}
+
 jobs:
   build:
     name: Build release asset
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -30,6 +30,8 @@ env:
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
+permissions: {}
+
 jobs:
     verify:
         name: Verify
@@ -122,6 +124,10 @@ jobs:
     cherry-pick-run:
         name: Run cherry pick tool
         runs-on: ubuntu-20.04
+        permissions:
+          actions: write
+          contents: write
+          pull-requests: write
         needs: [prep, check-release-branch-exists]
         if: success()
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,16 @@ defaults:
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   test:
     name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
     timeout-minutes: 30
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     continue-on-error: ${{ matrix.wp == 'nightly' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -10,10 +10,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     verify:
         name: Verify
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/cot-build-and-e2e-tests-daily.yml
+++ b/.github/workflows/cot-build-and-e2e-tests-daily.yml
@@ -8,10 +8,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     cot-e2e-tests-run:
         name: Runs E2E tests with COT enabled.
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-report
@@ -66,6 +70,8 @@ jobs:
     cot-api-tests-run:
         name: Runs API tests with COT enabled.
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
@@ -124,6 +130,8 @@ jobs:
               contains( needs.*.result, 'failure' )
             )
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         needs: [cot-api-tests-run, cot-e2e-tests-run]
         steps:
             - name: Create dirs

--- a/.github/workflows/cot-pr-build-and-e2e-tests.yml
+++ b/.github/workflows/cot-pr-build-and-e2e-tests.yml
@@ -8,11 +8,15 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     cot-e2e-tests-run:
         name: Runs E2E tests with COT enabled.
         if: "${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'focus: custom order tables' }}"
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-report
@@ -68,6 +72,8 @@ jobs:
         name: Runs API tests with COT enabled.
         if: "${{ github.event_name == 'workflow_dispatch' || github.event.label.name == 'focus: custom order tables' }}"
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
@@ -126,6 +132,8 @@ jobs:
               contains( needs.*.result, 'failure' )
             )
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         needs: [cot-api-tests-run, cot-e2e-tests-run]
         steps:
             - name: Create dirs

--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -4,11 +4,15 @@ on:
     branches: ["trunk", "release/**"]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     if: github.repository == 'woocommerce/woocommerce'
     name: Build WooCommerce zip
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
 
@@ -35,6 +39,8 @@ jobs:
     name: Push to Mirror
     needs: [build]
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - name: Create directories
         run: |

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 0 * * *' # Run at 12 AM UTC.
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   build:
     if: github.repository_owner == 'woocommerce'
@@ -12,6 +15,8 @@ jobs:
       matrix:
         build: [trunk]
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,6 +45,8 @@ jobs:
   update:
     name: Update nightly tag commit ref
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
     steps:
       - name: Update nightly tag
         uses: richardsimko/github-tag-action@v1.0.5

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -6,10 +6,15 @@ on:
                 description: 'Enter a specific package to release, or releases separated by commas, ie @woocommerce/components,@woocommerce/number. Leaving this input blank will release all eligible packages.'
                 required: false
                 default: '-a'
+
+permissions: {}
+
 jobs:
     release:
         name: Run packages release script
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
             

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,10 +9,15 @@ env:
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
+permissions: {}
+
 jobs:
     changelog-version-update:
         name: Update changelog and version
         runs-on: ubuntu-20.04
+        permissions:
+          contents: write
+          pull-requests: write
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -7,10 +7,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     e2e-tests-run:
         name: Runs E2E tests.
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
@@ -79,6 +83,8 @@ jobs:
     api-tests-run:
         name: Runs API tests.
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
@@ -129,6 +135,8 @@ jobs:
     k6-tests-run:
         name: Runs k6 Performance tests
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
 
@@ -162,6 +170,10 @@ jobs:
             )
         runs-on: ubuntu-20.04
         needs: [api-tests-run, e2e-tests-run]
+        permissions:
+          contents: read
+          issues: write
+          pull-requests: write
         env:
             E2E_GRAND_TOTAL: ${{needs.e2e-tests-run.outputs.E2E_GRAND_TOTAL}}
         steps:

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -7,10 +7,14 @@ concurrency:
     group: build-${{ github.event_name == 'push' && github.run_id || 'pr' }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     build:
         if: github.repository_owner == 'woocommerce'
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -8,11 +8,16 @@ defaults:
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   test:
     name: Code coverage (PHP 7.4, WP Latest)
     timeout-minutes: 30
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -8,11 +8,16 @@ concurrency:
     cancel-in-progress: true
 env:
     PHPCS: ./plugins/woocommerce/vendor/bin/phpcs # Run WooCommerce phpcs setup in phpcs-changed instead of default
+
+permissions: {}
+
 jobs:
     test:
         name: Code sniff (PHP 7.4, WP Latest)
         timeout-minutes: 15
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -1,9 +1,14 @@
 name: Highlight templates changes
 on: pull_request
+
+permissions: {}
+
 jobs:
     analyze:
         name: Check pull request changes to highlight
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         outputs:
             results: ${{ steps.results.outputs.results }}
         steps:

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -6,10 +6,15 @@ on:
 concurrency:
   group: changelogger-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   changelogger_used:
     name: Changelogger use
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -5,10 +5,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     lint-test-js:
         name: Lint and Test JS
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -8,9 +8,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   label_project:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/labeler@v3
       with:

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -9,11 +9,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     prcheck:
         name: Smoke test a pull request.
         if: "${{ contains(github.event.label.name, 'run: smoke tests') }}"
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
+          pull-requests: write
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -8,11 +8,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   test:
     name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
     timeout-minutes: 30
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     continue-on-error: ${{ matrix.wp == 'nightly' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/prepare-package-release.yml
+++ b/.github/workflows/prepare-package-release.yml
@@ -6,10 +6,16 @@ on:
                 description: 'Enter a specific package to release, or packages separated by commas, ie @woocommerce/components,@woocommerce/number. Leaving this input to the default "-a" will prepare to release all eligible packages.'
                 required: false
                 default: '-a'
+
+permissions: {}
+
 jobs:
     prepare:
         name: Run prepare script
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
+          pull-requests: write
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/prime-cache.yml
+++ b/.github/workflows/prime-cache.yml
@@ -9,10 +9,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true  
 
+permissions: {}
+
 jobs:
   prime:
     name: Prime cache
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -3,11 +3,15 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}
+
 jobs:
   process-pull-request-after-merge:
     name: "Process a pull request after it's merged"
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write
     steps:
       - name: "Get the action scripts"
         run: |

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -15,9 +15,14 @@ env:
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
+permissions: {}
+
 jobs:
     create-changelog-prs:
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
+          pull-requests: write
         steps:
             - name: Checkout code
               uses: actions/checkout@v3

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -20,6 +20,8 @@ env:
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
     GIT_AUTHOR_EMAIL: 'no-reply@woocommerce.com'
 
+permissions: {}
+
 jobs:
     verify-code-freeze:
         name: 'Verify that today is the day of the code freeze'
@@ -57,6 +59,8 @@ jobs:
     maybe-create-next-milestone-and-release-branch:
         name: 'Maybe create next milestone and release branch'
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         needs: verify-code-freeze
         if: needs.verify-code-freeze.outputs.freeze == 0
         outputs:
@@ -84,6 +88,9 @@ jobs:
     prep-trunk:
         name: Preps trunk for next development cycle
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
+          pull-requests: write
         needs: maybe-create-next-milestone-and-release-branch
         steps:
             - name: Checkout code
@@ -151,6 +158,8 @@ jobs:
     trigger-changelog-action:
         name: 'Trigger changelog action'
         runs-on: ubuntu-20.04
+        permissions:
+          actions: write
         needs: maybe-create-next-milestone-and-release-branch
         steps:
             - name: 'Trigger changelog action'

--- a/.github/workflows/smoke-test-daily-site-check.yml
+++ b/.github/workflows/smoke-test-daily-site-check.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '25 7 * * *'
 
+permissions: {}
+
 jobs:
   ping_site:
     runs-on: ubuntu-20.04

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -14,10 +14,14 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions: {}
+
 jobs:
     e2e-tests:
         name: E2E tests on nightly build
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
             ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
@@ -76,6 +80,8 @@ jobs:
     api-tests:
         name: API tests on nightly build
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         needs: [e2e-tests]
         if: success() || failure()
         env:
@@ -120,6 +126,8 @@ jobs:
     k6-tests:
         name: k6 tests on nightly build
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         needs: [api-tests]
         if: success() || failure()
         steps:
@@ -170,6 +178,8 @@ jobs:
     test-plugins:
         name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         env:
             USE_WP_ENV: 1
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
@@ -243,6 +253,8 @@ jobs:
             ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         needs: [test-plugins, k6-tests]
         steps:
             - name: Create dirs

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -5,10 +5,15 @@ on:
             release_id:
                 description: 'WooCommerce Release Id'
                 required: true
+
+permissions: {}
+
 jobs:
     login-run:
         name: Daily smoke test on release.
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         steps:
             - uses: actions/checkout@v3
               with:
@@ -49,6 +54,8 @@ jobs:
     test-wp-version:
         name: Smoke test on L-${{ matrix.wp }} WordPress version
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         strategy:
             matrix:
                 wp: ['1', '2']
@@ -104,6 +111,8 @@ jobs:
     test-plugins:
         name: Smoke tests with ${{ matrix.plugin }} plugin installed
         runs-on: ubuntu-20.04
+        permissions:
+          contents: read
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -3,11 +3,17 @@ on:
   schedule:
     - cron: '21 0 * * *'
 
+permissions: {}
+
 jobs:
   stale:
     if: |
       ! contains(github.event.issue.labels.*.name, 'type: enhancement')
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v3
         with:

--- a/.github/workflows/syncpack.yml
+++ b/.github/workflows/syncpack.yml
@@ -6,9 +6,14 @@ on:
       - trunk
     paths:
       - '**/package.json'
+
+permissions: {}
+
 jobs:
   syncpack:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: syncpack
     steps:
       - name: 'Checkout'

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -4,9 +4,14 @@ on:
   issues:
     types: opened
 
+permissions: {}
+
 jobs:
   add_label:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/triage-replies.yml
+++ b/.github/workflows/triage-replies.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types:
       - labeled
+
+permissions: {}
+
 jobs:
   add-dev-comment:
     if: "github.event.label.name == 'needs: developer feedback'"

--- a/.github/workflows/update-feedback-labels.yml
+++ b/.github/workflows/update-feedback-labels.yml
@@ -1,6 +1,8 @@
 name: 'Update contributor feedback labels on comment'
 on: 'issue_comment'
 
+permissions: {}
+
 jobs:
   feedback:
     if: |
@@ -10,6 +12,8 @@ jobs:
       github.event.issue.state == 'open' &&
       contains(github.event.issue.labels.*.name, 'needs: author feedback')
     runs-on: ubuntu-20.04
+    permissions:
+      issues: write
     steps:
     - name: Add has feedback
       uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a layer of security by specifically enforcing the minimum required permissions for `GITHUB_TOKEN`. Because many marketplace actions we're using implicitly uses `GITHUB_TOKEN` with default permissions which is not always secure. I've added the default `permissions: {}` at the top of each workflow to reset the permissions to basically none. Then on the job level add back in the permission minimally needed for the action. Note this does not affect custom tokens (such as PAT).

I've tested as much as conveniently possible with the fork but some non critical workflows we might have to observe and fix if permissions are too strict.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Check that all CI passes which denotes that the permission levels are enough for them to run.
2. For all non CI workflows, you can create a fork and test them manually there. But I think it may be too much and perhaps just observe the actions and correct from there.
3.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
