### PR TITLE
Properly handle product filtering query vars when front page is ‘shop’

### DIFF
--- a/plugins/woocommerce/changelog/fix-35983
+++ b/plugins/woocommerce/changelog/fix-35983
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix for product filters when 'shop' page is the front page.


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since 7.1, the version of `woocommerce-blocks` bundled with WC, [is registering query vars associated to product filters](https://github.com/woocommerce/woocommerce-blocks/blob/4a23b414870c1cf82c6e75f1b02cf9bd8aa4f52c/src/BlockTypes/ProductQuery.php#L30) (say `filter_color` or `filter_size`) as proper WP query vars for their filters.

When a product filter is in use, those `$_GET` params become query vars in the main query, which isn't a problem most of the time, but it is when the "shop" page is also the home page. That's because WP assumes the home page can only have [certain query vars active](https://github.com/WordPress/wordpress-develop/blob/d0fc6ddc711417e96fcdd8f9f672422f12a2245e/src/wp-includes/class-wp-query.php#L1032). Otherwise, the request is not considered a 'page' request and it's instead marked with `is_home = true` (which is incorrect in this case). This in turn breaks our code in `WC_Query` [which handles this scenario](https://github.com/woocommerce/woocommerce/blob/3daeac9a698f71f84619a37335d5289598a5b394/plugins/woocommerce/includes/class-wc-query.php#L320). The result is that the filters don't work and you get a weird posts page instead of products.

This PR permits `WC_Query` to "correct" the main query (by correctly setting `is_home`, `is_page`, `page_id`, etc.) when product filter query vars are in use.

Closes #35983.

### For discussion

The PR assumes we only want a few variables to be considered 'valid' variables on the front page, following what WP does. That said, this approach isn't flexible, as exemplified by breakage resulting from WC Blocks adding a few query vars. An alternative would be to just allow any query vars on this page (which would be even easier at the code level), but then this could possibly break other code too.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to Settings > Reading. Select the radio button labeled "A static page" and choose your "Shop" page from in the "Homepage" dropdown.
2. Go to Appearance > Widgets and add some product filter widgets, such as "Filter by attribute" or "Filter by price".
3. Go to your site's homepage.
4. You should see the regular "Shop" page with products.
5. Use any of the filter widgets to filter the results.
6. Confirm that:
   - On `trunk`, filtering doesn't work.
   - On this branch, filtering works.

<!-- End testing instructions —>

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] —>

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
