### PR TITLE
Order emails: improve responsiveness and RTL support

### DIFF
--- a/plugins/woocommerce/changelog/fix-31478-responsive-emails
+++ b/plugins/woocommerce/changelog/fix-31478-responsive-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure order emails are responsive in most email clients, including when the current language is RTL.

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -54,7 +54,8 @@ defined( 'ABSPATH' ) || exit;
 																		apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) )
 																	)
 																)
-															); ?>
+															);
+															?>
 														</td>
 													</tr>
 												</table>

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -12,45 +12,49 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 3.7.0
+ * @version 7.4.0
  */
 
 defined( 'ABSPATH' ) || exit;
 ?>
-															</div>
+																		</div>
+																	</td>
+																</tr>
+															</table>
+															<!-- End Content -->
 														</td>
 													</tr>
 												</table>
-												<!-- End Content -->
+												<!-- End Body -->
 											</td>
 										</tr>
 									</table>
-									<!-- End Body -->
 								</td>
-							</tr>
-						</table>
-					</td>
-				</tr>
-				<tr>
-					<td align="center" valign="top">
-						<!-- Footer -->
-						<table border="0" cellpadding="10" cellspacing="0" width="600" id="template_footer">
+							</tr	>
 							<tr>
-								<td valign="top">
-									<table border="0" cellpadding="10" cellspacing="0" width="100%">
+								<td align="center" valign="top">
+									<!-- Footer -->
+									<table border="0" cellpadding="10" cellspacing="0" width="100%" id="template_footer">
 										<tr>
-											<td colspan="2" valign="middle" id="credit">
-												<?php echo wp_kses_post( wpautop( wptexturize( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) ) ) ); ?>
+											<td valign="top">
+												<table border="0" cellpadding="10" cellspacing="0" width="100%">
+													<tr>
+														<td colspan="2" valign="middle" id="credit">
+															<?php echo wp_kses_post( wpautop( wptexturize( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) ) ) ); ?>
+														</td>
+													</tr>
+												</table>
 											</td>
 										</tr>
 									</table>
+									<!-- End Footer -->
 								</td>
 							</tr>
 						</table>
-						<!-- End Footer -->
-					</td>
-				</tr>
-			</table>
-		</div>
+					</div>
+				</td>
+				<td><!-- Deliberately empty to support consistent sizing and layout across multiple email clients. --></td>
+			</tr>
+		</table>
 	</body>
 </html>

--- a/plugins/woocommerce/templates/emails/email-footer.php
+++ b/plugins/woocommerce/templates/emails/email-footer.php
@@ -30,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 										</tr>
 									</table>
 								</td>
-							</tr	>
+							</tr>
 							<tr>
 								<td align="center" valign="top">
 									<!-- Footer -->
@@ -40,7 +40,21 @@ defined( 'ABSPATH' ) || exit;
 												<table border="0" cellpadding="10" cellspacing="0" width="100%">
 													<tr>
 														<td colspan="2" valign="middle" id="credit">
-															<?php echo wp_kses_post( wpautop( wptexturize( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) ) ) ); ?>
+															<?php
+															echo wp_kses_post(
+																wpautop(
+																	wptexturize(
+																		/**
+																		 * Provides control over the email footer text used for most order emails.
+																		 *
+																		 * @since 4.0.0
+																		 *
+																		 * @param string $email_footer_text
+																		 */
+																		apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) )
+																	)
+																)
+															); ?>
 														</td>
 													</tr>
 												</table>

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -38,8 +38,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<td align="center" valign="top">
 									<div id="template_header_image">
 										<?php
-										if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
-											echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
+										$img = get_option( 'woocommerce_email_header_image' );
+
+										if ( $img ) {
+											echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( get_bloginfo( 'name', 'display' ) ) . '" /></p>';
 										}
 										?>
 									</div>
@@ -50,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header">
 													<tr>
 														<td id="header_wrapper">
-															<h1><?php echo $email_heading; ?></h1>
+															<h1><?php echo esc_html( $email_heading ); ?></h1>
 														</td>
 													</tr>
 												</table>

