### PR TITLE
Remove button styles if the block theme has button styles defined in theme.json

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-button-styles-when-custom-block-theme
+++ b/plugins/woocommerce/changelog/fix-remove-button-styles-when-custom-block-theme
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove default WooCommerce button styles if using a block theme which adds button styles in theme.json

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -769,7 +769,6 @@ $tt2-gray: #f7f7f7;
 
 		#coupon_code,
 		.actions .button {
-			height: auto;
 			margin-right: 0;
 		}
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -121,6 +121,11 @@
 
 			+ .single_add_to_cart_button {
 				min-height: 51px;
+				// We need to remove top and bottom padding because we are setting a fixed
+				// height. This is to prevent the button from being cut off. !important is
+				// needed to override the Elements API styles, which also use !important.
+				padding-top: 0 !important;
+				padding-bottom: 0 !important;
 			}
 		}
 
@@ -306,8 +311,14 @@
 		#coupon_code,
 		.actions .button {
 			height: 50px;
-			padding: 0.9rem 1.1rem;
 			font-size: var(--wp--preset--font-size--small);
+			padding-left: 1.1rem;
+			padding-right: 1.1rem;
+			// We need to remove top and bottom padding because we are setting a fixed
+			// height. This is to prevent the button from being cut off. !important is
+			// needed to override the Elements API styles, which also use !important.
+			padding-top: 0 !important;
+			padding-bottom: 0 !important;
 		}
 
 		@media only screen and ( max-width: 768px ) {

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -600,6 +600,7 @@ p.demo_store,
 		}
 
 		.button {
+			display: inline-block;
 			margin-top: 1em;
 		}
 
@@ -682,98 +683,6 @@ p.demo_store,
 					background: $secondary;
 					color: darken($secondary, 40%);
 				}
-			}
-		}
-	}
-
-	/**
-	 * Buttons
-	 */
-	a.button,
-	button.button,
-	input.button,
-	#respond input#submit {
-		font-size: 100%;
-		margin: 0;
-		line-height: 1;
-		cursor: pointer;
-		position: relative;
-		text-decoration: none;
-		overflow: visible;
-		padding: 0.618em 1em;
-		font-weight: 700;
-		border-radius: 3px;
-		left: auto;
-		color: $secondarytext;
-		background-color: $secondary;
-		border: 0;
-		display: inline-block;
-		background-image: none;
-		box-shadow: none;
-		text-shadow: none;
-
-		&.loading {
-			opacity: 0.25;
-			padding-right: 2.618em;
-
-			&::after {
-				font-family: "WooCommerce";
-				content: "\e01c";
-				vertical-align: top;
-				font-weight: 400;
-				position: absolute;
-				top: 0.618em;
-				right: 1em;
-				animation: spin 2s linear infinite;
-			}
-		}
-
-		&.added::after {
-			font-family: "WooCommerce";
-			content: "\e017";
-			margin-left: 0.53em;
-			vertical-align: bottom;
-		}
-
-		&:hover {
-			background-color: darken($secondary, 5%);
-			text-decoration: none;
-			background-image: none;
-			color: $secondarytext;
-		}
-
-		&.alt {
-			background-color: $primary;
-			color: $primarytext;
-			-webkit-font-smoothing: antialiased;
-
-			&:hover {
-				background-color: darken($primary, 5%);
-				color: $primarytext;
-			}
-
-			&.disabled,
-			&:disabled,
-			&:disabled[disabled],
-			&.disabled:hover,
-			&:disabled:hover,
-			&:disabled[disabled]:hover {
-				background-color: $primary;
-				color: $primarytext;
-			}
-		}
-
-		&:disabled,
-		&.disabled,
-		&:disabled[disabled] {
-			color: inherit;
-			cursor: not-allowed;
-			opacity: 0.5;
-			padding: 0.618em 1em;
-
-			&:hover {
-				color: inherit;
-				background-color: $secondary;
 			}
 		}
 	}
