### PR TITLE
Validate Norweigan postcodes/rework code for 4-digit post code validation

### DIFF
--- a/plugins/woocommerce/changelog/four-digit-postcodes
+++ b/plugins/woocommerce/changelog/four-digit-postcodes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Validation of Norweigan postcodes has been added.

--- a/plugins/woocommerce/includes/class-wc-validation.php
+++ b/plugins/woocommerce/includes/class-wc-validation.php
@@ -51,19 +51,17 @@ class WC_Validation {
 
 		switch ( $country ) {
 			case 'AT':
+			case 'BE':
+			case 'CH':
+			case 'HU':
+			case 'NO':
 				$valid = (bool) preg_match( '/^([0-9]{4})$/', $postcode );
 				break;
 			case 'BA':
 				$valid = (bool) preg_match( '/^([7-8]{1})([0-9]{4})$/', $postcode );
 				break;
-			case 'BE':
-				$valid = (bool) preg_match( '/^([0-9]{4})$/i', $postcode );
-				break;
 			case 'BR':
 				$valid = (bool) preg_match( '/^([0-9]{5})([-])?([0-9]{3})$/', $postcode );
-				break;
-			case 'CH':
-				$valid = (bool) preg_match( '/^([0-9]{4})$/i', $postcode );
 				break;
 			case 'DE':
 				$valid = (bool) preg_match( '/^([0]{1}[1-9]{1}|[1-9]{1}[0-9]{1})[0-9]{3}$/', $postcode );
@@ -78,9 +76,6 @@ class WC_Validation {
 				break;
 			case 'GB':
 				$valid = self::is_gb_postcode( $postcode );
-				break;
-			case 'HU':
-				$valid = (bool) preg_match( '/^([0-9]{4})$/i', $postcode );
 				break;
 			case 'IE':
 				$valid = (bool) preg_match( '/([AC-FHKNPRTV-Y]\d{2}|D6W)[0-9AC-FHKNPRTV-Y]{4}/', wc_normalize_postcode( $postcode ) );


### PR DESCRIPTION
- This is a "re-play" of https://github.com/woocommerce/woocommerce/pull/36271 and it has the same commits by the original author.
- Unfortunately, it was not possible to directly update the branch in the original PR to add a changelog, etc, so for expediency I created this branch.

---

### Testing instructions

1. Add an item to your cart and try to checkout.
2. Supply a Norweigan address (an example would be *Askerveien 61, 1384 Asker, Norway)* except set the postcode to something other than a string of 4 digits:

<img width="630" alt="no-postcode-5" src="https://user-images.githubusercontent.com/3594411/210450111-b804e722-79e7-44d7-ad65-716880b2767d.png">

3. Complete all other required fields and try to checkout. You should see a validation error in relation to the postcode:

![no-postcode-err](https://user-images.githubusercontent.com/3594411/210450221-ffef3983-1359-4212-97c4-3526fd283b69.png)

4. Now correct the postcode to a set of 4 digits, as in the original example address I shared *("1384"),* and try to checkout once more. This time you should enjoy success.
5. Optionally, consider applying a similar test but with addresses in Austria, Belgium, Hungary, or Switzerland (each of which also requires a 4-digit postcode).