### PR TITLE
Don't run CI checks on PRs that are just changelog changes

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests-skip.yml
+++ b/.github/workflows/pr-build-and-e2e-tests-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Run tests against PR
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -1,7 +1,9 @@
 name: Run tests against PR
 on:
-    pull_request:
     workflow_dispatch:
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +16,7 @@ jobs:
         name: Runs E2E tests.
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
@@ -84,7 +86,7 @@ jobs:
         name: Runs API tests.
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         env:
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
@@ -136,7 +138,7 @@ jobs:
         name: Runs k6 Performance tests
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         steps:
             - uses: actions/checkout@v3
 
@@ -171,9 +173,9 @@ jobs:
         runs-on: ubuntu-20.04
         needs: [api-tests-run, e2e-tests-run]
         permissions:
-          contents: read
-          issues: write
-          pull-requests: write
+            contents: read
+            issues: write
+            pull-requests: write
         env:
             E2E_GRAND_TOTAL: ${{needs.e2e-tests-run.outputs.E2E_GRAND_TOTAL}}
         steps:

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -3,7 +3,7 @@ on:
     workflow_dispatch:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-build-live-branch-skip.yml
+++ b/.github/workflows/pr-build-live-branch-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Build Live Branch
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -2,7 +2,7 @@ name: Build Live Branch
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
 
 concurrency:
     # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.

--- a/.github/workflows/pr-build-live-branch.yml
+++ b/.github/workflows/pr-build-live-branch.yml
@@ -1,6 +1,8 @@
 name: Build Live Branch
 on:
     pull_request:
+        paths-ignore:
+            - 'changelog/**'
 
 concurrency:
     # Cancel concurrent jobs on pull_request but not push, by including the run_id in the concurrency group for the latter.
@@ -14,7 +16,7 @@ jobs:
         if: github.repository_owner == 'woocommerce'
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-code-coverage-skip.yml
+++ b/.github/workflows/pr-code-coverage-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Run code coverage on PR
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -1,59 +1,60 @@
 name: Run code coverage on PR
 on:
-  pull_request:
-  workflow_dispatch:
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
+    workflow_dispatch:
 defaults:
-  run:
-    shell: bash
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    run:
+        shell: bash
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  test:
-    name: Code coverage (PHP 7.4, WP Latest)
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-    services:
-      database:
-        image: mysql:5.6
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 100
+    test:
+        name: Code coverage (PHP 7.4, WP Latest)
+        timeout-minutes: 30
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        services:
+            database:
+                image: mysql:5.6
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 100
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-      - name: Tool versions
-        run: |
-          php --version
-          composer --version
+            - name: Tool versions
+              run: |
+                  php --version
+                  composer --version
 
-      - name: Build Admin feature config
-        working-directory: plugins/woocommerce
-        run:
-          pnpm run build:feature-config
+            - name: Build Admin feature config
+              working-directory: plugins/woocommerce
+              run: pnpm run build:feature-config
 
-      - name: Init DB and WP
-        working-directory: plugins/woocommerce
-        run: bash tests/bin/install.sh woo_test root root 127.0.0.1 latest
+            - name: Init DB and WP
+              working-directory: plugins/woocommerce
+              run: bash tests/bin/install.sh woo_test root root 127.0.0.1 latest
 
