### PR TITLE
E2e/fix obw industry spec

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-obw-industry-spec
+++ b/plugins/woocommerce/changelog/e2e-fix-obw-industry-spec
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flakiness of the `can save industry changes when navigating back to "Store Details"` E2E test.

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -27,6 +27,10 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 			storeDetails.us.expectedIndustries
 		);
 		await page.click( 'button >> text=Continue' );
+		await expect( page ).toHaveURL( /.*step=product-types/ );
+		await expect(
+			page.locator( '.product-types button >> text=Continue' )
+		).toBeVisible();
 	} );
 
 	// eslint-disable-next-line jest/expect-expect

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -45,8 +45,8 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 
 		// Navigate back to "Store Details" section
 		await page.click( 'button >> text=Store Details' );
-
 		await onboarding.handleSaveChangesModal( page, { saveChanges: true } );
+		await page.locator( 'text="Welcome to WooCommerce"' ).waitFor();
 
 		// Navigate back to "Industry" section
 		await page.click( 'button >> text=Industry' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

### Changes proposed in this Pull Request:

Fixes recent flakiness in the `can save industry changes when navigating back to "Store Details"` E2E test by adding some assertions.

Closes #36259.

### How to test the changes in this Pull Request:

1. Go to https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml
2. Click on the "Run workflow" dropdown > select the branch of this PR (`e2e/fix-obw-industry-spec`) > then click "Run workflow. 
3. Wait for it to finish.
4. Verify that all the E2E tests passed:
    <img width="265" alt="Screen Shot 2023-01-02 at 7 47 48 PM" src="https://user-images.githubusercontent.com/4509348/210273169-b8e1aebb-62a0-4573-94af-f288555fa1a7.png">

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
