### PR TITLE
Fix signature mismatch in WC CLI command api calls

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-cli-commands
+++ b/plugins/woocommerce/changelog/fix-wc-cli-commands
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the signature mismatch affecting wc cli commands ability to fetch user subscription data.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1280,6 +1280,8 @@ class WC_Helper {
 			$source = 'inbox-notes';
 		elseif ( stripos( $request_uri, 'admin-ajax.php' ) ) :
 			$source = 'heartbeat-api';
+		elseif ( defined( 'WP_CLI' ) && WP_CLI ) :
+			$source = 'wc-cli';
 		endif;
 
 		// Obtain the connected user info.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1289,7 +1289,7 @@ class WC_Helper {
 			'subscriptions',
 			array(
 				'authenticated' => true,
-				'query_string'  => esc_url( '?source=' . $source ),
+				'query_string'  => '' !== $source ? esc_url( '?source=' . $source ) : '',
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, the WC CLI command for listing user subscriptions (`wp wc com extension list`) is not working. Due to this `wp wc extension install` used for installing extensions via CLI is also affected.

This PR fixes `wp wc com extension list` command by correcting how the helper API client is calculating the request signature when the source parameter is empty.

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Make sure the site is connected to WCCOM via `<your test site root>wp-admin/admin.php?page=wc-addons&section=helper`
2. Run `wp wc com extension list`
3. This should display a list of extensions available for the site.
![Screenshot 2022-07-08 at 15 24 13](https://user-images.githubusercontent.com/1531403/178000645-5e54bc84-6520-41df-ae2a-ed52acf6120d.png)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
