### PR TITLE
Add ability to filter variations by local attributes in REST API

### DIFF
--- a/plugins/woocommerce/changelog/add-36117
+++ b/plugins/woocommerce/changelog/add-36117
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add ability to filter variations by local attributes in REST API

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -809,6 +809,22 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		// Set post_status.
 		$args['post_status'] = $request['status'];
 
+		// Filter by local attributes.
+		if ( ! empty( $request['local_attributes'] ) && is_array( $request['local_attributes'] ) ) {
+			foreach ( $request['local_attributes'] as $attribute ) {
+				if ( ! isset( $attribute['attribute'] ) || ! isset( $attribute['term'] ) ) {
+					continue;
+				}
+				$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+					$args,
+					array(
+						'key'     => 'attribute_' . $attribute['attribute'],
+						'value'   => $attribute['term'],
+					)
+				);
+			}
+		}
+
 		// Filter by sku.
 		if ( ! empty( $request['sku'] ) ) {
 			$skus = explode( ',', $request['sku'] );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -815,11 +815,11 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				if ( ! isset( $attribute['attribute'] ) || ! isset( $attribute['term'] ) ) {
 					continue;
 				}
-				$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+				$args['meta_query'] = $this->add_meta_query( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					$args,
 					array(
-						'key'     => 'attribute_' . $attribute['attribute'],
-						'value'   => $attribute['term'],
+						'key'   => 'attribute_' . $attribute['attribute'],
+						'value' => $attribute['term'],
 					)
 				);
 			}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the ability to filter variations by local attributes so we can allow users to sort and filter variations based on attributes in the new client-side experience.

Closes #36117 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Using Postman or some other request tool, make a GET request to `wp-json/wc/v3/products/{product_id}/variations` using a product ID that has some variations
2. Use the attributes and terms in the body of the request using the `local_attributes` property:
```
{
    "local_attributes": [
        {
            "attribute": "size",
            "term": "Small"
        },
        {
            "attribute": "color",
            "term": "Blue"
        }
    ]
}
```
Note that you can add any number of attributes, but each must be an object with both the `attribute` property and the `term` property.  Invalid schema will be ignored
3. Note that the variations returned are the ones with the respective attributes

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
