### PR TITLE
Skip custom search for HPOS API queries as it's handled already.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36212
+++ b/plugins/woocommerce/changelog/fix-36212
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip custom search for HPOS API queries as it's handled already.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

For the posts-based data store, we were firing wc_order_search manually before it went to WC_Query since our search for posts was custom (i.e. it needed to also search in the order_items table, which WP_Query does not support). However, for HPOS, this isn't required, and OrderTableDataStore can handle the search param properly. 

This PR skips the wc_order_search call when HPOS is active and lets OrderTableDataStore ultimately deal with it.

Fixes https://github.com/woocommerce/woocommerce/issues/36212

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->


1. Send an API request with the `search` param set, like so `/wp-json/wc/v3/orders?s=beanie`. Check that results are as expected.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
