### PR TITLE
Fix: order refunds REST API endpoint reading from posts table even with HPOS active

### DIFF
--- a/plugins/woocommerce/changelog/fix-rest-api-refunds-for-hpos
+++ b/plugins/woocommerce/changelog/fix-rest-api-refunds-for-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix REST API order refunds enpoint when HPOS is active, and make v2 orders endpoint compatible with HPOS

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -10,6 +10,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 /**
  * REST API Orders controller class.
  *
@@ -1981,5 +1983,34 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get objects.
+	 *
+	 * @param  array $query_args Query args.
+	 * @return array
+	 */
+	protected function get_objects( $query_args ) {
+		// Do not use WC_Order_Query for the CPT datastore.
+		if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			return parent::get_objects( $query_args );
+		}
+
+		$query   = new \WC_Order_Query(
+			array_merge(
+				$query_args,
+				array(
+					'paginate' => true,
+				)
+			)
+		);
+		$results = $query->get_orders();
+
+		return array(
+			'objects' => $results->orders,
+			'total'   => $results->total,
+			'pages'   => $results->max_num_pages,
+		);
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -158,7 +158,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		 * The dynamic portion of the hook name, `$this->post_type`,
 		 * refers to the object type slug.
 		 *
-		 * @since ?
+		 * @since 7.4.0
 		 *
 		 * @param WC_Data         $order    Object object.
 		 * @param WP_REST_Request $request  Request object.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -158,6 +158,8 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		 * The dynamic portion of the hook name, `$this->post_type`,
 		 * refers to the object type slug.
 		 *
+		 * @since ?
+		 *
 		 * @param WC_Data         $order    Object object.
 		 * @param WP_REST_Request $request  Request object.
 		 * @param bool            $creating If is creating a new object.
@@ -244,7 +246,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		$cpt_hidden_keys = array();
 
 		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$cpt_hidden_keys = (new \WC_Order_Data_Store_CPT())->get_internal_meta_keys();
+			$cpt_hidden_keys = ( new \WC_Order_Data_Store_CPT() )->get_internal_meta_keys();
 		}
 
 		// XXX: This might be removed once we finalize the design for internal keys vs meta vs props in COT.
@@ -308,35 +310,6 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		}
 
 		return $args;
-	}
-
-	/**
-	 * Get objects.
-	 *
-	 * @param  array $query_args Query args.
-	 * @return array
-	 */
-	protected function get_objects( $query_args ) {
-		// Do not use WC_Order_Query for the CPT datastore.
-		if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			return parent::get_objects( $query_args );
-		}
-
-		$query   = new \WC_Order_Query(
-			array_merge(
-				$query_args,
-				array(
-					'paginate' => true,
-				)
-			)
-		);
-		$results = $query->get_orders();
-
-		return array(
-			'objects' => $results->orders,
-			'total'   => $results->total,
-			'pages'   => $results->max_num_pages,
-		);
 	}
 
 	/**


### PR DESCRIPTION
-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Move the `get_objects` method, which retrieves order objects from the proper source depending on whether HPOS is active or not, from the `WC_REST_Orders_Controller` class to the `WC_REST_Orders_V2_Controller` class. This has two effects:

1. Make the `/orders` endpoint compatible with REST API v2 when HPOS is active (fixing v1 would require additional work).

2. Fix the `/orders/<id>/refunds` endpoint for v2 and v3.

Without this fix what happens is that the v2 endpoint for orders and the v2 and v3 endpoints for refunds always retrieve data from the posts table even when HPOS active (since the controller classes are ultimately based on `WC_REST_Posts_Controller` and any non-overridden behavior relies in the posts table).

Moving the method in just the orders class fixes the refunds too because the class hierarchy is `WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller` (and `WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller`).

Closes #35855.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Enable HPOS and make the orders table authoritative, but **disable the table synchronization**.

![image](https://user-images.githubusercontent.com/937723/210763240-e4efbcea-5a72-41ba-b3d5-4d9aad126835.png)

2. Create a completed new order with a product, then create a refund for the order.

3. Verify that the REST API endpoint `/wp-json/wc/v3/orders` includes the order you just created, and the same for the `v2` endpoint (without the fix that's true for the `v3` endpoint only).

4. Verify that the REST API endpoint `/wp-json/wc/v3/orders/<order id>/refunds` is returning the refund you created for the order, and the same for the `v2` endpoint (without the fix an empty array is returned for both endpoints).

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
