### PR TITLE
Product variations should inherit parent product properties

### DIFF
--- a/packages/js/data/changelog/add-35989
+++ b/packages/js/data/changelog/add-35989
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add manage_stock parent value to product variation type definition

--- a/packages/js/data/src/product-variations/types.ts
+++ b/packages/js/data/src/product-variations/types.ts
@@ -55,13 +55,21 @@ export interface ProductVariationImage {
 
 export type ProductVariation = Omit<
 	Product,
-	'name' | 'slug' | 'attributes' | 'images'
+	'name' | 'slug' | 'attributes' | 'images' | 'manage_stock'
 > & {
 	attributes: ProductVariationAttribute[];
 	/**
 	 * Variation image data.
 	 */
 	image?: ProductVariationImage;
+	/**
+	 * Stock management at variation level. It can have a
+	 * 'parent' value if the parent product is managing
+	 * the stock at the time the variation was created.
+	 *
+	 * @default false
+	 */
+	manage_stock: boolean | 'parent';
 };
 
 type Query = Omit< ProductQuery, 'name' >;

--- a/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
@@ -36,8 +36,14 @@ export const ProductVariationFormActions: React.FC = () => {
 	const onSave = async () => {
 		setIsSaving( true );
 		updateProductVariation< Promise< ProductVariation > >(
-			{ id: variationId, product_id: productId },
-			values
+			{ id: variationId, product_id: productId, context: 'edit' },
+			{
+				...values,
+				manage_stock:
+					values.manage_stock === 'parent'
+						? undefined
+						: values?.manage_stock,
+			}
 		)
 			.then( () => {
 				createNotice(

--- a/plugins/woocommerce/changelog/add-35989
+++ b/plugins/woocommerce/changelog/add-35989
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Remove manage_stock 'parent' value before saving the variation


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35989

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create variations from a brand new product using the legacy experiance `Products -> Add New`.
2. Consider keeping all variations fields by default during creation.
3. Grab the productId and the variation id you want to test.
4. Make sure the parent product has an image, manage_stock set to true, sku, and dimensions set.
5. Visit `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}/variation/{variationId}`.
6. Under `General` tab and `Variant details` the first parent product image should be shown as the default variant image. It's possible to change the image or remove it. After saving the new changes the new image should persist across refreshs.
7. In `Pricing` tab the behabiour is the same but for now its require a backend implementation to keep the product pricing when changing a product from simple to variable. Consider variable products does not have pricing values when creating.
8. Under `Inventory` tab if parent product has manage_stock in true and is false in variation then the product quantity will be disabled and its not possible to edit them. If manage_stock is set to false in parent then the variation stock should be changeable.
10. Under `Shipping` tab, the default selected shipping class is now `Same as parent`, and under dimensions the fields should sown the parent product values as placeholders. After change them and save the variation, the new values should override the parent ones.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
