### PR TITLE
Convert HTML to blocks in product variation description

### DIFF
--- a/plugins/woocommerce-admin/client/products/sections/product-variation-details-section.tsx
+++ b/plugins/woocommerce-admin/client/products/sections/product-variation-details-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockInstance, serialize, parse } from '@wordpress/blocks';
+import { BlockInstance, serialize, rawHandler } from '@wordpress/blocks';
 import {
 	CheckboxControl,
 	Card,
@@ -55,7 +55,7 @@ export const ProductVariationDetailsSection: React.FC = () => {
 
 	const [ descriptionBlocks, setDescriptionBlocks ] = useState<
 		BlockInstance[]
-	>( parse( values.description || '' ) );
+	>( rawHandler( { HTML: values.description } ) );
 
 	const imageFieldProps = getInputProps( 'image' );
 

--- a/plugins/woocommerce/changelog/fix-36206
+++ b/plugins/woocommerce/changelog/fix-36206
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Convert HTML to blocks in product variation description


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes an issue with the description not being persisted for variations.  The description gets sanitized on the server, removing block tags.  We convert the HTML into blocks on component mount to get around this.

Note that the HTML is still shown in the legacy experience, but I think that this is okay since this is valid and will be shown correctly on the frontend.  For example, a user would add an HTML `ima` tag in the legacy experience in order to show images.

<img width="818" alt="Screen Shot 2022-12-30 at 1 11 02 PM" src="https://user-images.githubusercontent.com/10561050/210111883-f9a1c8c5-1a57-46d7-9f28-9082d175fcaa.png">


Closes #36206  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some variations using the legacy experience
2. Navigate to the new product experience for that variation using the product ID and variation ID in this URL `admin.php?page=wc-admin&path=/{product_id}/variation/{variation_id}&tab=general`
3. Enter some text/blocks in the description field
4. Save the item (note that you may need to update the SKU and toggle the manage stock toggle under “Inventory” to make this a valid product until this bug is resolved)
5. Refresh the page
6. Note that the description is persisted and shown on refresh
7. View the product on the frontend and note that the description is shown as expected

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
