### PR TITLE
Update unread note count copy

### DIFF
--- a/packages/js/components/changelog/update-34929-copy
+++ b/packages/js/components/changelog/update-34929-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Allow longer copy in the badge component

--- a/packages/js/components/src/badge/style.scss
+++ b/packages/js/components/src/badge/style.scss
@@ -8,6 +8,7 @@
 	font-size: 14px;
 	line-height: 27px;
 	align-items: center;
-	width: 32px;
-	height: 28px;
+	min-width: 32px;
+	min-height: 28px;
+	padding: 0 $gap-smaller;
 }

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import {
 	EmptyContent,
@@ -10,6 +10,7 @@ import {
 	EllipsisMenu,
 } from '@woocommerce/components';
 import { Card, CardHeader, Button, CardFooter } from '@wordpress/components';
+import interpolateComponents from '@automattic/interpolate-components';
 import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -126,18 +127,22 @@ const renderNotes = ( {
 						<Text size="20" lineHeight="28px" variant="title.small">
 							{ __( 'Inbox', 'woocommerce' ) }
 						</Text>
-						<Badge
-							count={ sprintf(
-								/* translators: Number of unread notes */
-								_n(
-									'%d new message since your last visit',
-									'%d new messages since your last visit',
-									unreadNotesCount,
+						<Text
+							size="14"
+							lineHeight="28px"
+							variant="title.small"
+							className="wooocommerce-inbox-card__header-unread-messages"
+						>
+							{ interpolateComponents( {
+								mixedString: __(
+									'New messages since last visit: {{count /}}',
 									'woocommerce'
 								),
-								unreadNotesCount
-							) }
-						/>
+								components: {
+									count: <Badge count={ unreadNotesCount } />,
+								},
+							} ) }
+						</Text>
 					</div>
 					<EllipsisMenu
 						label={ __( 'Inbox Notes Options', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/inbox-panel/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import {
 	EmptyContent,
@@ -126,7 +126,18 @@ const renderNotes = ( {
 						<Text size="20" lineHeight="28px" variant="title.small">
 							{ __( 'Inbox', 'woocommerce' ) }
 						</Text>
-						<Badge count={ unreadNotesCount } />
+						<Badge
+							count={ sprintf(
+								/* translators: Number of unread notes */
+								_n(
+									'%d new message since your last visit',
+									'%d new messages since your last visit',
+									unreadNotesCount,
+									'woocommerce'
+								),
+								unreadNotesCount
+							) }
+						/>
 					</div>
 					<EllipsisMenu
 						label={ __( 'Inbox Notes Options', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/inbox-panel/index.scss
+++ b/plugins/woocommerce-admin/client/inbox-panel/index.scss
@@ -2,6 +2,14 @@
 	margin: 0 $gap-large;
 }
 
+.wooocommerce-inbox-card__header {
+	display: flex;
+}
+
+.wooocommerce-inbox-card__header-unread-messages {
+	margin-left: $gap;
+}
+
 .woocommerce-layout__inbox-panel-header {
 	padding: $gap-large;
 

--- a/plugins/woocommerce/changelog/update-34929-copy
+++ b/plugins/woocommerce/changelog/update-34929-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update unread note count badge copy


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the copy in the badge for unread note count and allows longer text inside of badges.  cc @pmcpinto @jarekmorawski 
<img width="398" alt="Screen Shot 2022-12-30 at 1 59 52 PM" src="https://user-images.githubusercontent.com/10561050/210114441-71834df7-273e-41d7-9510-755f44cfa5f7.png">



<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a site with at least 1 or more unread notes
2. Visit the home page and scroll down to see the notes
3. Note the unread copy text "X new messages since your last visit"

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