-      - name: Run unit tests with code coverage. Allow to fail.
-        working-directory: plugins/woocommerce
-        run: |
-          RUN_CODE_COVERAGE=1 bash tests/bin/phpunit.sh
-          exit 0
-      
-      - name: Send code coverage to Codecov.
-        run: |
-          bash <(curl -s https://codecov.io/bash)
+            - name: Run unit tests with code coverage. Allow to fail.
+              working-directory: plugins/woocommerce
+              run: |
+                  RUN_CODE_COVERAGE=1 bash tests/bin/phpunit.sh
+                  exit 0
+
+            - name: Send code coverage to Codecov.
+              run: |
+                  bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/pr-code-coverage.yml
+++ b/.github/workflows/pr-code-coverage.yml
@@ -2,7 +2,7 @@ name: Run code coverage on PR
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
     workflow_dispatch:
 defaults:
     run:

--- a/.github/workflows/pr-code-sniff-skip.yml
+++ b/.github/workflows/pr-code-sniff-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Run code coverage on PR
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -1,5 +1,8 @@
 name: Run code sniff on PR
-on: pull_request
+on:
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
 defaults:
     run:
         shell: bash
@@ -17,7 +20,7 @@ jobs:
         timeout-minutes: 15
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/pr-code-sniff.yml
+++ b/.github/workflows/pr-code-sniff.yml
@@ -2,7 +2,7 @@ name: Run code sniff on PR
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
 defaults:
     run:
         shell: bash

--- a/.github/workflows/pr-highlight-changes-skip.yml
+++ b/.github/workflows/pr-highlight-changes-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Highlight templates changes
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -1,5 +1,8 @@
 name: Highlight templates changes
-on: pull_request
+on:
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
 
 permissions: {}
 
@@ -8,7 +11,7 @@ jobs:
         name: Check pull request changes to highlight
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         outputs:
             results: ${{ steps.results.outputs.results }}
         steps:
@@ -29,32 +32,32 @@ jobs:
             - name: Check results
               uses: actions/github-script@v6
               with:
-                script: |
-                  const template = '${{ steps.run.outputs.templates }}';
+                  script: |
+                      const template = '${{ steps.run.outputs.templates }}';
 
-                  if ( template === '' ) {
-                    return;
-                  }
+                      if ( template === '' ) {
+                        return;
+                      }
 
-                  const templateArr = template.split( '\n' );
-                  const modTemplateArr = [];
-                  let needsVersionBump = false;
+                      const templateArr = template.split( '\n' );
+                      const modTemplateArr = [];
+                      let needsVersionBump = false;
 
-                  templateArr.forEach( ( el ) => {
-                    if ( el.match( /NOTICE/ ) ) {
-                      modTemplateArr.pop();
-                      return;
-                    }
+                      templateArr.forEach( ( el ) => {
+                        if ( el.match( /NOTICE/ ) ) {
+                          modTemplateArr.pop();
+                          return;
+                        }
 
-                    if ( el.match( /WARNING/ ) ) {
-                      needsVersionBump = true;
-                    }
+                        if ( el.match( /WARNING/ ) ) {
+                          needsVersionBump = true;
+                        }
 
-                    modTemplateArr.push( el );
-                  } );
+                        modTemplateArr.push( el );
+                      } );
 
-                  const templateResult = modTemplateArr.join( '\n' );
+                      const templateResult = modTemplateArr.join( '\n' );
 
-                  if ( needsVersionBump ) {
-                    core.setFailed( `Templates have changed but template versions were not bumped:\n${ templateResult }` );
-                  }
+                      if ( needsVersionBump ) {
+                        core.setFailed( `Templates have changed but template versions were not bumped:\n${ templateResult }` );
+                      }

--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -2,7 +2,7 @@ name: Highlight templates changes
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
 
 permissions: {}
 

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -2,7 +2,7 @@ name: Run lint checks potentially affecting projects across the monorepo
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
         branches:
             - 'trunk'
 concurrency:

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,8 +1,6 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on:
     pull_request:
-        paths-ignore:
-            - '**/changelog/**'
         branches:
             - 'trunk'
 concurrency:

--- a/.github/workflows/pr-lint-monorepo.yml
+++ b/.github/workflows/pr-lint-monorepo.yml
@@ -1,37 +1,39 @@
 name: Run lint checks potentially affecting projects across the monorepo
 on:
-  pull_request:
-    branches:
-      - 'trunk'
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
+        branches:
+            - 'trunk'
 concurrency:
-  group: changelogger-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: changelogger-${{ github.event_name }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  changelogger_used:
-    name: Changelogger use
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+    changelogger_used:
+        name: Changelogger use
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  fetch-depth: 0
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build: false
 
-      - name: Check change files are touched for touched projects
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
-        run: php tools/monorepo/check-changelogger-use.php --debug "$BASE" "$HEAD"
+            - name: Check change files are touched for touched projects
+              env:
+                  BASE: ${{ github.event.pull_request.base.sha }}
+                  HEAD: ${{ github.event.pull_request.head.sha }}
+              run: php tools/monorepo/check-changelogger-use.php --debug "$BASE" "$HEAD"
 
-      - name: Run changelog validation
-        run: pnpm run -r changelog validate
+            - name: Run changelog validation
+              run: pnpm run -r changelog validate

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -3,7 +3,7 @@ name: Lint and tests for JS packages and woocommerce-admin/client
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -1,6 +1,9 @@
 name: Lint and tests for JS packages and woocommerce-admin/client
 
-on: pull_request
+on:
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
@@ -12,15 +15,15 @@ jobs:
         name: Lint and Test JS
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
+            contents: read
         steps:
             - uses: actions/checkout@v3
 
             - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo              
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
             - name: Lint
               run: pnpm run -r --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
 
             - name: Test
-              run: pnpm run test --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color  
+              run: pnpm run test --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color

--- a/.github/workflows/pr-lint-test-skip.yml
+++ b/.github/workflows/pr-lint-test-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Run smoke tests against pull request.
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -2,7 +2,7 @@ name: 'Label Pull Request Project'
 on:
     pull_request_target:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
         types:
             - opened
             - synchronize

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -1,23 +1,25 @@
 name: 'Label Pull Request Project'
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    pull_request_target:
+        paths-ignore:
+            - 'changelog/**'
+        types:
+            - opened
+            - synchronize
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  label_project:
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-    - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/project-pr-labeler.yml
+    label_project:
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - uses: actions/labeler@v3
+              with:
+                  repo-token: '${{ secrets.GITHUB_TOKEN }}'
+                  configuration-path: .github/project-pr-labeler.yml

--- a/.github/workflows/pr-project-label.yml
+++ b/.github/workflows/pr-project-label.yml
@@ -1,8 +1,6 @@
 name: 'Label Pull Request Project'
 on:
     pull_request_target:
-        paths-ignore:
-            - '**/changelog/**'
         types:
             - opened
             - synchronize

--- a/.github/workflows/pr-smoke-test-skip.yml
+++ b/.github/workflows/pr-smoke-test-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Lint and tests for JS packages and woocommerce-admin/client
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -2,7 +2,7 @@ name: Run smoke tests against pull request.
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
         branches:
             - trunk
         types:

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -1,13 +1,15 @@
 name: Run smoke tests against pull request.
 on:
     pull_request:
+        paths-ignore:
+            - 'changelog/**'
         branches:
             - trunk
         types:
             - labeled
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions: {}
 
@@ -17,8 +19,8 @@ jobs:
         if: "${{ contains(github.event.label.name, 'run: smoke tests') }}"
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
-          pull-requests: write
+            contents: read
+            pull-requests: write
         steps:
             - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-unit-tests-skip.yml
+++ b/.github/workflows/pr-unit-tests-skip.yml
@@ -1,0 +1,12 @@
+# Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: Run unit tests on PR
+on:
+    pull_request:
+        paths:
+            - '!**'
+            - '**/changelog/**'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - run: 'echo "No build required"'

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -2,7 +2,7 @@ name: Run unit tests on PR
 on:
     pull_request:
         paths-ignore:
-            - 'changelog/**'
+            - '**/changelog/**'
 defaults:
     run:
         shell: bash

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -1,73 +1,75 @@
 name: Run unit tests on PR
-on: 
-  pull_request
+on:
+    pull_request:
+        paths-ignore:
+            - 'changelog/**'
 defaults:
-  run:
-    shell: bash
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    run:
+        shell: bash
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  test:
-    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-    continue-on-error: ${{ matrix.wp == 'nightly' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '7.4', '8.0' ]
-        wp: [ "latest" ]
-        include:
-          - wp: nightly
-            php: '7.4'
-          - wp: '5.9'
-            php: 7.4
-          - wp: '5.8'
-            php: 7.4
-    services:
-      database:
-        image: mysql:5.6
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-    steps:
-      - uses: actions/checkout@v3
+    test:
+        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
+        timeout-minutes: 30
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        continue-on-error: ${{ matrix.wp == 'nightly' }}
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ['7.4', '8.0']
+                wp: ['latest']
+                include:
+                    - wp: nightly
+                      php: '7.4'
+                    - wp: '5.9'
+                      php: 7.4
+                    - wp: '5.8'
+                      php: 7.4
+        services:
+            database:
+                image: mysql:5.6
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          php-version: ${{ matrix.php }}
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  php-version: ${{ matrix.php }}
 
-      - name: Tool versions
-        run: |
-          php --version
-          composer --version
+            - name: Tool versions
+              run: |
+                  php --version
+                  composer --version
 
-      - name: Add PHP8 Compatibility.
-        run: |
-          if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
-             cd plugins/woocommerce
-             curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-             unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-             composer bin phpunit config --unset platform
-             composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-             composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-             rm -rf ./vendor/phpunit/
-             composer dump-autoload
-           fi
+            - name: Add PHP8 Compatibility.
+              run: |
+                  if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
+                     cd plugins/woocommerce
+                     curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
+                     unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
+                     composer bin phpunit config --unset platform
+                     composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
+                     composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
+                     rm -rf ./vendor/phpunit/
+                     composer dump-autoload
+                   fi
 
-      - name: Init DB and WP
-        working-directory: plugins/woocommerce
-        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
+            - name: Init DB and WP
+              working-directory: plugins/woocommerce
+              run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 
-      - name: Run tests
-        working-directory: plugins/woocommerce
-        run: pnpm run test --filter=woocommerce --color
+            - name: Run tests
+              working-directory: plugins/woocommerce
+              run: pnpm run test --filter=woocommerce --color


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This changes many of the PR checks so that they won't run in the case that a PR **only includes changes to changelog entries**. This ensures that automated PRs that move or adjust changelog entries will not waste time running time consuming checks that we know are not impacted by a change to a changelog.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Fork WooCommerce and enable actions
2. In your fork merge this PR into it or push it directly to trunk on your fork. whatever suits you
3. Make all the pr checks changed here "required" checks in your fork repo.
4. Now make sure your local copy of your fork is up to date with those changes and create a new branch and add a new changelog entry.
5. Create a PR to your own fork, and note that none of the PR checks are run.
6. Now to check the reverse make a change in a single file anywhere else in your fork
7. Create a PR for that change and see that the checks do run.

Here's an example changelog entry only PR in my fork: https://github.com/samueljseay/woocommerce/pull/19

Here's an example PR that changes a changelog and some other file: https://github.com/samueljseay/woocommerce/pull/21

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
