### PR TITLE
Adding WooProductSectionItem slotfill 

### DIFF
--- a/packages/js/components/changelog/add-36015-mvp-section-slot
+++ b/packages/js/components/changelog/add-36015-mvp-section-slot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding the WooProductSectionItem slotfill component.

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -86,3 +86,4 @@ export * as TourKitTypes from './tour-kit/types';
 export { CollapsibleContent } from './collapsible-content';
 export { createOrderedChildren, sortFillsByOrder } from './utils';
 export { WooProductFieldItem as __experimentalWooProductFieldItem } from './woo-product-field-item';
+export { WooProductSectionItem as __experimentalWooProductSectionItem } from './woo-product-section-item';

--- a/packages/js/components/src/woo-product-section-item/README.md
+++ b/packages/js/components/src/woo-product-section-item/README.md
@@ -33,7 +33,7 @@ This is the fill component. You must provide the `id` prop to identify your sect
 | Prop         | Type     | Description                                                                                                              |
 | -------------| -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `id`         | String   | A unique string to identify your fill. Used for configuiration management.                                               |
-| `location`   | String   | The string used to identify the particular location that you wan tto render your Section.                                |
+| `location`   | String   | The string used to identify the particular location that you want to render your section.                                |
 | `pluginId`   | String   | A unique plugin ID to identify the plugin/extension that this fill is associated with.                                   |
 | `order`      | Number   | (optional) This number will dictate the order that the sections rendered by a Slot will be appear.                       |
 

--- a/packages/js/components/src/woo-product-section-item/README.md
+++ b/packages/js/components/src/woo-product-section-item/README.md
@@ -1,0 +1,46 @@
+# WooProductSectionItem Slot & Fill
+
+A Slotfill component that will allow you to add a new section to the product editor.
+
+## Usage
+
+```jsx
+<WooProductSectionItem id={ key } location="tab-general" order={ 2 } pluginId="test-plugin" >
+  { () => {
+    return (
+      <ProductSectionLayout
+        title={ __( 'Product test section', 'woocommerce' ) }
+        description={ __(
+          'In this area you can describe the section.',
+          'woocommerce'
+        ) }
+      >
+        <Card>
+          <CardBody>{ /* Section content */ }</CardBody>
+        </Card>
+		  </ProductSectionLayout>
+    );
+} }
+</WooProductSectionItem>
+
+<WooProductSectionItem.Slot location="tab-general" />
+```
+
+### WooProductSectionItem (fill)
+
+This is the fill component. You must provide the `id` prop to identify your section fill with a unique string. This component will accept a series of props:
+
+| Prop         | Type     | Description                                                                                                              |
+| -------------| -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `id`         | String   | A unique string to identify your fill. Used for configuiration management.                                               |
+| `location`   | String   | The string used to identify the particular location that you wan tto render your Section.                                |
+| `pluginId`   | String   | A unique plugin ID to identify the plugin/extension that this fill is associated with.                                   |
+| `order`      | Number   | (optional) This number will dictate the order that the sections rendered by a Slot will be appear.                       |
+
+### WooProductSectionItem.Slot (slot)
+
+This is the slot component, and will not be used as frequently. It must also receive the required `location` prop that will be identical to the fill `location`.
+
+| Name        | Type   | Description                                                                                          |
+| ----------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `location`  | String | Unique to the location that the Slot appears, and must be the same as the one provided to any fills. |

--- a/packages/js/components/src/woo-product-section-item/README.md
+++ b/packages/js/components/src/woo-product-section-item/README.md
@@ -5,7 +5,7 @@ A Slotfill component that will allow you to add a new section to the product edi
 ## Usage
 
 ```jsx
-<WooProductSectionItem id={ key } location="tab-general" order={ 2 } pluginId="test-plugin" >
+<WooProductSectionItem id={ key } location="tab/general" order={ 2 } pluginId="test-plugin" >
   { () => {
     return (
       <ProductSectionLayout
@@ -23,7 +23,7 @@ A Slotfill component that will allow you to add a new section to the product edi
 } }
 </WooProductSectionItem>
 
-<WooProductSectionItem.Slot location="tab-general" />
+<WooProductSectionItem.Slot location="tab/general" />
 ```
 
 ### WooProductSectionItem (fill)

--- a/packages/js/components/src/woo-product-section-item/index.ts
+++ b/packages/js/components/src/woo-product-section-item/index.ts
@@ -1,0 +1,1 @@
+export * from './woo-product-section-item';

