### PR TITLE
Update WooCommerce Blocks to 9.1.4

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.1.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.1.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.1.4

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "9.1.3"
+		"woocommerce/woocommerce-blocks": "9.1.4"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e07f604ec32eb59e76bf37b0126d4533",
+    "content-hash": "5d6aa45a4ccd532e09383828f396c06d",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.1.3",
+            "version": "v9.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "6e49666a8270f395d15c6b58cd0c5ce111df5ecf"
+                "reference": "03d5efd33206aa11684dee2c493bbbe9a4e417c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/6e49666a8270f395d15c6b58cd0c5ce111df5ecf",
-                "reference": "6e49666a8270f395d15c6b58cd0c5ce111df5ecf",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/03d5efd33206aa11684dee2c493bbbe9a4e417c8",
+                "reference": "03d5efd33206aa11684dee2c493bbbe9a4e417c8",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.1.3"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.1.4"
             },
-            "time": "2022-12-22T09:15:52+00:00"
+            "time": "2023-01-05T23:41:26+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull request updates the WooCommerce Blocks plugin to 9.1.3. 

This update removes compatibility of the “Products (Beta)” block from WordPress versions below 6.1.

## Blocks 9.1.4

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8102)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/a680ca27df0a9b88d6130137a90d698c12c906b7/docs/internal-developers/testing/releases/914.md)

---

### Changelog entry

#### Compatibility

- Products (Beta): Remove the block from WordPress 6.0 and lower. ([8112](https://github.com/woocommerce/woocommerce-blocks/pull/8112))
