### PR TITLE
Fix bug when filtering for customer_id=0.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35852
+++ b/plugins/woocommerce/changelog/fix-35852
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix bug when filtering for customer_id=0.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -279,7 +279,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			? $request['customer']
 			: null;
 
-		if ( $cot_customer ) {
+		if ( ! is_null( $cot_customer ) ) {
 			unset( $request['customer'] );
 		}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a small bug where empty results are returning when passing customer=0 as a param for REST API. This was happening because we were unsettling the `customer` param with an `if` statement, but it would also hit the if condition when param is set to `0`. This PR fixes it by changing the check to use `is_null` instead.

Closes #35852

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create an order with guest as customer (so that customer_id is 0).
2. Create another order with a logged in user as customer.
3. Send an API request with customer=0 param like so: `/wc/v3/orders?customer=0&_fields=id,customer_id&orderby=id&order=desc`. 
4. Check that guest order id is present, but logged customer id is not present.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