@@ -1737,6 +1646,102 @@ p.demo_store,
 
 		.woocommerce-form-login__rememberme {
 			display: inline-block;
+		}
+	}
+}
+
+
+/**
+ * Buttons
+ */
+.woocommerce:where(body:not(.woocommerce-block-theme-has-button-styles)),
+:where(body:not(.woocommerce-block-theme-has-button-styles)) .woocommerce {
+	a.button,
+	button.button,
+	input.button,
+	#respond input#submit {
+		font-size: 100%;
+		margin: 0;
+		line-height: 1;
+		cursor: pointer;
+		position: relative;
+		text-decoration: none;
+		overflow: visible;
+		padding: 0.618em 1em;
+		font-weight: 700;
+		border-radius: 3px;
+		left: auto;
+		color: $secondarytext;
+		background-color: $secondary;
+		border: 0;
+		display: inline-block;
+		background-image: none;
+		box-shadow: none;
+		text-shadow: none;
+
+		&.loading {
+			opacity: 0.25;
+			padding-right: 2.618em;
+
+			&::after {
+				font-family: "WooCommerce";
+				content: "\e01c";
+				vertical-align: top;
+				font-weight: 400;
+				position: absolute;
+				top: 0.618em;
+				right: 1em;
+				animation: spin 2s linear infinite;
+			}
+		}
+
+		&.added::after {
+			font-family: "WooCommerce";
+			content: "\e017";
+			margin-left: 0.53em;
+			vertical-align: bottom;
+		}
+
+		&:hover {
+			background-color: darken($secondary, 5%);
+			text-decoration: none;
+			background-image: none;
+			color: $secondarytext;
+		}
+
+		&.alt {
+			background-color: $primary;
+			color: $primarytext;
+			-webkit-font-smoothing: antialiased;
+
+			&:hover {
+				background-color: darken($primary, 5%);
+				color: $primarytext;
+			}
+
+			&.disabled,
+			&:disabled,
+			&:disabled[disabled],
+			&.disabled:hover,
+			&:disabled:hover,
+			&:disabled[disabled]:hover {
+				background-color: $primary;
+				color: $primarytext;
+			}
+		}
+
+		&:disabled,
+		&.disabled,
+		&:disabled[disabled] {
+			color: inherit;
+			cursor: not-allowed;
+			opacity: 0.5;
+			padding: 0.618em 1em;
+
+			&:hover {
+				color: inherit;
+				background-color: $secondary;
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -541,3 +541,36 @@ function wc_wp_theme_get_element_class_name( $element ) {
 
 	return '';
 }
+
+/**
+ * Given an element name, returns true or false depending on whether the
+ * current theme has styles for that element defined in theme.json.
+ *
+ * If the theme is not a block theme or the WP-related function is not defined,
+ * return false.
+ *
+ * @param string $element The name of the element.
+ *
+ * @since 7.4.0
+ * @return bool
+ */
+function wc_block_theme_has_styles_for_element( $element ) {
+	if (
+		! wc_current_theme_is_fse_theme() ||
+		wc_wp_theme_get_element_class_name( $element ) === ''
+	) {
+		return false;
+	}
+
+	if ( function_exists( 'wp_get_global_styles' ) ) {
+		$global_styles = wp_get_global_styles();
+		if (
+			array_key_exists( 'elements', $global_styles ) &&
+			array_key_exists( $element, $global_styles['elements'] )
+		) {
+			return is_array( $global_styles['elements'][ $element ] );
+		}
+	}
+
+	return false;
+}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -339,6 +339,12 @@ function wc_body_class( $classes ) {
 		}
 	}
 
+	if ( wc_block_theme_has_styles_for_element( 'button' ) ) {
+
+		$classes[] = 'woocommerce-block-theme-has-button-styles';
+
+	}
+
 	$classes[] = 'woocommerce-no-js';
 
 	add_action( 'wp_footer', 'wc_no_js' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a `.woocommerce-block-theme-has-button-styles` class to the `body` element of the page if the theme in use is a block theme that defines button styles in `theme.json` using the Elements API. Using that class, we then disable all button styling provided by WC core (I used a `:where()` selector so these changes shouldn't affect the specificity of CSS selectors).

Closes https://github.com/woocommerce/woocommerce-blocks/issues/7972 (_Shop and product page_ buttons).

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Enable a theme which adds button styles via `theme.json` and is not Twenty Twenty-Three.
2. Go to the _Shop_ page.
3. Verify _Add to Cart_ buttons follow the theme style.

Before | After
--- | --
![imatge](https://user-images.githubusercontent.com/3616980/209929607-625c33c9-66f1-4648-9e87-3802e5e646e4.png) | ![imatge](https://user-images.githubusercontent.com/3616980/209929480-f151435f-3d90-47d8-a334-f8679137e0c9.png)


4. Go to the single product page.
5. Verify _Add to Cart_ button follows the theme style.

Before | After
--- | ---
![Single Product page with purple icon](https://user-images.githubusercontent.com/3616980/209928714-c07215ed-b917-437c-9c99-6306c8154c47.png) | ![Single Product page with button following theme styles](https://user-images.githubusercontent.com/3616980/209932623-f2b828fd-5cdb-4a8d-87cc-e38400b1839e.png)

6. Repeat the same in other pages with buttons. Ie: _Account details_, _Cart_ (with cart shortcode), _Checkout_ (with checkout shortcode), etc.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/209931185-9b0f625d-2cdc-4770-93a1-41b585a94078.png) | ![imatge](https://user-images.githubusercontent.com/3616980/209931164-e20902ee-07fa-4484-9c51-36bb6a562e83.png)

7. Now repeat the steps above with [Storefront](https://wordpress.org/themes/storefront/), another classic theme (ie: [GeneratePress](https://wordpress.org/themes/generatepress/)), [Twenty Twenty-Two](https://wordpress.org/themes/twentytwentytwo/) and [Twenty Twenty-Three](https://wordpress.org/themes/twentytwentythree/).
8. Verify in none of them there are any regressions between `trunk` and this branch.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