--- a/plugins/woocommerce/templates/emails/email-header.php
+++ b/plugins/woocommerce/templates/emails/email-header.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 4.0.0
+ * @version 7.4.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,42 +24,47 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html <?php language_attributes(); ?>>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=<?php bloginfo( 'charset' ); ?>" />
+		<meta content="width=device-width, initial-scale=1.0" name="viewport">
 		<title><?php echo get_bloginfo( 'name', 'display' ); ?></title>
 	</head>
 	<body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
-		<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>">
-			<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
-				<tr>
-					<td align="center" valign="top">
-						<div id="template_header_image">
-							<?php
-							if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
-								echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
-							}
-							?>
-						</div>
-						<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_container">
+		<table width="100%" id="outer_wrapper">
+			<tr>
+				<td><!-- Deliberately empty to support consistent sizing and layout across multiple email clients. --></td>
+				<td width="600">
+					<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>">
+						<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
 							<tr>
 								<td align="center" valign="top">
-									<!-- Header -->
-									<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header">
+									<div id="template_header_image">
+										<?php
+										if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
+											echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
+										}
+										?>
+									</div>
+									<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_container">
 										<tr>
-											<td id="header_wrapper">
-												<h1><?php echo $email_heading; ?></h1>
+											<td align="center" valign="top">
+												<!-- Header -->
+												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header">
+													<tr>
+														<td id="header_wrapper">
+															<h1><?php echo $email_heading; ?></h1>
+														</td>
+													</tr>
+												</table>
+												<!-- End Header -->
 											</td>
 										</tr>
-									</table>
-									<!-- End Header -->
-								</td>
-							</tr>
-							<tr>
-								<td align="center" valign="top">
-									<!-- Body -->
-									<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_body">
 										<tr>
-											<td valign="top" id="body_content">
-												<!-- Content -->
-												<table border="0" cellpadding="20" cellspacing="0" width="100%">
+											<td align="center" valign="top">
+												<!-- Body -->
+												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_body">
 													<tr>
-														<td valign="top">
-															<div id="body_content_inner">
+														<td valign="top" id="body_content">
+															<!-- Content -->
+															<table border="0" cellpadding="20" cellspacing="0" width="100%">
+																<tr>
+																	<td valign="top">
+																		<div id="body_content_inner">

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -231,4 +231,23 @@ img {
 	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
 	max-width: 100%;
 }
+
+/**
+ * Media queries are not supported by all email clients, however they do work on modern mobile
+ * Gmail clients and can help us achieve better consistency there.
+ */
+@media screen and (max-width: 600px) {
+	#header_wrapper {
+		padding: 27px 36px !important;
+		font-size: 24px;
+	}
+
+	#body_content table > tbody > tr > td {
+		padding: 10px !important;
+	}
+
+	#body_content_inner {
+		font-size: 10px !important;
+	}
+}
 <?php

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 4.0.0
+ * @version 7.4.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -44,15 +44,21 @@ $text_lighter_40 = wc_hex_lighter( $text, 40 );
 // body{padding: 0;} ensures proper scale/positioning of the email in the iOS native email app.
 ?>
 body {
+	background-color: <?php echo esc_attr( $bg ); ?>;
 	padding: 0;
+	text-align: center;
+}
+
+#outer_wrapper {
+	background-color: <?php echo esc_attr( $bg ); ?>;
 }
 
 #wrapper {
-	background-color: <?php echo esc_attr( $bg ); ?>;
-	margin: 0;
+	margin: 0 auto;
 	padding: 70px 0;
 	-webkit-text-size-adjust: none !important;
 	width: 100%;
+	max-width: 600px;
 }
 
 #template_container {

--- a/plugins/woocommerce/tests/legacy/data/sample-email.html
+++ b/plugins/woocommerce/tests/legacy/data/sample-email.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <html>
 <head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
