### PR TITLE
Add support for sorting by includes param.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36212
+++ b/plugins/woocommerce/changelog/fix-36212
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip custom search for HPOS API queries as it's handled already.

--- a/plugins/woocommerce/changelog/fix-36214
+++ b/plugins/woocommerce/changelog/fix-36214
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add support for sorting by includes param.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -987,7 +987,10 @@ class OrdersTableQuery {
 		}
 
 		if ( 'include' === $orderby || 'post__in' === $orderby ) {
-			$ids           = $this->args['id'];
+			$ids = $this->args['id'] ?? $this->args['includes'];
+			if ( empty( $ids ) ) {
+				return;
+			}
 			$ids           = array_map( 'absint', $ids );
 			$this->orderby = array( "FIELD( {$this->tables['orders']}.id, " . implode( ',', $ids ) . ' )' );
 			return;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -509,8 +509,17 @@ class OrdersTableQuery {
 			return;
 		}
 
+		// No need to sanitize, will be processed in calling function.
+		if ( 'include' === $orderby || 'post__in' === $orderby ) {
+			return;
+		}
+
 		if ( is_string( $orderby ) ) {
-			$orderby = array( $orderby => $order );
+			$orderby_fields = array_map( 'trim', explode( ' ', $orderby ) );
+			$orderby        = array();
+			foreach ( $orderby_fields as $field ) {
+				$orderby[ $field ] = $order;
+			}
 		}
 
 		$this->args['orderby'] = array();
@@ -974,6 +983,13 @@ class OrdersTableQuery {
 
 		if ( 'none' === $orderby ) {
 			$this->orderby = '';
+			return;
+		}
+
+		if ( 'include' === $orderby || 'post__in' === $orderby ) {
+			$ids           = $this->args['id'];
+			$ids           = array_map( 'absint', $ids );
+			$this->orderby = array( "FIELD( {$this->tables['orders']}.id, " . implode( ',', $ids ) . ' )' );
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1350,6 +1350,39 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Ensure sorting by `includes` param works as expected.
+	 */
+	public function test_cot_query_sort_includes() {
+		$this->disable_cot_sync();
+		$order_1 = new WC_Order();
+		$this->switch_data_store( $order_1, $this->sut );
+		$order_1->save();
+
+		$order_2 = new WC_Order();
+		$this->switch_data_store( $order_2, $this->sut );
+		$this->disable_cot_sync();
+		$order_2->save();
+
+		$query        = new OrdersTableQuery(
+			array(
+				'orderby'  => 'include',
+				'includes' => array( $order_1->get_id(), $order_2->get_id() ),
+			)
+		);
+		$orders_array = $query->orders;
+		$this->assertEquals( array( $order_1->get_id(), $order_2->get_id() ), array( $orders_array[0], $orders_array[1] ) );
+
+		$query        = new OrdersTableQuery(
+			array(
+				'orderby'  => 'include',
+				'includes' => array( $order_2->get_id(), $order_1->get_id() ),
+			)
+		);
+		$orders_array = $query->orders;
+		$this->assertEquals( array( $order_2->get_id(), $order_1->get_id() ), array( $orders_array[0], $orders_array[1] ) );
+	}
+
+	/**
 	 * @testDox Ensure search works as expected on updated orders.
 	 */
 	public function test_cot_query_search_update() {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1360,7 +1360,6 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		$order_2 = new WC_Order();
 		$this->switch_data_store( $order_2, $this->sut );
-		$this->disable_cot_sync();
 		$order_2->save();
 
 		$query        = new OrdersTableQuery(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Supports sorting by `includes` param to return results sorted based on a list of order ids passed. This was already supported in Posts data store but we missed supporting it in HPOS during initial implementation.

Closes #36214 , depends on #36213

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

(Note that this is also covered in e2e tests currently WIP in https://github.com/woocommerce/woocommerce/pull/36219)

1. Have a store with at least two orders, let's say with ID xxx, yyy.
1. Make an API request for GET orders, like so: `/v3/orders?include=xxx,yyy&orderby=include`. 
2. Check that in the result, you get orders sorted based exactly same as the order of ids that you have passed.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
