### PR TITLE
Add product variation flag to hide WIP

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -199,7 +199,9 @@ export const getPages = () => {
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'manage_woocommerce',
 		} );
+	}
 
+	if ( window.wcAdminFeatures[ 'product-variation-management' ] ) {
 		pages.push( {
 			container: EditProductPage,
 			path: '/product/:productId/variation/:variationId',

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -130,12 +130,14 @@ const EditProductPage: React.FC = () => {
 						</div>
 					</ProductFormLayout>
 				) }
-			{ productVariation && product && (
-				<ProductVariationForm
-					product={ product }
-					productVariation={ productVariation }
-				/>
-			) }
+			{ window.wcAdminFeatures[ 'product-variation-management' ] &&
+				productVariation &&
+				product && (
+					<ProductVariationForm
+						product={ product }
+						productVariation={ productVariation }
+					/>
+				) }
 			{ ! isProductVariation &&
 				product &&
 				( product.status !== 'trash' || wasDeletedUsingAction ) && (

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -69,10 +69,14 @@ export const ProductForm: React.FC< {
 				>
 					<ProductShippingSection product={ product } />
 				</ProductFormTab>
-				<ProductFormTab name="options" title="Options">
-					<OptionsSection />
-					<ProductVariationsSection />
-				</ProductFormTab>
+				{ window.wcAdminFeatures[ 'product-variation-management' ] ? (
+					<ProductFormTab name="options" title="Options">
+						<OptionsSection />
+						<ProductVariationsSection />
+					</ProductFormTab>
+				) : (
+					<></>
+				) }
 			</ProductFormLayout>
 			<ProductFormFooter />
 		</Form>

--- a/plugins/woocommerce-admin/client/products/utils/get-derived-product-type.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-derived-product-type.ts
@@ -4,6 +4,10 @@
 import { Product } from '@woocommerce/data';
 
 export const getDerivedProductType = ( product: Partial< Product > ) => {
+	if ( ! window.wcAdminFeatures[ 'product-variation-management' ] ) {
+		return 'simple';
+	}
+
 	const hasOptions = !! product.attributes?.find(
 		( attribute ) => attribute.options.length && attribute.variation
 	);

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -20,6 +20,7 @@ declare global {
 			onboarding: boolean;
 			'onboarding-tasks': boolean;
 			'payment-gateway-suggestions': boolean;
+			'product-variation-management': boolean;
 			'remote-inbox-notifications': boolean;
 			'remote-free-extensions': boolean;
 			settings: boolean;

--- a/plugins/woocommerce/changelog/add-36276
+++ b/plugins/woocommerce/changelog/add-36276
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product variations flag to only show work in development

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -17,6 +17,7 @@
 		"new-product-management-experience": false,
 		"onboarding": true,
 		"onboarding-tasks": true,
+		"product-variation-management": false,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -18,6 +18,7 @@
 		"onboarding": true,
 		"onboarding-tasks": true,
 		"payment-gateway-suggestions": true,
+		"product-variation-management": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"settings": false,


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the variation work behind a feature flag to prevent access to WIP in the built plugin.

<img width="359" alt="Screen Shot 2023-01-04 at 4 01 24 PM" src="https://user-images.githubusercontent.com/10561050/210840250-167e0138-8d64-49b5-a96d-8ed05743dc04.png">


Closes #36276 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Start the plugin in development mode `pnpm --filter=woocommerce/client/admin run start`
2. Navigate to the new product experience (Products -> Add new (MVP) )
3. Check that you can still see and use the options tab and all variations work continues to work as expected
4. Build the plugin as a zip `cd plugins/woocommerce && npm run build:zip`
5. Upload this zip to a site and check that the “Options” and all variations work is hidden
6. Optionally, edit an existing product `/wp-admin/admin.php?page=wc-admin&path=/product/{product_id}`
7. After save, make sure that your product is saved as a simple product by checking it in the legacy product page

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
