### PR TITLE
Derive product type from product attributes

### DIFF
--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -21,6 +21,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { CurrencyContext } from '../lib/currency-context';
+import { getDerivedProductType } from './utils/get-derived-product-type';
 import {
 	NUMBERS_AND_DECIMAL_SEPARATOR,
 	ONLY_ONE_DECIMAL_SEPARATOR,
@@ -70,8 +71,8 @@ export function useProductHelper() {
 	/**
 	 * Create product with status.
 	 *
-	 * @param {Product} product the product to be created.
-	 * @param {string}  status the product status.
+	 * @param {Product} product    the product to be created.
+	 * @param {string}  status     the product status.
 	 * @param {boolean} skipNotice if the notice should be skipped (default: false).
 	 * @return {Promise<Product>} Returns a promise with the created product.
 	 */
@@ -88,6 +89,7 @@ export function useProductHelper() {
 			return createProduct( {
 				...product,
 				status,
+				type: getDerivedProductType( product ),
 			} ).then(
 				( newProduct ) => {
 					if ( ! skipNotice ) {
@@ -163,9 +165,9 @@ export function useProductHelper() {
 	/**
 	 * Update product with status.
 	 *
-	 * @param {number} productId the product id to be updated.
-	 * @param {Product} product the product to be updated.
-	 * @param {string}  status the product status.
+	 * @param {number}  productId  the product id to be updated.
+	 * @param {Product} product    the product to be updated.
+	 * @param {string}  status     the product status.
 	 * @param {boolean} skipNotice if the notice should be skipped (default: false).
 	 * @return {Promise<Product>} Returns a promise with the updated product.
 	 */
@@ -183,6 +185,7 @@ export function useProductHelper() {
 			return updateProduct( productId, {
 				...product,
 				status,
+				type: getDerivedProductType( product ),
 			} )
 				.then( async ( updatedProduct ) =>
 					updateVariationsOrder(
@@ -242,7 +245,7 @@ export function useProductHelper() {
 	 * Creates a copy of the given product with the given status.
 	 *
 	 * @param {Product} product the product to be copied.
-	 * @param {string}  status the product status.
+	 * @param {string}  status  the product status.
 	 * @return {Promise<Product>} promise with the newly created and copied product.
 	 */
 	const copyProductWithStatus = useCallback(

--- a/plugins/woocommerce-admin/client/products/utils/get-derived-product-type.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-derived-product-type.ts
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+
+export const getDerivedProductType = ( product: Partial< Product > ) => {
+	const hasOptions = !! product.attributes?.find(
+		( attribute ) => attribute.options.length && attribute.variation
+	);
+
+	if ( hasOptions ) {
+		return 'variable';
+	}
+
+	return 'simple';
+};

--- a/plugins/woocommerce-admin/client/products/utils/test/get-derived-product-type.ts
+++ b/plugins/woocommerce-admin/client/products/utils/test/get-derived-product-type.ts
@@ -1,0 +1,73 @@
+/**
+ * Internal dependencies
+ */
+import { getDerivedProductType } from '../get-derived-product-type';
+
+describe( 'getDerivedProductType', () => {
+	it( 'should be simple when no attributes exist', () => {
+		const type = getDerivedProductType( {
+			id: 123,
+			attributes: [],
+		} );
+		expect( type ).toBe( 'simple' );
+	} );
+
+	it( 'should be simple when no attributes used for variations exist', () => {
+		const type = getDerivedProductType( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Color',
+					options: [ 'Red', 'Blue' ],
+					position: 0,
+					variation: false,
+					visible: true,
+				},
+			],
+		} );
+		expect( type ).toBe( 'simple' );
+	} );
+
+	it( 'should be simple when no options exist for a variation', () => {
+		const type = getDerivedProductType( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Color',
+					options: [],
+					position: 0,
+					variation: true,
+					visible: true,
+				},
+			],
+		} );
+		expect( type ).toBe( 'simple' );
+	} );
+
+	it( 'should be variable when at least one attribute can be used for variations', () => {
+		const type = getDerivedProductType( {
+			id: 123,
+			attributes: [
+				{
+					id: 0,
+					name: 'Size',
+					options: [ 'Small', 'Medium' ],
+					position: 0,
+					variation: false,
+					visible: true,
+				},
+				{
+					id: 0,
+					name: 'Color',
+					options: [ 'Red', 'Blue' ],
+					position: 1,
+					variation: true,
+					visible: true,
+				},
+			],
+		} );
+		expect( type ).toBe( 'variable' );
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-36204
+++ b/plugins/woocommerce/changelog/fix-36204
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Derive product type from product attributes


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR derives the product type based on attributes and sets this type on product creation or update.

This has potential to become very complex with all the product types and custom product types and we’ll have to consider extensibility long-term.  But for the MVP, I think we can stick to `variable` and `simple` product types.

Closes #36204 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a product with some variations in the legacy experience
2. Navigate to the product in the new experience `admin.php?page=wc-admin&path=/{product_id}`
3. Make some changes and save
4. Make sure the product type is variable (either under the Network tab where the request is made in your browser or by visiting the product in the legacy experience)
5. Delete all the options using the new product experience (not variations)
6. Make some changes to price or other fields that can’t normally be used in variable products
7. Update the product and note the changes are persisted and the type has been changed to “simple.”


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
