### PR TITLE
Make secondQuestion  and title params optional in CES Prompt

### DIFF
--- a/packages/js/customer-effort-score/README.md
+++ b/packages/js/customer-effort-score/README.md
@@ -29,12 +29,14 @@ export function CustomerEffortScoreConsole( { label } ) {
     const onNoticeShown = () => console.log( 'onNoticeShown' );
     const onModalShown = () => console.log( 'onModalShown' );
     const onNoticeDismissed = () => console.log( 'onNoticeDismissed' );
-    const recordScore = ( score, comments ) => console.log( { score, comments } );
+    const recordScore = ( score, score2, comments ) => console.log( { score, score2, comments } );
 
     return (
         <CustomerEffortScore
 			recordScoreCallback={ recordScore }
-			label={ label }
+			title="My title" 
+            firstQuestion="My first question"
+            secondQuestion="My optional second question"
 			onNoticeShownCallback={ onNoticeShown }
 			onNoticeDismissedCallback={ onNoticeDismissed }
 			onModalShownCallback={ onModalShown }
@@ -62,7 +64,8 @@ const MyComponent = function() {
 		setCeses( 
 			ceses.concat( 
 				<CustomerEffortScoreConsole
-					label={ `survey ${ceses.length + 1}` }
+					title={ `survey ${ceses.length + 1}` }
+                    firstQuestion="My first question"
 					key={ ceses.length + 1 }
 				/> 
 			) 

--- a/packages/js/customer-effort-score/changelog/update-customer-effort-score
+++ b/packages/js/customer-effort-score/changelog/update-customer-effort-score
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Set secondQuestion and title as optional

--- a/packages/js/customer-effort-score/src/customer-effort-score.tsx
+++ b/packages/js/customer-effort-score/src/customer-effort-score.tsx
@@ -19,11 +19,11 @@ type CustomerEffortScoreProps = {
 		secondScore: number,
 		comments: string
 	) => void;
-	title: string;
+	title?: string;
 	description?: string;
 	noticeLabel?: string;
 	firstQuestion: string;
-	secondQuestion: string;
+	secondQuestion?: string;
 	onNoticeShownCallback?: () => void;
 	onNoticeDismissedCallback?: () => void;
 	onModalShownCallback?: () => void;
@@ -39,11 +39,11 @@ type CustomerEffortScoreProps = {
  *
  * @param {Object}   props                           Component props.
  * @param {Function} props.recordScoreCallback       Function to call when the score should be recorded.
- * @param {string}   props.title                     The title displayed in the modal.
+ * @param {string}   [props.title]                   The title displayed in the modal.
  * @param {string}   props.description               The description displayed in the modal.
  * @param {string}   props.noticeLabel               The notice label displayed in the notice.
  * @param {string}   props.firstQuestion             The first survey question.
- * @param {string}   props.secondQuestion            The second survey question.
+ * @param {string}   [props.secondQuestion]          The second survey question.
  * @param {Function} props.onNoticeShownCallback     Function to call when the notice is shown.
  * @param {Function} props.onNoticeDismissedCallback Function to call when the notice is dismissed.
  * @param {Function} props.onModalShownCallback      Function to call when the modal is shown.
@@ -120,7 +120,7 @@ CustomerEffortScore.propTypes = {
 	/**
 	 * The title displayed in the modal.
 	 */
-	title: PropTypes.string.isRequired,
+	title: PropTypes.string,
 	/**
 	 * The function to call when the notice is shown.
 	 */
@@ -137,6 +137,14 @@ CustomerEffortScore.propTypes = {
 	 * Icon (React component) to be displayed.
 	 */
 	icon: PropTypes.element,
+	/**
+	 * The first survey question.
+	 */
+	firstQuestion: PropTypes.string.isRequired,
+	/**
+	 * The second survey question.
+	 */
+	secondQuestion: PropTypes.string,
 };
 
 export { CustomerEffortScore };

--- a/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -28,14 +28,14 @@ import { __ } from '@wordpress/i18n';
  * @param {string}   props.title               Title displayed in the modal.
  * @param {string}   props.description         Description displayed in the modal.
  * @param {string}   props.firstQuestion       The first survey question.
- * @param {string}   props.secondQuestion      The second survey question.
+ * @param {string}   [props.secondQuestion]    An optional second survey question.
  * @param {string}   props.defaultScore        Default score.
  * @param {Function} props.onCloseModal        Callback for when user closes modal by clicking cancel.
  * @param {Function} props.customOptions       List of custom score options, contains label and value.
  */
 function CustomerFeedbackModal( {
 	recordScoreCallback,
-	title,
+	title = __( 'Please share your feedback', 'woocommerce' ),
 	description,
 	firstQuestion,
 	secondQuestion,
@@ -48,10 +48,10 @@ function CustomerFeedbackModal( {
 		secondScore: number,
 		comments: string
 	) => void;
-	title: string;
+	title?: string;
 	description?: string;
 	firstQuestion: string;
-	secondQuestion: string;
+	secondQuestion?: string;
 	defaultScore?: number;
 	onCloseModal?: () => void;
 	customOptions?: { label: string; value: string }[];
@@ -112,7 +112,8 @@ function CustomerFeedbackModal( {
 		if (
 			! (
 				Number.isInteger( firstQuestionScore ) &&
-				Number.isInteger( secondQuestionScore )
+				( ! secondQuestionScore ||
+					Number.isInteger( secondQuestionScore ) )
 			)
 		) {
 			setShowNoScoreMessage( true );
@@ -175,28 +176,32 @@ function CustomerFeedbackModal( {
 				/>
 			</div>
 
-			<Text
-				variant="subtitle.small"
-				as="p"
-				weight="600"
-				size="14"
-				lineHeight="20px"
-			>
-				{ secondQuestion }
-			</Text>
+			{ secondQuestion && (
+				<Text
+					variant="subtitle.small"
+					as="p"
+					weight="600"
+					size="14"
+					lineHeight="20px"
+				>
+					{ secondQuestion }
+				</Text>
+			) }
 
-			<div className="woocommerce-customer-effort-score__selection">
-				<RadioControl
-					selected={ secondQuestionScore.toString( 10 ) }
-					options={ options }
-					onChange={ ( value ) =>
-						onRadioControlChange(
-							value as string,
-							setSecondQuestionScore
-						)
-					}
-				/>
-			</div>
+			{ secondQuestion && (
+				<div className="woocommerce-customer-effort-score__selection">
+					<RadioControl
+						selected={ secondQuestionScore.toString( 10 ) }
+						options={ options }
+						onChange={ ( value ) =>
+							onRadioControlChange(
+								value as string,
+								setSecondQuestionScore
+							)
+						}
+					/>
+				</div>
+			) }
 
 			{ [ firstQuestionScore, secondQuestionScore ].some(
 				( score ) => score === 1 || score === 2
@@ -250,9 +255,9 @@ function CustomerFeedbackModal( {
 
 CustomerFeedbackModal.propTypes = {
 	recordScoreCallback: PropTypes.func.isRequired,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.string,
 	firstQuestion: PropTypes.string.isRequired,
-	secondQuestion: PropTypes.string.isRequired,
+	secondQuestion: PropTypes.string,
 	defaultScore: PropTypes.number,
 	onCloseModal: PropTypes.func,
 };

--- a/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/js/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -110,11 +110,8 @@ function CustomerFeedbackModal( {
 
 	const sendScore = () => {
 		if (
-			! (
-				Number.isInteger( firstQuestionScore ) &&
-				( ! secondQuestionScore ||
-					Number.isInteger( secondQuestionScore ) )
-			)
+			! Number.isInteger( firstQuestionScore ) ||
+			( secondQuestion && ! Number.isInteger( secondQuestionScore ) )
 		) {
 			setShowNoScoreMessage( true );
 			return;

--- a/packages/js/customer-effort-score/src/customer-feedback-modal/test/index.tsx
+++ b/packages/js/customer-effort-score/src/customer-feedback-modal/test/index.tsx
@@ -107,4 +107,34 @@ describe( 'CustomerFeedbackModal', () => {
 			} );
 		}
 	);
+
+	it( 'should render even if no second question is provided', async () => {
+		render(
+			<CustomerFeedbackModal
+				recordScoreCallback={ mockRecordScoreCallback }
+				title="Testing"
+				firstQuestion="First question"
+			/>
+		);
+
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+		// Should be only one neutral emoji, since there is one question only
+		expect( screen.getAllByLabelText( 'Neutral' ).length ).toBe( 1 );
+	} );
+
+	it( 'should render default title if no title is provided', async () => {
+		render(
+			<CustomerFeedbackModal
+				recordScoreCallback={ mockRecordScoreCallback }
+				firstQuestion="First question"
+			/>
+		);
+
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+		expect(
+			screen.queryByLabelText( 'Please share your feedback' )
+		).toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow up for https://github.com/woocommerce/woocommerce/pull/35680#issuecomment-1369403269

This PR makes title and secondQuestion optional offering backwards compatibility.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a new CES prompt score with 1 question and no title
2. The component renders the question and the title as "Please share your feedback"
3. The second question doesn't appear and the component is functional. 
4. You can send scores.
5. Adding a second question show the second question in the modal.
6. You can send scores.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
