### PR TITLE
Improve breadcrumb navigation accessibility

### DIFF
--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2294,14 +2294,18 @@ if ( ! function_exists( 'woocommerce_breadcrumb' ) ) {
 				'woocommerce_breadcrumb_defaults',
 				array(
 					'delimiter'   => '&nbsp;&#47;&nbsp;',
-					'wrap_before' => '<nav class="woocommerce-breadcrumb">',
+					'wrap_before' => '<nav class="woocommerce-breadcrumb" aria-label="%s">',
 					'wrap_after'  => '</nav>',
+					/* translators: accessibility text for the breadcrumb navigation landmark region. */
+					'aria_label'  => __( 'Breadcrumb', 'woocommerce' ),
 					'before'      => '',
 					'after'       => '',
 					'home'        => _x( 'Home', 'breadcrumb', 'woocommerce' ),
 				)
 			)
 		);
+
+		$args['wrap_before'] = sprintf( $args['wrap_before'], esc_attr( $args['aria_label'] ) );
 
 		$breadcrumbs = new WC_Breadcrumb();
 

--- a/plugins/woocommerce/templates/global/breadcrumb.php
+++ b/plugins/woocommerce/templates/global/breadcrumb.php
@@ -31,7 +31,7 @@ if ( ! empty( $breadcrumb ) ) {
 		if ( ! empty( $crumb[1] ) && sizeof( $breadcrumb ) !== $key + 1 ) {
 			echo '<a href="' . esc_url( $crumb[1] ) . '">' . esc_html( $crumb[0] ) . '</a>';
 		} else {
-			echo esc_html( $crumb[0] );
+			echo '<span aria-current="page">' . esc_html( $crumb[0] ) . '</span>';
 		}
 
 		echo $after;


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the accessibility of the breadcrumb navigation by
* adding the `aria-current` attribute to the last crumb to indicate that this element represents the current page.
* adding the `aria-label` attribute to the `nav` element, as it is necessary to provide additional labeling when there is more than one landmark of the same type on the page, which is very likely for the `nav` element.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
