### PR TITLE
Allow product tab navigation without prompting for unsaved changes

### DIFF
--- a/packages/js/navigation/changelog/fix-36205
+++ b/packages/js/navigation/changelog/fix-36205
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix return value on parseAdminUrl

--- a/packages/js/navigation/src/index.js
+++ b/packages/js/navigation/src/index.js
@@ -314,7 +314,7 @@ export const isWCAdmin = ( url = window.location.href ) => {
  * Returns a parsed object for an absolute or relative admin URL.
  *
  * @param {*} url - the url to test.
- * @return {Object} - the URL object of the given url.
+ * @return {URL} - the URL object of the given url.
  */
 export const parseAdminUrl = ( url ) => {
 	if ( url.startsWith( 'http' ) ) {

--- a/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
+++ b/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
@@ -3,10 +3,16 @@
  */
 import { useContext, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { UNSAFE_NavigationContext as NavigationContext } from 'react-router-dom';
+import { parseAdminUrl } from '@woocommerce/navigation';
+import {
+	Location,
+	UNSAFE_NavigationContext as NavigationContext,
+	useLocation,
+} from 'react-router-dom';
 
 export default function usePreventLeavingPage(
 	hasUnsavedChanges: boolean,
+	shouldConfirm?: ( path: URL, fromUrl: Location ) => boolean,
 	/**
 	 * Some browsers ignore this message currently on before unload event.
 	 *
@@ -20,7 +26,9 @@ export default function usePreventLeavingPage(
 			__( 'Changes you made may not be saved.', 'woocommerce' ),
 		[ message ]
 	);
-	const { navigator } = useContext( NavigationContext );
+	const nav = useContext( NavigationContext );
+	const { navigator } = nav;
+	const fromUrl = useLocation();
 
 	// This effect prevent react router from navigate and show
 	// a confirmation message. It's a work around to beforeunload
@@ -30,6 +38,15 @@ export default function usePreventLeavingPage(
 			const push = navigator.push;
 
 			navigator.push = ( ...args: Parameters< typeof push > ) => {
+				const toUrl = parseAdminUrl( args[ 0 ] ) as URL;
+				if (
+					typeof shouldConfirm === 'function' &&
+					! shouldConfirm( toUrl, fromUrl )
+				) {
+					push( ...args );
+					return;
+				}
+
 				/* eslint-disable-next-line no-alert */
 				const result = window.confirm( confirmMessage );
 				if ( result !== false ) {

--- a/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
+++ b/plugins/woocommerce-admin/client/hooks/usePreventLeavingPage.ts
@@ -26,8 +26,7 @@ export default function usePreventLeavingPage(
 			__( 'Changes you made may not be saved.', 'woocommerce' ),
 		[ message ]
 	);
-	const nav = useContext( NavigationContext );
-	const { navigator } = nav;
+	const { navigator } = useContext( NavigationContext );
 	const fromUrl = useLocation();
 
 	// This effect prevent react router from navigate and show

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -24,6 +24,7 @@ import { store } from '@wordpress/viewport';
 /**
  * Internal dependencies
  */
+import { preventLeavingProductForm } from './utils/prevent-leaving-product-form';
 import usePreventLeavingPage from '~/hooks/usePreventLeavingPage';
 import { WooHeaderItem } from '~/header/utils';
 import { useProductHelper } from './use-product-helper';
@@ -47,13 +48,7 @@ export const ProductFormActions: React.FC = () => {
 	const { isDirty, isValidForm, values, resetForm } =
 		useFormContext< Product >();
 
-	usePreventLeavingPage( isDirty, ( toUrl, fromUrl ) => {
-		const toParams = new URLSearchParams( toUrl.search );
-		const fromParams = new URLSearchParams( fromUrl.search );
-		toParams.delete( 'tab' );
-		fromParams.delete( 'tab' );
-		return toParams.toString() !== fromParams.toString();
-	} );
+	usePreventLeavingPage( isDirty, preventLeavingProductForm );
 
 	useCustomerEffortScoreExitPageTracker(
 		! values.id ? 'new_product' : 'editing_new_product',

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -47,7 +47,14 @@ export const ProductFormActions: React.FC = () => {
 	const { isDirty, isValidForm, values, resetForm } =
 		useFormContext< Product >();
 
-	usePreventLeavingPage( isDirty );
+	usePreventLeavingPage( isDirty, ( toUrl, fromUrl ) => {
+		const toParams = new URLSearchParams( toUrl.search );
+		const fromParams = new URLSearchParams( fromUrl.search );
+		toParams.delete( 'tab' );
+		fromParams.delete( 'tab' );
+		return toParams.toString() !== fromParams.toString();
+	} );
+
 	useCustomerEffortScoreExitPageTracker(
 		! values.id ? 'new_product' : 'editing_new_product',
 		isDirty

--- a/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
@@ -16,6 +16,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { preventLeavingProductForm } from './utils/prevent-leaving-product-form';
 import usePreventLeavingPage from '~/hooks/usePreventLeavingPage';
 import { WooHeaderItem } from '~/header/utils';
 import './product-form-actions.scss';
@@ -30,7 +31,7 @@ export const ProductVariationFormActions: React.FC = () => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isSaving, setIsSaving ] = useState( false );
 
-	usePreventLeavingPage( isDirty );
+	usePreventLeavingPage( isDirty, preventLeavingProductForm );
 
 	const onSave = async () => {
 		setIsSaving( true );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -25,8 +25,8 @@ const onDraftCES = jest.fn().mockResolvedValue( {} );
 
 jest.mock( '@wordpress/plugins', () => ( { registerPlugin: jest.fn() } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	...jest.requireActual( '@wordpress/data' ),
+jest.mock( '@woocommerce/data', () => ( {
+	...jest.requireActual( '@woocommerce/data' ),
 	useDispatch: jest.fn().mockReturnValue( { updateOptions: jest.fn() } ),
 	useSelect: jest.fn().mockReturnValue( { productCESAction: 'hide' } ),
 } ) );

--- a/plugins/woocommerce-admin/client/products/utils/prevent-leaving-product-form.ts
+++ b/plugins/woocommerce-admin/client/products/utils/prevent-leaving-product-form.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { Location } from 'react-router-dom';
+
+/**
+ * Allow switching between tabs without prompting for unsaved changes.
+ */
+export const preventLeavingProductForm = ( toUrl: URL, fromUrl: Location ) => {
+	const toParams = new URLSearchParams( toUrl.search );
+	const fromParams = new URLSearchParams( fromUrl.search );
+	toParams.delete( 'tab' );
+	fromParams.delete( 'tab' );
+	return toParams.toString() !== fromParams.toString();
+};

--- a/plugins/woocommerce-admin/client/products/utils/test/prevent-leaving-product-form.test.ts
+++ b/plugins/woocommerce-admin/client/products/utils/test/prevent-leaving-product-form.test.ts
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { Location } from 'react-router-dom';
+
+/**
+ * Internal dependencies
+ */
+import { preventLeavingProductForm } from '../prevent-leaving-product-form';
+
+describe( 'preventLeavingProductForm', () => {
+	it( 'should allow leaving when the paths are identical', () => {
+		const toUrl = new URL(
+			'http://mysite.com/admin.php?page=wc-admin&path=/product/123&tab=general'
+		);
+		const fromUrl = {
+			search: 'admin.php?page=wc-admin&path=/product/123&tab=general',
+		} as Location;
+		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		expect( shouldPrevent ).toBe( true );
+	} );
+
+	it( 'should prevent leaving when the paths are different', () => {
+		const toUrl = new URL(
+			'http://mysite.com/admin.php?page=wc-admin&path=/product/456&tab=general'
+		);
+		const fromUrl = {
+			search: 'admin.php?page=wc-admin&path=/product/123&tab=general',
+		} as Location;
+		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		expect( shouldPrevent ).toBe( true );
+	} );
+
+	it( 'should allow leaving when the paths are the same but the tab is different', () => {
+		const toUrl = new URL(
+			'http://mysite.com/admin.php?page=wc-admin&path=/product/123&tab=general'
+		);
+		const fromUrl = {
+			search: 'admin.php?page=wc-admin&path=/product/123&tab=shipping',
+		} as Location;
+		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		expect( shouldPrevent ).toBe( true );
+	} );
+
+	it( 'should prevent leaving when non-tab params are different', () => {
+		const toUrl = new URL(
+			'http://mysite.com/admin.php?page=wc-admin&path=/product/123&tab=general&other_param=a'
+		);
+		const fromUrl = {
+			search: 'admin.php?page=wc-admin&path=/product/123&tab=shipping&other_param=b',
+		} as Location;
+		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		expect( shouldPrevent ).toBe( true );
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-36205
+++ b/plugins/woocommerce/changelog/fix-36205
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Allow product tab navigation without prompting for unsaved changes


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, attempting to navigate between tabs on the same product form would trigger the unsaved changes warning if any form changes existed.  This PR allows navigation between the tabs without that warning.

Closes #36205  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product experience (Products -> Add new (MVP))
2. Add some changes to the form, but don't save
3. Click on the tabs (General/Inventory/Shipping/etc)
4. Make sure you can navigate without being prompted to save changes
5. Click to any other page (try non-React pages such as legacy pages and React pages such as Analytics)
6. Make sure you are still prompted to save changes before leaving

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
