### PR TITLE
Fix navigation between variations and tab selection

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.tsx
@@ -202,7 +202,8 @@ export const Variations: React.FC = () => {
 							<Link
 								href={ getNewPath(
 									{},
-									`/product/${ productId }/variation/${ variation.id }`
+									`/product/${ productId }/variation/${ variation.id }`,
+									{}
 								) }
 								type="wc-admin"
 								className="components-button"

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-variation-navigation.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-variation-navigation.ts
@@ -33,13 +33,15 @@ export default function useProductVariationNavigation( {
 		prevHref: prevVariationId
 			? getNewPath(
 					persistedQuery,
-					`/product/${ product.id }/variation/${ prevVariationId }`
+					`/product/${ product.id }/variation/${ prevVariationId }`,
+					{}
 			  )
 			: undefined,
 		nextHref: nextVariationId
 			? getNewPath(
 					persistedQuery,
-					`/product/${ product.id }/variation/${ nextVariationId }`
+					`/product/${ product.id }/variation/${ nextVariationId }`,
+					{}
 			  )
 			: undefined,
 	};

--- a/plugins/woocommerce-admin/client/products/product-variation-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.tsx
@@ -50,7 +50,7 @@ export const ProductVariationForm: React.FC< {
 			ref={ formRef }
 		>
 			<ProductVariationFormHeader />
-			<ProductFormLayout>
+			<ProductFormLayout key={ productVariation.id }>
 				<ProductFormTab name="general" title="General">
 					<ProductVariationDetailsSection />
 				</ProductFormTab>

--- a/plugins/woocommerce/changelog/fix-36237
+++ b/plugins/woocommerce/changelog/fix-36237
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix navigation between variations and tab selection


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the issue where the variations page does not load initially when clicking “Edit.”

<img width="251" alt="Screen Shot 2022-12-30 at 7 20 46 AM" src="https://user-images.githubusercontent.com/10561050/210085986-bd674708-1325-4f54-9c47-c02a63a62dca.png">

Closes #36237  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->



### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some variations in the legacy experience
2. Navigate to the product in the new experience `admin.php?page=wc-admin&path=/{product_id}`
3. Click “Edit” on a variation
4. Make sure the “General” tab is loaded
<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
