### PR TITLE
Use more generic selectors for HPOS<>Posts compatibility

### DIFF
--- a/plugins/woocommerce/changelog/e2e-modify-search-selector
+++ b/plugins/woocommerce/changelog/e2e-modify-search-selector
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Minor change in E2E selectory.
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -46,8 +46,8 @@ test.describe( 'Edit order', () => {
 		await page.goto( `wp-admin/post.php?post=${ orderId }&action=edit` );
 
 		// make sure we're on the order details page
-		await expect( page.locator( 'h1.components-text' ) ).toContainText(
-			'Edit Order'
+		await expect( page.locator( 'h1.wp-heading-inline' ) ).toContainText(
+			/Edit [oO]rder/
 		);
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-search.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-search.spec.js
@@ -140,7 +140,7 @@ test.describe( 'WooCommerce Orders > Search orders', () => {
 
 	test( 'can search for order by order id', async ( { page } ) => {
 		await page.goto( 'wp-admin/edit.php?post_type=shop_order' );
-		await page.fill( '#post-search-input', orderId.toString() );
+		await page.fill( '[type=search][name=s]', orderId.toString() );
 		await page.click( '#search-submit' );
 
 		await expect(
@@ -153,7 +153,7 @@ test.describe( 'WooCommerce Orders > Search orders', () => {
 			page,
 		} ) => {
 			await page.goto( 'wp-admin/edit.php?post_type=shop_order' );
-			await page.fill( '#post-search-input', queries[ i ][ 0 ] );
+			await page.fill( '[type=search][name=s]', queries[ i ][ 0 ] );
 			await page.click( '#search-submit' );
 
 			await expect(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a minor change for selectors in order admin screens so that the same selectors work for both HPOS and CPT screens.

Explanation:

1. `h1.wp-heading-inline` > `/Edit [oO]rder/` instead of `h1.components-text` > `Edit Order` : In HPOS we display `Edit Order` but in posts we display `Edit order`. So [oO] regex covers both uppercase and lowercase o. Similarly we use the main heading instead of wc-admin breadcrumb to make sure we are on current page.
2. `[type=search][name=s]` instead of `#post-search-input` : This is because search box with this is ID is only rendered for post screen. Generalizing it to a selectors that renders for both.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Make sure that E2E tests pass.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