--- a/packages/js/components/src/woo-product-section-item/woo-product-section-item.tsx
+++ b/packages/js/components/src/woo-product-section-item/woo-product-section-item.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Slot, Fill } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren, sortFillsByOrder } from '../utils';
+
+type WooProductSectionItemProps = {
+	id: string;
+	location: string;
+	pluginId: string;
+	order?: number;
+};
+
+type WooProductFieldSlotProps = {
+	location: string;
+};
+
+export const WooProductSectionItem: React.FC< WooProductSectionItemProps > & {
+	Slot: React.FC< Slot.Props & WooProductFieldSlotProps >;
+} = ( { children, order = 1, location } ) => (
+	<Fill name={ `woocommerce_product_section_${ location }` }>
+		{ ( fillProps: Fill.Props ) => {
+			return createOrderedChildren< Fill.Props >(
+				children,
+				order,
+				fillProps
+			);
+		} }
+	</Fill>
+);
+
+WooProductSectionItem.Slot = ( { fillProps, location } ) => (
+	<Slot
+		name={ `woocommerce_product_section_${ location }` }
+		fillProps={ fillProps }
+	>
+		{ ( fills ) => {
+			if ( ! sortFillsByOrder ) {
+				return null;
+			}
+
+			return sortFillsByOrder( fills );
+		} }
+	</Slot>
+);

--- a/plugins/woocommerce-admin/client/products/product-form-tab.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-tab.tsx
@@ -8,7 +8,7 @@ export const ProductFormTab: React.FC< {
 	name: string;
 	title: string;
 	children: JSX.Element | JSX.Element[] | string;
-} > = ( { name, title, children } ) => {
+} > = ( { name, children } ) => {
 	const classes = classnames(
 		'woocommerce-product-form-tab',
 		'woocommerce-product-form-tab__' + name

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { Form, FormRef } from '@woocommerce/components';
+import {
+	Form,
+	FormRef,
+	__experimentalWooProductSectionItem as WooProductSectionItem,
+} from '@woocommerce/components';
 import { PartialProduct, Product } from '@woocommerce/data';
 import { Ref } from 'react';
 
@@ -47,6 +51,7 @@ export const ProductForm: React.FC< {
 					<ProductDetailsSection />
 					<ImagesSection />
 					<AttributesSection />
+					<WooProductSectionItem.Slot location="tab/general" />
 				</ProductFormTab>
 				<ProductFormTab
 					name="pricing"

--- a/plugins/woocommerce/changelog/add-36015-mvp-section-slot
+++ b/plugins/woocommerce/changelog/add-36015-mvp-section-slot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding the WooProductSectionItem slot within the product editor general tab.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the WooProductSectionItem slot fill, which will be used to inject sections into various locations on the product editor. 

Closes #36015  .

**Other thoughts:**
- Right now this is very simple, but it will also require 3PD to import the ProductSectionLayout, Card and CardBody components in order to build a section that looks like others on the page. Should we just inject these for them? Alternatively we could keep these simple and then provide an additional component that will bring everything together.
- If a 3PD creates their own section, they would need to manually insert the `<WooProductFieldItem />` slot in order to allow others to inject fields. That makes it optional to have a field slot at all; is that what we want? Any greater abstractions as described in the last bullet point could inject this slot as well.

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch
2. Enable the `new-product-management-experience` feature flag. 
3. Include a test slot anywhere within the application JS. Something like this:
```js
/**
 * External dependencies
 */
import { __ } from '@wordpress/i18n';
import { __experimentalWooProductSectionItem as WooProductSectionItem } from '@woocommerce/components';
import { Card, CardBody } from '@wordpress/components';
import { registerPlugin } from '@wordpress/plugins';

/**
 * Internal dependencies
 */
import { ProductSectionLayout } from '~/products/layout/product-section-layout';

const TestSection = () => {
	return (
		<ProductSectionLayout
			title={ __( 'Product test section', 'woocommerce' ) }
			description={ __(
				'This is a test. This is ONLY a test.',
				'woocommerce'
			) }
		>
			<Card>
				<CardBody>testing</CardBody>
			</Card>
		</ProductSectionLayout>
	);
};

registerPlugin( 'wc-admin-product-editor-test-section', {
	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
	scope: 'woocommerce-admin',
	render: () => (
		<WooProductSectionItem
			id="test-section"
			location="tab/general"
			pluginId="test-plugin"
		>
			{ () => <TestSection /> }
		</WooProductSectionItem>
	),
} );

```
4. Navigate to Products -> Add New (MVP)
5. You should see the test section appear at the bottom of the general tab.

![image](https://user-images.githubusercontent.com/444632/211101511-c786e96b-81f3-4c24-8036-610175c8c717.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