-<body style="padding: 0;"><p class="text" style='color: #3c3c3c; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif;'>Hello World!</p></body>
+<body style="background-color: #f7f7f7; padding: 0; text-align: center;" bgcolor="#f7f7f7"><p class="text" style='color: #3c3c3c; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif;'>Hello World!</p></body>
 </html>


### PR DESCRIPTION
It seems that order emails composed in RTL-mode (such as if the site language is Arabic) do not have the same level of responsiveness as do LTR emails. In particular, they render poorly in the context of mobile email clients like Gmail. For reference, here are side-by-side screenshots of the same order email as they appear using *Gmail App Pixel 5:*

| LTR (no cut-off) | RTL (email is cut-off) |
| --- | --- |
| ![gmail-mob-rtl-init](https://user-images.githubusercontent.com/3594411/210817438-d4c5572e-36fa-4c37-b413-27d616924375.png) | ![gmail-mob-ltr-init](https://user-images.githubusercontent.com/3594411/210817426-3137eeb2-97c4-4d16-8ee1-d65854bf7bbc.png) |


It's not completely clear why this would be the case, as the email structure and CSS is essentially the same in both cases. However, the presence of `dir="rtl"` does seem to have a notable impact on how these emails render. This PR attempts to address that and introduce more consistency. 

Note that styling emails is a fiddly business, as different email clients support different CSS rules, have their own default styles, sometimes use completely different layout engines, etc. Consequently, we cannot easily fix how RTL emails render without also touching LTR emails, however overall I feel we have a net improvement (and we can iterate further if necessary).

Closes https://github.com/woocommerce/woocommerce/issues/31478.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

To test this change:

- I recommend using a suitable email testing tool, like Litmus or [Email on Acid](https://app.emailonacid.com) which is capable of testing how an email renders via a wide range of mobile, desktop and web clients.
- You will require an 'email catcher' tool or plugin, from which you can retrieve the HTML of the generated emails.
- You will need to be able to generate new order emails in both LTR and RTL languages.

Relating to the final point, my methodology was to test with the default language (which is US English) and then with Arabic. To do this, you of course need the appropriate language packs:

```sh
wp language core install ar; \
wp language plugin install woocommerce ar
```

I then identified a suitable existing order. Supposing the order ID was `123` I used the following WP CLI code to generate a new order email first in the default language (US English):

```sh
wp option set WPLANG ""; \
wp eval "add_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' ); ( new WC_Email_New_Order )->trigger( 123 );"
```

And then in the second language (Arabic in this example):

```sh
wp option set WPLANG "ar"; \
wp eval "add_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' ); ( new WC_Email_New_Order )->trigger( 123 );"
```

Of course, correct the order ID to whatever is appropriate in your case. Also note you can test different email types. For instance, to test the "order is processing" email in ther default language (filter code is not needed in this context):

```sh
wp option set WPLANG ""; \
wp eval "( new WC_Email_Customer_Processing_Order )->trigger( 123 );"
```

I hope that all makes sense, but reach out if I can clarify. From there:

1. Try generating new order emails in an LTR and RTL language *without* this change.
2. Repeat, but with this change in place.
3. Compare the emails, pass them through a suitable testing tool.
4. When using an RTL language, the appearance and layout should be much closer to what we were seeing for LTR languages: nothing should be cut-off regardless of text direction.

In my own testing, there was a very high degree of compatibility and little observable change with web and desktop clients. In the case of mobile clients, the change is more obvious but I think introduces more consistency across the board.

<!-- End testing instructions -->

### Other information:

- Most styles are inlined via Emogrifier. The responsive media queries I added will **not** be inlined and therefore will not be observed by some email clients—but they do make a positive difference in the case of modern mobile Gmail, etc.
- You may notice I've added a new table which nests other divs and tables. This is unfortunate, but necessary to maintain a decent-looking layout with Outlook (desktop and web varieties), as they seem not to support various CSS rules such as `max-width`.
- An (incomplete) community PR also exists in relation to the same problem [(#36310)](https://github.com/woocommerce/woocommerce/pull/36310). Once/if we are happy with *this* PR, let's remember to circle back and close that one.

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
