### PR TITLE
Set child orders to be children of current order parent before deleting.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35909
+++ b/plugins/woocommerce/changelog/fix-35909
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set child orders to be children of current order parent before deleting for consistency.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1766,7 +1766,9 @@ FROM $order_meta_table
 			 */
 			do_action( 'woocommerce_before_delete_order', $order_id, $order );
 
+			$this->unlink_child_orders( $order );
 			$this->delete_order_data_from_custom_order_tables( $order_id );
+
 			$order->set_id( 0 );
 
 			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
@@ -1794,6 +1796,19 @@ FROM $order_meta_table
 
 			do_action( 'woocommerce_trash_order', $order_id ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		}
+	}
+
+	private function unlink_child_orders( $order ) {
+		global $wpdb;
+		$order_table = self::get_orders_table_name();
+		$order_parent = $order->get_parent_id();
+		$wpdb->update(
+			$order_table,
+			array( 'parent_order_id' => $order_parent ),
+			array( 'parent_order_id' => $order->get_id() ),
+			array( '%d' ),
+			array( '%d' )
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1766,7 +1766,7 @@ FROM $order_meta_table
 			 */
 			do_action( 'woocommerce_before_delete_order', $order_id, $order );
 
-			$this->unlink_child_orders( $order );
+			$this->upshift_child_orders( $order );
 			$this->delete_order_data_from_custom_order_tables( $order_id );
 
 			$order->set_id( 0 );
@@ -1798,7 +1798,14 @@ FROM $order_meta_table
 		}
 	}
 
-	private function unlink_child_orders( $order ) {
+	/**
+	 * Helper method to set child orders to the parent order's parent.
+	 *
+	 * @param \WC_Abstract_Order $order Order object.
+	 *
+	 * @return void
+	 */
+	private function upshift_child_orders( $order ) {
 		global $wpdb;
 		$order_table = self::get_orders_table_name();
 		$order_parent = $order->get_parent_id();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1807,7 +1807,7 @@ FROM $order_meta_table
 	 */
 	private function upshift_child_orders( $order ) {
 		global $wpdb;
-		$order_table = self::get_orders_table_name();
+		$order_table  = self::get_orders_table_name();
 		$order_parent = $order->get_parent_id();
 		$wpdb->update(
 			$order_table,

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1900,6 +1900,25 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox When parent order is deleted, child orders should be upshifted.
+	 */
+	public function test_child_orders_are_promoted_when_parent_is_deleted() {
+		$this->toggle_cot( true );
+		$order = new WC_Order();
+		$order->save();
+
+		$child_order = new WC_Order();
+		$child_order->set_parent_id( $order->get_id() );
+		$child_order->save();
+
+		$this->assertEquals( $order->get_id(), $child_order->get_parent_id() );
+		$this->sut->delete( $order, array( 'force_delete' => true ) );
+		$child_order = wc_get_order( $child_order->get_id() );
+
+		$this->assertEquals( 0, $child_order->get_parent_id() );
+	}
+
+	/**
 	 * @testDox Make sure get_order return false when checking an order of different order types without warning.
 	 */
 	public function test_get_order_with_id_for_different_type() {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the posts table structure, when a post is deleted that has child orders, [WP would upshift all the child posts to the parent of deleted post](https://github.com/WordPress/WordPress/blob/master/wp-includes/post.php#L3420-L3427). We missed doing that for HPOS. This causes fatals when a parent post is deleted, but child posts are loaded, for example, by REST API or generally in the interface.

This PR fixes this issue by adding similar upshifts for child orders of deleted parent orders.

Closes #35909, #35850

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section). 
(Note: Dedicated testing is not required since it would be eventually covered in e2e tests in #36219)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

(Unfortunately, there is no good way to simulate this using the interface, so we will use REST API to do it).
1. Create a new order using API request like so: `POST /wc/v3/orders`. Data can be set to `{}`.
2. Create another order, but specify the parent as the order created in step 1. For example: `POST /wc/v3/orders` with data `{ "parent_id": xxxx}` where xxxx is the ID of order created in step 1.
3. Delete the first order like so: `DELETE /wc/v3/orders/xxxx?force=true`
4. Get the order from step 2 again `GET /wc/v3/orders/{child_order_id`. Check that it's not fatal, and that the parent id is set to `0`.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
