### PR TITLE
Improve accessibility of various navigation elements

### DIFF
--- a/plugins/woocommerce/changelog/feature-nav-a11y
+++ b/plugins/woocommerce/changelog/feature-nav-a11y
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Improve accessibility of the account, breadcrumb, products and reviews navigation.

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -682,6 +682,10 @@ p.demo_store,
 					background: $secondary;
 					color: darken($secondary, 40%);
 				}
+
+				span[aria-hidden="true"] {
+					padding: 0;
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1415,8 +1415,8 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 	 * Get the product thumbnail, or the placeholder if not set.
 	 *
 	 * @param string $size (default: 'woocommerce_thumbnail').
-	 * @param  array $attr Image attributes.
-	 * @param  bool  $placeholder True to return $placeholder if no image is found, or false to return an empty string.
+	 * @param array  $attr Image attributes.
+	 * @param bool   $placeholder True to return $placeholder if no image is found, or false to return an empty string.
 	 * @return string
 	 */
 	function woocommerce_get_product_thumbnail( $size = 'woocommerce_thumbnail', $attr = array(), $placeholder = true ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2294,14 +2294,18 @@ if ( ! function_exists( 'woocommerce_breadcrumb' ) ) {
 				'woocommerce_breadcrumb_defaults',
 				array(
 					'delimiter'   => '&nbsp;&#47;&nbsp;',
-					'wrap_before' => '<nav class="woocommerce-breadcrumb">',
+					'wrap_before' => '<nav class="woocommerce-breadcrumb" aria-label="%s">',
 					'wrap_after'  => '</nav>',
+					/* translators: accessibility text for the breadcrumb navigation. */
+					'aria_label'  => __( 'Breadcrumb', 'woocommerce' ),
 					'before'      => '',
 					'after'       => '',
 					'home'        => _x( 'Home', 'breadcrumb', 'woocommerce' ),
 				)
 			)
 		);
+
+		$args['wrap_before'] = sprintf( $args['wrap_before'], esc_attr( $args['aria_label'] ) );
 
 		$breadcrumbs = new WC_Breadcrumb();
 

--- a/plugins/woocommerce/templates/global/breadcrumb.php
+++ b/plugins/woocommerce/templates/global/breadcrumb.php
@@ -37,7 +37,7 @@ if ( ! empty( $breadcrumb ) ) {
 		echo $after;
 
 		if ( count( $breadcrumb ) !== $key + 1 ) {
-			echo $delimiter;
+			echo '<span aria-hidden="true">' . $delimiter . '</span>';
 		}
 	}
 

--- a/plugins/woocommerce/templates/global/breadcrumb.php
+++ b/plugins/woocommerce/templates/global/breadcrumb.php
@@ -31,7 +31,7 @@ if ( ! empty( $breadcrumb ) ) {
 		if ( ! empty( $crumb[1] ) && sizeof( $breadcrumb ) !== $key + 1 ) {
 			echo '<a href="' . esc_url( $crumb[1] ) . '">' . esc_html( $crumb[0] ) . '</a>';
 		} else {
-			echo esc_html( $crumb[0] );
+			echo '<span aria-current="page">' . esc_html( $crumb[0] ) . '</span>';
 		}
 
 		echo $after;

--- a/plugins/woocommerce/templates/global/breadcrumb.php
+++ b/plugins/woocommerce/templates/global/breadcrumb.php
@@ -28,7 +28,7 @@ if ( ! empty( $breadcrumb ) ) {
 
 		echo $before;
 
-		if ( ! empty( $crumb[1] ) && sizeof( $breadcrumb ) !== $key + 1 ) {
+		if ( ! empty( $crumb[1] ) && count( $breadcrumb ) !== $key + 1 ) {
 			echo '<a href="' . esc_url( $crumb[1] ) . '">' . esc_html( $crumb[0] ) . '</a>';
 		} else {
 			echo '<span aria-current="page">' . esc_html( $crumb[0] ) . '</span>';
@@ -36,7 +36,7 @@ if ( ! empty( $breadcrumb ) ) {
 
 		echo $after;
 
-		if ( sizeof( $breadcrumb ) !== $key + 1 ) {
+		if ( count( $breadcrumb ) !== $key + 1 ) {
 			echo $delimiter;
 		}
 	}

--- a/plugins/woocommerce/templates/global/breadcrumb.php
+++ b/plugins/woocommerce/templates/global/breadcrumb.php
@@ -22,11 +22,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! empty( $breadcrumb ) ) {
 
-	echo $wrap_before;
+	echo wp_kses_post( $wrap_before );
 
 	foreach ( $breadcrumb as $key => $crumb ) {
 
-		echo $before;
+		echo wp_kses_post( $before );
 
 		if ( ! empty( $crumb[1] ) && count( $breadcrumb ) !== $key + 1 ) {
 			echo '<a href="' . esc_url( $crumb[1] ) . '">' . esc_html( $crumb[0] ) . '</a>';
@@ -34,13 +34,13 @@ if ( ! empty( $breadcrumb ) ) {
 			echo '<span aria-current="page">' . esc_html( $crumb[0] ) . '</span>';
 		}
 
-		echo $after;
+		echo wp_kses_post( $after );
 
 		if ( count( $breadcrumb ) !== $key + 1 ) {
-			echo '<span aria-hidden="true">' . $delimiter . '</span>';
+			echo '<span aria-hidden="true">' . wp_kses_post( $delimiter ) . '</span>';
 		}
 	}
 
-	echo $wrap_after;
+	echo wp_kses_post( $wrap_after );
 
 }

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -28,7 +28,7 @@ if ( $total <= 1 ) {
 	return;
 }
 ?>
-<nav class="woocommerce-pagination">
+<nav class="woocommerce-pagination" aria-label="<?php esc_attr_e( 'Products', 'woocommerce' ); ?>">
 	<?php
 	echo paginate_links(
 		apply_filters(

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -34,27 +34,29 @@ $next_text = sprintf( $prev_next, is_rtl() ? '&larr;' : '&rarr;', esc_html_x( 'N
 ?>
 <nav class="woocommerce-pagination" aria-label="<?php esc_attr_e( 'Products', 'woocommerce' ); ?>">
 	<?php
-	echo paginate_links(
-		/**
-		 * Filters the paginated links arguments of the catalog pagination.
-		 *
-		 * @param array $args The arguments of paginate_links().
-		 *
-		 * @since 2.0.0
-		 */
-		apply_filters(
-			'woocommerce_pagination_args',
-			array( // WPCS: XSS ok.
-				'base'      => $base,
-				'format'    => $format,
-				'add_args'  => false,
-				'current'   => max( 1, $current ),
-				'total'     => $total,
-				'prev_text' => $prev_text,
-				'next_text' => $next_text,
-				'type'      => 'list',
-				'end_size'  => 3,
-				'mid_size'  => 3,
+	echo wp_kses_post(
+		paginate_links(
+			/**
+			 * Filters the paginated links arguments of the catalog pagination.
+			 *
+			 * @since 2.0.0
+			 * @link https://developer.wordpress.org/reference/functions/paginate_links/#parameters
+			 * @param array $args The arguments of paginate_links().
+			 */
+			apply_filters(
+				'woocommerce_pagination_args',
+				array(
+					'base'      => $base,
+					'format'    => $format,
+					'add_args'  => false,
+					'current'   => max( 1, $current ),
+					'total'     => $total,
+					'prev_text' => $prev_text,
+					'next_text' => $next_text,
+					'type'      => 'list',
+					'end_size'  => 3,
+					'mid_size'  => 3,
+				)
 			)
 		)
 	);

--- a/plugins/woocommerce/templates/loop/pagination.php
+++ b/plugins/woocommerce/templates/loop/pagination.php
@@ -19,18 +19,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$total   = isset( $total ) ? $total : wc_get_loop_prop( 'total_pages' );
+$total = isset( $total ) ? $total : wc_get_loop_prop( 'total_pages' );
+if ( $total <= 1 ) {
+	return;
+}
+
 $current = isset( $current ) ? $current : wc_get_loop_prop( 'current_page' );
 $base    = isset( $base ) ? $base : esc_url_raw( str_replace( 999999999, '%#%', remove_query_arg( 'add-to-cart', get_pagenum_link( 999999999, false ) ) ) );
 $format  = isset( $format ) ? $format : '';
 
-if ( $total <= 1 ) {
-	return;
-}
+$prev_next = '<span aria-hidden="true">%1$s</span><span class="screen-reader-text">%2$s</span>';
+$prev_text = sprintf( $prev_next, is_rtl() ? '&rarr;' : '&larr;', esc_html_x( 'Previous', 'pagination', 'woocommerce' ) );
+$next_text = sprintf( $prev_next, is_rtl() ? '&larr;' : '&rarr;', esc_html_x( 'Next', 'pagination', 'woocommerce' ) );
 ?>
 <nav class="woocommerce-pagination" aria-label="<?php esc_attr_e( 'Products', 'woocommerce' ); ?>">
 	<?php
 	echo paginate_links(
+		/**
+		 * Filters the paginated links arguments of the catalog pagination.
+		 *
+		 * @param array $args The arguments of paginate_links().
+		 *
+		 * @since 2.0.0
+		 */
 		apply_filters(
 			'woocommerce_pagination_args',
 			array( // WPCS: XSS ok.
@@ -39,8 +50,8 @@ if ( $total <= 1 ) {
 				'add_args'  => false,
 				'current'   => max( 1, $current ),
 				'total'     => $total,
-				'prev_text' => is_rtl() ? '&rarr;' : '&larr;',
-				'next_text' => is_rtl() ? '&larr;' : '&rarr;',
+				'prev_text' => $prev_text,
+				'next_text' => $next_text,
 				'type'      => 'list',
 				'end_size'  => 3,
 				'mid_size'  => 3,

--- a/plugins/woocommerce/templates/myaccount/navigation.php
+++ b/plugins/woocommerce/templates/myaccount/navigation.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_before_account_navigation' );
 ?>
 
-<nav class="woocommerce-MyAccount-navigation">
+<nav class="woocommerce-MyAccount-navigation" aria-label="<?php esc_attr_e( 'My account', 'woocommerce' ); ?>">
 	<ul>
 		<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
 			<li class="<?php echo wc_get_account_menu_item_classes( $endpoint ); ?>">

--- a/plugins/woocommerce/templates/myaccount/navigation.php
+++ b/plugins/woocommerce/templates/myaccount/navigation.php
@@ -19,6 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Fires before the My account navigation is rendered.
+ *
+ * @since 2.6.0
+ */
 do_action( 'woocommerce_before_account_navigation' );
 global $wp;
 ?>
@@ -27,11 +32,17 @@ global $wp;
 	<ul>
 		<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
 			<?php $current = isset( $wp->query_vars[ $endpoint ] ) ? ' aria-current="page"' : ''; ?>
-			<li class="<?php echo wc_get_account_menu_item_classes( $endpoint ); ?>">
+			<li class="<?php echo wc_get_account_menu_item_classes( $endpoint ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- sanitized using sanitize_html_class() ?>">
 				<a href="<?php echo esc_url( wc_get_account_endpoint_url( $endpoint ) ); ?>"<?php echo $current; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>><?php echo esc_html( $label ); ?></a>
 			</li>
 		<?php endforeach; ?>
 	</ul>
 </nav>
 
-<?php do_action( 'woocommerce_after_account_navigation' ); ?>
+<?php
+/**
+ * Fires after the My account navigation is rendered.
+ *
+ * @since 2.6.0
+ */
+do_action( 'woocommerce_after_account_navigation' );

--- a/plugins/woocommerce/templates/myaccount/navigation.php
+++ b/plugins/woocommerce/templates/myaccount/navigation.php
@@ -20,13 +20,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 do_action( 'woocommerce_before_account_navigation' );
+global $wp;
 ?>
 
 <nav class="woocommerce-MyAccount-navigation" aria-label="<?php esc_attr_e( 'My account', 'woocommerce' ); ?>">
 	<ul>
 		<?php foreach ( wc_get_account_menu_items() as $endpoint => $label ) : ?>
+			<?php $current = isset( $wp->query_vars[ $endpoint ] ) ? ' aria-current="page"' : ''; ?>
 			<li class="<?php echo wc_get_account_menu_item_classes( $endpoint ); ?>">
-				<a href="<?php echo esc_url( wc_get_account_endpoint_url( $endpoint ) ); ?>"><?php echo esc_html( $label ); ?></a>
+				<a href="<?php echo esc_url( wc_get_account_endpoint_url( $endpoint ) ); ?>"<?php echo $current; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>><?php echo esc_html( $label ); ?></a>
 			</li>
 		<?php endforeach; ?>
 	</ul>

--- a/plugins/woocommerce/templates/single-product-reviews.php
+++ b/plugins/woocommerce/templates/single-product-reviews.php
@@ -32,7 +32,17 @@ if ( ! comments_open() ) {
 			if ( $count && wc_review_ratings_enabled() ) {
 				/* translators: 1: reviews count 2: product name */
 				$reviews_title = sprintf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), esc_html( $count ), '<span>' . get_the_title() . '</span>' );
-				echo apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product ); // WPCS: XSS ok.
+				echo wp_kses_post(
+					/**
+					 * Filters the title for the reviews section on single product pages.
+					 *
+					 * @since 3.6.0
+					 * @param string     $reviews_title The title.
+					 * @param int        $count         The total reviews count for the product.
+					 * @param WC_Product $product       The product data.
+					 */
+					apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product )
+				);
 			} else {
 				esc_html_e( 'Reviews', 'woocommerce' );
 			}
@@ -41,13 +51,31 @@ if ( ! comments_open() ) {
 
 		<?php if ( have_comments() ) : ?>
 			<ol class="commentlist">
-				<?php wp_list_comments( apply_filters( 'woocommerce_product_review_list_args', array( 'callback' => 'woocommerce_comments' ) ) ); ?>
+				<?php
+				wp_list_comments(
+					/**
+					 * Filters the arguments used in retrieving the review list.
+					 *
+					 * @since 2.1.0
+					 * @link https://developer.wordpress.org/reference/functions/wp_list_comments/#parameters
+					 * @param array An array of arguments for displaying reviewss.
+					 */
+					apply_filters( 'woocommerce_product_review_list_args', array( 'callback' => 'woocommerce_comments' ) )
+				);
+				?>
 			</ol>
 
 			<?php
 			if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) :
 				echo '<nav class="woocommerce-pagination" aria-label="' . esc_attr__( 'Reviews', 'woocommerce' ) . '">';
 				paginate_comments_links(
+					/**
+					 * Filters the arguments for reviews pagination links.
+					 *
+					 * @since 2.1.0
+					 * @link https://developer.wordpress.org/reference/functions/paginate_links/#parameters
+					 * @param array Pagination arguments.
+					 */
 					apply_filters(
 						'woocommerce_comment_pagination_args',
 						array(
@@ -133,7 +161,16 @@ if ( ! comments_open() ) {
 
 				$comment_form['comment_field'] .= '<p class="comment-form-comment"><label for="comment">' . esc_html__( 'Your review', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label><textarea id="comment" name="comment" cols="45" rows="8" required></textarea></p>';
 
-				comment_form( apply_filters( 'woocommerce_product_review_comment_form_args', $comment_form ) );
+				comment_form(
+					/**
+					 * Filters the review comment form arguments.
+					 *
+					 * @since 2.0.0
+					 * @link https://developer.wordpress.org/reference/functions/comment_form/#parameters
+					 * @param array $comment_form The review comment form arguments.
+					 */
+					apply_filters( 'woocommerce_product_review_comment_form_args', $comment_form )
+				);
 				?>
 			</div>
 		</div>

--- a/plugins/woocommerce/templates/single-product-reviews.php
+++ b/plugins/woocommerce/templates/single-product-reviews.php
@@ -46,7 +46,7 @@ if ( ! comments_open() ) {
 
 			<?php
 			if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) :
-				echo '<nav class="woocommerce-pagination">';
+				echo '<nav class="woocommerce-pagination" aria-label="' . esc_attr__( 'Reviews', 'woocommerce' ) . '">';
 				paginate_comments_links(
 					apply_filters(
 						'woocommerce_comment_pagination_args',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the accessibility of the account, breadcrumb, products and reviews navigation by
* adding the `aria-label` attribute to the `<nav>` element, as it is necessary to provide additional labeling when there is more than one landmark of the same type on the page, which is very likely with the `<nav>` elements.
* adding the `aria-current` attribute to the current navigation item to inform people using assistive technology that the item is the current navigation item which is usually indicated by different styling. 
* adding the `aria-hidden` attribute to the breadcrumb separators to prevent redundant and potentially distracting verbosity.
* adding the `aria-hidden` attribute to the pagination arrows and complementing them with text for people using assistive technology. 

Notes concerning the breadcrumb navigation:
* Since the last breadcrumb is not a link, the aria-current is optional. I don't mind removing the attribute again.
* Using "Breadcrumb" as aria-label might not be the best solution, because it assumes all users know what a breadcrumb navigation is. I've seen "You are here:" as an alternative, both visible and visually hidden. I don't mind changing that either.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
