### PR TITLE
Fix attributes/options lists corrupt render

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -24,7 +24,10 @@ import { getAdminLink } from '@woocommerce/settings';
 import './attribute-field.scss';
 import { AddAttributeModal } from './add-attribute-modal';
 import { EditAttributeModal } from './edit-attribute-modal';
-import { reorderSortableProductAttributePositions } from './utils';
+import {
+	getAttributeKey,
+	reorderSortableProductAttributePositions,
+} from './utils';
 import { sift } from '../../../utils';
 import { AttributeEmptyState } from '../attribute-empty-state';
 import {
@@ -247,7 +250,7 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 			keyValue: Record< number | string, ProductAttribute >,
 			attribute: ProductAttribute
 		) => {
-			keyValue[ attribute.position ] = attribute;
+			keyValue[ getAttributeKey( attribute ) ] = attribute;
 			return keyValue;
 		},
 		{} as Record< number, ProductAttribute >

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/attribute-field.tsx
@@ -244,10 +244,10 @@ export const AttributeField: React.FC< AttributeFieldProps > = ( {
 	);
 	const attributeKeyValues = filteredAttributes.reduce(
 		(
-			keyValue: Record< number, ProductAttribute >,
+			keyValue: Record< number | string, ProductAttribute >,
 			attribute: ProductAttribute
 		) => {
-			keyValue[ attribute.id ] = attribute;
+			keyValue[ attribute.position ] = attribute;
 			return keyValue;
 		},
 		{} as Record< number, ProductAttribute >

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/test/utils.spec.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/test/utils.spec.ts
@@ -6,7 +6,10 @@ import { ProductAttribute } from '@woocommerce/data';
 /**
  * Internal dependencies
  */
-import { reorderSortableProductAttributePositions } from '../utils';
+import {
+	getAttributeKey,
+	reorderSortableProductAttributePositions,
+} from '../utils';
 
 const attributeList: Record< number, ProductAttribute > = {
 	15: {
@@ -38,9 +41,9 @@ const attributeList: Record< number, ProductAttribute > = {
 describe( 'reorderSortableProductAttributePositions', () => {
 	it( 'should update product attribute positions depending on JSX.Element order', () => {
 		const elements = [
-			{ key: '3' },
-			{ key: '15' },
-			{ key: '1' },
+			{ props: { attribute: attributeList[ '3' ] } },
+			{ props: { attribute: attributeList[ '15' ] } },
+			{ props: { attribute: attributeList[ '1' ] } },
 		] as JSX.Element[];
 		const newList = reorderSortableProductAttributePositions(
 			elements,
@@ -53,19 +56,19 @@ describe( 'reorderSortableProductAttributePositions', () => {
 		expect( newList[ 2 ].position ).toEqual( 2 );
 		expect( newList[ 2 ].id ).toEqual( 1 );
 	} );
+} );
 
-	it( 'should filter out elements that do not contain a key', () => {
-		const elements = [
-			{ key: '3' },
-			{},
-			{ key: '15' },
-			{},
-			{ key: '1' },
-		] as JSX.Element[];
-		const newList = reorderSortableProductAttributePositions(
-			elements,
-			attributeList
-		);
-		expect( newList.length ).toEqual( 3 );
+describe( 'getAttributeKey', () => {
+	attributeList[ '20' ] = {
+		id: 0,
+		name: 'Quality',
+		position: 3,
+		visible: true,
+		variation: true,
+		options: [ 'low', 'high' ],
+	};
+	it( 'should return the attribute key', () => {
+		expect( getAttributeKey( attributeList[ '15' ] ) ).toEqual( 15 );
+		expect( getAttributeKey( attributeList[ '20' ] ) ).toEqual( 'Quality' );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
@@ -14,11 +14,11 @@ export function reorderSortableProductAttributePositions(
 	attributeKeyValues: Record< number, ProductAttribute >
 ): ProductAttribute[] {
 	return items
-		.map( ( item, index ): ProductAttribute | undefined => {
-			const key = item.key ? parseInt( item.key as string, 10 ) : NaN;
-			if ( key !== NaN && attributeKeyValues[ key ] ) {
+		.map( ( { props }, index ): ProductAttribute | undefined => {
+			const position = props?.attribute ? props?.attribute.position : NaN;
+			if ( ! isNaN( position ) && attributeKeyValues[ position ] ) {
 				return {
-					...attributeKeyValues[ key ],
+					...attributeKeyValues[ position ],
 					position: index,
 				};
 			}

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
@@ -27,8 +27,6 @@ export function reorderSortableProductAttributePositions(
 ): ProductAttribute[] {
 	return items
 		.map( ( { props }, index ): ProductAttribute | undefined => {
-			// const position = props?.attribute ? props?.attribute.position : NaN;
-			// if ( ! isNaN( position ) && attributeKeyValues[ position ] ) {
 			const key = getAttributeKey( props?.attribute );
 			if ( attributeKeyValues[ key ] ) {
 				return {

--- a/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
+++ b/plugins/woocommerce-admin/client/products/fields/attribute-field/utils.ts
@@ -4,6 +4,18 @@
 import { ProductAttribute } from '@woocommerce/data';
 
 /**
+ * Returns the attribute key. The key will be the `id` or the `name` when the id is 0.
+ *
+ * @param { ProductAttribute } attribute product attribute.
+ * @return string|number
+ */
+export function getAttributeKey(
+	attribute: ProductAttribute
+): number | string {
+	return attribute.id !== 0 ? attribute.id : attribute.name;
+}
+
+/**
  * Updates the position of a product attribute from the new items JSX.Element list.
  *
  * @param { JSX.Element[] } items              list of JSX elements coming back from sortable container.
@@ -11,14 +23,16 @@ import { ProductAttribute } from '@woocommerce/data';
  */
 export function reorderSortableProductAttributePositions(
 	items: JSX.Element[],
-	attributeKeyValues: Record< number, ProductAttribute >
+	attributeKeyValues: Record< number | string, ProductAttribute >
 ): ProductAttribute[] {
 	return items
 		.map( ( { props }, index ): ProductAttribute | undefined => {
-			const position = props?.attribute ? props?.attribute.position : NaN;
-			if ( ! isNaN( position ) && attributeKeyValues[ position ] ) {
+			// const position = props?.attribute ? props?.attribute.position : NaN;
+			// if ( ! isNaN( position ) && attributeKeyValues[ position ] ) {
+			const key = getAttributeKey( props?.attribute );
+			if ( attributeKeyValues[ key ] ) {
 				return {
-					...attributeKeyValues[ position ],
+					...attributeKeyValues[ key ],
 					position: index,
 				};
 			}

--- a/plugins/woocommerce/changelog/fix-36190_attribute_lists_corrupt_renders
+++ b/plugins/woocommerce/changelog/fix-36190_attribute_lists_corrupt_renders
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix attribute lists corrupt renders
+Fix attributes/options lists corrupt render #36236

--- a/plugins/woocommerce/changelog/fix-36190_attribute_lists_corrupt_renders
+++ b/plugins/woocommerce/changelog/fix-36190_attribute_lists_corrupt_renders
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix attribute lists corrupt renders


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes the `Attributes` and `Options` lists. Reordering the list items broke the lists.

Closes #36190.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Add some attributes or options to a product (create at least one local and one global attribute or option).
2. Reorder the attributes.
3. No attribute should be repeated or missing.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
