### PR TITLE
Analytics: Decode HTML entities in CategoryBreadcrumbs

### DIFF
--- a/plugins/woocommerce-admin/client/analytics/report/categories/breadcrumbs.js
+++ b/plugins/woocommerce-admin/client/analytics/report/categories/breadcrumbs.js
@@ -4,6 +4,7 @@
 import { Component } from '@wordpress/element';
 import { first, last } from 'lodash';
 import { Spinner } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 import { Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 
@@ -49,7 +50,9 @@ export default class CategoryBreadcrumbs extends Component {
 
 		return category ? (
 			<div className="woocommerce-table__breadcrumbs">
-				{ this.getCategoryAncestors( category, categories ) }
+				{ decodeEntities(
+					this.getCategoryAncestors( category, categories )
+				) }
 				<Link
 					href={ getNewPath(
 						persistedQuery,
@@ -61,7 +64,7 @@ export default class CategoryBreadcrumbs extends Component {
 					) }
 					type="wc-admin"
 				>
-					{ category.name }
+					{ decodeEntities( category.name ) }
 				</Link>
 			</div>
 		) : (

--- a/plugins/woocommerce/changelog/fix-analytics-category-breadcrumbs-html-entities
+++ b/plugins/woocommerce/changelog/fix-analytics-category-breadcrumbs-html-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Decode HTML entities in CategoryBreadcrumbs.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR decodes HTML entities in category names in the `CategoryBreadcrumbs` Analytics component, which is used in the Products and Categories Analytics reports.

This addresses a customer issue (5833679-zd-woothemes), where they had category names with ampersands (`&`) in them that were not being properly displayed. 

Before:

<img width="1059" alt="Screenshot 2023-01-06 at 11 45 37" src="https://user-images.githubusercontent.com/2098816/211060222-5bb695bc-1af9-49a8-b2ca-cc54ac279bcf.png">

<img width="1059" alt="Screenshot 2023-01-06 at 11 46 03" src="https://user-images.githubusercontent.com/2098816/211060237-06f8180f-71d5-4d14-a8ff-ef396c352ab9.png">

After:

<img width="1059" alt="Screenshot 2023-01-06 at 11 47 54" src="https://user-images.githubusercontent.com/2098816/211060266-44a0a644-b970-4e2e-b556-9cebe88b0ed7.png">

<img width="1059" alt="Screenshot 2023-01-06 at 11 48 12" src="https://user-images.githubusercontent.com/2098816/211060282-a25a7b87-f53d-4ee5-9a57-39655171db32.png">


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a category with an ampersand (`&`) in the name.
2. Create a product and assign it to that category.
3. Create an order that contains that product.
4. Run the Products and Categories Analytics reports and verify that the category name appears correctly, with the ampersand HTML entity (`&amp;`) decoded.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.