### PR TITLE
Adding translator's comments to the shipping prefix to enhance transl…

### DIFF
--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -410,7 +410,13 @@ class WC_Countries {
 	public function shipping_to_prefix( $country_code = '' ) {
 		$country_code = $country_code ? $country_code : WC()->customer->get_shipping_country();
 		$countries    = array( 'AE', 'CZ', 'DO', 'GB', 'NL', 'PH', 'US', 'USAF' );
-		$return       = in_array( $country_code, $countries, true ) ? __( 'to the', 'woocommerce' ) : __( 'to', 'woocommerce' );
+		if ( in_array( $country_code, $countries, true ) ) {
+			/* translators: prefix for shipping countries that differ from the form 'to country', e.g. 'to the USA' */
+			$return =  __( 'to the', 'woocommerce' )
+		} else {
+			/* translators: prefix for shipping country, e.g. 'to Germany' */
+			$return =  __( 'to', 'woocommerce' );
+		}
 
 		return apply_filters( 'woocommerce_countries_shipping_to_prefix', $return, $country_code );
 	}


### PR DESCRIPTION
I think it needed more than translator’s comments to make this principle of creating the right prefixes work. For example in german we would need Switzerland to be added to the list of countries needing the "to the"-prefix, while UK would need it's own, different kind of prefix ('in die ...' <> 'in das ...'). And I have no clue about other languages, but I assume it could get even more difficult there. But for the moment,  I propose the changes appended.


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
