### PR TITLE
Make HPOS UX more consistent with posts (so that same e2e tests passes).

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-edit-consistency
+++ b/plugins/woocommerce/changelog/fix-order-edit-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make HPOS UX more consistent with posts UI (so that same e2e tests passes for both).

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -34,6 +34,20 @@ class Edit {
 	private $order;
 
 	/**
+	 * Action name that the form is currently handling. Could be new_order or edit_order.
+	 *
+	 * @var string
+	 */
+	private $current_action;
+
+	/**
+	 * Message to be displayed to the user. Index of message from the messages array registered when declaring shop_order post type.
+	 *
+	 * @var int
+	 */
+	private $message;
+
+	/**
 	 * Hooks all meta-boxes for order edit page. This is static since this may be called by post edit form rendering.
 	 *
 	 * @param string $screen_id Screen ID.
@@ -124,6 +138,15 @@ class Edit {
 	}
 
 	/**
+	 * Set the current action for the form.
+	 *
+	 * @param string $action Action name.
+	 */
+	public function set_current_action( string $action ) {
+		$this->current_action = $action;
+	}
+
+	/**
 	 * Hooks meta box for order specific meta.
 	 */
 	private function add_order_specific_meta_box() {
@@ -163,6 +186,9 @@ class Edit {
 		 */
 		do_action( 'woocommerce_process_shop_order_meta', $this->order->get_id(), $this->order );
 
+		// Order updated message.
+		$this->message = 1;
+
 		// Refresh the order from DB.
 		$this->order = wc_get_order( $this->order->get_id() );
 		$theorder    = $this->order;
@@ -188,7 +214,39 @@ class Edit {
 	 * Render order edit page.
 	 */
 	public function display() {
-		$this->render_wrapper_start();
+		/**
+		 * This is used by the order edit page to show messages in the notice fields.
+		 * It should be similar to post_updated_messages filter, i.e.:
+		 * array(
+		 * 	 {order_type} => array(
+		 * 		1 => 'Order updated.',
+		 * 		2 => 'Custom field updated.',
+		 * ...
+		 * ).
+		 *
+		 * The index to be displayed is computed from the $_GET['message'] variable.
+		 *
+		 * @since 7.4.0.
+		 */
+		$messages = apply_filters( 'woocommerce_order_updated_messages', array() );
+
+		/**
+		 * Backward compatibility for displaying messages using the post fields.
+		 *
+		 * @since 7.4.0. (Although available earlier by the posts based screen).
+		 */
+		$messages = apply_filters( 'post_updated_messages', $messages );
+
+		$message = $this->message;
+		if ( isset( $_GET['message'] ) ) {
+			$message = absint( $_GET['message'] );
+		}
+
+		if ( isset( $message ) ) {
+			$message = $messages[ $this->order->get_type() ][ $message ] ?? false;
+		}
+
+		$this->render_wrapper_start( '', $message );
 		$this->render_meta_boxes();
 		$this->render_wrapper_end();
 	}
@@ -210,10 +268,14 @@ class Edit {
 		?>
 		<div class="wrap">
 		<h1 class="wp-heading-inline">
-			<?php echo esc_html( $post_type->labels->edit_item ); ?>
+			<?php
+			echo 'new_order' === $this->current_action ? esc_html( $post_type->labels->add_new_item ) : esc_html( $post_type->labels->edit_item );
+			?>
 		</h1>
 		<?php
-		echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
+		if ( 'edit_order' === $this->current_action ) {
+			echo ' <a href="' . esc_url( $new_page_url ) . '" class="page-title-action">' . esc_html( $post_type->labels->add_new ) . '</a>';
+		}
 		?>
 		<hr class="wp-header-end">
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -218,9 +218,9 @@ class Edit {
 		 * This is used by the order edit page to show messages in the notice fields.
 		 * It should be similar to post_updated_messages filter, i.e.:
 		 * array(
-		 * 	 {order_type} => array(
-		 * 		1 => 'Order updated.',
-		 * 		2 => 'Custom field updated.',
+		 *   {order_type} => array(
+		 *      1 => 'Order updated.',
+		 *      2 => 'Custom field updated.',
 		 * ...
 		 * ).
 		 *

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -211,6 +211,7 @@ class PageController {
 					$this->order_edit_form = new Edit();
 					$this->order_edit_form->setup( $this->order );
 				}
+				$this->order_edit_form->set_current_action( $this->current_action );
 				$this->order_edit_form->display();
 				break;
 			case 'list_orders':
@@ -285,7 +286,7 @@ class PageController {
 
 		$this->order = new $order_class_name();
 		$this->order->set_object_read( false );
-		$this->order->set_status( 'auto-draft' );
+		$this->order->set_status( 'pending' );
 		$this->order->save();
 
 		$theorder = $this->order;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds multiple changes for consistency between HPOS and posts UX:

1. Order updated message after successfully updating the order.
<img width="1023" alt="Screenshot 2023-01-05 at 4 36 43 PM" src="https://user-images.githubusercontent.com/7571618/210766009-839779e4-a291-4b40-b061-0c5552c93727.png">


2. "Add new order" instead of "Edit order" when adding new order.

<img width="933" alt="Screenshot 2023-01-05 at 4 36 17 PM" src="https://user-images.githubusercontent.com/7571618/210765949-afbac05b-6c09-4481-9650-8e2eb99d26f8.png">


This is how Posts already behaves, but HPOS was slightly different. Now they become consistent and same e2e will pass for both data sources.

In posts, whenever we would update the order, there is a message presented 
<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. With HPOS enabled, click on add new order button in order admin screen. Make sure that the heading says "Add new order" instead of "Edit order".
2. Update any order from the order edit screen. Make sure that a dismissable message with is presented with text "Order Updated"

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
